### PR TITLE
fix: native paste operations in Firefox

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -11,11 +11,13 @@
   },
   "dependencies": {
     "@portabletext/editor": "workspace:^",
+    "@portabletext/patches": "workspace:^",
     "@sanity/ui": "^2.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@sanity/types": "^3.47.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.13.1",

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -13,46 +13,55 @@ import {PortableTextBlock} from '@sanity/types'
 import {schema} from './schema'
 import {useState} from 'react'
 import {applyAll} from '@portabletext/patches/apply'
-import {Code, Stack} from '@sanity/ui'
+import {Box, Code, Flex, Spinner, Stack} from '@sanity/ui'
 import {wait} from './wait'
 
 export function Editor() {
+  const [loading, setLoading] = useState(false)
   const [value, setValue] = useState<Array<PortableTextBlock>>([])
 
   return (
     <Stack space={2}>
-      <PortableTextEditor
-        onChange={(change) => {
-          if (change.type === 'mutation') {
-            setValue(applyAll(value, change.patches))
-          }
-        }}
-        schemaType={schema}
-      >
-        <PortableTextEditable
-          onPaste={(data) => {
-            const text = data.event.clipboardData.getData('text')
-            if (text === 'heading') {
-              return wait(2000).then(() => ({
-                insert: [
-                  {
-                    _type: 'block',
-                    children: [{_type: 'span', text: 'heading'}],
-                    style: 'h1',
-                  },
-                ],
-              }))
-            }
-          }}
-          renderAnnotation={renderAnnotation}
-          renderBlock={renderBlock}
-          renderChild={renderChild}
-          renderDecorator={renderDecorator}
-          renderListItem={renderListItem}
-          renderPlaceholder={renderPlaceholder}
-          renderStyle={renderStyle}
-        />
-      </PortableTextEditor>
+      <Flex gap={2} align="center">
+        <Box flex={1}>
+          <PortableTextEditor
+            onChange={(change) => {
+              if (change.type === 'mutation') {
+                setValue(applyAll(value, change.patches))
+              }
+              if (change.type === 'loading') {
+                setLoading(change.isLoading)
+              }
+            }}
+            schemaType={schema}
+          >
+            <PortableTextEditable
+              onPaste={(data) => {
+                const text = data.event.clipboardData.getData('text')
+                if (text === 'heading') {
+                  return wait(2000).then(() => ({
+                    insert: [
+                      {
+                        _type: 'block',
+                        children: [{_type: 'span', text: 'heading'}],
+                        style: 'h1',
+                      },
+                    ],
+                  }))
+                }
+              }}
+              renderAnnotation={renderAnnotation}
+              renderBlock={renderBlock}
+              renderChild={renderChild}
+              renderDecorator={renderDecorator}
+              renderListItem={renderListItem}
+              renderPlaceholder={renderPlaceholder}
+              renderStyle={renderStyle}
+            />
+          </PortableTextEditor>
+        </Box>
+        {loading ? <Spinner /> : null}{' '}
+      </Flex>
       <Code as="code" size={0} language="json">
         {JSON.stringify(value, null, 2)}
       </Code>

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -9,21 +9,39 @@ import {
   RenderPlaceholderFunction,
   RenderStyleFunction,
 } from '@portabletext/editor'
+import {PortableTextBlock} from '@sanity/types'
 import {schema} from './schema'
+import {useState} from 'react'
+import {applyAll} from '@portabletext/patches/apply'
+import {Code, Stack} from '@sanity/ui'
 
 export function Editor() {
+  const [value, setValue] = useState<Array<PortableTextBlock>>([])
+
   return (
-    <PortableTextEditor onChange={() => {}} schemaType={schema}>
-      <PortableTextEditable
-        renderAnnotation={renderAnnotation}
-        renderBlock={renderBlock}
-        renderChild={renderChild}
-        renderDecorator={renderDecorator}
-        renderListItem={renderListItem}
-        renderPlaceholder={renderPlaceholder}
-        renderStyle={renderStyle}
-      />
-    </PortableTextEditor>
+    <Stack space={2}>
+      <PortableTextEditor
+        onChange={(change) => {
+          if (change.type === 'mutation') {
+            setValue(applyAll(value, change.patches))
+          }
+        }}
+        schemaType={schema}
+      >
+        <PortableTextEditable
+          renderAnnotation={renderAnnotation}
+          renderBlock={renderBlock}
+          renderChild={renderChild}
+          renderDecorator={renderDecorator}
+          renderListItem={renderListItem}
+          renderPlaceholder={renderPlaceholder}
+          renderStyle={renderStyle}
+        />
+      </PortableTextEditor>
+      <Code as="code" size={0} language="json">
+        {JSON.stringify(value, null, 2)}
+      </Code>
+    </Stack>
   )
 }
 

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -14,6 +14,7 @@ import {schema} from './schema'
 import {useState} from 'react'
 import {applyAll} from '@portabletext/patches/apply'
 import {Code, Stack} from '@sanity/ui'
+import {wait} from './wait'
 
 export function Editor() {
   const [value, setValue] = useState<Array<PortableTextBlock>>([])
@@ -29,6 +30,20 @@ export function Editor() {
         schemaType={schema}
       >
         <PortableTextEditable
+          onPaste={(data) => {
+            const text = data.event.clipboardData.getData('text')
+            if (text === 'heading') {
+              return wait(2000).then(() => ({
+                insert: [
+                  {
+                    _type: 'block',
+                    children: [{_type: 'span', text: 'heading'}],
+                    style: 'h1',
+                  },
+                ],
+              }))
+            }
+          }}
           renderAnnotation={renderAnnotation}
           renderBlock={renderBlock}
           renderChild={renderChild}

--- a/apps/playground/src/wait.ts
+++ b/apps/playground/src/wait.ts
@@ -1,0 +1,5 @@
+export function wait(delay: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay)
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:^
         version: link:../../packages/editor
+      '@portabletext/patches':
+        specifier: workspace:^
+        version: link:../../packages/patches
       '@sanity/ui':
         specifier: ^2.4.0
         version: 2.4.0(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11)
@@ -45,6 +48,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@sanity/types':
+        specifier: ^3.47.0
+        version: 3.47.0(debug@3.2.7)
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3


### PR DESCRIPTION
Before this change, the paste operation would always be wrapped in a Promise
even when the `onPaste` handler didn't return anything. The
`if (result && result.insert) {` condition would then check if the result of
the paste handler was meaningful and if not we would default to pasting
normally, reading from the `clipboardData`. However, at this point the
`clipboardData` might already be empty. In fact, this is the case in Firefox
even for immediately resolved Promises, causing paste to not work at all if
your `onPaste` handler returned `undefined`. Now, we only wrap the paste
operation in a promise if the `onPaste` handler returns something.