### PR TITLE
fix: reset selection on blur

### DIFF
--- a/packages/editor/src/editor/components/Synchronizer.tsx
+++ b/packages/editor/src/editor/components/Synchronizer.tsx
@@ -124,6 +124,16 @@ export function Synchronizer(props: SynchronizerProps) {
           })
           onChange(next) // Keep this out of the startTransition!
           break
+        case 'blur':
+          // Set the selection state in a transition, we don't need the state immediately.
+          startTransition(() => {
+            if (debugVerbose) {
+              debug('Resetting selection')
+            }
+            setSelection(null)
+          })
+          onChange(next)
+          break
         default:
           onChange(next)
       }


### PR DESCRIPTION
https://github.com/portabletext/editor/assets/4602382/94caf8aa-5d86-4398-9d14-910a402eb543

Make a selection:
![Screenshot 2024-06-26 at 15 34 46](https://github.com/portabletext/editor/assets/4602382/5c7ace98-8314-482e-bd6a-1a7da87d20cd)

And then blur the editor:
![Screenshot 2024-06-26 at 15 34 19](https://github.com/portabletext/editor/assets/4602382/c3437f3c-9daa-4297-a0b1-e453037300c5)

Before this change, the selection would be persisted after blurring the editor. This would make the toolbar still function:
![Screenshot 2024-06-26 at 15 34 48](https://github.com/portabletext/editor/assets/4602382/0c6dbcac-7466-4c18-9c66-ad7a16cae1d5)

The problem is (unsurprisingly) also present in the Studio (notice the selected "B" in the blurred editor):
![Screenshot 2024-06-26 at 15 37 23](https://github.com/portabletext/editor/assets/4602382/f80144e4-0b77-4e67-a4e6-429b014cc92a)
