### PR TITLE
chore(playground): make patches work

### DIFF
--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -35,6 +35,12 @@ export function Editor(props: {editorRef: EditorActorRef}) {
       }>(),
     [],
   )
+  props.editorRef.on('patches', (event) => {
+    patches$.next({
+      patches: event.patches,
+      snapshot: event.snapshot,
+    })
+  })
   const [loading, setLoading] = useState(false)
 
   return (


### PR DESCRIPTION
Before this change, the editor machine didn't do anything with incoming patches. Now, the machine emits the patches and in turn, the `Editor` component listens to that event and passes the patches into the `patches$` observable.

Patch `origin` is now also properly overwritten by moving the overwrite under the spread.