### PR TITLE
fix(editor): allow returning Promise(undefined) in paste handler

### DIFF
--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -404,7 +404,10 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         Promise.resolve(onPasteResult)
           .then((result) => {
             debug('Custom paste function from client resolved', result)
-            if (result && result.insert) {
+            if (!result || !result.insert) {
+              debug('No result from custom paste handler, pasting normally')
+              slateEditor.insertData(event.clipboardData)
+            } else if (result.insert) {
               slateEditor.insertFragment(
                 toSlateValue(result.insert as PortableTextBlock[], {schemaTypes}),
               )

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -394,7 +394,12 @@ export interface PasteData {
   value: PortableTextBlock[] | undefined
 }
 
-/** @beta */
+/**
+ * @beta
+ * It is encouraged not to return `Promise<undefined>` from the `OnPasteFn` as
+ * a mechanism to fall back to the native paste behaviour. This doesn't work in
+ * all cases. Always return plain `undefined` if possible.
+ **/
 export type OnPasteFn = (data: PasteData) => OnPasteResultOrPromise
 
 /** @beta */


### PR DESCRIPTION
Before this change, nothing would happen if you returned `undefined` wrapped in a `Promise` from the paste handler. Now, we treat this as a signal to fall back and paste normally by passing `event.clipboardData` to the internal `.insertData(...)` method. This resembles how the paste handler control flow functioned before https://github.com/portabletext/editor/pull/28. However, returning `Promise(undefined)` is not encouraged since it doesn't do what you expect in Firefox. In Firefox, the `clipboardData` isn't available anymore after the Promise microtask.