### PR TITLE
fix(editor): prevent deleting non-empty text block on DELETE

### DIFF
--- a/packages/editor/src/editor/plugins/createWithHotKeys.ts
+++ b/packages/editor/src/editor/plugins/createWithHotKeys.ts
@@ -195,12 +195,16 @@ export function createWithHotkeys(
         ) as SlateTextBlock | VoidElement
         const focusBlockPath = editor.selection.focus.path.slice(0, 1)
         const focusBlock = Node.descendant(editor, focusBlockPath) as SlateTextBlock | VoidElement
+        const isTextBlock = isPortableTextTextBlock(focusBlock)
+        const isEmptyFocusBlock =
+          isTextBlock && focusBlock.children.length === 1 && focusBlock.children?.[0]?.text === ''
 
         if (
           nextBlock &&
           focusBlock &&
           !Editor.isVoid(editor, focusBlock) &&
-          Editor.isVoid(editor, nextBlock)
+          Editor.isVoid(editor, nextBlock) &&
+          isEmptyFocusBlock
         ) {
           debug('Preventing deleting void block below')
           event.preventDefault()


### PR DESCRIPTION
Before this change, pressing DELETE in the beginning of a text block, before a custom block (void element), would delete the entire text block and select the custom block. Now, this behaviour is only triggered if the focused text block is empty.