### PR TITLE
fix(editor): insertBlock now properly replaces empty text blocks

### DIFF
--- a/packages/editor/.eslintrc.cjs
+++ b/packages/editor/.eslintrc.cjs
@@ -110,6 +110,7 @@ const config = {
     'sort-imports': 'off', // handled by simple-import-sort
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
+    'max-nested-callbacks': 'off',
     'no-undef': 'off',
     'no-dupe-class-members': 'off', // doesn't work with TS overrides
     'no-shadow': 'off',

--- a/packages/editor/src/editor/__tests__/insert-block.test.tsx
+++ b/packages/editor/src/editor/__tests__/insert-block.test.tsx
@@ -1,0 +1,98 @@
+import {describe, expect, jest, test} from '@jest/globals'
+import {Schema} from '@sanity/schema'
+import {type PortableTextBlock} from '@sanity/types'
+import {render, waitFor} from '@testing-library/react'
+import {createRef, type RefObject} from 'react'
+
+import {type EditorChange, type EditorSelection} from '../../types/editor'
+import {PortableTextEditable} from '../Editable'
+import {PortableTextEditor} from '../PortableTextEditor'
+
+const schema = Schema.compile({
+  types: [
+    {name: 'portable-text', type: 'array', of: [{type: 'block'}, {type: 'image'}]},
+    {name: 'image', type: 'object'},
+  ],
+}).get('portable-text')
+
+describe(PortableTextEditor.insertBlock.name, () => {
+  test('Scenario: Replacing an empty text block with a custom block', async () => {
+    const editorRef: RefObject<PortableTextEditor> = createRef()
+    const emptyTextBlock: PortableTextBlock = {
+      _key: 'ba',
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          _key: 'sa',
+          text: '',
+          marks: [],
+        },
+      ],
+      style: 'normal',
+    }
+    const imageBlock: PortableTextBlock = {
+      _key: 'bb',
+      _type: 'image',
+    }
+    const initialValue: Array<PortableTextBlock> = [emptyTextBlock, imageBlock]
+    const onChange: (change: EditorChange) => void = jest.fn()
+
+    render(
+      <PortableTextEditor
+        ref={editorRef}
+        schemaType={schema}
+        value={initialValue}
+        keyGenerator={() => 'bc'}
+        onChange={onChange}
+      >
+        <PortableTextEditable />
+      </PortableTextEditor>,
+    )
+
+    // Given an empty text block followed by an image
+    await waitFor(() => {
+      if (editorRef.current) {
+        expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
+        expect(onChange).toHaveBeenCalledWith({type: 'ready'})
+      }
+    })
+
+    // And a selection in the empty text block
+    const initialSelection: EditorSelection = {
+      anchor: {path: [{_key: 'ba'}, 'children', {_key: 'sa'}], offset: 0},
+      focus: {path: [{_key: 'ba'}, 'children', {_key: 'sa'}], offset: 0},
+      backward: false,
+    }
+    await waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.select(editorRef.current, initialSelection)
+      }
+    })
+    await waitFor(() => {
+      if (editorRef.current) {
+        expect(onChange).toHaveBeenCalledWith({type: 'selection', selection: initialSelection})
+      }
+    })
+
+    // When a new image is inserted
+    await waitFor(() => {
+      if (editorRef.current) {
+        const imageBlockType = editorRef.current.schemaTypes.blockObjects.find(
+          (object) => object.name === 'image',
+        )!
+        PortableTextEditor.insertBlock(editorRef.current, imageBlockType)
+      }
+    })
+
+    // Then the empty text block is replaced with the new image
+    await waitFor(() => {
+      if (editorRef.current) {
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {_key: 'bc', _type: 'image'},
+          {_key: 'bb', _type: 'image'},
+        ])
+      }
+    })
+  })
+})

--- a/packages/editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/editor/src/editor/plugins/createWithEditableAPI.ts
@@ -173,22 +173,22 @@ export function createWithEditableAPI(
           ],
           portableTextEditor,
         )[0] as unknown as Node
-        const [focusBlock] = Array.from(
+
+        const focusBlock = Array.from(
           Editor.nodes(editor, {
             at: editor.selection.focus.path.slice(0, 1),
             match: (n) => n._type === types.block.name,
           }),
-        )[0] || [undefined]
-
-        const isEmptyTextBlock = focusBlock && isEqualToEmptyEditor([focusBlock], types)
-
-        if (isEmptyTextBlock) {
-          // If the text block is empty, remove it before inserting the new block.
-          Transforms.removeNodes(editor, {at: editor.selection})
-        }
+        )[0]
 
         Editor.insertNode(editor, block)
+
+        if (focusBlock && isEqualToEmptyEditor([focusBlock[0]], types)) {
+          Transforms.removeNodes(editor, {at: focusBlock[1]})
+        }
+
         editor.onChange()
+
         return (
           toPortableTextRange(
             fromSlateValue(editor.children, types.block.name, KEY_TO_VALUE_ELEMENT.get(editor)),


### PR DESCRIPTION
Before this change, the insert position of the new block would be off-by-one, so if you had an editor containing

```
[empty text block]
[custom block]
```

then the new block would end up after the existing custom block:

```
[custom block]
[new custom block]
```