### PR TITLE
fix(editor): allow undoing part-deletion of annotated text

### DIFF
--- a/packages/editor/e2e-tests/__tests__/annotations.test.ts
+++ b/packages/editor/e2e-tests/__tests__/annotations.test.ts
@@ -48,6 +48,50 @@ describe('Feature: Annotations', () => {
     expect(span?.marks).toEqual([commentKey])
   })
 
+  it('Scenario: Redoing the deletion of the last char of annotated text', async () => {
+    const [editorA] = await getEditors()
+
+    // Given the text "foo"
+    await editorA.insertText('foo')
+
+    // And a "comment" around the text
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 0},
+      focus: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 3},
+    })
+    await editorA.toggleMark('m')
+    const value = await editorA.getValue()
+    const block = value && isPortableTextBlock(value[0]) ? value[0] : undefined
+    const commentKey = block?.markDefs?.[0]?._key
+    const spanKey = block?.children[0]?._key
+
+    // When "Backspace" is pressed once
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 3},
+      focus: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 3},
+    })
+    await editorA.pressKey('Backspace')
+
+    // And "undo" is performed
+    await editorA.undo()
+
+    // When "redo" is performed
+    await editorA.redo()
+
+    const valueAfterRedo = await editorA.getValue()
+    const blockAfterRedo =
+      valueAfterRedo && isPortableTextBlock(valueAfterRedo[0]) ? valueAfterRedo[0] : undefined
+
+    // Then the text is "foo"
+    expect(blockAfterRedo?.children[0]?.text).toBe('fo')
+
+    // And the text is marked with a "comment"
+    expect(blockAfterRedo?.children[0]?.marks).toEqual([commentKey])
+
+    // And the key is unchanged
+    expect(blockAfterRedo?.children[0]?._key).toBe(spanKey)
+  })
+
   it('Scenario: Undoing inserting text after annotated text', async () => {
     const [editorA] = await getEditors()
 

--- a/packages/editor/src/utils/withPreserveKeys.ts
+++ b/packages/editor/src/utils/withPreserveKeys.ts
@@ -9,6 +9,13 @@ export function withPreserveKeys(editor: Editor, fn: () => void): void {
   PRESERVE_KEYS.set(editor, prev)
 }
 
+export function withoutPreserveKeys(editor: Editor, fn: () => void): void {
+  const prev = isPreservingKeys(editor)
+  PRESERVE_KEYS.set(editor, false)
+  fn()
+  PRESERVE_KEYS.set(editor, prev)
+}
+
 export function isPreservingKeys(editor: Editor): boolean | undefined {
   return PRESERVE_KEYS.get(editor)
 }


### PR DESCRIPTION
Before this change, the editor would crash if you tried to undo deleting part
of an annotated text (from behind). This is because undoing the `remove_text`
operation results in an `insert_text` operation. And we have special logic in
place to make sure that `insert_text` right after annotated text results in a
new node without annotations. This not only results in an invalid state (we
didn't want to the node to be split), but it also results in a subsequent crash
when the selection stored on the undo stack would try to select inside the
unsplit node.