### PR TITLE
fix(editor): fix merge spans normalisation logic

### DIFF
--- a/packages/editor/e2e-tests/__tests__/annotations.test.ts
+++ b/packages/editor/e2e-tests/__tests__/annotations.test.ts
@@ -454,4 +454,39 @@ describe('Feature: Annotations', () => {
       ],
     })
   })
+
+  it('Scenario: Deleting emphasised paragraph with comment in the middle', async () => {
+    const [editorA] = await getEditors()
+
+    // Given the text "foo bar baz"
+    await editorA.insertText('foo bar baz')
+
+    // And "em" around "foo bar baz"
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 0},
+      focus: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 11},
+    })
+    await editorA.toggleMark('i')
+
+    // And a "comment" around "bar"
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 4},
+      focus: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 7},
+    })
+    await editorA.toggleMark('m')
+
+    const valueAfterMark = await editorA.getValue()
+    const blockAfterMark =
+      valueAfterMark && isPortableTextBlock(valueAfterMark[0]) ? valueAfterMark[0] : undefined
+
+    await editorA.setSelection({
+      anchor: {path: [{_key: 'A-4'}, 'children', {_key: 'A-3'}], offset: 0},
+      focus: {
+        path: [{_key: 'A-4'}, 'children', {_key: blockAfterMark!.children[2]._key}],
+        offset: 4,
+      },
+    })
+
+    await editorA.pressKey('Backspace')
+  })
 })


### PR DESCRIPTION
There were a couple of problems with the code before this change:

1. Merge spans normalisation would only be run on spans and as a result of
  specific operations.
2. Merge spans normalisation could run on spans that were already removed.

Now, the normalisation logic is structured as normalisation logic would
normally be structured. It's the parent block that takes care of merging spans
and the normalisation is run whenever the editor deems that it's time to run
normalisation. This makes sure that all spans in the editor at all times are
normalised, not just those that were touched by a specific operation. This
takes care of both problem (1) and (2). We now also don't run
`editor.onChange()` after custom normalisation anymore. Instead, we `return` to
trigger a new normalisation pass.