### PR TITLE
feat(editor): support annotations across blocks, annotations and decorators

### DIFF
--- a/packages/editor/e2e-tests/__tests__/annotations-across-blocks.feature
+++ b/packages/editor/e2e-tests/__tests__/annotations-across-blocks.feature
@@ -4,54 +4,46 @@ Feature: Annotations Across Blocks
     Given two editors
     And a global keymap
 
-  # Warning: Possible wrong behaviour
-  # "foo" should also be marked with a link
   Scenario: Adding annotation across blocks
     Given an empty editor
     When "foo" is typed
     And "Enter" is pressed
     And "bar" is typed
     And "foobar" is selected
-    And "link" "l1" is toggled
-    Then "foo" has no marks
-    And "bar" has marks "l1"
+    And "link" "l1,l2" is toggled
+    Then "foo" has marks "l1"
+    And "bar" has marks "l2"
 
-  # Warning: Possible wrong behaviour
-  # "bar" should also be marked with a link
   Scenario: Adding annotation across blocks (backwards selection)
     Given an empty editor
     When "foo" is typed
     And "Enter" is pressed
     And "bar" is typed
     And "foobar" is selected backwards
-    And "link" "l1" is toggled
+    And "link" "l1,l2" is toggled
     Then "foo" has marks "l1"
-    And "bar" has no marks
+    And "bar" has marks "l2"
 
-  # Warning: Possible wrong behaviour
-  # "foo" should also be marked with a link
   Scenario: Adding annotation across an image
     Given the text "foo"
     And an "image"
     When "Enter" is pressed
     And "bar" is typed
     And "foobar" is selected
-    And "link" "l1" is toggled
-    Then "foo" has no marks
-    And "bar" has marks "l1"
+    And "link" "l1,l2" is toggled
+    Then "foo" has marks "l1"
+    And "bar" has marks "l2"
     And "foo,\n,image,\n,bar" is selected
 
-  # Warning: Possible wrong behaviour
-  # "bar" should also be marked with a link
   Scenario: Adding annotation across an image (backwards selection)
     Given the text "foo"
     And an "image"
     When "Enter" is pressed
     And "bar" is typed
     And "foobar" is selected backwards
-    And "link" "l1" is toggled
+    And "link" "l1,l2" is toggled
     Then "foo" has marks "l1"
-    And "bar" has no marks
+    And "bar" has marks "l2"
     And "foo,\n,image,\n,bar" is selected
 
   # Warning: Possible wrong behaviour

--- a/packages/editor/e2e-tests/__tests__/annotations-overlapping-decorators.feature
+++ b/packages/editor/e2e-tests/__tests__/annotations-overlapping-decorators.feature
@@ -22,19 +22,6 @@ Feature: Annotations Overlapping Decorators
     And "bar" has marks "l1,strong"
     And " baz" has marks "l1"
 
-  # Warning: Inconsistent behaviour
-  # "bar" should be marked with "strong,l1"
-  Scenario: Adding an annotation across a decorator
-    Given the text "foo bar baz"
-    And "strong" around "bar"
-    When "foo bar baz" is selected
-    And "link" "l1" is toggled
-    Then the text is "foo bar baz"
-    And "foo bar baz" has marks "l1"
-
-  # Mimics Google Docs' behaviour
-  # Mimics Notion's behaviour
-  @skip
   Scenario: Adding an annotation across a decorator
     Given the text "foo bar baz"
     And "strong" around "bar"
@@ -45,54 +32,42 @@ Feature: Annotations Overlapping Decorators
     And "bar" has marks "strong,l1"
     And " baz" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "foo" should be marked with l1
-  # "b" should be marked with strong,l1
-  # "ar" should be marked with strong
   Scenario: Annotation overlapping decorator
     Given the text "foobar"
     And "strong" around "bar"
     When "foob" is selected
     And "link" "l1" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "strong,l1"
+    Then the text is "foo,b,ar"
+    And "foo" has marks "l1"
+    And "b" has marks "strong,l1"
     And "ar" has marks "strong"
 
-  # Warning: Possible wrong behaviour
-  # "foo" should be marked with l1
-  # "b" should be marked with strong,l1
-  # "ar" should be marked with strong
   Scenario: Annotation overlapping decorator (backwards selection)
     Given the text "foobar"
     And "strong" around "bar"
     When "foob" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "l1"
+    Then the text is "foo,b,ar"
+    And "foo" has marks "l1"
+    And "b" has marks "strong,l1"
     And "ar" has marks "strong"
 
-  # Warning: Possible wrong behaviour
-  # "fo" should be marked with strong
-  # "o" should be marked with "strong,l1"
-  # "bar" should be marked with l1
   Scenario: Annotation overlapping decorator from behind
     Given the text "foobar"
     And "strong" around "foo"
     When "obar" is selected
     And "link" "l1" is toggled
-    Then the text is "fo,obar"
+    Then the text is "fo,o,bar"
     Then "fo" has marks "strong"
-    And "obar" has marks "l1"
+    And "o" has marks "strong,l1"
+    And "bar" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "fo" should be marked with strong
-  # "o" should be marked with "strong,l1"
-  # "bar" should be marked with l1
   Scenario: Annotation overlapping decorator from behind (backwards selection)
     Given the text "foobar"
     And "strong" around "foo"
     When "obar" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "fo,obar"
+    Then the text is "fo,o,bar"
     Then "fo" has marks "strong"
-    And "obar" has marks "strong,l1"
+    And "o" has marks "strong,l1"
+    And "bar" has marks "l1"

--- a/packages/editor/e2e-tests/__tests__/annotations-overlapping.feature
+++ b/packages/editor/e2e-tests/__tests__/annotations-overlapping.feature
@@ -4,68 +4,53 @@ Feature: Overlapping Annotations
     Given two editors
     And a global keymap
 
-  # Warning: Possible wrong behaviour
-  # "foo" should be marked with c1
-  # "b" should be marked with c1,l1
-  # "ar" should be marked with l1
   Scenario: Overlapping annotation
     Given the text "foobar"
     And a "link" "l1" around "bar"
     When "foob" is selected
     And "comment" "c1" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "l1,c1"
+    Then the text is "foo,b,ar"
+    And "foo" has marks "c1"
+    And "b" has marks "l1,c1"
     And "ar" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "foo" should be marked with c1
-  # "b" should be marked with c1,l1
-  # "ar" should be marked with l1
   Scenario: Overlapping annotation (backwards selection)
     Given the text "foobar"
     And a "link" "l1" around "bar"
     When "foob" is selected backwards
     And "comment" "c1" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "c1"
+    Then the text is "foo,b,ar"
+    And "foo" has marks "c1"
+    And "b" has marks "l1,c1"
     And "ar" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "fo" should be marked with c1
-  # "o" should be marked with "c1,l1"
-  # "bar" should be marked with l1
   Scenario: Overlapping annotation from behind
     Given the text "foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected
     And "link" "l1" is toggled
-    Then the text is "fo,obar"
+    Then the text is "fo,o,bar"
     Then "fo" has marks "c1"
-    And "obar" has marks "l1"
+    And "o" has marks "c1,l1"
+    And "bar" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "fo" should be marked with c1
-  # "o" should be marked with "c1,l1"
-  # "bar" should be marked with l1
   Scenario: Overlapping annotation from behind (backwards selection)
     Given the text "foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "fo,obar"
+    Then the text is "fo,o,bar"
     Then "fo" has marks "c1"
-    And "obar" has marks "c1,l1"
+    And "o" has marks "c1,l1"
+    And "bar" has marks "l1"
 
-  # Warning: Possible wrong behaviour
-  # "foob" should be marked with c2
-  # "ar" should be marked with c1
   Scenario: Overlapping same-type annotation
     Given the text "foobar"
     And a "comment" "c1" around "bar"
     When "foob" is selected
     And "comment" "c2" is toggled
     Then the text is "foob,ar"
-    And "foob" has marks "c1,c2"
+    And "foob" has marks "c2"
     And "ar" has marks "c1"
 
   Scenario: Overlapping same-type annotation (backwards selection)
@@ -86,9 +71,6 @@ Feature: Overlapping Annotations
     And "fo" has marks "c1"
     And "obar" has marks "c2"
 
-  # Warning: Possible wrong behaviour
-  # "fo" should be marked with c1
-  # "obar" should be marked with c2
   Scenario: Overlapping same-type annotation from behind (backwards selection)
     Given the text "foobar"
     And a "comment" "c1" around "foo"
@@ -96,4 +78,4 @@ Feature: Overlapping Annotations
     And "comment" "c2" is toggled
     Then the text is "fo,obar"
     And "fo" has marks "c1"
-    And "obar" has marks "c1,c2"
+    And "obar" has marks "c2"

--- a/packages/editor/src/editor/PortableTextEditor.tsx
+++ b/packages/editor/src/editor/PortableTextEditor.tsx
@@ -210,8 +210,22 @@ export class PortableTextEditor extends Component<PortableTextEditorProps> {
     editor: PortableTextEditor,
     type: ObjectSchemaType,
     value?: {[prop: string]: unknown},
-  ): {spanPath: Path; markDefPath: Path} | undefined =>
-    editor.editable?.addAnnotation(type, value)
+  ):
+    | {
+        /**
+         * @deprecated An annotation may be applied to multiple blocks, resulting
+         * in multiple `markDef`'s being created. Use `markDefPaths` instead.
+         */
+        markDefPath: Path
+        markDefPaths: Array<Path>
+        /**
+         * @deprecated Does not return anything meaningful since an annotation
+         * can span multiple blocks and spans. If references the span closest
+         * to the focus point of the selection.
+         */
+        spanPath: Path
+      }
+    | undefined => editor.editable?.addAnnotation(type, value)
   static blur = (editor: PortableTextEditor): void => {
     debug('Host blurred')
     editor.editable?.blur()

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -47,7 +47,9 @@ export interface EditableAPI {
   addAnnotation: (
     type: ObjectSchemaType,
     value?: {[prop: string]: unknown},
-  ) => {spanPath: Path; markDefPath: Path} | undefined
+  ) =>
+    | {markDefPath: Path; markDefPaths: Array<Path>; spanPath: Path}
+    | undefined
   blur: () => void
   delete: (
     selection: EditorSelection,


### PR DESCRIPTION
Before this change, adding an annotation to a cross-block selection would only
apply it to the focus block (the block which the focus point of the selection
points to). Additionally, when adding the annotation to the selected spans of
said block, all existing decorators and annotations would be removed in the
process.

Now, annotations can be added across blocks and on top of existing decorators
and annotations.

It's worth noting that:

- Adding an annotation across blocks essentially creates copies of the
  annotation. Each `markDef` is given its own unique key.
- Adding an annotation across another annotation of the same type will remove
  the part of the existing annotation which is selected. (Two links on the same
  text doesn't make sense, similar to how you can't double-bold a piece of
  text).