### PR TITLE
test(editor): remove accidentally hardcoded URI

### DIFF
--- a/packages/editor/e2e-tests/__tests__/gherkin-driver.ts
+++ b/packages/editor/e2e-tests/__tests__/gherkin-driver.ts
@@ -93,7 +93,7 @@ export function Feature<TContext extends Record<string, any> = object>({
   const gherkinDocument = parser.parse(featureText)
   const pickles = Gherkin.compile(
     gherkinDocument,
-    'block-objects.feature',
+    (gherkinDocument.feature?.name ?? '').replace(' ', '-'),
     uuidFn,
   )
 


### PR DESCRIPTION
I don't think this URI is important, but it still looks bad to hardcode it.