### PR TITLE
fix(editor): defer patch/mutation changes until the editor is dirty

### DIFF
--- a/packages/editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -81,10 +81,12 @@ export function createWithPortableTextMarkModel(
               JSON.stringify(child, null, 2),
               JSON.stringify(nextNode, null, 2),
             )
+            editorActor.send({type: 'normalizing'})
             Transforms.mergeNodes(editor, {
               at: [childPath[0], childPath[1] + 1],
               voids: true,
             })
+            editorActor.send({type: 'done normalizing'})
             return
           }
         }
@@ -95,7 +97,9 @@ export function createWithPortableTextMarkModel(
        */
       if (editor.isTextBlock(node) && !Array.isArray(node.markDefs)) {
         debug('Adding .markDefs to block node')
+        editorActor.send({type: 'normalizing'})
         Transforms.setNodes(editor, {markDefs: []}, {at: path})
+        editorActor.send({type: 'done normalizing'})
         return
       }
 
@@ -104,7 +108,9 @@ export function createWithPortableTextMarkModel(
        */
       if (editor.isTextSpan(node) && !Array.isArray(node.marks)) {
         debug('Adding .marks to span node')
+        editorActor.send({type: 'normalizing'})
         Transforms.setNodes(editor, {marks: []}, {at: path})
+        editorActor.send({type: 'done normalizing'})
         return
       }
 
@@ -122,11 +128,13 @@ export function createWithPortableTextMarkModel(
         if (editor.isTextBlock(block)) {
           if (node.text === '' && annotations && annotations.length > 0) {
             debug('Removing annotations from empty span node')
+            editorActor.send({type: 'normalizing'})
             Transforms.setNodes(
               editor,
               {marks: node.marks?.filter((mark) => decorators.includes(mark))},
               {at: path},
             )
+            editorActor.send({type: 'done normalizing'})
             return
           }
         }
@@ -150,6 +158,7 @@ export function createWithPortableTextMarkModel(
 
             if (orphanedAnnotations.length > 0) {
               debug('Removing orphaned annotations from span node')
+              editorActor.send({type: 'normalizing'})
               Transforms.setNodes(
                 editor,
                 {
@@ -159,6 +168,7 @@ export function createWithPortableTextMarkModel(
                 },
                 {at: childPath},
               )
+              editorActor.send({type: 'done normalizing'})
               return
             }
           }
@@ -186,6 +196,7 @@ export function createWithPortableTextMarkModel(
 
           if (orphanedAnnotations.length > 0) {
             debug('Removing orphaned annotations from span node')
+            editorActor.send({type: 'normalizing'})
             Transforms.setNodes(
               editor,
               {
@@ -195,6 +206,7 @@ export function createWithPortableTextMarkModel(
               },
               {at: path},
             )
+            editorActor.send({type: 'done normalizing'})
             return
           }
         }
@@ -215,7 +227,9 @@ export function createWithPortableTextMarkModel(
 
         if (markDefs.length !== newMarkDefs.length) {
           debug('Removing duplicate markDefs')
+          editorActor.send({type: 'normalizing'})
           Transforms.setNodes(editor, {markDefs: newMarkDefs}, {at: path})
+          editorActor.send({type: 'done normalizing'})
           return
         }
       }
@@ -241,6 +255,7 @@ export function createWithPortableTextMarkModel(
         })
         if (node.markDefs && !isEqual(newMarkDefs, node.markDefs)) {
           debug('Removing markDef not in use')
+          editorActor.send({type: 'normalizing'})
           Transforms.setNodes(
             editor,
             {
@@ -248,6 +263,7 @@ export function createWithPortableTextMarkModel(
             },
             {at: path},
           )
+          editorActor.send({type: 'done normalizing'})
           return
         }
       }

--- a/packages/editor/src/editor/plugins/index.ts
+++ b/packages/editor/src/editor/plugins/index.ts
@@ -63,8 +63,16 @@ export const withPlugins = <T extends Editor>(
     })
   }
   const operationToPatches = createOperationToPatches(schemaTypes)
-  const withObjectKeys = createWithObjectKeys(schemaTypes, keyGenerator)
-  const withSchemaTypes = createWithSchemaTypes({schemaTypes, keyGenerator})
+  const withObjectKeys = createWithObjectKeys(
+    editorActor,
+    schemaTypes,
+    keyGenerator,
+  )
+  const withSchemaTypes = createWithSchemaTypes({
+    editorActor,
+    schemaTypes,
+    keyGenerator,
+  })
   const withEditableAPI = createWithEditableAPI(
     portableTextEditor,
     schemaTypes,
@@ -90,8 +98,10 @@ export const withPlugins = <T extends Editor>(
     schemaTypes,
     keyGenerator,
   )
-  const withPortableTextBlockStyle =
-    createWithPortableTextBlockStyle(schemaTypes)
+  const withPortableTextBlockStyle = createWithPortableTextBlockStyle(
+    editorActor,
+    schemaTypes,
+  )
 
   const withPlaceholderBlock = createWithPlaceholderBlock()
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,11 +1,16 @@
-export type {PortableTextEditableProps} from './editor/Editable'
+export {type Patch} from '@portabletext/patches'
 export {PortableTextEditable} from './editor/Editable'
+export type {PortableTextEditableProps} from './editor/Editable'
+export {
+  editorMachine,
+  type EditorActor,
+  type MutationEvent,
+  type PatchEvent,
+} from './editor/editor-machine'
 export {usePortableTextEditor} from './editor/hooks/usePortableTextEditor'
 export {defaultKeyGenerator as keyGenerator} from './editor/hooks/usePortableTextEditorKeyGenerator'
 export {usePortableTextEditorSelection} from './editor/hooks/usePortableTextEditorSelection'
-export type {PortableTextEditorProps} from './editor/PortableTextEditor'
 export {PortableTextEditor} from './editor/PortableTextEditor'
+export type {PortableTextEditorProps} from './editor/PortableTextEditor'
 export * from './types/editor'
 export * from './types/options'
-export {type Patch} from '@portabletext/patches'
-export {type EditorActor, editorMachine} from './editor/editor-machine'


### PR DESCRIPTION
Before this change, `patch` and `mutation` changes/events could be emitted from
the editor even if no edits had been made. This could happen happen if the
editor was instantiated with a value that didn't adhere to the format and
therefore got normalized as soon as it entered the editor (e.g. `.mardDefs`
added to blocks). To mitigate this, we now defer these events as long as they
happen as part of the initial normalization process. As soon as a single
`patch` (or `mutation`, but probably not) happens out side of the
`normalization` state, we assume the editor is dirty. From this point we
emit all pending events and immediately emit all other events going forward.