### PR TITLE
fix(editor): treat annotations as proper boundaries

### DIFF
--- a/packages/editor/e2e-tests/__tests__/annotations-overlapping-decorators.feature
+++ b/packages/editor/e2e-tests/__tests__/annotations-overlapping-decorators.feature
@@ -4,6 +4,61 @@ Feature: Annotations Overlapping Decorators
     Given one editor
     And a global keymap
 
+  Scenario Outline: Inserting text at the edge of a decorated annotation
+    Given the text <text>
+    And a "link" "l1" around <annotated>
+    And "strong" around <decorated>
+    When the caret is put <position>
+    And "new" is typed
+    Then the text is <new text>
+
+    Examples:
+      | text          | annotated     | decorated | position      | new text           |
+      | "foo bar baz" | "bar"         | "bar"     | after "foo "  | "foo new,bar, baz" |
+      | "foo bar baz" | "bar"         | "bar"     | before "bar"  | "foo new,bar, baz" |
+      | "foo bar baz" | "bar"         | "bar"     | after "bar"   | "foo ,bar,new baz" |
+      | "foo bar baz" | "bar"         | "bar"     | before " baz" | "foo ,bar,new baz" |
+      | "foo"         | "foo"         | "foo"     | before "foo"  | "new,foo"          |
+      | "foo"         | "foo"         | "foo"     | after "foo"   | "foo,new"          |
+      | "foo bar baz" | "foo bar baz" | "bar"     | after "foo "  | "foo new,bar, baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"     | before "bar"  | "foo new,bar, baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"     | after "bar"   | "foo ,bar,new baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"     | before " baz" | "foo ,bar,new baz" |
+
+  Scenario: Splitting block before a decorated annotation
+    Given the text "bar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the caret is put before "bar"
+    And "Enter" is pressed
+    And "ArrowUp" is pressed
+    And "foo" is typed
+    Then the text is "foo,\n,bar"
+    And the caret is after "foo"
+    And "foo" has no marks
+
+  Scenario: Splitting block after a decorated annotation
+    Given the text "bar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the caret is put after "bar"
+    And "Enter" is pressed
+    And "baz" is typed
+    Then the text is "bar,\n,baz"
+    And the caret is after "baz"
+    And "baz" has no marks
+
+  Scenario: Splitting block after a decorated annotation #2
+    Given the text "foobar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the caret is put after "bar"
+    And "Enter" is pressed
+    And "baz" is typed
+    Then the text is "foo,bar,\n,baz"
+    And the caret is after "baz"
+    And "baz" has no marks
+
   Scenario: Annotation and decorator on the same text
     Given the text "foo bar baz"
     When "bar" is selected

--- a/packages/editor/e2e-tests/__tests__/annotations-overlapping.feature
+++ b/packages/editor/e2e-tests/__tests__/annotations-overlapping.feature
@@ -4,6 +4,23 @@ Feature: Overlapping Annotations
     Given one editor
     And a global keymap
 
+  Scenario Outline: Inserting text at the edge of overlapping annotations
+    Given the text <text>
+    And a "link" "l1" around <link>
+    And a "comment" "c1" around <comment>
+    When the caret is put <position>
+    And "new" is typed
+    Then the text is <new text>
+
+    Examples:
+      | text          | link          | comment | position      | new text           |
+      | "foo bar baz" | "foo bar baz" | "bar"   | after "foo "  | "foo new,bar, baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"   | before "bar"  | "foo new,bar, baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"   | after "bar"   | "foo ,bar,new baz" |
+      | "foo bar baz" | "foo bar baz" | "bar"   | before " baz" | "foo ,bar,new baz" |
+      | "foo"         | "foo"         | "foo"   | before "foo"  | "new,foo"          |
+      | "foo"         | "foo"         | "foo"   | after "foo"   | "foo,new"          |
+
   Scenario: Overlapping annotation
     Given the text "foobar"
     And a "link" "l1" around "bar"

--- a/packages/editor/e2e-tests/__tests__/decorators.feature
+++ b/packages/editor/e2e-tests/__tests__/decorators.feature
@@ -5,14 +5,21 @@ Feature: Decorators
     Given one editor
     And a global keymap
 
-  Scenario: Inserting text after a decorator
-    Given the text "foo"
-    And "strong" around "foo"
-    Then "foo" has marks "strong"
-    When the caret is put after "foo"
-    And "bar" is typed
-    Then the text is "foobar"
-    Then "foobar" has marks "strong"
+  Scenario Outline: Inserting text at the edge of a decorator
+    Given the text <text>
+    And "strong" around <decorated>
+    When the caret is put <position>
+    And "new" is typed
+    Then the text is <new text>
+
+    Examples:
+      | text          | decorated | position      | new text           |
+      | "foo bar baz" | "bar"     | after "foo "  | "foo new,bar, baz" |
+      | "foo bar baz" | "bar"     | before "bar"  | "foo new,bar, baz" |
+      | "foo bar baz" | "bar"     | after "bar"   | "foo ,barnew, baz" |
+      | "foo bar baz" | "bar"     | before " baz" | "foo ,barnew, baz" |
+      | "foo"         | "foo"     | before "foo"  | "newfoo"           |
+      | "foo"         | "foo"     | after "foo"   | "foonew"           |
 
   Scenario: Toggling bold inside italic
     Given the text "foo bar baz"


### PR DESCRIPTION
This change covers even more scenarios related to inserting text before or
after an annotation. It is well known that text inserted after a link will not
be put inside that link. But this change takes this concept a bit further and
makes sure that any decorators inside the link won't leak either. This treats
the annotation as a proper boundary.

This change also fixes some inconsistencies related to inserting text
before/after overlapping annotations.