### PR TITLE
refactor(editor): refactor Behavior API

### DIFF
--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -550,14 +550,6 @@ export const PortableTextEditable = forwardRef<
       if (onBeforeInput) {
         onBeforeInput(event)
       }
-
-      if (!event.defaultPrevented && event.inputType === 'insertText') {
-        editorActor.send({
-          type: 'before insert text',
-          nativeEvent: event,
-          editor: slateEditor,
-        })
-      }
     },
     [onBeforeInput],
   )
@@ -646,11 +638,6 @@ export const PortableTextEditable = forwardRef<
         props.onKeyDown(event)
       }
       if (!event.isDefaultPrevented()) {
-        editorActor.send({
-          type: 'key down',
-          nativeEvent: event.nativeEvent,
-          editor: slateEditor,
-        })
         slateEditor.pteWithHotKeys(event)
       }
     },

--- a/packages/editor/src/editor/behavior/behavior.actions.ts
+++ b/packages/editor/src/editor/behavior/behavior.actions.ts
@@ -33,12 +33,29 @@ export const behaviorActionImplementations: BehaviourActionImplementations = {
       Transforms.setNodes(event.editor, {style: event.style}, {at})
     }
   },
+  'delete backward': ({event}) => {
+    // Since this calls the native Editor method it will trigger a new behavior
+    // event
+    Editor.deleteBackward(event.editor, {unit: event.unit})
+  },
   'delete text': ({event}) => {
     Transforms.delete(event.editor, {
       at: toSlateRange(event.selection, event.editor)!,
     })
   },
+  'insert break': ({event}) => {
+    // Since this calls the native Editor method it will trigger a new behavior
+    // event
+    Editor.insertBreak(event.editor)
+  },
+  'insert soft break': ({event}) => {
+    // Since this calls the native Editor method it will trigger a new behavior
+    // event
+    Editor.insertSoftBreak(event.editor)
+  },
   'insert text': ({event}) => {
+    // Since this calls the native Editor method it will trigger a new behavior
+    // event
     Editor.insertText(event.editor, event.text)
   },
   'insert text block': ({context, event}) => {

--- a/packages/editor/src/editor/behavior/behavior.core.ts
+++ b/packages/editor/src/editor/behavior/behavior.core.ts
@@ -1,37 +1,19 @@
-import {isHotkey} from 'is-hotkey-esm'
 import {defineBehavior} from './behavior.types'
 import {getFocusBlockObject} from './behavior.utils'
 
-const overwriteSoftReturn = defineBehavior({
-  on: 'key down',
-  guard: ({event}) => isHotkey('shift+enter', event.nativeEvent),
-  actions: [
-    ({event}) => {
-      event.nativeEvent.preventDefault()
-      return {type: 'insert text', text: '\n'}
-    },
-  ],
+const softReturn = defineBehavior({
+  on: 'insert soft break',
+  actions: [() => ({type: 'insert text', text: '\n'})],
 })
 
-const enterOnVoidBlock = defineBehavior({
-  on: 'key down',
-  guard: ({context, event}) => {
-    const isEnter = isHotkey('enter', event.nativeEvent)
-
-    if (!isEnter) {
-      return false
-    }
-
+const breakingVoidBlock = defineBehavior({
+  on: 'insert break',
+  guard: ({context}) => {
     const focusBlockObject = getFocusBlockObject(context)
 
     return !!focusBlockObject
   },
-  actions: [
-    ({event}) => {
-      event.nativeEvent.preventDefault()
-      return {type: 'insert text block', decorators: []}
-    },
-  ],
+  actions: [() => ({type: 'insert text block', decorators: []})],
 })
 
-export const coreBehaviors = [overwriteSoftReturn, enterOnVoidBlock]
+export const coreBehaviors = [softReturn, breakingVoidBlock]

--- a/packages/editor/src/editor/behavior/behavior.types.ts
+++ b/packages/editor/src/editor/behavior/behavior.types.ts
@@ -1,4 +1,5 @@
 import type {KeyedSegment, PortableTextBlock} from '@sanity/types'
+import type {TextUnit} from 'slate'
 import type {
   EditorSelection,
   PortableTextMemberSchemaTypes,
@@ -19,14 +20,22 @@ export type BehaviorContext = {
  */
 export type BehaviorEvent =
   | {
-      type: 'key down'
-      nativeEvent: KeyboardEvent
-      editor: PortableTextSlateEditor
+      type: 'delete backward'
+      unit: TextUnit
+      default: () => void
     }
   | {
-      type: 'before insert text'
-      nativeEvent: InputEvent
-      editor: PortableTextSlateEditor
+      type: 'insert soft break'
+      default: () => void
+    }
+  | {
+      type: 'insert break'
+      default: () => void
+    }
+  | {
+      type: 'insert text'
+      text: string
+      default: () => void
     }
 
 /**
@@ -48,9 +57,11 @@ export type BehaviorGuard<
  */
 export type BehaviorActionIntend =
   | {
-      type: 'insert text'
-      text: string
-    }
+      [TBehaviorEvent in BehaviorEvent as TBehaviorEvent['type']]: Omit<
+        TBehaviorEvent,
+        'default'
+      >
+    }[BehaviorEvent['type']]
   | {
       type: 'insert text block'
       decorators: Array<string>

--- a/packages/editor/src/editor/plugins/create-with-event-listeners.ts
+++ b/packages/editor/src/editor/plugins/create-with-event-listeners.ts
@@ -1,0 +1,60 @@
+import type {Editor} from 'slate'
+import type {EditorActor} from '../editor-machine'
+
+export function createWithEventListeners(editorActor: EditorActor) {
+  return function withEventListeners(editor: Editor) {
+    const {deleteBackward, insertBreak, insertSoftBreak, insertText} = editor
+
+    editor.deleteBackward = (unit) => {
+      editorActor.send({
+        type: 'behavior event',
+        behaviorEvent: {
+          type: 'delete backward',
+          unit,
+          default: () => deleteBackward(unit),
+        },
+        editor,
+      })
+      return
+    }
+
+    editor.insertBreak = () => {
+      editorActor.send({
+        type: 'behavior event',
+        behaviorEvent: {
+          type: 'insert break',
+          default: insertBreak,
+        },
+        editor,
+      })
+      return
+    }
+
+    editor.insertSoftBreak = () => {
+      editorActor.send({
+        type: 'behavior event',
+        behaviorEvent: {
+          type: 'insert soft break',
+          default: insertSoftBreak,
+        },
+        editor,
+      })
+      return
+    }
+
+    editor.insertText = (text, options) => {
+      editorActor.send({
+        type: 'behavior event',
+        behaviorEvent: {
+          type: 'insert text',
+          text,
+          default: () => insertText(text, options),
+        },
+        editor,
+      })
+      return
+    }
+
+    return editor
+  }
+}

--- a/packages/editor/src/editor/plugins/index.ts
+++ b/packages/editor/src/editor/plugins/index.ts
@@ -3,6 +3,7 @@ import type {BaseOperation, Editor, Node, NodeEntry} from 'slate'
 import type {PortableTextSlateEditor} from '../../types/editor'
 import type {createEditorOptions} from '../../types/options'
 import {createOperationToPatches} from '../../utils/operationToPatches'
+import {createWithEventListeners} from './create-with-event-listeners'
 import {createWithEditableAPI} from './createWithEditableAPI'
 import {createWithInsertBreak} from './createWithInsertBreak'
 import {createWithMaxBlocks} from './createWithMaxBlocks'
@@ -109,6 +110,7 @@ export const withPlugins = <T extends Editor>(
     editorActor,
     schemaTypes,
   )
+  const withEventListeners = createWithEventListeners(editorActor)
 
   e.destroy = () => {
     const originalFunctions = originalFnMap.get(e)
@@ -145,18 +147,20 @@ export const withPlugins = <T extends Editor>(
 
   // Ordering is important here, selection dealing last, data manipulation in the middle and core model stuff first.
   return {
-    editor: withSchemaTypes(
-      withObjectKeys(
-        withPortableTextMarkModel(
-          withPortableTextBlockStyle(
-            withPortableTextLists(
-              withPlaceholderBlock(
-                withUtils(
-                  withMaxBlocks(
-                    withUndoRedo(
-                      withPatches(
-                        withPortableTextSelections(
-                          withEditableAPI(withInsertBreak(e)),
+    editor: withEventListeners(
+      withSchemaTypes(
+        withObjectKeys(
+          withPortableTextMarkModel(
+            withPortableTextBlockStyle(
+              withPortableTextLists(
+                withPlaceholderBlock(
+                  withUtils(
+                    withMaxBlocks(
+                      withUndoRedo(
+                        withPatches(
+                          withPortableTextSelections(
+                            withEditableAPI(withInsertBreak(e)),
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
Instead of hooking into native events we now hook into bespoke "Slate events". This is not only provides a cleaner Behavior API. It's also more correct since you don't have to figure out yourself what native events might correspond to events like `insert break` and `delete backward`.