### PR TITLE
fix(editor): refactor internal Behavior API

### DIFF
--- a/packages/editor/src/editor/behavior/behavior.action.insert-break.ts
+++ b/packages/editor/src/editor/behavior/behavior.action.insert-break.ts
@@ -1,8 +1,8 @@
 import {isEqual} from 'lodash'
 import {Editor, Node, Path, Range, Transforms} from 'slate'
 import type {SlateTextBlock, VoidElement} from '../../types/slate'
-import type {BehaviourActionImplementation} from '../behavior/behavior.actions'
-import type {BehaviorAction, PickFromUnion} from '../behavior/behavior.types'
+import type {BehaviourActionImplementation} from './behavior.actions'
+import type {BehaviorAction, PickFromUnion} from './behavior.types'
 
 export const insertBreakActionImplementation: BehaviourActionImplementation<
   PickFromUnion<BehaviorAction, 'type', 'insert break' | 'insert soft break'>

--- a/packages/editor/src/editor/behavior/behavior.actions.ts
+++ b/packages/editor/src/editor/behavior/behavior.actions.ts
@@ -1,7 +1,7 @@
 import {deleteBackward, Editor, insertText, Transforms} from 'slate'
 import type {PortableTextMemberSchemaTypes} from '../../types/editor'
 import {toSlateRange} from '../../utils/ranges'
-import {insertBreakActionImplementation} from '../plugins/createWithInsertBreak'
+import {insertBreakActionImplementation} from './behavior.action.insert-break'
 import type {
   BehaviorAction,
   BehaviorEvent,

--- a/packages/editor/src/editor/behavior/behavior.core.ts
+++ b/packages/editor/src/editor/behavior/behavior.core.ts
@@ -3,7 +3,7 @@ import {getFocusBlockObject} from './behavior.utils'
 
 const softReturn = defineBehavior({
   on: 'insert soft break',
-  actions: [() => ({type: 'insert text', text: '\n'})],
+  actions: [() => [{type: 'insert text', text: '\n'}]],
 })
 
 const breakingVoidBlock = defineBehavior({
@@ -13,7 +13,7 @@ const breakingVoidBlock = defineBehavior({
 
     return !!focusBlockObject
   },
-  actions: [() => ({type: 'insert text block', decorators: []})],
+  actions: [() => [{type: 'insert text block', decorators: []}]],
 })
 
 export const coreBehaviors = [softReturn, breakingVoidBlock]

--- a/packages/editor/src/editor/plugins/create-with-event-listeners.ts
+++ b/packages/editor/src/editor/plugins/create-with-event-listeners.ts
@@ -3,15 +3,12 @@ import type {EditorActor} from '../editor-machine'
 
 export function createWithEventListeners(editorActor: EditorActor) {
   return function withEventListeners(editor: Editor) {
-    const {deleteBackward, insertBreak, insertSoftBreak, insertText} = editor
-
     editor.deleteBackward = (unit) => {
       editorActor.send({
         type: 'behavior event',
         behaviorEvent: {
           type: 'delete backward',
           unit,
-          default: () => deleteBackward(unit),
         },
         editor,
       })
@@ -23,7 +20,6 @@ export function createWithEventListeners(editorActor: EditorActor) {
         type: 'behavior event',
         behaviorEvent: {
           type: 'insert break',
-          default: insertBreak,
         },
         editor,
       })
@@ -35,7 +31,6 @@ export function createWithEventListeners(editorActor: EditorActor) {
         type: 'behavior event',
         behaviorEvent: {
           type: 'insert soft break',
-          default: insertSoftBreak,
         },
         editor,
       })
@@ -48,7 +43,7 @@ export function createWithEventListeners(editorActor: EditorActor) {
         behaviorEvent: {
           type: 'insert text',
           text,
-          default: () => insertText(text, options),
+          options,
         },
         editor,
       })

--- a/packages/editor/src/editor/plugins/createWithInsertBreak.ts
+++ b/packages/editor/src/editor/plugins/createWithInsertBreak.ts
@@ -1,224 +1,206 @@
 import {isEqual} from 'lodash'
 import {Editor, Node, Path, Range, Transforms} from 'slate'
-import type {
-  PortableTextMemberSchemaTypes,
-  PortableTextSlateEditor,
-} from '../../types/editor'
 import type {SlateTextBlock, VoidElement} from '../../types/slate'
-import type {EditorActor} from '../editor-machine'
+import type {BehaviourActionImplementation} from '../behavior/behavior.actions'
+import type {BehaviorAction, PickFromUnion} from '../behavior/behavior.types'
 
-export function createWithInsertBreak(
-  editorActor: EditorActor,
-  types: PortableTextMemberSchemaTypes,
-): (editor: PortableTextSlateEditor) => PortableTextSlateEditor {
-  return function withInsertBreak(
-    editor: PortableTextSlateEditor,
-  ): PortableTextSlateEditor {
-    const {insertBreak} = editor
+export const insertBreakActionImplementation: BehaviourActionImplementation<
+  PickFromUnion<BehaviorAction, 'type', 'insert break' | 'insert soft break'>
+> = ({context, action}) => {
+  const keyGenerator = context.keyGenerator
+  const schema = context.schema
+  const editor = action.editor
 
-    editor.insertBreak = () => {
-      if (!editor.selection) {
-        insertBreak()
-        return
-      }
+  if (!editor.selection) {
+    return
+  }
 
-      const [focusSpan] = Array.from(
-        Editor.nodes(editor, {
-          mode: 'lowest',
-          at: editor.selection.focus,
-          match: (n) => editor.isTextSpan(n),
-          voids: false,
+  const [focusSpan] = Array.from(
+    Editor.nodes(editor, {
+      mode: 'lowest',
+      at: editor.selection.focus,
+      match: (n) => editor.isTextSpan(n),
+      voids: false,
+    }),
+  )[0] ?? [undefined]
+  const focusDecorators =
+    focusSpan.marks?.filter((mark) =>
+      schema.decorators.some((decorator) => decorator.value === mark),
+    ) ?? []
+  const focusAnnotations =
+    focusSpan.marks?.filter(
+      (mark) =>
+        !schema.decorators.some((decorator) => decorator.value === mark),
+    ) ?? []
+
+  const focusBlockPath = editor.selection.focus.path.slice(0, 1)
+  const focusBlock = Node.descendant(editor, focusBlockPath) as
+    | SlateTextBlock
+    | VoidElement
+
+  if (editor.isTextBlock(focusBlock)) {
+    const [start, end] = Range.edges(editor.selection)
+    const atTheStartOfBlock = isEqual(end, {
+      path: [...focusBlockPath, 0],
+      offset: 0,
+    })
+
+    if (atTheStartOfBlock && Range.isCollapsed(editor.selection)) {
+      Editor.insertNode(
+        editor,
+        editor.pteCreateTextBlock({
+          decorators: focusAnnotations.length === 0 ? focusDecorators : [],
+          listItem: focusBlock.listItem,
+          level: focusBlock.level,
         }),
-      )[0] ?? [undefined]
-      const focusDecorators =
-        focusSpan.marks?.filter((mark) =>
-          types.decorators.some((decorator) => decorator.value === mark),
-        ) ?? []
-      const focusAnnotations =
-        focusSpan.marks?.filter(
-          (mark) =>
-            !types.decorators.some((decorator) => decorator.value === mark),
-        ) ?? []
+      )
 
-      const focusBlockPath = editor.selection.focus.path.slice(0, 1)
-      const focusBlock = Node.descendant(editor, focusBlockPath) as
-        | SlateTextBlock
-        | VoidElement
+      const [nextBlockPath] = Path.next(focusBlockPath)
 
-      if (editor.isTextBlock(focusBlock)) {
-        const [start, end] = Range.edges(editor.selection)
-        const atTheStartOfBlock = isEqual(end, {
-          path: [...focusBlockPath, 0],
-          offset: 0,
-        })
+      Transforms.select(editor, {
+        anchor: {path: [nextBlockPath, 0], offset: 0},
+        focus: {path: [nextBlockPath, 0], offset: 0},
+      })
 
-        if (atTheStartOfBlock && Range.isCollapsed(editor.selection)) {
-          Editor.insertNode(
-            editor,
-            editor.pteCreateTextBlock({
-              decorators: focusAnnotations.length === 0 ? focusDecorators : [],
-              listItem: focusBlock.listItem,
-              level: focusBlock.level,
-            }),
-          )
-
-          const [nextBlockPath] = Path.next(focusBlockPath)
-
-          Transforms.select(editor, {
-            anchor: {path: [nextBlockPath, 0], offset: 0},
-            focus: {path: [nextBlockPath, 0], offset: 0},
-          })
-
-          return
-        }
-
-        const lastFocusBlockChild =
-          focusBlock.children[focusBlock.children.length - 1]
-        const atTheEndOfBlock = isEqual(start, {
-          path: [...focusBlockPath, focusBlock.children.length - 1],
-          offset: editor.isTextSpan(lastFocusBlockChild)
-            ? lastFocusBlockChild.text.length
-            : 0,
-        })
-
-        if (atTheEndOfBlock && Range.isCollapsed(editor.selection)) {
-          Editor.insertNode(
-            editor,
-            editor.pteCreateTextBlock({
-              decorators: [],
-              listItem: focusBlock.listItem,
-              level: focusBlock.level,
-            }),
-          )
-
-          const [nextBlockPath] = Path.next(focusBlockPath)
-
-          Transforms.setSelection(editor, {
-            anchor: {path: [nextBlockPath, 0], offset: 0},
-            focus: {path: [nextBlockPath, 0], offset: 0},
-          })
-
-          return
-        }
-
-        const isInTheMiddleOfNode = !atTheStartOfBlock && !atTheEndOfBlock
-
-        if (isInTheMiddleOfNode) {
-          Editor.withoutNormalizing(editor, () => {
-            if (!editor.selection) {
-              return
-            }
-
-            Transforms.splitNodes(editor, {
-              at: editor.selection,
-            })
-
-            const [nextNode, nextNodePath] = Editor.node(
-              editor,
-              Path.next(focusBlockPath),
-              {depth: 1},
-            )
-
-            Transforms.setSelection(editor, {
-              anchor: {path: [...nextNodePath, 0], offset: 0},
-              focus: {path: [...nextNodePath, 0], offset: 0},
-            })
-
-            /**
-             * Assign new keys to markDefs that are now split across two blocks
-             */
-            if (
-              editor.isTextBlock(nextNode) &&
-              nextNode.markDefs &&
-              nextNode.markDefs.length > 0
-            ) {
-              const newMarkDefKeys = new Map<string, string>()
-
-              const prevNodeSpans = Array.from(
-                Node.children(editor, focusBlockPath),
-              )
-                .map((entry) => entry[0])
-                .filter((node) => editor.isTextSpan(node))
-              const children = Node.children(editor, nextNodePath)
-
-              for (const [child, childPath] of children) {
-                if (!editor.isTextSpan(child)) {
-                  continue
-                }
-
-                const marks = child.marks ?? []
-
-                // Go through the marks of the span and figure out if any of
-                // them refer to annotations that are also present in the
-                // previous block
-                for (const mark of marks) {
-                  if (
-                    types.decorators.some(
-                      (decorator) => decorator.value === mark,
-                    )
-                  ) {
-                    continue
-                  }
-
-                  if (
-                    prevNodeSpans.some((prevNodeSpan) =>
-                      prevNodeSpan.marks?.includes(mark),
-                    ) &&
-                    !newMarkDefKeys.has(mark)
-                  ) {
-                    // This annotation is both present in the previous block
-                    // and this block, so let's assign a new key to it
-                    newMarkDefKeys.set(
-                      mark,
-                      editorActor.getSnapshot().context.keyGenerator(),
-                    )
-                  }
-                }
-
-                const newMarks = marks.map(
-                  (mark) => newMarkDefKeys.get(mark) ?? mark,
-                )
-
-                // No need to update the marks if they are the same
-                if (!isEqual(marks, newMarks)) {
-                  Transforms.setNodes(
-                    editor,
-                    {marks: newMarks},
-                    {
-                      at: childPath,
-                    },
-                  )
-                }
-              }
-
-              // Time to update all the markDefs that need a new key because
-              // they've been split across blocks
-              const newMarkDefs = nextNode.markDefs.map((markDef) => ({
-                ...markDef,
-                _key: newMarkDefKeys.get(markDef._key) ?? markDef._key,
-              }))
-
-              // No need to update the markDefs if they are the same
-              if (!isEqual(nextNode.markDefs, newMarkDefs)) {
-                Transforms.setNodes(
-                  editor,
-                  {markDefs: newMarkDefs},
-                  {
-                    at: nextNodePath,
-                    match: (node) => editor.isTextBlock(node),
-                  },
-                )
-              }
-            }
-          })
-          editor.onChange()
-          return
-        }
-      }
-
-      insertBreak()
+      return
     }
 
-    return editor
+    const lastFocusBlockChild =
+      focusBlock.children[focusBlock.children.length - 1]
+    const atTheEndOfBlock = isEqual(start, {
+      path: [...focusBlockPath, focusBlock.children.length - 1],
+      offset: editor.isTextSpan(lastFocusBlockChild)
+        ? lastFocusBlockChild.text.length
+        : 0,
+    })
+
+    if (atTheEndOfBlock && Range.isCollapsed(editor.selection)) {
+      Editor.insertNode(
+        editor,
+        editor.pteCreateTextBlock({
+          decorators: [],
+          listItem: focusBlock.listItem,
+          level: focusBlock.level,
+        }),
+      )
+
+      const [nextBlockPath] = Path.next(focusBlockPath)
+
+      Transforms.setSelection(editor, {
+        anchor: {path: [nextBlockPath, 0], offset: 0},
+        focus: {path: [nextBlockPath, 0], offset: 0},
+      })
+
+      return
+    }
+
+    const isInTheMiddleOfNode = !atTheStartOfBlock && !atTheEndOfBlock
+
+    if (isInTheMiddleOfNode) {
+      Editor.withoutNormalizing(editor, () => {
+        if (!editor.selection) {
+          return
+        }
+
+        Transforms.splitNodes(editor, {
+          at: editor.selection,
+        })
+
+        const [nextNode, nextNodePath] = Editor.node(
+          editor,
+          Path.next(focusBlockPath),
+          {depth: 1},
+        )
+
+        Transforms.setSelection(editor, {
+          anchor: {path: [...nextNodePath, 0], offset: 0},
+          focus: {path: [...nextNodePath, 0], offset: 0},
+        })
+
+        /**
+         * Assign new keys to markDefs that are now split across two blocks
+         */
+        if (
+          editor.isTextBlock(nextNode) &&
+          nextNode.markDefs &&
+          nextNode.markDefs.length > 0
+        ) {
+          const newMarkDefKeys = new Map<string, string>()
+
+          const prevNodeSpans = Array.from(
+            Node.children(editor, focusBlockPath),
+          )
+            .map((entry) => entry[0])
+            .filter((node) => editor.isTextSpan(node))
+          const children = Node.children(editor, nextNodePath)
+
+          for (const [child, childPath] of children) {
+            if (!editor.isTextSpan(child)) {
+              continue
+            }
+
+            const marks = child.marks ?? []
+
+            // Go through the marks of the span and figure out if any of
+            // them refer to annotations that are also present in the
+            // previous block
+            for (const mark of marks) {
+              if (
+                schema.decorators.some((decorator) => decorator.value === mark)
+              ) {
+                continue
+              }
+
+              if (
+                prevNodeSpans.some((prevNodeSpan) =>
+                  prevNodeSpan.marks?.includes(mark),
+                ) &&
+                !newMarkDefKeys.has(mark)
+              ) {
+                // This annotation is both present in the previous block
+                // and this block, so let's assign a new key to it
+                newMarkDefKeys.set(mark, keyGenerator())
+              }
+            }
+
+            const newMarks = marks.map(
+              (mark) => newMarkDefKeys.get(mark) ?? mark,
+            )
+
+            // No need to update the marks if they are the same
+            if (!isEqual(marks, newMarks)) {
+              Transforms.setNodes(
+                editor,
+                {marks: newMarks},
+                {
+                  at: childPath,
+                },
+              )
+            }
+          }
+
+          // Time to update all the markDefs that need a new key because
+          // they've been split across blocks
+          const newMarkDefs = nextNode.markDefs.map((markDef) => ({
+            ...markDef,
+            _key: newMarkDefKeys.get(markDef._key) ?? markDef._key,
+          }))
+
+          // No need to update the markDefs if they are the same
+          if (!isEqual(nextNode.markDefs, newMarkDefs)) {
+            Transforms.setNodes(
+              editor,
+              {markDefs: newMarkDefs},
+              {
+                at: nextNodePath,
+                match: (node) => editor.isTextBlock(node),
+              },
+            )
+          }
+        }
+      })
+      editor.onChange()
+      return
+    }
   }
 }

--- a/packages/editor/src/editor/plugins/index.ts
+++ b/packages/editor/src/editor/plugins/index.ts
@@ -5,7 +5,6 @@ import type {createEditorOptions} from '../../types/options'
 import {createOperationToPatches} from '../../utils/operationToPatches'
 import {createWithEventListeners} from './create-with-event-listeners'
 import {createWithEditableAPI} from './createWithEditableAPI'
-import {createWithInsertBreak} from './createWithInsertBreak'
 import {createWithMaxBlocks} from './createWithMaxBlocks'
 import {createWithObjectKeys} from './createWithObjectKeys'
 import {createWithPatches} from './createWithPatches'
@@ -99,8 +98,6 @@ export const withPlugins = <T extends Editor>(
 
   const withPlaceholderBlock = createWithPlaceholderBlock()
 
-  const withInsertBreak = createWithInsertBreak(editorActor, schemaTypes)
-
   const withUtils = createWithUtils({
     editorActor,
     schemaTypes,
@@ -131,9 +128,7 @@ export const withPlugins = <T extends Editor>(
               withUtils(
                 withPlaceholderBlock(
                   withPortableTextLists(
-                    withPortableTextSelections(
-                      withEditableAPI(withInsertBreak(e)),
-                    ),
+                    withPortableTextSelections(withEditableAPI(e)),
                   ),
                 ),
               ),
@@ -158,9 +153,7 @@ export const withPlugins = <T extends Editor>(
                     withMaxBlocks(
                       withUndoRedo(
                         withPatches(
-                          withPortableTextSelections(
-                            withEditableAPI(withInsertBreak(e)),
-                          ),
+                          withPortableTextSelections(withEditableAPI(e)),
                         ),
                       ),
                     ),

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -5,8 +5,8 @@ export type {
   BehaviorContext,
   BehaviorEvent,
   BehaviorGuard,
-  RaiseBehaviorActionIntend,
   PickFromUnion,
+  BehaviorActionIntendSet,
 } from './editor/behavior/behavior.types'
 export {PortableTextEditable} from './editor/Editable'
 export type {PortableTextEditableProps} from './editor/Editable'


### PR DESCRIPTION
Cleans up the internal Behavior API, mitigates some (unobtrusive) loops and as
a bonus also allows behavior actions to be defined in sets. The idea is that
each set of actions is its own undo step and run without normalisation. The
undo part seems to not quite work yet, however. Will revisit.

Another bonus of this commit is that it changes how we overwrite the built-in
`insertBreak` functionality. Instead creating a Slate plugin we just define the
custom functionality as the default behavior action.