### PR TITLE
fix: move `@xstate/react` from dev to production dependency

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@portabletext/patches": "1.1.0",
+    "@xstate/react": "^4.1.3",
     "debug": "^4.3.4",
     "is-hotkey-esm": "^1.0.0",
     "lodash": "^4.17.21",
@@ -99,7 +100,6 @@
     "@typescript-eslint/parser": "^8.12.2",
     "@vitejs/plugin-react": "^4.3.3",
     "@vitest/browser": "^2.1.4",
-    "@xstate/react": "^4.1.3",
     "babel-plugin-react-compiler": "beta",
     "dotenv": "^16.4.5",
     "eslint": "8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@portabletext/patches':
         specifier: workspace:*
         version: link:../patches
+      '@xstate/react':
+        specifier: ^4.1.3
+        version: 4.1.3(@types/react@18.3.12)(react@18.3.1)(xstate@5.18.2)
       debug:
         specifier: ^4.3.4
         version: 4.3.7
@@ -296,9 +299,6 @@ importers:
       '@vitest/browser':
         specifier: ^2.1.4
         version: 2.1.4(@types/node@18.19.59)(playwright@1.48.2)(typescript@5.6.3)(vite@5.4.10(@types/node@18.19.59)(terser@5.36.0))(vitest@2.1.4)
-      '@xstate/react':
-        specifier: ^4.1.3
-        version: 4.1.3(@types/react@18.3.12)(react@18.3.1)(xstate@5.18.2)
       babel-plugin-react-compiler:
         specifier: beta
         version: 19.0.0-beta-6fc168f-20241025


### PR DESCRIPTION
Note: This is currently breaking `sanity@next`.

[This line](https://github.com/portabletext/editor/blob/995bbe5e43f62061c4ebe8a71403c26c2a3acbea/packages/editor/src/editor/use-editor.ts#L6) is importing from `@xstate/react`, which is marked as a dev dependency - not a production dependency, so it is not installed for most applications.