### PR TITLE
chore: adjust react compiler linter and cron schedule

### DIFF
--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -2,7 +2,7 @@ name: Maintain React Compiler
 
 on:
   schedule:
-    - cron: "0 0 * * 1-5" # Runs at midnight UTC every weekday (Monday to Friday)
+    - cron: "10 12 * * 1" # Runs at 12:10 PM UTC every Monday, which is 3 hours after the React Compiler release: https://github.com/facebook/react/blob/989af12f72080c17db03ead91d99b6394a215564/.github/workflows/compiler_prereleases_weekly.yml#L5-L6
   workflow_dispatch:
 
 concurrency:

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -45,7 +45,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:lint": "biome lint .",
     "check:types": "tsc",
-    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --plugin react-hooks --rule 'react-compiler/react-compiler: [warn]' --rule 'react-hooks/rules-of-hooks: [error]' --rule 'react-hooks/exhaustive-deps: [error]' src",
+    "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ignore-pattern '**/__tests__/**' --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --plugin react-hooks --rule 'react-compiler/react-compiler: [warn,{__unstable_donotuse_reportAllBailouts: true}]' --rule 'react-hooks/rules-of-hooks: [error]' --rule 'react-hooks/exhaustive-deps: [error]' src",
     "clean": "del .turbo && del lib && del node_modules",
     "dev": "pkg-utils watch",
     "lint:fix": "biome lint --write .",


### PR DESCRIPTION
The official schedule is every monday at 9AM. So it's unnecessary for our workflow to run every day, I've changed it to run 3 hours after theirs so it's likely that their release pipeline have finished by then.
Also enabled expanded reporting by the linter so we know if it's bailing out due to other reasons than hook violations, for example due to not yet supporting a specific pattern (like try/catch).