### PR TITLE
fix: move Slate editor teardown logic to createSlateEditor

### DIFF
--- a/packages/editor/src/editor/PortableTextEditor.tsx
+++ b/packages/editor/src/editor/PortableTextEditor.tsx
@@ -232,10 +232,6 @@ export class PortableTextEditor extends Component<
     }
   }
 
-  componentWillUnmount(): void {
-    this.slateEditor.destroy()
-  }
-
   public setEditable = (editable: EditableAPI) => {
     this.editable = {...this.editable, ...editable}
   }

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -18,7 +18,6 @@ type SlateEditorConfig = {
 export type SlateEditor = {
   instance: PortableTextSlateEditor
   initialValue: Array<Descendant>
-  destroy: () => void
 }
 
 const slateEditors = new WeakMap<EditorActor, SlateEditor>()
@@ -48,12 +47,8 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
     unsubscriptions.push(subscription())
   }
 
-  const initialValue = [instance.pteCreateTextBlock({decorators: []})]
-
-  const slateEditor: SlateEditor = {
-    instance,
-    initialValue,
-    destroy: () => {
+  config.editorActor.subscribe((snapshot) => {
+    if (snapshot.status !== 'active') {
       debug('Destroying Slate editor')
       instance.destroy()
       for (const unsubscribe of unsubscriptions) {
@@ -61,7 +56,14 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
       }
       subscriptions = []
       unsubscriptions = []
-    },
+    }
+  })
+
+  const initialValue = [instance.pteCreateTextBlock({decorators: []})]
+
+  const slateEditor: SlateEditor = {
+    instance,
+    initialValue,
   }
 
   slateEditors.set(config.editorActor, slateEditor)


### PR DESCRIPTION
This fixes an issue where the Slate editor could be torn down from within `PortableTextEditor` (if it unmounted and mounted again) and never set properly up again. To avoid writing setup logic for the editor, it feels simpler and more robust to just tear it down if the `EditorActor` is stopped.