### PR TITLE
fix(performance regression): bail out quicker on native behavior events

### DIFF
--- a/packages/editor/src/editor/behavior/behavior.actions.ts
+++ b/packages/editor/src/editor/behavior/behavior.actions.ts
@@ -45,8 +45,8 @@ import {textBlockSetActionImplementation} from './behavior.action.text-block.set
 import {textBlockUnsetActionImplementation} from './behavior.action.text-block.unset'
 import type {
   BehaviorAction,
-  BehaviorEvent,
   PickFromUnion,
+  SyntheticBehaviorEvent,
 } from './behavior.types'
 
 export type BehaviorActionImplementationContext = Pick<
@@ -82,7 +82,6 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
   'focus': ({action}) => {
     ReactEditor.focus(action.editor)
   },
-  'copy': () => {},
   'delete.backward': ({action}) => {
     deleteBackward(action.editor, action.unit)
   },
@@ -186,8 +185,6 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
   'effect': ({action}) => {
     action.effect()
   },
-  'key.down': () => {},
-  'key.up': () => {},
   'list item.add': addListItemActionImplementation,
   'list item.remove': removeListItemActionImplementation,
   'list item.toggle': toggleListItemActionImplementation,
@@ -227,7 +224,6 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
     })
   },
   'noop': () => {},
-  'paste': () => {},
   'select': ({action}) => {
     const newSelection = toSlateRange(action.selection, action.editor)
 
@@ -434,7 +430,7 @@ function performDefaultAction({
   action,
 }: {
   context: BehaviorActionImplementationContext
-  action: PickFromUnion<BehaviorAction, 'type', BehaviorEvent['type']>
+  action: PickFromUnion<BehaviorAction, 'type', SyntheticBehaviorEvent['type']>
 }) {
   switch (action.type) {
     case 'annotation.add': {
@@ -460,13 +456,6 @@ function performDefaultAction({
     }
     case 'blur': {
       behaviorActionImplementations.blur({
-        context,
-        action,
-      })
-      break
-    }
-    case 'copy': {
-      behaviorActionImplementations.copy({
         context,
         action,
       })
@@ -549,29 +538,8 @@ function performDefaultAction({
       })
       break
     }
-    case 'key.down': {
-      behaviorActionImplementations['key.down']({
-        context,
-        action,
-      })
-      break
-    }
-    case 'key.up': {
-      behaviorActionImplementations['key.up']({
-        context,
-        action,
-      })
-      break
-    }
     case 'list item.toggle': {
       behaviorActionImplementations['list item.toggle']({
-        context,
-        action,
-      })
-      break
-    }
-    case 'paste': {
-      behaviorActionImplementations.paste({
         context,
         action,
       })

--- a/packages/editor/src/editor/behavior/behavior.types.ts
+++ b/packages/editor/src/editor/behavior/behavior.types.ts
@@ -7,7 +7,7 @@ import type {EditorContext} from '../editor-snapshot'
 /**
  * @alpha
  */
-export type BehaviorEvent =
+export type SyntheticBehaviorEvent =
   | {
       type: 'annotation.add'
       annotation: {
@@ -30,10 +30,6 @@ export type BehaviorEvent =
     }
   | {
       type: 'blur'
-    }
-  | {
-      type: 'copy'
-      data: DataTransfer
     }
   | {
       type: 'decorator.add'
@@ -85,7 +81,20 @@ export type BehaviorEvent =
       options?: TextInsertTextOptions
     }
   | {
-      type: 'paste'
+      type: 'list item.toggle'
+      listItem: string
+    }
+  | {
+      type: 'style.toggle'
+      style: string
+    }
+
+/**
+ * @alpha
+ */
+export type NativeBehaviorEvent =
+  | {
+      type: 'copy'
       data: DataTransfer
     }
   | {
@@ -103,33 +112,29 @@ export type BehaviorEvent =
       >
     }
   | {
-      type: 'list item.toggle'
-      listItem: string
-    }
-  | {
-      type: 'style.toggle'
-      style: string
+      type: 'paste'
+      data: DataTransfer
     }
 
 /**
  * @alpha
  */
 export type BehaviorGuard<
-  TBehaviorEvent extends BehaviorEvent,
+  TAnyBehaviorEvent extends BehaviorEvent,
   TGuardResponse,
 > = ({
   context,
   event,
 }: {
   context: EditorContext
-  event: TBehaviorEvent
+  event: TAnyBehaviorEvent
 }) => TGuardResponse | false
 
 /**
  * @alpha
  */
 export type BehaviorActionIntend =
-  | BehaviorEvent
+  | SyntheticBehaviorEvent
   | {
       type: 'insert.span'
       text: string
@@ -227,21 +232,26 @@ export type BehaviorAction = BehaviorActionIntend & {
 /**
  * @alpha
  */
+export type BehaviorEvent = SyntheticBehaviorEvent | NativeBehaviorEvent
+
+/**
+ * @alpha
+ */
 export type Behavior<
-  TBehaviorEventType extends BehaviorEvent['type'] = BehaviorEvent['type'],
+  TAnyBehaviorEventType extends BehaviorEvent['type'] = BehaviorEvent['type'],
   TGuardResponse = true,
 > = {
   /**
    * The internal editor event that triggers this behavior.
    */
-  on: TBehaviorEventType
+  on: TAnyBehaviorEventType
   /**
    * Predicate function that determines if the behavior should be executed.
    * Returning a non-nullable value from the guard will pass the value to the
    * actions and execute them.
    */
   guard?: BehaviorGuard<
-    PickFromUnion<BehaviorEvent, 'type', TBehaviorEventType>,
+    PickFromUnion<BehaviorEvent, 'type', TAnyBehaviorEventType>,
     TGuardResponse
   >
   /**
@@ -255,21 +265,15 @@ export type Behavior<
  */
 export type BehaviorActionIntendSet<TGuardResponse = true> = (
   guardResponse: TGuardResponse,
-) => Array<
-  OmitFromUnion<
-    BehaviorActionIntend,
-    'type',
-    'copy' | 'key.down' | 'key.up' | 'paste'
-  >
->
+) => Array<BehaviorActionIntend>
 
 /**
  * @alpha
  */
 export function defineBehavior<
-  TBehaviorEventType extends BehaviorEvent['type'],
+  TAnyBehaviorEventType extends BehaviorEvent['type'],
   TGuardResponse = true,
->(behavior: Behavior<TBehaviorEventType, TGuardResponse>): Behavior {
+>(behavior: Behavior<TAnyBehaviorEventType, TGuardResponse>): Behavior {
   return behavior as unknown as Behavior
 }
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -15,14 +15,16 @@ export {
 } from './editor/behavior/behavior.markdown'
 export {
   defineBehavior,
+  type BehaviorEvent,
   type Behavior,
   type BehaviorActionIntend,
   type BehaviorActionIntendSet,
-  type BehaviorEvent,
+  type SyntheticBehaviorEvent,
   type BehaviorGuard,
+  type BlockOffset,
+  type NativeBehaviorEvent,
   type OmitFromUnion,
   type PickFromUnion,
-  type BlockOffset,
 } from './editor/behavior/behavior.types'
 export type {Editor, EditorConfig, EditorEvent} from './editor/create-editor'
 export type {SlateEditor} from './editor/create-slate-editor'


### PR DESCRIPTION
Holding down an arrow key to go up and down through the editor text was
noticeably slow before this change. Now, we separate native and synthetic
behavior events and bail out quicker if a native event shouldn't be handled.
`NativeBehaviorEvent`s simply don't have default actions anymore. Which makes a
lot of sense since they were noops in the first place.