### PR TITLE
fix: disable shadcn base colors to fix dark mode

### DIFF
--- a/apps/docs/src/styles/globals.css
+++ b/apps/docs/src/styles/globals.css
@@ -60,7 +60,4 @@
   * {
     @apply border-border;
   }
-  body {
-    @apply bg-background text-foreground;
-  }
 }

--- a/apps/docs/tailwind.config.mjs
+++ b/apps/docs/tailwind.config.mjs
@@ -1,7 +1,12 @@
 import starlightPlugin from '@astrojs/starlight-tailwind'
 
 // Generated color palettes
-const accent = {200: '#aecaf8', 600: '#0049b4', 900: '#0c2f68', 950: '#0d2346'}
+const accent = {
+  200: '#aecaf8',
+  600: '#0049b4',
+  900: '#0c2f68',
+  950: '#0d2346',
+}
 const gray = {
   100: '#f4f6fa',
   200: '#eaeef5',


### PR DESCRIPTION
This removes the shadcn styling to body, thus fixing the Starlight theme dark mode