### PR TITLE
docs(fix): fix logic in autoCloseParens example

### DIFF
--- a/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
@@ -76,9 +76,7 @@ You can write behaviors to auto-close common paired characters. This example clo
 const autoCloseParens = defineBehavior({
   on: 'insert.text',
   guard: ({context, event}) => {
-    if (event.text !== '(') {
-      return false
-    }
+    return event.text === '('
   },
   actions: [
     ({event, context}) => [


### PR DESCRIPTION
Guard needs to return true or a value for the actions to work.