### PR TITLE
wip: annotated typedocs progress

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -3,7 +3,13 @@ import starlight from '@astrojs/starlight'
 import tailwind from '@astrojs/tailwind'
 import {defineConfig} from 'astro/config'
 import starlightLinksValidator from 'starlight-links-validator'
-import starlightTypeDoc, {typeDocSidebarGroup} from 'starlight-typedoc'
+import {createStarlightTypeDocPlugin} from 'starlight-typedoc'
+
+const [editorTypeDoc, editorTypeDocSidebar] = createStarlightTypeDocPlugin()
+const [behaviorTypeDoc, behaviorTypeDocSidebar] = createStarlightTypeDocPlugin()
+const [selectorsTypeDoc, selectorsTypeDocSidebar] =
+  createStarlightTypeDocPlugin()
+const tsconfig = '../../packages/editor/tsconfig.json'
 
 // https://astro.build/config
 export default defineConfig({
@@ -41,9 +47,31 @@ export default defineConfig({
         },
         {
           label: 'Reference',
-          autogenerate: {directory: 'reference'},
+          collapsed: true,
+          items: [
+            {
+              label: 'Editor',
+              items: [
+                {label: 'Overview', slug: 'reference/editor'},
+                {...editorTypeDocSidebar, badge: 'Generated'},
+              ],
+            },
+            {
+              label: 'Behaviors',
+              items: [
+                {label: 'Overview', slug: 'reference/behavior-api'},
+                {...behaviorTypeDocSidebar, badge: 'Generated'},
+              ],
+            },
+            {
+              label: 'Selectors',
+              items: [
+                {label: 'Overview', slug: 'reference/selectors'},
+                {...selectorsTypeDocSidebar, badge: 'Generated'},
+              ],
+            },
+          ],
         },
-        typeDocSidebarGroup,
         {
           label: 'Integrations',
           autogenerate: {directory: 'integrations'},
@@ -54,22 +82,38 @@ export default defineConfig({
         },
       ],
       plugins: [
-        starlightTypeDoc({
-          entryPoints: [
-            '../../packages/editor/src/index.ts',
-            '../../packages/editor/src/behaviors/index.ts',
-            '../../packages/editor/src/selectors/index.ts',
-          ],
+        editorTypeDoc({
+          entryPoints: ['../../packages/editor/src/index.ts'],
+          output: 'api/editor',
           typeDoc: {
-            navigation: {
-              includeGroups: true,
-            },
-            categorizeByGroup: true,
             excludeReferences: true,
-            groupOrder: ['Components', '*'],
           },
-
-          tsconfig: '../../packages/editor/tsconfig.json',
+          sidebar: {
+            collapsed: true,
+          },
+          tsconfig,
+        }),
+        behaviorTypeDoc({
+          entryPoints: ['../../packages/editor/src/behaviors/index.ts'],
+          output: 'api/behaviors',
+          typeDoc: {
+            excludeReferences: true,
+          },
+          sidebar: {
+            collapsed: true,
+          },
+          tsconfig,
+        }),
+        selectorsTypeDoc({
+          entryPoints: ['../../packages/editor/src/selectors/index.ts'],
+          output: 'api/selectors',
+          typeDoc: {
+            excludeReferences: true,
+          },
+          sidebar: {
+            collapsed: true,
+          },
+          tsconfig,
         }),
         ...(process.env.CHECK_LINKS ? [starlightLinksValidator()] : []),
       ],

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -55,7 +55,20 @@ export default defineConfig({
       ],
       plugins: [
         starlightTypeDoc({
-          entryPoints: ['../../packages/editor/src/index.ts'],
+          entryPoints: [
+            '../../packages/editor/src/index.ts',
+            '../../packages/editor/src/behaviors/index.ts',
+            '../../packages/editor/src/selectors/index.ts',
+          ],
+          typeDoc: {
+            navigation: {
+              includeGroups: true,
+            },
+            categorizeByGroup: true,
+            excludeReferences: true,
+            groupOrder: ['Components', '*'],
+          },
+
           tsconfig: '../../packages/editor/tsconfig.json',
         }),
         ...(process.env.CHECK_LINKS ? [starlightLinksValidator()] : []),

--- a/apps/docs/src/content/docs/reference/behavior-api.mdx
+++ b/apps/docs/src/content/docs/reference/behavior-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Behavior API
+title: Behavior API Overview
 description: Reference documentation for the Behavior API.
 ---
 

--- a/apps/docs/src/content/docs/reference/editor.mdx
+++ b/apps/docs/src/content/docs/reference/editor.mdx
@@ -1,7 +1,11 @@
 ---
-title: Hooks
-description: Hooks reference
+title: Editor API Overview
+description: Editor API reference overview
 ---
+
+The editor API provides access to the editor context and selectors for deriving state.
+
+Use the following hooks to access the editor from within your components.
 
 ## `useEditor`
 

--- a/apps/docs/src/content/docs/reference/selectors.mdx
+++ b/apps/docs/src/content/docs/reference/selectors.mdx
@@ -1,5 +1,5 @@
 ---
-title: Selectors
+title: Selectors API Overview
 description: Selectors reference
 prev: false
 next: false

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -17,6 +17,16 @@ export default defineConfig({
         allowMultiple: true,
         syntaxKind: 'block',
       },
+      {
+        name: 'group',
+        allowMultiple: true,
+        syntaxKind: 'block',
+      },
+      {
+        name: 'groupDescription',
+        allowMultiple: true,
+        syntaxKind: 'block',
+      },
     ],
     rules: {
       // Disable rules for now

--- a/packages/editor/src/behaviors/behavior.markdown.ts
+++ b/packages/editor/src/behaviors/behavior.markdown.ts
@@ -25,6 +25,48 @@ export type MarkdownBehaviorsConfig = {
 
 /**
  * @beta
+ * Create markdown behaviors for common markdown actions such as converting ### to headings, --- to HRs, and more.
+ *
+ * @example
+ * Configure the bundled markdown behaviors
+ * ```ts
+ * import {EditorProvider} from '@portabletext/editor'
+ * import {createMarkdownBehaviors, coreBehaviors} from '@portabletext/editor/behaviors'
+ *
+ * function App() {
+ *  return (
+ *   <EditorProvider
+ *    initialConfig={{
+ *    behaviors: [
+ *    ...coreBehaviors,
+ *    ...createMarkdownBehaviors({
+ *        horizontalRuleObject: ({schema}) => {
+ *          const name = schema.blockObjects.find(
+ *            (object) => object.name === 'break',
+ *          )?.name
+ *          return name ? {name} : undefined
+ *        },
+ *        defaultStyle: ({schema}) => schema.styles[0].value,
+ *        headingStyle: ({schema, level}) =>
+ *          schema.styles.find((style) => style.value === `h${level}`)
+ *            ?.value,
+ *        blockquoteStyle: ({schema}) =>
+ *          schema.styles.find((style) => style.value === 'blockquote')
+ *            ?.value,
+ *        unorderedListStyle: ({schema}) =>
+ *          schema.lists.find((list) => list.value === 'bullet')?.value,
+ *        orderedListStyle: ({schema}) =>
+ *          schema.lists.find((list) => list.value === 'number')?.value,
+ *      }),
+ *      ]
+ *    }}
+ *    >
+ *    {...}
+ *    </EditorProvider>
+ *  )
+ * }
+ * ```
+ *
  */
 export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
   const automaticBlockquoteOnSpace = defineBehavior({

--- a/packages/editor/src/behaviors/behavior.types.ts
+++ b/packages/editor/src/behaviors/behavior.types.ts
@@ -294,6 +294,21 @@ export type BehaviorActionIntendSet<
 
 /**
  * @beta
+ *
+ * @example
+ *
+ * ```tsx
+ * const noLowerCaseA = defineBehavior({
+ *   on: 'insert.text',
+ *   guard: ({event, context}) => event.text === 'a',
+ *   actions: [({event, context}) => [{type: 'insert.text', text: 'A'}]],
+ * })
+ * ```
+ *
+ *
+ *
+ *
+ *
  */
 export function defineBehavior<
   TBehaviorEventType extends BehaviorEvent['type'],

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -113,6 +113,23 @@ export type PortableTextEditableProps = Omit<
 
 /**
  * @public
+ *
+ *
+ * The core component that renders the editor. Must be placed within the {@link EventProvider} component.
+ *
+ * @example
+ * ```tsx
+ * import { PortableTextEditable, EditorProvider } from '@portabletext/editor'
+ *
+ * function MyComponent() {
+ *  return (
+ *   <EditorProvider>
+ *    <PortableTextEditable />
+ *  </EditorProvider>
+ *  )
+ * }
+ * ```
+ * @group Components
  */
 export const PortableTextEditable = forwardRef<
   Omit<HTMLDivElement, 'as' | 'onPaste' | 'onBeforeInput'>,

--- a/packages/editor/src/editor/define-schema.ts
+++ b/packages/editor/src/editor/define-schema.ts
@@ -28,6 +28,26 @@ export type SchemaDefinition<
 
 /**
  * @public
+ * A helper wrapper that adds editor support, such as autocomplete and type checking, for a schema definition.
+ * @example
+ * ```ts
+ * import { defineSchema } from '@portabletext/editor'
+ *
+ * const schemaDefinition = defineSchema({
+ *  decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+ *  annotations: [{name: 'link'}],
+ *  styles: [
+ *    {name: 'normal'},
+ *    {name: 'h1'},
+ *    {name: 'h2'},
+ *    {name: 'h3'},
+ *    {name: 'blockquote'},
+ *  ],
+ *  lists: [],
+ *  inlineObjects: [],
+ *  blockObjects: [],
+ * }
+ * ```
  */
 export function defineSchema<const TSchemaDefinition extends SchemaDefinition>(
   definition: TSchemaDefinition,

--- a/packages/editor/src/editor/editor-event-listener.tsx
+++ b/packages/editor/src/editor/editor-event-listener.tsx
@@ -5,6 +5,51 @@ import {useEditor} from './editor-provider'
 
 /**
  * @public
+ * Listen for events emitted by the editor. Must be used inside `EditorProvider`. Events available include:
+ *  - 'blurred'
+ *  - 'done loading'
+ *  - 'editable'
+ *  - 'error'
+ *  - 'focused'
+ *  - 'invalid value'
+ *  - 'loading'
+ *  - 'mutation'
+ *  - 'patch'
+ *  - 'read only'
+ *  - 'ready'
+ *  - 'selection'
+ *  - 'value changed'
+ *
+ * @example
+ * Listen and log events.
+ * ```tsx
+ * import {EditorEventListener, EditorProvider} from '@portabletext/editor'
+ *
+ * function MyComponent() {
+ *  return (
+ *  <EditorProvider>
+ *   <EditorEventListener
+ *    on={(event) => {
+ *     console.log(event)
+ *    }
+ *   } />
+ *   { ... }
+ * </EditorProvider>
+ *  )
+ * }
+ * ```
+ * @example
+ * Handle events when there is a mutation.
+ * ```tsx
+ * <EditorEventListener
+ *  on={(event) => {
+ *    if (event.type === 'mutation') {
+ *      console.log('Value changed:', event.snapshot)
+ *    }
+ *  }}
+ * />
+ * ```
+ * @group Components
  */
 export function EditorEventListener(props: {
   on: (event: EditorEmittedEvent) => void

--- a/packages/editor/src/editor/editor-provider.tsx
+++ b/packages/editor/src/editor/editor-provider.tsx
@@ -23,6 +23,21 @@ export type EditorProviderProps = {
 
 /**
  * @public
+ * The EditorProvider component is used to set up the editor context and configure the Portable Text Editor.
+ * @example
+ * ```tsx
+ * import {EditorProvider} from '@portabletext/editor'
+ *
+ * function App() {
+ *  return (
+ *    <EditorProvider initialConfig={{ ... }} >
+ *      ...
+ *    </EditorProvider>
+ *  )
+ * }
+ *
+ * ```
+ * @group Components
  */
 export function EditorProvider(props: EditorProviderProps) {
   const editor = useCreateEditor(props.initialConfig)
@@ -66,6 +81,18 @@ export function EditorProvider(props: EditorProviderProps) {
 
 /**
  * @public
+ * Get the current editor context from the `EditorProvider`.
+ * Must be used inside the `EditorProvider` component.
+ * @returns The current editor object.
+ * @example
+ * ```tsx
+ * import { useEditor } from '@portabletext/editor'
+ *
+ * function MyComponent() {
+ *  const editor = useEditor()
+ * }
+ * ```
+ * @group Hooks
  */
 export function useEditor() {
   const editor = React.useContext(EditorContext)

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -17,6 +17,27 @@ export type EditorSelector<TSelected> = (snapshot: EditorSnapshot) => TSelected
 
 /**
  * @public
+ * Hook to select a value from the editor state.
+ * @example
+ * Pass a selector as the second argument
+ * ```tsx
+ * import { useEditorSelector } from '@portabletext/editor'
+ *
+ * function MyComponent(editor) {
+ *  const value = useEditorSelector(editor, selector)
+ * }
+ * ```
+ * @example
+ * Pass an inline selector as the second argument.
+ * In this case, use the editor context to obtain the schema.
+ * ```tsx
+ * import { useEditorSelector } from '@portabletext/editor'
+ *
+ * function MyComponent(editor) {
+ *  const schema = useEditorSelector(editor, (snapshot) => snapshot.context.schema)
+ * }
+ * ```
+ * @group Hooks
  */
 export function useEditorSelector<TSelected>(
   editor: Editor,


### PR DESCRIPTION
Quite a few misc complications still with the typedocs. Not entirely sure if the problem is how we do things, how they assume people do things, or something in between. 

I did discover that `pkg-utils` is blocking our ability to wholesale use all the typedocs tags. Should be able to manually add them via `package.config.ts` until we hit an inline tag. At the point the library will need an update since the type only supports `block` and `modifier` right now.

If the groups or categories will actually work, I think we'll be in good shape, but this implementation is still just "okay".