### PR TITLE
fix(behavior): remove `annotation.toggle` and `decorator.(add|remove)` events

### DIFF
--- a/apps/docs/src/components/editor/toolbar.tsx
+++ b/apps/docs/src/components/editor/toolbar.tsx
@@ -128,16 +128,25 @@ function AnnotationButton(props: {annotation: {name: string}}) {
           variant={active ? 'default' : 'ghost'}
           size="icon"
           onClick={() => {
-            editor.send({
-              type: 'annotation.toggle',
-              annotation: {
-                name: props.annotation.name,
-                value:
-                  props.annotation.name === 'link'
-                    ? {href: 'https://example.com'}
-                    : {},
-              },
-            })
+            if (active) {
+              editor.send({
+                type: 'annotation.remove',
+                annotation: {
+                  name: props.annotation.name,
+                },
+              })
+            } else {
+              editor.send({
+                type: 'annotation.add',
+                annotation: {
+                  name: props.annotation.name,
+                  value:
+                    props.annotation.name === 'link'
+                      ? {href: 'https://example.com'}
+                      : {},
+                },
+              })
+            }
             editor.send({type: 'focus'})
           }}
         >

--- a/apps/docs/src/content/docs/reference/behavior-api.mdx
+++ b/apps/docs/src/content/docs/reference/behavior-api.mdx
@@ -36,10 +36,7 @@ const noLowerCaseA = defineBehavior({
 
 - annotation.add
 - annotation.remove
-- annotation.toggle
 - blur
-- decorator.add
-- decorator.remove
 - decorator.toggle
 - delete.backward
 - delete.forward
@@ -59,10 +56,7 @@ Actions as part of synthetic events
 
 - annotation.add
 - annotation.remove
-- annotation.toggle
 - blur
-- decorator.add
-- decorator.remove
 - decorator.toggle
 - delete.backward
 - delete.forward
@@ -78,6 +72,9 @@ Actions as part of synthetic events
 
 Additional actions
 
+- annotation.toggle
+- decorator.add
+- decorator.remove
 - insert.span
 - insert.text block
 - list item.add

--- a/apps/playground/src/portable-text-toolbar.tsx
+++ b/apps/playground/src/portable-text-toolbar.tsx
@@ -116,22 +116,31 @@ function AnnotationToolbarButton(props: {
         size="sm"
         isSelected={active}
         onPress={() => {
-          editor.send({
-            type: 'annotation.toggle',
-            annotation: {
-              name: props.annotation.name,
-              value:
-                props.annotation.name === 'comment'
-                  ? {
-                      text: 'Consider rewriting this',
-                    }
-                  : props.annotation.name === 'link'
+          if (active) {
+            editor.send({
+              type: 'annotation.remove',
+              annotation: {
+                name: props.annotation.name,
+              },
+            })
+          } else {
+            editor.send({
+              type: 'annotation.add',
+              annotation: {
+                name: props.annotation.name,
+                value:
+                  props.annotation.name === 'comment'
                     ? {
-                        href: 'https://example.com',
+                        text: 'Consider rewriting this',
                       }
-                    : {},
-            },
-          })
+                    : props.annotation.name === 'link'
+                      ? {
+                          href: 'https://example.com',
+                        }
+                      : {},
+              },
+            })
+          }
           editor.send({type: 'focus'})
         }}
       >

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -302,16 +302,25 @@ function AnnotationButton(props: {annotation: {name: string}}) {
         textDecoration: active ? 'underline' : 'unset',
       }}
       onClick={() => {
-        editor.send({
-          type: 'annotation.toggle',
-          annotation: {
-            name: props.annotation.name,
-            value:
-              props.annotation.name === 'link'
-                ? {href: 'https://example.com'}
-                : {},
-          },
-        })
+        if (active) {
+          editor.send({
+            type: 'annotation.remove',
+            annotation: {
+              name: props.annotation.name,
+            },
+          })
+        } else {
+          editor.send({
+            type: 'annotation.add',
+            annotation: {
+              name: props.annotation.name,
+              value:
+                props.annotation.name === 'link'
+                  ? {href: 'https://example.com'}
+                  : {},
+            },
+          })
+        }
         editor.send({type: 'focus'})
       }}
     >

--- a/packages/editor/gherkin-tests/editors.tsx
+++ b/packages/editor/gherkin-tests/editors.tsx
@@ -12,6 +12,7 @@ import {
 import type {Behavior} from '../src/behaviors'
 import type {EditorEmittedEvent} from '../src/editor/editor-machine'
 import {EditorProvider, useEditor} from '../src/editor/editor-provider'
+import * as selectors from '../src/selectors'
 import type {EditorActorRef, TestActorRef} from './test-machine'
 
 export function Editors(props: {testRef: TestActorRef}) {
@@ -221,6 +222,10 @@ function InlineObjectButtons() {
 
 function CommentButtons() {
   const editor = useEditor()
+  const isActive = useEditorSelector(
+    editor,
+    selectors.isActiveAnnotation('comment'),
+  )
 
   return (
     <>
@@ -259,13 +264,22 @@ function CommentButtons() {
         type="button"
         data-testid="button-toggle-comment"
         onClick={() => {
-          editor.send({
-            type: 'annotation.toggle',
-            annotation: {
-              name: 'comment',
-              value: {text: 'Consider rewriting this'},
-            },
-          })
+          if (isActive) {
+            editor.send({
+              type: 'annotation.remove',
+              annotation: {
+                name: 'comment',
+              },
+            })
+          } else {
+            editor.send({
+              type: 'annotation.add',
+              annotation: {
+                name: 'comment',
+                value: {text: 'Consider rewriting this'},
+              },
+            })
+          }
           editor.send({type: 'focus'})
         }}
       >
@@ -277,6 +291,10 @@ function CommentButtons() {
 
 function LinkButtons() {
   const editor = useEditor()
+  const isActive = useEditorSelector(
+    editor,
+    selectors.isActiveAnnotation('link'),
+  )
 
   return (
     <>
@@ -315,13 +333,22 @@ function LinkButtons() {
         type="button"
         data-testid="button-toggle-link"
         onClick={() => {
-          editor.send({
-            type: 'annotation.toggle',
-            annotation: {
-              name: 'link',
-              value: {href: 'https://example.com'},
-            },
-          })
+          if (isActive) {
+            editor.send({
+              type: 'annotation.remove',
+              annotation: {
+                name: 'link',
+              },
+            })
+          } else {
+            editor.send({
+              type: 'annotation.add',
+              annotation: {
+                name: 'link',
+                value: {href: 'https://example.com'},
+              },
+            })
+          }
           editor.send({type: 'focus'})
         }}
       >

--- a/packages/editor/src/behavior-actions/behavior.actions.ts
+++ b/packages/editor/src/behavior-actions/behavior.actions.ts
@@ -275,6 +275,27 @@ export function performAction({
   action: BehaviorAction
 }) {
   switch (action.type) {
+    case 'annotation.toggle': {
+      behaviorActionImplementations['annotation.toggle']({
+        context,
+        action,
+      })
+      break
+    }
+    case 'decorator.add': {
+      behaviorActionImplementations['decorator.add']({
+        context,
+        action,
+      })
+      break
+    }
+    case 'decorator.remove': {
+      behaviorActionImplementations['decorator.remove']({
+        context,
+        action,
+      })
+      break
+    }
     case 'delete.block': {
       behaviorActionImplementations['delete.block']({
         context,
@@ -429,29 +450,8 @@ function performDefaultAction({
       })
       break
     }
-    case 'annotation.toggle': {
-      behaviorActionImplementations['annotation.toggle']({
-        context,
-        action,
-      })
-      break
-    }
     case 'blur': {
       behaviorActionImplementations.blur({
-        context,
-        action,
-      })
-      break
-    }
-    case 'decorator.add': {
-      behaviorActionImplementations['decorator.add']({
-        context,
-        action,
-      })
-      break
-    }
-    case 'decorator.remove': {
-      behaviorActionImplementations['decorator.remove']({
         context,
         action,
       })

--- a/packages/editor/src/behaviors/behavior.types.ts
+++ b/packages/editor/src/behaviors/behavior.types.ts
@@ -23,22 +23,7 @@ export type SyntheticBehaviorEvent =
       }
     }
   | {
-      type: 'annotation.toggle'
-      annotation: {
-        name: string
-        value: {[prop: string]: unknown}
-      }
-    }
-  | {
       type: 'blur'
-    }
-  | {
-      type: 'decorator.add'
-      decorator: string
-    }
-  | {
-      type: 'decorator.remove'
-      decorator: string
     }
   | {
       type: 'decorator.toggle'
@@ -129,6 +114,21 @@ export type BehaviorActionIntend =
   | {
       type: 'raise'
       event: SyntheticBehaviorEvent
+    }
+  | {
+      type: 'annotation.toggle'
+      annotation: {
+        name: string
+        value: {[prop: string]: unknown}
+      }
+    }
+  | {
+      type: 'decorator.add'
+      decorator: string
+    }
+  | {
+      type: 'decorator.remove'
+      decorator: string
     }
   | {
       type: 'insert.span'

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -63,10 +63,7 @@ export type EditorEvent = PickFromUnion<
   'type',
   | 'annotation.add'
   | 'annotation.remove'
-  | 'annotation.toggle'
   | 'blur'
-  | 'decorator.add'
-  | 'decorator.remove'
   | 'decorator.toggle'
   | 'focus'
   | 'insert.block object'

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -166,10 +166,7 @@ export type InternalEditorEmittedEvent =
       'type',
       | 'annotation.add'
       | 'annotation.remove'
-      | 'annotation.toggle'
       | 'blur'
-      | 'decorator.add'
-      | 'decorator.remove'
       | 'decorator.toggle'
       | 'insert.block object'
       | 'insert.inline object'
@@ -452,13 +449,7 @@ export const editorMachine = setup({
             'behavior event': {
               actions: 'handle behavior event',
             },
-            'annotation.add': {
-              actions: emit(({event}) => event),
-            },
-            'annotation.remove': {
-              actions: emit(({event}) => event),
-            },
-            'annotation.toggle': {
+            'annotation.*': {
               actions: emit(({event}) => event),
             },
             'blur': {

--- a/packages/editor/src/editor/plugins/create-with-event-listeners.ts
+++ b/packages/editor/src/editor/plugins/create-with-event-listeners.ts
@@ -39,44 +39,11 @@ export function createWithEventListeners(
             })
             break
           }
-          case 'annotation.toggle': {
-            editorActor.send({
-              type: 'behavior event',
-              behaviorEvent: {
-                type: 'annotation.toggle',
-                annotation: event.annotation,
-              },
-              editor,
-            })
-            break
-          }
           case 'blur': {
             editorActor.send({
               type: 'behavior event',
               behaviorEvent: {
                 type: 'blur',
-              },
-              editor,
-            })
-            break
-          }
-          case 'decorator.add': {
-            editorActor.send({
-              type: 'behavior event',
-              behaviorEvent: {
-                type: 'decorator.add',
-                decorator: event.decorator,
-              },
-              editor,
-            })
-            break
-          }
-          case 'decorator.remove': {
-            editorActor.send({
-              type: 'behavior event',
-              behaviorEvent: {
-                type: 'decorator.remove',
-                decorator: event.decorator,
               },
               editor,
             })
@@ -168,30 +135,6 @@ export function createWithEventListeners(
     })
 
     const {select} = editor
-
-    editor.addMark = (mark) => {
-      editorActor.send({
-        type: 'behavior event',
-        behaviorEvent: {
-          type: 'decorator.add',
-          decorator: mark,
-        },
-        editor,
-      })
-      return
-    }
-
-    editor.removeMark = (mark) => {
-      editorActor.send({
-        type: 'behavior event',
-        behaviorEvent: {
-          type: 'decorator.remove',
-          decorator: mark,
-        },
-        editor,
-      })
-      return
-    }
 
     editor.deleteBackward = (unit) => {
       editorActor.send({


### PR DESCRIPTION
These are potentially confusing because `annotation.toggle` doesn't trigger
`annotation.add` or `annotation.remove` events and `decorator.toggle` doesn't
trigger `decorator.add` or `decorator.remove`. Therefore, it feels more
intuitive to remove `annotation.toggle` while keeping
`annotation.add`/`annotation.remove` and remove
`decorator.add`/`decorator.remove` while keeping `decorator.toggle`.

`annotation.toggle`, `decorator.add` and `decorator.remove` still exist as
built-in actions that can be performed.