### PR TITLE
fix: only generate new `_key`s when necessary

### DIFF
--- a/packages/editor/src/behavior-actions/behavior.action.insert.block.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.insert.block.ts
@@ -6,7 +6,11 @@ import type {BehaviorActionImplementation} from './behavior.actions'
 export const insertBlockActionImplementation: BehaviorActionImplementation<
   'insert.block'
 > = ({context, action}) => {
-  const parsedBlock = parseBlock({block: action.block, context})
+  const parsedBlock = parseBlock({
+    block: action.block,
+    context,
+    options: {refreshKeys: false},
+  })
 
   if (!parsedBlock) {
     throw new Error(`Failed to parse block ${JSON.stringify(action.block)}`)

--- a/packages/editor/src/converters/converter.portable-text.ts
+++ b/packages/editor/src/converters/converter.portable-text.ts
@@ -38,7 +38,11 @@ export const converterPortableText = defineConverter({
     }
 
     const parsedBlocks = blocks.flatMap((block) => {
-      const parsedBlock = parseBlock({context, block})
+      const parsedBlock = parseBlock({
+        context,
+        block,
+        options: {refreshKeys: true},
+      })
       return parsedBlock ? [parsedBlock] : []
     })
 

--- a/packages/editor/src/editor/__tests__/handleClick.test.tsx
+++ b/packages/editor/src/editor/__tests__/handleClick.test.tsx
@@ -28,7 +28,7 @@ async function getEditableElement(
 describe('adds empty text block if its needed', () => {
   const newBlock = {
     _type: 'myTestBlockType',
-    _key: '3',
+    _key: '1',
     style: 'normal',
     markDefs: [],
     children: [
@@ -96,7 +96,7 @@ describe('adds empty text block if its needed', () => {
       },
       {
         _type: 'myTestBlockType',
-        _key: '3',
+        _key: '1',
         style: 'normal',
         markDefs: [],
         children: [

--- a/packages/editor/src/editor/__tests__/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/src/editor/__tests__/pteWarningsSelfSolving.test.tsx
@@ -337,7 +337,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
         PortableTextEditor.focus(editorRef.current)
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
           {
-            _key: '5',
+            _key: '3',
             _type: 'myTestBlockType',
             children: [{_key: '4', _type: 'span', marks: [], text: ''}],
             markDefs: [],

--- a/packages/editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
+++ b/packages/editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
@@ -111,12 +111,12 @@ describe('plugin:withEditableAPI: .insertChild()', () => {
                 text: 'Block A',
               },
               {
-                _key: '3',
+                _key: '2',
                 _type: 'someObject',
                 color: 'red',
               },
               {
-                _key: '4',
+                _key: '3',
                 _type: 'span',
                 marks: [],
                 text: '',
@@ -155,12 +155,12 @@ describe('plugin:withEditableAPI: .insertChild()', () => {
                 text: 'Block A',
               },
               {
-                _key: '3',
+                _key: '2',
                 _type: 'someObject',
                 color: 'red',
               },
               {
-                _key: '7',
+                _key: '5',
                 _type: 'span',
                 marks: [],
                 text: ' ',
@@ -172,8 +172,8 @@ describe('plugin:withEditableAPI: .insertChild()', () => {
         ])
 
         expect(PortableTextEditor.getSelection(editorRef.current)).toEqual({
-          anchor: {path: [{_key: 'a'}, 'children', {_key: '7'}], offset: 1},
-          focus: {path: [{_key: 'a'}, 'children', {_key: '7'}], offset: 1},
+          anchor: {path: [{_key: 'a'}, 'children', {_key: '5'}], offset: 1},
+          focus: {path: [{_key: 'a'}, 'children', {_key: '5'}], offset: 1},
           backward: false,
         })
       }
@@ -240,7 +240,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
     await waitFor(() => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
-          {_key: '2', _type: 'someObject', color: 'red'},
+          {_key: '1', _type: 'someObject', color: 'red'},
         ])
       }
     })
@@ -292,7 +292,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
           ...initialValue,
-          {_key: '2', _type: 'someObject', color: 'red'},
+          {_key: '1', _type: 'someObject', color: 'red'},
         ])
       }
     })
@@ -345,7 +345,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
     await waitFor(() => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
-          {_key: '2', _type: 'someObject', color: 'red'},
+          {_key: '1', _type: 'someObject', color: 'red'},
           ...initialValue,
         ])
       }
@@ -402,7 +402,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
           ...value,
-          {_key: '2', _type: 'someObject', color: 'yellow'},
+          {_key: '1', _type: 'someObject', color: 'yellow'},
         ])
       }
     })
@@ -455,7 +455,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
           value[0],
-          {_key: '2', _type: 'someObject', color: 'yellow'},
+          {_key: '1', _type: 'someObject', color: 'yellow'},
           value[1],
         ])
       }
@@ -504,7 +504,7 @@ describe('plugin:withEditableAPI: .insertBlock()', () => {
       if (editorRef.current) {
         expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
           value[0],
-          {_key: '2', _type: 'someObject', color: 'yellow'},
+          {_key: '1', _type: 'someObject', color: 'yellow'},
         ])
       }
     })

--- a/packages/editor/src/editor/plugins/__tests__/withPortableTextMarkModel.test.tsx
+++ b/packages/editor/src/editor/plugins/__tests__/withPortableTextMarkModel.test.tsx
@@ -73,41 +73,34 @@ describe('plugin:withPortableTextMarksModel', () => {
             anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 3},
           })
           PortableTextEditor.toggleMark(editorRef.current, 'strong')
-          expect(PortableTextEditor.getValue(editorRef.current))
-            .toMatchInlineSnapshot(`
-        [
-          {
-            "_key": "a",
-            "_type": "myTestBlockType",
-            "children": [
-              {
-                "_key": "a1",
-                "_type": "span",
-                "marks": [
-                  "strong",
-                ],
-                "text": "1",
-              },
-              {
-                "_key": "2",
-                "_type": "span",
-                "marks": [],
-                "text": "23",
-              },
-              {
-                "_key": "1",
-                "_type": "span",
-                "marks": [
-                  "strong",
-                ],
-                "text": "4",
-              },
-            ],
-            "markDefs": [],
-            "style": "normal",
-          },
-        ]
-      `)
+          expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+            {
+              _key: 'a',
+              _type: 'myTestBlockType',
+              children: [
+                {
+                  _key: 'a1',
+                  _type: 'span',
+                  marks: ['strong'],
+                  text: '1',
+                },
+                {
+                  _key: '2',
+                  _type: 'span',
+                  marks: [],
+                  text: '23',
+                },
+                {
+                  _key: '1',
+                  _type: 'span',
+                  marks: ['strong'],
+                  text: '4',
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ])
         }
       })
       await waitFor(() => {
@@ -461,11 +454,11 @@ describe('plugin:withPortableTextMarksModel', () => {
               style: 'normal',
             },
             {
-              _key: '5',
+              _key: '1',
               _type: 'myTestBlockType',
               children: [
                 {
-                  _key: '3',
+                  _key: '2',
                   _type: 'span',
                   marks: [],
                   text: '',

--- a/packages/editor/src/editor/plugins/createWithObjectKeys.ts
+++ b/packages/editor/src/editor/plugins/createWithObjectKeys.ts
@@ -43,11 +43,19 @@ export function createWithObjectKeys(
       }
 
       if (operation.type === 'split_node') {
+        const existingKeys = [...Node.descendants(editor)].map(
+          ([node]) => node._key,
+        )
+
         apply({
           ...operation,
           properties: {
             ...operation.properties,
-            _key: editorActor.getSnapshot().context.keyGenerator(),
+            _key:
+              operation.properties._key === undefined ||
+              existingKeys.includes(operation.properties._key)
+                ? editorActor.getSnapshot().context.keyGenerator()
+                : operation.properties._key,
           },
         })
 
@@ -56,11 +64,19 @@ export function createWithObjectKeys(
 
       if (operation.type === 'insert_node') {
         if (!Editor.isEditor(operation.node)) {
+          const existingKeys = [...Node.descendants(editor)].map(
+            ([node]) => node._key,
+          )
+
           apply({
             ...operation,
             node: {
               ...operation.node,
-              _key: editorActor.getSnapshot().context.keyGenerator(),
+              _key:
+                operation.node._key === undefined ||
+                existingKeys.includes(operation.node._key)
+                  ? editorActor.getSnapshot().context.keyGenerator()
+                  : operation.node._key,
             },
           })
 

--- a/packages/editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -361,6 +361,7 @@ export function createWithPortableTextMarkModel(
           ) {
             Transforms.insertNodes(editor, {
               ...op.node,
+              _key: editorActor.getSnapshot().context.keyGenerator(),
               marks:
                 op.node.marks?.filter(
                   (mark) => !annotationsEnding.includes(mark),
@@ -382,6 +383,7 @@ export function createWithPortableTextMarkModel(
           ) {
             Transforms.insertNodes(editor, {
               ...op.node,
+              _key: editorActor.getSnapshot().context.keyGenerator(),
               marks:
                 op.node.marks?.filter(
                   (mark) => !annotationsStarting.includes(mark),
@@ -403,6 +405,7 @@ export function createWithPortableTextMarkModel(
           ) {
             Transforms.insertNodes(editor, {
               ...op.node,
+              _key: editorActor.getSnapshot().context.keyGenerator(),
               marks: nextSpanDecorators,
             })
             return


### PR DESCRIPTION
This allows you to manually insert a block with a custom key andnot worry about it getting overwritten by the internals of the editor.