### PR TITLE
fix(block-tools): ensure single line breaks in blockquotes

### DIFF
--- a/packages/block-tools/src/HtmlDeserializer/index.ts
+++ b/packages/block-tools/src/HtmlDeserializer/index.ts
@@ -221,7 +221,7 @@ export default class HtmlDeserializer {
       ) {
         ret.children.forEach((child, index) => {
           if (isMinimalSpan(child) && child.text === '\r') {
-            child.text = '\n\n'
+            child.text = '\n'
             if (index === 0 || index === ret.children.length - 1) {
               ret.children.splice(index, 1)
             }

--- a/packages/block-tools/src/HtmlDeserializer/rules/html.ts
+++ b/packages/block-tools/src/HtmlDeserializer/rules/html.ts
@@ -67,27 +67,44 @@ export default function createHTMLRules(
           ...HTML_HEADER_TAGS,
         }
         delete blocks.blockquote
+        const nonBlockquoteBlocks = Object.keys(blocks)
 
         const children: HTMLElement[] = []
+
         el.childNodes.forEach((node, index) => {
+          if (!el.ownerDocument) {
+            return
+          }
+
           if (
             node.nodeType === 1 &&
-            Object.keys(blocks).includes(
+            nonBlockquoteBlocks.includes(
               (node as Element).localName.toLowerCase(),
             )
           ) {
-            if (!el.ownerDocument) {
-              return
+            const span = el.ownerDocument.createElement('span')
+
+            const previousChild = children[children.length - 1]
+
+            if (
+              previousChild &&
+              previousChild.nodeType === 3 &&
+              previousChild.textContent?.trim()
+            ) {
+              // Only prepend line break if the previous node is a non-empty
+              // text node.
+              span.appendChild(el.ownerDocument.createTextNode('\r'))
             }
 
-            const span = el.ownerDocument.createElement('span')
-            span.appendChild(el.ownerDocument.createTextNode('\r'))
             node.childNodes.forEach((cn) => {
               span.appendChild(cn.cloneNode(true))
             })
+
             if (index !== el.childNodes.length) {
+              // Only append line break if this is not the last child
               span.appendChild(el.ownerDocument.createTextNode('\r'))
             }
+
             children.push(span)
           } else {
             children.push(node as HTMLElement)

--- a/packages/block-tools/test/html-to-blocks/blockquote.test.ts
+++ b/packages/block-tools/test/html-to-blocks/blockquote.test.ts
@@ -1,0 +1,237 @@
+import {JSDOM} from 'jsdom'
+import {describe, expect, test} from 'vitest'
+import {htmlToBlocks} from '../../src'
+import defaultSchema from '../fixtures/defaultSchema'
+import {createTestKeyGenerator} from '../test-key-generator'
+
+const blockContentType = defaultSchema
+  .get('blogPost')
+  .fields.find((field: any) => field.name === 'body').type
+
+describe(htmlToBlocks.name, () => {
+  test('blockquote of paragraphs', () => {
+    expect(
+      htmlToBlocks(
+        `<blockquote><p>foo bar baz</p><p>fizz buzz</p></blockquote>`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz\nfizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of paragraphs and whitespace', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  <p>foo bar baz</p>
+  <p>fizz buzz</p>
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz\nfizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of paragraph and text node', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  <p>foo bar baz</p>
+  fizz buzz
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz\nfizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of text node and paragraph', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  foo bar baz
+  <p>fizz buzz</p>
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz\nfizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of headings', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  <h1>foo bar baz</h1>
+  <h2>fizz buzz</h2>
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz\nfizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of spans', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  <span>foo bar baz</span>
+  <span>fizz buzz</span>
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz fizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+
+  test('blockquote of text nodes', () => {
+    expect(
+      htmlToBlocks(
+        `
+<blockquote>
+  foo bar baz
+  fizz buzz
+</blockquote>
+`,
+        blockContentType,
+        {
+          parseHtml: (html) => new JSDOM(html).window.document,
+          keyGenerator: createTestKeyGenerator(),
+        },
+      ),
+    ).toEqual([
+      {
+        _key: 'randomKey0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'randomKey1',
+            _type: 'span',
+            marks: [],
+            text: 'foo bar baz fizz buzz',
+          },
+        ],
+        markDefs: [],
+        style: 'blockquote',
+      },
+    ])
+  })
+})

--- a/packages/block-tools/test/tests/HtmlDeserializer/customRules/output.json
+++ b/packages/block-tools/test/tests/HtmlDeserializer/customRules/output.json
@@ -39,7 +39,7 @@
       {
         "_type": "span",
         "marks": [],
-        "text": "\n\n",
+        "text": "\n",
         "_key": "randomKey7"
       },
       {

--- a/packages/block-tools/test/tests/HtmlDeserializer/nestedContainers/output.json
+++ b/packages/block-tools/test/tests/HtmlDeserializer/nestedContainers/output.json
@@ -62,7 +62,7 @@
       {
         "_type": "span",
         "marks": [],
-        "text": "And I'm a quote within a quote within a quote within a quote.\n\nI am a stupid paragraph within with a stupid ",
+        "text": "And I'm a quote within a quote within a quote within a quote.\nI am a stupid paragraph within with a stupid ",
         "_key": "randomKey10"
       },
       {


### PR DESCRIPTION
Before this change, each line break in a blockquote would be double (`\n\n`).
And if the HTML had whitespace, it could potentially yield four line breaks
between each line of text. Now, only a single line break is added between lines
of text in a blockquote.

**Real-world scenario:**

In Notion, it's somehow possible to end up with two merged blockquotes (I'm actually not exactly sure how to do this, I just copy/pasted the example from another Notion document that prompted this fix):

![Screenshot 2025-02-06 at 11 03 10](https://github.com/user-attachments/assets/5a4d09ca-d9bc-4851-91fd-ab98aff9ab75)

Copying that puts the following HTML on the clipboard:

```html
<meta charset='utf-8'><blockquote>
<p>foo bar baz</p>
<p>fizz buzz</p>
</blockquote>
<!-- notionvc: fad7c39a-dfab-437d-83a0-bbac20480256 -->
```

Pasting this would previously yield:

![Screenshot 2025-02-06 at 11 06 06](https://github.com/user-attachments/assets/d5e37262-107f-4a64-9d61-ba544546cc34)

But now it yields:

![Screenshot 2025-02-06 at 11 06 12](https://github.com/user-attachments/assets/01dd353f-92a8-4b1c-acab-bd7a891d39e5)
