### PR TITLE
fix: make sure value sync is retried when busy

### DIFF
--- a/packages/editor/src/editor/PortableTextEditor.tsx
+++ b/packages/editor/src/editor/PortableTextEditor.tsx
@@ -684,7 +684,6 @@ export class PortableTextEditor extends Component<
   static getFragment = (
     editor: PortableTextEditor,
   ): PortableTextBlock[] | undefined => {
-    debug(`Host getting fragment`)
     return editor.editable?.getFragment()
   }
 

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -287,6 +287,7 @@ export const syncMachine = setup({
             1000: [
               {
                 guard: 'is busy',
+                target: '.',
                 reenter: true,
                 actions: [
                   () => {


### PR DESCRIPTION
Before this change, the sync machine would not reenter the `busy` state and
thus it wouldn't restart the 1000ms interval to check the busy state again.
This meant that if the machine tried to sync a value at the same time as
concurrent edits were happening, the machine would get stuck and never leave
the `busy` state. Specifying the `target` of the transition solves this issue.