### PR TITLE
fix(selector.getSelectedSpans): don't include spans at the edge of a selection

### DIFF
--- a/packages/editor/src/selectors/selector.get-selected-spans.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-spans.test.ts
@@ -1,123 +1,221 @@
-import {expect, test} from 'vitest'
+import type {PortableTextBlock} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
 import {getSelectedSpans, type EditorSchema, type EditorSelection} from '.'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 
-test(getSelectedSpans.name, () => {
-  function snapshot(selection: EditorSelection): EditorSnapshot {
+const fooBar = {
+  _type: 'block',
+  _key: 'b1',
+  children: [
+    {
+      _type: 'span',
+      _key: 's1',
+      text: 'foo',
+      marks: ['strong'],
+    },
+    {
+      _type: 'span',
+      _key: 's2',
+      text: 'bar',
+    },
+  ],
+}
+const image = {
+  _type: 'image',
+  _key: 'b2',
+}
+const baz = {
+  _type: 'block',
+  _key: 'b3',
+  children: [
+    {
+      _type: 'span',
+      _key: 's3',
+      text: 'baz',
+    },
+  ],
+}
+
+describe(getSelectedSpans.name, () => {
+  function snapshot(
+    value: Array<PortableTextBlock>,
+    selection: EditorSelection,
+  ): EditorSnapshot {
     return {
       context: {
         converters: [],
         schema: {} as EditorSchema,
         keyGenerator: () => '',
         activeDecorators: [],
-        value: [
-          {
-            _type: 'block',
-            _key: 'b1',
-            children: [
-              {
-                _type: 'span',
-                _key: 's1',
-                text: 'foo',
-                marks: ['strong'],
-              },
-              {
-                _type: 'span',
-                _key: 's2',
-                text: 'bar',
-              },
-            ],
-          },
-          {
-            _type: 'image',
-            _key: 'b2',
-          },
-          {
-            _type: 'block',
-            _key: 'b3',
-            children: [
-              {
-                _type: 'span',
-                _key: 's3',
-                text: 'baz',
-              },
-            ],
-          },
-        ],
+        value,
         selection,
       },
     }
   }
 
-  expect(
-    getSelectedSpans(
-      snapshot({
-        anchor: {
-          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-          offset: 0,
-        },
-        focus: {
-          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-          offset: 3,
-        },
-      }),
-    ),
-  ).toEqual([
-    {
-      node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
-      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-    },
-  ])
+  test('selecting a single span', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar, image, baz], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 3,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+    ])
+  })
 
-  expect(
-    getSelectedSpans(
-      snapshot({
-        anchor: {
-          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-          offset: 2,
-        },
-        focus: {
-          path: [{_key: 'b1'}, 'children', {_key: 's2'}],
-          offset: 3,
-        },
-      }),
-    ),
-  ).toEqual([
-    {
-      node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
-      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-    },
-    {
-      node: {_type: 'span', _key: 's2', text: 'bar'},
-      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
-    },
-  ])
+  test('selecting from start-span to start-span', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+            offset: 0,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+    ])
+  })
 
-  expect(
-    getSelectedSpans(
-      snapshot({
-        anchor: {
-          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-          offset: 2,
-        },
-        focus: {
-          path: [{_key: 'b3'}, 'children', {_key: 's3'}],
-          offset: 2,
-        },
-      }),
-    ),
-  ).toEqual([
-    {
-      node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
-      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
-    },
-    {
-      node: {_type: 'span', _key: 's2', text: 'bar'},
-      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
-    },
-    {
-      node: {_type: 'span', _key: 's3', text: 'baz'},
-      path: [{_key: 'b3'}, 'children', {_key: 's3'}],
-    },
-  ])
+  test('selection from mid-span to mid-span', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 2,
+          },
+          focus: {
+            path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+            offset: 3,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+      {
+        node: {_type: 'span', _key: 's2', text: 'bar'},
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      },
+    ])
+  })
+
+  test('selecting from end-span to end-span', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+            offset: 3,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's2', text: 'bar'},
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      },
+    ])
+  })
+
+  test('selecting from start-span to start-span across blocks', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar, baz], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: 'b3'}, 'children', {_key: 's3'}],
+            offset: 0,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's2', text: 'bar'},
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      },
+    ])
+  })
+
+  test('selecting from mid-span to mid-span across blocks', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar, image, baz], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 2,
+          },
+          focus: {
+            path: [{_key: 'b3'}, 'children', {_key: 's3'}],
+            offset: 2,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+      {
+        node: {_type: 'span', _key: 's2', text: 'bar'},
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      },
+      {
+        node: {_type: 'span', _key: 's3', text: 'baz'},
+        path: [{_key: 'b3'}, 'children', {_key: 's3'}],
+      },
+    ])
+  })
+
+  test('selecting from end-span to end-span across blocks', () => {
+    expect(
+      getSelectedSpans(
+        snapshot([fooBar, baz], {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: 'b3'}, 'children', {_key: 's3'}],
+            offset: 3,
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        node: {_type: 'span', _key: 's3', text: 'baz'},
+        path: [{_key: 'b3'}, 'children', {_key: 's3'}],
+      },
+    ])
+  })
 })

--- a/packages/editor/src/selectors/selector.get-selected-spans.ts
+++ b/packages/editor/src/selectors/selector.get-selected-spans.ts
@@ -62,10 +62,12 @@ export const getSelectedSpans: EditorSelector<
         }
 
         if (startSpanKey && child._key === startSpanKey) {
-          selectedSpans.push({
-            node: child,
-            path: [{_key: block._key}, 'children', {_key: child._key}],
-          })
+          if (startPoint.offset < child.text.length) {
+            selectedSpans.push({
+              node: child,
+              path: [{_key: block._key}, 'children', {_key: child._key}],
+            })
+          }
 
           if (startSpanKey === endSpanKey) {
             break
@@ -75,10 +77,12 @@ export const getSelectedSpans: EditorSelector<
         }
 
         if (endSpanKey && child._key === endSpanKey) {
-          selectedSpans.push({
-            node: child,
-            path: [{_key: block._key}, 'children', {_key: child._key}],
-          })
+          if (endPoint.offset > 0) {
+            selectedSpans.push({
+              node: child,
+              path: [{_key: block._key}, 'children', {_key: child._key}],
+            })
+          }
           break
         }
 
@@ -104,10 +108,12 @@ export const getSelectedSpans: EditorSelector<
         }
 
         if (endSpanKey && child._key === endSpanKey) {
-          selectedSpans.push({
-            node: child,
-            path: [{_key: block._key}, 'children', {_key: child._key}],
-          })
+          if (endPoint.offset > 0) {
+            selectedSpans.push({
+              node: child,
+              path: [{_key: block._key}, 'children', {_key: child._key}],
+            })
+          }
           break
         }
 

--- a/packages/editor/src/selectors/selector.is-active-annotation.ts
+++ b/packages/editor/src/selectors/selector.is-active-annotation.ts
@@ -1,7 +1,8 @@
 import {isPortableTextTextBlock} from '@sanity/types'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getSelectedSpans} from './selector.get-selected-spans'
-import {getSelectedBlocks} from './selectors'
+import {isSelectionExpanded} from './selector.is-selection-expanded'
+import {getFocusSpan, getSelectedBlocks} from './selectors'
 
 /**
  * @public
@@ -15,7 +16,13 @@ export function isActiveAnnotation(
     }
 
     const selectedBlocks = getSelectedBlocks(snapshot)
-    const selectedSpans = getSelectedSpans(snapshot)
+    const focusSpan = getFocusSpan(snapshot)
+
+    const selectedSpans = isSelectionExpanded(snapshot)
+      ? getSelectedSpans(snapshot)
+      : focusSpan
+        ? [focusSpan]
+        : []
 
     if (selectedSpans.length === 0) {
       return false


### PR DESCRIPTION
Before this change, the `getSelectedSpans` selector would include start and
end spans of a selection even if they were right at the edge of a selection.
Not only is this unexpected (the text of the spans is not visually selected),
it also results in other issues downstream. For example, the
`isActiveDecorator` would return `false` for a decorator that is clearly
(visually) active in the current selection.

`isActiveAnnotation` also needs to be adjusted as a result of this change. It
is expected that you can toggle an annotation with a collapsed selection, so in
this case we need to use `getFocusSpan` instead of `getSelectedSpan`.