### PR TITLE
feat: Add support for Data Tables and DocStrings

### DIFF
--- a/packages/racejar/example/hello-herman.test.ts
+++ b/packages/racejar/example/hello-herman.test.ts
@@ -2,8 +2,8 @@ import {expect} from 'vitest'
 import {Given, Then, When} from '../src/step-definitions'
 import {Feature} from '../src/vitest'
 
-function greet(name: string) {
-  return `Hello, ${name}!`
+function greet(name: string, greeting: string) {
+  return `Hello ${name}, ${greeting}`
 }
 
 type Context = {
@@ -16,15 +16,19 @@ Feature({
     Feature: Greeting
       Scenario: Greeting a person
         Given the person "Herman"
-        When greeting the person
-        Then the greeting is "Hello, Herman!"`,
+        When greeting the person with:
+          | how are you? |
+        Then the greeting is "Hello Herman, how are you?"`,
   stepDefinitions: [
     Given('the person {string}', (context: Context, person: string) => {
       context.person = person
     }),
-    When('greeting the person', (context: Context) => {
-      context.greeting = greet(context.person)
-    }),
+    When(
+      'greeting the person with:',
+      (context: Context, greeting: string[][]) => {
+        context.greeting = greet(context.person, greeting[0][0])
+      },
+    ),
     Then('the greeting is {string}', (context: Context, greeting: string) => {
       expect(context.greeting).toBe(greeting)
     }),

--- a/packages/racejar/src/compile-feature.ts
+++ b/packages/racejar/src/compile-feature.ts
@@ -118,6 +118,16 @@ export function compileFeature<
       }
 
       const args = matchingStep.args.map((arg) => arg.getValue(matchingStep))
+      if (step.argument?.dataTable) {
+        args.push(
+          step.argument.dataTable.rows.map((row) =>
+            row.cells.map((cell) => cell.value),
+          ),
+        )
+      }
+      if (step.argument?.docString) {
+        args.push(step.argument.docString.content)
+      }
 
       return (stepContext: TStepContext | undefined) =>
         matchingStep.callback(


### PR DESCRIPTION
This adds support for Data Tables and DocStrings.

I deliberately did not create a `DataTable` class (as in the original `@cucumber/cucumber`).
I think it's better to keep this out of the library.

I really like what you have done with racejar - making it possible to use Cucumber from other test runners.
Would you be open to extracting racejar to a separate repo?
I have started using Racejar for a my startup (openartmarket.com), so I would be interested in some level of co-maintenance.

I'm the original creator of Cucumber, but I haven't been involved with it for a few years now.
There is an active group of maintainers of Cucumber in the `cucumber` GitHub org, and if they are open to it, we could host the repo there (if everyone agrees). /cc @davidjgoss