### PR TITLE
feat: add support for Before and After hooks

### DIFF
--- a/packages/racejar/example/hooks.test.ts
+++ b/packages/racejar/example/hooks.test.ts
@@ -1,9 +1,10 @@
 import {expect} from 'vitest'
+import {After, Before} from '../src/hooks'
 import {Given, Then, When} from '../src/step-definitions'
 import {Feature} from '../src/vitest'
 
-function greet(name: string, greeting: string) {
-  return `Hello ${name}, ${greeting}`
+function greet(prefix: string, name: string) {
+  return `${prefix} ${name}`
 }
 
 type Context = {
@@ -17,19 +18,23 @@ Feature({
     Feature: Greeting
       Scenario: Greeting a person
         Given the person "Herman"
-        When greeting the person with:
-          | how are you? |
-        Then the greeting is "Hello Herman, how are you?"`,
+        When greeting the person
+        Then the greeting is "Hello Herman"`,
+  hooks: [
+    Before((context: Context) => {
+      context.greetingPrefix = 'Hello'
+    }),
+    After((context: Context) => {
+      expect(context.greeting).toBe('Hello Herman')
+    }),
+  ],
   stepDefinitions: [
     Given('the person {string}', (context: Context, person: string) => {
       context.person = person
     }),
-    When(
-      'greeting the person with:',
-      (context: Context, greeting: string[][]) => {
-        context.greeting = greet(context.person, greeting[0][0])
-      },
-    ),
+    When('greeting the person', (context: Context) => {
+      context.greeting = greet(context.greetingPrefix, context.person)
+    }),
     Then('the greeting is {string}', (context: Context, greeting: string) => {
       expect(context.greeting).toBe(greeting)
     }),

--- a/packages/racejar/src/hooks.ts
+++ b/packages/racejar/src/hooks.ts
@@ -1,0 +1,32 @@
+/**
+ * @public
+ */
+export type Hook<TContext extends Record<string, any> = object> = {
+  type: 'Before' | 'After'
+  callback: HookCallback<TContext>
+}
+
+/**
+ * @public
+ */
+export type HookCallback<TContext extends Record<string, any> = object> = (
+  context: TContext,
+) => Promise<void> | void
+
+/**
+ * @public
+ */
+export function Before<TContext extends Record<string, any> = object>(
+  callback: HookCallback<TContext>,
+): Hook<TContext> {
+  return {type: 'Before', callback}
+}
+
+/**
+ * @public
+ */
+export function After<TContext extends Record<string, any> = object>(
+  callback: HookCallback<TContext>,
+): Hook<TContext> {
+  return {type: 'After', callback}
+}

--- a/packages/racejar/src/index.ts
+++ b/packages/racejar/src/index.ts
@@ -1,3 +1,4 @@
 export * from './compile-feature'
 export * from './create-parameter-type'
 export * from './step-definitions'
+export * from './hooks'

--- a/packages/racejar/src/vitest/vitest-gherkin-driver.ts
+++ b/packages/racejar/src/vitest/vitest-gherkin-driver.ts
@@ -1,6 +1,7 @@
 import type {ParameterType} from '@cucumber/cucumber-expressions'
-import {describe, test} from 'vitest'
+import {afterEach, beforeEach, describe, test} from 'vitest'
 import {compileFeature} from '../compile-feature'
+import type {Hook} from '../hooks'
 import type {StepDefinition} from '../step-definitions'
 
 /**
@@ -8,15 +9,18 @@ import type {StepDefinition} from '../step-definitions'
  */
 export function Feature<TContext extends Record<string, any> = object>({
   featureText,
+  hooks,
   stepDefinitions,
   parameterTypes,
 }: {
   featureText: string
+  hooks?: Array<Hook<TContext>>
   stepDefinitions: Array<StepDefinition<TContext, any, any, any>>
   parameterTypes?: Array<ParameterType<unknown>>
 }) {
   const feature = compileFeature({
     featureText,
+    hooks,
     stepDefinitions,
     parameterTypes,
   })
@@ -30,6 +34,14 @@ export function Feature<TContext extends Record<string, any> = object>({
 
   describeFn(feature.name, () => {
     for (const scenario of feature.scenarios) {
+      for (const before of scenario.beforeHooks) {
+        beforeEach(before)
+      }
+
+      for (const after of scenario.afterHooks) {
+        afterEach(after)
+      }
+
       const testFn =
         scenario.tag === 'only'
           ? test.only


### PR DESCRIPTION
This adds support for Before and After hooks.

Cucumber allows for scoping of hooks via tags - I have not added this in this PR.

Hooks are useful for setting up context (such as clearing a database).