### PR TITLE
fix(markdown emphasis): fix edge case producing wrong match

### DIFF
--- a/packages/editor/src/behaviors/behavior.markdown-emphasis.ts
+++ b/packages/editor/src/behaviors/behavior.markdown-emphasis.ts
@@ -9,6 +9,10 @@ import {
 } from 'xstate'
 import type {Editor} from '../editor/create-editor'
 import {useEditor} from '../editor/editor-provider'
+import {
+  getTextToBold,
+  getTextToItalic,
+} from '../internal-utils/get-text-to-emphasize'
 import type {EditorSchema} from '../selectors'
 import * as selectors from '../selectors'
 import * as utils from '../utils'
@@ -42,11 +46,6 @@ export function useMarkdownEmphasisBehaviors(props: {
     },
   })
 }
-
-const italicRegex =
-  /(?<!\*)\*(?!\s)([^*\n]+?)(?<!\s)\*(?!\*)|(?<!_)_(?!\s)([^_\n]+?)(?<!\s)_(?!_)$/
-const boldRegex =
-  /(?<!\*)\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*(?!\*)|(?<!_)__(?!\s)([^_\n]+?)(?<!\s)__(?!_)$/
 
 type MarkdownEmphasisEvent =
   | {
@@ -99,9 +98,7 @@ const emphasisListener: CallbackLogicFunction<
 
         const textBefore = selectors.getBlockTextBefore({context})
 
-        const textToItalic = `${textBefore}${event.text}`
-          .match(italicRegex)
-          ?.at(0)
+        const textToItalic = getTextToItalic(`${textBefore}${event.text}`)
 
         if (textToItalic !== undefined && italicDecorator !== undefined) {
           const prefixOffsets = {
@@ -146,7 +143,7 @@ const emphasisListener: CallbackLogicFunction<
           }
         }
 
-        const textToBold = `${textBefore}${event.text}`.match(boldRegex)?.at(0)
+        const textToBold = getTextToBold(`${textBefore}${event.text}`)
 
         if (textToBold !== undefined && boldDecorator !== undefined) {
           const prefixOffsets = {

--- a/packages/editor/src/internal-utils/get-text-to-emphasize.test.ts
+++ b/packages/editor/src/internal-utils/get-text-to-emphasize.test.ts
@@ -1,0 +1,36 @@
+import {expect, test} from 'vitest'
+import {getTextToBold, getTextToItalic} from './get-text-to-emphasize'
+
+test(getTextToItalic.name, () => {
+  expect(getTextToItalic('Hello *world*')).toBe('*world*')
+  expect(getTextToItalic('Hello _world_')).toBe('_world_')
+  expect(getTextToItalic('*Hello*world*')).toBe('*world*')
+  expect(getTextToItalic('_Hello_world_')).toBe('_world_')
+
+  expect(getTextToItalic('Hello *world')).toBe(undefined)
+  expect(getTextToItalic('Hello world*')).toBe(undefined)
+  expect(getTextToItalic('Hello *world* *')).toBe(undefined)
+
+  expect(getTextToItalic('_Hello*world_')).toBe('_Hello*world_')
+  expect(getTextToItalic('*Hello_world*')).toBe('*Hello_world*')
+
+  expect(getTextToItalic('*hello\nworld*')).toBe(undefined)
+  expect(getTextToItalic('_hello\nworld_')).toBe(undefined)
+})
+
+test(getTextToBold.name, () => {
+  expect(getTextToBold('Hello **world**')).toBe('**world**')
+  expect(getTextToBold('Hello __world__')).toBe('__world__')
+  expect(getTextToBold('**Hello**world**')).toBe('**world**')
+  expect(getTextToBold('__Hello__world__')).toBe('__world__')
+
+  expect(getTextToBold('Hello **world')).toBe(undefined)
+  expect(getTextToBold('Hello world**')).toBe(undefined)
+  expect(getTextToBold('Hello **world** **')).toBe(undefined)
+
+  expect(getTextToBold('__Hello**world__')).toBe('__Hello**world__')
+  expect(getTextToBold('**Hello__world**')).toBe('**Hello__world**')
+
+  expect(getTextToBold('**hello\nworld**')).toBe(undefined)
+  expect(getTextToBold('__hello\nworld__')).toBe(undefined)
+})

--- a/packages/editor/src/internal-utils/get-text-to-emphasize.ts
+++ b/packages/editor/src/internal-utils/get-text-to-emphasize.ts
@@ -1,0 +1,18 @@
+const asteriskPairRegex = '(?<!\\*)\\*(?!\\s)([^*\\n]+?)(?<!\\s)\\*(?!\\*)'
+const underscorePairRegex = '(?<!_)_(?!\\s)([^_\\n]+?)(?<!\\s)_(?!_)'
+const italicRegex = new RegExp(`(${asteriskPairRegex}|${underscorePairRegex})$`)
+
+const doubleAsteriskPairRegex =
+  '(?<!\\*)\\*\\*(?!\\s)([^*\\n]+?)(?<!\\s)\\*\\*(?!\\*)'
+const doubleUnderscorePairRegex = '(?<!_)__(?!\\s)([^_\\n]+?)(?<!\\s)__(?!_)'
+const boldRegex = new RegExp(
+  `(${doubleAsteriskPairRegex}|${doubleUnderscorePairRegex})$`,
+)
+
+export function getTextToItalic(text: string) {
+  return text.match(italicRegex)?.at(0)
+}
+
+export function getTextToBold(text: string) {
+  return text.match(boldRegex)?.at(0)
+}


### PR DESCRIPTION
I had forgot a `$` for the first part of each regex so `*Hello*world*` would result in `*Hello*` as a match, not `*world*`. This has now been fixed and unit tests have been added.