### PR TITLE
fix: make sure Mod+Backspace can delete line

### DIFF
--- a/packages/editor/src/behavior-actions/behavior.actions.ts
+++ b/packages/editor/src/behavior-actions/behavior.actions.ts
@@ -1,10 +1,4 @@
-import {
-  deleteBackward,
-  deleteForward,
-  insertText,
-  Path,
-  Transforms,
-} from 'slate'
+import {deleteForward, insertText, Path, Transforms} from 'slate'
 import {ReactEditor} from 'slate-react'
 import type {
   BehaviorAction,
@@ -95,7 +89,7 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
   },
   'delete': deleteActionImplementation,
   'delete.backward': ({action}) => {
-    deleteBackward(action.editor, action.unit)
+    action.editor.deleteBackward(action.unit)
   },
   'delete.forward': ({action}) => {
     deleteForward(action.editor, action.unit)


### PR DESCRIPTION
The `deleteBackward` method on the `editor` object contains special handling for line deletion. If we use the `deleteBackward` transformation directly, we miss out on that.

https://github.com/ianstormtaylor/slate/blob/7a8ab18c527c97aebcafe5b88032da38aa1664b0/packages/slate-dom/src/plugin/with-dom.ts#L93