### PR TITLE
fix: `block.(set|unset)`

### DIFF
--- a/packages/editor/src/behavior-actions/behavior.action.block.set.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.block.set.ts
@@ -1,10 +1,13 @@
-import {Transforms} from 'slate'
+import {Editor, Transforms, type Element as SlateElement} from 'slate'
+import {parseBlock} from '../internal-utils/parse-blocks'
 import {toSlateRange} from '../internal-utils/ranges'
+import {fromSlateValue, toSlateValue} from '../internal-utils/values'
+import {KEY_TO_VALUE_ELEMENT} from '../internal-utils/weakMaps'
 import type {BehaviorActionImplementation} from './behavior.actions'
 
 export const blockSetBehaviorActionImplementation: BehaviorActionImplementation<
   'block.set'
-> = ({action}) => {
+> = ({context, action}) => {
   const location = toSlateRange(
     {
       anchor: {path: action.at, offset: 0},
@@ -14,10 +17,50 @@ export const blockSetBehaviorActionImplementation: BehaviorActionImplementation<
   )
 
   if (!location) {
-    return
+    throw new Error(
+      `Unable to convert ${JSON.stringify(action.at)} into a Slate Range`,
+    )
   }
 
-  const {at, editor, type, ...payload} = action
+  const blockEntry = Editor.node(action.editor, location, {depth: 1})
+  const block = blockEntry?.[0]
 
-  Transforms.setNodes(action.editor, payload, {at: location})
+  if (!block) {
+    throw new Error(`Unable to find block at ${JSON.stringify(action.at)}`)
+  }
+
+  const parsedBlock = fromSlateValue(
+    [block],
+    context.schema.block.name,
+    KEY_TO_VALUE_ELEMENT.get(action.editor),
+  ).at(0)
+
+  if (!parsedBlock) {
+    throw new Error(`Unable to parse block at ${JSON.stringify(action.at)}`)
+  }
+
+  const {_type, ...filteredProps} = action.props
+
+  const updatedBlock = parseBlock({
+    context,
+    block: {
+      ...parsedBlock,
+      ...filteredProps,
+    },
+    options: {refreshKeys: false},
+  })
+
+  if (!updatedBlock) {
+    throw new Error(`Unable to update block at ${JSON.stringify(action.at)}`)
+  }
+
+  const slateBlock = toSlateValue([updatedBlock], {
+    schemaTypes: context.schema,
+  })?.at(0) as SlateElement | undefined
+
+  if (!slateBlock) {
+    throw new Error(`Unable to convert block to Slate value`)
+  }
+
+  Transforms.setNodes(action.editor, slateBlock, {at: location})
 }

--- a/packages/editor/src/behavior-actions/behavior.action.block.unset.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.block.unset.ts
@@ -1,10 +1,14 @@
-import {Transforms} from 'slate'
+import {omit} from 'lodash'
+import {Editor, Transforms} from 'slate'
+import {isTextBlock, parseBlock} from '../internal-utils/parse-blocks'
 import {toSlateRange} from '../internal-utils/ranges'
+import {fromSlateValue} from '../internal-utils/values'
+import {KEY_TO_VALUE_ELEMENT} from '../internal-utils/weakMaps'
 import type {BehaviorActionImplementation} from './behavior.actions'
 
 export const blockUnsetBehaviorActionImplementation: BehaviorActionImplementation<
   'block.unset'
-> = ({action}) => {
+> = ({context, action}) => {
   const location = toSlateRange(
     {
       anchor: {path: action.at, offset: 0},
@@ -14,8 +18,78 @@ export const blockUnsetBehaviorActionImplementation: BehaviorActionImplementatio
   )
 
   if (!location) {
+    throw new Error(
+      `Unable to convert ${JSON.stringify(action.at)} into a Slate Range`,
+    )
+  }
+
+  const blockEntry = Editor.node(action.editor, location, {depth: 1})
+  const block = blockEntry?.[0]
+
+  if (!block) {
+    throw new Error(`Unable to find block at ${JSON.stringify(action.at)}`)
+  }
+
+  const parsedBlock = fromSlateValue(
+    [block],
+    context.schema.block.name,
+    KEY_TO_VALUE_ELEMENT.get(action.editor),
+  ).at(0)
+
+  if (!parsedBlock) {
+    throw new Error(`Unable to parse block at ${JSON.stringify(action.at)}`)
+  }
+
+  if (isTextBlock(context.schema, parsedBlock)) {
+    const propsToRemove = action.props.filter((prop) => prop !== '_type')
+
+    const updatedTextBlock = parseBlock({
+      context,
+      block: omit(parsedBlock, propsToRemove),
+      options: {refreshKeys: false},
+    })
+
+    if (!updatedTextBlock) {
+      throw new Error(`Unable to update block at ${JSON.stringify(action.at)}`)
+    }
+
+    const propsToSet: Record<string, unknown> = {}
+
+    for (const prop of propsToRemove) {
+      if (!(prop in updatedTextBlock)) {
+        propsToSet[prop] = undefined
+      } else {
+        propsToSet[prop] = (updatedTextBlock as Record<string, unknown>)[prop]
+      }
+    }
+
+    Transforms.setNodes(action.editor, propsToSet, {at: location})
+
     return
   }
 
-  Transforms.unsetNodes(action.editor, action.props, {at: location})
+  const updatedBlockObject = parseBlock({
+    context,
+    block: omit(
+      parsedBlock,
+      action.props.filter((prop) => prop !== '_type'),
+    ),
+    options: {refreshKeys: false},
+  })
+
+  if (!updatedBlockObject) {
+    throw new Error(`Unable to update block at ${JSON.stringify(action.at)}`)
+  }
+
+  const {_type, _key, ...props} = updatedBlockObject
+
+  Transforms.setNodes(
+    action.editor,
+    {
+      _type,
+      _key,
+      value: props,
+    },
+    {at: location},
+  )
 }

--- a/packages/editor/src/behaviors/behavior.types.ts
+++ b/packages/editor/src/behaviors/behavior.types.ts
@@ -38,7 +38,7 @@ export type SyntheticBehaviorEvent =
   | {
       type: 'block.set'
       at: [KeyedSegment]
-      [props: string]: unknown
+      props: Record<string, unknown>
     }
   | {
       type: 'block.unset'

--- a/packages/editor/src/internal-utils/parse-blocks.ts
+++ b/packages/editor/src/internal-utils/parse-blocks.ts
@@ -4,6 +4,7 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@sanity/types'
+import type {EditorSchema} from '../editor/define-schema'
 import type {EditorContext} from '../editor/editor-snapshot'
 import {isTypedObject} from './asserters'
 
@@ -53,6 +54,19 @@ function parseBlockObject({
         ? blockObject._key
         : context.keyGenerator(),
   }
+}
+
+export function isTextBlock(
+  schema: EditorSchema,
+  block: unknown,
+): block is PortableTextTextBlock {
+  return (
+    parseTextBlock({
+      block,
+      context: {schema, keyGenerator: () => ''},
+      options: {refreshKeys: false},
+    }) !== undefined
+  )
 }
 
 function parseTextBlock({

--- a/packages/editor/tests/event.block.set.test.tsx
+++ b/packages/editor/tests/event.block.set.test.tsx
@@ -1,0 +1,317 @@
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+} from '../src'
+import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
+
+describe('event.block.set', () => {
+  test('Scenario: adding block object property', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.set',
+      at: [{_key: urlBlockKey}],
+      props: {
+        description: 'Sanity is a headless CMS',
+      },
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+          description: 'Sanity is a headless CMS',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: updating block object _key', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    const newUrlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'block.set',
+      at: [{_key: urlBlockKey}],
+      props: {
+        _key: newUrlBlockKey,
+      },
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: newUrlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: updating block object _type is a noop', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.set',
+      at: [{_key: urlBlockKey}],
+      props: {
+        _type: 'block',
+      },
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: adding text block property', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            styles: [{name: 'normal'}, {name: 'h1'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const textBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: textBlockKey,
+        _type: 'block',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(
+        editorRef.current?.getSnapshot().context.value,
+      ).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          style: 'normal',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.set',
+      at: [{_key: textBlockKey}],
+      props: {
+        style: 'h1',
+      },
+    })
+
+    await vi.waitFor(() => {
+      return expect(
+        editorRef.current?.getSnapshot().context.value,
+      ).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          style: 'h1',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: adding custom block property', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            styles: [{name: 'normal'}, {name: 'h1'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const textBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: textBlockKey,
+        _type: 'block',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(
+        editorRef.current?.getSnapshot().context.value,
+      ).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          style: 'normal',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.set',
+      at: [{_key: textBlockKey}],
+      props: {
+        foo: 'bar',
+      },
+    })
+
+    await vi.waitFor(() => {
+      return expect(
+        editorRef.current?.getSnapshot().context.value,
+      ).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          foo: 'bar',
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.block.unset.test.tsx
+++ b/packages/editor/tests/event.block.unset.test.tsx
@@ -1,0 +1,383 @@
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+} from '../src'
+import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
+import {EditorRefPlugin} from '../src/plugins'
+
+describe('event.block.unset', () => {
+  test('Scenario: removing block object property', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: urlBlockKey}],
+      props: ['href'],
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: removing block object _key sets a new _key', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: urlBlockKey}],
+      props: ['_key'],
+    })
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.value).toMatchObject([
+        {
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+      expect(
+        editorRef.current?.getSnapshot().context.value[0]._key,
+      ).not.toEqual(urlBlockKey)
+    })
+  })
+
+  test('Scenario: removing block object _type is a noop', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'url'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const urlBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: urlBlockKey,
+        _type: 'url',
+        href: 'https://www.sanity.io',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: urlBlockKey}],
+      props: ['_type'],
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: urlBlockKey,
+          _type: 'url',
+          href: 'https://www.sanity.io',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: removing text block listItem', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            lists: [{name: 'bullet'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const textBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: textBlockKey,
+        _type: 'block',
+        children: [
+          {_key: keyGenerator(), _type: 'span', text: 'Hello, world!'},
+        ],
+        listItem: 'bullet',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(
+        editorRef.current?.getSnapshot().context.value,
+      ).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          listItem: 'bullet',
+          style: 'normal',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: textBlockKey}],
+      props: ['listItem'],
+    })
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.value).toMatchObject([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+        },
+      ])
+      expect(editorRef.current?.getSnapshot().context.value[0].listItem).toBe(
+        undefined,
+      )
+    })
+  })
+
+  test('Scenario: removing text block style', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            styles: [{name: 'normal'}, {name: 'h1'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const textBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: textBlockKey,
+        _type: 'block',
+        children: [
+          {_key: keyGenerator(), _type: 'span', text: 'Hello, world!'},
+        ],
+        style: 'h1',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          children: [
+            {_key: 'k3', _type: 'span', text: 'Hello, world!', marks: []},
+          ],
+          markDefs: [],
+          style: 'h1',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: textBlockKey}],
+      props: ['style'],
+    })
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          children: [
+            {_key: 'k3', _type: 'span', text: 'Hello, world!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Removing text block children is a noop', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const textBlockKey = keyGenerator()
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _key: textBlockKey,
+        _type: 'block',
+        children: [
+          {_key: keyGenerator(), _type: 'span', text: 'Hello, world!'},
+        ],
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          children: [
+            {_key: 'k3', _type: 'span', text: 'Hello, world!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    editorRef.current?.send({
+      type: 'block.unset',
+      at: [{_key: textBlockKey}],
+      props: ['children'],
+    })
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        {
+          _key: textBlockKey,
+          _type: 'block',
+          children: [
+            {_key: 'k3', _type: 'span', text: 'Hello, world!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
`block.set` and `block.unset` to set/unset arbitrary props (and the _key) on block objects now works as expected. See the two commits for more detail.