### PR TITLE
fix(types): remove cyclic dependencies

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -70,6 +70,7 @@
     "build": "pkg-utils build --strict --check --clean",
     "check:lint": "biome lint .",
     "check:types": "tsc",
+    "check:types:watch": "tsc --watch",
     "check:react-compiler": "eslint --cache --no-inline-config --no-eslintrc --ignore-pattern '**/__tests__/**' --ext .cjs,.mjs,.js,.jsx,.ts,.tsx --parser @typescript-eslint/parser --plugin react-compiler --plugin react-hooks --rule 'react-compiler/react-compiler: [warn,{__unstable_donotuse_reportAllBailouts: true}]' --rule 'react-hooks/rules-of-hooks: [error]' --rule 'react-hooks/exhaustive-deps: [error]' src",
     "clean": "del .turbo && del lib && del node_modules",
     "dev": "pkg-utils watch",

--- a/packages/editor/src/behaviors/behavior.decorator-pair.ts
+++ b/packages/editor/src/behaviors/behavior.decorator-pair.ts
@@ -1,3 +1,4 @@
+import type {EditorSchema} from '../editor/define-schema'
 import {createPairRegex} from '../internal-utils/get-text-to-emphasize'
 import * as selectors from '../selectors'
 import type {BlockOffset} from '../types/block-offset'
@@ -5,7 +6,7 @@ import * as utils from '../utils'
 import {defineBehavior} from './behavior.types'
 
 export function createDecoratorPairBehavior(config: {
-  decorator: ({schema}: {schema: selectors.EditorSchema}) => string | undefined
+  decorator: ({schema}: {schema: EditorSchema}) => string | undefined
   pair: {char: string; amount: number}
   onDecorate: (offset: BlockOffset) => void
 }) {

--- a/packages/editor/src/behaviors/index.ts
+++ b/packages/editor/src/behaviors/index.ts
@@ -1,11 +1,3 @@
-export type {EditorSchema} from '../editor/define-schema'
-export type {EditorContext} from '../editor/editor-snapshot'
-export type {PickFromUnion} from '../type-utils'
-export type {
-  EditorSelection,
-  EditorSelectionPoint,
-  PortableTextMemberSchemaTypes,
-} from '../types/editor'
 export {
   createCodeEditorBehaviors,
   type CodeEditorBehaviorsConfig,

--- a/packages/editor/src/converters/converter.text-html.serialize.test.ts
+++ b/packages/editor/src/converters/converter.text-html.serialize.test.ts
@@ -1,12 +1,12 @@
 import type {PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
+import type {EditorSelection} from '..'
 import {
   compileSchemaDefinition,
   defineSchema,
   type SchemaDefinition,
 } from '../editor/define-schema'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
-import type {EditorSelection} from '../utils'
 import {converterTextHtml} from './converter.text-html'
 import {coreConverters} from './converters.core'
 

--- a/packages/editor/src/converters/converter.text-plain.test.ts
+++ b/packages/editor/src/converters/converter.text-plain.test.ts
@@ -1,12 +1,12 @@
 import type {PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
 import {expect, test} from 'vitest'
+import type {EditorSelection} from '..'
 import {
   compileSchemaDefinition,
   defineSchema,
   type SchemaDefinition,
 } from '../editor/define-schema'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
-import type {EditorSelection} from '../utils'
 import {converterTextPlain} from './converter.text-plain'
 import {coreConverters} from './converters.core'
 

--- a/packages/editor/src/internal-utils/create-test-snapshot.ts
+++ b/packages/editor/src/internal-utils/create-test-snapshot.ts
@@ -1,5 +1,5 @@
+import type {EditorSnapshot} from '..'
 import {compileSchemaDefinition, defineSchema} from '../editor/define-schema'
-import type {EditorSnapshot} from '../selectors'
 import {createTestKeyGenerator} from './test-key-generator'
 
 export function createTestSnapshot(snapshot: {

--- a/packages/editor/src/plugins/plugin.decorator-shortcut.ts
+++ b/packages/editor/src/plugins/plugin.decorator-shortcut.ts
@@ -10,8 +10,8 @@ import {
 import {createDecoratorPairBehavior} from '../behaviors/behavior.decorator-pair'
 import {defineBehavior} from '../behaviors/behavior.types'
 import type {Editor} from '../editor/create-editor'
+import type {EditorSchema} from '../editor/define-schema'
 import {useEditor} from '../editor/editor-provider'
-import type {EditorSchema} from '../selectors'
 import type {BlockOffset} from '../types/block-offset'
 import * as utils from '../utils'
 

--- a/packages/editor/src/selectors/index.ts
+++ b/packages/editor/src/selectors/index.ts
@@ -1,11 +1,3 @@
-export type {EditorSchema} from '../editor/define-schema'
-export type {EditorSelector} from '../editor/editor-selector'
-export type {EditorContext, EditorSnapshot} from '../editor/editor-snapshot'
-export type {
-  EditorSelection,
-  EditorSelectionPoint,
-  PortableTextMemberSchemaTypes,
-} from '../types/editor'
 export {getActiveAnnotations} from './selector.get-active-annotations'
 export {getActiveListItem} from './selector.get-active-list-item'
 export {getActiveStyle} from './selector.get-active-style'

--- a/packages/editor/src/selectors/selector.get-active-annotations.test.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotations.test.ts
@@ -1,7 +1,7 @@
 import type {PortableTextBlock} from '@sanity/types'
 import {expect, test} from 'vitest'
+import type {EditorSelection} from '..'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
-import type {EditorSelection} from '../utils'
 import {getActiveAnnotations} from './selector.get-active-annotations'
 
 function snapshot(value: Array<PortableTextBlock>, selection: EditorSelection) {

--- a/packages/editor/src/selectors/selector.get-caret-word-selection.test.ts
+++ b/packages/editor/src/selectors/selector.get-caret-word-selection.test.ts
@@ -1,8 +1,8 @@
 import type {PortableTextBlock} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
+import type {EditorSelection} from '..'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
 import {createTestKeyGenerator} from '../internal-utils/test-key-generator'
-import type {EditorSelection} from '../utils'
 import {getCaretWordSelection} from './selector.get-caret-word-selection'
 
 const keyGenerator = createTestKeyGenerator()

--- a/packages/editor/src/selectors/selector.get-selected-spans.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-spans.test.ts
@@ -1,7 +1,8 @@
 import type {PortableTextBlock} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
-import {getSelectedSpans, type EditorSelection} from '.'
+import type {EditorSelection} from '..'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
+import {getSelectedSpans} from './selector.get-selected-spans'
 
 const fooBar = {
   _type: 'block',

--- a/packages/editor/src/selectors/selector.get-selection-end-point.ts
+++ b/packages/editor/src/selectors/selector.get-selection-end-point.ts
@@ -1,5 +1,5 @@
+import type {EditorSelectionPoint} from '..'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {EditorSelectionPoint} from '../utils'
 
 /**
  * @public

--- a/packages/editor/src/selectors/selector.get-selection-start-point.ts
+++ b/packages/editor/src/selectors/selector.get-selection-start-point.ts
@@ -1,5 +1,5 @@
+import type {EditorSelectionPoint} from '..'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {EditorSelectionPoint} from '../utils'
 
 /**
  * @public

--- a/packages/editor/src/selectors/selector.get-selection-text.test.ts
+++ b/packages/editor/src/selectors/selector.get-selection-text.test.ts
@@ -1,6 +1,6 @@
 import type {PortableTextBlock} from '@sanity/types'
 import {expect, test} from 'vitest'
-import type {EditorSelection} from '.'
+import type {EditorSelection} from '..'
 import {compileSchemaDefinition, defineSchema} from '../editor/define-schema'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
 import {getSelectionText} from './selector.get-selection-text'

--- a/packages/editor/src/selectors/selector.get-selection.ts
+++ b/packages/editor/src/selectors/selector.get-selection.ts
@@ -1,4 +1,5 @@
-import type {EditorSelection, EditorSelector} from './_exports'
+import type {EditorSelection} from '..'
+import type {EditorSelector} from '../editor/editor-selector'
 
 /**
  * @public

--- a/packages/editor/src/selectors/selector.get-value.ts
+++ b/packages/editor/src/selectors/selector.get-value.ts
@@ -1,5 +1,5 @@
 import type {PortableTextBlock} from '@sanity/types'
-import type {EditorSelector} from './_exports'
+import type {EditorSelector} from '../editor/editor-selector'
 
 /**
  * @public

--- a/packages/editor/src/selectors/selector.is-active-decorator.test.ts
+++ b/packages/editor/src/selectors/selector.is-active-decorator.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest'
-import type {EditorSelection} from '.'
+import type {EditorSelection} from '..'
 import {createTestSnapshot} from '../internal-utils/create-test-snapshot'
 import {isActiveDecorator} from './selector.is-active-decorator'
 

--- a/packages/editor/src/utils/index.ts
+++ b/packages/editor/src/utils/index.ts
@@ -1,4 +1,3 @@
-export type {EditorSelection, EditorSelectionPoint} from '../types/editor'
 export {
   blockOffsetToSpanSelectionPoint,
   spanSelectionPointToBlockOffset,

--- a/packages/editor/src/utils/util.block-offsets-to-selection.ts
+++ b/packages/editor/src/utils/util.block-offsets-to-selection.ts
@@ -1,5 +1,5 @@
 import type {PortableTextBlock} from '@sanity/types'
-import type {EditorSelection} from '../selectors'
+import type {EditorSelection} from '..'
 import type {BlockOffset} from '../types/block-offset'
 import {blockOffsetToSpanSelectionPoint} from './util.block-offset'
 

--- a/packages/editor/src/utils/util.is-span.ts
+++ b/packages/editor/src/utils/util.is-span.ts
@@ -1,5 +1,5 @@
 import type {PortableTextChild, PortableTextSpan} from '@sanity/types'
-import type {EditorContext} from '../selectors'
+import type {EditorContext} from '..'
 
 /**
  * @public

--- a/packages/editor/src/utils/util.is-text-block.ts
+++ b/packages/editor/src/utils/util.is-text-block.ts
@@ -1,5 +1,5 @@
 import type {PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
-import type {EditorContext} from '../selectors'
+import type {EditorContext} from '..'
 
 /**
  * @public

--- a/packages/editor/src/utils/util.merge-text-blocks.ts
+++ b/packages/editor/src/utils/util.merge-text-blocks.ts
@@ -1,6 +1,6 @@
 import type {PortableTextTextBlock} from '@sanity/types'
+import type {EditorContext} from '..'
 import {parseBlock} from '../internal-utils/parse-blocks'
-import type {EditorContext} from '../selectors'
 import {isTextBlock} from './util.is-text-block'
 
 /**

--- a/packages/editor/src/utils/util.slice-blocks.ts
+++ b/packages/editor/src/utils/util.slice-blocks.ts
@@ -4,7 +4,7 @@ import {
   isPortableTextTextBlock,
   type PortableTextBlock,
 } from '@sanity/types'
-import type {EditorSelection} from '../selectors'
+import type {EditorSelection} from '..'
 
 /**
  * @public

--- a/packages/editor/src/utils/util.split-text-block.ts
+++ b/packages/editor/src/utils/util.split-text-block.ts
@@ -1,7 +1,9 @@
 import type {PortableTextTextBlock} from '@sanity/types'
-import {isTextBlock, sliceBlocks, type EditorSelectionPoint} from '.'
-import type {EditorContext} from '../selectors'
+import type {EditorSelectionPoint} from '..'
+import type {EditorContext} from '../editor/editor-snapshot'
 import {isSpan} from './util.is-span'
+import {isTextBlock} from './util.is-text-block'
+import {sliceBlocks} from './util.slice-blocks'
 
 /**
  * @beta


### PR DESCRIPTION
`/behaviors`, `/selectors` and `/utils` shouldn't reexport types from the main
export. This is confusing, unnecessary and easily creates cyclic dependencies.