### PR TITLE
Update @xstate/react to 5.0.3

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -95,7 +95,7 @@
     "@portabletext/block-tools": "workspace:*",
     "@portabletext/patches": "workspace:*",
     "@portabletext/to-html": "^2.0.14",
-    "@xstate/react": "^5.0.2",
+    "@xstate/react": "^5.0.3",
     "debug": "^4.4.0",
     "get-random-values-esm": "^1.0.2",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
         version: 19.0.0-beta-bafa41b-20250307(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: experimental
-        version: 0.0.0-experimental-029e8bd6-20250306(eslint@8.57.1)
+        version: 0.0.0-experimental-d331ba04-20250307(eslint@8.57.1)
       postcss:
         specifier: ^8.4.49
         version: 8.5.3
@@ -291,7 +291,7 @@ importers:
         version: 19.0.0-beta-bafa41b-20250307(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react-hooks:
         specifier: experimental
-        version: 0.0.0-experimental-029e8bd6-20250306(eslint@9.19.0(jiti@1.21.7))
+        version: 0.0.0-experimental-d331ba04-20250307(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
         version: 0.4.18(eslint@9.19.0(jiti@1.21.7))
@@ -364,7 +364,7 @@ importers:
         version: 19.0.0-beta-bafa41b-20250307(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react-hooks:
         specifier: experimental
-        version: 0.0.0-experimental-029e8bd6-20250306(eslint@9.19.0(jiti@1.21.7))
+        version: 0.0.0-experimental-d331ba04-20250307(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
         version: 0.4.18(eslint@9.19.0(jiti@1.21.7))
@@ -436,8 +436,8 @@ importers:
         specifier: ^2.0.14
         version: 2.0.14
       '@xstate/react':
-        specifier: ^5.0.2
-        version: 5.0.2(@types/react@19.0.10)(react@19.0.0)(xstate@5.19.2)
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.0.10)(react@19.0.0)(xstate@5.19.2)
       debug:
         specifier: ^4.4.0
         version: 4.4.0
@@ -531,7 +531,7 @@ importers:
         version: 19.0.0-beta-bafa41b-20250307(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: experimental
-        version: 0.0.0-experimental-029e8bd6-20250306(eslint@8.57.1)
+        version: 0.0.0-experimental-d331ba04-20250307(eslint@8.57.1)
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
@@ -3284,6 +3284,15 @@ packages:
       xstate:
         optional: true
 
+  '@xstate/react@5.0.3':
+    resolution: {integrity: sha512-Zdnn0VTPcVdoaAiW0OX6Nkvdoe7SNGjfaZqM61NKhjt2aNULqiicmDu2tOd1ChzlRWYDxGTdbzVqqVyMLpoHJw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      xstate: ^5.19.2
+    peerDependenciesMeta:
+      xstate:
+        optional: true
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3888,8 +3897,8 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react-hooks@0.0.0-experimental-029e8bd6-20250306:
-    resolution: {integrity: sha512-kCCm3sy7xrBI5PsLYnWmj+S+lC14M4y8HQInAPHzlnOMfT7yiWNvIUcKQkeorZLPP1Wo+2Cu+OLbiAIDyWSbTQ==}
+  eslint-plugin-react-hooks@0.0.0-experimental-d331ba04-20250307:
+    resolution: {integrity: sha512-nCE8wVid8kurFLS0tfQCJ6JP+60+Ezv0ZbzG/uYe+/AX5A6m2CIan1iZ2sGK86ppcuy8YvnSwWrWLLJ1OtGqsQ==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
@@ -10014,6 +10023,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@xstate/react@5.0.3(@types/react@19.0.10)(react@19.0.0)(xstate@5.19.2)':
+    dependencies:
+      react: 19.0.0
+      use-isomorphic-layout-effect: 1.2.0(@types/react@19.0.10)(react@19.0.0)
+      use-sync-external-store: 1.4.0(react@19.0.0)
+    optionalDependencies:
+      xstate: 5.19.2
+    transitivePeerDependencies:
+      - '@types/react'
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -10731,11 +10750,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@0.0.0-experimental-029e8bd6-20250306(eslint@8.57.1):
+  eslint-plugin-react-hooks@0.0.0-experimental-d331ba04-20250307(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-react-hooks@0.0.0-experimental-029e8bd6-20250306(eslint@9.19.0(jiti@1.21.7)):
+  eslint-plugin-react-hooks@0.0.0-experimental-d331ba04-20250307(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       eslint: 9.19.0(jiti@1.21.7)
 


### PR DESCRIPTION
This PR updates `@xstate/react` to 5.0.3, which supports React 19.