### PR TITLE
fix: speed up initial value sync

### DIFF
--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -526,7 +526,7 @@ async function* getBlocks({
 }) {
   let index = 0
   for await (const block of slateValue) {
-    if (streamBlocks) {
+    if (streamBlocks && index % 10 === 0) {
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
     }
     yield [block, index] as const


### PR DESCRIPTION
By syncing 10 blocks at a time. It's unbearably slow to sync large docs, but this *should* give a speed increase without tanking perf.