### PR TITLE
fix: allow skipping range decoration setup

### DIFF
--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -175,10 +175,11 @@ export const PortableTextEditable = forwardRef<
 
   const rangeDecorationsActor = useActorRef(rangeDecorationsMachine, {
     input: {
-      readOnly,
-      slateEditor,
-      schema: schemaTypes,
       rangeDecorations: rangeDecorations ?? [],
+      readOnly,
+      schema: schemaTypes,
+      slateEditor,
+      skipSetup: !editorActor.getSnapshot().matches({setup: 'setting up'}),
     },
   })
   useSelector(rangeDecorationsActor, (s) => s.context.updateCount)


### PR DESCRIPTION
Some scenarios with running PTE in dev mode can potentially rerender `Editable` and recreate the range decorations machine. At this point the `ready` event might already have been fired so the new range decorations machine never gets set up properly. This fix mitigates this scenario by checking the state of the editor machine to see if we can skip the setup step (since in that case the `ready` event won't fire)