### PR TITLE
fix(sync): only delete text from non-empty spans

### DIFF
--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -735,12 +735,14 @@ function _updateBlock(
               Text.isText(oldBlockChild) &&
               oldBlockChild._type === 'span'
             if (isSpanNode && isTextChanged) {
-              Transforms.delete(slateEditor, {
-                at: {
-                  focus: {path, offset: 0},
-                  anchor: {path, offset: oldBlockChild.text.length},
-                },
-              })
+              if (oldBlockChild.text.length > 0) {
+                Transforms.delete(slateEditor, {
+                  at: {
+                    focus: {path, offset: 0},
+                    anchor: {path, offset: oldBlockChild.text.length},
+                  },
+                })
+              }
               Transforms.insertText(slateEditor, currentBlockChild.text, {
                 at: path,
               })


### PR DESCRIPTION
Otherwise we end up deleting the entire span, which is not what we want.