### PR TITLE
feat(behaviors): replace Synthetic Event Actions with `execute`

### DIFF
--- a/apps/docs/src/content/docs/concepts/behavior.mdx
+++ b/apps/docs/src/content/docs/concepts/behavior.mdx
@@ -21,7 +21,11 @@ Behaviors are defined with the `defineBehavior` helper. Here's an example event 
 defineBehavior({
   on: 'insert.text',
   guard: ({snapshot, event}) => event.text === 'a',
-  actions: [({snapshot, event}) => [{type: 'insert.text', text: 'A'}]],
+  actions: [
+    ({snapshot, event}) => [
+      {type: 'execute', event: {type: 'insert.text', text: 'A'}},
+    ],
+  ],
 })
 ```
 
@@ -35,10 +39,12 @@ Revisiting the three step process above:
 
 Whenever you enter text into the editor, activate a toolbar button, or anything else happens in the editor it sends an event.
 
-There are two categories of Behavior Events:
+There are four categories of Behavior Events:
 
 - Native Events: Events that come from the browser or device directly.
-- Synthetic Events: Abstracted events specific to the editor.
+- Abstract Events: Intermediate events that resolve to Synthetic Events.
+- Synthetic Events: Low-level editor-specific events.
+- Custom Events: Events that you create yourself.
 
 <LinkCard
   title="Behavior API reference"
@@ -49,7 +55,7 @@ There are two categories of Behavior Events:
 The Behavior API uses events to trigger actions by listening for a specific event.
 
 :::note
-Synthetic events have default actions that share their name. Only one behavior per event is allowed to alter the default action.
+All events except native events can be executed or raised from within behaviors, but only synthetic events are guaranteed to resolve into a state change.
 :::
 
 ## Guards
@@ -87,7 +93,7 @@ Guards are optional. This means it's possible to create an unconditional behavio
 ```js
 const softReturn = defineBehavior({
   on: 'insert.soft break',
-  actions: [() => [{type: 'insert.text', text: '\n'}]],
+  actions: [() => [execute({type: 'insert.text', text: '\n'})]],
 })
 ```
 
@@ -103,7 +109,7 @@ So far we've only seen examples that invoke a single action, but you can send mu
 
 ### Raise events within actions
 
-While some actions share names with events, it's important to remember that actions don't send events. To send an event with an action, use the `raise` action type or the `raise` helper. This is useful for chaining behaviors and default events.
+To send an event back into the editor, use the `raise` action type or the `raise` helper. This is useful for chaining behaviors and default events.
 
 ```tsx
 // Approach A: With the type set to 'raise'

--- a/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
@@ -9,25 +9,22 @@ import {CardGrid, LinkCard} from '@astrojs/starlight/components'
 
 Below are some common behavior examples. You can also find a list of core behaviors [on GitHub](https://github.com/portabletext/editor/tree/main/packages/editor/src/behaviors).
 
-To add these to your editor, first import `defineBehavior` and optionally the `coreBehaviors`.
+To add these to your editor, first import `defineBehavior` as well as the `BehaviorPlugin`.
 
 ```tsx
-import {coreBehaviors, defineBehavior} from '@portabletext/editor'
+import {defineBehavior} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin} from '@portabletext/editor/plugins'
 ```
 
-Then, register the behavior with the `EditorProvider`. Spread the core behaviors if you want to include them.
+Then, register the behavior within the `EditorProvider` using the `BehaviorPlugin`.
 
 ```tsx
 <EditorProvider
   initialConfig={{
     schemaDefinition,
-    behaviors: [
-      ...coreBehaviors,
-      // Your behaviors here
-      logInsertText,
-    ],
   }}
 >
+  <BehaviorPlugin behaviors={[logInsertText]} />
   {/* ... */}
 </EditorProvider>
 ```
@@ -62,7 +59,21 @@ const logInsertText = defineBehavior({
           console.log(event)
         },
       },
-      event,
+    ],
+  ],
+})
+```
+
+The `effect` action also has a shorthand function:
+
+```tsx
+const logInsertText = defineBehavior({
+  on: 'insert.text',
+  actions: [
+    ({event}) => [
+      effect(() => {
+        console.log(event)
+      }),
     ],
   ],
 })
@@ -80,27 +91,50 @@ const autoCloseParens = defineBehavior({
   },
   actions: [
     ({snapshot, event}) => [
-      // Send the original event that includes the '('
-      event,
-      // Send a new insert.text event with a closing parenthesis
+      // Execute the original event that includes the '('
+      {type: 'execute', event},
+      // Execute a new insert.text event with a closing parenthesis
       {
-        type: 'insert.text',
-        text: ')',
+        type: 'execute',
+        event: {
+          type: 'insert.text',
+          text: ')',
+        },
       },
-      // Send a select event to move the cursor in between the parens
+      // Execute a select event to move the cursor in between the parens
       {
-        type: 'select',
-        selection: {
-          anchor: {
-            path: snapshot.context.selection.anchor.path,
-            offset: snapshot.context.selection.anchor.offset + 1,
-          },
-          focus: {
-            path: snapshot.context.selection.focus.path,
-            offset: snapshot.context.selection.focus.offset + 1,
+        type: 'execute',
+        event: {
+          type: 'select',
+          selection: {
+            anchor: {
+              path: snapshot.context.selection.anchor.path,
+              offset: snapshot.context.selection.anchor.offset + 1,
+            },
+            focus: {
+              path: snapshot.context.selection.focus.path,
+              offset: snapshot.context.selection.focus.offset + 1,
+            },
           },
         },
       },
+    ],
+  ],
+})
+```
+
+The `execute` action also has a shorthand function:
+
+```tsx
+const autoCloseParens = defineBehavior({
+  on: 'insert.text',
+  guard: ({snapshot, event}) => {
+    return event.text === '('
+  },
+  actions: [
+    ({snapshot, event}) => [
+      execute(event),
+      // ...
     ],
   ],
 })
@@ -119,9 +153,9 @@ Test it out in the [Playground](https://playground.portabletext.org).
 
 You can leverage the behavior by importing `createEmojiPickerBehaviors` from `@portabletext/editor/behaviors`. See the editor source above for a usage example.
 
-## Raise a synthetic event
+## Raise events
 
-Sometimes you want to trigger a synthetic event from within an action. This sends the event back to the editor, where the editor treats it like any other event.
+Sometimes you want to trigger an event from within an action. This sends the event back to the editor, where the editor treats it like any other event.
 
 ```tsx
 const raisedUppercaseA = defineBehavior({

--- a/apps/docs/src/content/docs/guides/create-behavior.mdx
+++ b/apps/docs/src/content/docs/guides/create-behavior.mdx
@@ -31,15 +31,15 @@ Here's an example behavior:
 const noLowerCaseA = defineBehavior({
   on: 'insert.text',
   guard: ({event}) => event.text === 'a',
-  actions: [() => [{type: 'insert.text', text: 'A'}]],
+  actions: [() => [{type: 'execute', event: {type: 'insert.text', text: 'A'}}]],
 })
 ```
 
 Let's break it down:
 
-1. It listens for the `insert.text` event. You can use any [native or synthetic event](/reference/behavior-api#behavior-event-types) here.
+1. It listens for the `insert.text` event. You can use any [native, abstract, synthetic or custom event](/reference/behavior-api#behavior-event-types) here.
 2. The guard checks if the text that triggered this event is equal to a lowercase `a`. The guard is true and the behavior will perform the actions.
-3. It sends an `insert.text` action with with "A" instead of "a".
+3. It sends an `execute` action with an `insert.text` event to insert "A" instead of "a".
 
 <LinkCard
   title="Understanding Behaviors"
@@ -49,15 +49,16 @@ Let's break it down:
 
 ## Register the behavior
 
-In order to use the behavior, add it to the `EditorProvider`. If you want to avoid overwriting the default behaviors, import them and register them with your custom behavior.
+In order to use the behavior, add it to the `EditorProvider` using the `BehaviorPlugin`.
 
 ```tsx
-import {coreBehaviors, defineBehavior} from '@portabletext/editor/behaviors'
+import {defineBehavior} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin} from '@portabletext/editor/plugins'
 
 const noLowerCaseA = defineBehavior({
     on: 'insert.text',
     guard: ({event}) => event.text === 'a',
-    actions: [() => [{type: 'insert.text', text: 'A'}]],
+    actions: [() => [{type: 'execute', event: {type: 'insert.text', text: 'A'}}]],
 })
 
 // ...
@@ -65,12 +66,9 @@ const noLowerCaseA = defineBehavior({
 <EditorProvider
     initialConfig={{
         schemaDefinition,
-        behaviors: [
-            ...coreBehaviors,
-            noLowerCaseA,
-        ]
     }}
 >
+    <BehaviorPlugin behaviors={[noLowerCaseA]} />
     {/* ... */}
 </EditorProvider>
 ```

--- a/apps/playground/src/emoji-picker.tsx
+++ b/apps/playground/src/emoji-picker.tsx
@@ -5,7 +5,13 @@ import {
   type EditorSelectionPoint,
   type EditorSnapshot,
 } from '@portabletext/editor'
-import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {
+  defineBehavior,
+  effect,
+  execute,
+  noop,
+  raise,
+} from '@portabletext/editor/behaviors'
 import * as selectors from '@portabletext/editor/selectors'
 import * as utils from '@portabletext/editor/utils'
 import {useActorRef, useSelector} from '@xstate/react'
@@ -104,16 +110,13 @@ const colonListenerCallback: CallbackLogicFunction<
       },
       actions: [
         (_, {point, blockOffset}) => [
-          {
+          execute({
             type: 'insert.text',
             text: ':',
-          },
-          {
-            type: 'effect',
-            effect: () => {
-              sendBack({type: 'colon inserted', point, blockOffset})
-            },
-          },
+          }),
+          effect(() => {
+            sendBack({type: 'colon inserted', point, blockOffset})
+          }),
         ],
       ],
     }),
@@ -131,15 +134,10 @@ const escapeListenerCallback: CallbackLogicFunction<
       guard: ({event}) => event.originEvent.key === 'Escape',
       actions: [
         () => [
-          {
-            type: 'noop',
-          },
-          {
-            type: 'effect',
-            effect: () => {
-              sendBack({type: 'dismiss'})
-            },
-          },
+          noop(),
+          effect(() => {
+            sendBack({type: 'dismiss'})
+          }),
         ],
       ],
     }),
@@ -220,20 +218,17 @@ const emojiInsertListener: CallbackLogicFunction<
         on: 'custom.insert emoji',
         actions: [
           ({event}) => [
-            {
-              type: 'effect',
-              effect: () => {
-                sendBack({type: 'dismiss'})
-              },
-            },
-            raise({
+            effect(() => {
+              sendBack({type: 'dismiss'})
+            }),
+            execute({
               type: 'delete.text',
               at: {anchor: event.anchor, focus: event.focus},
             }),
-            {
+            execute({
               type: 'insert.text',
               text: event.emoji,
-            },
+            }),
           ],
         ],
       }),
@@ -354,16 +349,13 @@ const textChangeListener: CallbackLogicFunction<
             : false,
         actions: [
           ({event}, {focus}) => [
-            {
-              type: 'effect',
-              effect: () => {
-                sendBack({
-                  ...event,
-                  focus,
-                })
-              },
-            },
-            event,
+            effect(() => {
+              sendBack({
+                ...event,
+                focus,
+              })
+            }),
+            execute(event),
           ],
         ],
       }),
@@ -377,16 +369,13 @@ const textChangeListener: CallbackLogicFunction<
             : false,
         actions: [
           ({event}, {focus}) => [
-            {
-              type: 'effect',
-              effect: () => {
-                sendBack({
-                  type: 'delete.backward',
-                  focus,
-                })
-              },
-            },
-            event,
+            effect(() => {
+              sendBack({
+                type: 'delete.backward',
+                focus,
+              })
+            }),
+            execute(event),
           ],
         ],
       }),
@@ -400,16 +389,13 @@ const textChangeListener: CallbackLogicFunction<
             : false,
         actions: [
           ({event}, {focus}) => [
-            {
-              type: 'effect',
-              effect: () => {
-                sendBack({
-                  type: 'delete.forward',
-                  focus,
-                })
-              },
-            },
-            event,
+            effect(() => {
+              sendBack({
+                type: 'delete.forward',
+                focus,
+              })
+            }),
+            execute(event),
           ],
         ],
       }),

--- a/packages/editor/src/behaviors/behavior.emoji-picker.ts
+++ b/packages/editor/src/behaviors/behavior.emoji-picker.ts
@@ -1,7 +1,7 @@
 import {assertEvent, assign, createActor, setup} from 'xstate'
 import {isHotkey} from '../internal-utils/is-hotkey'
 import * as selectors from '../selectors'
-import {raise} from './behavior.types.action'
+import {effect, execute, noop} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 const emojiCharRegEx = /^[a-zA-Z-_0-9]{1}$/
@@ -118,19 +118,16 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
       },
       actions: [
         () => [
-          {
+          execute({
             type: 'insert.text',
             text: ':',
-          },
+          }),
         ],
         (_, params) => [
-          {
-            type: 'effect',
-            effect: () => {
-              emojiPickerActor.send({type: 'select'})
-            },
-          },
-          raise({
+          effect(() => {
+            emojiPickerActor.send({type: 'select'})
+          }),
+          execute({
             type: 'delete.text',
             at: {
               anchor: {
@@ -143,10 +140,10 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
               },
             },
           }),
-          {
+          execute({
             type: 'insert.text',
             text: params.emoji,
-          },
+          }),
         ],
       ],
     }),
@@ -220,13 +217,10 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
         (_, params) => {
           if (params.action === 'select') {
             return [
-              {
-                type: 'effect',
-                effect: () => {
-                  emojiPickerActor.send({type: 'select'})
-                },
-              },
-              raise({
+              effect(() => {
+                emojiPickerActor.send({type: 'select'})
+              }),
+              execute({
                 type: 'delete.text',
                 at: {
                   anchor: {
@@ -239,10 +233,10 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
                   },
                 },
               }),
-              {
+              execute({
                 type: 'insert.text',
                 text: params.emoji,
-              },
+              }),
             ]
           }
 
@@ -250,15 +244,10 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
             return [
               // If we are navigating then we want to hijack the key event and
               // turn it into a noop.
-              {
-                type: 'noop',
-              },
-              {
-                type: 'effect',
-                effect: () => {
-                  emojiPickerActor.send({type: 'navigate up'})
-                },
-              },
+              noop(),
+              effect(() => {
+                emojiPickerActor.send({type: 'navigate up'})
+              }),
             ]
           }
 
@@ -266,25 +255,17 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
             return [
               // If we are navigating then we want to hijack the key event and
               // turn it into a noop.
-              {
-                type: 'noop',
-              },
-              {
-                type: 'effect',
-                effect: () => {
-                  emojiPickerActor.send({type: 'navigate down'})
-                },
-              },
+              noop(),
+              effect(() => {
+                emojiPickerActor.send({type: 'navigate down'})
+              }),
             ]
           }
 
           return [
-            {
-              type: 'effect',
-              effect: () => {
-                emojiPickerActor.send({type: 'reset'})
-              },
-            },
+            effect(() => {
+              emojiPickerActor.send({type: 'reset'})
+            }),
           ]
         },
       ],

--- a/packages/editor/src/behaviors/behavior.links.ts
+++ b/packages/editor/src/behaviors/behavior.links.ts
@@ -1,6 +1,7 @@
 import type {EditorSchema} from '../editor/define-schema'
 import {looksLikeUrl} from '../internal-utils/looks-like-url'
 import * as selectors from '../selectors'
+import {execute} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 /**
@@ -36,10 +37,10 @@ export function createLinkBehaviors(config: LinkBehaviorsConfig) {
     },
     actions: [
       (_, {annotation}) => [
-        {
+        execute({
           type: 'annotation.add',
           annotation,
-        },
+        }),
       ],
     ],
   })
@@ -68,11 +69,11 @@ export function createLinkBehaviors(config: LinkBehaviorsConfig) {
     },
     actions: [
       (_, {annotation, url}) => [
-        {
+        execute({
           type: 'insert.span',
           text: url,
           annotations: [annotation],
-        },
+        }),
       ],
     ],
   })

--- a/packages/editor/src/behaviors/behavior.markdown.ts
+++ b/packages/editor/src/behaviors/behavior.markdown.ts
@@ -3,7 +3,7 @@ import type {EditorSchema} from '../editor/define-schema'
 import * as selectors from '../selectors'
 import {spanSelectionPointToBlockOffset} from '../utils/util.block-offset'
 import {getTextBlockText} from '../utils/util.get-text-block-text'
-import {raise} from './behavior.types.action'
+import {execute} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 /**
@@ -120,23 +120,23 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
     },
     actions: [
       () => [
-        {
+        execute({
           type: 'insert.text',
           text: ' ',
-        },
+        }),
       ],
       (_, {focusTextBlock, style}) => [
-        {
+        execute({
           type: 'block.unset',
           props: ['listItem', 'level'],
           at: focusTextBlock.path,
-        },
-        {
+        }),
+        execute({
           type: 'block.set',
           props: {style},
           at: focusTextBlock.path,
-        },
-        raise({
+        }),
+        execute({
           type: 'delete.text',
           at: {
             anchor: {
@@ -200,21 +200,21 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
     },
     actions: [
       (_, {hrCharacter}) => [
-        {
+        execute({
           type: 'insert.text',
           text: hrCharacter,
-        },
+        }),
       ],
       (_, {hrObject, hrBlockOffsets}) => [
-        {
+        execute({
           type: 'insert.block',
           placement: 'before',
           block: {
             _type: hrObject.name,
             ...(hrObject.value ?? {}),
           },
-        },
-        raise({
+        }),
+        execute({
           type: 'delete.text',
           at: hrBlockOffsets,
         }),
@@ -238,41 +238,44 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
     },
     actions: [
       (_, {hrCharacters}) => [
-        {
+        execute({
           type: 'insert.text',
           text: hrCharacters,
-        },
+        }),
       ],
       ({snapshot}, {hrObject, focusBlock}) =>
         isPortableTextTextBlock(focusBlock.node)
           ? [
-              {
+              execute({
                 type: 'insert.block',
                 block: {
                   _type: snapshot.context.schema.block.name,
                   children: focusBlock.node.children,
                 },
                 placement: 'after',
-              },
-              {
+              }),
+              execute({
                 type: 'insert.block',
                 block: {
                   _type: hrObject.name,
                   ...(hrObject.value ?? {}),
                 },
                 placement: 'after',
-              },
-              {type: 'delete.block', at: focusBlock.path},
+              }),
+              execute({
+                type: 'delete.block',
+                at: focusBlock.path,
+              }),
             ]
           : [
-              {
+              execute({
                 type: 'insert.block',
                 block: {
                   _type: hrObject.name,
                   ...(hrObject.value ?? {}),
                 },
                 placement: 'after',
-              },
+              }),
             ],
     ],
   })
@@ -337,19 +340,19 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
       return false
     },
     actions: [
-      ({event}) => [event],
+      ({event}) => [execute(event)],
       (_, {focusTextBlock, style, level}) => [
-        {
+        execute({
           type: 'block.unset',
           props: ['listItem', 'level'],
           at: focusTextBlock.path,
-        },
-        {
+        }),
+        execute({
           type: 'block.set',
           props: {style},
           at: focusTextBlock.path,
-        },
-        raise({
+        }),
+        execute({
           type: 'delete.text',
           at: {
             anchor: {
@@ -394,11 +397,11 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
     },
     actions: [
       (_, {defaultStyle, focusTextBlock}) => [
-        {
+        execute({
           type: 'block.set',
           props: {style: defaultStyle},
           at: focusTextBlock.path,
-        },
+        }),
       ],
     ],
   })
@@ -477,9 +480,9 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
       return false
     },
     actions: [
-      ({event}) => [event],
+      ({event}) => [execute(event)],
       (_, {focusTextBlock, style, listItem, listItemLength}) => [
-        {
+        execute({
           type: 'block.set',
           props: {
             listItem,
@@ -487,8 +490,8 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
             style,
           },
           at: focusTextBlock.path,
-        },
-        raise({
+        }),
+        execute({
           type: 'delete.text',
           at: {
             anchor: {

--- a/packages/editor/src/behaviors/index.ts
+++ b/packages/editor/src/behaviors/index.ts
@@ -14,7 +14,10 @@ export {
 } from './behavior.markdown'
 
 export {
+  execute,
+  noop,
   raise,
+  effect,
   type BehaviorAction,
   type BehaviorActionSet,
 } from './behavior.types.action'

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -10,7 +10,6 @@ import {
   type ActorRefFrom,
 } from 'xstate'
 import {coreBehaviors} from '../behaviors/behavior.core'
-import {defaultBehaviors} from '../behaviors/behavior.default'
 import {performEvent} from '../behaviors/behavior.perform-event'
 import type {Behavior} from '../behaviors/behavior.types.behavior'
 import type {BehaviorEvent} from '../behaviors/behavior.types.event'
@@ -297,7 +296,8 @@ export const editorMachine = setup({
       assertEvent(event, ['behavior event'])
 
       performEvent({
-        behaviors: [...context.behaviors.values(), ...defaultBehaviors],
+        mode: 'raise',
+        behaviors: [...context.behaviors.values()],
         event: event.behaviorEvent,
         editor: event.editor,
         keyGenerator: context.keyGenerator,

--- a/packages/editor/src/plugins/plugin.decorator-shortcut.ts
+++ b/packages/editor/src/plugins/plugin.decorator-shortcut.ts
@@ -8,6 +8,7 @@ import {
   type CallbackLogicFunction,
 } from 'xstate'
 import {createDecoratorPairBehavior} from '../behaviors/behavior.decorator-pair'
+import {effect, execute} from '../behaviors/behavior.types.action'
 import {defineBehavior} from '../behaviors/behavior.types.behavior'
 import type {Editor} from '../editor/create-editor'
 import type {EditorSchema} from '../editor/define-schema'
@@ -132,15 +133,12 @@ const deleteBackwardListenerCallback: CallbackLogicFunction<
       on: 'delete.backward',
       actions: [
         () => [
-          {
+          execute({
             type: 'history.undo',
-          },
-          {
-            type: 'effect',
-            effect: () => {
-              sendBack({type: 'delete.backward'})
-            },
-          },
+          }),
+          effect(() => {
+            sendBack({type: 'delete.backward'})
+          }),
         ],
       ],
     }),

--- a/packages/editor/src/plugins/plugin.one-line.tsx
+++ b/packages/editor/src/plugins/plugin.one-line.tsx
@@ -1,4 +1,4 @@
-import {defineBehavior, raise} from '../behaviors'
+import {defineBehavior, execute, raise} from '../behaviors'
 import * as selectors from '../selectors'
 import * as utils from '../utils'
 import {BehaviorPlugin} from './plugin.behavior'
@@ -14,7 +14,7 @@ const oneLineBehaviors = [
       snapshot.context.selection && selectors.isSelectionExpanded(snapshot)
         ? {selection: snapshot.context.selection}
         : false,
-    actions: [(_, {selection}) => [{type: 'delete', at: selection}]],
+    actions: [(_, {selection}) => [execute({type: 'delete', at: selection})]],
   }),
   /**
    * All other cases of `insert.break` should be aborted.
@@ -59,12 +59,12 @@ const oneLineBehaviors = [
     },
     actions: [
       ({event}) => [
-        {
+        execute({
           type: 'insert.block',
           block: event.block,
           placement: 'auto',
           select: 'end',
-        },
+        }),
       ],
     ],
   }),

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -1,0 +1,366 @@
+import {page, userEvent} from '@vitest/browser/context'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+} from '../src'
+import {defineBehavior, effect, execute, noop, raise} from '../src/behaviors'
+import {getTersePt} from '../src/internal-utils/terse-pt'
+import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
+import {BehaviorPlugin} from '../src/plugins'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
+
+describe('Behavior API', () => {
+  test('Scenario: Suppressing raised events while executing', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [raise({type: 'insert.text', text: 'b'})]],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'b',
+              // The insertion of 'a' is executed, which means the event
+              // doesn't trigger any other Behavior from this point.
+              // Hence, no infinite loop is created.
+              actions: [() => [execute({type: 'insert.text', text: 'a'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['a'])
+    })
+  })
+
+  test('Scenario: Executing custom events', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              // As an exception, you can execute custom events and this *will*
+              // trigger any Behavior that listens for this event
+              actions: [() => [execute({type: 'custom.raise b'})]],
+            }),
+            defineBehavior({
+              on: 'custom.raise b',
+              // But any `raise` further down the chain will be suppressed to
+              // an execution.
+              actions: [() => [raise({type: 'insert.text', text: 'b'})]],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              // Not called
+              guard: ({event}) => event.text === 'b',
+              actions: [() => [execute({type: 'insert.text', text: 'c'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['b'])
+    })
+  })
+
+  test('Scenario: Raising one custom event as the result of executing another', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              // Executing `custom.a`
+              actions: [() => [execute({type: 'custom.a'})]],
+            }),
+            defineBehavior({
+              on: 'custom.a',
+              // Suppresses this into an `execute`
+              actions: [() => [raise({type: 'custom.b'})]],
+            }),
+            defineBehavior({
+              on: 'custom.b',
+              // Which ends up executing this
+              actions: [() => [execute({type: 'insert.text', text: 'b'})]],
+            }),
+            defineBehavior({
+              on: 'custom.b',
+              // But not this, of course
+              actions: [() => [execute({type: 'insert.text', text: 'c'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['b'])
+    })
+  })
+
+  test('Scenario: Sending custom events', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.hello world',
+              actions: [
+                () => [execute({type: 'insert.text', text: 'Hello, world!'})],
+              ],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editorRef.current?.send({type: 'custom.hello world'})
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['Hello, world!'])
+    })
+  })
+
+  test('Scenario: Raised events default to their default action', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.hello world',
+              actions: [
+                // No Behavior listens for this event, so it ends up being
+                // executed.
+                () => [raise({type: 'insert.text', text: 'Hello, world!'})],
+              ],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editorRef.current?.send({type: 'custom.hello world'})
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['Hello, world!'])
+    })
+  })
+
+  test("Scenario: Empty action sets don't affect the chain of events", async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => []],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [], () => []],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [execute({type: 'insert.text', text: 'b'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['b'])
+    })
+  })
+
+  test("Scenario: Effect-only actions don't affect the chain of events", async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [effect(() => {})]],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [execute({type: 'insert.text', text: 'b'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['b'])
+    })
+  })
+
+  test('Scenario: Noop actions cancel the chain of events', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [noop()]],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [() => [execute({type: 'insert.text', text: 'b'})]],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual([''])
+    })
+  })
+})

--- a/packages/editor/tests/editor-snapshot.test.tsx
+++ b/packages/editor/tests/editor-snapshot.test.tsx
@@ -9,7 +9,7 @@ import {
   type Editor,
   type EditorSnapshot,
 } from '../src'
-import {defineBehavior} from '../src/behaviors'
+import {defineBehavior, execute} from '../src/behaviors'
 import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
 import {BehaviorPlugin, EditorRefPlugin} from '../src/plugins'
 
@@ -40,20 +40,20 @@ describe('EditorSnapshot', () => {
                   inspectSelection(snapshot.context.selection)
                   inspectValue(snapshot.context.value)
                   return [
-                    {
+                    execute({
                       type: 'insert.text',
                       text: 'b',
-                    },
+                    }),
                   ]
                 },
                 ({snapshot}) => {
                   inspectSelection(snapshot.context.selection)
                   inspectValue(snapshot.context.value)
                   return [
-                    {
+                    execute({
                       type: 'insert.text',
                       text: 'c',
-                    },
+                    }),
                   ]
                 },
               ],

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -2,7 +2,7 @@ import {page, userEvent} from '@vitest/browser/context'
 import * as React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {defineBehavior, raise} from '../src/behaviors'
+import {defineBehavior, execute, raise} from '../src/behaviors'
 import type {Editor} from '../src/editor/create-editor'
 import {defineSchema} from '../src/editor/define-schema'
 import {PortableTextEditable} from '../src/editor/Editable'
@@ -32,15 +32,15 @@ describe('event.history.undo', () => {
               guard: ({event}) => event.text === 'x',
               actions: [
                 // The 'x' is inserted in its own undo step
-                ({event}) => [event],
+                ({event}) => [execute(event)],
                 // And then deleted again and replaced with 'y*' in another undo step
                 () => [
-                  {type: 'delete.backward', unit: 'character'},
-                  {type: 'insert.text', text: 'y'},
-                  {type: 'insert.text', text: '*'},
+                  execute({type: 'delete.backward', unit: 'character'}),
+                  execute({type: 'insert.text', text: 'y'}),
+                  execute({type: 'insert.text', text: '*'}),
                 ],
                 // And finally 'z' gets its own undo step as well
-                () => [{type: 'insert.text', text: 'z'}],
+                () => [execute({type: 'insert.text', text: 'z'})],
               ],
             }),
           ]}
@@ -104,9 +104,9 @@ describe('event.history.undo', () => {
               guard: ({event}) => event.text === 'x',
               actions: [
                 // This gets its own undo step
-                () => [{type: 'insert.text', text: 'y'}],
+                () => [execute({type: 'insert.text', text: 'y'})],
                 // And this also gets its own undo step
-                () => [{type: 'insert.text', text: 'z'}],
+                () => [execute({type: 'insert.text', text: 'z'})],
               ],
             }),
             defineBehavior({


### PR DESCRIPTION
This commit brings a fundamental change to Behavior Actions. Previously, each Synthetic Event had a corresponding Action that you could return in Action sets. These are the Actions that actually *do* something and which you can perform on the editor without any other Behavior interfering. This was useful, but also had two downsides:

1. The Actions looked a lot like Events (because they sort of were).
2. When returning Actions you miss out on all the useful Abstract Events. For example, if you want to do `select.previous block`, you have to `raise(...)` that which means you can't be sure another Behavior doesn't hijack the Event.

To resolve these two downsides, the Sythetic Event Actions are embraced as what they are: Synthetic Events. And in order to execute these you wrap them in `execute(...)` which can be seen as a sister function to `raise(...)`:

1. `raise` raises the Event into the machine so other Behaviors can respond to it
2. `execute` executes the Event into resolution, allowing no other Behavior to respond to it.

The only exception to rule (2) is that Behaviors listening for Custom Events will still be called if a Custom Event is executed. Otherwise, that Event wouldn't resolve to anything.

The great thing about this model is that:

1. You can't confuse Actions and Events anymore. There are only four Actions, `'execute'`, `'raise'`, `'noop'` and `'effect'`. And then there are a bunch of Events that you can listen for, execute or raise.
2. You can now execute Abstract Events like `select.previous block`!

(This commit also brings shorthand functions for `'noop'` and `'effect'` actions.)