### PR TITLE
feat(behaviors): add `move.backward` and `move.forward` events

### DIFF
--- a/packages/editor/src/behavior-actions/behavior.action.move.backward.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.move.backward.ts
@@ -1,0 +1,12 @@
+import {Transforms} from 'slate'
+import type {BehaviorActionImplementation} from './behavior.actions'
+
+export const moveBackwardActionImplementation: BehaviorActionImplementation<
+  'move.backward'
+> = ({action}) => {
+  Transforms.move(action.editor, {
+    unit: 'character',
+    distance: action.distance,
+    reverse: true,
+  })
+}

--- a/packages/editor/src/behavior-actions/behavior.action.move.forward.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.move.forward.ts
@@ -1,0 +1,11 @@
+import {Transforms} from 'slate'
+import type {BehaviorActionImplementation} from './behavior.actions'
+
+export const moveForwardActionImplementation: BehaviorActionImplementation<
+  'move.forward'
+> = ({action}) => {
+  Transforms.move(action.editor, {
+    unit: 'character',
+    distance: action.distance,
+  })
+}

--- a/packages/editor/src/behavior-actions/behavior.actions.ts
+++ b/packages/editor/src/behavior-actions/behavior.actions.ts
@@ -24,7 +24,9 @@ import {insertInlineObjectActionImplementation} from './behavior.action.insert-i
 import {insertSpanActionImplementation} from './behavior.action.insert-span'
 import {insertBlockActionImplementation} from './behavior.action.insert.block'
 import {insertTextActionImplementation} from './behavior.action.insert.text'
+import {moveBackwardActionImplementation} from './behavior.action.move.backward'
 import {moveBlockActionImplementation} from './behavior.action.move.block'
+import {moveForwardActionImplementation} from './behavior.action.move.forward'
 import {noopActionImplementation} from './behavior.action.noop'
 import {selectActionImplementation} from './behavior.action.select'
 import {splitBlockActionImplementation} from './behavior.action.split.block'
@@ -71,7 +73,9 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
   'insert.span': insertSpanActionImplementation,
   'insert.text': insertTextActionImplementation,
   'effect': effectActionImplementation,
+  'move.backward': moveBackwardActionImplementation,
   'move.block': moveBlockActionImplementation,
+  'move.forward': moveForwardActionImplementation,
   'noop': noopActionImplementation,
   'select': selectActionImplementation,
   'split.block': splitBlockActionImplementation,
@@ -220,8 +224,22 @@ export function performAction({
       })
       break
     }
+    case 'move.backward': {
+      behaviorActionImplementations['move.backward']({
+        context,
+        action,
+      })
+      break
+    }
     case 'move.block': {
       behaviorActionImplementations['move.block']({
+        context,
+        action,
+      })
+      break
+    }
+    case 'move.forward': {
+      behaviorActionImplementations['move.forward']({
         context,
         action,
       })

--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -75,7 +75,9 @@ const syntheticBehaviorEventTypes = [
   'insert.block',
   'insert.span',
   'insert.text',
+  'move.backward',
   'move.block',
+  'move.forward',
   'select',
   'split.block',
 ] as const
@@ -179,9 +181,17 @@ export type SyntheticBehaviorEvent =
       text: string
     }
   | {
+      type: StrictExtract<SyntheticBehaviorEventType, 'move.backward'>
+      distance: number
+    }
+  | {
       type: StrictExtract<SyntheticBehaviorEventType, 'move.block'>
       at: [KeyedSegment]
       to: [KeyedSegment]
+    }
+  | {
+      type: StrictExtract<SyntheticBehaviorEventType, 'move.forward'>
+      distance: number
     }
   | {
       type: StrictExtract<SyntheticBehaviorEventType, 'select'>


### PR DESCRIPTION
Ideally, these should be Abstract Events mapping to Synthetic `select` Events, but that would be a rather big task to implement since it would require us to do the position calculation ourselves in a Behavior instead of letting Slate do the calculation: https://github.com/ianstormtaylor/slate/blob/main/packages/slate/src/editor/positions.ts

However, in the future, it would be good to implement this ourselves.