### PR TITLE
fix(block parsing): strip unknown fields from text blocks

### DIFF
--- a/packages/editor/src/internal-utils/parse-blocks.test.ts
+++ b/packages/editor/src/internal-utils/parse-blocks.test.ts
@@ -379,7 +379,6 @@ describe(parseSpan.name, () => {
       _type: 'span',
       text: '',
       marks: [],
-      foo: 'bar',
     })
   })
 

--- a/packages/editor/src/internal-utils/parse-blocks.ts
+++ b/packages/editor/src/internal-utils/parse-blocks.ts
@@ -169,8 +169,7 @@ function parseTextBlock({
     .filter((child) => child !== undefined)
 
   const parsedBlock: PortableTextTextBlock = {
-    // Spread the entire block to allow custom properties on it
-    ...block,
+    _type: context.schema.block.name,
     _key,
     children:
       children.length > 0
@@ -186,37 +185,30 @@ function parseTextBlock({
     markDefs,
   }
 
-  /**
-   * Reset text block .style if it's somehow set to an invalid type
-   */
   if (
-    typeof parsedBlock.style !== 'string' ||
-    !context.schema.styles.find((style) => style.name === block.style)
+    typeof block.style === 'string' &&
+    context.schema.styles.find((style) => style.name === block.style)
   ) {
+    parsedBlock.style = block.style
+  } else {
     const defaultStyle = context.schema.styles.at(0)?.name
 
     if (defaultStyle !== undefined) {
       parsedBlock.style = defaultStyle
     } else {
-      delete parsedBlock.style
+      console.error('Expected default style')
     }
   }
 
-  /**
-   * Reset text block .listItem if it's somehow set to an invalid type
-   */
   if (
-    typeof parsedBlock.listItem !== 'string' ||
-    !context.schema.lists.find((list) => list.name === block.listItem)
+    typeof block.listItem === 'string' &&
+    context.schema.lists.find((list) => list.name === block.listItem)
   ) {
-    delete parsedBlock.listItem
+    parsedBlock.listItem = block.listItem
   }
 
-  /**
-   * Reset text block .level if it's somehow set to an invalid type
-   */
-  if (typeof parsedBlock.level !== 'number') {
-    delete parsedBlock.level
+  if (typeof block.level === 'number') {
+    parsedBlock.level = block.level
   }
 
   return parsedBlock

--- a/packages/editor/src/internal-utils/parse-blocks.ts
+++ b/packages/editor/src/internal-utils/parse-blocks.ts
@@ -272,8 +272,6 @@ export function parseSpan({
   })
 
   return {
-    // Spread the entire span to allow custom properties on it
-    ...span,
     _type: 'span',
     _key: options.refreshKeys
       ? context.keyGenerator()

--- a/packages/editor/tests/event.block.set.test.tsx
+++ b/packages/editor/tests/event.block.set.test.tsx
@@ -265,7 +265,7 @@ describe('event.block.set', () => {
     })
   })
 
-  test('Scenario: adding custom block property', async () => {
+  test("Scenario: Text blocks don't accept custom props", async () => {
     const editorRef = React.createRef<Editor>()
     const keyGenerator = createTestKeyGenerator()
 
@@ -315,13 +315,13 @@ describe('event.block.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(
-        editorRef.current?.getSnapshot().context.value,
-      ).toMatchObject([
+      return expect(editorRef.current?.getSnapshot().context.value).toEqual([
         {
           _key: textBlockKey,
           _type: 'block',
-          foo: 'bar',
+          children: [{_key: 'k3', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
         },
       ])
     })

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -237,4 +237,69 @@ describe('event.insert.block', () => {
       },
     ])
   })
+
+  test('Scenario: Stripping unknown span props', () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [
+          {
+            _type: 'span',
+            text: 'foo',
+            foo: 'bar', // <-- unknown prop
+            baz: {
+              fizz: 'buzz',
+            }, // <-- unknown prop
+          },
+        ],
+      },
+      placement: 'after',
+    })
+
+    expect(editorRef.current?.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'k1',
+            _type: 'span',
+            text: '',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _key: 'k2',
+        _type: 'block',
+        children: [
+          {
+            _key: 'k3',
+            _type: 'span',
+            text: 'foo',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
 })

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -167,4 +167,74 @@ describe('event.insert.block', () => {
       },
     ])
   })
+
+  test('Scenario: Stripping unknown text block props', () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({lists: [{name: 'bullet'}]}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    editorRef.current?.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [
+          {
+            _type: 'span',
+            text: 'foo',
+          },
+        ],
+        foo: 'bar', // <-- unknown prop
+        baz: {
+          fizz: 'buzz',
+        }, // <-- unknown prop
+        listItem: 'bullet', // <-- known prop, in the schema
+        level: 1, // <-- known prop that doesn't need to be in the schema
+        style: 'h1', // <-- known prop, but not in the schema
+      },
+      placement: 'after',
+    })
+
+    expect(editorRef.current?.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k0',
+        _type: 'block',
+        children: [
+          {
+            _key: 'k1',
+            _type: 'span',
+            text: '',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _key: 'k2',
+        _type: 'block',
+        children: [
+          {
+            _key: 'k3',
+            _type: 'span',
+            text: 'foo',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+        listItem: 'bullet',
+        level: 1,
+      },
+    ])
+  })
 })


### PR DESCRIPTION
When blocks are pasted or inserted, they go through `parseBlock(...)`. This change makes sure we strip unknown fields/props from those blocks in the process.