### PR TITLE
fix: provide `Editor` from a global Context

### DIFF
--- a/packages/editor/src/editor/editor-context.tsx
+++ b/packages/editor/src/editor/editor-context.tsx
@@ -1,0 +1,7 @@
+import {createGloballyScopedContext} from '../internal-utils/globally-scoped-context'
+import type {Editor} from './create-editor'
+
+export const EditorContext = createGloballyScopedContext<Editor | null>(
+  '@portabletext/editor/context/editor',
+  null,
+)

--- a/packages/editor/src/editor/editor-provider.tsx
+++ b/packages/editor/src/editor/editor-provider.tsx
@@ -5,10 +5,10 @@ import {Synchronizer} from './components/Synchronizer'
 import {
   createInternalEditor,
   editorConfigToMachineInput,
-  type Editor,
   type EditorConfig,
 } from './create-editor'
 import {EditorActorContext} from './editor-actor-context'
+import {EditorContext} from './editor-context'
 import {editorMachine} from './editor-machine'
 import {PortableTextEditorContext} from './hooks/usePortableTextEditor'
 import {PortableTextEditorSelectionProvider} from './hooks/usePortableTextEditorSelection'
@@ -17,8 +17,6 @@ import {
   RouteEventsToChanges,
   type PortableTextEditorProps,
 } from './PortableTextEditor'
-
-const EditorContext = React.createContext<Editor | undefined>(undefined)
 
 /**
  * @public

--- a/packages/editor/src/internal-utils/global-scope.ts
+++ b/packages/editor/src/internal-utils/global-scope.ts
@@ -1,0 +1,19 @@
+/**
+ * Gets the global scope instance in a given environment.
+ *
+ * The strategy is to return the most modern, and if not, the most common:
+ * - The `globalThis` variable is the modern approach to accessing the global scope
+ * - The `window` variable is the global scope in a web browser
+ * - The `self` variable is the global scope in workers and others
+ * - The `global` variable is the global scope in Node.js
+ */
+function getGlobalScope() {
+  if (typeof globalThis !== 'undefined') return globalThis
+  if (typeof window !== 'undefined') return window
+  if (typeof self !== 'undefined') return self
+  if (typeof global !== 'undefined') return global
+
+  throw new Error('@portabletext/editor: could not locate global scope')
+}
+
+export const globalScope = getGlobalScope() as any

--- a/packages/editor/src/internal-utils/globally-scoped-context.ts
+++ b/packages/editor/src/internal-utils/globally-scoped-context.ts
@@ -1,0 +1,39 @@
+import {createContext, type Context} from 'react'
+import {globalScope} from './global-scope'
+
+/**
+ * As `@portabletext/editor` is declared as a dependency, and may be
+ * duplicated, sometimes across major versions it's critical that vital
+ * React Contexts are shared even when there is a duplicate.
+ *
+ * We have to support a Sanity Plugin being able to call hooks like
+ * `useEditor`, and then read the context setup by `sanity`, which calls
+ * `EditorProvider`, even if the provider and hook are different instances in
+ * memory.
+ *
+ * For this reason it's vital that all changes to globally scoped providers
+ * remain fully backwards compatible.
+ */
+export function createGloballyScopedContext<
+  ContextType,
+  const T extends ContextType = ContextType,
+>(
+  /**
+   * Enforce that all Symbol.for keys used for globally scoped contexts have a predictable prefix
+   */
+  key: `@portabletext/editor/context/${string}`,
+  defaultValue: T,
+): Context<ContextType> {
+  const symbol = Symbol.for(key)
+
+  /**
+   * Prevent errors about re-renders on React SSR on Next.js App Router
+   */
+  if (typeof document === 'undefined') {
+    return createContext<ContextType>(defaultValue)
+  }
+
+  globalScope[symbol] = globalScope[symbol] ?? createContext<T>(defaultValue)
+
+  return globalScope[symbol]
+}


### PR DESCRIPTION
I guess it doesn't hurt to try this out.

Code more-or-less copy/pasted from https://github.com/sanity-io/ui/blob/main/src/core/lib/createGlobalScopedContext.ts