### PR TITLE
feat(behaviors): simplify event propagation by introducing `forward(event)`

### DIFF
--- a/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
@@ -46,7 +46,7 @@ Read more about using behaviors and building your own with these guides:
 
 ## Log inserted text
 
-Send and `effect` type action along with an `effect` to perform side effects.
+Send and `effect` type action along with a `forward` action to perform side effects without altering the chain of events.
 
 ```js
 const logInsertText = defineBehavior({
@@ -59,12 +59,16 @@ const logInsertText = defineBehavior({
           console.log(event)
         },
       },
+      {
+        type: 'forward',
+        event,
+      },
     ],
   ],
 })
 ```
 
-The `effect` action also has a shorthand function:
+The `effect` and `forward` actions also have shorthand functions:
 
 ```tsx
 const logInsertText = defineBehavior({
@@ -74,6 +78,7 @@ const logInsertText = defineBehavior({
       effect(() => {
         console.log(event)
       }),
+      forward(event),
     ],
   ],
 })

--- a/apps/docs/src/content/docs/reference/behavior-api.mdx
+++ b/apps/docs/src/content/docs/reference/behavior-api.mdx
@@ -89,8 +89,8 @@ const noLowerCaseA = defineBehavior({
 ## Behavior Actions
 
 - [execute](#execute)
+- [forward](#forward)
 - [raise](#raise)
-- noop
 - effect
 
 ### `execute`
@@ -125,6 +125,37 @@ const executedUppercaseA = defineBehavior({
   actions: [({snapshot, event}) => [execute({type: 'insert.text', text: 'A'})]],
 })
 ```
+
+### `forward`
+
+The `forward` action type is used to forward events to the next Behavior.
+
+Properties:
+
+- type: `forward`
+- event: Behavior event object
+
+```tsx
+const forwardedUppercaseA = defineBehavior({
+  on: 'insert.text',
+  guard: ({snapshot, event}) => event.text === 'a',
+  actions: [({snapshot, event}) => [{type: 'forward', event: {type: 'insert.text', text: 'A'}})]],
+})
+```
+
+When an event is forwarded, the next Behavior will be triggered.
+
+The `forward` action also has a handy shorthand function:
+
+```tsx
+const forwardedUppercaseA = defineBehavior({
+  on: 'insert.text',
+  guard: ({snapshot, event}) => event.text === 'a',
+  actions: [({snapshot, event}) => [forward({type: 'insert.text', text: 'A'})]],
+})
+```
+
+### `raise`
 
 The `raise` action type is used to sends events back into the editor.
 

--- a/apps/docs/src/content/docs/reference/plugins.mdx
+++ b/apps/docs/src/content/docs/reference/plugins.mdx
@@ -23,6 +23,10 @@ function LogTextPlugin() {
                 console.log(event)
               },
             },
+            {
+              type: 'forward',
+              event,
+            },
           ],
         ],
       }),

--- a/apps/playground/src/emoji-picker.tsx
+++ b/apps/playground/src/emoji-picker.tsx
@@ -9,7 +9,6 @@ import {
   defineBehavior,
   effect,
   execute,
-  noop,
   raise,
 } from '@portabletext/editor/behaviors'
 import * as selectors from '@portabletext/editor/selectors'
@@ -134,7 +133,6 @@ const escapeListenerCallback: CallbackLogicFunction<
       guard: ({event}) => event.originEvent.key === 'Escape',
       actions: [
         () => [
-          noop(),
           effect(() => {
             sendBack({type: 'dismiss'})
           }),
@@ -157,9 +155,6 @@ const arrowListenerCallback: CallbackLogicFunction<
         actions: [
           () => [
             {
-              type: 'noop',
-            },
-            {
               type: 'effect',
               effect: () => {
                 sendBack({type: 'navigate down'})
@@ -175,9 +170,6 @@ const arrowListenerCallback: CallbackLogicFunction<
         guard: ({event}) => event.originEvent.key === 'ArrowUp',
         actions: [
           () => [
-            {
-              type: 'noop',
-            },
             {
               type: 'effect',
               effect: () => {
@@ -299,9 +291,6 @@ const emojiInsertListener: CallbackLogicFunction<
           event.originEvent.key === 'Enter' || event.originEvent.key === 'Tab',
         actions: [
           () => [
-            {
-              type: 'noop',
-            },
             {
               type: 'effect',
               effect: () => {

--- a/packages/editor/src/behavior-actions/behavior.action.noop.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.noop.ts
@@ -1,5 +1,0 @@
-import type {BehaviorActionImplementation} from './behavior.actions'
-
-export const noopActionImplementation: BehaviorActionImplementation<
-  'noop'
-> = () => {}

--- a/packages/editor/src/behavior-actions/behavior.actions.ts
+++ b/packages/editor/src/behavior-actions/behavior.actions.ts
@@ -25,7 +25,6 @@ import {insertTextActionImplementation} from './behavior.action.insert.text'
 import {moveBackwardActionImplementation} from './behavior.action.move.backward'
 import {moveBlockActionImplementation} from './behavior.action.move.block'
 import {moveForwardActionImplementation} from './behavior.action.move.forward'
-import {noopActionImplementation} from './behavior.action.noop'
 import {selectActionImplementation} from './behavior.action.select'
 
 const debug = debugWithName('behaviors:action')
@@ -71,7 +70,6 @@ const behaviorActionImplementations: BehaviorActionImplementations = {
   'move.backward': moveBackwardActionImplementation,
   'move.block': moveBlockActionImplementation,
   'move.forward': moveForwardActionImplementation,
-  'noop': noopActionImplementation,
   'select': selectActionImplementation,
 }
 
@@ -220,13 +218,6 @@ export function performAction({
     }
     case 'move.forward': {
       behaviorActionImplementations['move.forward']({
-        context,
-        action,
-      })
-      break
-    }
-    case 'noop': {
-      behaviorActionImplementations.noop({
         context,
         action,
       })

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -22,6 +22,6 @@ export const coreDndBehaviors = [
 
       return draggingOverDragOrigin
     },
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
 ]

--- a/packages/editor/src/behaviors/behavior.default.ts
+++ b/packages/editor/src/behaviors/behavior.default.ts
@@ -111,7 +111,7 @@ export const defaultBehaviors = [
 
       return focusSpan && selectionCollapsed
     },
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   defineBehavior({
     on: 'clipboard.copy',
@@ -132,7 +132,7 @@ export const defaultBehaviors = [
 
       return focusSpan && selectionCollapsed
     },
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   defineBehavior({
     on: 'clipboard.cut',
@@ -214,7 +214,7 @@ export const defaultBehaviors = [
         : false
       return droppingOnDragOrigin
     },
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   defineBehavior({
     on: 'drag.drop',

--- a/packages/editor/src/behaviors/behavior.emoji-picker.ts
+++ b/packages/editor/src/behaviors/behavior.emoji-picker.ts
@@ -1,7 +1,7 @@
 import {assertEvent, assign, createActor, setup} from 'xstate'
 import {isHotkey} from '../internal-utils/is-hotkey'
 import * as selectors from '../selectors'
-import {effect, execute, noop} from './behavior.types.action'
+import {effect, execute, forward} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 const emojiCharRegEx = /^[a-zA-Z-_0-9]{1}$/
@@ -66,7 +66,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
         return {emojis}
       },
       actions: [
-        (_, params) => [
+        ({event}, params) => [
           {
             type: 'effect',
             effect: () => {
@@ -76,6 +76,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
               })
             },
           },
+          forward(event),
         ],
       ],
     }),
@@ -242,9 +243,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
 
           if (params.action === 'navigate up') {
             return [
-              // If we are navigating then we want to hijack the key event and
-              // turn it into a noop.
-              noop(),
+              // If we are navigating then we want to hijack the key event
               effect(() => {
                 emojiPickerActor.send({type: 'navigate up'})
               }),
@@ -253,9 +252,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
 
           if (params.action === 'navigate down') {
             return [
-              // If we are navigating then we want to hijack the key event and
-              // turn it into a noop.
-              noop(),
+              // If we are navigating then we want to hijack the key event
               effect(() => {
                 emojiPickerActor.send({type: 'navigate down'})
               }),
@@ -298,7 +295,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
         return {emojis}
       },
       actions: [
-        (_, params) => [
+        ({event}, params) => [
           {
             type: 'effect',
             effect: () => {
@@ -308,6 +305,7 @@ export function createEmojiPickerBehaviors<TEmojiMatch>(
               })
             },
           },
+          forward(event),
         ],
       ],
     }),

--- a/packages/editor/src/behaviors/behavior.types.action.ts
+++ b/packages/editor/src/behaviors/behavior.types.action.ts
@@ -4,6 +4,7 @@ import type {PortableTextSlateEditor} from '../types/editor'
 import type {
   AbstractBehaviorEventType,
   CustomBehaviorEvent,
+  NativeBehaviorEvent,
   SyntheticBehaviorEvent,
 } from './behavior.types.event'
 
@@ -16,11 +17,12 @@ export type BehaviorAction =
       event: SyntheticBehaviorEvent
     }
   | {
-      type: 'raise'
-      event: SyntheticBehaviorEvent | CustomBehaviorEvent
+      type: 'forward'
+      event: NativeBehaviorEvent | SyntheticBehaviorEvent | CustomBehaviorEvent
     }
   | {
-      type: 'noop'
+      type: 'raise'
+      event: SyntheticBehaviorEvent | CustomBehaviorEvent
     }
   | {
       type: 'effect'
@@ -34,6 +36,15 @@ export function execute(
   event: SyntheticBehaviorEvent,
 ): PickFromUnion<BehaviorAction, 'type', 'execute'> {
   return {type: 'execute', event}
+}
+
+/**
+ * @beta
+ */
+export function forward(
+  event: NativeBehaviorEvent | SyntheticBehaviorEvent | CustomBehaviorEvent,
+): PickFromUnion<BehaviorAction, 'type', 'forward'> {
+  return {type: 'forward', event}
 }
 
 /**
@@ -57,13 +68,6 @@ export function effect(
 /**
  * @beta
  */
-export function noop(): PickFromUnion<BehaviorAction, 'type', 'noop'> {
-  return {type: 'noop'}
-}
-
-/**
- * @beta
- */
 export type BehaviorActionSet<TBehaviorEvent, TGuardResponse> = (
   payload: {
     snapshot: EditorSnapshot
@@ -74,7 +78,6 @@ export type BehaviorActionSet<TBehaviorEvent, TGuardResponse> = (
 
 export type InternalBehaviorAction = (
   | OmitFromUnion<SyntheticBehaviorEvent, 'type', AbstractBehaviorEventType>
-  | {type: 'noop'}
   | {type: 'effect'; effect: () => void}
 ) & {
   editor: PortableTextSlateEditor

--- a/packages/editor/src/behaviors/index.ts
+++ b/packages/editor/src/behaviors/index.ts
@@ -15,7 +15,7 @@ export {
 
 export {
   execute,
-  noop,
+  forward,
   raise,
   effect,
   type BehaviorAction,

--- a/packages/editor/src/editor/components/Element.tsx
+++ b/packages/editor/src/editor/components/Element.tsx
@@ -21,7 +21,7 @@ import {
   useSlateStatic,
   type RenderElementProps,
 } from 'slate-react'
-import {defineBehavior} from '../../behaviors'
+import {defineBehavior, forward} from '../../behaviors'
 import {debugWithName} from '../../internal-utils/debug'
 import type {EventPositionBlock} from '../../internal-utils/event-position'
 import {fromSlateValue} from '../../internal-utils/values'
@@ -146,9 +146,6 @@ export const Element: FunctionComponent<ElementProps> = ({
               setDragPositionBlock(event.position.block)
             },
           },
-          {
-            type: 'noop',
-          },
         ],
       ],
     })
@@ -173,13 +170,14 @@ export const Element: FunctionComponent<ElementProps> = ({
         return event.type !== 'drag.dragover'
       },
       actions: [
-        () => [
+        ({event}) => [
           {
             type: 'effect',
             effect: () => {
               setDragPositionBlock(undefined)
             },
           },
+          forward(event),
         ],
       ],
     })

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -336,6 +336,7 @@ export const editorMachine = setup({
       performEvent({
         mode: 'raise',
         behaviors: [...context.behaviors.values()],
+        remainingEventBehaviors: [...context.behaviors.values()],
         event: event.behaviorEvent,
         editor: event.editor,
         keyGenerator: context.keyGenerator,

--- a/packages/editor/src/plugins/plugin.decorator-shortcut.ts
+++ b/packages/editor/src/plugins/plugin.decorator-shortcut.ts
@@ -8,7 +8,7 @@ import {
   type CallbackLogicFunction,
 } from 'xstate'
 import {createDecoratorPairBehavior} from '../behaviors/behavior.decorator-pair'
-import {effect, execute} from '../behaviors/behavior.types.action'
+import {effect, execute, forward} from '../behaviors/behavior.types.action'
 import {defineBehavior} from '../behaviors/behavior.types.behavior'
 import type {Editor} from '../editor/create-editor'
 import {useEditor} from '../editor/editor-provider'
@@ -108,13 +108,14 @@ const selectionListenerCallback: CallbackLogicFunction<
         }
       },
       actions: [
-        (_, {blockOffsets}) => [
+        ({event}, {blockOffsets}) => [
           {
             type: 'effect',
             effect: () => {
               sendBack({type: 'selection', blockOffsets})
             },
           },
+          forward(event),
         ],
       ],
     }),

--- a/packages/editor/src/plugins/plugin.one-line.tsx
+++ b/packages/editor/src/plugins/plugin.one-line.tsx
@@ -21,7 +21,7 @@ const oneLineBehaviors = [
    */
   defineBehavior({
     on: 'insert.break',
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   /**
    * `insert.block` `before` or `after` is not allowed in a one-line editor.
@@ -30,7 +30,7 @@ const oneLineBehaviors = [
     on: 'insert.block',
     guard: ({event}) =>
       event.placement === 'before' || event.placement === 'after',
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   /**
    * An ordinary `insert.block` is acceptable if it's a text block. In that
@@ -67,7 +67,7 @@ const oneLineBehaviors = [
    */
   defineBehavior({
     on: 'insert.block',
-    actions: [() => [{type: 'noop'}]],
+    actions: [],
   }),
   /**
    * If multiple blocks are inserted, then the non-text blocks are filtered out

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -2,7 +2,7 @@ import {page, userEvent} from '@vitest/browser/context'
 import * as React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {defineBehavior, execute, raise} from '../src/behaviors'
+import {defineBehavior, execute, forward, raise} from '../src/behaviors'
 import type {Editor} from '../src/editor/create-editor'
 import {PortableTextEditable} from '../src/editor/Editable'
 import {EditorProvider} from '../src/editor/editor-provider'
@@ -113,8 +113,8 @@ describe('event.history.undo', () => {
               on: 'insert.text',
               guard: ({event}) => event.text === 'a',
               actions: [
-                // But when 'x' is raised, the Behavior above is called
-                // recursively and the actions are merged into a single undo step
+                // Since this Behavior doesn't do any `execute` actions,
+                // it will not squash the undo stack
                 () => [raise({type: 'insert.text', text: 'x'})],
               ],
             }),
@@ -140,7 +140,7 @@ describe('event.history.undo', () => {
     await vi.waitFor(() => {
       expect(
         getTersePt(editorRef.current?.getSnapshot().context.value),
-      ).toEqual([''])
+      ).toEqual(['y'])
     })
   })
 
@@ -197,6 +197,61 @@ describe('event.history.undo', () => {
       expect(
         getTersePt(editorRef.current?.getSnapshot().context.value),
       ).toEqual([''])
+    })
+  })
+
+  test('Scenario: A lonely `forward` action does not squash the recursive undo stack', async () => {
+    const editorRef = React.createRef<Editor>()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition: defineSchema({}),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [({event}) => [forward(event)]],
+            }),
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [
+                // 'A' is inserted in its own undo step
+                () => [execute({type: 'insert.text', text: 'A'})],
+                // 'B' is inserted in its own undo step
+                () => [execute({type: 'insert.text', text: 'B'})],
+              ],
+            }),
+          ]}
+        />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await userEvent.type(locator, 'a')
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['AB'])
+    })
+
+    editorRef.current?.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['A'])
     })
   })
 })


### PR DESCRIPTION
Consider this: If someone today asks "how does a Behavior affect event propagation?", then the answer would be:

It depends.

1. If your `guard` is truthy, but you didn't configure any `actions`, then the `event` is forwarded to the next Behavior.
2. If you return any Action from `actions` then your Behavior "owns" the `event.
3. Except if you only do `effect` Actions. Those will not affect the event propagation, because it should be possible to do side effects without interrupting the `event`.
4. However, if you do want to interrupt the `event` while doing the side effect, you can reach for the special `noop` action.

After the introduction of `forward` (and the removal of `noop`), the answer is:

1. If your `guard` is truthy you own the `event`.

It's that simple.

The rest of the rules are easy to learn:

1. If you don't do any `actions`, event propagation stops and nothing happens.
2. If you only do `effect`s then that's that. Nothing happens (except your effect).
3. And you have the option to `execute`, `forward` or `raise` the same `event` or completely different Events if you like.

`execute` and `raise` already exist and with the introduction of `forward` we now have three options on how to granularly control event propagation:

1. You can `execute` Synthetic Events to resolution. This means that executing `insert.text` inserts the text. No Behavior will intercept it.
2. You can `forward` any Event type. This very handy for composition if you want to let the remaining Behaviors with lower priority respond to an `event` without altering it (if you `raise` the same `event` again without altering it then you most likely end up in an infinite loop.)
3. You can `raise` Synthetic and Custom Events, which means they are sent back into the machinery and go through the entire Behavior stack again.

In conclusion, introducing `forward` and removing `noop` simplifies how we think about event propagation. You have to learn the differences between `execute`, `forward` and `raise`, but when those are learned, the rules are simple. And the benefit is clear when looking at the improved `TextFileDeserializerPlugin` and `ImageDeserializerPlugin` in the Playground that no longer have to mutate the `dataTransfer` in order to avoid an infinite loop when raising the `'deserialize'` event again.