### PR TITLE
fix(`delete`): don't delete when having a collapsed span selection

### DIFF
--- a/packages/editor/gherkin-spec/insert.blocks.feature
+++ b/packages/editor/gherkin-spec/insert.blocks.feature
@@ -107,3 +107,23 @@ Feature: Insert Blocks
       | after "foo"  | "before"  | "bar\|[image]\|baz\|foo" |
       | after "foo"  | "after"   | "foo\|bar\|[image]\|baz" |
       | after "foo"  | "auto"    | "foobar\|[image]\|baz"   |
+
+  Scenario: Pasting text blocks between two text blocks
+    Given the text "foo"
+    When "Enter" is pressed
+    And "bar" is typed
+    And the caret is put after "foo"
+    And blocks are inserted "auto"
+      ```
+      [
+        {
+          "_type": "block",
+          "children": [{"_type": "span", "text": "foo"}]
+        },
+        {
+          "_type": "block",
+          "children": [{"_type": "span", "text": "bar"}]
+        }
+      ]
+      ```
+    Then the text is "foofoo|bar|bar"

--- a/packages/editor/src/behavior-actions/behavior.action.delete.ts
+++ b/packages/editor/src/behavior-actions/behavior.action.delete.ts
@@ -1,15 +1,35 @@
+import {Range} from 'slate'
 import {toSlateRange} from '../internal-utils/ranges'
+import {getFocusBlock, getFocusChild} from '../internal-utils/slate-utils'
 import type {BehaviorActionImplementation} from './behavior.actions'
 
 export const deleteActionImplementation: BehaviorActionImplementation<
   'delete'
-> = ({action}) => {
+> = ({context, action}) => {
   const range = toSlateRange(action.at, action.editor)
 
   if (!range) {
     throw new Error(
       `Failed to get Slate Range for selection ${JSON.stringify(action.at)}`,
     )
+  }
+
+  if (Range.isCollapsed(range)) {
+    const [focusBlock] = getFocusBlock({
+      editor: {...action.editor, selection: range},
+    })
+    const [focusChild] = getFocusChild({
+      editor: {...action.editor, selection: range},
+    })
+
+    if (
+      focusBlock &&
+      focusBlock._type === context.schema.block.name &&
+      focusChild &&
+      focusChild._type === context.schema.span.name
+    ) {
+      return
+    }
   }
 
   action.editor.delete({at: range})

--- a/packages/editor/tests/event.delete.test.tsx
+++ b/packages/editor/tests/event.delete.test.tsx
@@ -1,0 +1,109 @@
+import {page} from '@vitest/browser/context'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import type {Editor} from '../src/editor/create-editor'
+import {PortableTextEditable} from '../src/editor/Editable'
+import {EditorProvider} from '../src/editor/editor-provider'
+import {defineSchema} from '../src/editor/editor-schema'
+import {getTersePt} from '../src/internal-utils/terse-pt'
+import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
+
+describe('event.delete', () => {
+  test('Scenario: Deleting collapsed selection', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            blockObjects: [{name: 'image'}],
+          }),
+          initialValue: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'foo',
+                },
+              ],
+            },
+            {
+              _type: 'block',
+              _key: 'k2',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k3',
+                  text: 'bar',
+                },
+              ],
+            },
+            {
+              _type: 'image',
+              _key: 'k4',
+            },
+          ],
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['foo', '|', 'bar', '|', '[image]'])
+    })
+
+    editorRef.current?.send({
+      type: 'delete',
+      at: {
+        anchor: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 3,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['foo', '|', 'bar', '|', '[image]'])
+    })
+
+    editorRef.current?.send({
+      type: 'delete',
+      at: {
+        anchor: {
+          path: [{_key: 'k4'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'k4'}],
+          offset: 0,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        getTersePt(editorRef.current?.getSnapshot().context.value),
+      ).toEqual(['foo', '|', 'bar'])
+    })
+  })
+})


### PR DESCRIPTION
Slate might merge the next block into the focus block if the next block is also a text block and there's no need for this. Sending `delete` on a collapsed selection inside a span should always be a noop.