### PR TITLE
fix: guard against `guard` errors

### DIFF
--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -138,12 +138,22 @@ export function performEvent({
   for (const eventBehavior of eventBehaviors) {
     eventBehaviorIndex++
 
-    const shouldRun =
-      eventBehavior.guard === undefined ||
-      eventBehavior.guard({
-        snapshot: guardSnapshot,
-        event,
-      })
+    let shouldRun = false
+
+    try {
+      shouldRun =
+        eventBehavior.guard === undefined ||
+        eventBehavior.guard({
+          snapshot: guardSnapshot,
+          event,
+        })
+    } catch (error) {
+      console.error(
+        new Error(
+          `Evaluating guard for "${event.type}" failed due to: ${error.message}`,
+        ),
+      )
+    }
 
     if (!shouldRun) {
       continue


### PR DESCRIPTION
We have no control over the `guard` and it might throw errors. In that case it's important that they don't bring down the entire editor.