### PR TITLE
fix(`insert.blocks`): issue with inserting into empty editor

### DIFF
--- a/packages/editor/gherkin-spec/insert.block.feature
+++ b/packages/editor/gherkin-spec/insert.block.feature
@@ -183,6 +183,30 @@ Feature: Insert Block
       | "auto"    | "end"    | "foobar"   |
       | "auto"    | "none"   | "barfoo"   |
 
+  Scenario Outline: Inserting and selecting text block on an empty selected editor
+    Given the editor is focused
+    When a block is inserted <placement> and selected at the <position>
+      ```
+      {
+        "_type": "block",
+        "children": [{"_type": "span", "text": "foo"}]
+      }
+      ```
+    And "bar" is typed
+    Then the text is <text>
+
+    Examples:
+      | placement | position | text       |
+      | "before"  | "start"  | "barfoo\|" |
+      | "before"  | "end"    | "foobar\|" |
+      | "before"  | "none"   | "foo\|bar" |
+      | "after"   | "start"  | "\|barfoo" |
+      | "after"   | "end"    | "\|foobar" |
+      | "after"   | "none"   | "bar\|foo" |
+      | "auto"    | "start"  | "barfoo"   |
+      | "auto"    | "end"    | "foobar"   |
+      | "auto"    | "none"   | "barfoo"   |
+
   Scenario Outline: Inserting block object on block object
     Given a block at "auto" selected at the <block selection>
       ```

--- a/packages/editor/gherkin-tests-v2/step-definitions.tsx
+++ b/packages/editor/gherkin-tests-v2/step-definitions.tsx
@@ -42,7 +42,9 @@ export const stepDefinitions = [
   }),
 
   Given('the editor is focused', async (context: Context) => {
-    await userEvent.click(context.editor.locator)
+    context.editor.ref.current.send({
+      type: 'focus',
+    })
 
     await vi.waitFor(() => {
       const selection = context.editor.selection()

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -42,6 +42,9 @@ const debug = debugWithName('editor machine')
 export type PatchesEvent = {
   type: 'patches'
   patches: Array<Patch>
+  /**
+   * @deprecated Unused by the editor
+   */
   snapshot: Array<PortableTextBlock> | undefined
 }
 

--- a/packages/editor/src/operations/behavior.operation.insert.block.ts
+++ b/packages/editor/src/operations/behavior.operation.insert.block.ts
@@ -220,6 +220,26 @@ export function insertBlock({
       if (editor.isTextBlock(endBlock) && editor.isTextBlock(block)) {
         const selectionStartPoint = Range.start(currentSelection)
 
+        if (isEqualToEmptyEditor([endBlock], schema)) {
+          const currentSelection = editor.selection
+
+          Transforms.insertNodes(editor, [block], {
+            at: endBlockPath,
+            select: false,
+          })
+          Transforms.removeNodes(editor, {at: Path.next(endBlockPath)})
+
+          if (select === 'start') {
+            Transforms.select(editor, selectionStartPoint)
+          } else if (select === 'end') {
+            Transforms.select(editor, Editor.end(editor, endBlockPath))
+          } else {
+            Transforms.select(editor, currentSelection)
+          }
+
+          return
+        }
+
         if (select === 'end') {
           Transforms.insertFragment(editor, [block], {
             voids: true,

--- a/packages/editor/tests/event.patch.test.tsx
+++ b/packages/editor/tests/event.patch.test.tsx
@@ -1,0 +1,120 @@
+import {insert, setIfMissing, unset, type Patch} from '@portabletext/patches'
+import {page} from '@vitest/browser/context'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {EditorProvider, PortableTextEditable, type Editor} from '../src'
+import {defineSchema} from '../src/editor/editor-schema'
+import {createTestKeyGenerator} from '../src/internal-utils/test-key-generator'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+
+describe('event.patch', () => {
+  test('Scenario: Inserting two text blocks where the first one is empty', async () => {
+    const editorRef = React.createRef<Editor>()
+    const keyGenerator = createTestKeyGenerator()
+    const patches: Array<Patch> = []
+
+    render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator,
+          schemaDefinition: defineSchema({
+            styles: [{name: 'normal'}, {name: 'h1'}],
+          }),
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+        <PortableTextEditable />
+      </EditorProvider>,
+    )
+
+    const editorLocator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(editorLocator).toBeInTheDocument())
+
+    editorRef.current?.send({type: 'focus'})
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 0,
+        },
+        backward: false,
+      })
+    })
+
+    const emptyParagraph = {
+      _type: 'block',
+      _key: keyGenerator(),
+      children: [{_type: 'span', _key: keyGenerator(), text: '', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const h1 = {
+      _type: 'block',
+      _key: keyGenerator(),
+      children: [{_type: 'span', _key: keyGenerator(), text: 'Foo', marks: []}],
+      markDefs: [],
+      style: 'h1',
+    }
+
+    editorRef.current?.send({
+      type: 'insert.blocks',
+      blocks: [emptyParagraph, h1],
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      expect(editorRef.current?.getSnapshot().context.value).toEqual([
+        emptyParagraph,
+        h1,
+      ])
+    })
+
+    expect(patches).toEqual(
+      [
+        // Initial setting up patch
+        setIfMissing([], []),
+        // Inserting placeholder block
+        insert(
+          [
+            {
+              _type: 'block',
+              _key: 'k0',
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          'before',
+          [0],
+        ),
+        // Inserting new empty paragraph before placeholder
+        insert([emptyParagraph], 'before', [{_key: 'k0'}]),
+        // Removing placeholder since placement is 'auto' and that means
+        // "merging" into the existing text
+        unset([{_key: 'k0'}]),
+        // Unsetting everything since the editor is "empty"
+        unset([]),
+        // Initial setting up patch
+        setIfMissing([], []),
+        // Inserting the empty paragraph which can now be considered the placeholder
+        insert([emptyParagraph], 'before', [0]),
+        // Inserting the h1
+        insert([h1], 'after', [{_key: emptyParagraph._key}]),
+      ].map((patch) => ({...patch, origin: 'local'})),
+    )
+  })
+})


### PR DESCRIPTION
Wrong patches would be produced if the `auto`-inserted blocks started with an
empty text block and were inserted into an empty editor.

Ultimately, this could end up inserting the empty block twice leading to
duplicate keys in the backend.