### PR TITLE
fix: allow `renderListItem`/`renderStyle` without `renderBlock`

### DIFF
--- a/packages/editor/gherkin-tests/hand-coded.test.tsx
+++ b/packages/editor/gherkin-tests/hand-coded.test.tsx
@@ -484,11 +484,15 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await putCaretAfterText(editorA, 'じでした。')
     await pressButton(editorA, 'Backspace', 1)
 
+    await expectText([`${initialText.slice(0, -1)}`])
+
     const newPrefix = 'new prefix'
 
     await userEvent.click(editorB.locator)
     await putCaretBeforeText(editorB, '彼は、')
     await type(editorB, newPrefix)
+
+    await expectText([`${newPrefix}${initialText.slice(0, -1)}`])
 
     await userEvent.click(editorB.locator)
     await putCaretBeforeText(editorB, '彼は、')

--- a/packages/editor/src/editor/components/render-text-block.tsx
+++ b/packages/editor/src/editor/components/render-text-block.tsx
@@ -154,7 +154,7 @@ export function RenderTextBlock(props: {
               type: legacyBlockSchemaType,
               value: props.textBlock,
             })
-          : props.children}
+          : children}
       </div>
       {dragPositionBlock === 'end' ? <DropIndicator /> : null}
     </div>


### PR DESCRIPTION
Before this change, the `children` modified by `renderListeItem` and `renderStyle` would only be returned through `renderBlock`. There seems to be no good reason to enforce this constraint and therefore it has been removed. This means that `renderStyle` or `renderListItem` can now be used in isolation without needing to worry about adding a placeholder render function like:

```tsx
renderBlock={(props) => <>{props.children}</>}
```