### PR TITLE
fix(renderBlock): avoid stale focused state

### DIFF
--- a/apps/playground/src/components/button.tsx
+++ b/apps/playground/src/components/button.tsx
@@ -8,7 +8,7 @@ import {focusRing} from './utils'
 
 export interface ButtonProps extends RACButtonProps {
   size?: 'sm'
-  variant?: 'primary' | 'secondary' | 'destructive'
+  variant?: 'primary' | 'secondary' | 'destructive' | 'ghost'
 }
 
 export const button = tv({
@@ -16,6 +16,7 @@ export const button = tv({
   base: 'inline-flex items-center gap-2 px-5 py-2 text-sm text-center transition rounded-lg border border-black/10 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] cursor-default',
   variants: {
     variant: {
+      ghost: 'border-none',
       primary: 'bg-blue-600 pressed:bg-blue-800 text-white',
       secondary: 'bg-gray-100 pressed:bg-gray-300 text-gray-800',
       destructive: 'bg-red-700 pressed:bg-red-900 text-white',
@@ -53,6 +54,11 @@ export const button = tv({
       variant: 'secondary',
       isSelected: true,
       class: 'bg-gray-700 hover:bg-gray-800 pressed:bg-gray-900 text-white',
+    },
+    {
+      variant: 'ghost',
+      size: 'sm',
+      class: 'p-0',
     },
   ],
 })

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -21,7 +21,13 @@ import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {useSelector} from '@xstate/react'
 import {createStore} from '@xstate/store'
-import {CopyIcon, TrashIcon} from 'lucide-react'
+import {
+  CopyIcon,
+  LinkIcon,
+  PencilIcon,
+  SeparatorHorizontalIcon,
+  TrashIcon,
+} from 'lucide-react'
 import {useEffect, useState, type JSX} from 'react'
 import {TooltipTrigger} from 'react-aria-components'
 import {reverse} from 'remeda'
@@ -592,19 +598,25 @@ const renderAnnotation: RenderAnnotationFunction = (props) => {
 }
 
 const breakStyle = tv({
-  base: 'h-1 my-1',
+  base: 'my-1 p-1 flex items-center justify-center gap-1 border-2 border-gray-300 rounded',
   variants: {
     selected: {
-      true: 'bg-blue-300',
+      true: 'border-blue-300',
+    },
+    focused: {
+      true: 'bg-blue-50',
     },
   },
 })
 
 const imageStyle = tv({
-  base: 'flex my-1 items-center gap-1 border-2 border-gray-300 rounded px-1 text-sm',
+  base: 'grid grid-cols-[auto_1fr] my-1 items-start gap-1 border-2 border-gray-300 rounded text-sm',
   variants: {
     selected: {
       true: 'border-blue-300',
+    },
+    focused: {
+      true: 'bg-blue-50',
     },
   },
 })
@@ -625,10 +637,14 @@ const RenderBlock = (props: BlockRenderProps) => {
 
   if (props.schemaType.name === 'break') {
     children = (
-      <Separator
-        orientation="horizontal"
-        className={breakStyle({selected: props.selected})}
-      />
+      <div
+        className={breakStyle({
+          selected: props.selected,
+          focused: props.focused,
+        })}
+      >
+        <SeparatorHorizontalIcon className="size-4" />
+      </div>
     )
   }
 
@@ -636,8 +652,38 @@ const RenderBlock = (props: BlockRenderProps) => {
 
   if (image) {
     children = (
-      <div className={imageStyle({selected: props.selected})}>
-        <img src={image.value.url} alt={image.value.alt ?? ''} />
+      <div
+        className={imageStyle({
+          selected: props.selected,
+          focused: props.focused,
+        })}
+      >
+        <div className="bg-gray-200 size-20 overflow-clip flex items-center justify-center">
+          <img
+            className="object-scale-down max-w-full"
+            src={image.value.url}
+            alt={image.value.alt ?? ''}
+          />
+        </div>
+        <div className="flex flex-col gap-1 p-1 overflow-hidden">
+          <div className="flex items-center gap-1">
+            <TooltipTrigger>
+              <Button variant="ghost" size="sm">
+                <LinkIcon className="size-3 shrink-0" />
+              </Button>
+              <Tooltip className="max-w-120">
+                <span className="wrap-anywhere">{image.value.url}</span>
+              </Tooltip>
+            </TooltipTrigger>
+            <span className="text-ellipsis overflow-hidden whitespace-nowrap">
+              {image.value.url}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <PencilIcon className="size-3 shrink-0" />
+            <span className="text-xs text-slate-500">{image.value.alt}</span>
+          </div>
+        </div>
       </div>
     )
   }

--- a/packages/editor/src/editor/components/render-block-object.tsx
+++ b/packages/editor/src/editor/components/render-block-object.tsx
@@ -2,7 +2,11 @@ import type {PortableTextObject} from '@sanity/types'
 import {useSelector} from '@xstate/react'
 import {useContext, useRef, useState, type ReactElement} from 'react'
 import {Range, type Element as SlateElement} from 'slate'
-import {useSelected, useSlateStatic, type RenderElementProps} from 'slate-react'
+import {
+  useSelected,
+  useSlateSelector,
+  type RenderElementProps,
+} from 'slate-react'
 import type {EventPositionBlock} from '../../internal-utils/event-position'
 import type {RenderBlockFunction} from '../../types/editor'
 import {EditorActorContext} from '../editor-actor-context'
@@ -22,8 +26,13 @@ export function RenderBlockObject(props: {
     useState<EventPositionBlock>()
   const blockObjectRef = useRef<HTMLDivElement>(null)
 
-  const slateEditor = useSlateStatic()
   const selected = useSelected()
+  const focused = useSlateSelector(
+    (editor) =>
+      selected &&
+      editor.selection !== null &&
+      Range.isCollapsed(editor.selection),
+  )
 
   const editorActor = useContext(EditorActorContext)
 
@@ -45,11 +54,6 @@ export function RenderBlockObject(props: {
       `Block object type ${props.element._type} not found in Schema`,
     )
   }
-
-  const focused =
-    selected &&
-    slateEditor.selection !== null &&
-    Range.isCollapsed(slateEditor.selection)
 
   return (
     <div

--- a/packages/editor/src/editor/components/render-text-block.tsx
+++ b/packages/editor/src/editor/components/render-text-block.tsx
@@ -2,7 +2,11 @@ import type {PortableTextTextBlock} from '@sanity/types'
 import {useSelector} from '@xstate/react'
 import {useContext, useRef, useState, type ReactElement} from 'react'
 import {Range, type Element as SlateElement} from 'slate'
-import {useSelected, useSlateStatic, type RenderElementProps} from 'slate-react'
+import {
+  useSelected,
+  useSlateSelector,
+  type RenderElementProps,
+} from 'slate-react'
 import type {EventPositionBlock} from '../../internal-utils/event-position'
 import type {
   RenderBlockFunction,
@@ -28,8 +32,13 @@ export function RenderTextBlock(props: {
     useState<EventPositionBlock>()
   const blockRef = useRef<HTMLDivElement>(null)
 
-  const slateEditor = useSlateStatic()
   const selected = useSelected()
+  const focused = useSlateSelector(
+    (editor) =>
+      selected &&
+      editor.selection !== null &&
+      Range.isCollapsed(editor.selection),
+  )
 
   const editorActor = useContext(EditorActorContext)
 
@@ -41,11 +50,6 @@ export function RenderTextBlock(props: {
   const legacySchema = useSelector(editorActor, (s) =>
     s.context.getLegacySchema(),
   )
-
-  const focused =
-    selected &&
-    slateEditor.selection !== null &&
-    Range.isCollapsed(slateEditor.selection)
 
   let children = props.children
 


### PR DESCRIPTION
Before this change, the `focused` state derived in `RenderTextBlock` and `RenderBlockObject` could be stale. This is because it's derived from the `selected` state and the `editor.selection`. However, changes to the `editor.selection` itself doesn't trigger a rerender. This means that if the block is `selected` as part of an expanded selection and afterwards `selected` as part of a collapsed selection, the `focused` wouldn't go from `false` to `true`. This has been fixed by deriving the `focused` state in a Slate selector, causing it to be recalculated on each state change.

I've also updated the Playground block render style so rendered block objects look a bit nicer and also reflect the `focused` state:
![Screenshot 2025-06-20 at 08 58 08](https://github.com/user-attachments/assets/fc2b1b25-e2dd-4866-a0a6-afc416c7c872)
