### PR TITLE
fix(regression): allow splitting all text blocks in the middle

### DIFF
--- a/packages/editor/src/behaviors/behavior.abstract.split.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.split.ts
@@ -108,7 +108,6 @@ export const abstractSplitBehaviors = [
             context: {
               ...snapshot.context,
               selection: newTextBlockSelection,
-              value: [focusTextBlock.node],
             },
           })
           .at(0),


### PR DESCRIPTION
The selector was incorrectly passed an adjusted value, only containing the
focus text block.