### PR TITLE
fix(`PortableTextEditor.delete`): issue with deleting the last block

### DIFF
--- a/packages/editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
+++ b/packages/editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
@@ -136,25 +136,22 @@ describe('plugin:withEditableAPI: .delete()', () => {
     await waitFor(() => {
       if (editorRef.current) {
         // New keys here confirms that a placeholder block has been created
-        expect(PortableTextEditor.getValue(editorRef.current))
-          .toMatchInlineSnapshot(`
-          [
-            {
-              "_key": "k2",
-              "_type": "myTestBlockType",
-              "children": [
-                {
-                  "_key": "k3",
-                  "_type": "span",
-                  "marks": [],
-                  "text": "",
-                },
-              ],
-              "markDefs": [],
-              "style": "normal",
-            },
-          ]
-        `)
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'k2',
+            _type: 'myTestBlockType',
+            children: [
+              {
+                _key: 'k3',
+                _type: 'span',
+                marks: [],
+                text: '',
+              },
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
       }
     })
   })

--- a/packages/editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/editor/src/editor/plugins/createWithEditableAPI.ts
@@ -15,6 +15,8 @@ import {
 } from 'slate'
 import type {DOMNode} from 'slate-dom'
 import {ReactEditor} from 'slate-react'
+import {buildIndexMaps} from '../../internal-utils/build-index-maps'
+import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
 import {debugWithName} from '../../internal-utils/debug'
 import {toSlateRange} from '../../internal-utils/ranges'
 import {
@@ -502,8 +504,24 @@ export function createEditableAPI(
           // that would insert the placeholder into the actual value
           // which should remain empty)
           if (editor.children.length === 0) {
-            editor.children = [editor.pteCreateTextBlock({decorators: []})]
+            const placeholderBlock = createPlaceholderBlock(
+              editorActor.getSnapshot().context,
+            )
+            editor.children = [placeholderBlock]
+            editor.value = [placeholderBlock]
+
+            buildIndexMaps(
+              {
+                schema: editorActor.getSnapshot().context.schema,
+                value: editor.value,
+              },
+              {
+                blockIndexMap: editor.blockIndexMap,
+                listIndexMap: editor.listIndexMap,
+              },
+            )
           }
+
           editor.onChange()
         }
       }


### PR DESCRIPTION
Deleting the last block using `PortableTextEditor.delete(...)` would insert a new placeholder text block without Slate knowing about it. This caused an issue since we don't get notified of the insertion and therefore can't update the `.value` cache and the block indexes. To mitigate this, we update these caches manually, but down the line it's worth revisiting the scattered logic that takes care of inserting placeholder blocks.