### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/packages/block-tools/package.json
+++ b/packages/block-tools/package.json
@@ -66,7 +66,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@sanity/types": "^3.98.0",
+    "@sanity/types": "^3.98.0 || ^4.0.0-0",
     "@types/react": "18 || 19"
   },
   "publishConfig": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -139,8 +139,8 @@
     "vitest-browser-react": "^1.0.0"
   },
   "peerDependencies": {
-    "@sanity/schema": "^3.98.0",
-    "@sanity/types": "^3.98.0",
+    "@sanity/schema": "^3.98.0 || ^4.0.0-0",
+    "@sanity/types": "^3.98.0 || ^4.0.0-0",
     "react": "^16.9 || ^17 || ^18 || ^19",
     "rxjs": "^7.8.2"
   },


### PR DESCRIPTION
Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
Progress: resolved 1025, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ sanity 4.0.0-0
  └─┬ @portabletext/editor 1.57.1
    ├── ✕ unmet peer @sanity/types@^3.98.0: found 4.0.0-0
    ├── ✕ unmet peer @sanity/schema@^3.98.0: found 4.0.0-0
    └─┬ @portabletext/block-tools 1.1.36
      └── ✕ unmet peer @sanity/types@^3.98.0: found 4.0.0-0
```
This fixes it.