### PR TITLE
fix: use `rolldown` instead of `api-extractor` for dts generation

### DIFF
--- a/packages/block-tools/package.config.ts
+++ b/packages/block-tools/package.config.ts
@@ -31,4 +31,5 @@ export default defineConfig({
     noImplicitBrowsersList: 'off',
     noImplicitSideEffects: 'error',
   },
+  dts: 'rolldown',
 })

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -43,4 +43,5 @@ export default defineConfig({
   },
   babel: {reactCompiler: true},
   reactCompilerOptions: {target: '18'},
+  dts: 'rolldown',
 })

--- a/packages/keyboard-shortcuts/package.config.ts
+++ b/packages/keyboard-shortcuts/package.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
   babel: {reactCompiler: true},
   reactCompilerOptions: {target: '19'},
+  dts: 'rolldown',
 })

--- a/packages/patches/package.config.ts
+++ b/packages/patches/package.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   strictOptions: {
     noImplicitBrowsersList: 'off',
   },
+  dts: 'rolldown',
 })

--- a/packages/toolbar/package.config.ts
+++ b/packages/toolbar/package.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
   babel: {reactCompiler: true},
   reactCompilerOptions: {target: '19'},
+  dts: 'rolldown',
 })


### PR DESCRIPTION
[There's an issue in `@microsoft/api-extractor` that leads to partially broken generation of `.d.ts` files](https://github.com/microsoft/rushstack/issues/5106), [it's affecting `@portabletext/editor`](https://github.com/sanity-io/sanity/pull/9989).

By switching to `rolldown` we get healthy dts builds, [as seen in this test PR](https://github.com/sanity-io/sanity/pull/10000), and by looking at the diff output and how relative `import type from '../does-not-exist'` statements no longer appearing:
- [`@portabletext/editor`](https://npmdiff.dev/%40portabletext%2Feditor/1.58.0/2.0.0-canary.0/) – no more [`import {EditorPriority as EditorPriority_2} from '../priority/priority.types'`](https://npmdiff.dev/%40portabletext%2Feditor/1.58.0/2.0.0-canary.0/package/lib/index.d.cts)
- [`@portabletext/keyboard-shortcuts`](https://npmdiff.dev/%40portabletext%2Fkeyboard-shortcuts/1.1.0/2.0.0-canary.0/) – no more [`import {KeyboardShortcut as KeyboardShortcut_2} from './keyboard-shortcuts'`](https://npmdiff.dev/%40portabletext%2Fkeyboard-shortcuts/1.1.0/2.0.0-canary.0/package/dist/index.d.ts/)


These packages didn't have any problems yet, and changing to `rolldown` doesn't cause any regressions:
- [`@portabletext/block-tools`](https://npmdiff.dev/%40portabletext%2Fblock-tools/1.1.38/2.0.0-canary.0/)
- [`@portabletext/patches`](https://npmdiff.dev/%40portabletext%2Fpatches/1.1.5/2.0.0-canary.0/)
- [`@portabletext/toolbar`](https://npmdiff.dev/%40portabletext%2Ftoolbar/1.0.7/2.0.0-canary.0/)