### PR TITLE
feat: consider range decorations changed if `payload` has changed

### DIFF
--- a/packages/editor/src/editor/__tests__/RangeDecorations.test.tsx
+++ b/packages/editor/src/editor/__tests__/RangeDecorations.test.tsx
@@ -33,6 +33,7 @@ describe('RangeDecorations', () => {
           anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
           focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
         },
+        payload: {id: 'a'},
       },
     ]
 
@@ -85,6 +86,7 @@ describe('RangeDecorations', () => {
           anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
           focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
         },
+        payload: {id: 'a'},
       },
     ]
     rerender(
@@ -111,6 +113,7 @@ describe('RangeDecorations', () => {
           anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
           focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 4},
         },
+        payload: {id: 'a'},
       },
     ]
     rerender(
@@ -138,6 +141,7 @@ describe('RangeDecorations', () => {
           anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
           focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
         },
+        payload: {id: 'a'},
       },
     ]
     rerender(
@@ -155,6 +159,62 @@ describe('RangeDecorations', () => {
         3,
         'updated-with-different',
       ])
+    })
+
+    // Update the range decorations with a new payload
+    rangeDecorations = [
+      {
+        component: RangeDecorationTestComponent,
+        selection: {
+          anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
+          focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
+        },
+        payload: {id: 'b'},
+      },
+    ]
+    rerender(
+      <PortableTextEditorTester
+        keyGenerator={createTestKeyGenerator()}
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([
+        rangeDecorationIteration,
+        'updated-with-different-payload',
+      ]).toEqual([4, 'updated-with-different-payload'])
+    })
+
+    // Update the range decorations with a new payload again
+    rangeDecorations = [
+      {
+        component: RangeDecorationTestComponent,
+        selection: {
+          anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 0},
+          focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 2},
+        },
+        payload: {id: 'c'},
+      },
+    ]
+    rerender(
+      <PortableTextEditorTester
+        keyGenerator={createTestKeyGenerator()}
+        onChange={onChange}
+        rangeDecorations={rangeDecorations}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    await waitFor(() => {
+      expect([
+        rangeDecorationIteration,
+        'updated-with-different-payload',
+      ]).toEqual([5, 'updated-with-different-payload'])
     })
   })
 })

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -254,6 +254,7 @@ export const rangeDecorationsMachine = setup({
         (decoratedRange) => ({
           anchor: decoratedRange.rangeDecoration.selection?.anchor,
           focus: decoratedRange.rangeDecoration.selection?.focus,
+          payload: decoratedRange.rangeDecoration.payload,
         }),
       )
 
@@ -261,6 +262,7 @@ export const rangeDecorationsMachine = setup({
         (rangeDecoration) => ({
           anchor: rangeDecoration.selection?.anchor,
           focus: rangeDecoration.selection?.focus,
+          payload: rangeDecoration.payload,
         }),
       )
 


### PR DESCRIPTION
Previously, range decorations would only be considered changed if their anchor or focus positions had changed. However, there are other parts of the range decoration that may change between renders:

1. The component rendered.
2. The payload data.

For many use cases, it's desirable to re-render the range decoration when these underlying properties change. This commit adds the payload data to the object compared to achieve this. If the developer wishes to ensure the range decoration component is re-rendered, they can do so by adding some unique property to the payload data (such as a key or id).