### PR TITLE
fix(deps): downgrade `use-effect-event`

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -106,7 +106,7 @@
     "slate": "0.117.2",
     "slate-dom": "^0.117.4",
     "slate-react": "0.117.4",
-    "use-effect-event": "^2.0.3",
+    "use-effect-event": "^1.0.2",
     "xstate": "^5.20.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
         specifier: 0.117.4
         version: 0.117.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(slate-dom@0.117.4(slate@0.117.2))(slate@0.117.2)
       use-effect-event:
-        specifier: ^2.0.3
-        version: 2.0.3(react@19.1.0)
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.1.0)
       xstate:
         specifier: ^5.20.1
         version: 5.20.1
@@ -6532,8 +6532,8 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-effect-event@2.0.3:
-    resolution: {integrity: sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==}
+  use-effect-event@1.0.2:
+    resolution: {integrity: sha512-9c8AAmtQja4LwJXI0EQPhQCip6dmrcSe0FMcTUZBeGh/XTCOLgw3Qbt0JdUT8Rcrm/ZH+Web7MIcMdqgQKdXJg==}
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
 
@@ -14310,7 +14310,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-effect-event@2.0.3(react@19.1.0):
+  use-effect-event@1.0.2(react@19.1.0):
     dependencies:
       react: 19.1.0
 


### PR DESCRIPTION
It was previously downgraded in
https://github.com/portabletext/editor/pull/1260, but then got upgraded again in https://github.com/portabletext/editor/pull/1444.

v2 of the package is breaking the editor in various instances. I don't have an overview of why/when it happens, but until I do, I can't upgrade the package to v2.