### PR TITLE
fix: remove `use-effect-event`

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -106,7 +106,6 @@
     "slate": "0.118.0",
     "slate-dom": "^0.117.4",
     "slate-react": "0.117.4",
-    "use-effect-event": "^1.0.2",
     "xstate": "^5.20.1"
   },
   "devDependencies": {

--- a/packages/editor/src/editor-event-listener.tsx
+++ b/packages/editor/src/editor-event-listener.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react'
-import {useEffectEvent} from 'use-effect-event'
 import type {EditorEmittedEvent} from './editor/relay-machine'
 import {useEditor} from './editor/use-editor'
 
@@ -16,15 +15,14 @@ export function EditorEventListener(props: {
   on: (event: EditorEmittedEvent) => void
 }) {
   const editor = useEditor()
-  const on = useEffectEvent(props.on)
 
   useEffect(() => {
-    const subscription = editor.on('*', on)
+    const subscription = editor.on('*', props.on)
 
     return () => {
       subscription.unsubscribe()
     }
-  }, [editor])
+  }, [editor, props.on])
 
   return null
 }

--- a/packages/editor/src/plugins/plugin.event-listener.tsx
+++ b/packages/editor/src/plugins/plugin.event-listener.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react'
-import {useEffectEvent} from 'use-effect-event'
 import type {EditorEmittedEvent} from '../editor/relay-machine'
 import {useEditor} from '../editor/use-editor'
 
@@ -56,15 +55,14 @@ export function EventListenerPlugin(props: {
   on: (event: EditorEmittedEvent) => void
 }) {
   const editor = useEditor()
-  const on = useEffectEvent(props.on)
 
   useEffect(() => {
-    const subscription = editor.on('*', on)
+    const subscription = editor.on('*', props.on)
 
     return () => {
       subscription.unsubscribe()
     }
-  }, [editor])
+  }, [editor, props.on])
 
   return null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,9 +459,6 @@ importers:
       slate-react:
         specifier: 0.117.4
         version: 0.117.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(slate-dom@0.117.4(slate@0.118.0))(slate@0.118.0)
-      use-effect-event:
-        specifier: ^1.0.2
-        version: 1.0.2(react@19.1.1)
       xstate:
         specifier: ^5.20.1
         version: 5.20.1
@@ -6531,11 +6528,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-effect-event@1.0.2:
-    resolution: {integrity: sha512-9c8AAmtQja4LwJXI0EQPhQCip6dmrcSe0FMcTUZBeGh/XTCOLgw3Qbt0JdUT8Rcrm/ZH+Web7MIcMdqgQKdXJg==}
-    peerDependencies:
-      react: ^18.3 || ^19.0.0-0
 
   use-isomorphic-layout-effect@1.2.0:
     resolution: {integrity: sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==}
@@ -14303,10 +14295,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-effect-event@1.0.2(react@19.1.1):
-    dependencies:
-      react: 19.1.1
 
   use-isomorphic-layout-effect@1.2.0(@types/react@19.1.9)(react@19.1.1):
     dependencies:


### PR DESCRIPTION
`editor` is stable so the only thing that could trigger a resubscription is if `props.on` changes (which is what you would want).