### PR TITLE
chore(deps): use rc of react-hooks linter

### DIFF
--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-      - run: pnpm -r up --ignore-scripts react-compiler-runtime@rc babel-plugin-react-compiler@rc eslint-plugin-react-hooks@experimental
+      - run: pnpm -r up --ignore-scripts react-compiler-runtime@rc babel-plugin-react-compiler@rc eslint-plugin-react-hooks@rc
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
@@ -42,7 +42,7 @@ jobs:
       - if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
-          body: I ran `pnpm -r up react-compiler-runtime@rc babel-plugin-react-compiler@rc eslint-plugin-react-hooks@experimental` 🧑‍💻
+          body: I ran `pnpm -r up react-compiler-runtime@rc babel-plugin-react-compiler@rc eslint-plugin-react-hooks@rc` 🧑‍💻
           branch: actions/react-compiler
           commit-message: "fix(deps): update react compiler dependencies 🤖 ✨"
           labels: 🤖 bot

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -45,7 +45,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "eslint": "8.57.1",
-    "eslint-plugin-react-hooks": "0.0.0-experimental-dffacc7b-20250717",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^1.0.0",
     "tailwindcss": "^4.1.10",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -23,7 +23,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "eslint": "^9.13.0",
-    "eslint-plugin-react-hooks": "0.0.0-experimental-dffacc7b-20250717",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
     "typescript": "~5.6.2",

--- a/examples/legacy/package.json
+++ b/examples/legacy/package.json
@@ -30,7 +30,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "eslint": "^9.13.0",
-    "eslint-plugin-react-hooks": "0.0.0-experimental-dffacc7b-20250717",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
     "typescript": "~5.6.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -127,7 +127,7 @@
     "@vitest/coverage-istanbul": "^3.2.4",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "eslint": "8.57.1",
-    "eslint-plugin-react-hooks": "0.0.0-experimental-dffacc7b-20250717",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "jsdom": "^26.0.0",
     "racejar": "workspace:*",
     "react": "^19.1.1",

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/parser": "^8.38.0",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "eslint": "8.57.1",
-    "eslint-plugin-react-hooks": "0.0.0-experimental-dffacc7b-20250717",
+    "eslint-plugin-react-hooks": "6.0.0-rc.1",
     "react": "^19.1.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,8 +229,8 @@ importers:
         specifier: 8.57.1
         version: 8.57.1
       eslint-plugin-react-hooks:
-        specifier: 0.0.0-experimental-dffacc7b-20250717
-        version: 0.0.0-experimental-dffacc7b-20250717(eslint@8.57.1)
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@8.57.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -284,8 +284,8 @@ importers:
         specifier: ^9.13.0
         version: 9.23.0(jiti@2.4.2)
       eslint-plugin-react-hooks:
-        specifier: 0.0.0-experimental-dffacc7b-20250717
-        version: 0.0.0-experimental-dffacc7b-20250717(eslint@9.23.0(jiti@2.4.2))
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
         version: 0.4.19(eslint@9.23.0(jiti@2.4.2))
@@ -354,8 +354,8 @@ importers:
         specifier: ^9.13.0
         version: 9.23.0(jiti@2.4.2)
       eslint-plugin-react-hooks:
-        specifier: 0.0.0-experimental-dffacc7b-20250717
-        version: 0.0.0-experimental-dffacc7b-20250717(eslint@9.23.0(jiti@2.4.2))
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-react-refresh:
         specifier: ^0.4.14
         version: 0.4.19(eslint@9.23.0(jiti@2.4.2))
@@ -518,8 +518,8 @@ importers:
         specifier: 8.57.1
         version: 8.57.1
       eslint-plugin-react-hooks:
-        specifier: 0.0.0-experimental-dffacc7b-20250717
-        version: 0.0.0-experimental-dffacc7b-20250717(eslint@8.57.1)
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@8.57.1)
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
@@ -643,8 +643,8 @@ importers:
         specifier: 8.57.1
         version: 8.57.1
       eslint-plugin-react-hooks:
-        specifier: 0.0.0-experimental-dffacc7b-20250717
-        version: 0.0.0-experimental-dffacc7b-20250717(eslint@8.57.1)
+        specifier: 6.0.0-rc.1
+        version: 6.0.0-rc.1(eslint@8.57.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -4087,8 +4087,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-plugin-react-hooks@0.0.0-experimental-dffacc7b-20250717:
-    resolution: {integrity: sha512-wz5gjKUAy7aiD+ZGpxIkYKZ1XoZZLIy+wEkyLQxMHlNCdWmBYUUk1sxSdNndT1Gt/CZVZ0l+xrGPU3FgCbl1YA==}
+  eslint-plugin-react-hooks@6.0.0-rc.1:
+    resolution: {integrity: sha512-7C4c7bdtd/B7Q+HruZxYhGjwZVvJawvQpilEYlRG1Jncuk1ZNqrFy9bO8SJNieyj3iDh8WPQA7BzzPO7sNAyEA==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
@@ -11126,7 +11126,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@0.0.0-experimental-dffacc7b-20250717(eslint@8.57.1):
+  eslint-plugin-react-hooks@6.0.0-rc.1(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/parser': 7.28.0
@@ -11138,7 +11138,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@0.0.0-experimental-dffacc7b-20250717(eslint@9.23.0(jiti@2.4.2)):
+  eslint-plugin-react-hooks@6.0.0-rc.1(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/parser': 7.28.0


### PR DESCRIPTION
Since we no longer use `use-effect-event` we no longer need the experimental lint plugin