### PR TITLE
fix: reduce peer deps duplication and set min node 22 version

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -17,10 +17,10 @@
     "test:unit:watch": "vitest"
   },
   "dependencies": {
-    "@portabletext/block-tools": "workspace:^",
-    "@portabletext/editor": "workspace:^",
+    "@portabletext/block-tools": "workspace:*",
+    "@portabletext/editor": "workspace:*",
     "@portabletext/keyboard-shortcuts": "workspace:*",
-    "@portabletext/patches": "workspace:^",
+    "@portabletext/patches": "workspace:*",
     "@portabletext/plugin-markdown-shortcuts": "^1.0.14",
     "@portabletext/plugin-one-line": "^1.0.17",
     "@portabletext/toolbar": "workspace:*",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@portabletext/editor": "workspace:^",
+    "@portabletext/editor": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/legacy/package.json
+++ b/examples/legacy/package.json
@@ -12,8 +12,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@portabletext/editor": "workspace:^",
-    "@portabletext/patches": "workspace:^",
+    "@portabletext/editor": "workspace:*",
+    "@portabletext/patches": "workspace:*",
     "@sanity/schema": "^4.0.1",
     "@xstate/react": "^4.1.3",
     "react": "^19.1.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -147,7 +147,7 @@
     "rxjs": "^7.8.2"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=20.19 <22 || >=22.12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -92,10 +92,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@portabletext/block-tools": "workspace:*",
-    "@portabletext/keyboard-shortcuts": "workspace:*",
-    "@portabletext/patches": "workspace:*",
-    "@portabletext/schema": "workspace:*",
+    "@portabletext/block-tools": "workspace:^",
+    "@portabletext/keyboard-shortcuts": "workspace:^",
+    "@portabletext/patches": "workspace:^",
+    "@portabletext/schema": "workspace:^",
     "@portabletext/to-html": "^2.0.14",
     "@xstate/react": "^6.0.0",
     "debug": "^4.4.1",
@@ -140,7 +140,7 @@
     "vitest-browser-react": "^1.0.1"
   },
   "peerDependencies": {
-    "@portabletext/sanity-bridge": "workspace:*",
+    "@portabletext/sanity-bridge": "workspace:^",
     "@sanity/schema": "^4.4.1",
     "@sanity/types": "^4.4.1",
     "react": "^18.3 || ^19",

--- a/packages/sanity-bridge/package.json
+++ b/packages/sanity-bridge/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "turbo run build"
   },
   "dependencies": {
-    "@portabletext/schema": "workspace:*",
+    "@portabletext/schema": "workspace:^",
     "get-random-values-esm": "^1.0.2",
     "lodash.startcase": "^4.4.0"
   },

--- a/packages/sanity-bridge/package.json
+++ b/packages/sanity-bridge/package.json
@@ -62,7 +62,7 @@
     "@sanity/types": "^4.4.1"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=20.19 <22 || >=22.12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -47,7 +47,7 @@
     "prepublishOnly": "turbo run build"
   },
   "dependencies": {
-    "@portabletext/keyboard-shortcuts": "workspace:*",
+    "@portabletext/keyboard-shortcuts": "workspace:^",
     "@xstate/react": "^6.0.0",
     "react-compiler-runtime": "19.1.0-rc.2",
     "xstate": "^5.20.2"
@@ -65,7 +65,7 @@
     "typescript": "^5.9.2"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:*",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,13 +433,13 @@ importers:
         specifier: workspace:*
         version: link:../block-tools
       '@portabletext/keyboard-shortcuts':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../keyboard-shortcuts
       '@portabletext/patches':
         specifier: workspace:*
         version: link:../patches
       '@portabletext/schema':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../schema
       '@portabletext/to-html':
         specifier: ^2.0.14
@@ -627,7 +627,7 @@ importers:
   packages/sanity-bridge:
     dependencies:
       '@portabletext/schema':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../schema
       get-random-values-esm:
         specifier: ^1.0.2
@@ -664,7 +664,7 @@ importers:
   packages/toolbar:
     dependencies:
       '@portabletext/keyboard-shortcuts':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../keyboard-shortcuts
       '@xstate/react':
         specifier: ^6.0.0


### PR DESCRIPTION
Node v22 added support for `require(esm)` in 22.12, we've updated the node engines semver in `sanity` and other packages to reflect this, for the same reasons we do it for `22.19`.
While here I noticed the usage of `workspace:*` and `workspace:^` is a bit inconsistent and not as optimized as it could be.
The guideline is that generally `workspace:*` should always be used, as it means the exact version.
Technically, a package like `apps/playground/package.json` isn't published to npm, so what it wants is the equivalent of `workspace:`, it wants the workspace package, whatever the version is, semver ranges doesn't matter. (That might be why the default syntax for `catalog` is `catalog:` and not `catalog:*`).

When packages are published it matters what comes after the `:`. `workspace:*` is replaced with the exact version of the package it refers to. That makes it suitable to `devDependencies`, if `package-a` only has a `devDependency` on `package-b` then it might be useful to see when inspecting `package-a`'s exact version of `package-b` at the time of publish, especially if `package-b` has since published new versions while `package-a` has not.
For `dependencies` and `peerDependencies` the `workspace:^` should be used. That way, if `sanity` bumps `@portabletext/block-tools` but haven't bumped `@portabletext/editor` yet then we don't get two instances of `@portabletext/block-tools` unless it's necessary (they are different major versions).