### PR TITLE
feat: support `PortableTextEditable` callback ref

### DIFF
--- a/.changeset/modern-jeans-appear.md
+++ b/.changeset/modern-jeans-appear.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: support `PortableTextEditable` callback ref


### PR DESCRIPTION
The logic also attempts to simplify the internals of `PortableTextEditable` by
avoiding keeping track of a local `ref` and a local `activeElement`. Instead,
the `MutationObserver` on the DOM node is set up in a callback ref itself, and
`validateSelection` has been pulled out as a standalone function.