### PR TITLE
chore(changeset): remove experimental `updateInternalDependents`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,8 +8,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["docs", "playground", "example-basic", "example-legacy"],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "updateInternalDependents": "always"
-  }
+  "ignore": ["docs", "playground", "example-basic", "example-legacy"]
 }


### PR DESCRIPTION
It seems to bump packages the wrong way. A `feat` change to `@portabletext/editor` caused a major bump to `@portabletext/toolbar`.