### PR TITLE
docs(chore): add missing libraries to serializers list

### DIFF
--- a/apps/docs/src/content/docs/integrations/serializers.mdx
+++ b/apps/docs/src/content/docs/integrations/serializers.mdx
@@ -4,7 +4,7 @@ title: 'Serializers'
 
 import {CardGrid, LinkCard} from '@astrojs/starlight/components'
 
-Serializers take Portable Text and output common formats like HTML, framework components, and more.
+Serializers take Portable Text and output common formats like HTML, framework components, and more. For more official serializers and integrations, see the [Portable Text organization on GitHub](https://github.com/portabletext/).
 
 ## JavaScript
 
@@ -29,6 +29,18 @@ Serializers take Portable Text and output common formats like HTML, framework co
         title="astro-portabletext"
         description="Integrate Portable Text content in Astro"
         href="https://github.com/theisel/astro-portabletext" />
+    <LinkCard
+        title="react-pdf-portabletext"
+        description="Portable Text to React PDF"
+        href="https://github.com/portabletext/react-pdf-portabletext" />
+    <LinkCard
+        title="react-native-portabletext"
+        description="Portable Text to React Native"
+        href="https://github.com/portabletext/react-native-portabletext" />
+    <LinkCard
+        title="solid-portabletext"
+        description="Portable Text to Solid"
+        href="https://github.com/portabletext/solid-portabletext" />
 
 </CardGrid>
 
@@ -79,5 +91,15 @@ Serializers take Portable Text and output common formats like HTML, framework co
     title="flutter_portabletext"
     description="Render Portable Text"
     href="https://github.com/JobiJoba/flutter_portabletext"
+  />
+</CardGrid>
+
+## CMS integrations
+
+<CardGrid>
+  <LinkCard
+    title="Portable Text with Hugo"
+    description="Portable Text in Hugo"
+    href="https://gohugo.io/functions/transform/portabletext/"
   />
 </CardGrid>


### PR DESCRIPTION
Adds a few missing serializers to the integrations doc page, and adds a blurb at the top directing users to the PT org for more. 