### PR TITLE
fix: keep `IS_FOCUSED` `false` as long as the editor is read-only

### DIFF
--- a/.changeset/floppy-trams-argue.md
+++ b/.changeset/floppy-trams-argue.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+keep `IS_FOCUSED` `false` as long as the editor is read-only

--- a/packages/editor/src/operations/behavior.operation.select.ts
+++ b/packages/editor/src/operations/behavior.operation.select.ts
@@ -1,4 +1,5 @@
 import {Transforms} from 'slate'
+import {IS_FOCUSED, IS_READ_ONLY} from 'slate-dom'
 import {toSlateRange} from '../internal-utils/to-slate-range'
 import type {BehaviorOperationImplementation} from './behavior.operations'
 
@@ -18,5 +19,9 @@ export const selectOperationImplementation: BehaviorOperationImplementation<
     Transforms.select(operation.editor, newSelection)
   } else {
     Transforms.deselect(operation.editor)
+  }
+
+  if (IS_FOCUSED.get(operation.editor) && IS_READ_ONLY.get(operation.editor)) {
+    IS_FOCUSED.set(operation.editor, false)
   }
 }


### PR DESCRIPTION
Slate's internal `IS_FOCUSED` can potentially be set to `true` for the editor
inside the `onDOMSelectionChange` handler even though the editor is read-only:
https://github.com/ianstormtaylor/slate/blob/a8fc9a415881bf5af4c72680327ba539db3a2b74/packages/slate-react/src/components/editable.tsx#L293

This can in some cases cause `DOMEditor.toSlatePoint` to produce a wrong point
if the editor is read-only. If the `potentialNonEditableNode` in that method
turns out to be the editor itself because it is marked with
`content-editable="false"` (because the editor is read-only) and no `leafNode`
is found (because the event origins froma non-leaf node, for example a `div`)
then the method ends in the `} else if (nonEditableNode) {` clause. At this
point
`const elementNode = nonEditableNode.closest('[data-slate-node="element"]')`
searches for a Slate node, but if the `nonEditableNode` is the editor itself,
this search ends up going beyond and above the editor. If the editor is nested
inside another editor then it might actually find a node from another editor.

Further down the method, `DOMEditor.toSlateNode` is called, and if this is
called with a DOM node from another editor then we might end up with results
that crash the editor:
https://github.com/ianstormtaylor/slate/blob/a8fc9a415881bf5af4c72680327ba539db3a2b74/packages/slate-dom/src/plugin/dom-editor.ts#L912

This is because `DOMEditor.toSlateNode` uses the global `ELEMENT_TO_NODE`
WeakMap where all nodes from all editors on the page potentially can be stored:
https://github.com/ianstormtaylor/slate/blob/a8fc9a415881bf5af4c72680327ba539db3a2b74/packages/slate-dom/src/plugin/dom-editor.ts#L682

In the end, `DOMEditor.toSlatePoint` can end up producing an invalid point
because of this cascade of adverse events. This can in turn crash the editor
when it attempts to set the DOM Selection based on this newly found invalid
point.

---

It might be
[a bug in Slate](https://github.com/ianstormtaylor/slate/issues/5947) that
`nonEditableNode.closest('[data-slate-node="element"]')` can end up going above
the editor itself, but for now we can mitigate all of the above if we simply
make sure that `IS_FOCUSED` is kept false as long as the editor is read-only.

This seems to have no adverse effect since it merely blocks `setDomSelection`
from running inside the `useIsomorphicLayoutEffect`:
https://github.com/ianstormtaylor/slate/blob/a8fc9a415881bf5af4c72680327ba539db3a2b74/packages/slate-react/src/components/editable.tsx#L368