### PR TITLE
fix: avoid thrown error if the editor has been unmounted

### DIFF
--- a/.changeset/great-ghosts-tell.md
+++ b/.changeset/great-ghosts-tell.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: avoid thrown error if the editor has been unmounted
+
+The editor attempts to validate its selection upon unexpected DOM changes. However, in some cases, this logic might run after the editor has been unmounted and removed from the DOM. In this case an error would be thrown because no editor DOM node could be found. This error has now been suppressed as there is no need to surface it to the user.

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -1027,7 +1027,18 @@ function validateSelection(slateEditor: Editor, activeElement: HTMLDivElement) {
   if (!slateEditor.selection) {
     return
   }
-  const root = ReactEditor.findDocumentOrShadowRoot(slateEditor)
+
+  let root: Document | ShadowRoot | undefined
+
+  try {
+    root = ReactEditor.findDocumentOrShadowRoot(slateEditor)
+  } catch {}
+
+  if (!root) {
+    // The editor has most likely been unmounted
+    return
+  }
+
   // Return if the editor isn't the active element
   if (activeElement !== root.activeElement) {
     return


### PR DESCRIPTION
The editor attempts to validate its selection upon unexpected DOM changes. However, in some cases, this logic might run after the editor has been unmounted and removed from the DOM. In this case an error would be thrown because no editor DOM node could be found. This error has now been suppressed as there is no need to surface it to the user.