### PR TITLE
fix: avoid render functions causing unmounts

### DIFF
--- a/.changeset/slick-apples-post.md
+++ b/.changeset/slick-apples-post.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: avoid render functions causing unmounts

--- a/packages/editor/src/editor/components/render-block-object.tsx
+++ b/packages/editor/src/editor/components/render-block-object.tsx
@@ -8,6 +8,7 @@ import {
 } from 'slate-react'
 import type {EventPositionBlock} from '../../internal-utils/event-position'
 import type {
+  BlockRenderProps,
   PortableTextMemberSchemaTypes,
   RenderBlockFunction,
 } from '../../types/editor'
@@ -73,7 +74,8 @@ export function RenderBlockObject(props: {
         draggable={!props.readOnly}
       >
         {props.renderBlock && legacySchemaType ? (
-          <props.renderBlock
+          <RenderBlock
+            renderBlock={props.renderBlock}
             editorElementRef={blockObjectRef}
             focused={focused}
             path={[{_key: props.element._key}]}
@@ -83,7 +85,7 @@ export function RenderBlockObject(props: {
             value={blockObject}
           >
             <RenderDefaultBlockObject blockObject={blockObject} />
-          </props.renderBlock>
+          </RenderBlock>
         ) : (
           <RenderDefaultBlockObject blockObject={blockObject} />
         )}
@@ -91,4 +93,29 @@ export function RenderBlockObject(props: {
       {dragPositionBlock === 'end' ? <DropIndicator /> : null}
     </div>
   )
+}
+
+function RenderBlock({
+  renderBlock,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  type,
+  value,
+}: {
+  renderBlock: RenderBlockFunction
+} & BlockRenderProps) {
+  return renderBlock({
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    type,
+    value,
+  })
 }

--- a/packages/editor/src/editor/components/render-inline-object.tsx
+++ b/packages/editor/src/editor/components/render-inline-object.tsx
@@ -9,6 +9,7 @@ import {
 } from 'slate-react'
 import {getPointBlock} from '../../internal-utils/slate-utils'
 import type {
+  BlockChildRenderProps,
   PortableTextMemberSchemaTypes,
   RenderChildFunction,
 } from '../../types/editor'
@@ -79,7 +80,8 @@ export function RenderInlineObject(props: {
       {props.children}
       <span ref={inlineObjectRef} style={{display: 'inline-block'}}>
         {props.renderChild && block && legacySchemaType ? (
-          <props.renderChild
+          <RenderChild
+            renderChild={props.renderChild}
             annotations={[]}
             editorElementRef={inlineObjectRef}
             selected={selected}
@@ -90,11 +92,38 @@ export function RenderInlineObject(props: {
             type={legacySchemaType}
           >
             <RenderDefaultInlineObject inlineObject={inlineObject} />
-          </props.renderChild>
+          </RenderChild>
         ) : (
           <RenderDefaultInlineObject inlineObject={inlineObject} />
         )}
       </span>
     </span>
   )
+}
+
+function RenderChild({
+  renderChild,
+  annotations,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  value,
+  type,
+}: {
+  renderChild: RenderChildFunction
+} & BlockChildRenderProps) {
+  return renderChild({
+    annotations,
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    value,
+    type,
+  })
 }

--- a/packages/editor/src/editor/components/render-span.tsx
+++ b/packages/editor/src/editor/components/render-span.tsx
@@ -9,6 +9,9 @@ import {
   isSelectionCollapsed,
 } from '../../selectors'
 import type {
+  BlockAnnotationRenderProps,
+  BlockChildRenderProps,
+  BlockDecoratorRenderProps,
   EditorSelection,
   RenderAnnotationFunction,
   RenderChildFunction,
@@ -140,7 +143,8 @@ export function RenderSpan(props: RenderSpanProps) {
 
     if (path && legacyDecoratorSchemaType && props.renderDecorator) {
       children = (
-        <props.renderDecorator
+        <RenderDecorator
+          renderDecorator={props.renderDecorator}
           editorElementRef={spanRef}
           focused={focused}
           path={path}
@@ -150,7 +154,7 @@ export function RenderSpan(props: RenderSpanProps) {
           type={legacyDecoratorSchemaType}
         >
           {children}
-        </props.renderDecorator>
+        </RenderDecorator>
       )
     }
   }
@@ -166,7 +170,8 @@ export function RenderSpan(props: RenderSpanProps) {
       if (block && path && props.renderAnnotation) {
         children = (
           <span ref={spanRef}>
-            <props.renderAnnotation
+            <RenderAnnotation
+              renderAnnotation={props.renderAnnotation}
               block={block}
               editorElementRef={spanRef}
               focused={focused}
@@ -177,7 +182,7 @@ export function RenderSpan(props: RenderSpanProps) {
               type={legacyAnnotationSchemaType}
             >
               {children}
-            </props.renderAnnotation>
+            </RenderAnnotation>
           </span>
         )
       } else {
@@ -196,7 +201,8 @@ export function RenderSpan(props: RenderSpanProps) {
 
     if (child) {
       children = (
-        <props.renderChild
+        <RenderChild
+          renderChild={props.renderChild}
           annotations={annotationMarkDefs}
           editorElementRef={spanRef}
           focused={focused}
@@ -207,7 +213,7 @@ export function RenderSpan(props: RenderSpanProps) {
           type={legacySchema.span}
         >
           {children}
-        </props.renderChild>
+        </RenderChild>
       )
     }
   }
@@ -217,4 +223,83 @@ export function RenderSpan(props: RenderSpanProps) {
       {children}
     </span>
   )
+}
+
+function RenderAnnotation({
+  renderAnnotation,
+  block,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  value,
+  type,
+}: {
+  renderAnnotation: RenderAnnotationFunction
+} & BlockAnnotationRenderProps) {
+  return renderAnnotation({
+    block,
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    value,
+    type,
+  })
+}
+
+function RenderDecorator({
+  renderDecorator,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  value,
+  type,
+}: {
+  renderDecorator: RenderDecoratorFunction
+} & BlockDecoratorRenderProps) {
+  return renderDecorator({
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    value,
+    type,
+  })
+}
+
+function RenderChild({
+  renderChild,
+  annotations,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  value,
+  type,
+}: {
+  renderChild: RenderChildFunction
+} & BlockChildRenderProps) {
+  return renderChild({
+    annotations,
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    value,
+    type,
+  })
 }

--- a/packages/editor/src/editor/components/render-text-block.tsx
+++ b/packages/editor/src/editor/components/render-text-block.tsx
@@ -8,6 +8,9 @@ import {
 } from 'slate-react'
 import type {EventPositionBlock} from '../../internal-utils/event-position'
 import type {
+  BlockListItemRenderProps,
+  BlockRenderProps,
+  BlockStyleRenderProps,
   PortableTextMemberSchemaTypes,
   RenderBlockFunction,
   RenderListItemFunction,
@@ -61,7 +64,8 @@ export function RenderTextBlock(props: {
 
     if (legacyStyleSchemaType) {
       children = (
-        <props.renderStyle
+        <RenderStyle
+          renderStyle={props.renderStyle}
           block={props.textBlock}
           editorElementRef={blockRef}
           focused={focused}
@@ -71,7 +75,7 @@ export function RenderTextBlock(props: {
           value={props.textBlock.style}
         >
           {children}
-        </props.renderStyle>
+        </RenderStyle>
       )
     } else {
       console.error(
@@ -87,7 +91,8 @@ export function RenderTextBlock(props: {
 
     if (legacyListItemSchemaType) {
       children = (
-        <props.renderListItem
+        <RenderListItem
+          renderListItem={props.renderListItem}
           block={props.textBlock}
           editorElementRef={blockRef}
           focused={focused}
@@ -98,7 +103,7 @@ export function RenderTextBlock(props: {
           schemaType={legacyListItemSchemaType}
         >
           {children}
-        </props.renderListItem>
+        </RenderListItem>
       )
     } else {
       console.error(
@@ -152,7 +157,8 @@ export function RenderTextBlock(props: {
       {dragPositionBlock === 'start' ? <DropIndicator /> : null}
       <div ref={blockRef}>
         {props.renderBlock ? (
-          <props.renderBlock
+          <RenderBlock
+            renderBlock={props.renderBlock}
             editorElementRef={blockRef}
             focused={focused}
             level={props.textBlock.level}
@@ -165,7 +171,7 @@ export function RenderTextBlock(props: {
             value={props.textBlock}
           >
             {children}
-          </props.renderBlock>
+          </RenderBlock>
         ) : (
           children
         )}
@@ -173,4 +179,87 @@ export function RenderTextBlock(props: {
       {dragPositionBlock === 'end' ? <DropIndicator /> : null}
     </div>
   )
+}
+
+function RenderBlock({
+  renderBlock,
+  children,
+  editorElementRef,
+  focused,
+  level,
+  listItem,
+  path,
+  selected,
+  style,
+  schemaType,
+  type,
+  value,
+}: {
+  renderBlock: RenderBlockFunction
+} & BlockRenderProps) {
+  return renderBlock({
+    children,
+    editorElementRef,
+    focused,
+    level,
+    listItem,
+    path,
+    selected,
+    style,
+    schemaType,
+    type,
+    value,
+  })
+}
+
+function RenderListItem({
+  renderListItem,
+  block,
+  children,
+  editorElementRef,
+  focused,
+  level,
+  path,
+  schemaType,
+  selected,
+  value,
+}: {
+  renderListItem: RenderListItemFunction
+} & BlockListItemRenderProps) {
+  return renderListItem({
+    block,
+    children,
+    editorElementRef,
+    focused,
+    level,
+    path,
+    schemaType,
+    selected,
+    value,
+  })
+}
+
+function RenderStyle({
+  renderStyle,
+  block,
+  children,
+  editorElementRef,
+  focused,
+  path,
+  schemaType,
+  selected,
+  value,
+}: {
+  renderStyle: RenderStyleFunction
+} & BlockStyleRenderProps) {
+  return renderStyle({
+    block,
+    children,
+    editorElementRef,
+    focused,
+    path,
+    schemaType,
+    selected,
+    value,
+  })
 }


### PR DESCRIPTION
By using a stable wrapper component that isn't being recreated, this change keeps the React Compiler happy and mitigates re-render issues that can affect downstream usages like in Sanity Studio.

The previous `<props.renderX` trick was used to avoid the React Compiler flagging Ref violations when calling `props.renderX(` since that call references Ref Objects during render.

However, `<props.renderX` causes unnecessary unmounts because the React element is being recreated over and over. To mitigate this, and keep the React Compiler happy, `props.renderX(` is now called in a wrapper component instead.