### PR TITLE
fix: avoid crashing if incoming child is `null`

### DIFF
--- a/.changeset/plain-donkeys-think.md
+++ b/.changeset/plain-donkeys-think.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: avoid crashing if incoming child is `null`

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -1,5 +1,5 @@
 import {insert, set, setIfMissing, unset} from '@portabletext/patches'
-import {isTextBlock} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {
   PortableTextBlock,
   PortableTextSpan,
@@ -228,9 +228,9 @@ export function validateValue(
         const allUsedMarks = uniq(
           flatten(
             textBlock.children
-              .filter((cld) => cld._type === types.span.name)
+              .filter((child) => isSpan({schema: types}, child))
               .map((cld) => cld.marks || []),
-          ) as string[],
+          ),
         )
 
         // Test that all markDefs are in use (remove orphaned markDefs)

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -1,0 +1,192 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import type {EditorEmittedEvent} from '../src/editor/relay-machine'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('Value validation', () => {
+  test('Initial value with `null` child results in a validation error', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const events: Array<EditorEmittedEvent> = []
+    await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: keyGenerator(),
+          children: [null],
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            events.push(event)
+          }}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'invalid value',
+        }),
+        {type: 'ready'},
+      ])
+    })
+  })
+
+  test('Scenario: Initial value with `null` child in second block results in a validation error', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const events: Array<EditorEmittedEvent> = []
+    await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: keyGenerator(),
+          children: [
+            {_type: 'span', _key: keyGenerator(), text: 'foo', marks: []},
+          ],
+        },
+        {
+          _type: 'block',
+          _key: keyGenerator(),
+          children: [null],
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            events.push(event)
+          }}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'invalid value',
+        }),
+        {type: 'ready'},
+      ])
+    })
+  })
+
+  test('Scenario: Setting child to `null` results in a validation error', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const events: Array<EditorEmittedEvent> = []
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: ['strong']},
+          ],
+        },
+      ],
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            events.push(event)
+          }}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo,bar'])
+    })
+
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'value changed',
+        }),
+        {type: 'ready'},
+      ])
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            null,
+          ],
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(events.slice(2)).toEqual([
+        expect.objectContaining({
+          type: 'invalid value',
+        }),
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo,bar'])
+    })
+  })
+
+  test('Scenario: New block with `null` child results in a validation error', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const events: Array<EditorEmittedEvent> = []
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            events.push(event)
+          }}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(events).toEqual([{type: 'ready'}])
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: keyGenerator(),
+          children: [
+            {_type: 'span', _key: keyGenerator(), text: 'foo', marks: []},
+          ],
+        },
+        {
+          _type: 'block',
+          _key: keyGenerator(),
+          children: [null],
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(events.slice(1)).toEqual([
+        expect.objectContaining({
+          type: 'invalid value',
+        }),
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Before this change, `updateValue` would call `toSlateValue` on the incoming value before running `validateValue`. This could cause the editor to crash since `toSlateValue` expects a somewhat normalized value. In the case of a child being `null`, the function would crash when attempting to destructure the `child` object. To fix this, a `toSlateBlock` function has been abstracted which only runs *after* validation. This is much safer and also, logically, makes more sense. However, `validateValue` wasn't without flaws. After moving the call to `toSlateBlock`, `validateValue` would now crash when attempting to collect `allUsedMarks`. To fix this, we first check if each `child` is actually a span object before collecting its `marks`.