### PR TITLE
fix(deps): bundle Slate packages to prevent version conflicts

### DIFF
--- a/.changeset/bundle-slate-packages.md
+++ b/.changeset/bundle-slate-packages.md
@@ -1,0 +1,8 @@
+---
+"@portabletext/editor": patch
+---
+
+Bundle Slate packages to prevent version conflicts
+
+Slate packages (`slate`, `slate-dom`, `slate-react`) are now bundled into the `@portabletext/editor` output instead of being external dependencies. This prevents issues when multiple versions of `@portabletext/editor` exist in the same application, where shared `slate-dom` instances could cause WeakMap and state conflicts.
+

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,15 @@
     {
       "matchFileNames": ["packages/editor/package.json"],
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["@sanity/schema", "@sanity/types", "react", "rxjs"],
+      "matchPackageNames": [
+        "@sanity/schema",
+        "@sanity/types",
+        "react",
+        "rxjs",
+        "slate",
+        "slate-dom",
+        "slate-react"
+      ],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
     },

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -6,32 +6,7 @@ export default defineConfig({
   },
   dist: 'lib',
   extract: {
-    customTags: [
-      {
-        name: 'hidden',
-        allowMultiple: true,
-        syntaxKind: 'block',
-      },
-      {
-        name: 'todo',
-        allowMultiple: true,
-        syntaxKind: 'block',
-      },
-      {
-        name: 'group',
-        allowMultiple: true,
-        syntaxKind: 'block',
-      },
-      {
-        name: 'groupDescription',
-        allowMultiple: true,
-        syntaxKind: 'block',
-      },
-    ],
-    rules: {
-      // Disable rules for now
-      'ae-incompatible-release-tags': 'off',
-    },
+    enabled: false, // due to incompatibility with slate-dom and bundling dts
   },
   rollup: {
     optimizeLodash: true,

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -96,9 +96,6 @@
     "lodash": "^4.17.21",
     "lodash.startcase": "^4.4.0",
     "react-compiler-runtime": "1.0.0",
-    "slate": "^0.120.0",
-    "slate-dom": "^0.119.0",
-    "slate-react": "^0.120.0",
     "xstate": "^5.24.0"
   },
   "devDependencies": {
@@ -127,6 +124,9 @@
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "rxjs": "^7.8.2",
+    "slate": "^0.120.0",
+    "slate-dom": "^0.119.0",
+    "slate-react": "^0.120.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,15 +484,6 @@ importers:
       react-compiler-runtime:
         specifier: 1.0.0
         version: 1.0.0(react@19.2.1)
-      slate:
-        specifier: ^0.120.0
-        version: 0.120.0
-      slate-dom:
-        specifier: ^0.119.0
-        version: 0.119.0(slate@0.120.0)
-      slate-react:
-        specifier: ^0.120.0
-        version: 0.120.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.119.0(slate@0.120.0))(slate@0.120.0)
       xstate:
         specifier: ^5.24.0
         version: 5.24.0
@@ -572,6 +563,15 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      slate:
+        specifier: ^0.120.0
+        version: 0.120.0
+      slate-dom:
+        specifier: ^0.119.0
+        version: 0.119.0(slate@0.120.0)
+      slate-react:
+        specifier: ^0.120.0
+        version: 0.120.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(slate-dom@0.119.0(slate@0.120.0))(slate@0.120.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
Slate packages (`slate`, `slate-dom`, `slate-react`) are now bundled into the
`@portabletext/editor` output instead of being external dependencies.

This prevents issues when multiple versions of `@portabletext/editor`
exist in the same application. For example, Canvas depends on both
`@portabletext/editor` directly and on Sanity Studio, which depends on its
own version of `@portabletext/editor`. Since `slate-react` declares
`slate-dom` as a peer dependency, each PTE version brought its own
`slate-dom` instance, causing WeakMap and state conflicts that broke the
editor.

By bundling Slate:

1. Each PTE version has its own isolated Slate instance
2. No shared `slate-dom` to conflict over
3. Consumers don't need to manage Slate version overrides

This is shouldn't be a breaking change since Slate is an implementation detail
and not exposed in the public API.

Note: The API Extractor had to be disabled since it errors out when bundling
Slate. Slate is indirectly exposed in public APIs which is unfortunate, but
very hard to fix. We'll therefore miss out in API Extractors tsdoc validation,
which feels like a reasonable tradeoff.