### PR TITLE
fix dts slate types issue

### DIFF
--- a/.changeset/light-flowers-allow.md
+++ b/.changeset/light-flowers-allow.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+Fixes an issue with `DOMNode` not being defined in generated dts

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -96,3 +96,12 @@ export type {
 } from './types/editor'
 export type {HotkeyOptions} from './types/options'
 export type {AnnotationPath, BlockPath, ChildPath} from './types/paths'
+
+// Fixes an issue where slate aliased types from (https://github.com/ianstormtaylor/slate/blob/eae2474124949a4e2239568876663ce201357ac6/packages/slate-dom/src/utils/dom.ts#L5-L15)
+// does not make it into the generated dts.
+declare global {
+  type DOMNode = typeof globalThis.Node
+  type DOMRange = typeof globalThis.Range
+  type DOMSelection = typeof globalThis.Selection
+  type DOMStaticRange = typeof globalThis.StaticRange
+}


### PR DESCRIPTION
The build is failing on `sanity` due to the generated DTS missing the slate aliases for `DOMNode` and such: https://github.com/sanity-io/sanity/actions/runs/20061681899/job/57539938043?pr=11431