### PR TITLE
fix: remove unused `KEY_TO_SLATE_ELEMENT` WeakMap

### DIFF
--- a/.changeset/olive-cougars-battle.md
+++ b/.changeset/olive-cougars-battle.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: remove unused `KEY_TO_SLATE_ELEMENT` WeakMap

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -7,7 +7,6 @@ import type {PortableTextSlateEditor} from '../types/slate-editor'
 import type {EditorActor} from './editor-machine'
 import {withPlugins} from './plugins/with-plugins'
 import type {RelayActor} from './relay-machine'
-import {KEY_TO_SLATE_ELEMENT} from './weakMaps'
 
 const debug = debugWithName('setup')
 
@@ -41,8 +40,6 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
     relayActor: config.relayActor,
     subscriptions: config.subscriptions,
   })
-
-  KEY_TO_SLATE_ELEMENT.set(instance, {})
 
   buildIndexMaps(
     {

--- a/packages/editor/src/editor/weakMaps.ts
+++ b/packages/editor/src/editor/weakMaps.ts
@@ -5,9 +5,6 @@ import type {EditorSelection} from '../types/editor'
 export const IS_PROCESSING_REMOTE_CHANGES: WeakMap<Editor, boolean> =
   new WeakMap()
 
-export const KEY_TO_SLATE_ELEMENT: WeakMap<Editor, any | undefined> =
-  new WeakMap()
-
 // Keep object relation to slate range in the portable-text-range
 export const SLATE_TO_PORTABLE_TEXT_RANGE = new WeakMap<
   Range,

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -18,7 +18,6 @@ import {
 } from '@sanity/diff-match-patch'
 import {Editor, Element, Node, Text, Transforms, type Descendant} from 'slate'
 import type {EditorContext} from '../editor/editor-snapshot'
-import {KEY_TO_SLATE_ELEMENT} from '../editor/weakMaps'
 import type {Path} from '../types/paths'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -131,11 +130,7 @@ function insertPatch(
   if (!block) {
     if (patch.path.length === 1 && patch.path[0] === 0) {
       const blocksToInsert = patch.items.map((item) =>
-        toSlateBlock(
-          item as PortableTextBlock,
-          {schemaTypes: context.schema},
-          KEY_TO_SLATE_ELEMENT.get(editor),
-        ),
+        toSlateBlock(item as PortableTextBlock, {schemaTypes: context.schema}),
       )
 
       Transforms.insertNodes(editor, blocksToInsert, {
@@ -156,11 +151,7 @@ function insertPatch(
   if (patch.path.length === 1) {
     const {items, position} = patch
     const blocksToInsert = items.map((item) =>
-      toSlateBlock(
-        item as PortableTextBlock,
-        {schemaTypes: context.schema},
-        KEY_TO_SLATE_ELEMENT.get(editor),
-      ),
+      toSlateBlock(item as PortableTextBlock, {schemaTypes: context.schema}),
     )
     const targetBlockIndex = block.index
     const normalizedIdx =
@@ -203,7 +194,6 @@ function insertPatch(
   const childrenToInsert = toSlateBlock(
     {...block.node, children: items as PortableTextChild[]},
     {schemaTypes: context.schema},
-    KEY_TO_SLATE_ELEMENT.get(editor),
   )
   const normalizedIdx =
     position === 'after' ? targetChild.index + 1 : targetChild.index

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -287,13 +287,7 @@ export function insertNodePatch(
     if (targetKey) {
       return [
         insert(
-          [
-            fromSlateBlock(
-              {schema},
-              operation.node as Descendant,
-              schema.block.name,
-            ),
-          ],
+          [fromSlateBlock(operation.node as Descendant, schema.block.name)],
           position,
           [{_key: targetKey}],
         ),
@@ -302,13 +296,7 @@ export function insertNodePatch(
     return [
       setIfMissing(beforeValue, []),
       insert(
-        [
-          fromSlateBlock(
-            {schema},
-            operation.node as Descendant,
-            schema.block.name,
-          ),
-        ],
+        [fromSlateBlock(operation.node as Descendant, schema.block.name)],
         'before',
         [operation.path[0]],
       ),
@@ -379,7 +367,6 @@ export function splitNodePatch(
     const oldBlock = beforeValue[operation.path[0]]
     if (isTextBlock({schema}, oldBlock)) {
       const targetValue = fromSlateBlock(
-        {schema},
         children[operation.path[0] + 1],
         schema.block.name,
       )
@@ -399,7 +386,6 @@ export function splitNodePatch(
     if (isSpan({schema}, splitSpan)) {
       const targetSpans = (
         fromSlateBlock(
-          {schema},
           {
             ...splitBlock,
             children: splitBlock.children.slice(
@@ -484,7 +470,6 @@ export function mergeNodePatch(
   if (operation.path.length === 1) {
     if (block?._key) {
       const newBlock = fromSlateBlock(
-        {schema},
         children[operation.path[0] - 1],
         schema.block.name,
       )

--- a/packages/editor/src/internal-utils/slate-utils.ts
+++ b/packages/editor/src/internal-utils/slate-utils.ts
@@ -292,7 +292,7 @@ function elementToBlock({
   schema: EditorSchema
   element: Element
 }) {
-  return fromSlateBlock({schema}, element, schema.block.name)
+  return fromSlateBlock(element, schema.block.name)
 }
 
 function isBlockElement(


### PR DESCRIPTION
The `KEY_TO_SLATE_ELEMENT` optimization for preserving referential equality was incomplete and unnecessary:

- No React.memo or memoization relied on reference equality
- The sync-machine already used deep equality checks (isEqualBlocks)
- The keyMap was never cleaned up, causing a potential memory leak