### PR TITLE
fix: preserve formatting during text replacement in Safari

### DIFF
--- a/.changeset/large-worms-vanish.md
+++ b/.changeset/large-worms-vanish.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: preserve formatting during text replacement in Safari
+
+Fixed an issue where text formatting (bold, italic, etc.) was lost when Safari performed text replacements such as autocorrect or spelling fixes.

--- a/packages/editor/src/behaviors/behavior.abstract.input.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.input.ts
@@ -1,0 +1,65 @@
+import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
+import {forward, raise} from './behavior.types.action'
+import {defineBehavior} from './behavior.types.behavior'
+
+export const abstractInputBehaviors = [
+  defineBehavior({
+    on: 'input.*',
+    guard: ({snapshot}) => isSelectionExpanded(snapshot),
+    actions: [({event}) => [raise({type: 'delete'}), forward(event)]],
+  }),
+  /**
+   * Handle input events where HTML equals plain text (e.g., Safari autocorrect).
+   * In this case, we use insert.text to preserve existing marks.
+   */
+  defineBehavior({
+    on: 'input.*',
+    guard: ({event}) => {
+      const text = event.originEvent.dataTransfer.getData('text/plain')
+      const html = event.originEvent.dataTransfer.getData('text/html')
+      const types = event.originEvent.dataTransfer.types
+
+      if (!text) {
+        return false
+      }
+
+      // Multi-line text should go through deserialize for proper paragraph handling
+      if (text.includes('\n')) {
+        return false
+      }
+
+      if (types.length === 1) {
+        return {text}
+      }
+
+      if (types.length > 2) {
+        return false
+      }
+
+      if (html && text === html) {
+        return {text}
+      }
+
+      return false
+    },
+    actions: [
+      (_, {text}) => [
+        raise({
+          type: 'insert.text',
+          text,
+        }),
+      ],
+    ],
+  }),
+  defineBehavior({
+    on: 'input.*',
+    actions: [
+      ({event}) => [
+        raise({
+          type: 'deserialize',
+          originEvent: event,
+        }),
+      ],
+    ],
+  }),
+]

--- a/packages/editor/src/behaviors/behavior.abstract.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.ts
@@ -5,6 +5,7 @@ import {abstractAnnotationBehaviors} from './behavior.abstract.annotation'
 import {abstractDecoratorBehaviors} from './behavior.abstract.decorator'
 import {abstractDeleteBehaviors} from './behavior.abstract.delete'
 import {abstractDeserializeBehaviors} from './behavior.abstract.deserialize'
+import {abstractInputBehaviors} from './behavior.abstract.input'
 import {abstractInsertBehaviors} from './behavior.abstract.insert'
 import {abstractKeyboardBehaviors} from './behavior.abstract.keyboard'
 import {abstractListItemBehaviors} from './behavior.abstract.list-item'
@@ -113,21 +114,11 @@ export const abstractBehaviors = [
       ],
     ],
   }),
-  defineBehavior({
-    on: 'input.*',
-    actions: [
-      ({event}) => [
-        raise({
-          type: 'deserialize',
-          originEvent: event,
-        }),
-      ],
-    ],
-  }),
   ...abstractAnnotationBehaviors,
   ...abstractDecoratorBehaviors,
   ...abstractDeleteBehaviors,
   ...abstractDeserializeBehaviors,
+  ...abstractInputBehaviors,
   ...abstractInsertBehaviors,
   ...abstractKeyboardBehaviors,
   ...abstractListItemBehaviors,

--- a/packages/editor/tests/event.input.test.tsx
+++ b/packages/editor/tests/event.input.test.tsx
@@ -1,0 +1,373 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {
+  getSelectionAfterText,
+  getTextSelection,
+} from '../src/internal-utils/text-selection'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.input.*', () => {
+  test('Scenario: text/html equal to text/plain', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'em'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello wrold',
+              marks: ['em'],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    const selection = getTextSelection(editor.getSnapshot().context, 'wrold')
+
+    editor.send({
+      type: 'select',
+      at: selection,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(selection)
+    })
+
+    // Simulate Safari text replacement
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'world')
+    dataTransfer.setData('text/html', 'world')
+
+    editor.send({
+      type: 'input.*',
+      originEvent: {dataTransfer},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello world',
+              marks: ['em'],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(editor.getSnapshot().context.selection).toEqual(
+        getSelectionAfterText(editor.getSnapshot().context, 'world'),
+      )
+    })
+  })
+
+  test('Scenario: only text/plain', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const block = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {
+          _type: 'span',
+          _key: spanKey,
+          text: 'hello wrold',
+          marks: ['em'],
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'em'}],
+      }),
+      initialValue: [block],
+    })
+
+    await userEvent.click(locator)
+
+    const selection = getTextSelection(editor.getSnapshot().context, 'wrold')
+
+    editor.send({
+      type: 'select',
+      at: selection,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(selection)
+    })
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'world')
+
+    editor.send({
+      type: 'input.*',
+      originEvent: {dataTransfer},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...block,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello world',
+              marks: ['em'],
+            },
+          ],
+        },
+      ])
+      expect(editor.getSnapshot().context.selection).toEqual(
+        getSelectionAfterText(editor.getSnapshot().context, 'world'),
+      )
+    })
+  })
+
+  test('Scenario: multi-line text/plain falls through to deserialize', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const block = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {
+          _type: 'span',
+          _key: spanKey,
+          text: 'hello wrold',
+          marks: ['em'],
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'em'}],
+      }),
+      initialValue: [block],
+    })
+
+    await userEvent.click(locator)
+
+    const selection = getTextSelection(editor.getSnapshot().context, 'wrold')
+
+    editor.send({
+      type: 'select',
+      at: selection,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(selection)
+    })
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'world\n\nmore')
+
+    editor.send({
+      type: 'input.*',
+      originEvent: {dataTransfer},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...block,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello world',
+              marks: ['em'],
+            },
+          ],
+        },
+        {
+          _key: 'k9',
+          _type: 'block',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k11',
+              text: 'more',
+              marks: ['em'],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: text/plain with soft break', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const block = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {
+          _type: 'span',
+          _key: spanKey,
+          text: 'hello wrold',
+          marks: ['em'],
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'em'}],
+      }),
+      initialValue: [block],
+    })
+
+    await userEvent.click(locator)
+
+    const selection = getTextSelection(editor.getSnapshot().context, 'wrold')
+
+    editor.send({
+      type: 'select',
+      at: selection,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(selection)
+    })
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'world\nmore')
+
+    editor.send({
+      type: 'input.*',
+      originEvent: {dataTransfer},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...block,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello world\nmore',
+              marks: ['em'],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: multi-line text/html equal to text/plain falls through to deserialize', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const block = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {
+          _type: 'span',
+          _key: spanKey,
+          text: 'hello wrold',
+          marks: ['em'],
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'em'}],
+      }),
+      initialValue: [block],
+    })
+
+    await userEvent.click(locator)
+
+    const selection = getTextSelection(editor.getSnapshot().context, 'wrold')
+
+    editor.send({
+      type: 'select',
+      at: selection,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(selection)
+    })
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'world\n\nmore')
+    dataTransfer.setData('text/html', 'world\n\nmore')
+
+    editor.send({
+      type: 'input.*',
+      originEvent: {dataTransfer},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...block,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'hello world',
+              marks: ['em'],
+            },
+          ],
+        },
+        {
+          _key: 'k9',
+          _type: 'block',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k11',
+              text: 'more',
+              marks: ['em'],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Safari text replacements trigger `insertReplacementText` input events with a
`DataTransfer` containing both `text/plain` and `text/html`. When the HTML is
just plain text (no formatting), the deserialization flow would insert it as
is without inheriting any surrounding formatting.

This fix detects when input events contain only plain text (or HTML
matching the plain text) and uses `insert.text` instead of the deserialize
flow. If the text is multiline, it still flows through the deserialization
flow, which has been adjusted to account for `input.*` events acting as paste
events.