### PR TITLE
fix: make unique key checks faster

### DIFF
--- a/.changeset/twenty-candies-do.md
+++ b/.changeset/twenty-candies-do.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: make unique key checks faster


### PR DESCRIPTION
Instead of getting the keys of all blocks in the editor every time a block is inserted (O(N)), we check if the `blockIndexMap` has the key (O(1)). For span and inline object insertion we still iterate through the parent text block's children, but these arrays are usually fairly small.