### PR TITLE
fix: avoid redundant nested calls to skip normalization

### DIFF
--- a/.changeset/nine-schools-raise.md
+++ b/.changeset/nine-schools-raise.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: avoid redundant nested calls to skip normalization

--- a/packages/editor/src/operations/operation.perform.ts
+++ b/packages/editor/src/operations/operation.perform.ts
@@ -51,7 +51,7 @@ export function performOperation({
   context: OperationContext
   operation: Operation
 }) {
-  Editor.withoutNormalizing(operation.editor, () => {
+  const perform = () => {
     try {
       switch (operation.type) {
         case 'annotation.add': {
@@ -184,9 +184,15 @@ export function performOperation({
     } catch (error) {
       console.error(
         new Error(
-          `Executing "${operation.type}" failed due to: ${error.message}`,
+          `Performing "${operation.type}" failed due to: ${error.message}`,
         ),
       )
     }
-  })
+  }
+
+  if (Editor.isNormalizing(operation.editor)) {
+    Editor.withoutNormalizing(operation.editor, perform)
+  } else {
+    perform()
+  }
 }


### PR DESCRIPTION
When inserting multiple blocks using `insert.blocks` (for example by pasting), the editor would call `withoutNormalizing` in `performEvent`. From here on out, each recursive call to `performEvent` and each call to `performOperation` could result in `withoutNormalizing` calls as well. Especially when pasting many blocks, this caused unnecessary overhead when checking/setting the `NORMALIZING` WeakMap internally.