### PR TITLE
docs: update outdated documentation

### DIFF
--- a/apps/docs/src/content/docs/concepts/behavior.mdx
+++ b/apps/docs/src/content/docs/concepts/behavior.mdx
@@ -42,7 +42,8 @@ Whenever you enter text into the editor, activate a toolbar button, or anything 
 There are four categories of Behavior Events:
 
 - Native Events: Events that come from the browser or device directly.
-- Synthetic Events: Editor-specific events.
+- Synthetic Events: Editor-specific events that directly modify the editor state.
+- Abstract Events: Higher-level events that are translated into synthetic events (e.g., `delete.backward`, `insert.break`).
 - Custom Events: Events that you create yourself.
 
 <LinkCard

--- a/apps/docs/src/content/docs/concepts/portabletext.mdx
+++ b/apps/docs/src/content/docs/concepts/portabletext.mdx
@@ -144,7 +144,7 @@ The following terms come up when dealing with Portable Text and the editor. Some
 - Marks: `markDefs` exist in the Portable Text format and connect spans with annotations and decorators. A span can have multiple marks associated with it. Such as text that is bold and italic.
 - List items: Blocks can be labeled as list items to resemble lists.
 - Selection: The range of text selected, or the cursor location in the editor at a given time.
-- Section collapse: A collapsed section is one where nothing is selected and is instead a single point.
+- Selection collapsed: A collapsed selection is one where nothing is selected and is instead a single point (cursor).
 - Anchor: Where the user began the selection.
 - Focus: Where the user ends the selection.
 - Offset: A distance, in characters, from the selection.

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -254,7 +254,8 @@ import {
   useToolbarSchema,
   type ExtendDecoratorSchemaType,
   type ExtendStyleSchemaType,
-  type ToolbarSchema,
+  type ToolbarDecoratorSchemaType,
+  type ToolbarStyleSchemaType,
 } from '@portabletext/toolbar'
 
 function Toolbar() {

--- a/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/guides/behavior-cheat-sheet.mdx
@@ -147,16 +147,43 @@ const autoCloseParens = defineBehavior({
 
 ## Emoji Picker
 
-Using a factory to create behaviors, a state machine, and custom components results in an emoji picker that triggers when you insert `:`.
+An emoji picker that triggers when you insert `:` is available as a separate plugin package.
 
 ![Emoji picker in Portable Text Editor](../../../assets/emoji-picker.png)
 
 Test it out in the [Playground](https://playground.portabletext.org).
 
-- [View the behavior source](https://github.com/portabletext/editor/blob/main/packages/editor/src/behaviors/behavior.emoji-picker.ts).
-- [View the editor source](https://github.com/portabletext/editor/blob/main/apps/playground/src/editor.tsx).
+Install the package:
 
-You can leverage the behavior by importing `createEmojiPickerBehaviors` from `@portabletext/editor/behaviors`. See the editor source above for a usage example.
+```bash
+npm install @portabletext/plugin-emoji-picker
+```
+
+Use the `useEmojiPicker` hook to handle the state and logic:
+
+```tsx
+import {
+  createMatchEmojis,
+  useEmojiPicker,
+} from '@portabletext/plugin-emoji-picker'
+
+const matchEmojis = createMatchEmojis({
+  emojis: {
+    '😂': ['joy', 'laugh'],
+    '😹': ['joy_cat'],
+  },
+})
+
+function EmojiPickerComponent() {
+  const {keyword, matches, selectedIndex, onDismiss, onNavigateTo, onSelect} =
+    useEmojiPicker({matchEmojis})
+
+  // Render your emoji picker UI using these values
+}
+```
+
+- [View the plugin source](https://github.com/portabletext/editor/tree/main/packages/plugin-emoji-picker).
+- [View the playground editor source](https://github.com/portabletext/editor/blob/main/apps/playground/src/editor.tsx).
 
 ## Raise events
 

--- a/apps/docs/src/content/docs/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/guides/custom-rendering.md
@@ -13,7 +13,10 @@ The following props can be passed to the `PortableTextEditable` component:
 - `renderBlock`: For block objects (e.g., images, embeds).
 - `renderChild`: For inline objects (e.g., custom emoji, stock symbols).
 - `renderDecorator`: For decorators (e.g., strong, italic, emphasis text).
-- `renderStyle`: For core text block types (e.g., normal, h1, h2, h3, blockquote)
+- `renderStyle`: For core text block types (e.g., normal, h1, h2, h3, blockquote).
+- `renderListItem`: For list item styling (e.g., bullet, numbered lists).
+- `renderPlaceholder`: For custom placeholder text when the editor is empty.
+- `rangeDecorations`: For highlighting specific ranges of text (e.g., search results, comments).
 
 All the different render functions passed to `PortableTextEditable` can be defined as stand-alone React components.
 
@@ -113,6 +116,51 @@ function isStockTicker(
 ): props is PortableTextChild & {symbol: string} {
   return 'symbol' in props
 }
+
+// List items
+const renderListItem: RenderListItemFunction = (props) => {
+  return <>{props.children}</>
+}
+```
+
+:::note
+List items in Portable Text don't nest like HTML lists. The `renderListItem` function wraps the content, but visual nesting is achieved through CSS. See the [example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) for list styling patterns.
+:::
+
+## Placeholder text
+
+Use `renderPlaceholder` to display custom placeholder text when the editor is empty:
+
+```tsx
+<PortableTextEditable
+  renderPlaceholder={() => <span style={{color: '#999'}}>Start typing...</span>}
+  // ... other props
+/>
+```
+
+## Range decorations
+
+Use `rangeDecorations` to highlight specific ranges of text. This is useful for features like search highlighting, comments, or collaborative cursors:
+
+```tsx
+import type {RangeDecoration} from '@portabletext/editor'
+
+const decorations: RangeDecoration[] = [
+  {
+    selection: {
+      anchor: {path: [{_key: 'block1'}, 'children', {_key: 'span1'}], offset: 0},
+      focus: {path: [{_key: 'block1'}, 'children', {_key: 'span1'}], offset: 5},
+    },
+    component: ({children}) => (
+      <span style={{backgroundColor: 'yellow'}}>{children}</span>
+    ),
+  },
+]
+
+<PortableTextEditable
+  rangeDecorations={decorations}
+  // ... other props
+/>
 ```
 
 You can apply styles, libraries like Tailwind, or use custom react components within the rendering functions.

--- a/apps/docs/src/content/docs/guides/customize-toolbar.mdx
+++ b/apps/docs/src/content/docs/guides/customize-toolbar.mdx
@@ -20,25 +20,31 @@ Each hook accepts an individual schema item and returns a `send` method and a `s
 For example, a button can use `useDecoratorButton` to create interactive buttons for decorators. The hook accepts details about the decorator, provided by the `useToolbarSchema` hook.
 
 ```tsx
-import { type ToolbarDecoratorSchemaType, useDecoratorButton, useToolbarSchema} from '@portabletext/toolbar'
+import {
+  useDecoratorButton,
+  useToolbarSchema,
+  type ToolbarDecoratorSchemaType,
+} from '@portabletext/toolbar'
 
 const DecoratorButton = (props: {schemaType: ToolbarDecoratorSchemaType}) => {
   const decoratorButton = useDecoratorButton(props)
   return (
     <button
-      onClick{() => decoratorButton.send({type: 'toggle'})}
-      className={decoratorButton.snapshot.matches({enabled: 'active'}) ? 'active' : ''}
+      onClick={() => decoratorButton.send({type: 'toggle'})}
+      className={
+        decoratorButton.snapshot.matches({enabled: 'active'}) ? 'active' : ''
+      }
     >
-    {props.schemaType.name}
+      {props.schemaType.name}
     </button>
   )
 }
 
-function ToolbarPlugin(){
+function ToolbarPlugin() {
   const toolbarSchema = useToolbarSchema()
   return (
     <div>
-      {toolBarSchema.decorators?.map((decorator)=>(
+      {toolBarSchema.decorators?.map((decorator) => (
         <DecoratorButton key={decorator.name} schemaType={decorator} />
       ))}
     </div>
@@ -62,7 +68,7 @@ function App() {
 }
 ```
 
-### The `userEditor` hook
+### The `useEditor` hook
 
 The toolbar library is more closely linked to parts of the PTE—like decorators, styles, and annotations—but you can also access editor state without the context of individual schema items with `useEditor`.
 
@@ -229,6 +235,27 @@ function ToolbarPlugin() {
   )
 }
 ```
+
+## Additional toolbar hooks
+
+The `@portabletext/toolbar` package provides several additional hooks for building toolbar components:
+
+**Button hooks:**
+
+- `useDecoratorButton` - Create buttons for toggling decorators (bold, italic, etc.)
+- `useStyleSelector` - Create style selectors/dropdowns
+- `useListButton` - Create buttons for list formatting
+- `useAnnotationButton` - Create buttons for annotations (links, etc.)
+- `useBlockObjectButton` - Create buttons for inserting block objects
+- `useInlineObjectButton` - Create buttons for inserting inline objects
+
+**Popover hooks:**
+
+- `useAnnotationPopover` - Manage popovers for annotation editing (e.g., link URL input)
+- `useBlockObjectPopover` - Manage popovers for block object editing
+- `useInlineObjectPopover` - Manage popovers for inline object editing
+
+Each hook returns a `send` method for dispatching events and a `snapshot` for reading state.
 
 ## Use selectors to reflect editor state
 

--- a/apps/docs/src/content/docs/reference/behavior-api.mdx
+++ b/apps/docs/src/content/docs/reference/behavior-api.mdx
@@ -12,8 +12,10 @@ Reference docs for the behavior API.
 Options Object
 
 - on (string): Internal editor event
-- guard (function or boolean): function accepts `snapshot` and `event`, returns boolean
-- actions (array): function accepts `snapshot` and `event`, returns array of actions
+- guard (function or boolean): function accepts `snapshot`, `event`, and `dom`, returns boolean or guard response
+- actions (array): function accepts `snapshot`, `event`, `dom`, and guard response, returns array of actions
+
+The `dom` parameter provides access to DOM-related utilities like `dom.findDOMNode()` for accessing the underlying DOM elements.
 
 ### Example
 
@@ -21,7 +23,11 @@ Options Object
 const noLowerCaseA = defineBehavior({
   on: 'insert.text',
   guard: ({snapshot, event}) => event.text === 'a',
-  actions: [({snapshot, event}) => [{type: 'insert.text', text: 'A'}]],
+  actions: [
+    ({snapshot, event}) => [
+      {type: 'execute', event: {type: 'insert.text', text: 'A'}},
+    ],
+  ],
 })
 ```
 

--- a/apps/docs/src/content/docs/reference/block-tools.mdx
+++ b/apps/docs/src/content/docs/reference/block-tools.mdx
@@ -12,6 +12,10 @@ The Block Tools package provides tools for working with Portable Text blocks.
 
 ## Example
 
+:::note
+The examples below use `@sanity/schema` for schema compilation, which is typically used with Sanity CMS. If you're not using Sanity, you can use the block tools directly with your own schema types that match the expected structure.
+:::
+
 Let's start with a complete example:
 
 ```js

--- a/apps/docs/src/content/docs/reference/selectors.mdx
+++ b/apps/docs/src/content/docs/reference/selectors.mdx
@@ -7,7 +7,7 @@ next: false
 
 import {CardGrid, LinkCard} from '@astrojs/starlight/components'
 
-Selectors are pure functions that act like shortcuts for deriving state from the editor snapshot.
+Selectors are pure functions that derive state from the editor snapshot. They provide a clean way to access editor state without directly parsing the snapshot structure.
 
 ```tsx
 import * as selectors from '@portabletext/editor/selectors'
@@ -28,40 +28,134 @@ Selectors are commonly used for creating behaviors and toolbar components.
   />
 </CardGrid>
 
-## Condition selectors
-
-Condition selectors return a truth response if the condition is met.
-
-- isActiveAnnotation
-- isActiveDecorator
-- isActiveListItem
-- isActiveStyle
-- isSelectionCollapsed
-- isSelectionExpanded
-
-## Getters
-
-Getter type selectors retrieve information from the editor snapshot.
-
 :::note
 Unsure what a "span" is or what "focus" means in this context? Check the [common terms](/concepts/portabletext/#common-terms) section.
 :::
 
-- getActiveListItem
-- getActiveStyle
-- getSelectedSpans
-- getSelectionText
-- getBlockTextBefore
-- getFocusBlock
-- getFocusListBlock
-- getFocusTextBlock
-- getFocusBlockObjects
-- getFocusChild
-- getFocusSpan
-- getFirstBlock
-- getLastBlock
-- getSelectedBlocks
-- getSelectionStartBlock
-- getSelectionEndBlock
-- getPreviousBlock
-- getNextBlock
+## Condition Selectors
+
+Condition selectors return a boolean or truthy value based on the current editor state.
+
+### Active State Conditions
+
+- `isActiveAnnotation(name)` - Returns `true` if the specified annotation is active in the selection
+- `isActiveDecorator(name)` - Returns `true` if the specified decorator is active in the selection
+- `isActiveListItem(name)` - Returns `true` if the specified list type is active
+- `isActiveStyle(name)` - Returns `true` if the specified style is active
+
+### Selection Conditions
+
+- `isSelectionCollapsed` - Returns `true` if the selection is collapsed (cursor with no range)
+- `isSelectionExpanded` - Returns `true` if the selection spans multiple characters
+
+### Position Conditions
+
+- `isAtTheStartOfBlock` - Returns `true` if the cursor is at the start of a block
+- `isAtTheEndOfBlock` - Returns `true` if the cursor is at the end of a block
+- `isSelectingEntireBlocks` - Returns `true` if entire blocks are selected
+
+### Range Conditions
+
+- `isOverlappingSelection` - Returns `true` if selections overlap
+- `isPointBeforeSelection` - Returns `true` if a point is before the current selection
+- `isPointAfterSelection` - Returns `true` if a point is after the current selection
+
+## Block Selectors
+
+Retrieve block-level elements from the editor.
+
+### Navigation
+
+- `getFirstBlock` - Get the first block in the editor
+- `getLastBlock` - Get the last block in the editor
+- `getNextBlock` - Get the block after the current focus block
+- `getPreviousBlock` - Get the block before the current focus block
+
+### Focus & Anchor
+
+- `getAnchorBlock` - Get the block where the selection anchor is located
+- `getFocusBlock` - Get the block where the selection focus is located
+
+### Selection Range
+
+- `getSelectedBlocks` - Get all blocks within the current selection
+- `getSelectionStartBlock` - Get the block at the start of the selection
+- `getSelectionEndBlock` - Get the block at the end of the selection
+
+## Text Block Selectors
+
+Retrieve text blocks specifically (excludes block objects).
+
+- `getAnchorTextBlock` - Get the text block where the selection anchor is located
+- `getFocusTextBlock` - Get the text block where the selection focus is located
+- `getSelectedTextBlocks` - Get all text blocks within the current selection
+- `getFocusListBlock` - Get the list block where focus is located (if in a list)
+
+## Span Selectors
+
+Retrieve span elements (text segments within blocks).
+
+- `getAnchorSpan` - Get the span where the selection anchor is located
+- `getFocusSpan` - Get the span where the selection focus is located
+- `getNextSpan` - Get the span after the current focus span
+- `getPreviousSpan` - Get the span before the current focus span
+- `getSelectedSpans` - Get all spans within the current selection
+
+## Child Selectors
+
+Retrieve child elements within blocks.
+
+- `getAnchorChild` - Get the child element where the selection anchor is located
+- `getFocusChild` - Get the child element where the selection focus is located
+- `getSelectionStartChild` - Get the child at the start of the selection
+- `getSelectionEndChild` - Get the child at the end of the selection
+
+## Inline Object Selectors
+
+Retrieve inline objects (custom elements embedded in text).
+
+- `getFocusInlineObject` - Get the inline object at the current focus position
+- `getNextInlineObject` - Get the next inline object after focus
+- `getNextInlineObjects` - Get all inline objects after focus
+- `getPreviousInlineObject` - Get the previous inline object before focus
+- `getPreviousInlineObjects` - Get all inline objects before focus
+
+## Block Object Selectors
+
+Retrieve block objects (custom block-level elements).
+
+- `getFocusBlockObject` - Get the block object at the current focus position
+
+## Selection Selectors
+
+Get information about the current selection.
+
+- `getSelection` - Get the current selection (anchor and focus points)
+- `getSelectionText` - Get the text content of the current selection
+- `getSelectedValue` - Get the Portable Text value of the selected content
+- `getSelectionStartPoint` - Get the starting point of the selection
+- `getSelectionEndPoint` - Get the ending point of the selection
+- `getCaretWordSelection` - Get the word selection at the caret position
+
+## Active State Selectors
+
+Get information about active formatting and marks.
+
+- `getActiveAnnotations` - Get all active annotations in the selection
+- `getActiveListItem` - Get the active list item type
+- `getActiveStyle` - Get the active block style
+- `getMarkState` - Get comprehensive mark state information for the selection
+
+## Text Position Selectors
+
+Get text content relative to the cursor position.
+
+- `getBlockTextBefore` - Get text in the current block before the cursor
+- `getBlockTextAfter` - Get text in the current block after the cursor
+- `getBlockOffsets` - Get character offsets within the current block
+
+## Value Selectors
+
+Access the editor value.
+
+- `getValue` - Get the complete Portable Text value from the editor


### PR DESCRIPTION
> [!NOTE]
> I asked Claude to go through the documentation and check what was outdated and this is what came out of it in the first go. I've looked through it, and I think the changes look reasonable. There's still some events that are undocumented, but in the interest of smaller PRs, I think this is a good start.

Critical fixes:
  - Fix emoji picker docs to reference correct package (@portabletext/plugin-emoji-picker)
  - Expand selectors reference from 23 to 54 selectors, organized by category
  - Fix behavior API example with correct action type wrapper syntax

Documentation improvements:
  - Add Abstract Events to behavior event categories
  - Fix typos in customize-toolbar.mdx (onClick syntax, useEditor hook name)
  - Document additional toolbar hooks (useAnnotationButton, useListButton, popovers, etc.)
  - Add renderListItem, renderPlaceholder, and rangeDecorations documentation
  - Fix type imports in getting-started.mdx
  - Document dom parameter in behavior guards and actions
  - Fix "Section collapse" -> "Selection collapsed" terminology
  - Add Sanity schema note to block-tools.mdx