### PR TITLE
fix: listen for emitted 'selection' events rather than 'select' Behavior events

### DIFF
--- a/.changeset/petite-moments-cross.md
+++ b/.changeset/petite-moments-cross.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-input-rule': patch
+---
+
+fix: issue with Backspace sometimes undoing after the selection has moved

--- a/packages/plugin-input-rule/src/edge-cases.feature
+++ b/packages/plugin-input-rule/src/edge-cases.feature
@@ -219,3 +219,12 @@ Feature: Edge Cases
     Given the text ""
     When "1*2*3" is inserted
     Then the text is "1×2×3"
+
+  Scenario: Backspace after typing following input rule should delete character
+    Given the text ""
+    When "->" is typed
+    Then the text is "→"
+    When "foo" is typed
+    Then the text is "→foo"
+    When "{Backspace}" is pressed
+    Then the text is "→fo"


### PR DESCRIPTION
`'select'` events might not always reach the input rule which cause it to linger in the `'input rule applied'` state longer than needed which in turn can cause confusing behavior where Backspace does an undo way after the input rule has been applied.