### PR TITLE
fix: handle undefined `__TEST__` global in mutation machine

### DIFF
--- a/packages/editor/src/editor/mutation-machine.ts
+++ b/packages/editor/src/editor/mutation-machine.ts
@@ -167,7 +167,7 @@ export const mutationMachine = setup({
         () => {
           sendBack({type: 'emit changes'})
         },
-        __TEST__ ? 250 : 1000,
+        typeof __TEST__ !== 'undefined' && __TEST__ ? 250 : 1000,
       )
 
       return () => {


### PR DESCRIPTION
Apps that import directly from source (e.g., via path aliases) bypass the package build step that replaces `__TEST__`.