### PR TITLE
fix: simplify emoji picker

### DIFF
--- a/apps/playground/src/emoji-picker.tsx
+++ b/apps/playground/src/emoji-picker.tsx
@@ -4,7 +4,7 @@ import {
   type EmojiMatch,
 } from '@portabletext/plugin-emoji-picker'
 import emojis from 'emojilib'
-import Fuse, {type FuseResult} from 'fuse.js'
+import Fuse from 'fuse.js'
 import {useEffect, useRef} from 'react'
 import {Button} from './primitives/button'
 import {FloatingPanel} from './primitives/floating-panel'
@@ -21,110 +21,50 @@ const emojiList: EmojiEntry[] = Object.entries(emojis).map(
   }),
 )
 
-function fuseResultToEmojiMatch(result: FuseResult<EmojiEntry>): EmojiMatch {
-  const match = result.matches?.[0]
-  const matchedKeyword = match?.value ?? result.item.keywords[0] ?? ''
-  const indices = match?.indices?.[0]
+const fuse = new Fuse(emojiList, {
+  keys: ['keywords'],
+  threshold: 0.3,
+  ignoreLocation: true,
+})
 
-  if (indices) {
-    const [start, end] = indices
-    const startSlice = matchedKeyword.slice(0, start)
-    const matchedPart = matchedKeyword.slice(start, end + 1)
-    const endSlice = matchedKeyword.slice(end + 1)
-
-    if (startSlice === '' && endSlice === '') {
-      return {
-        type: 'exact',
-        key: result.item.emoji,
-        emoji: result.item.emoji,
-        keyword: matchedPart,
-      }
-    }
-
-    return {
-      type: 'partial',
-      key: result.item.emoji,
-      emoji: result.item.emoji,
-      keyword: matchedPart,
-      startSlice,
-      endSlice,
-    }
-  }
-
-  return {
-    type: 'exact',
-    key: result.item.emoji,
-    emoji: result.item.emoji,
-    keyword: matchedKeyword,
-  }
-}
-
-// Pre-filter emoji list by first character to reduce Fuse.js search space
-function getFilteredEmojiList(keyword: string): EmojiEntry[] {
+function matchEmojis({keyword}: {keyword: string}): EmojiMatch[] {
   if (!keyword) {
     return []
   }
 
   const lowerKeyword = keyword.toLowerCase()
 
-  // Filter to emojis that have at least one keyword containing the first char
-  // This dramatically reduces the search space for Fuse.js
-  return emojiList.filter((entry) =>
-    entry.keywords.some((kw) => kw.includes(lowerKeyword[0])),
-  )
-}
+  return fuse
+    .search(keyword)
+    .slice(0, 50)
+    .map((result): EmojiMatch => {
+      const exactKeyword = result.item.keywords.find(
+        (kw) => kw === lowerKeyword,
+      )
 
-// Cache to avoid re-creating Fuse instances
-let cachedFilterChar = ''
-let cachedFuse: Fuse<EmojiEntry> | null = null
+      if (exactKeyword) {
+        return {
+          type: 'exact',
+          key: result.item.emoji,
+          emoji: result.item.emoji,
+          keyword: exactKeyword,
+        }
+      }
 
-function getFuseForKeyword(keyword: string): Fuse<EmojiEntry> {
-  const filterChar = keyword[0]?.toLowerCase() ?? ''
+      const matchingKeyword =
+        result.item.keywords.find((kw) => kw.includes(lowerKeyword)) ??
+        result.item.keywords[0] ??
+        ''
 
-  if (filterChar !== cachedFilterChar || !cachedFuse) {
-    cachedFilterChar = filterChar
-    const filtered = getFilteredEmojiList(keyword)
-    cachedFuse = new Fuse(filtered, {
-      keys: ['keywords'],
-      threshold: 0.3,
-      includeMatches: true,
+      return {
+        type: 'partial',
+        key: result.item.emoji,
+        emoji: result.item.emoji,
+        keyword: matchingKeyword,
+        startSlice: '',
+        endSlice: '',
+      }
     })
-  }
-
-  return cachedFuse
-}
-
-function matchEmojis({keyword}: {keyword: string}): EmojiMatch[] {
-  if (!keyword || keyword.length > 20) {
-    return []
-  }
-
-  const lowerKeyword = keyword.toLowerCase()
-
-  // Check for exact match first (fast path)
-  const exactMatch = emojiList.find((entry) =>
-    entry.keywords.includes(lowerKeyword),
-  )
-
-  const fuse = getFuseForKeyword(keyword)
-
-  if (exactMatch) {
-    return [
-      {
-        type: 'exact' as const,
-        key: exactMatch.emoji,
-        emoji: exactMatch.emoji,
-        keyword,
-      },
-      ...fuse
-        .search(keyword)
-        .slice(0, 50)
-        .filter((result) => result.item.emoji !== exactMatch.emoji)
-        .map(fuseResultToEmojiMatch),
-    ]
-  }
-
-  return fuse.search(keyword).slice(0, 50).map(fuseResultToEmojiMatch)
 }
 
 export function EmojiPickerPlugin() {
@@ -181,11 +121,7 @@ export function EmojiListBox(props: {
     <ol className="p-1" style={{maxHeight: 200, overflowY: 'auto'}}>
       {visibleMatches.map((match, index) => (
         <EmojiListItem
-          key={
-            match.type === 'exact'
-              ? `${match.emoji}-${match.keyword}`
-              : `${match.emoji}-${match.startSlice}${match.keyword}${match.endSlice}`
-          }
+          key={`${match.emoji}-${match.keyword}`}
           match={match}
           selected={props.selectedIndex === index}
           onMouseEnter={() => {
@@ -222,13 +158,7 @@ function EmojiListItem(props: {
       onClick={props.onSelect}
     >
       <span className="mr-2">{props.match.emoji}</span>
-      <span className="text-gray-500">
-        :{props.match.type === 'partial' && props.match.startSlice}
-        <span className="bg-yellow-200 text-gray-700">
-          {props.match.keyword}
-        </span>
-        {props.match.type === 'partial' && props.match.endSlice}:
-      </span>
+      <span className="text-gray-500">:{props.match.keyword}:</span>
     </li>
   )
 }


### PR DESCRIPTION
- Use single Fuse instance instead of per-character caching
- Remove unused highlighting (startSlice/endSlice)
- Show matching keyword instead of first keyword
- Mark matches as 'exact' only when keyword matches exactly