### PR TITLE
fix: use `process.env['NODE_ENV'] === 'test'` instead of `__TEST__`

### DIFF
--- a/.changeset/funny-forks-dig.md
+++ b/.changeset/funny-forks-dig.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: use `process.env['NODE_ENV'] === 'test'` instead of `__TEST__`

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -3,7 +3,6 @@ import {defineConfig} from '@sanity/pkg-utils'
 export default defineConfig({
   define: {
     __DEV__: false,
-    __TEST__: false,
   },
   dist: 'lib',
   extract: {

--- a/packages/editor/src/editor/mutation-machine.ts
+++ b/packages/editor/src/editor/mutation-machine.ts
@@ -167,7 +167,8 @@ export const mutationMachine = setup({
         () => {
           sendBack({type: 'emit changes'})
         },
-        typeof __TEST__ !== 'undefined' && __TEST__ ? 250 : 1000,
+        // @ts-expect-error - dot notation required for Vite to replace at build time
+        process.env.NODE_ENV === 'test' ? 250 : 1000,
       )
 
       return () => {

--- a/packages/editor/src/globals.d.ts
+++ b/packages/editor/src/globals.d.ts
@@ -1,2 +1,1 @@
-declare const __TEST__: boolean
 declare const __DEV__: boolean

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
     },
     projects: [
       {
-        define: {
-          __TEST__: 'true',
-        },
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},

--- a/packages/plugin-emoji-picker/vitest.config.ts
+++ b/packages/plugin-emoji-picker/vitest.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     projects: [
       {
-        define: {
-          __TEST__: 'true',
-        },
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},

--- a/packages/plugin-input-rule/vitest.config.ts
+++ b/packages/plugin-input-rule/vitest.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     projects: [
       {
-        define: {
-          __TEST__: 'true',
-        },
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},

--- a/packages/plugin-markdown-shortcuts/vitest.config.ts
+++ b/packages/plugin-markdown-shortcuts/vitest.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     projects: [
       {
-        define: {
-          __TEST__: 'true',
-        },
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},

--- a/packages/plugin-typography/vitest.config.ts
+++ b/packages/plugin-typography/vitest.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     projects: [
       {
-        define: {
-          __TEST__: 'true',
-        },
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},


### PR DESCRIPTION
`__TEST__` was replaced with `false` at build time, meaning consumers' test environments couldn't benefit from the shorter 250ms mutation interval. They always got the 1000ms production value. Using `process.env['NODE_ENV']` is evaluated at runtime, so any test runner that sets `NODE_ENV=test` (standard behavior for Jest, Vitest, etc.) automatically gets the faster interval.