### PR TITLE
fix: allow copy events on inline objects

### DIFF
--- a/.changeset/three-kiwis-cheer.md
+++ b/.changeset/three-kiwis-cheer.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: allow copying inline object

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -74,14 +74,17 @@ export function RenderInlineObject(props: {
   return (
     <span
       {...props.attributes}
-      draggable={!props.readOnly}
       className="pt-inline-object"
       data-child-key={inlineObject._key}
       data-child-name={inlineObject._type}
       data-child-type="object"
     >
       {props.children}
-      <span ref={inlineObjectRef} style={{display: 'inline-block'}}>
+      <span
+        ref={inlineObjectRef}
+        style={{display: 'inline-block'}}
+        draggable={!props.readOnly}
+      >
         {props.renderChild && path && legacySchemaType ? (
           <RenderChild
             renderChild={props.renderChild}


### PR DESCRIPTION
The `draggable` attribute on the top-level span in inline objects interfered with copy events when the attribute was set to `true`. This meant that you couldn't copy inline objects when the editor was editable, only when it was in read-only.

The `draggable="true"` attribute changes browser event handling to prioritize drag operations over selection. This prevents proper DOM selection from being established, causing the copy event to never fire.

Per the HTML5 Drag and Drop spec, draggable elements cannot be selected normally - "text or other elements within it can no longer be selected in the normal way" (MDN). This is a design choice, not a bug.