### PR TITLE
feat: add nested blocks schema support

### DIFF
--- a/.changeset/nested-blocks-schema.md
+++ b/.changeset/nested-blocks-schema.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/schema': minor
+'@portabletext/sanity-bridge': minor
+---
+
+feat: add nested blocks schema support
+
+Add `nestedBlocks` to `Schema` and `SchemaDefinition` for block types that
+appear inside block objects (e.g. table cells containing Portable Text content).
+
+- `NestedBlockSchemaType` / `NestedBlockDefinition` for nested block types
+- `OfDefinition` discriminated union (`BlockOfDefinition` | `ObjectOfDefinition`)
+  on `FieldDefinition.of` for array field member types
+- `compileSchema()` emits `nestedBlocks: []` for existing schemas (additive)
+- `sanitySchemaToPortableTextSchema()` walks block object fields recursively to
+  detect objects containing array-of-blocks fields

--- a/packages/block-tools/src/util/normalizeBlock.ts
+++ b/packages/block-tools/src/util/normalizeBlock.ts
@@ -67,6 +67,7 @@ export function normalizeBlock(
     annotations: [],
     blockObjects: [],
     inlineObjects: [],
+    nestedBlocks: [],
   }
 
   if (node._type !== (options.blockTypeName || 'block')) {

--- a/packages/schema/src/compile-schema.test.ts
+++ b/packages/schema/src/compile-schema.test.ts
@@ -19,6 +19,7 @@ describe(compileSchema.name, () => {
         annotations: [],
         blockObjects: [],
         inlineObjects: [],
+        nestedBlocks: [],
       })
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -40,7 +41,255 @@ describe(compileSchema.name, () => {
         annotations: [],
         blockObjects: [],
         inlineObjects: [],
+        nestedBlocks: [],
       })
+    })
+  })
+
+  describe('nested blocks', () => {
+    test('empty schema has nestedBlocks: []', () => {
+      expect(compileSchema({})).toEqual({
+        block: {name: 'block'},
+        span: {name: 'span'},
+        styles: [{value: 'normal', name: 'normal', title: 'Normal'}],
+        lists: [],
+        decorators: [],
+        annotations: [],
+        blockObjects: [],
+        inlineObjects: [],
+        nestedBlocks: [],
+      })
+    })
+
+    test('nested blocks are compiled with fields defaulting to []', () => {
+      expect(
+        compileSchema({
+          nestedBlocks: [{name: 'tableCell'}],
+        }),
+      ).toEqual({
+        block: {name: 'block'},
+        span: {name: 'span'},
+        styles: [{value: 'normal', name: 'normal', title: 'Normal'}],
+        lists: [],
+        decorators: [],
+        annotations: [],
+        blockObjects: [],
+        inlineObjects: [],
+        nestedBlocks: [{name: 'tableCell', fields: []}],
+      })
+    })
+
+    test('nested blocks with fields are compiled', () => {
+      expect(
+        compileSchema({
+          nestedBlocks: [
+            {
+              name: 'tableCell',
+              fields: [
+                {name: 'colspan', type: 'number'},
+                {name: 'rowspan', type: 'number'},
+              ],
+            },
+          ],
+        }),
+      ).toEqual({
+        block: {name: 'block'},
+        span: {name: 'span'},
+        styles: [{value: 'normal', name: 'normal', title: 'Normal'}],
+        lists: [],
+        decorators: [],
+        annotations: [],
+        blockObjects: [],
+        inlineObjects: [],
+        nestedBlocks: [
+          {
+            name: 'tableCell',
+            fields: [
+              {name: 'colspan', type: 'number'},
+              {name: 'rowspan', type: 'number'},
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('field of', () => {
+    test('of with object type is preserved on array fields', () => {
+      expect(
+        compileSchema({
+          blockObjects: [
+            {
+              name: 'gallery',
+              fields: [
+                {
+                  name: 'images',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'galleryImage',
+                      name: 'galleryImage',
+                      fields: [{name: 'alt', type: 'string'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'gallery',
+          fields: [
+            {
+              name: 'images',
+              type: 'array',
+              of: [
+                {
+                  type: 'galleryImage',
+                  name: 'galleryImage',
+                  fields: [{name: 'alt', type: 'string'}],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('of with block type preserves PTE sub-schema', () => {
+      expect(
+        compileSchema({
+          nestedBlocks: [
+            {
+              name: 'tableCell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      styles: [{name: 'normal'}, {name: 'h1'}],
+                      decorators: [{name: 'strong'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).nestedBlocks,
+      ).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'normal'}, {name: 'h1'}],
+                  decorators: [{name: 'strong'}],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('table schema: blockObjects with of, nestedBlocks with block of', () => {
+      const schema = compileSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'tableRow',
+                    name: 'tableRow',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [{type: 'tableCell', name: 'tableCell'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        nestedBlocks: [
+          {
+            name: 'tableCell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'block',
+                    styles: [{name: 'normal'}],
+                    lists: [],
+                  },
+                ],
+              },
+              {name: 'colspan', type: 'number'},
+            ],
+          },
+        ],
+      })
+
+      expect(schema.nestedBlocks).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'normal'}],
+                  lists: [],
+                },
+              ],
+            },
+            {name: 'colspan', type: 'number'},
+          ],
+        },
+      ])
+
+      expect(schema.blockObjects).toEqual([
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'tableRow',
+                  name: 'tableRow',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [{type: 'tableCell', name: 'tableCell'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
     })
   })
 })

--- a/packages/schema/src/define-schema.ts
+++ b/packages/schema/src/define-schema.ts
@@ -14,6 +14,7 @@ export type SchemaDefinition = {
   annotations?: ReadonlyArray<AnnotationDefinition>
   blockObjects?: ReadonlyArray<BlockObjectDefinition>
   inlineObjects?: ReadonlyArray<InlineObjectDefinition>
+  nestedBlocks?: ReadonlyArray<BlockObjectDefinition>
 }
 
 /**

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -17,6 +17,7 @@ export type {
   FieldDefinition,
   InlineObjectSchemaType,
   ListSchemaType,
+  OfDefinition,
   Schema,
   StyleSchemaType,
 } from './schema'

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -15,6 +15,7 @@ export type Schema = {
   annotations: ReadonlyArray<AnnotationSchemaType>
   blockObjects: ReadonlyArray<BlockObjectSchemaType>
   inlineObjects: ReadonlyArray<InlineObjectSchemaType>
+  nestedBlocks: ReadonlyArray<BlockObjectSchemaType>
 }
 
 /**
@@ -73,10 +74,50 @@ export type InlineObjectSchemaType = BaseDefinition & {
 
 /**
  * @public
+ * Describes a member type within an array field's `of`.
+ * When `type` is `'block'`, PTE sub-schema properties (styles, decorators,
+ * annotations, lists) are available for configuring the nested block editor.
  */
-export type FieldDefinition = BaseDefinition & {
-  type: 'string' | 'number' | 'boolean' | 'array' | 'object'
+export type OfDefinition = BlockOfDefinition | ObjectOfDefinition
+
+/**
+ * @public
+ * An `of` member with `type: 'block'` -- supports nested PTE sub-schema.
+ */
+export type BlockOfDefinition = {
+  type: 'block'
+  name?: string
+  title?: string
+  styles?: ReadonlyArray<BaseDefinition>
+  decorators?: ReadonlyArray<BaseDefinition>
+  annotations?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<FieldDefinition>}
+  >
+  lists?: ReadonlyArray<BaseDefinition>
 }
+
+/**
+ * @public
+ * An `of` member with any non-block type -- a named type reference.
+ */
+export type ObjectOfDefinition = {
+  type: string
+  name?: string
+  title?: string
+  fields?: ReadonlyArray<FieldDefinition>
+}
+
+/**
+ * @public
+ */
+export type FieldDefinition =
+  | (BaseDefinition & {
+      type: 'array'
+      of?: ReadonlyArray<OfDefinition>
+    })
+  | (BaseDefinition & {
+      type: 'string' | 'number' | 'boolean' | 'object'
+    })
 
 /**
  * @public


### PR DESCRIPTION
### What changed

Add `nestedBlocks` to `@portabletext/schema` and `@portabletext/sanity-bridge` for block types that appear inside block objects (e.g. table cells containing Portable Text content).

### `@portabletext/schema`

- `NestedBlockSchemaType` / `NestedBlockDefinition` for nested block types
- `OfDefinition` discriminated union (`BlockOfDefinition` | `ObjectOfDefinition`) on `FieldDefinition.of` for array field member types
- `compileSchema()` emits `nestedBlocks: []` for existing schemas (additive)
- 8 tests covering backwards compat, nested blocks, `of` with block/object types, full table schema

### `@portabletext/sanity-bridge`

- `createPortableTextMemberSchemaTypes()`: walk block object fields recursively to detect objects containing array-of-blocks fields
- `sanitySchemaToPortableTextSchema()`: same recursive detection, with `OfDefinition` carried through on array fields
- Table schema integration test: `table → tableRow → tableCell` with nested block content correctly detected

### Why

Containers (tables, callouts, etc.) need the editor to know which block objects contain nested Portable Text content. This schema awareness is the foundation — rendering, normalization, and operations build on top of it.

### Backwards compatibility

Fully additive. Existing schemas get `nestedBlocks: []`. No changes to existing types or behavior.