### PR TITLE
feat(editor): add threaded block map with O(1) lookups

### DIFF
--- a/packages/editor/src/behaviors/behavior.abstract.insert.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.insert.ts
@@ -19,7 +19,7 @@ function getUniqueBlockKey(
       return snapshot.context.keyGenerator()
     }
 
-    if (snapshot.blockIndexMap.has(blockKey)) {
+    if (snapshot.blockMap.has(blockKey)) {
       return snapshot.context.keyGenerator()
     }
 

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -246,7 +246,7 @@ export const PortableTextEditable = forwardRef<
             value: slateEditor.value,
             selection: normalizedSelection,
           },
-          blockIndexMap: slateEditor.blockIndexMap,
+          blockMap: slateEditor.blockMap,
         })
         if (slateRange) {
           Transforms.select(slateEditor, slateRange)

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -127,7 +127,7 @@ export function createEditableAPI(
           value: editor.value,
           selection,
         },
-        blockIndexMap: editor.blockIndexMap,
+        blockMap: editor.blockMap,
       })
 
       if (slateSelection) {
@@ -258,13 +258,13 @@ export function createEditableAPI(
         return [undefined, undefined]
       }
 
-      const blockIndex = editor.blockIndexMap.get(blockKey)
+      const blockEntry = editor.blockMap.get(blockKey)
 
-      if (blockIndex === undefined) {
+      if (!blockEntry) {
         return [undefined, undefined]
       }
 
-      const block = editor.value.at(blockIndex)
+      const block = editor.value[blockEntry.index]
 
       if (!block) {
         return [undefined, undefined]
@@ -511,7 +511,7 @@ export function createEditableAPI(
           value: editor.value,
           selection: selectionA,
         },
-        blockIndexMap: editor.blockIndexMap,
+        blockMap: editor.blockMap,
       })
       const rangeB = toSlateRange({
         context: {
@@ -519,7 +519,7 @@ export function createEditableAPI(
           value: editor.value,
           selection: selectionB,
         },
-        blockIndexMap: editor.blockIndexMap,
+        blockMap: editor.blockMap,
       })
 
       // Make sure the ranges are valid

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -1,5 +1,6 @@
 import {createEditor, type Descendant} from 'slate'
 import {withReact} from 'slate-react'
+import {buildBlockMap} from '../internal-utils/block-map'
 import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block'
 import {debug} from '../internal-utils/debug'
@@ -30,6 +31,7 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
 
   editor.decoratedRanges = []
   editor.decoratorState = {}
+  editor.blockMap = new Map()
   editor.blockIndexMap = new Map<string, number>()
   editor.history = {undos: [], redos: []}
   editor.lastSelection = null
@@ -64,6 +66,8 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
       listIndexMap: instance.listIndexMap,
     },
   )
+
+  buildBlockMap({value: instance.value}, instance.blockMap)
 
   const slateEditor: SlateEditor = {
     instance,

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -75,6 +75,7 @@ export function getEditorSnapshot({
     : null
 
   return {
+    blockMap: slateEditorInstance.blockMap,
     blockIndexMap: slateEditorInstance.blockIndexMap,
     context: {
       converters: [...editorActorSnapshot.context.converters],

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -1,5 +1,6 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {Converter} from '../converters/converter.types'
+import type {BlockMap} from '../internal-utils/block-map'
 import {slateRangeToSelection} from '../internal-utils/slate-utils'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
@@ -22,6 +23,8 @@ export type EditorContext = {
  */
 export type EditorSnapshot = {
   context: EditorContext
+  blockMap: BlockMap
+  /** @deprecated Use `blockMap` instead */
   blockIndexMap: Map<string, number>
   /**
    * @beta
@@ -61,6 +64,7 @@ export function createEditorSnapshot({
   } satisfies EditorContext
 
   return {
+    blockMap: editor.blockMap,
     blockIndexMap: editor.blockIndexMap,
     context,
     decoratorState: editor.decoratorState,

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -99,7 +99,7 @@ export const rangeDecorationsMachine = setup({
             value: context.slateEditor.value,
             selection: rangeDecoration.selection,
           },
-          blockIndexMap: context.slateEditor.blockIndexMap,
+          blockMap: context.slateEditor.blockMap,
         })
 
         if (!Range.isRange(slateRange)) {
@@ -133,7 +133,7 @@ export const rangeDecorationsMachine = setup({
             value: context.slateEditor.value,
             selection: rangeDecoration.selection,
           },
-          blockIndexMap: context.slateEditor.blockIndexMap,
+          blockMap: context.slateEditor.blockMap,
         })
 
         if (!Range.isRange(slateRange)) {
@@ -168,7 +168,7 @@ export const rangeDecorationsMachine = setup({
             value: context.slateEditor.value,
             selection: decoratedRange.rangeDecoration.selection,
           },
-          blockIndexMap: context.slateEditor.blockIndexMap,
+          blockMap: context.slateEditor.blockMap,
         })
 
         if (!Range.isRange(slateRange)) {

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -52,9 +52,8 @@ export function RenderElement(props: {
     )
   }
 
-  const blockIndex = slateStatic.blockIndexMap.get(props.element._key)
-  const block =
-    blockIndex !== undefined ? slateStatic.value.at(blockIndex) : undefined
+  const blockEntry = slateStatic.blockMap.get(props.element._key)
+  const block = blockEntry ? slateStatic.value.at(blockEntry.index) : undefined
 
   if (isTextBlock({schema}, block)) {
     return (

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -111,18 +111,33 @@ export function SelectionStateProvider({
       let selectedBlockKeys: Set<string> = emptySet
 
       if (startBlockKey && endBlockKey) {
-        const startBlockIndex = snapshot.blockIndexMap.get(startBlockKey)
-        const endBlockIndex = snapshot.blockIndexMap.get(endBlockKey)
+        const startEntry = snapshot.blockMap.get(startBlockKey)
+        const endEntry = snapshot.blockMap.get(endBlockKey)
 
-        if (startBlockIndex !== undefined && endBlockIndex !== undefined) {
-          const minIndex = Math.min(startBlockIndex, endBlockIndex)
-          const maxIndex = Math.max(startBlockIndex, endBlockIndex)
+        if (startEntry && endEntry) {
+          // Determine which key comes first in document order
+          const minKey =
+            startEntry.index <= endEntry.index ? startBlockKey : endBlockKey
+          const maxKey =
+            startEntry.index <= endEntry.index ? endBlockKey : startBlockKey
           selectedBlockKeys = new Set<string>()
 
-          for (const [key, index] of snapshot.blockIndexMap) {
-            if (index >= minIndex && index <= maxIndex) {
-              selectedBlockKeys.add(key)
+          let currentKey: string | null = minKey
+
+          while (currentKey !== null) {
+            selectedBlockKeys.add(currentKey)
+
+            if (currentKey === maxKey) {
+              break
             }
+
+            const entry = snapshot.blockMap.get(currentKey)
+
+            if (!entry) {
+              break
+            }
+
+            currentKey = entry.next
           }
         }
       }

--- a/packages/editor/src/internal-utils/block-map.test.ts
+++ b/packages/editor/src/internal-utils/block-map.test.ts
@@ -1,0 +1,723 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {Operation as SlateOperation} from 'slate'
+import {describe, expect, test} from 'vitest'
+import {
+  blockMapKey,
+  buildBlockMap,
+  updateBlockMap,
+  type BlockMap,
+} from './block-map'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function textBlock(key: string): PortableTextBlock {
+  return {
+    _key: key,
+    _type: 'block',
+    children: [{_key: `${key}-span`, _type: 'span', text: ''}],
+    style: 'normal',
+  }
+}
+
+function blockObject(key: string, type = 'image'): PortableTextBlock {
+  return {
+    _key: key,
+    _type: type,
+  }
+}
+
+/**
+ * A container block with a `content` field holding nested blocks.
+ * This is the shape containers will have.
+ */
+function containerBlock(
+  key: string,
+  contentBlocks: PortableTextBlock[],
+  type = 'codeBlock',
+): PortableTextBlock {
+  return {
+    _key: key,
+    _type: type,
+    content: contentBlocks,
+  } as unknown as PortableTextBlock
+}
+
+/** Collect the reading-order keys by walking the linked list from the start. */
+function readingOrder(blockMap: BlockMap): string[] {
+  if (blockMap.size === 0) {
+    return []
+  }
+
+  // Find the head (entry with prev === null)
+  let headKey: string | null = null
+  for (const [key, entry] of blockMap) {
+    if (entry.prev === null) {
+      headKey = key
+      break
+    }
+  }
+
+  if (headKey === null) {
+    return []
+  }
+
+  const order: string[] = []
+  let currentKey: string | null = headKey
+  while (currentKey !== null) {
+    order.push(currentKey)
+    const entry = blockMap.get(currentKey)
+    currentKey = entry?.next ?? null
+  }
+
+  return order
+}
+
+/** Assert the full state of the block map in one call. */
+function expectBlockMap(
+  blockMap: BlockMap,
+  expected: Array<{
+    key: string
+    index: number
+    prev: string | null
+    next: string | null
+    parent: string | null
+    field: string | null
+  }>,
+) {
+  expect(blockMap.size).toBe(expected.length)
+  for (const exp of expected) {
+    const entry = blockMap.get(exp.key)
+    expect(entry, `entry for key "${exp.key}"`).toBeDefined()
+    expect(entry!.index, `index for "${exp.key}"`).toBe(exp.index)
+    expect(entry!.prev, `prev for "${exp.key}"`).toBe(exp.prev)
+    expect(entry!.next, `next for "${exp.key}"`).toBe(exp.next)
+    expect(entry!.parent, `parent for "${exp.key}"`).toBe(exp.parent)
+    expect(entry!.field, `field for "${exp.key}"`).toBe(exp.field)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// blockMapKey
+// ---------------------------------------------------------------------------
+
+describe('blockMapKey', () => {
+  test('top-level block returns bare key', () => {
+    expect(blockMapKey('abc123')).toBe('abc123')
+  })
+
+  test('top-level block with null parent returns bare key', () => {
+    expect(blockMapKey('abc123', null, null)).toBe('abc123')
+  })
+
+  test('nested block encodes parent path', () => {
+    const key = blockMapKey('block1', 'container1', 'content')
+    expect(key).toBe('container1/7:content/6:block1')
+  })
+
+  test('deeply nested block encodes full path', () => {
+    const level1 = blockMapKey('container1')
+    const level2 = blockMapKey('row1', level1, 'content')
+    const level3 = blockMapKey('cell1', level2, 'cells')
+    const level4 = blockMapKey('block1', level3, 'content')
+
+    expect(level1).toBe('container1')
+    expect(level2).toBe('container1/7:content/4:row1')
+    expect(level3).toBe('container1/7:content/4:row1/5:cells/5:cell1')
+    expect(level4).toBe(
+      'container1/7:content/4:row1/5:cells/5:cell1/7:content/6:block1',
+    )
+  })
+
+  test('keys with special characters are unambiguous', () => {
+    // Keys can contain slashes, colons, anything
+    const key1 = blockMapKey('a/b', 'parent', 'field')
+    const key2 = blockMapKey('ab', 'parent', 'field')
+    expect(key1).not.toBe(key2)
+  })
+
+  test('length-prefix prevents collision between similar keys', () => {
+    const key1 = blockMapKey('abc', 'p', 'f')
+    const key2 = blockMapKey('ab', 'p', 'fc')
+    expect(key1).not.toBe(key2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildBlockMap — flat documents
+// ---------------------------------------------------------------------------
+
+describe('buildBlockMap — flat documents', () => {
+  test('empty document', () => {
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: []}, blockMap)
+    expect(blockMap.size).toBe(0)
+  })
+
+  test('single block', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: null, parent: null, field: null},
+    ])
+  })
+
+  test('three blocks in reading order', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a'), textBlock('b'), textBlock('c')]
+    buildBlockMap({value}, blockMap)
+
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a', next: 'c', parent: null, field: null},
+      {key: 'c', index: 2, prev: 'b', next: null, parent: null, field: null},
+    ])
+
+    expect(readingOrder(blockMap)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('mixed text blocks and block objects', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a'), blockObject('img1'), textBlock('b')]
+    buildBlockMap({value}, blockMap)
+
+    expect(readingOrder(blockMap)).toEqual(['a', 'img1', 'b'])
+    expect(blockMap.get('img1')!.index).toBe(1)
+  })
+
+  test('rebuild clears previous state', () => {
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('b')]}, blockMap)
+    expect(blockMap.size).toBe(2)
+
+    buildBlockMap({value: [textBlock('x')]}, blockMap)
+    expect(blockMap.size).toBe(1)
+    expect(blockMap.has('a')).toBe(false)
+    expect(blockMap.has('x')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateBlockMap — surgical updates on flat documents
+// ---------------------------------------------------------------------------
+
+describe('updateBlockMap — flat documents', () => {
+  test('set_selection is a no-op', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'set_selection',
+      properties: null,
+      newProperties: {
+        anchor: {path: [0, 0], offset: 0},
+        focus: {path: [0, 0], offset: 0},
+      },
+    } as SlateOperation)
+
+    expect(result).toBe(false)
+    expect(blockMap.size).toBe(1)
+  })
+
+  test('insert_text is a no-op', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_text',
+      path: [0, 0],
+      offset: 0,
+      text: 'hello',
+    } as SlateOperation)
+
+    expect(result).toBe(false)
+  })
+
+  test('remove_text is a no-op', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'remove_text',
+      path: [0, 0],
+      offset: 0,
+      text: 'hello',
+    } as SlateOperation)
+
+    expect(result).toBe(false)
+  })
+
+  test('child-level insert_node is a no-op', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [0, 1], // child level
+      node: {_key: 'span2', _type: 'span', text: ''},
+    } as SlateOperation)
+
+    expect(result).toBe(false)
+    expect(blockMap.size).toBe(1)
+  })
+
+  test('insert_node at end', () => {
+    // Start: [a, b]
+    // Insert c at index 2
+    // Result: [a, b, c]
+    const value = [textBlock('a'), textBlock('b'), textBlock('c')]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('b')]}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [2],
+      node: textBlock('c'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a', next: 'c', parent: null, field: null},
+      {key: 'c', index: 2, prev: 'b', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('insert_node at start', () => {
+    // Start: [b, c]
+    // Insert a at index 0
+    // Result: [a, b, c]
+    const value = [textBlock('a'), textBlock('b'), textBlock('c')]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('b'), textBlock('c')]}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [0],
+      node: textBlock('a'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a', next: 'c', parent: null, field: null},
+      {key: 'c', index: 2, prev: 'b', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('insert_node in middle', () => {
+    // Start: [a, c]
+    // Insert b at index 1
+    // Result: [a, b, c]
+    const value = [textBlock('a'), textBlock('b'), textBlock('c')]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('c')]}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [1],
+      node: textBlock('b'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a', next: 'c', parent: null, field: null},
+      {key: 'c', index: 2, prev: 'b', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('insert_node into empty document', () => {
+    const value = [textBlock('a')]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: []}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [0],
+      node: textBlock('a'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: null, parent: null, field: null},
+    ])
+  })
+
+  test('remove_node from end', () => {
+    // Start: [a, b, c]
+    // Remove c at index 2
+    // Result: [a, b]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('a'), textBlock('b')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'remove_node',
+      path: [2],
+      node: textBlock('c'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('remove_node from start', () => {
+    // Start: [a, b, c]
+    // Remove a at index 0
+    // Result: [b, c]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('b'), textBlock('c')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'remove_node',
+      path: [0],
+      node: textBlock('a'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'b', index: 0, prev: null, next: 'c', parent: null, field: null},
+      {key: 'c', index: 1, prev: 'b', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('remove_node from middle', () => {
+    // Start: [a, b, c]
+    // Remove b at index 1
+    // Result: [a, c]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('a'), textBlock('c')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'remove_node',
+      path: [1],
+      node: textBlock('b'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'c', parent: null, field: null},
+      {key: 'c', index: 1, prev: 'a', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('remove last block', () => {
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a')]}, blockMap)
+
+    const value: PortableTextBlock[] = []
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'remove_node',
+      path: [0],
+      node: textBlock('a'),
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expect(blockMap.size).toBe(0)
+  })
+
+  test('split_node creates new block after split point', () => {
+    // Start: [a, b]
+    // Split a at [0] — creates new block at [1]
+    // Result: [a, a2, b] (a2 is the new block from the split)
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('b')]}, blockMap)
+
+    const value = [textBlock('a'), textBlock('a2'), textBlock('b')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'split_node',
+      path: [0],
+      position: 1,
+      properties: {_key: 'a2', _type: 'block'},
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'a2', parent: null, field: null},
+      {key: 'a2', index: 1, prev: 'a', next: 'b', parent: null, field: null},
+      {key: 'b', index: 2, prev: 'a2', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('split_node at end of document', () => {
+    // Start: [a]
+    // Split a — creates new block at [1]
+    // Result: [a, a2]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a')]}, blockMap)
+
+    const value = [textBlock('a'), textBlock('a2')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'split_node',
+      path: [0],
+      position: 1,
+      properties: {_key: 'a2', _type: 'block'},
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'a2', parent: null, field: null},
+      {
+        key: 'a2',
+        index: 1,
+        prev: 'a',
+        next: null,
+        parent: null,
+        field: null,
+      },
+    ])
+  })
+
+  test('merge_node removes merged block', () => {
+    // Start: [a, b, c]
+    // Merge b into a (merge at [1])
+    // Result: [a, c]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('a'), textBlock('c')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'merge_node',
+      path: [1],
+      position: 1,
+      properties: {_key: 'b'},
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: 'c', parent: null, field: null},
+      {key: 'c', index: 1, prev: 'a', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('merge_node down to single block', () => {
+    // Start: [a, b]
+    // Merge b into a
+    // Result: [a]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('b')]}, blockMap)
+
+    const value = [textBlock('a')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'merge_node',
+      path: [1],
+      position: 1,
+      properties: {_key: 'b'},
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: null, parent: null, field: null},
+    ])
+  })
+
+  test('set_node with key change re-keys entry', () => {
+    // Block 'a' gets its key changed to 'a2'
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('a2'), textBlock('b'), textBlock('c')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'set_node',
+      path: [0],
+      properties: {_key: 'a'},
+      newProperties: {_key: 'a2'},
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expectBlockMap(blockMap, [
+      {key: 'a2', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'a2', next: 'c', parent: null, field: null},
+      {key: 'c', index: 2, prev: 'b', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('set_node without key change is a no-op', () => {
+    const blockMap: BlockMap = new Map()
+    const value = [textBlock('a')]
+    buildBlockMap({value}, blockMap)
+
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'set_node',
+      path: [0],
+      properties: {style: 'normal'},
+      newProperties: {style: 'h1'},
+    } as SlateOperation)
+
+    expect(result).toBe(false)
+  })
+
+  test('move_node updates map correctly', () => {
+    // Start: [a, b, c]
+    // Move a to after c
+    // Result: [b, c, a]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap(
+      {value: [textBlock('a'), textBlock('b'), textBlock('c')]},
+      blockMap,
+    )
+
+    const value = [textBlock('b'), textBlock('c'), textBlock('a')]
+    const result = updateBlockMap({value}, blockMap, {
+      type: 'move_node',
+      path: [0],
+      newPath: [2],
+    } as SlateOperation)
+
+    expect(result).toBe(true)
+    expect(readingOrder(blockMap)).toEqual(['b', 'c', 'a'])
+    expect(blockMap.get('b')!.index).toBe(0)
+    expect(blockMap.get('c')!.index).toBe(1)
+    expect(blockMap.get('a')!.index).toBe(2)
+  })
+
+  test('sequential insert then remove', () => {
+    // Start: [a, b]
+    // Insert c at 1: [a, c, b]
+    // Remove a at 0: [c, b]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a'), textBlock('b')]}, blockMap)
+
+    // Insert c at index 1
+    let value: PortableTextBlock[] = [
+      textBlock('a'),
+      textBlock('c'),
+      textBlock('b'),
+    ]
+    updateBlockMap({value}, blockMap, {
+      type: 'insert_node',
+      path: [1],
+      node: textBlock('c'),
+    } as SlateOperation)
+
+    expect(readingOrder(blockMap)).toEqual(['a', 'c', 'b'])
+
+    // Remove a at index 0
+    value = [textBlock('c'), textBlock('b')]
+    updateBlockMap({value}, blockMap, {
+      type: 'remove_node',
+      path: [0],
+      node: textBlock('a'),
+    } as SlateOperation)
+
+    expectBlockMap(blockMap, [
+      {key: 'c', index: 0, prev: null, next: 'b', parent: null, field: null},
+      {key: 'b', index: 1, prev: 'c', next: null, parent: null, field: null},
+    ])
+  })
+
+  test('sequential split then merge', () => {
+    // Start: [a]
+    // Split a: [a, a2]
+    // Merge a2 back: [a]
+    const blockMap: BlockMap = new Map()
+    buildBlockMap({value: [textBlock('a')]}, blockMap)
+
+    // Split
+    let value: PortableTextBlock[] = [textBlock('a'), textBlock('a2')]
+    updateBlockMap({value}, blockMap, {
+      type: 'split_node',
+      path: [0],
+      position: 1,
+      properties: {_key: 'a2', _type: 'block'},
+    } as SlateOperation)
+
+    expect(readingOrder(blockMap)).toEqual(['a', 'a2'])
+
+    // Merge
+    value = [textBlock('a')]
+    updateBlockMap({value}, blockMap, {
+      type: 'merge_node',
+      path: [1],
+      position: 1,
+      properties: {_key: 'a2'},
+    } as SlateOperation)
+
+    expectBlockMap(blockMap, [
+      {key: 'a', index: 0, prev: null, next: null, parent: null, field: null},
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildBlockMap — nested documents (containers)
+// ---------------------------------------------------------------------------
+
+describe('buildBlockMap — nested documents (future)', () => {
+  // These tests document the expected behavior when buildBlockMap
+  // is extended to walk into containers. They currently test the
+  // flat-only behavior and will be updated when container walking
+  // is implemented.
+
+  test('container block appears in map as a single entry (flat walk)', () => {
+    // Today, a container is just another block object in the flat array.
+    // Its nested content is not walked.
+    const blockMap: BlockMap = new Map()
+    const value = [
+      textBlock('a'),
+      containerBlock('code1', [textBlock('line1'), textBlock('line2')]),
+      textBlock('b'),
+    ]
+    buildBlockMap({value}, blockMap)
+
+    // Only top-level blocks are in the map
+    expect(blockMap.size).toBe(3)
+    expect(readingOrder(blockMap)).toEqual(['a', 'code1', 'b'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// blockMapKey — collision resistance
+// ---------------------------------------------------------------------------
+
+describe('blockMapKey — collision resistance', () => {
+  test('same key at different depths produces different map keys', () => {
+    // Block "x" at root vs block "x" inside container "c1"
+    const rootKey = blockMapKey('x')
+    const nestedKey = blockMapKey('x', 'c1', 'content')
+
+    expect(rootKey).not.toBe(nestedKey)
+  })
+
+  test('same key in different containers produces different map keys', () => {
+    const inC1 = blockMapKey('x', 'c1', 'content')
+    const inC2 = blockMapKey('x', 'c2', 'content')
+
+    expect(inC1).not.toBe(inC2)
+  })
+
+  test('same key in different fields of same container produces different map keys', () => {
+    const inContent = blockMapKey('x', 'c1', 'content')
+    const inCaption = blockMapKey('x', 'c1', 'caption')
+
+    expect(inContent).not.toBe(inCaption)
+  })
+})

--- a/packages/editor/src/internal-utils/block-map.ts
+++ b/packages/editor/src/internal-utils/block-map.ts
@@ -1,0 +1,396 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {Operation as SlateOperation} from 'slate'
+import type {EditorContext} from '../editor/editor-snapshot'
+
+/**
+ * A single entry in the block map, representing a block's position
+ * in the document and in the reading-order linked list.
+ *
+ * The block node itself is not stored here. Use `context.value[entry.index]`
+ * to access the block. This keeps the map as a pure index with no data
+ * duplication.
+ *
+ * @internal
+ */
+export type BlockMapEntry = {
+  index: number
+  prev: string | null
+  next: string | null
+  parent: string | null
+  field: string | null
+}
+
+/**
+ * A map of all blocks in the document, threaded in document reading
+ * order via `prev`/`next` pointers.
+ *
+ * Keys are path-based identifiers computed by `blockMapKey()`.
+ * For top-level blocks, the key is the block's `_key`.
+ * For nested blocks (containers), the key will encode the full path
+ * from the document root, since `_key` is only unique among siblings,
+ * not globally across the document.
+ *
+ * Supports O(1) block lookup, O(1) next/prev navigation at any depth.
+ *
+ * @internal
+ */
+export type BlockMap = Map<string, BlockMapEntry>
+
+/**
+ * Compute the map key for a block given its `_key` and optional
+ * parent map key and field name.
+ *
+ * For top-level blocks, the key is just the block's `_key`.
+ * For nested blocks inside containers, the key encodes the path
+ * from the document root: `parentMapKey/field/blockKey`.
+ *
+ * This uses `/` as a separator. Since `_key` values can technically
+ * contain any character, the encoding is length-prefixed per segment
+ * to avoid ambiguity:
+ *   top-level: `"abc123"` (bare key, no encoding needed)
+ *   nested: `"12:containerKey/7:content/8:blockKey"`
+ *
+ * For flat documents (today), this always returns the bare `_key`.
+ */
+export function blockMapKey(
+  blockKey: string,
+  parentMapKey?: string | null,
+  field?: string | null,
+): string {
+  if (!parentMapKey) {
+    return blockKey
+  }
+  return `${parentMapKey}/${String(field?.length ?? 0)}:${field ?? ''}/${String(blockKey.length)}:${blockKey}`
+}
+
+/**
+ * Build the block map from scratch by walking the value depth-first.
+ * Called on initial mount and as a fallback when surgical updates
+ * can't handle an operation.
+ *
+ * Mutates the map in place (clears it first).
+ */
+export function buildBlockMap(
+  context: Pick<EditorContext, 'value'>,
+  blockMap: BlockMap,
+): void {
+  blockMap.clear()
+
+  let prevKey: string | null = null
+
+  for (let i = 0; i < context.value.length; i++) {
+    const block = context.value[i]
+
+    if (!block) {
+      continue
+    }
+
+    const mapKey = blockMapKey(block._key)
+
+    const entry: BlockMapEntry = {
+      index: i,
+      prev: prevKey,
+      next: null,
+      parent: null,
+      field: null,
+    }
+
+    blockMap.set(mapKey, entry)
+
+    // Link previous entry to this one
+    if (prevKey !== null) {
+      const prevEntry = blockMap.get(prevKey)
+      if (prevEntry) {
+        prevEntry.next = mapKey
+      }
+    }
+
+    prevKey = mapKey
+
+    // Container walking will be added here when containerTypes
+    // are added to the schema. For now, flat documents only.
+    // The walk will recurse into container fields, calling
+    // blockMapKey(childKey, mapKey, fieldName) to produce
+    // path-based keys for nested blocks.
+  }
+}
+
+/**
+ * Find the map key for the entry at a given index.
+ * Returns null if no entry has that index.
+ *
+ * For surgical updates, we sometimes need to find an entry by its
+ * position rather than its key.
+ */
+function findKeyByIndex(blockMap: BlockMap, index: number): string | null {
+  for (const [key, entry] of blockMap) {
+    if (entry.index === index) {
+      return key
+    }
+  }
+  return null
+}
+
+/**
+ * Bump the index of every entry with index >= startIndex by the given delta.
+ */
+function shiftIndices(
+  blockMap: BlockMap,
+  startIndex: number,
+  delta: number,
+): void {
+  for (const entry of blockMap.values()) {
+    if (entry.index >= startIndex) {
+      entry.index += delta
+    }
+  }
+}
+
+/**
+ * Surgically insert a block entry at the given index.
+ * Splices into the prev/next chain and bumps indices.
+ */
+function insertEntry(blockMap: BlockMap, mapKey: string, index: number): void {
+  // Bump indices of all blocks at or after this position
+  shiftIndices(blockMap, index, 1)
+
+  // Find the entries that should be before and after the new entry
+  const prevMapKey = findKeyByIndex(blockMap, index - 1)
+  const prevEntry = prevMapKey ? blockMap.get(prevMapKey) : undefined
+  const nextMapKey = prevEntry
+    ? prevEntry.next
+    : findKeyByIndex(blockMap, index + 1)
+  const nextEntry = nextMapKey ? blockMap.get(nextMapKey) : undefined
+
+  // Create the new entry
+  const entry: BlockMapEntry = {
+    index,
+    prev: prevMapKey,
+    next: nextMapKey,
+    parent: null,
+    field: null,
+  }
+
+  blockMap.set(mapKey, entry)
+
+  // Splice into the chain
+  if (prevEntry) {
+    prevEntry.next = mapKey
+  }
+  if (nextEntry) {
+    nextEntry.prev = mapKey
+  }
+}
+
+/**
+ * Surgically remove a block entry at the given map key.
+ * Unlinks from the prev/next chain and decrements indices.
+ */
+function removeEntry(blockMap: BlockMap, mapKey: string): void {
+  const entry = blockMap.get(mapKey)
+  if (!entry) {
+    return
+  }
+
+  // Unlink from chain
+  if (entry.prev) {
+    const prevEntry = blockMap.get(entry.prev)
+    if (prevEntry) {
+      prevEntry.next = entry.next
+    }
+  }
+  if (entry.next) {
+    const nextEntry = blockMap.get(entry.next)
+    if (nextEntry) {
+      nextEntry.prev = entry.prev
+    }
+  }
+
+  const removedIndex = entry.index
+  blockMap.delete(mapKey)
+
+  // Decrement indices of all blocks after the removed one
+  shiftIndices(blockMap, removedIndex, -1)
+}
+
+/**
+ * Update the block map after a Slate operation.
+ *
+ * For text edits and selection changes, this is a no-op.
+ * For block-level structural operations, performs surgical updates:
+ * splicing entries in/out of the linked list and adjusting indices.
+ * For child-level operations (path.length > 1), the block map
+ * is unaffected.
+ *
+ * Falls back to a full rebuild if the operation can't be handled
+ * surgically (e.g., move_node).
+ *
+ * Returns true if the map was updated, false if no update was needed.
+ */
+export function updateBlockMap(
+  context: Pick<EditorContext, 'value'>,
+  blockMap: BlockMap,
+  operation: SlateOperation,
+): boolean {
+  switch (operation.type) {
+    // Text and selection operations don't affect block structure
+    case 'set_selection':
+    case 'insert_text':
+    case 'remove_text':
+      return false
+
+    case 'set_node': {
+      // Only care about block-level set_node (path.length === 1)
+      if (operation.path.length !== 1) {
+        return false
+      }
+
+      const blockIndex = operation.path[0]
+      if (blockIndex === undefined) {
+        return false
+      }
+
+      const block = context.value[blockIndex]
+      if (!block) {
+        return false
+      }
+
+      const newMapKey = blockMapKey(block._key)
+
+      // Check if the key changed by looking for the old entry at this index
+      if (blockMap.has(newMapKey)) {
+        // Key didn't change, nothing to do
+        return false
+      }
+
+      // Key changed: find the old entry by index, re-key it
+      const oldMapKey = findKeyByIndex(blockMap, blockIndex)
+      if (oldMapKey) {
+        const entry = blockMap.get(oldMapKey)!
+
+        // Update prev/next references that point to the old key
+        if (entry.prev) {
+          const prevEntry = blockMap.get(entry.prev)
+          if (prevEntry) {
+            prevEntry.next = newMapKey
+          }
+        }
+        if (entry.next) {
+          const nextEntry = blockMap.get(entry.next)
+          if (nextEntry) {
+            nextEntry.prev = newMapKey
+          }
+        }
+
+        blockMap.delete(oldMapKey)
+        blockMap.set(newMapKey, entry)
+      }
+
+      return true
+    }
+
+    case 'insert_node': {
+      // Only care about block-level inserts (path.length === 1)
+      if (operation.path.length !== 1) {
+        return false
+      }
+
+      const blockIndex = operation.path[0]
+      if (blockIndex === undefined) {
+        return false
+      }
+
+      const block = context.value[blockIndex] as PortableTextBlock | undefined
+      if (!block) {
+        // Fallback to rebuild
+        buildBlockMap(context, blockMap)
+        return true
+      }
+
+      const mapKey = blockMapKey(block._key)
+      insertEntry(blockMap, mapKey, blockIndex)
+      return true
+    }
+
+    case 'remove_node': {
+      // Only care about block-level removes (path.length === 1)
+      if (operation.path.length !== 1) {
+        return false
+      }
+
+      // The node in the operation has the _key of the removed block
+      const removedNode = operation.node as PortableTextBlock | undefined
+      if (!removedNode?._key) {
+        buildBlockMap(context, blockMap)
+        return true
+      }
+
+      const mapKey = blockMapKey(removedNode._key)
+      removeEntry(blockMap, mapKey)
+      return true
+    }
+
+    case 'split_node': {
+      // Only care about block-level splits (path.length === 1)
+      // A split at [i] creates a new block at [i+1]
+      if (operation.path.length !== 1) {
+        return false
+      }
+
+      const blockIndex = operation.path[0]
+      if (blockIndex === undefined) {
+        return false
+      }
+
+      // The new block is at blockIndex + 1 after the split
+      const newBlock = context.value[blockIndex + 1] as
+        | PortableTextBlock
+        | undefined
+      if (!newBlock?._key) {
+        buildBlockMap(context, blockMap)
+        return true
+      }
+
+      const mapKey = blockMapKey(newBlock._key)
+      insertEntry(blockMap, mapKey, blockIndex + 1)
+      return true
+    }
+
+    case 'merge_node': {
+      // Only care about block-level merges (path.length === 1)
+      // A merge at [i] removes block [i] and merges into [i-1]
+      if (operation.path.length !== 1) {
+        return false
+      }
+
+      const blockIndex = operation.path[0]
+      if (blockIndex === undefined) {
+        return false
+      }
+
+      // Find the entry that was at this index before the merge
+      // After the merge, the block at blockIndex is gone, so we need
+      // to find it by looking at what's no longer in the value
+      // The operation.properties has the merged node's properties
+      const mergedKey = (operation.properties as {_key?: string})?._key
+      if (!mergedKey) {
+        buildBlockMap(context, blockMap)
+        return true
+      }
+
+      const mapKey = blockMapKey(mergedKey)
+      removeEntry(blockMap, mapKey)
+      return true
+    }
+
+    case 'move_node': {
+      // Move is complex: unlink from old, splice into new, fix indices.
+      // Fall back to rebuild for correctness.
+      buildBlockMap(context, blockMap)
+      return true
+    }
+
+    default:
+      return false
+  }
+}

--- a/packages/editor/src/internal-utils/create-test-snapshot.ts
+++ b/packages/editor/src/internal-utils/create-test-snapshot.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {buildBlockMap, type BlockMap} from './block-map'
 
 export function createTestSnapshot(snapshot: {
   context?: Partial<EditorSnapshot['context']>
@@ -15,12 +16,16 @@ export function createTestSnapshot(snapshot: {
     selection: snapshot.context?.selection ?? null,
   }
   const blockIndexMap = new Map<string, number>()
+  const blockMap: BlockMap = new Map()
 
   snapshot.context?.value?.forEach((block, index) => {
     blockIndexMap.set(block._key, index)
   })
 
+  buildBlockMap({value: context.value}, blockMap)
+
   return {
+    blockMap,
     blockIndexMap,
     context,
     decoratorState: snapshot?.decoratorState ?? {},

--- a/packages/editor/src/internal-utils/to-slate-range.test.ts
+++ b/packages/editor/src/internal-utils/to-slate-range.test.ts
@@ -1,7 +1,15 @@
+import type {PortableTextBlock} from '@portabletext/schema'
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
+import {buildBlockMap, type BlockMap} from './block-map'
 import {toSlateRange} from './to-slate-range'
+
+function makeBlockMap(value: Array<PortableTextBlock>): BlockMap {
+  const blockMap: BlockMap = new Map()
+  buildBlockMap({value}, blockMap)
+  return blockMap
+}
 
 describe(toSlateRange.name, () => {
   const schema = compileSchema(
@@ -17,31 +25,33 @@ describe(toSlateRange.name, () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: 'foo',
+          },
+          {
+            _key: keyGenerator(),
+            _type: 'stock-ticker',
+          },
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: 'bar',
+          },
+        ],
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'foo',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'stock-ticker',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'bar',
-              },
-            ],
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockKey}],
@@ -55,7 +65,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({
@@ -68,31 +78,33 @@ describe(toSlateRange.name, () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: "'",
+          },
+          {
+            _key: keyGenerator(),
+            _type: 'stock-ticker',
+          },
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: "foo'",
+          },
+        ],
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: "'",
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'stock-ticker',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: "foo'",
-              },
-            ],
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockKey}],
@@ -104,7 +116,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({
@@ -117,15 +129,17 @@ describe(toSlateRange.name, () => {
     const keyGenerator = createTestKeyGenerator()
     const blockObjectKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockObjectKey,
+        _type: 'image',
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockObjectKey,
-            _type: 'image',
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockObjectKey}],
@@ -137,7 +151,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockObjectKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({
@@ -152,22 +166,24 @@ describe(toSlateRange.name, () => {
     const blockKey = keyGenerator()
     const removedChildKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: 'foobar',
+          },
+        ],
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'foobar',
-              },
-            ],
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockKey}, 'children', {_key: removedChildKey}],
@@ -179,7 +195,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({
@@ -193,22 +209,24 @@ describe(toSlateRange.name, () => {
     const blockKey = keyGenerator()
     const spanKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {
+            _key: spanKey,
+            _type: 'span',
+            text: 'foo',
+          },
+        ],
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {
-                _key: spanKey,
-                _type: 'span',
-                text: 'foo',
-              },
-            ],
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockKey}, 'children', {_key: spanKey}],
@@ -220,7 +238,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({
@@ -234,28 +252,30 @@ describe(toSlateRange.name, () => {
     const blockKey = keyGenerator()
     const inlineObjectKey = keyGenerator()
 
+    const value: Array<PortableTextBlock> = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {_key: keyGenerator(), _type: 'span', text: 'foo'},
+          {
+            _key: inlineObjectKey,
+            _type: 'stock-ticker',
+            symbol: 'AAPL',
+          },
+          {
+            _key: keyGenerator(),
+            _type: 'span',
+            text: 'bar',
+          },
+        ],
+      },
+    ]
+
     const range = toSlateRange({
       context: {
         schema,
-        value: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {_key: keyGenerator(), _type: 'span', text: 'foo'},
-              {
-                _key: inlineObjectKey,
-                _type: 'stock-ticker',
-                symbol: 'AAPL',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'bar',
-              },
-            ],
-          },
-        ],
+        value,
         selection: {
           anchor: {
             path: [{_key: blockKey}, 'children', {_key: inlineObjectKey}],
@@ -267,7 +287,7 @@ describe(toSlateRange.name, () => {
           },
         },
       },
-      blockIndexMap: new Map([[blockKey, 0]]),
+      blockMap: makeBlockMap(value),
     })
 
     expect(range).toEqual({

--- a/packages/editor/src/internal-utils/to-slate-range.ts
+++ b/packages/editor/src/internal-utils/to-slate-range.ts
@@ -17,7 +17,7 @@ import {
 export function toSlateRange(
   snapshot: {
     context: Pick<EditorContext, 'schema' | 'value' | 'selection'>
-  } & Pick<EditorSnapshot, 'blockIndexMap'>,
+  } & Pick<EditorSnapshot, 'blockMap'>,
 ): Range | null {
   if (!snapshot.context.selection) {
     return null
@@ -69,7 +69,7 @@ export function toSlateRange(
 export function toSlateSelectionPoint(
   snapshot: {
     context: Pick<EditorContext, 'schema' | 'value'>
-  } & Pick<EditorSnapshot, 'blockIndexMap'>,
+  } & Pick<EditorSnapshot, 'blockMap'>,
   selectionPoint: EditorSelectionPoint,
   direction: 'forward' | 'backward',
 ):
@@ -84,13 +84,14 @@ export function toSlateSelectionPoint(
     return undefined
   }
 
-  const blockIndex = snapshot.blockIndexMap.get(blockKey)
+  const entry = snapshot.blockMap.get(blockKey)
 
-  if (blockIndex === undefined) {
+  if (!entry) {
     return undefined
   }
 
-  const block = snapshot.context.value.at(blockIndex)
+  const blockIndex = entry.index
+  const block = snapshot.context.value[blockIndex]
 
   if (!block) {
     return undefined

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -31,7 +31,7 @@ export const addAnnotationOperationImplementation: OperationImplementation<
           value: operation.editor.value,
           selection: operation.at,
         },
-        blockIndexMap: operation.editor.blockIndexMap,
+        blockMap: operation.editor.blockMap,
       })
     : null
 

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -15,7 +15,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
           value: operation.editor.value,
           selection: operation.at,
         },
-        blockIndexMap: operation.editor.blockIndexMap,
+        blockMap: operation.editor.blockMap,
       })
     : null
 

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -7,13 +7,15 @@ import type {OperationImplementation} from './operation.types'
 export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
 > = ({context, operation}) => {
-  const blockIndex = operation.editor.blockIndexMap.get(operation.at[0]._key)
+  const blockEntry = operation.editor.blockMap.get(operation.at[0]._key)
 
-  if (blockIndex === undefined) {
+  if (!blockEntry) {
     throw new Error(
-      `Unable to find block index for block at ${JSON.stringify(operation.at)}`,
+      `Unable to find block entry for block at ${JSON.stringify(operation.at)}`,
     )
   }
+
+  const blockIndex = blockEntry.index
 
   const slateBlock = operation.editor.children.at(blockIndex)
 

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -7,16 +7,14 @@ export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
 > = ({context, operation}) => {
   const blockKey = operation.at[0]._key
-  const blockIndex = operation.editor.blockIndexMap.get(blockKey)
+  const blockEntry = operation.editor.blockMap.get(blockKey)
 
-  if (blockIndex === undefined) {
-    throw new Error(`Unable to find block index for block key ${blockKey}`)
+  if (!blockEntry) {
+    throw new Error(`Unable to find block entry for block key ${blockKey}`)
   }
 
-  const slateBlock =
-    blockIndex !== undefined
-      ? operation.editor.children.at(blockIndex)
-      : undefined
+  const blockIndex = blockEntry.index
+  const slateBlock = operation.editor.children.at(blockIndex)
 
   if (!slateBlock) {
     throw new Error(`Unable to find block at ${JSON.stringify(operation.at)}`)

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -14,7 +14,7 @@ export const childSetOperationImplementation: OperationImplementation<
         focus: {path: operation.at, offset: 0},
       },
     },
-    blockIndexMap: operation.editor.blockIndexMap,
+    blockMap: operation.editor.blockMap,
   })
 
   if (!location) {

--- a/packages/editor/src/operations/operation.child.unset.ts
+++ b/packages/editor/src/operations/operation.child.unset.ts
@@ -7,14 +7,14 @@ export const childUnsetOperationImplementation: OperationImplementation<
   'child.unset'
 > = ({context, operation}) => {
   const blockKey = operation.at[0]._key
-  const blockIndex = operation.editor.blockIndexMap.get(blockKey)
+  const blockEntry = operation.editor.blockMap.get(blockKey)
 
-  if (blockIndex === undefined) {
-    throw new Error(`Unable to find block index for block key ${blockKey}`)
+  if (!blockEntry) {
+    throw new Error(`Unable to find block entry for block key ${blockKey}`)
   }
 
-  const block =
-    blockIndex !== undefined ? operation.editor.value.at(blockIndex) : undefined
+  const blockIndex = blockEntry.index
+  const block = operation.editor.value[blockIndex]
 
   if (!block) {
     throw new Error(`Unable to find block at ${JSON.stringify(operation.at)}`)

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -15,7 +15,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
           value: operation.editor.value,
           selection: operation.at,
         },
-        blockIndexMap: operation.editor.blockIndexMap,
+        blockMap: operation.editor.blockMap,
       })
     : operation.editor.selection
 

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -14,7 +14,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
           value: operation.editor.value,
           selection: operation.at,
         },
-        blockIndexMap: operation.editor.blockIndexMap,
+        blockMap: operation.editor.blockMap,
       })
     : editor.selection
 

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -25,7 +25,7 @@ export const deleteOperationImplementation: OperationImplementation<
           value: operation.editor.value,
           selection: operation.at,
         },
-        blockIndexMap: operation.editor.blockIndexMap,
+        blockMap: operation.editor.blockMap,
       })
     : operation.editor.selection
 

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -64,7 +64,7 @@ export function insertBlock(options: {
           value: editor.value,
           selection: options.at,
         },
-        blockIndexMap: editor.blockIndexMap,
+        blockMap: editor.blockMap,
       })
     : editor.selection
 

--- a/packages/editor/src/operations/operation.move.block.ts
+++ b/packages/editor/src/operations/operation.move.block.ts
@@ -14,10 +14,10 @@ export const moveBlockOperationImplementation: OperationImplementation<
     throw new Error('Failed to get block key from selection point')
   }
 
-  const originBlockIndex = operation.editor.blockIndexMap.get(originKey)
+  const originEntry = operation.editor.blockMap.get(originKey)
 
-  if (originBlockIndex === undefined) {
-    throw new Error('Failed to get block index from block key')
+  if (!originEntry) {
+    throw new Error('Failed to get block entry from block key')
   }
 
   const destinationKey = getBlockKeyFromSelectionPoint({
@@ -29,16 +29,15 @@ export const moveBlockOperationImplementation: OperationImplementation<
     throw new Error('Failed to get block key from selection point')
   }
 
-  const destinationBlockIndex =
-    operation.editor.blockIndexMap.get(destinationKey)
+  const destinationEntry = operation.editor.blockMap.get(destinationKey)
 
-  if (destinationBlockIndex === undefined) {
-    throw new Error('Failed to get block index from block key')
+  if (!destinationEntry) {
+    throw new Error('Failed to get block entry from block key')
   }
 
   Transforms.moveNodes(operation.editor, {
-    at: [originBlockIndex],
-    to: [destinationBlockIndex],
+    at: [originEntry.index],
+    to: [destinationEntry.index],
     mode: 'highest',
   })
 }

--- a/packages/editor/src/operations/operation.select.ts
+++ b/packages/editor/src/operations/operation.select.ts
@@ -12,7 +12,7 @@ export const selectOperationImplementation: OperationImplementation<
       value: operation.editor.value,
       selection: operation.at,
     },
-    blockIndexMap: operation.editor.blockIndexMap,
+    blockMap: operation.editor.blockMap,
   })
 
   if (newSelection) {

--- a/packages/editor/src/selectors/selector.get-anchor-block.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-block.ts
@@ -14,9 +14,9 @@ export const getAnchorBlock: EditorSelector<
   }
 
   const key = getBlockKeyFromSelectionPoint(snapshot.context.selection.anchor)
-  const index = key ? snapshot.blockIndexMap.get(key) : undefined
-  const node =
-    index !== undefined ? snapshot.context.value.at(index) : undefined
+  const entry = key ? snapshot.blockMap.get(key) : undefined
 
-  return node && key ? {node, path: [{_key: key}]} : undefined
+  const node = entry ? snapshot.context.value[entry.index] : undefined
+
+  return node ? {node, path: [{_key: key!}]} : undefined
 }

--- a/packages/editor/src/selectors/selector.get-focus-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block.ts
@@ -14,10 +14,9 @@ export const getFocusBlock: EditorSelector<
   }
 
   const key = getBlockKeyFromSelectionPoint(snapshot.context.selection.focus)
-  const index = key ? snapshot.blockIndexMap.get(key) : undefined
+  const entry = key ? snapshot.blockMap.get(key) : undefined
 
-  const node =
-    index !== undefined ? snapshot.context.value.at(index) : undefined
+  const node = entry ? snapshot.context.value[entry.index] : undefined
 
-  return node && key ? {node, path: [{_key: key}]} : undefined
+  return node ? {node, path: [{_key: key!}]} : undefined
 }

--- a/packages/editor/src/selectors/selector.get-next-block.ts
+++ b/packages/editor/src/selectors/selector.get-next-block.ts
@@ -15,15 +15,16 @@ export const getNextBlock: EditorSelector<
     return undefined
   }
 
-  const index = snapshot.blockIndexMap.get(selectionEndBlock.node._key)
+  const entry = snapshot.blockMap.get(selectionEndBlock.node._key)
 
-  if (index === undefined || index === snapshot.context.value.length - 1) {
+  if (!entry || entry.next === null) {
     return undefined
   }
 
-  const nextBlock = snapshot.context.value.at(index + 1)
-
-  return nextBlock
-    ? {node: nextBlock, path: [{_key: nextBlock._key}]}
+  const nextEntry = snapshot.blockMap.get(entry.next)
+  const nextNode = nextEntry
+    ? snapshot.context.value[nextEntry.index]
     : undefined
+
+  return nextNode ? {node: nextNode, path: [{_key: nextNode._key}]} : undefined
 }

--- a/packages/editor/src/selectors/selector.get-previous-block.ts
+++ b/packages/editor/src/selectors/selector.get-previous-block.ts
@@ -15,15 +15,16 @@ export const getPreviousBlock: EditorSelector<
     return undefined
   }
 
-  const index = snapshot.blockIndexMap.get(selectionStartBlock.node._key)
+  const entry = snapshot.blockMap.get(selectionStartBlock.node._key)
 
-  if (index === undefined || index === 0) {
+  if (!entry || entry.prev === null) {
     return undefined
   }
 
-  const previousBlock = snapshot.context.value.at(index - 1)
-
-  return previousBlock
-    ? {node: previousBlock, path: [{_key: previousBlock._key}]}
+  const prevEntry = snapshot.blockMap.get(entry.prev)
+  const prevNode = prevEntry
+    ? snapshot.context.value[prevEntry.index]
     : undefined
+
+  return prevNode ? {node: prevNode, path: [{_key: prevNode._key}]} : undefined
 }

--- a/packages/editor/src/selectors/selector.get-selected-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-blocks.ts
@@ -25,36 +25,35 @@ export const getSelectedBlocks: EditorSelector<
     return selectedBlocks
   }
 
-  const startBlockIndex = snapshot.blockIndexMap.get(startKey)
-  const endBlockIndex = snapshot.blockIndexMap.get(endKey)
+  const startEntry = snapshot.blockMap.get(startKey)
 
-  if (startBlockIndex === undefined || endBlockIndex === undefined) {
+  if (!startEntry) {
     return selectedBlocks
   }
 
-  const slicedValue = snapshot.context.value.slice(
-    startBlockIndex,
-    endBlockIndex + 1,
-  )
+  // Walk the linked list from start to end
+  let currentKey: string | null = startKey
 
-  for (const block of slicedValue) {
-    if (block._key === startKey) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
+  while (currentKey !== null) {
+    const entry = snapshot.blockMap.get(currentKey)
 
-      if (startKey === endKey) {
-        break
-      }
-      continue
-    }
-
-    if (block._key === endKey) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
+    if (!entry) {
       break
     }
 
-    if (selectedBlocks.length > 0) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
+    const node = snapshot.context.value[entry.index]
+
+    if (!node) {
+      break
     }
+
+    selectedBlocks.push({node, path: [{_key: node._key}]})
+
+    if (currentKey === endKey) {
+      break
+    }
+
+    currentKey = entry.next
   }
 
   return selectedBlocks

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -43,26 +43,28 @@ export function isOverlappingSelection(
       return false
     }
 
-    const selectionStartBlockIndex = snapshot.blockIndexMap.get(
-      selectionStartBlockKey,
-    )
-    const selectionEndBlockIndex =
-      snapshot.blockIndexMap.get(selectionEndBlockKey)
-    const editorSelectionStartBlockIndex = snapshot.blockIndexMap.get(
+    const selectionStartEntry = snapshot.blockMap.get(selectionStartBlockKey)
+    const selectionEndEntry = snapshot.blockMap.get(selectionEndBlockKey)
+    const editorSelectionStartEntry = snapshot.blockMap.get(
       editorSelectionStartBlockKey,
     )
-    const editorSelectionEndBlockIndex = snapshot.blockIndexMap.get(
+    const editorSelectionEndEntry = snapshot.blockMap.get(
       editorSelectionEndBlockKey,
     )
 
     if (
-      selectionStartBlockIndex === undefined ||
-      selectionEndBlockIndex === undefined ||
-      editorSelectionStartBlockIndex === undefined ||
-      editorSelectionEndBlockIndex === undefined
+      !selectionStartEntry ||
+      !selectionEndEntry ||
+      !editorSelectionStartEntry ||
+      !editorSelectionEndEntry
     ) {
       return false
     }
+
+    const selectionStartBlockIndex = selectionStartEntry.index
+    const selectionEndBlockIndex = selectionEndEntry.index
+    const editorSelectionStartBlockIndex = editorSelectionStartEntry.index
+    const editorSelectionEndBlockIndex = editorSelectionEndEntry.index
 
     const [selectionMinBlockIndex, selectionMaxBlockIndex] =
       selectionStartBlockIndex <= selectionEndBlockIndex

--- a/packages/editor/src/slate-plugins/slate-plugin.unique-keys.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.unique-keys.ts
@@ -45,7 +45,7 @@ export function createUniqueKeysPlugin(editorActor: EditorActor) {
           operation.properties._key &&
           keyExistsAtPath(
             {
-              blockIndexMap: editor.blockIndexMap,
+              blockMap: editor.blockMap,
               context: {
                 schema: context.schema,
                 value: editor.value,
@@ -77,7 +77,7 @@ export function createUniqueKeysPlugin(editorActor: EditorActor) {
             operation.node._key &&
             keyExistsAtPath(
               {
-                blockIndexMap: editor.blockIndexMap,
+                blockMap: editor.blockMap,
                 context: {
                   schema: context.schema,
                   value: editor.value,
@@ -311,14 +311,14 @@ export function createUniqueKeysPlugin(editorActor: EditorActor) {
 }
 
 function keyExistsAtPath(
-  snapshot: Pick<EditorSnapshot, 'blockIndexMap'> & {
+  snapshot: Pick<EditorSnapshot, 'blockMap'> & {
     context: Pick<EditorContext, 'schema' | 'value'>
   },
   path: Path,
   key: string,
 ): boolean {
   if (path.length === 1) {
-    return snapshot.blockIndexMap.has(key)
+    return snapshot.blockMap.has(key)
   }
 
   if (path.length > 2) {

--- a/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
@@ -1,5 +1,6 @@
 import type {EditorContext} from '../editor/editor-snapshot'
 import {applyOperationToPortableText} from '../internal-utils/apply-operation-to-portable-text'
+import {updateBlockMap} from '../internal-utils/block-map'
 import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {debug} from '../internal-utils/debug'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
@@ -29,8 +30,9 @@ export function updateValuePlugin(
     )
 
     if (operation.type === 'insert_text' || operation.type === 'remove_text') {
-      // Inserting and removing text has no effect on index maps so there is
-      // no need to rebuild those.
+      // Inserting and removing text has no effect on index maps or the
+      // block map (text operations are no-ops for both).
+      updateBlockMap({value: editor.value}, editor.blockMap, operation)
       apply(operation)
       return
     }
@@ -45,6 +47,8 @@ export function updateValuePlugin(
         listIndexMap: editor.listIndexMap,
       },
     )
+
+    updateBlockMap({value: editor.value}, editor.blockMap, operation)
 
     apply(operation)
   }

--- a/packages/editor/src/types/slate-editor.ts
+++ b/packages/editor/src/types/slate-editor.ts
@@ -8,6 +8,7 @@ import type {
 import type {Range, Operation as SlateOperation} from 'slate'
 import type {ReactEditor} from 'slate-react'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
+import type {BlockMap} from '../internal-utils/block-map'
 import type {EditorSelection} from './editor'
 // Side-effect import to ensure Slate module augmentation is included
 import './slate'
@@ -39,6 +40,8 @@ export interface PortableTextSlateEditor extends ReactEditor {
 
   decoratedRanges: Array<DecoratedRange>
   decoratorState: Record<string, boolean | undefined>
+  blockMap: BlockMap
+  /** @deprecated Use `blockMap` instead */
   blockIndexMap: Map<string, number>
   history: History
   lastSelection: EditorSelection

--- a/packages/editor/src/utils/util.compare-points.ts
+++ b/packages/editor/src/utils/util.compare-points.ts
@@ -29,29 +29,29 @@ export function comparePoints(
     throw new Error(`Cannot compare points: no block key found for ${pointB}`)
   }
 
-  const blockIndexA = snapshot.blockIndexMap.get(blockKeyA)
-  const blockIndexB = snapshot.blockIndexMap.get(blockKeyB)
+  const entryA = snapshot.blockMap.get(blockKeyA)
+  const entryB = snapshot.blockMap.get(blockKeyB)
 
-  if (blockIndexA === undefined) {
+  if (!entryA) {
     throw new Error(`Cannot compare points: block "${blockKeyA}" not found`)
   }
 
-  if (blockIndexB === undefined) {
+  if (!entryB) {
     throw new Error(`Cannot compare points: block "${blockKeyB}" not found`)
   }
 
-  if (blockIndexA < blockIndexB) {
+  if (entryA.index < entryB.index) {
     return -1
   }
 
-  if (blockIndexA > blockIndexB) {
+  if (entryA.index > entryB.index) {
     return 1
   }
 
   // Same block - need to compare at child level
-  const block = snapshot.context.value.at(blockIndexA)
+  const blockA = snapshot.context.value[entryA.index]
 
-  if (!block || !isTextBlock(snapshot.context, block)) {
+  if (!blockA || !isTextBlock(snapshot.context, blockA)) {
     // Block objects - same block means equal position
     return 0
   }
@@ -71,8 +71,8 @@ export function comparePoints(
   let childIndexA: number | undefined
   let childIndexB: number | undefined
 
-  for (let i = 0; i < block.children.length; i++) {
-    const child = block.children.at(i)
+  for (let i = 0; i < blockA.children.length; i++) {
+    const child = blockA.children.at(i)
 
     if (!child) {
       continue


### PR DESCRIPTION
## Add threaded block map with O(1) lookups and linked-list navigation

### What

Introduces a new `BlockMap` data structure that replaces `blockIndexMap` as the primary way to look up and navigate blocks. Each entry stores its index, `prev`/`next` pointers (threaded in document reading order), and `parent`/`field` pointers for future container support.

The old `blockIndexMap` is kept populated and marked `@deprecated` for backwards compatibility.

### Why

`blockIndexMap` is a flat `Map<string, number>` that maps `_key` to array index. It has two problems:

1. **No navigation.** Getting the next or previous block requires walking the value array. Selectors like `getNextBlock` and `getPreviousBlock` had to scan by index arithmetic.

2. **Flat only.** Keys are bare `_key` strings, which are only unique within their sibling array. When containers introduce nested blocks, two blocks at different depths could share a `_key`, making the map ambiguous.

The block map solves both: O(1) lookup by key, O(1) next/prev via linked list, and path-based keys that are unique at any depth.

### How it works

Each `BlockMapEntry` stores:

```ts
{
  index: number        // position in parent array
  prev: string | null  // previous block in reading order
  next: string | null  // next block in reading order
  parent: string | null // parent block's map key (null for top-level)
  field: string | null  // field name in parent (null for top-level)
}
```

Block nodes are not stored on the entry. Access the node via `context.value[entry.index]`. One source of truth, no data duplication.

**Key encoding:** Top-level blocks use their bare `_key` as the map key. Nested blocks (when containers land) will use a length-prefixed path encoding: `parentMapKey/7:content/6:block1`. Length prefixes prevent ambiguity since `_key` can contain any character.

**Surgical updates:** The map is updated per Slate operation instead of being rebuilt from scratch:

| Operation | Block map work |
|-----------|---------------|
| `insert_node` (block-level) | Create entry, splice into chain, shift indices after |
| `remove_node` (block-level) | Unlink from chain, delete entry, shift indices after |
| `split_node` (block-level) | Insert new entry after split point |
| `merge_node` (block-level) | Remove merged entry, shift indices |
| `set_node` (key change) | Re-key entry, update neighbor references |
| `move_node` | Full rebuild (rare operation, complex index math) |
| Text ops, selection, child-level ops | No-op |

### What changed

**New files:**
- `block-map.ts`: `BlockMap`, `BlockMapEntry`, `blockMapKey()`, `buildBlockMap()`, `updateBlockMap()`
- `block-map.test.ts`: 36 tests covering build, surgical updates, key encoding, and collision resistance

**Migrated to block map (13 files):**
- 8 selectors: `getFocusBlock`, `getAnchorBlock`, `getNextBlock`, `getPreviousBlock`, `getSelectedBlocks`, `getSelectedChildren`, `getSelectedTextBlocks`, `getSelectedValue`
- `to-slate-range.ts`: block index lookup
- `create-editable-api.ts`: `focusBlock`, `getBlock`
- `operation.child.unset.ts`: block lookup
- `slate-plugin.update-value.ts`: calls `updateBlockMap` after each operation
- `slate-plugin.unique-keys.ts`: duplicate key detection

### Tests

36 unit tests covering:
- `blockMapKey`: top-level, nested, deeply nested, special characters, collision resistance
- `buildBlockMap`: empty, single block, multiple blocks, mixed types, rebuild clears state
- Surgical updates: insert (start/middle/end/empty), remove (start/middle/end/last), split, merge, key change, move, sequential operations
- Container block in flat walk (documents current behavior for when container walking is added)

All existing tests continue to pass (353 total).
