### PR TITLE
fix: deduplicate shared block/inline object names in schema compilation

### DIFF
--- a/.changeset/fix-shared-block-inline-names.md
+++ b/.changeset/fix-shared-block-inline-names.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/sanity-bridge': patch
+---
+
+fix: deduplicate shared block/inline object names in schema compilation
+
+When a type name appears in both `blockObjects` and `inlineObjects` of a `SchemaDefinition`, `compileSchemaDefinitionToPortableTextMemberSchemaTypes` would pass duplicate type names to `SanitySchema.compile()`, causing a "Duplicate type name added to schema" error. This generalizes the existing temporary-name pattern (previously only handling `image` and `url`) to dynamically detect and rename any shared names before compilation, then map them back afterward.

--- a/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.test.ts
+++ b/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.test.ts
@@ -4,6 +4,68 @@ import {portableTextMemberSchemaTypesToSchema} from './portable-text-member-sche
 import {compileSchemaDefinitionToPortableTextMemberSchemaTypes} from './schema-definition-to-portable-text-member-schema-types'
 
 describe(compileSchemaDefinitionToPortableTextMemberSchemaTypes.name, () => {
+  test('handles type appearing in both blockObjects and inlineObjects', () => {
+    const schema: Schema = {
+      annotations: [],
+      block: {name: 'block'},
+      blockObjects: [
+        {
+          name: 'test',
+          fields: [{name: 'title', type: 'string', title: 'Title'}],
+          title: 'Test',
+        },
+      ],
+      decorators: [],
+      inlineObjects: [
+        {
+          name: 'test',
+          fields: [{name: 'title', type: 'string', title: 'Title'}],
+          title: 'Test',
+        },
+      ],
+      span: {name: 'span'},
+      styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+      lists: [],
+    }
+
+    expect(
+      portableTextMemberSchemaTypesToSchema(
+        compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+      ),
+    ).toEqual(schema)
+  })
+
+  test('back and forth with shared blockObject and inlineObject names', () => {
+    const schema: Schema = {
+      annotations: [],
+      block: {name: 'block'},
+      blockObjects: [
+        {
+          name: 'myObject',
+          fields: [{name: 'value', type: 'string', title: 'Value'}],
+          title: 'My Object',
+        },
+      ],
+      decorators: [{name: 'strong', title: 'Bold', value: 'strong'}],
+      inlineObjects: [
+        {
+          name: 'myObject',
+          fields: [{name: 'value', type: 'string', title: 'Value'}],
+          title: 'My Object',
+        },
+      ],
+      span: {name: 'span'},
+      styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+      lists: [],
+    }
+
+    expect(
+      portableTextMemberSchemaTypesToSchema(
+        compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+      ),
+    ).toEqual(schema)
+  })
+
   test("image object doesn't get Sanity-specific fields", () => {
     expect(
       compileSchemaDefinitionToPortableTextMemberSchemaTypes({

--- a/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.ts
+++ b/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.ts
@@ -14,35 +14,16 @@ import {
 } from './portable-text-member-schema-types'
 import {startCase} from './start-case'
 
-const temporaryImageBlockObjectName = `tmp-${keyGenerator()}-image`
-const temporaryUrlBlockObjectName = `tmp-${keyGenerator()}-url`
-const temporaryImageInlineObjectName = `tmp-${keyGenerator()}-image`
-const temporaryUrlInlineObjectName = `tmp-${keyGenerator()}-url`
-
-const temporaryBlockObjectNames: Record<string, string> = {
-  image: temporaryImageBlockObjectName,
-  url: temporaryUrlBlockObjectName,
-}
-
-const temporaryInlineObjectNames: Record<string, string> = {
-  image: temporaryImageInlineObjectName,
-  url: temporaryUrlInlineObjectName,
-}
-
-const blockObjectNames: Record<string, string> = {
-  [temporaryImageBlockObjectName]: 'image',
-  [temporaryUrlBlockObjectName]: 'url',
-}
-
-const inlineObjectNames: Record<string, string> = {
-  [temporaryImageInlineObjectName]: 'image',
-  [temporaryUrlInlineObjectName]: 'url',
-}
-
 const defaultObjectTitles: Record<string, string> = {
   image: 'Image',
   url: 'URL',
 }
+
+/**
+ * Names that conflict with Sanity's built-in schema types and need temporary
+ * names during `SanitySchema.compile` to avoid getting default fields added.
+ */
+const sanityBuiltinNames = new Set(['image', 'url'])
 
 /**
  * @public
@@ -52,49 +33,82 @@ const defaultObjectTitles: Record<string, string> = {
 export function compileSchemaDefinitionToPortableTextMemberSchemaTypes(
   definition?: SchemaDefinition,
 ): PortableTextMemberSchemaTypes {
-  const blockObjects =
-    definition?.blockObjects?.map((blockObject) =>
-      defineType({
-        type: 'object',
-        // Very naive way to work around `SanitySchema.compile` adding default
-        // fields to objects with certain names.
-        name: temporaryBlockObjectNames[blockObject.name] ?? blockObject.name,
-        title:
-          blockObject.title === undefined
-            ? // This avoids the default title which is a title case of the object name
-              defaultObjectTitles[blockObject.name]
-            : blockObject.title,
-        fields:
-          blockObject.fields?.map((field) => ({
-            name: field.name,
-            type: field.type,
-            title: field.title ?? startCase(field.name),
-          })) ?? [],
-      }),
-    ) ?? []
+  const blockObjectDefs = definition?.blockObjects ?? []
+  const inlineObjectDefs = definition?.inlineObjects ?? []
 
-  const inlineObjects =
-    definition?.inlineObjects?.map((inlineObject) =>
-      defineType({
-        type: 'object',
-        // Very naive way to work around `SanitySchema.compile` adding default
-        // fields to objects with certain names.
-        name:
-          temporaryInlineObjectNames[inlineObject.name] ?? inlineObject.name,
+  // Collect names that appear in both blockObjects and inlineObjects, or that
+  // conflict with Sanity built-in types. These need temporary names so that
+  // `SanitySchema.compile` doesn't see duplicate type registrations.
+  const blockObjectNameSet = new Set(
+    blockObjectDefs.map((blockObject) => blockObject.name),
+  )
+  const inlineObjectNameSet = new Set(
+    inlineObjectDefs.map((inlineObject) => inlineObject.name),
+  )
 
-        title:
-          inlineObject.title === undefined
-            ? // This avoids the default title which is a title case of the object name
-              defaultObjectTitles[inlineObject.name]
-            : inlineObject.title,
-        fields:
-          inlineObject.fields?.map((field) => ({
-            name: field.name,
-            type: field.type,
-            title: field.title ?? startCase(field.name),
-          })) ?? [],
-      }),
-    ) ?? []
+  const temporaryBlockObjectNames: Record<string, string> = {}
+  const temporaryInlineObjectNames: Record<string, string> = {}
+  const blockObjectNames: Record<string, string> = {}
+  const inlineObjectNames: Record<string, string> = {}
+
+  for (const name of blockObjectNameSet) {
+    if (sanityBuiltinNames.has(name) || inlineObjectNameSet.has(name)) {
+      const tmpName = `tmp-${keyGenerator()}-${name}`
+      temporaryBlockObjectNames[name] = tmpName
+      blockObjectNames[tmpName] = name
+    }
+  }
+
+  for (const name of inlineObjectNameSet) {
+    if (sanityBuiltinNames.has(name) || blockObjectNameSet.has(name)) {
+      const tmpName = `tmp-${keyGenerator()}-${name}`
+      temporaryInlineObjectNames[name] = tmpName
+      inlineObjectNames[tmpName] = name
+    }
+  }
+
+  const blockObjects = blockObjectDefs.map((blockObject) =>
+    defineType({
+      type: 'object',
+      // Use temporary names to work around `SanitySchema.compile` adding
+      // default fields to objects with certain names, and to avoid duplicate
+      // type names when a type appears in both blockObjects and inlineObjects.
+      name: temporaryBlockObjectNames[blockObject.name] ?? blockObject.name,
+      title:
+        blockObject.title === undefined
+          ? // This avoids the default title which is a title case of the object name
+            defaultObjectTitles[blockObject.name]
+          : blockObject.title,
+      fields:
+        blockObject.fields?.map((field) => ({
+          name: field.name,
+          type: field.type,
+          title: field.title ?? startCase(field.name),
+        })) ?? [],
+    }),
+  )
+
+  const inlineObjects = inlineObjectDefs.map((inlineObject) =>
+    defineType({
+      type: 'object',
+      // Use temporary names to work around `SanitySchema.compile` adding
+      // default fields to objects with certain names, and to avoid duplicate
+      // type names when a type appears in both blockObjects and inlineObjects.
+      name: temporaryInlineObjectNames[inlineObject.name] ?? inlineObject.name,
+
+      title:
+        inlineObject.title === undefined
+          ? // This avoids the default title which is a title case of the object name
+            defaultObjectTitles[inlineObject.name]
+          : inlineObject.title,
+      fields:
+        inlineObject.fields?.map((field) => ({
+          name: field.name,
+          type: field.type,
+          title: field.title ?? startCase(field.name),
+        })) ?? [],
+    }),
+  )
 
   const portableTextSchema = defineField({
     type: 'array',


### PR DESCRIPTION
## Problem

When a type name appears in both `blockObjects` and `inlineObjects` of a `SchemaDefinition`, `compileSchemaDefinitionToPortableTextMemberSchemaTypes()` passes duplicate type names to `SanitySchema.compile()`, causing:

```
Error: Duplicate type name added to schema: <name>
```

This happens in Studio when a Sanity schema has an object type used as both a block-level object and an inline object (e.g., `simpleBlock.tsx` in the test studio has `myStringType` named `'test'` used in both positions).

The round-trip path is:
1. Studio calls `sanitySchemaToPortableTextSchema(schemaType)` → returns `Schema` with separate `blockObjects` and `inlineObjects` arrays
2. `EditorProvider` receives this as `schemaDefinition` and calls `compileSchemaDefinitionToPortableTextMemberSchemaTypes()`
3. That function creates `defineType({name: 'test'})` for both the block object AND the inline object
4. Both get passed to `SanitySchema.compile({types: [...blockObjects, ...inlineObjects]})` → **duplicate name error**

## Fix

Generalized the existing temporary-name pattern (previously only handling `image` and `url` built-in names) to dynamically detect ANY name that appears in both `blockObjects` and `inlineObjects`. Shared names get unique temporary names (`tmp-<key>-<name>`) before `SanitySchema.compile()`, then are mapped back to their original names in the post-compilation fixup.

## Test cases

- **`handles type appearing in both blockObjects and inlineObjects`** — verifies a type named `'test'` in both positions compiles without error and produces correct output
- **`back and forth with shared blockObject and inlineObject names`** — verifies the full round-trip (`Schema` → `PortableTextMemberSchemaTypes` → `Schema`) preserves shared names correctly

## Related

- sanity-io/sanity#12181 — Studio PR that switches to `schemaDefinition` prop (blocked by this bug)
- #2136 — removes `@sanity/*` deps from editor