### PR TITLE
fix: harden sanity-bridge against built-in name collisions and fix inline object type.name

### DIFF
--- a/.changeset/sanity-bridge-robustness.md
+++ b/.changeset/sanity-bridge-robustness.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/sanity-bridge': patch
+---
+
+fix: harden schema compilation against built-in name collisions and restore inline object type names
+
+Adds `file`, `slug`, and `geopoint` to the set of Sanity built-in names that need temporary names during `SanitySchema.compile()`. Without this, schemas using these names as block or inline objects get extra fields injected by the Sanity schema compiler.
+
+Fixes inline object `type.name` restoration for shared and built-in names. Previously only `inlineObject.name` was restored from the temporary name, leaving `inlineObject.type.name` with the `tmp-` prefix.
+
+Simplifies the name restoration pass to mutate shared references directly instead of mapping over `portableText.of` separately.

--- a/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.test.ts
+++ b/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.test.ts
@@ -442,4 +442,670 @@ describe(compileSchemaDefinitionToPortableTextMemberSchemaTypes.name, () => {
       ),
     ).toEqual(schema)
   })
+
+  // --- Built-in name collision tests ---
+
+  describe('built-in name collisions', () => {
+    test("file blockObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'file'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'file', fields: []}])
+    })
+
+    test('file blockObject with custom fields preserves them', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'file', fields: [{name: 'url', type: 'string'}]}],
+      })
+      expect(result.blockObjects).toMatchObject([
+        {
+          name: 'file',
+          fields: [{name: 'url', type: {jsonType: 'string'}}],
+        },
+      ])
+    })
+
+    test("slug blockObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'slug'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'slug', fields: []}])
+    })
+
+    test("geopoint blockObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'geopoint'}],
+      })
+      expect(result.blockObjects).toMatchObject([
+        {name: 'geopoint', fields: []},
+      ])
+    })
+
+    test("url blockObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'url'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'url', fields: []}])
+    })
+
+    test("image inlineObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'image'}],
+      })
+      expect(result.inlineObjects).toMatchObject([{name: 'image', fields: []}])
+    })
+
+    test("file inlineObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'file'}],
+      })
+      expect(result.inlineObjects).toMatchObject([{name: 'file', fields: []}])
+    })
+
+    test("slug inlineObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'slug'}],
+      })
+      expect(result.inlineObjects).toMatchObject([{name: 'slug', fields: []}])
+    })
+
+    test("geopoint inlineObject doesn't get Sanity-specific fields", () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'geopoint'}],
+      })
+      expect(result.inlineObjects).toMatchObject([
+        {name: 'geopoint', fields: []},
+      ])
+    })
+
+    test('built-in name as both blockObject and inlineObject', () => {
+      const schema: Schema = {
+        annotations: [],
+        block: {name: 'block'},
+        blockObjects: [{name: 'image', fields: [], title: 'Image'}],
+        decorators: [],
+        inlineObjects: [{name: 'image', fields: [], title: 'Image'}],
+        span: {name: 'span'},
+        styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+        lists: [],
+      }
+
+      expect(
+        portableTextMemberSchemaTypesToSchema(
+          compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+        ),
+      ).toEqual(schema)
+    })
+
+    test('multiple built-in names in the same schema', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+          {name: 'file', fields: [{name: 'url', type: 'string'}]},
+        ],
+        inlineObjects: [
+          {name: 'slug', fields: [{name: 'current', type: 'string'}]},
+          {name: 'geopoint', fields: [{name: 'lat', type: 'number'}]},
+        ],
+      })
+
+      expect(result.blockObjects).toMatchObject([
+        {name: 'image', fields: [{name: 'src'}]},
+        {name: 'file', fields: [{name: 'url'}]},
+      ])
+      expect(result.inlineObjects).toMatchObject([
+        {name: 'slug', fields: [{name: 'current'}]},
+        {name: 'geopoint', fields: [{name: 'lat'}]},
+      ])
+    })
+  })
+
+  // --- Inline object type.name restoration ---
+
+  describe('inline object type.name restoration', () => {
+    test('shared name: inlineObject.type.name is restored', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'widget'}],
+        inlineObjects: [{name: 'widget'}],
+      })
+
+      for (const inlineObject of result.inlineObjects) {
+        if (inlineObject.name === 'widget') {
+          expect(inlineObject.type?.name).toBe('widget')
+        }
+      }
+    })
+
+    test('built-in name: inlineObject.type.name is restored', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'image'}],
+      })
+
+      for (const inlineObject of result.inlineObjects) {
+        if (inlineObject.name === 'image') {
+          expect(inlineObject.type?.name).toBe('image')
+        }
+      }
+    })
+
+    test('blockObject.type.name is restored for shared names', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'widget'}],
+        inlineObjects: [{name: 'widget'}],
+      })
+
+      for (const blockObject of result.blockObjects) {
+        if (blockObject.name === 'widget') {
+          expect(blockObject.type?.name).toBe('widget')
+        }
+      }
+    })
+  })
+
+  // --- Minimal schemas ---
+
+  describe('minimal schemas', () => {
+    test('empty definition compiles without error', () => {
+      expect(() =>
+        compileSchemaDefinitionToPortableTextMemberSchemaTypes(undefined),
+      ).not.toThrow()
+    })
+
+    test('empty object definition compiles without error', () => {
+      expect(() =>
+        compileSchemaDefinitionToPortableTextMemberSchemaTypes({}),
+      ).not.toThrow()
+    })
+
+    test('minimal schema with only styles', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        styles: [{name: 'normal', title: 'Normal'}],
+      })
+      expect(result.styles).toMatchObject([{value: 'normal'}])
+      expect(result.blockObjects).toEqual([])
+      expect(result.inlineObjects).toEqual([])
+    })
+
+    test('schema with no decorators', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        decorators: [],
+      })
+      expect(result.decorators).toEqual([])
+    })
+
+    test('schema with no annotations', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        annotations: [],
+      })
+      expect(result.annotations).toEqual([])
+    })
+
+    test('schema with no lists', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        lists: [],
+      })
+      expect(result.lists).toEqual([])
+    })
+
+    test('schema with only blockObjects', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'divider'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'divider'}])
+      expect(result.inlineObjects).toEqual([])
+    })
+
+    test('schema with only inlineObjects', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'emoji'}],
+      })
+      expect(result.inlineObjects).toMatchObject([{name: 'emoji'}])
+      expect(result.blockObjects).toEqual([])
+    })
+  })
+
+  // --- Annotations ---
+
+  describe('annotations', () => {
+    test('annotation with no fields', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        annotations: [{name: 'highlight'}],
+      })
+      expect(result.annotations).toMatchObject([
+        {name: 'highlight', fields: []},
+      ])
+    })
+
+    test('annotation with multiple fields', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        annotations: [
+          {
+            name: 'link',
+            fields: [
+              {name: 'href', type: 'string'},
+              {name: 'target', type: 'string'},
+            ],
+          },
+        ],
+      })
+      expect(result.annotations).toMatchObject([
+        {
+          name: 'link',
+          fields: [
+            {name: 'href', type: {jsonType: 'string'}},
+            {name: 'target', type: {jsonType: 'string'}},
+          ],
+        },
+      ])
+    })
+
+    test('multiple annotations', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        annotations: [
+          {name: 'link', fields: [{name: 'href', type: 'string'}]},
+          {name: 'comment', fields: [{name: 'id', type: 'string'}]},
+          {name: 'highlight'},
+        ],
+      })
+      expect(result.annotations).toHaveLength(3)
+      expect(result.annotations.map((a) => a.name)).toEqual([
+        'link',
+        'comment',
+        'highlight',
+      ])
+    })
+  })
+
+  // --- Title inference ---
+
+  describe('title inference', () => {
+    test('blockObject without title gets startCase title', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'myCustomBlock'}],
+      })
+      expect(result.blockObjects).toMatchObject([
+        {name: 'myCustomBlock', title: 'My Custom Block'},
+      ])
+    })
+
+    test('inlineObject without title gets startCase title', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects: [{name: 'inlineEmoji'}],
+      })
+      expect(result.inlineObjects).toMatchObject([
+        {name: 'inlineEmoji', title: 'Inline Emoji'},
+      ])
+    })
+
+    test('image blockObject without title gets "Image"', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'image'}],
+      })
+      expect(result.blockObjects).toMatchObject([
+        {name: 'image', title: 'Image'},
+      ])
+    })
+
+    test('url blockObject without title gets "URL"', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'url'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'url', title: 'URL'}])
+    })
+
+    test('explicit title overrides default', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'image', title: 'Photo'}],
+      })
+      expect(result.blockObjects).toMatchObject([
+        {name: 'image', title: 'Photo'},
+      ])
+    })
+
+    test('decorator without title gets startCase title', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        decorators: [{name: 'strike-through'}],
+      })
+      expect(result.decorators).toMatchObject([
+        {value: 'strike-through', title: 'Strike Through'},
+      ])
+    })
+
+    test('style without title gets startCase title', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        styles: [{name: 'normal'}, {name: 'blockquote'}],
+      })
+      expect(result.styles).toMatchObject(
+        expect.arrayContaining([
+          expect.objectContaining({
+            value: 'blockquote',
+            title: 'Blockquote',
+          }),
+        ]),
+      )
+    })
+
+    test('list without title gets startCase title', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        lists: [{name: 'bullet'}],
+      })
+      expect(result.lists).toMatchObject([{value: 'bullet', title: 'Bullet'}])
+    })
+  })
+
+  // --- Round-trip tests ---
+
+  describe('round-trip (schema -> compile -> convert back)', () => {
+    test('minimal schema round-trips', () => {
+      const schema: Schema = {
+        annotations: [],
+        block: {name: 'block'},
+        blockObjects: [],
+        decorators: [],
+        inlineObjects: [],
+        span: {name: 'span'},
+        styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+        lists: [],
+      }
+
+      expect(
+        portableTextMemberSchemaTypesToSchema(
+          compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+        ),
+      ).toEqual(schema)
+    })
+
+    test('schema with all feature types round-trips', () => {
+      const schema: Schema = {
+        annotations: [
+          {
+            name: 'link',
+            fields: [{name: 'href', type: 'string', title: 'URL'}],
+            title: 'Link',
+          },
+        ],
+        block: {name: 'block'},
+        blockObjects: [
+          {
+            name: 'divider',
+            fields: [{name: 'style', type: 'string', title: 'Style'}],
+            title: 'Divider',
+          },
+        ],
+        decorators: [
+          {name: 'strong', title: 'Bold', value: 'strong'},
+          {name: 'em', title: 'Italic', value: 'em'},
+        ],
+        inlineObjects: [
+          {
+            name: 'emoji',
+            fields: [{name: 'code', type: 'string', title: 'Code'}],
+            title: 'Emoji',
+          },
+        ],
+        span: {name: 'span'},
+        styles: [
+          {name: 'normal', title: 'Normal', value: 'normal'},
+          {name: 'h1', title: 'Heading 1', value: 'h1'},
+        ],
+        lists: [
+          {name: 'bullet', title: 'Bullet', value: 'bullet'},
+          {name: 'number', title: 'Number', value: 'number'},
+        ],
+      }
+
+      expect(
+        portableTextMemberSchemaTypesToSchema(
+          compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+        ),
+      ).toEqual(schema)
+    })
+
+    test('schema with built-in names round-trips', () => {
+      const schema: Schema = {
+        annotations: [],
+        block: {name: 'block'},
+        blockObjects: [
+          {name: 'image', fields: [], title: 'Image'},
+          {name: 'file', fields: [], title: 'File'},
+        ],
+        decorators: [],
+        inlineObjects: [
+          {name: 'slug', fields: [], title: 'Slug'},
+          {name: 'geopoint', fields: [], title: 'Geopoint'},
+        ],
+        span: {name: 'span'},
+        styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+        lists: [],
+      }
+
+      expect(
+        portableTextMemberSchemaTypesToSchema(
+          compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+        ),
+      ).toEqual(schema)
+    })
+
+    test('schema with shared names and built-in names round-trips', () => {
+      const schema: Schema = {
+        annotations: [],
+        block: {name: 'block'},
+        blockObjects: [
+          {name: 'image', fields: [], title: 'Image'},
+          {
+            name: 'widget',
+            fields: [{name: 'id', type: 'string', title: 'Id'}],
+            title: 'Widget',
+          },
+        ],
+        decorators: [],
+        inlineObjects: [
+          {name: 'image', fields: [], title: 'Image'},
+          {
+            name: 'widget',
+            fields: [{name: 'id', type: 'string', title: 'Id'}],
+            title: 'Widget',
+          },
+        ],
+        span: {name: 'span'},
+        styles: [{name: 'normal', title: 'Normal', value: 'normal'}],
+        lists: [],
+      }
+
+      expect(
+        portableTextMemberSchemaTypesToSchema(
+          compileSchemaDefinitionToPortableTextMemberSchemaTypes(schema),
+        ),
+      ).toEqual(schema)
+    })
+  })
+
+  // --- Stress tests ---
+
+  describe('stress tests', () => {
+    test('many blockObjects', () => {
+      const blockObjects = Array.from({length: 20}, (_, i) => ({
+        name: `blockType${i}`,
+        fields: [{name: 'value', type: 'string' as const}],
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects,
+      })
+
+      expect(result.blockObjects).toHaveLength(20)
+      for (let i = 0; i < 20; i++) {
+        expect(result.blockObjects[i]!.name).toBe(`blockType${i}`)
+      }
+    })
+
+    test('many inlineObjects', () => {
+      const inlineObjects = Array.from({length: 20}, (_, i) => ({
+        name: `inlineType${i}`,
+        fields: [{name: 'value', type: 'string' as const}],
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        inlineObjects,
+      })
+
+      expect(result.inlineObjects).toHaveLength(20)
+      for (let i = 0; i < 20; i++) {
+        expect(result.inlineObjects[i]!.name).toBe(`inlineType${i}`)
+      }
+    })
+
+    test('many decorators', () => {
+      const decorators = Array.from({length: 10}, (_, i) => ({
+        name: `decorator${i}`,
+        title: `Decorator ${i}`,
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        decorators,
+      })
+
+      expect(result.decorators).toHaveLength(10)
+    })
+
+    test('many annotations', () => {
+      const annotations = Array.from({length: 10}, (_, i) => ({
+        name: `annotation${i}`,
+        fields: [{name: 'value', type: 'string' as const}],
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        annotations,
+      })
+
+      expect(result.annotations).toHaveLength(10)
+    })
+
+    test('many styles', () => {
+      const styles = [
+        {name: 'normal', title: 'Normal'},
+        ...Array.from({length: 9}, (_, i) => ({
+          name: `style${i}`,
+          title: `Style ${i}`,
+        })),
+      ]
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        styles,
+      })
+
+      expect(result.styles).toHaveLength(10)
+    })
+
+    test('many lists', () => {
+      const lists = Array.from({length: 5}, (_, i) => ({
+        name: `list${i}`,
+        title: `List ${i}`,
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        lists,
+      })
+
+      expect(result.lists).toHaveLength(5)
+    })
+
+    test('many shared names between blockObjects and inlineObjects', () => {
+      const names = Array.from({length: 10}, (_, i) => `shared${i}`)
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: names.map((name) => ({
+          name,
+          fields: [{name: 'value', type: 'string' as const}],
+        })),
+        inlineObjects: names.map((name) => ({
+          name,
+          fields: [{name: 'value', type: 'string' as const}],
+        })),
+      })
+
+      expect(result.blockObjects).toHaveLength(10)
+      expect(result.inlineObjects).toHaveLength(10)
+
+      for (const name of names) {
+        expect(result.blockObjects.find((bo) => bo.name === name)).toBeDefined()
+        expect(
+          result.inlineObjects.find((io) => io.name === name),
+        ).toBeDefined()
+      }
+    })
+  })
+
+  // --- Field handling ---
+
+  describe('field handling', () => {
+    test('object with no fields', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'divider'}],
+      })
+      expect(result.blockObjects).toMatchObject([{name: 'divider', fields: []}])
+    })
+
+    test('object with many fields', () => {
+      const fields = Array.from({length: 10}, (_, i) => ({
+        name: `field${i}`,
+        type: 'string' as const,
+      }))
+
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'complex', fields}],
+      })
+
+      expect(result.blockObjects[0]!.fields).toHaveLength(10)
+    })
+
+    test('field title defaults to startCase of field name', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [
+          {name: 'test', fields: [{name: 'myFieldName', type: 'string'}]},
+        ],
+      })
+
+      expect(result.blockObjects[0]!.fields[0]!.type.title).toBe(
+        'My Field Name',
+      )
+    })
+
+    test('explicit field title is preserved', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [
+          {
+            name: 'test',
+            fields: [{name: 'myField', type: 'string', title: 'Custom Title'}],
+          },
+        ],
+      })
+
+      expect(result.blockObjects[0]!.fields[0]!.type.title).toBe('Custom Title')
+    })
+  })
+
+  // --- Sanity schema path (portableText array type) ---
+
+  describe('Sanity schema path', () => {
+    test('portableText array type is created correctly', () => {
+      const result = compileSchemaDefinitionToPortableTextMemberSchemaTypes({
+        blockObjects: [{name: 'divider'}],
+        inlineObjects: [{name: 'emoji'}],
+        decorators: [{name: 'strong'}],
+        styles: [{name: 'normal'}],
+        lists: [{name: 'bullet'}],
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      })
+
+      // The portableText field should be an array type
+      expect(result.portableText.jsonType).toBe('array')
+
+      // Block type should be present
+      expect(result.block.name).toBe('block')
+
+      // Span type should be present
+      expect(result.span.name).toBe('span')
+    })
+  })
 })

--- a/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.ts
+++ b/packages/sanity-bridge/src/schema-definition-to-portable-text-member-schema-types.ts
@@ -1,12 +1,6 @@
 import type {SchemaDefinition} from '@portabletext/schema'
 import {Schema as SanitySchema} from '@sanity/schema'
-import {
-  defineField,
-  defineType,
-  isArraySchemaType,
-  isObjectSchemaType,
-  type ObjectSchemaType,
-} from '@sanity/types'
+import {defineField, defineType} from '@sanity/types'
 import {keyGenerator} from './key-generator'
 import {
   createPortableTextMemberSchemaTypes,
@@ -23,7 +17,7 @@ const defaultObjectTitles: Record<string, string> = {
  * Names that conflict with Sanity's built-in schema types and need temporary
  * names during `SanitySchema.compile` to avoid getting default fields added.
  */
-const sanityBuiltinNames = new Set(['image', 'url'])
+const sanityBuiltinNames = new Set(['file', 'geopoint', 'image', 'slug', 'url'])
 
 /**
  * @public
@@ -158,57 +152,28 @@ export function compileSchemaDefinitionToPortableTextMemberSchemaTypes(
 
   const pteSchema = createPortableTextMemberSchemaTypes(schema)
 
-  return {
-    ...pteSchema,
-    portableText: {
-      ...pteSchema.portableText,
-      of: pteSchema.portableText.of.map((schemaType) => {
-        if (!isObjectSchemaType(schemaType)) {
-          return schemaType
-        }
+  // Restore original names on blockObjects and inlineObjects.
+  // These are shared references with portableText.of, so mutating them
+  // also restores names in the portableText array type's nested structure.
+  for (const blockObject of pteSchema.blockObjects) {
+    const originalName = blockObjectNames[blockObject.name]
+    if (originalName !== undefined) {
+      blockObject.name = originalName
+      if (blockObject.type) {
+        blockObject.type = {...blockObject.type, name: originalName}
+      }
+    }
+  }
 
-        const nameMapping = blockObjectNames[schemaType.name]
+  for (const inlineObject of pteSchema.inlineObjects) {
+    const originalName = inlineObjectNames[inlineObject.name]
+    if (originalName !== undefined) {
+      inlineObject.name = originalName
+      if (inlineObject.type) {
+        inlineObject.type = {...inlineObject.type, name: originalName}
+      }
+    }
+  }
 
-        schemaType.name = nameMapping ?? schemaType.name
-
-        for (const field of schemaType.fields) {
-          if (field.name !== 'children' || !isArraySchemaType(field.type)) {
-            continue
-          }
-
-          for (const ofSchemaType of field.type.of) {
-            const nameMapping = inlineObjectNames[ofSchemaType.name]
-
-            if (!nameMapping) {
-              continue
-            }
-
-            ofSchemaType.name = nameMapping
-          }
-        }
-
-        return schemaType
-      }),
-    },
-    blockObjects: pteSchema.blockObjects.map((blockObject) =>
-      blockObjectNames[blockObject.name] !== undefined
-        ? ({
-            ...blockObject,
-            name: blockObjectNames[blockObject.name],
-            type: {
-              ...blockObject.type,
-              name: blockObjectNames[blockObject.name],
-            },
-          } as ObjectSchemaType)
-        : blockObject,
-    ),
-    inlineObjects: pteSchema.inlineObjects.map((inlineObject) =>
-      inlineObjectNames[inlineObject.name] !== undefined
-        ? ({
-            ...inlineObject,
-            name: inlineObjectNames[inlineObject.name],
-          } as ObjectSchemaType)
-        : inlineObject,
-    ),
-  } satisfies PortableTextMemberSchemaTypes
+  return pteSchema
 }


### PR DESCRIPTION
## Summary

Two bug fixes and 49 regression tests for `@portabletext/sanity-bridge`.

### Add `file`, `slug`, and `geopoint` to built-in name guards

`sanityBuiltinNames` only guarded `image` and `url`. When schemas use `file`, `slug`, or `geopoint` as block or inline object names, `SanitySchema.compile()` injects extra fields (like `asset` on `file`, `current` on `slug`, `lat`/`lng`/`alt` on `geopoint`). These phantom fields break the schema round-trip.

**Fix:** Add `file`, `slug`, and `geopoint` to the set.

### Restore `inlineObject.type.name` in name-mapping pass

The name restoration pass restored `blockObject.name` AND `blockObject.type.name`, but only restored `inlineObject.name`, leaving `inlineObject.type.name` with the `tmp-` prefix. This affects any inline object that shares a name with a block object or uses a built-in name.

**Fix:** Restore `inlineObject.type.name` alongside `inlineObject.name`.

### Simplified name restoration

The old code had a `portableText.of` mapping pass that mutated shared references, followed by separate `blockObjects` and `inlineObjects` mapping passes. Because the objects are shared references, the mutation in `portableText.of` would change names before the later passes could look them up, causing the `blockObjects`/`inlineObjects` conditions to silently fail.

The new code restores names directly on `blockObjects` and `inlineObjects` first. Since these are shared references with `portableText.of`, the names propagate automatically. This removes the `portableText.of` mapping pass entirely and eliminates the mutation-ordering bug.

### Test coverage (49 new tests)

- **Built-in name collisions** (12 tests): `file`, `slug`, `geopoint`, `url`, `image` as block objects, inline objects, and combinations
- **Inline object type.name restoration** (3 tests): shared names, built-in names, block object type.name
- **Minimal schemas** (7 tests): undefined, empty, single feature type
- **Annotations** (3 tests): no fields, multiple fields, multiple annotations
- **Title inference** (8 tests): startCase defaults, explicit overrides, built-in defaults
- **Round-trips** (4 tests): minimal, full-featured, built-in names, mixed shared + built-in
- **Stress tests** (7 tests): 20 block objects, 20 inline objects, 10 shared names, many of each feature type
- **Field handling** (4 tests): no fields, many fields, title defaults, explicit titles
- **Sanity schema path** (1 test): portableText array type structure
