### PR TITLE
test: stabilize undo-redo collaboration test in Firefox

### DIFF
--- a/packages/editor/tests/undo-redo-collaboration.test.tsx
+++ b/packages/editor/tests/undo-redo-collaboration.test.tsx
@@ -351,7 +351,7 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
       expect(editorB.getSnapshot().context.selection).toEqual(selectionB)
     })
 
-    await userEvent.type(locatorB, middle)
+    editorB.send({type: 'insert.text', text: middle})
 
     await vi.waitFor(() => {
       expect(getTersePt(editor.getSnapshot().context)).toEqual([


### PR DESCRIPTION
## Problem

The `editor A undo their change after B did an unrelated change (single-line, emoji)` test in `undo-redo-collaboration.test.tsx` fails consistently in Firefox. The test types 70 characters via `userEvent.type(locatorB, middle)`, which dispatches keyboard events one at a time through Playwright's `page.keyboard` API. In Firefox, this is slow and prone to focus races when two editors share the same page, causing keystrokes to land on the wrong editor and corrupt state.

The corruption pattern varies between runs (`"magiclyal"` instead of `"magical"`, partial `middle` text appearing at the end), confirming a timing-dependent focus race.

## Fix

Replace `userEvent.type(locatorB, middle)` with `editorB.send({type: 'insert.text', text: middle})`. This inserts text programmatically, bypassing the browser's keyboard event pipeline entirely.

The test verifies collaborative undo behavior (editor A can undo its deletion after editor B inserts text). The mechanism of text insertion on editor B is not what's being tested, so using `editor.send` is equivalent.

## Context

This is the highest-frequency Firefox flake across our active PRs, hitting almost every Firefox CI run. The other tests in the same file pass because they type much shorter strings (3-11 chars vs 70 chars).