### PR TITLE
test: fix flaky Firefox decorator block split test

### DIFF
--- a/packages/editor/gherkin-spec/decorators.feature
+++ b/packages/editor/gherkin-spec/decorators.feature
@@ -223,7 +223,7 @@ Feature: Decorators
     And the caret is put before "foo"
     And "{Enter}" is pressed
     And "{ArrowUp}" is pressed
-    And "bar" is typed
+    And "bar" is inserted
     Then the text is "bar|foo"
     And "bar" has marks "strong"
     And "foo" has marks "strong"


### PR DESCRIPTION
## Problem

The 'Splitting block before decorator' scenario in `gherkin-spec/decorators.feature` (line 219) was flaky in Firefox CI. Expected `['bar', 'foo']` but got `['', 'barfoo']`.

## Root Cause

After pressing Enter to split a block and ArrowUp to navigate to the new empty block, `userEvent.type()` dispatches character-by-character keyboard events. In Firefox, the DOM selection may not have fully settled after ArrowUp, causing keystrokes to land in the wrong block.

## Fix

Replace `"bar" is typed` with `"bar" is inserted` to use `editor.send({type: 'insert.text', text})` for the text insertion. The test verifies block splitting and decorator preservation, not keyboard input behavior, so programmatic insertion is semantically equivalent.

This follows the same pattern as PR #2208 and commit 3892471e.