### PR TITLE
test: widen debounce window in typeahead picker tests for Firefox

### DIFF
--- a/packages/plugin-typeahead-picker/src/mention-picker.test.tsx
+++ b/packages/plugin-typeahead-picker/src/mention-picker.test.tsx
@@ -418,11 +418,13 @@ describe('Debouncing', () => {
     const callTimestamps: number[] = []
     const startTime = Date.now()
 
+    // Use a large debounce window so that even Firefox's slower
+    // character-by-character userEvent.type stays within a single window.
     const debouncedPicker = defineTypeaheadPicker<MentionMatch>({
       mode: 'async',
       trigger: /@/,
       keyword: /\w*/,
-      debounceMs: 300,
+      debounceMs: 1000,
       getMatches: async ({keyword}) => {
         callCount++
         callTimestamps.push(Date.now() - startTime)
@@ -473,14 +475,14 @@ describe('Debouncing', () => {
     })
 
     // Wait for debounce + fetch time
-    await new Promise((resolve) => setTimeout(resolve, 400))
+    await new Promise((resolve) => setTimeout(resolve, 1200))
 
     // Should have results for the final keyword
     await vi.waitFor(() => {
       expect(matchesLocator.element().textContent).toEqual('Result for abc')
     })
 
-    // With 300ms debouncing, rapid typing should result in fewer calls
+    // With 1000ms debouncing, rapid typing should result in fewer calls
     // than the 3 characters typed (a, ab, abc)
     expect(callCount).toBeLessThan(3)
   })

--- a/packages/plugin-typeahead-picker/src/typeahead-picker.test.tsx
+++ b/packages/plugin-typeahead-picker/src/typeahead-picker.test.tsx
@@ -306,10 +306,12 @@ describe('Sync mode debouncing', () => {
   test('delays getMatches calls when debounceMs is configured in sync mode', async () => {
     let callCount = 0
 
+    // Use a large debounce window so that even Firefox's slower
+    // character-by-character userEvent.type stays within a single window.
     const debouncedSyncPicker = defineTypeaheadPicker<SyncMatch>({
       trigger: /:/,
       keyword: /\w*/,
-      debounceMs: 300,
+      debounceMs: 1000,
       getMatches: ({keyword}) => {
         callCount++
         return [{key: '1', name: `Result for ${keyword}`}]
@@ -359,14 +361,14 @@ describe('Sync mode debouncing', () => {
     })
 
     // Wait for debounce time
-    await new Promise((resolve) => setTimeout(resolve, 400))
+    await new Promise((resolve) => setTimeout(resolve, 1200))
 
     // Should have results for the final keyword
     await vi.waitFor(() => {
       expect(matchesLocator.element().textContent).toEqual('Result for abc')
     })
 
-    // With 300ms debouncing, rapid typing should result in fewer calls
+    // With 1000ms debouncing, rapid typing should result in fewer calls
     // than the 3 characters typed (a, ab, abc)
     expect(callCount).toBeLessThan(3)
   })


### PR DESCRIPTION
## Problem

The debounce tests in `typeahead-picker.test.tsx` (sync mode) and `mention-picker.test.tsx` (async mode) were flaky in Firefox CI. The assertion `expect(callCount).toBeLessThan(3)` would fail because Firefox's slower `userEvent.type` could space characters >300ms apart, exceeding the debounce window and triggering separate `getMatches` calls for each keystroke.

## Fix

Increase `debounceMs` from 300 to 1000 and the corresponding wait timeout from 400 to 1200. This gives Firefox ample margin while still testing the core debounce behavior: rapid typing should coalesce into fewer `getMatches` calls than characters typed.