### PR TITLE
test: fix flaky WebKit emoji picker consecutive keywords test

### DIFF
--- a/packages/plugin-typeahead-picker/src/emoji-picker.feature
+++ b/packages/plugin-typeahead-picker/src/emoji-picker.feature
@@ -109,7 +109,7 @@ Feature: Emoji Picker
   Scenario: Two consecutive direct hits
     When the editor is focused
     And ":joy:" is typed
-    And ":joy_cat:" is typed
+    And ":joy_cat:" is inserted
     Then the text is "😂😹"
 
   Scenario: Picking the closest hit with Enter


### PR DESCRIPTION
## Problem

The 'Two consecutive direct hits' scenario in `emoji-picker.feature` was flaky in WebKit CI. After the first `:joy:` auto-completes to 😂, the DOM mutation and cursor repositioning may not have settled before `userEvent.type` starts dispatching character-by-character events for `:joy_cat:`.

## Fix

Replace `"is typed"` with `"is inserted"` for the second keyword to use `editor.send({type: 'insert.text', text})` instead of `userEvent.type`. The test verifies consecutive auto-completions, not keyboard input, so programmatic insertion is semantically equivalent.