### PR TITLE
test: fix flaky Firefox focus empty editor test

### DIFF
--- a/packages/editor/tests/focus.test.tsx
+++ b/packages/editor/tests/focus.test.tsx
@@ -28,21 +28,22 @@ describe('focus', () => {
       ),
     })
 
+    const expectedSelection = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      backward: false,
+    }
+
     const toolbarLocator = page.getByTestId('toolbar')
     await vi.waitFor(() => expect.element(toolbarLocator).toBeInTheDocument())
 
     await userEvent.click(locator)
 
+    // Wait for both focus and selection to settle.
+    // Firefox can be slow to process focus on empty contenteditable elements.
     await vi.waitFor(() => {
       expect(focusEvents.at(-1)).toEqual('focused')
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-        backward: false,
-      })
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
     })
 
     await userEvent.click(toolbarLocator)
@@ -55,14 +56,7 @@ describe('focus', () => {
 
     await vi.waitFor(() => {
       expect(focusEvents.at(-1)).toEqual('focused')
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-        backward: false,
-      })
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
     })
   })
 


### PR DESCRIPTION
## Problem

The 'Focusing on an empty editor' test in `focus.test.tsx` was flaky in Firefox CI. After clicking the editor, the focus event and selection could settle at different rates.

## Root Cause

The focus event assertion and selection assertion were in separate `vi.waitFor` blocks. The focus assertion could pass on a transient state (Firefox fires focus before the selection is fully set), and then the selection assertion would start polling from that point — but if the selection was briefly in an intermediate state, the assertion could fail.

## Fix

Combine focus event and selection assertions into a single `vi.waitFor` block so both conditions must be true simultaneously before the test proceeds. This eliminates the race between focus and selection settling in Firefox's slower contenteditable pipeline.