### PR TITLE
fix: give core behaviors unique priority IDs to preserve order through re-sorts

### DIFF
--- a/.changeset/fix-core-behavior-sort-stability.md
+++ b/.changeset/fix-core-behavior-sort-stability.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: give core behaviors unique priority IDs to preserve order through re-sorts

--- a/packages/editor/src/behaviors/behavior.core.ts
+++ b/packages/editor/src/behaviors/behavior.core.ts
@@ -1,4 +1,5 @@
 import {corePriority} from '../priority/priority.core'
+import {createEditorPriority} from '../priority/priority.types'
 import {coreAnnotationBehaviors} from './behavior.core.annotations'
 import {coreBlockObjectBehaviors} from './behavior.core.block-objects'
 import {coreDecoratorBehaviors} from './behavior.core.decorators'
@@ -7,7 +8,7 @@ import {coreInsertBehaviors} from './behavior.core.insert'
 import {coreInsertBreakBehaviors} from './behavior.core.insert-break'
 import {coreListBehaviors} from './behavior.core.lists'
 
-export const coreBehaviorsConfig = [
+const coreBehaviors = [
   ...coreAnnotationBehaviors,
   coreDecoratorBehaviors.strongShortcut,
   coreDecoratorBehaviors.emShortcut,
@@ -37,7 +38,27 @@ export const coreBehaviorsConfig = [
   coreInsertBreakBehaviors.breakingAtTheStartOfTextBlock,
   coreInsertBreakBehaviors.breakingEntireBlocks,
   coreInsertBreakBehaviors.breakingInlineObject,
-].map((behavior) => ({
-  behavior,
-  priority: corePriority,
-}))
+]
+
+// Each core behavior gets a unique priority chained to the previous one.
+// This preserves their declaration order through re-sorts triggered by
+// custom behavior registration/unregistration.
+let previousPriority = corePriority
+const coreBehaviorsConfigArray: Array<{
+  behavior: (typeof coreBehaviors)[number]
+  priority: ReturnType<typeof createEditorPriority>
+}> = []
+
+for (const behavior of coreBehaviors) {
+  const priority = createEditorPriority({
+    name: 'core',
+    reference: {
+      priority: previousPriority,
+      importance: 'lower',
+    },
+  })
+  coreBehaviorsConfigArray.push({behavior, priority})
+  previousPriority = priority
+}
+
+export const coreBehaviorsConfig = coreBehaviorsConfigArray

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
@@ -99,6 +99,19 @@ Feature: Markdown Behaviors
       | "h5"  |
       | "h6"  |
 
+  Scenario: Unordered list clear-on-enter works on second cycle
+    Given the text "-"
+    When the editor is focused
+    And "{Space}" is pressed
+    Then the text is ">-:"
+    When "{Enter}" is pressed
+    Then the text is ""
+    When "-" is typed
+    And "{Space}" is pressed
+    Then the text is ">-:"
+    When "{Enter}" is pressed
+    Then the text is ""
+
   Scenario Outline: Clear style on Backspace in empty block
     Given the text "foo"
     When the editor is focused


### PR DESCRIPTION
## Problem

All core behaviors shared a single `corePriority` object (same `priority.id`). The `sortByPriority` function builds a `Map` keyed by `priority.id`, so only one core behavior gets placed by the topological sort. The rest are appended as "remaining items" in Set iteration order.

This works on initial load (Set order matches declaration order). But when the input rule machine adds or removes its `delete.backward` behavior, it sets `behaviorsSorted = false`, triggering a re-sort. The re-sort scrambles core behavior order because the Map dedup loses their relative positions.

Concretely: pressing Enter on an empty list item should clear the list (via `clearListOnEnter`). On the second cycle (type `- `, Enter, Enter), `breakingAtTheStartOfTextBlock` ends up sorted before `clearListOnEnter` and matches first (empty block = cursor at start), creating a new list item instead of clearing.

## Fix

Each core behavior now gets its own unique priority ID, chained to the previous one via `reference.importance: 'lower'`. This creates a total order that the topological sort preserves through re-sorts.

Custom behaviors still reference `corePriority` with `importance: 'higher'`, so they continue to run before all core behaviors.

## Test

Added a regression test in `behavior.markdown.feature` that reproduces the second-cycle failure: type `- ` to trigger a bullet list, press Enter twice. The first Enter splits the empty list item, the second Enter should clear the list.