### PR TITLE
test: fix flaky Firefox insert break tests

### DIFF
--- a/packages/editor/gherkin-spec/insert.break.feature
+++ b/packages/editor/gherkin-spec/insert.break.feature
@@ -8,7 +8,7 @@ Feature: Insert Break
     When the editor is focused
     And the caret is put <position>
     And "{Enter}" is pressed
-    And "bar" is typed
+    And "bar" is inserted
     Then the text is <text>
     And the caret is <new position>
 
@@ -23,7 +23,7 @@ Feature: Insert Break
     When the editor is focused
     And the caret is put <position>
     And "{Enter}" is pressed
-    And "baz" is typed
+    And "baz" is inserted
     Then the text is <text>
     And the caret is <new position>
     When undo is performed
@@ -41,7 +41,7 @@ Feature: Insert Break
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
-    And "baz" is typed
+    And "baz" is inserted
     Then the text is "foo|baz,{stock-ticker},bar"
     And the caret is after "baz"
 


### PR DESCRIPTION
## Problem

The insert.break feature tests were flaky in Firefox CI. After pressing Enter to split a block, `userEvent.type()` fires character-by-character DOM events that race with the DOM update from the split — characters can land in the wrong block.

Error pattern: `expected ['', 'foo,bar'] to deeply equal ['foo', 'bar']` — Enter creates an empty block but typed text lands in the original block instead of the new one.

Surfaced on PR #2215 CI but is a pre-existing flake unrelated to that PR's changes.

## Fix

Change `"is typed"` to `"is inserted"` for text insertion after Enter in three scenarios:
- **Breaking text block** (line 11): `"bar" is typed` → `"bar" is inserted`
- **Breaking second text block** (line 26): `"baz" is typed` → `"baz" is inserted`
- **Breaking before inline object** (line 44): `"baz" is typed` → `"baz" is inserted`

`editor.send({type: 'insert.text'})` bypasses the DOM event pipeline while still exercising the behavior system and producing identical Slate operations (including correct undo history).

Same pattern as PR #2211 (decorator block split flake).