### PR TITLE
fix: smart undo with Backspace now works after input rules that produce inline objects

### DIFF
--- a/.changeset/fix-input-rule-smart-undo.md
+++ b/.changeset/fix-input-rule-smart-undo.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-input-rule': patch
+---
+
+fix: smart undo with Backspace now works after input rules that produce inline objects

--- a/packages/plugin-input-rule/src/rule.stock-ticker.feature
+++ b/packages/plugin-input-rule/src/rule.stock-ticker.feature
@@ -11,3 +11,15 @@ Feature: Stock Ticker Rule
     Examples:
       | text | inserted text | new text              |
       | ""   | "{AAPL}"      | ",{stock-ticker},new" |
+
+  Scenario Outline: Smart undo with Backspace
+    Given the text <text>
+    When the editor is focused
+    And <inserted text> is inserted
+    Then the text is <before undo>
+    When "{Backspace}" is pressed
+    Then the text is <after undo>
+
+    Examples:
+      | text | inserted text | before undo        | after undo |
+      | ""   | "{APPL}"      | ",{stock-ticker}," | "{APPL}"   |


### PR DESCRIPTION
When an input rule produces an inline object (e.g. the stock ticker rule transforms `{APPL}` into a stock-ticker inline object), pressing Backspace immediately after should undo the transformation back to the original text. This was broken.

**Root cause**

The input rule state machine tracks cursor position after a rule fires using `getBlockOffsets`, which internally calls `spanSelectionPointToBlockOffset`. That function iterates a block's children looking for the span matching the selection, but skips inline objects entirely. When the stock ticker rule raises a `select` action to position the cursor on the newly inserted inline object, `spanSelectionPointToBlockOffset` returns `undefined`, making `endOffsets` `undefined`.

After behavior execution completes, `editor.onChange()` fires a selection event. The selection listener picks it up and sends `selection changed` to the state machine. The `block offset changed` guard sees `!context.endOffsets` and returns `true`, transitioning back to `idle` before the user can press Backspace.

**Fix**

The state machine now tracks both `endOffsets` (block offsets) and `endSelection` (raw `EditorSelection`) after a rule fires. The selection listener also forwards the raw selection alongside block offsets.

The guard uses block offset comparison when both values are available (this preserves the existing normalization-tolerant behavior for text transform rules where the cursor stays on a span). When block offsets can't be computed (cursor on an inline object), it falls back to comparing raw selections with `isEqualSelections`.

**Test**

Added a "Smart undo with Backspace" scenario to the stock ticker feature file. Types `{APPL}`, verifies the inline object is inserted, presses Backspace, verifies the text is restored to `{APPL}`.