### PR TITLE
fix: produce valid Portable Text spans during internal text node creation

### DIFF
--- a/.changeset/text-node-factory.md
+++ b/.changeset/text-node-factory.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: produce valid Portable Text spans during internal text node creation

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -22,11 +22,14 @@ export type SlateEditor = {
 export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
   debug.setup('creating new slate editor instance')
 
-  const placeholderBlock = createPlaceholderBlock(
-    config.editorActor.getSnapshot().context,
-  )
+  const context = config.editorActor.getSnapshot().context
 
-  const editor = createEditor()
+  const placeholderBlock = createPlaceholderBlock(context)
+
+  const editor = createEditor({
+    schema: context.schema,
+    keyGenerator: context.keyGenerator,
+  })
 
   editor.decoratedRanges = []
   editor.decoratorState = {}
@@ -56,7 +59,7 @@ export function createSlateEditor(config: SlateEditorConfig): SlateEditor {
 
   buildIndexMaps(
     {
-      schema: config.editorActor.getSnapshot().context.schema,
+      schema: context.schema,
       value: instance.value,
     },
     {

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -37,7 +37,10 @@ const editorActor = createActor(editorMachine, {
 })
 const relayActor = createActor(relayMachine)
 
-const e = createEditor()
+const e = createEditor({
+  schema,
+  keyGenerator: defaultKeyGenerator,
+})
 e.value = []
 const editor = plugins(e, {
   editorActor,

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -19,7 +19,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
   // Ensure that block and inline nodes have at least one text child.
   if (Element.isElement(node) && node.children.length === 0) {
-    const child = {text: ''} as Node
+    const child = editor.createSpan()
     Transforms.insertNodes(editor, child, {
       at: path.concat(0),
       voids: true,
@@ -73,14 +73,14 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       // Ensure that inline nodes are surrounded by text nodes.
       if (editor.isInline(child)) {
         if (prev == null || !Text.isText(prev)) {
-          const newChild = {text: ''} as Node
+          const newChild = editor.createSpan()
           Transforms.insertNodes(editor, newChild, {
             at: path.concat(n),
             voids: true,
           })
           n++
         } else if (isLast) {
-          const newChild = {text: ''} as Node
+          const newChild = editor.createSpan()
           Transforms.insertNodes(editor, newChild, {
             at: path.concat(n + 1),
             voids: true,

--- a/packages/editor/src/slate/create-editor.ts
+++ b/packages/editor/src/slate/create-editor.ts
@@ -1,3 +1,4 @@
+import type {EditorSchema} from '../editor/editor-schema'
 import {
   addMark,
   deleteFragment,
@@ -12,6 +13,7 @@ import {
   removeMark,
   shouldNormalize,
   type Editor,
+  type Text,
 } from './'
 import {apply} from './core'
 import {
@@ -94,13 +96,23 @@ import {deleteText} from './transforms-text'
  * delegates because the object doesn't satisfy `Editor` until after plugin
  * application. This file gets rewritten in the PT-native fork (Step 3).
  */
-export const createEditor = (): Editor => {
+export const createEditor = (context: {
+  schema: EditorSchema
+  keyGenerator: () => string
+}): Editor => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const e: any = {
     children: [],
     operations: [],
     selection: null,
     marks: null,
+    createSpan: () =>
+      ({
+        _type: context.schema.span.name,
+        _key: context.keyGenerator(),
+        text: '',
+        marks: [],
+      }) as Text,
     isElementReadOnly: () => false,
     isInline: () => false,
     isSelectable: () => true,

--- a/packages/editor/src/slate/interfaces/editor.ts
+++ b/packages/editor/src/slate/interfaces/editor.ts
@@ -49,6 +49,7 @@ export interface BaseEditor {
   // Overrideable core methods.
 
   apply: (operation: Operation) => void
+  createSpan: () => Text
   getDirtyPaths: (operation: Operation) => Path[]
   getFragment: () => Descendant[]
   isElementReadOnly: (element: Element) => boolean

--- a/packages/editor/src/slate/transforms-node/split-nodes.ts
+++ b/packages/editor/src/slate/transforms-node/split-nodes.ts
@@ -75,7 +75,7 @@ export const splitNodes: NodeTransforms['splitNodes'] = (
           let after = Editor.after(editor, voidPath)
 
           if (!after) {
-            const text = {text: ''} as Node
+            const text = editor.createSpan()
             const afterPath = Path.next(voidPath)
             Transforms.insertNodes(editor, text, {at: afterPath, voids})
             after = Editor.point(editor, afterPath)!

--- a/packages/editor/tests/event.insert.child.test.tsx
+++ b/packages/editor/tests/event.insert.child.test.tsx
@@ -335,14 +335,9 @@ describe('event.insert.child', () => {
               _key: 'k5',
               _type: 'span',
               text: '',
+              marks: [],
             },
           ],
-        },
-        {
-          origin: 'local',
-          type: 'set',
-          path: [{_key: blockKey}, 'children', {_key: 'k5'}, 'marks'],
-          value: [],
         },
       ])
     })


### PR DESCRIPTION
During normalization and node splitting, the editor's internal tree engine creates text nodes as bare `{text: ''}` objects. These lack the `_type`, `_key`, and `marks` properties that Portable Text requires for valid spans.

This change makes the tree engine schema-aware when creating text nodes, so they come out as proper Portable Text spans from the start. No more relying on downstream promotion layers to fix them up after the fact.