### PR TITLE
Smart set_node: relax text/children constraints for void elements

### DIFF
--- a/.changeset/smart-set-node.md
+++ b/.changeset/smart-set-node.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: allow property updates on void block objects like images and breaks

--- a/packages/editor/src/internal-utils/apply-operation-to-portable-text.ts
+++ b/packages/editor/src/internal-utils/apply-operation-to-portable-text.ts
@@ -385,7 +385,7 @@ function applyOperationToPortableTextImmutable(
         const newNode = {...node}
 
         for (const key in newProperties) {
-          if (key === 'value') {
+          if (key === 'value' || key === 'children') {
             continue
           }
 
@@ -399,7 +399,7 @@ function applyOperationToPortableTextImmutable(
         }
 
         for (const key in properties) {
-          if (key === 'value') {
+          if (key === 'value' || key === 'children') {
             continue
           }
 

--- a/packages/editor/src/slate/interfaces/transforms/general.ts
+++ b/packages/editor/src/slate/interfaces/transforms/general.ts
@@ -1,4 +1,6 @@
 import {
+  Editor,
+  Element,
   Node,
   Path,
   Point,
@@ -6,8 +8,6 @@ import {
   Scrubber,
   Text,
   type Descendant,
-  type Editor,
-  type Element,
   type NodeEntry,
   type Operation,
   type Selection,
@@ -232,8 +232,20 @@ export const GeneralTransforms: GeneralTransforms = {
           const newNode = {...node}
 
           for (const key in newProperties) {
-            if (key === 'children' || key === 'text') {
-              throw new Error(`Cannot set the "${key}" property of nodes!`)
+            if (key === 'text' && Text.isText(node)) {
+              throw new Error(
+                `Cannot set the "text" property of text nodes! Use insert_text or remove_text instead.`,
+              )
+            }
+
+            if (
+              key === 'children' &&
+              Element.isElement(node) &&
+              !Editor.isVoid(editor, node)
+            ) {
+              throw new Error(
+                `Cannot set the "children" property of non-void elements!`,
+              )
             }
 
             const value = newProperties[key as keyof Node]

--- a/packages/editor/src/slate/transforms-node/set-nodes.ts
+++ b/packages/editor/src/slate/transforms-node/set-nodes.ts
@@ -3,6 +3,7 @@ import {Element} from '../interfaces/element'
 import type {Node} from '../interfaces/node'
 import {Path} from '../interfaces/path'
 import {Range} from '../interfaces/range'
+import {Text} from '../interfaces/text'
 import {Transforms} from '../interfaces/transforms'
 import type {NodeTransforms} from '../interfaces/transforms/node'
 import {matchPath} from '../utils/match-path'
@@ -92,7 +93,15 @@ export const setNodes: NodeTransforms['setNodes'] = (
       let hasChanges = false
 
       for (const k in props) {
-        if (k === 'children' || k === 'text') {
+        if (k === 'text' && Text.isText(node)) {
+          continue
+        }
+
+        if (
+          k === 'children' &&
+          Element.isElement(node) &&
+          !Editor.isVoid(editor, node)
+        ) {
           continue
         }
 


### PR DESCRIPTION
Relaxes the `set_node` operation constraints so that `text` and `children` properties are only rejected when they would violate Slate's data model — not unconditionally.

## What changed

**`general.ts` (operation handler):**
- `text`: Only throws for Text nodes (must use `insert_text`/`remove_text` for history correctness)
- `children`: Only throws for non-void Elements (structural children must not be set directly)

**`set-nodes.ts` (Transforms.setNodes):**
- Same conditional filtering — `text` skipped for Text nodes, `children` skipped for non-void Elements

**`apply-operation-to-portable-text.ts` (PT value layer):**
- Skips `children` when applying `set_node` to object nodes, preventing Slate void-child internals from leaking into portable text output

## Why

Opens a path for PR 3 (childless voids + value unification) to set properties on void elements via `set_node` operations. No behavior change for non-void nodes — existing tests pass unchanged.

## Base branch

Based on `feat-vendor-slate` (PR #2188).