### PR TITLE
fix(plugin-sdk-value): destructure props in useEffect deps

### DIFF
--- a/.changeset/fix-sdk-useeffect-deps.md
+++ b/.changeset/fix-sdk-useeffect-deps.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+Fix `useEffect` dependency array in `SDKValuePlugin` — destructure `props` into primitive values (`documentId`, `documentType`, `path`) to prevent subscriptions from being torn down and re-created on every parent re-render.

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -157,15 +157,17 @@ export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
  * @public
  */
 export function SDKValuePlugin(props: SDKValuePluginProps) {
+  const {documentId, documentType, path} = props
   // NOTE: the real `useEditDocument` suspends until the document is loaded into the SDK store
   const setSdkValue = useEditDocument(props)
   const instance = useSanityInstance(props)
   const editor = useEditor()
 
   useEffect(() => {
+    const handle = {documentId, documentType, path}
     const getEditorValue = () => editor.getSnapshot().context.value
     const {getCurrent: getSdkValue, subscribe: onSdkValueChange} =
-      getDocumentState<PortableTextBlock[]>(instance, props)
+      getDocumentState<PortableTextBlock[]>(instance, handle)
 
     let isLocalWrite = false
 
@@ -195,7 +197,7 @@ export function SDKValuePlugin(props: SDKValuePluginProps) {
       unsubscribeToEditorChanges()
       unsubscribeToSdkChanges()
     }
-  }, [editor, instance, props, setSdkValue])
+  }, [editor, instance, documentId, documentType, path, setSdkValue])
 
   return null
 }


### PR DESCRIPTION
## Problem

The `props` object reference was in the `useEffect` dependency array of `SDKValuePlugin`. Since `props` is a new object on every render, this caused all subscriptions (editor patch listener + SDK value change listener) to be torn down and re-created on every parent re-render.

This means every keystroke or state change in the parent component would:
1. Unsubscribe from editor patches
2. Unsubscribe from SDK value changes
3. Re-subscribe to both
4. Re-send `update value` with the current SDK value

## Fix

Destructure `props` into primitive values (`documentId`, `documentType`, `path`) and use those in the dependency array. The handle object is reconstructed inside the effect for `getDocumentState`.

```diff
- }, [editor, instance, props, setSdkValue])
+ }, [editor, instance, documentId, documentType, path, setSdkValue])
```

Subscriptions now only reset when the actual document identity changes.