### PR TITLE
feat: add optional `at` prop to `insert.text` event

### DIFF
--- a/.changeset/insert-text-at-prop.md
+++ b/.changeset/insert-text-at-prop.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: add optional `at` prop to `insert.text` event

--- a/packages/editor/gherkin-spec/insert.text.feature
+++ b/packages/editor/gherkin-spec/insert.text.feature
@@ -16,3 +16,21 @@ Feature: Insert text
       | "foo\|bar" | "b"       | "foo\|newar" |
       | "foo\|bar" | "ooba"    | "fnewr"      |
       | "foo\|bar" | "foobar"  | "new"        |
+
+  Scenario: Inserting text after a specific location
+    Given the text "foobar"
+    When the editor is focused
+    And "baz" is inserted after "foo"
+    Then the text is "foobazbar"
+
+  Scenario: Inserting text before a specific location
+    Given the text "foobar"
+    When the editor is focused
+    And "baz" is inserted before "foobar"
+    Then the text is "bazfoobar"
+
+  Scenario: Inserting text over an expanded range replaces the range
+    Given the text "foobar"
+    When the editor is focused
+    And "baz" is inserted over "ooba"
+    Then the text is "fbazr"

--- a/packages/editor/src/behaviors/behavior.core.insert.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert.ts
@@ -6,9 +6,21 @@ import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 export const coreInsertBehaviors = [
+  /**
+   * When the user has toggled pending marks (decorators/annotations), convert
+   * `insert.text` to `insert.child` with those marks applied.
+   *
+   * Skipped when `at` is provided because pending marks are relative to the
+   * current selection, not the `at` target. The inserted text will inherit
+   * marks from the surrounding context at the `at` location instead.
+   */
   defineBehavior({
     on: 'insert.text',
-    guard: ({snapshot}) => {
+    guard: ({snapshot, event}) => {
+      if (event.at) {
+        return false
+      }
+
       const focusSpan = getFocusSpan(snapshot)
 
       if (!focusSpan) {

--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -170,6 +170,7 @@ export type SyntheticBehaviorEvent =
   | {
       type: StrictExtract<SyntheticBehaviorEventType, 'insert.text'>
       text: string
+      at?: NonNullable<EditorSelection>
     }
   | {
       type: StrictExtract<SyntheticBehaviorEventType, 'move.backward'>

--- a/packages/editor/src/operations/operation.insert.text.ts
+++ b/packages/editor/src/operations/operation.insert.text.ts
@@ -1,8 +1,20 @@
 import {Transforms} from 'slate'
+import {toSlateRange} from '../internal-utils/to-slate-range'
 import type {OperationImplementation} from './operation.types'
 
 export const insertTextOperationImplementation: OperationImplementation<
   'insert.text'
-> = ({operation}) => {
-  Transforms.insertText(operation.editor, operation.text)
+> = ({context, operation}) => {
+  const at = operation.at
+    ? toSlateRange({
+        context: {
+          schema: context.schema,
+          value: operation.editor.value,
+          selection: operation.at,
+        },
+        blockIndexMap: operation.editor.blockIndexMap,
+      })
+    : undefined
+
+  Transforms.insertText(operation.editor, operation.text, at ? {at} : {})
 }

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -210,6 +210,33 @@ export const stepDefinitions = [
   When('{string} is inserted', (context: Context, text: string) => {
     context.editor.send({type: 'insert.text', text})
   }),
+  When(
+    '{string} is inserted after {string}',
+    (context: Context, text: string, afterText: string) => {
+      const at = getSelectionAfterText(
+        context.editor.getSnapshot().context,
+        afterText,
+      )
+      context.editor.send({type: 'insert.text', text, at})
+    },
+  ),
+  When(
+    '{string} is inserted before {string}',
+    (context: Context, text: string, beforeText: string) => {
+      const at = getSelectionBeforeText(
+        context.editor.getSnapshot().context,
+        beforeText,
+      )
+      context.editor.send({type: 'insert.text', text, at})
+    },
+  ),
+  When(
+    '{string} is inserted over {string}',
+    (context: Context, text: string, atText: string) => {
+      const at = getTextSelection(context.editor.getSnapshot().context, atText)
+      context.editor.send({type: 'insert.text', text, at})
+    },
+  ),
   Then(
     '{terse-pt} is in block {key}',
     (context: Context, text: Array<string>, key: string) => {


### PR DESCRIPTION
Adds an optional `at` prop to the `insert.text` event for programmatic text insertion at a specific location. This lets callers insert text without moving the current selection.

## Changes

- `behavior.types.event.ts`: Added `at?: NonNullable<EditorSelection>` to `insert.text`, matching `insert.block`, `delete`, `annotation.add`, etc.
- `operation.insert.text.ts`: Converts `at` to a Slate range and passes it to `Transforms.insertText`. Falls back to current selection when omitted.
- `behavior.abstract.insert.ts`: Expanded selection and no-selection behaviors use `event.at ?? snapshot.context.selection` as their operating location (same pattern as `insert.blocks`).
- `behavior.core.insert.ts`: Pending marks behavior skips when `at` is provided, since pending marks are selection-relative state. Inserted text inherits marks from the surrounding context at the target location instead.
- Three new gherkin scenarios: insert after, insert before, and insert over an expanded range.