### PR TITLE
Markdown editor prototype

### DIFF
--- a/apps/markdown-editor/.gitignore
+++ b/apps/markdown-editor/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.eslintcache

--- a/apps/markdown-editor/biome.json
+++ b/apps/markdown-editor/biome.json
@@ -1,0 +1,8 @@
+{
+  "extends": "//",
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  }
+}

--- a/apps/markdown-editor/eslint.config.js
+++ b/apps/markdown-editor/eslint.config.js
@@ -1,0 +1,19 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import {globalIgnores} from 'eslint/config'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  reactHooks.configs.flat.recommended,
+  {
+    files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {'react-hooks/exhaustive-deps': 'error'},
+  },
+])

--- a/apps/markdown-editor/index.html
+++ b/apps/markdown-editor/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown Editor</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="bg-stone-50 text-stone-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/markdown-editor/package.json
+++ b/apps/markdown-editor/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "markdown-editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "check:lint": "biome lint .",
+    "check:react-compiler": "eslint --cache .",
+    "check:types": "tsc --noEmit --pretty --project tsconfig.app.json",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@portabletext/editor": "workspace:*",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.16",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-formatter-gha": "^1.6.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "tailwindcss": "^4.1.16",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.1"
+  }
+}

--- a/apps/markdown-editor/src/App.tsx
+++ b/apps/markdown-editor/src/App.tsx
@@ -1,0 +1,24 @@
+import {defineSchema, EditorProvider} from '@portabletext/editor'
+import {MarkdownEditor} from './MarkdownEditor.tsx'
+
+const schemaDefinition = defineSchema({
+  styles: [{name: 'h1'}, {name: 'h2'}, {name: 'h3'}, {name: 'h4'}, {name: 'h5'}, {name: 'h6'}],
+})
+
+export function App() {
+  return (
+    <div className="min-h-screen bg-stone-50 flex flex-col items-center py-12 px-4">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold text-stone-800 mb-1">
+          Markdown Editor
+        </h1>
+        <p className="text-sm text-stone-500 mb-6">
+          Type markdown syntax directly. Formatting appears as you type.
+        </p>
+        <EditorProvider initialConfig={{schemaDefinition}}>
+          <MarkdownEditor />
+        </EditorProvider>
+      </div>
+    </div>
+  )
+}

--- a/apps/markdown-editor/src/MarkdownEditor.tsx
+++ b/apps/markdown-editor/src/MarkdownEditor.tsx
@@ -1,0 +1,37 @@
+import {
+  PortableTextEditable,
+  type BlockStyleRenderProps,
+} from '@portabletext/editor'
+import {useCallback} from 'react'
+import {useMarkdownBlockStyles} from './use-markdown-block-styles.ts'
+import {useMarkdownDecorations} from './use-markdown-decorations.ts'
+
+const styleClasses: Record<string, string> = {
+  normal: 'text-base',
+  h1: 'text-3xl font-bold',
+  h2: 'text-2xl font-semibold',
+  h3: 'text-xl font-semibold',
+  h4: 'text-lg font-medium',
+  h5: 'text-base font-medium',
+  h6: 'text-sm font-medium uppercase tracking-wide',
+}
+
+export function MarkdownEditor() {
+  const decorations = useMarkdownDecorations()
+  useMarkdownBlockStyles()
+
+  const renderStyle = useCallback((props: BlockStyleRenderProps) => {
+    const className = styleClasses[props.value] ?? styleClasses.normal
+    return <div className={className}>{props.children}</div>
+  }, [])
+
+  return (
+    <div className="bg-white rounded-lg border border-stone-200 shadow-sm">
+      <PortableTextEditable
+        className="outline-none p-6 min-h-[400px] text-stone-800 leading-relaxed [&>[data-slate-node=element]]:my-2"
+        rangeDecorations={decorations}
+        renderStyle={renderStyle}
+      />
+    </div>
+  )
+}

--- a/apps/markdown-editor/src/decoration-components.tsx
+++ b/apps/markdown-editor/src/decoration-components.tsx
@@ -1,0 +1,33 @@
+import type {PropsWithChildren} from 'react'
+
+export function BoldContent({children}: PropsWithChildren) {
+  return <strong className="font-bold">{children}</strong>
+}
+
+export function ItalicContent({children}: PropsWithChildren) {
+  return <em className="italic">{children}</em>
+}
+
+export function CodeContent({children}: PropsWithChildren) {
+  return (
+    <code className="bg-stone-200 px-1 py-0.5 rounded text-sm font-mono text-rose-600">
+      {children}
+    </code>
+  )
+}
+
+export function StrikethroughContent({children}: PropsWithChildren) {
+  return <del className="line-through text-stone-500">{children}</del>
+}
+
+export function SyntaxChars({children}: PropsWithChildren) {
+  return (
+    <span className="text-stone-400 font-normal not-italic no-underline">
+      {children}
+    </span>
+  )
+}
+
+export function HeadingSyntax({children}: PropsWithChildren) {
+  return <span className="text-stone-300 font-normal">{children}</span>
+}

--- a/apps/markdown-editor/src/index.css
+++ b/apps/markdown-editor/src/index.css
@@ -1,0 +1,11 @@
+@import 'tailwindcss';
+
+body {
+  font-family:
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}

--- a/apps/markdown-editor/src/main.tsx
+++ b/apps/markdown-editor/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import {App} from './App.tsx'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/apps/markdown-editor/src/markdown-parser.ts
+++ b/apps/markdown-editor/src/markdown-parser.ts
@@ -1,0 +1,110 @@
+/**
+ * Simple regex-based markdown parser for inline syntax.
+ * Extracts ranges with character offsets for decoration mapping.
+ *
+ * Each range has:
+ * - type: the markdown construct (strong, emphasis, heading, code, strikethrough)
+ * - from: start of opening delimiter
+ * - textStart: start of content (after delimiter)
+ * - textEnd: end of content (before closing delimiter)
+ * - to: end of closing delimiter
+ */
+
+export type MarkdownRangeType = 'strong' | 'emphasis' | 'code' | 'strikethrough'
+
+export type MarkdownRange = {
+  type: MarkdownRangeType
+  from: number
+  textStart: number
+  textEnd: number
+  to: number
+}
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6
+
+export type BlockParse = {
+  headingLevel: HeadingLevel | null
+  headingSyntaxEnd: number
+  ranges: Array<MarkdownRange>
+}
+
+/**
+ * Parse a single block's text for inline markdown syntax.
+ * Returns ranges sorted by position.
+ */
+export function parseBlockText(text: string): BlockParse {
+  const ranges: Array<MarkdownRange> = []
+
+  // Detect heading prefix: # through ######
+  let headingLevel: HeadingLevel | null = null
+  let headingSyntaxEnd = 0
+  const headingMatch = text.match(/^(#{1,6})\s/)
+  if (headingMatch) {
+    headingLevel = headingMatch[1].length as HeadingLevel
+    headingSyntaxEnd = headingMatch[0].length
+  }
+
+  // Bold: **text**
+  // Use a regex that finds ** pairs, non-greedy
+  const boldRegex = /\*\*(.+?)\*\*/g
+  let match: RegExpExecArray | null
+  match = boldRegex.exec(text)
+  while (match !== null) {
+    ranges.push({
+      type: 'strong',
+      from: match.index,
+      textStart: match.index + 2,
+      textEnd: match.index + 2 + match[1].length,
+      to: match.index + match[0].length,
+    })
+    match = boldRegex.exec(text)
+  }
+
+  // Italic: _text_ (using underscores to avoid conflict with * bold)
+  // Also support *text* but only single asterisks not preceded/followed by *
+  const underscoreItalicRegex = /(?<!\w)_(.+?)_(?!\w)/g
+  match = underscoreItalicRegex.exec(text)
+  while (match !== null) {
+    ranges.push({
+      type: 'emphasis',
+      from: match.index,
+      textStart: match.index + 1,
+      textEnd: match.index + 1 + match[1].length,
+      to: match.index + match[0].length,
+    })
+    match = underscoreItalicRegex.exec(text)
+  }
+
+  // Inline code: `text`
+  const codeRegex = /`([^`]+)`/g
+  match = codeRegex.exec(text)
+  while (match !== null) {
+    ranges.push({
+      type: 'code',
+      from: match.index,
+      textStart: match.index + 1,
+      textEnd: match.index + 1 + match[1].length,
+      to: match.index + match[0].length,
+    })
+    match = codeRegex.exec(text)
+  }
+
+  // Strikethrough: ~~text~~
+  const strikethroughRegex = /~~(.+?)~~/g
+  match = strikethroughRegex.exec(text)
+  while (match !== null) {
+    ranges.push({
+      type: 'strikethrough',
+      from: match.index,
+      textStart: match.index + 2,
+      textEnd: match.index + 2 + match[1].length,
+      to: match.index + match[0].length,
+    })
+    match = strikethroughRegex.exec(text)
+  }
+
+  // Sort by position
+  ranges.sort((a, b) => a.from - b.from)
+
+  return {headingLevel, headingSyntaxEnd, ranges}
+}

--- a/apps/markdown-editor/src/use-markdown-block-styles.ts
+++ b/apps/markdown-editor/src/use-markdown-block-styles.ts
@@ -1,0 +1,110 @@
+import {useEditor, useEditorSelector} from '@portabletext/editor'
+import {useEffect, useRef} from 'react'
+import type {HeadingLevel} from './markdown-parser.ts'
+import {parseBlockText} from './markdown-parser.ts'
+
+type BlockStyleData = {
+  key: string
+  text: string
+  currentStyle: string
+}
+
+function blockStyleDataEqual(
+  a: Array<BlockStyleData>,
+  b: Array<BlockStyleData>,
+): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let index = 0; index < a.length; index++) {
+    if (
+      a[index].key !== b[index].key ||
+      a[index].text !== b[index].text ||
+      a[index].currentStyle !== b[index].currentStyle
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+const headingStyleMap: Record<HeadingLevel, string> = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+  4: 'h4',
+  5: 'h5',
+  6: 'h6',
+}
+
+/**
+ * Syncs block styles based on markdown heading syntax.
+ * When a block starts with `# `, sets style to 'h1', etc.
+ * When heading syntax is removed, resets to 'normal'.
+ *
+ * Uses `block.set` with explicit path to avoid moving the cursor.
+ */
+export function useMarkdownBlockStyles() {
+  const editor = useEditor()
+  const isSyncing = useRef(false)
+
+  const blockData = useEditorSelector(
+    editor,
+    (snapshot): Array<BlockStyleData> => {
+      return snapshot.context.value.map((block) => {
+        if (!('children' in block) || !Array.isArray(block.children)) {
+          return {key: block._key, text: '', currentStyle: 'normal'}
+        }
+        const firstSpan = block.children[0]
+        const text =
+          firstSpan && 'text' in firstSpan ? String(firstSpan.text) : ''
+        const currentStyle =
+          'style' in block ? String(block.style ?? 'normal') : 'normal'
+        return {key: block._key, text, currentStyle}
+      })
+    },
+    blockStyleDataEqual,
+  )
+
+  useEffect(() => {
+    // Prevent re-entrant style updates
+    if (isSyncing.current) {
+      return
+    }
+
+    let didUpdate = false
+
+    for (const block of blockData) {
+      const parsed = parseBlockText(block.text)
+      const targetStyle = parsed.headingLevel
+        ? headingStyleMap[parsed.headingLevel]
+        : 'normal'
+
+      if (block.currentStyle !== targetStyle) {
+        if (!didUpdate) {
+          isSyncing.current = true
+          didUpdate = true
+        }
+
+        if (targetStyle === 'normal') {
+          // Remove style by unsetting it
+          editor.send({
+            type: 'block.unset',
+            at: [{_key: block.key}],
+            props: ['style'],
+          })
+        } else {
+          editor.send({
+            type: 'block.set',
+            at: [{_key: block.key}],
+            props: {style: targetStyle},
+          })
+        }
+      }
+    }
+
+    if (didUpdate) {
+      isSyncing.current = false
+    }
+  }, [editor, blockData])
+}

--- a/apps/markdown-editor/src/use-markdown-decorations.ts
+++ b/apps/markdown-editor/src/use-markdown-decorations.ts
@@ -1,0 +1,160 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type RangeDecoration,
+} from '@portabletext/editor'
+import {useMemo} from 'react'
+import {
+  BoldContent,
+  CodeContent,
+  ItalicContent,
+  StrikethroughContent,
+  SyntaxChars,
+} from './decoration-components.tsx'
+import {parseBlockText, type MarkdownRangeType} from './markdown-parser.ts'
+
+const formatComponents: Record<
+  MarkdownRangeType,
+  (props: React.PropsWithChildren) => React.ReactElement
+> = {
+  strong: BoldContent,
+  emphasis: ItalicContent,
+  code: CodeContent,
+  strikethrough: StrikethroughContent,
+}
+
+type BlockData = {
+  key: string
+  text: string
+  spanKey: string
+}
+
+function blocksEqual(a: Array<BlockData>, b: Array<BlockData>): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let blockIndex = 0; blockIndex < a.length; blockIndex++) {
+    if (
+      a[blockIndex].key !== b[blockIndex].key ||
+      a[blockIndex].text !== b[blockIndex].text ||
+      a[blockIndex].spanKey !== b[blockIndex].spanKey
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Hook that parses markdown syntax in editor blocks and returns
+ * RangeDecorations for inline formatting and syntax character styling.
+ *
+ * Block-level formatting (headings) is handled separately by
+ * useMarkdownBlockStyles which sets PT block style properties.
+ */
+export function useMarkdownDecorations(): Array<RangeDecoration> {
+  const editor = useEditor()
+
+  // Extract block keys and text content reactively
+  const blocks = useEditorSelector(
+    editor,
+    (snapshot): Array<BlockData> => {
+      return snapshot.context.value.map((block) => {
+        if (!('children' in block) || !Array.isArray(block.children)) {
+          return {key: block._key, text: '', spanKey: ''}
+        }
+        const firstSpan = block.children[0]
+        const text =
+          firstSpan && 'text' in firstSpan ? String(firstSpan.text) : ''
+        const spanKey =
+          firstSpan && '_key' in firstSpan ? String(firstSpan._key) : ''
+        return {key: block._key, text, spanKey}
+      })
+    },
+    blocksEqual,
+  )
+
+  // Parse all blocks and build decorations
+  const decorations = useMemo(() => {
+    const result: Array<RangeDecoration> = []
+
+    for (const block of blocks) {
+      if (!block.text || !block.spanKey) {
+        continue
+      }
+
+      const parsed = parseBlockText(block.text)
+
+      // Dim the heading syntax characters (# )
+      if (parsed.headingSyntaxEnd > 0) {
+        result.push({
+          component: SyntaxChars,
+          selection: {
+            anchor: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: 0,
+            },
+            focus: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: parsed.headingSyntaxEnd,
+            },
+          },
+        })
+      }
+
+      // Inline format decorations
+      for (const range of parsed.ranges) {
+        const component = formatComponents[range.type]
+
+        // Opening delimiter (e.g., **)
+        result.push({
+          component: SyntaxChars,
+          selection: {
+            anchor: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.from,
+            },
+            focus: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.textStart,
+            },
+          },
+        })
+
+        // Content (e.g., bold text)
+        result.push({
+          component,
+          selection: {
+            anchor: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.textStart,
+            },
+            focus: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.textEnd,
+            },
+          },
+        })
+
+        // Closing delimiter (e.g., **)
+        result.push({
+          component: SyntaxChars,
+          selection: {
+            anchor: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.textEnd,
+            },
+            focus: {
+              path: [{_key: block.key}, 'children', {_key: block.spanKey}],
+              offset: range.to,
+            },
+          },
+        })
+      }
+    }
+
+    return result
+  }, [blocks])
+
+  return decorations
+}

--- a/apps/markdown-editor/tsconfig.app.json
+++ b/apps/markdown-editor/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/markdown-editor/tsconfig.json
+++ b/apps/markdown-editor/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/markdown-editor/tsconfig.node.json
+++ b/apps/markdown-editor/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/markdown-editor/vite.config.ts
+++ b/apps/markdown-editor/vite.config.ts
@@ -1,0 +1,30 @@
+import path from 'node:path'
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import {defineConfig} from 'vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
+    }),
+    tailwindcss(),
+  ],
+  resolve: {
+    alias: {
+      '@portabletext/editor': path.resolve(
+        __dirname,
+        '../../packages/editor/src',
+      ),
+      '@portabletext/patches': path.resolve(
+        __dirname,
+        '../../packages/patches/src',
+      ),
+      '@portabletext/schema': path.resolve(
+        __dirname,
+        '../../packages/schema/src',
+      ),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,55 @@ importers:
         specifier: ^4.8.0
         version: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
 
+  apps/markdown-editor:
+    dependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.16
+        version: 4.1.18(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.2.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.1.1(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-formatter-gha:
+        specifier: ^1.6.0
+        version: 1.6.0
+      eslint-plugin-react-hooks:
+        specifier: ^7.0.1
+        version: 7.0.1(eslint@9.39.1(jiti@2.6.1))
+      tailwindcss:
+        specifier: ^4.1.16
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   apps/playground:
     dependencies:
       '@floating-ui/react-dom':


### PR DESCRIPTION
Standalone markdown editor app using PTE with syntax-as-truth model.

Text IS markdown: `**bold**` stored as plain text in PT spans with zero marks. Parser runs per-block on text change, produces RangeDecoration ranges for inline formatting. Block-level formatting (headings) synced to PT style property via block.set/block.unset.

**Schema:** `defineSchema({styles: [h1-h6]})` with zero decorators, zero marks. Normal style auto-injected.

**Supports:**
- Bold (`**text**`)
- Italic (`_text_`)
- Inline code (`\`text\``)
- Strikethrough (`~~text~~`)
- Headings (`#` through `######`)

**Architecture:**
- `markdown-parser.ts` - regex parser extracts ranges with character offsets
- `use-markdown-decorations.ts` - converts parse ranges to RangeDecorations
- `use-markdown-block-styles.ts` - syncs heading syntax to PT block style
- `decoration-components.tsx` - styling components (bold, italic, dim syntax chars)

Breaking syntax naturally removes formatting because the parser no longer matches. No behavior intercepts needed.