### PR TITLE
fix: forward on insert.text breaks undo batching

### DIFF
--- a/.changeset/fix-forward-undo-batching.md
+++ b/.changeset/fix-forward-undo-batching.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: forward on insert.text breaks undo batching


### PR DESCRIPTION
## Problem

When a behavior uses `forward(event)` on `insert.text` with a second action set, each typed character becomes its own undo step instead of merging with adjacent characters.

This breaks the expected undo behavior for any behavior that observes text insertion without modifying it (e.g., a behavior that forwards the text and then checks the block content to update styles).

## Root cause

`performEvent` sets a unique `undoStepId` for every `insert.text` event because it's synthetic (not in `nativeBehaviorEventTypes`). Without custom behaviors, the default handler clears `undoStepId` before running the operation, so consecutive characters merge via the history plugin's merge heuristic. But when a behavior `forward`s the event, `defaultBehaviorOverwritten = true` and the clearing never happens. Each character gets a unique `undoStepId`, preventing history merge.

## Fix

Add a merge heuristic in `undo-step.ts` for the case where consecutive operations have different defined `undoStepId`s. When both IDs are defined but different, and the operations are consecutive `insert_text` at adjacent offsets on the same path (or consecutive `remove_text`), merge them into the same undo step. This matches the existing merge behavior for the `undefined` ID case.

This approach avoids changing `performEvent` and preserves the existing undo step separation for:
- Custom events forwarding to `insert.block` (different op types, not `insert_text`)
- Input rule transformations (the transformation creates a new undo step boundary between the forwarded text and the rule application)

## Testing

Two new browser tests verify the fix:
- Forwarding `insert.text` preserves undo batching
- Forwarding `insert.text` with side effect preserves undo batching