### PR TITLE
chore: remove stale EditorChange reference from changeset

### DIFF
--- a/.changeset/remove-change-observable.md
+++ b/.changeset/remove-change-observable.md
@@ -21,7 +21,6 @@ Migration: Replace `change$.subscribe()` with `editor.on()` or
 has a 1:1 equivalent in the new event API.
 
 What's preserved:
-- `EditorChange` type (still used by sanity's `onEditorChange` prop)
 - `PortableTextEditor` class (separate deprecation path)
 - All static methods and `schemaTypes` property
 


### PR DESCRIPTION
The `remove-change-observable` changeset listed `EditorChange` type under "What's preserved" but it's being removed in PR #2244. Remove the stale reference so the release notes are accurate.