### PR TITLE
test: stabilize flaky browser tests for Firefox and WebKit

### DIFF
--- a/packages/plugin-input-rule/src/emoji-picker-rules.test.tsx
+++ b/packages/plugin-input-rule/src/emoji-picker-rules.test.tsx
@@ -116,8 +116,14 @@ Feature({
     Then(
       'the keyword is {string}',
       async (context: Context & {keywordLocator: Locator}, keyword: string) => {
-        await vi.waitFor(() =>
-          expect(context.keywordLocator.element().textContent).toEqual(keyword),
+        await vi.waitFor(
+          () =>
+            expect(context.keywordLocator.element().textContent).toEqual(
+              keyword,
+            ),
+          // WebKit needs more time to process characters through the input
+          // rule pipeline and subsequent React state updates.
+          {timeout: 3000},
         )
       },
     ),


### PR DESCRIPTION
Fixes two flaky browser tests:

**Firefox: Decorators > Splitting block before decorator**
The `{button} is pressed` step waited only for selection to change after Enter, but Firefox can update the selection before the block split is fully processed. Fix: when the button is Enter, also wait for the block count to increase.

**WebKit: Emoji Picker Rules > Consecutive keywords**
WebKit processes the input rule pipeline slower, causing the default 1000ms `vi.waitFor` timeout to expire. Fix: increase timeout to 3000ms.

No behavior changes. No changeset needed (test-only).