### PR TITLE
test: stabilize flaky emoji picker keyword assertion

### DIFF
--- a/packages/plugin-input-rule/src/emoji-picker-rules.test.tsx
+++ b/packages/plugin-input-rule/src/emoji-picker-rules.test.tsx
@@ -116,9 +116,7 @@ Feature({
     Then(
       'the keyword is {string}',
       async (context: Context & {keywordLocator: Locator}, keyword: string) => {
-        await vi.waitFor(() =>
-          expect(context.keywordLocator.element().textContent).toEqual(keyword),
-        )
+        await expect.element(context.keywordLocator).toHaveTextContent(keyword)
       },
     ),
   ],


### PR DESCRIPTION
The 'Consecutive keywords' test in emoji-picker-rules was flaky because it read `.element().textContent` synchronously inside `vi.waitFor`. This can see stale DOM content before React flushes the state update from `setKeyword`.

Switched to `expect.element(locator).toHaveTextContent(keyword)` which polls the locator properly until the assertion passes. This is the same pattern used in range-decorations.test.tsx.