### PR TITLE
fix: make Slate tree PT-native

### DIFF
--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -31,8 +31,9 @@ export function RenderElement(props: {
   const schema = useSelector(editorActor, (s) => s.context.schema)
   const slateStatic = useSlateStatic()
 
-  const isInline =
-    '__inline' in props.element && props.element.__inline === true
+  const isInline = schema.inlineObjects
+    .map((obj) => obj.name)
+    .includes(props.element._type)
 
   if (isInline) {
     return (

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -59,13 +59,7 @@ export function RenderInlineObject(props: {
     ? selectionState.focusedChildPath === serializedPath
     : false
 
-  const inlineObject = {
-    _key: props.element._key,
-    _type: props.element._type,
-    ...('value' in props.element && typeof props.element.value === 'object'
-      ? props.element.value
-      : {}),
-  }
+  const {children: _voidChildren, ...inlineObject} = props.element
 
   return (
     <span

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -22,7 +22,7 @@ import {
   isEqualValues,
 } from '../internal-utils/equality'
 import {validateValue} from '../internal-utils/validateValue'
-import {toSlateBlock, VOID_CHILD_KEY} from '../internal-utils/values'
+import {toSlateBlock} from '../internal-utils/values'
 import {deleteText, Editor, Node, Text, type Descendant} from '../slate'
 import {withRemoteChanges} from '../slate-plugins/slate-plugin.remote-changes'
 import {pluginWithoutHistory} from '../slate-plugins/slate-plugin.without-history'
@@ -974,14 +974,6 @@ function updateBlock({
             })
 
             slateEditor.onChange()
-          } else if (!isSpanNode) {
-            // If it's a inline block, also update the void text node key
-            debug.syncValue(
-              'Updating changed inline object child',
-              currentBlockChild,
-            )
-
-            applySetNode(slateEditor, {_key: VOID_CHILD_KEY}, [...path, 0])
           }
         } else if (oldBlockChild) {
           debug.syncValue('Replacing child', currentBlockChild)

--- a/packages/editor/src/internal-utils/__tests__/values.test.ts
+++ b/packages/editor/src/internal-utils/__tests__/values.test.ts
@@ -5,7 +5,7 @@ import {toSlateBlock} from '../values'
 const schemaTypes = compileSchema(defineSchema({}))
 
 describe(toSlateBlock.name, () => {
-  it('given type is custom with no custom properties, should include an empty text property in children and an empty value', () => {
+  it('given type is custom with no custom properties, should include an empty text property in children', () => {
     const result = toSlateBlock(
       {
         _type: 'image',
@@ -22,7 +22,6 @@ describe(toSlateBlock.name, () => {
           text: '',
         },
       ],
-      value: {},
     })
   })
 
@@ -87,7 +86,6 @@ describe(toSlateBlock.name, () => {
           text: '123',
         },
         {
-          __inline: true,
           _key: '1232',
           _type: 'image',
           children: [
@@ -98,10 +96,8 @@ describe(toSlateBlock.name, () => {
               text: '',
             },
           ],
-          value: {
-            asset: {
-              _ref: 'ref-123',
-            },
+          asset: {
+            _ref: 'ref-123',
           },
         },
       ],

--- a/packages/editor/src/internal-utils/apply-operation-to-portable-text.test.ts
+++ b/packages/editor/src/internal-utils/apply-operation-to-portable-text.test.ts
@@ -121,7 +121,7 @@ describe(applyOperationToPortableText.name, () => {
               _type: 'image',
               _key: k2,
               children: [{text: '', _key: VOID_CHILD_KEY, _type: 'span'}],
-              value: {src: 'https://example.com/image.jpg'},
+              src: 'https://example.com/image.jpg',
             },
           },
         ),
@@ -194,9 +194,8 @@ describe(applyOperationToPortableText.name, () => {
             node: {
               _type: 'stock-ticker',
               _key: k2,
-              __inline: true,
               children: [{text: '', _key: VOID_CHILD_KEY, _type: 'span'}],
-              value: {symbol: 'AAPL'},
+              symbol: 'AAPL',
             },
           },
         ),
@@ -633,9 +632,8 @@ describe(applyOperationToPortableText.name, () => {
             node: {
               _type: 'stock-ticker',
               _key: k2,
-              __inline: true,
               children: [{_type: 'span', _key: voidChild, text: ''}],
-              value: {symbol: 'AAPL'},
+              symbol: 'AAPL',
             },
           },
         ),
@@ -1289,7 +1287,7 @@ describe(applyOperationToPortableText.name, () => {
             path: [0],
             properties: {},
             newProperties: {
-              value: {src: 'https://example.com/image.jpg'},
+              src: 'https://example.com/image.jpg',
             },
           },
         ),
@@ -1320,13 +1318,11 @@ describe(applyOperationToPortableText.name, () => {
             type: 'set_node',
             path: [0],
             properties: {
-              value: {src: 'https://example.com/image.jpg'},
+              src: 'https://example.com/image.jpg',
             },
             newProperties: {
-              value: {
-                src: 'https://example.com/image.jpg',
-                alt: 'An image',
-              },
+              src: 'https://example.com/image.jpg',
+              alt: 'An image',
             },
           },
         ),
@@ -1352,11 +1348,9 @@ describe(applyOperationToPortableText.name, () => {
             type: 'set_node',
             path: [0],
             properties: {
-              value: {
-                alt: 'An image',
-              },
+              alt: 'An image',
             },
-            newProperties: {value: {}},
+            newProperties: {},
           },
         ),
       ).toEqual([{_type: 'image', _key: k0}])
@@ -1430,9 +1424,7 @@ describe(applyOperationToPortableText.name, () => {
             path: [0, 1],
             properties: {},
             newProperties: {
-              value: {
-                symbol: 'AAPL',
-              },
+              symbol: 'AAPL',
             },
           },
         ),
@@ -1639,10 +1631,10 @@ describe(applyOperationToPortableText.name, () => {
             type: 'set_node',
             path: [0],
             properties: {
-              value: {text: 'h'},
+              text: 'h',
             },
             newProperties: {
-              value: {text: 'hello'},
+              text: 'hello',
             },
           },
         ),
@@ -1692,10 +1684,10 @@ describe(applyOperationToPortableText.name, () => {
             type: 'set_node',
             path: [0, 1],
             properties: {
-              value: {text: 'J'},
+              text: 'J',
             },
             newProperties: {
-              value: {text: 'John Doe'},
+              text: 'John Doe',
             },
           },
         ),

--- a/packages/editor/src/internal-utils/apply-set-node.ts
+++ b/packages/editor/src/internal-utils/apply-set-node.ts
@@ -11,8 +11,9 @@ import type {PortableTextSlateEditor} from '../types/slate-editor'
  * Properties set to `null` are treated as deletions (matching the behavior
  * of `Transforms.unsetNodes`).
  *
- * Skips `children` and `text` since those are structural properties managed
- * by dedicated operations.
+ * Skips `children` since it is a structural property managed by dedicated
+ * operations. Skips `text` only for text nodes (spans) where it is managed
+ * by `insert_text`/`remove_text` operations.
  */
 export function applySetNode(
   editor: PortableTextSlateEditor,
@@ -20,11 +21,17 @@ export function applySetNode(
   path: Path,
 ): void {
   const node = Node.get(editor, path) as unknown as Record<string, unknown>
+  const isTextNode =
+    typeof node['text'] === 'string' && !Array.isArray(node['children'])
   const properties: Record<string, unknown> = {}
   const newProperties: Record<string, unknown> = {}
 
   for (const key of Object.keys(props)) {
-    if (key === 'children' || key === 'text') {
+    if (key === 'children') {
+      continue
+    }
+
+    if (key === 'text' && isTextNode) {
       continue
     }
 

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -313,7 +313,31 @@ function setPatch(
 
   // If this is targeting a text block child
   if (isTextBlock && child) {
-    if (Text.isText(child.node)) {
+    if (Element.isElement(child.node)) {
+      const propPath = patch.path.slice(3)
+      const reservedProps = ['_key', '_type', 'children']
+      const propEntry = propPath.at(0)
+
+      if (propEntry === undefined) {
+        return false
+      }
+
+      if (typeof propEntry === 'string' && reservedProps.includes(propEntry)) {
+        return false
+      }
+
+      const newNode = applyAll(child.node, [
+        {
+          ...patch,
+          path: patch.path.slice(3),
+        },
+      ])
+
+      applySetNode(editor, newNode as unknown as Record<string, unknown>, [
+        block.index,
+        child.index,
+      ])
+    } else if (Text.isText(child.node)) {
       if (Text.isText(value)) {
         if (patch.type === 'setIfMissing') {
           return false
@@ -334,13 +358,9 @@ function setPatch(
             offset: 0,
             text: newText,
           })
-          // call OnChange here to emit the new selection
-          // the user's selection might be interfering with
           editor.onChange()
         }
       } else {
-        // Setting non-text span property
-
         const propPath = patch.path.slice(3)
         const propEntry = propPath.at(0)
         const reservedProps = ['_key', '_type', 'text']
@@ -368,63 +388,21 @@ function setPatch(
           child.index,
         ])
       }
-    } else {
-      // Setting inline object property
-
-      const propPath = patch.path.slice(3)
-      const reservedProps = ['_key', '_type', 'children', '__inline']
-      const propEntry = propPath.at(0)
-
-      if (propEntry === undefined) {
-        return false
-      }
-
-      if (typeof propEntry === 'string' && reservedProps.includes(propEntry)) {
-        return false
-      }
-
-      // If the child is an inline object, we need to apply the patch to the
-      // `value` property object.
-      const value =
-        'value' in child.node && typeof child.node.value === 'object'
-          ? child.node.value
-          : {}
-
-      const newValue = applyAll(value, [
-        {
-          ...patch,
-          path: patch.path.slice(3),
-        },
-      ])
-
-      applySetNode(
-        editor,
-        {
-          ...(child.node as unknown as Record<string, unknown>),
-          value: newValue,
-        },
-        [block.index, child.index],
-      )
     }
 
     return true
-  } else if (block && 'value' in block.node) {
+  } else if (block && !isTextBlock) {
     if (patch.path.length > 1 && patch.path[1] !== 'children') {
-      const newVal = applyAll(block.node.value, [
+      const newNode = applyAll(block.node, [
         {
           ...patch,
           path: patch.path.slice(1),
         },
       ])
 
-      applySetNode(
-        editor,
-        {
-          ...(block.node as unknown as Record<string, unknown>),
-          value: newVal,
-        },
-        [block.index],
-      )
+      applySetNode(editor, newNode as unknown as Record<string, unknown>, [
+        block.index,
+      ])
     } else {
       return false
     }
@@ -479,39 +457,39 @@ function unsetPatch(editor: PortableTextSlateEditor, patch: UnsetPatch) {
     }
   }
 
-  if (child && !Text.isText(child.node)) {
-    // Unsetting inline object property
-
+  if (child && Element.isElement(child.node)) {
     const propPath = patch.path.slice(3)
     const propEntry = propPath.at(0)
-    const reservedProps = ['_key', '_type', 'children', '__inline']
+    const reservedProps = ['_key', '_type', 'children']
 
     if (propEntry === undefined) {
       return false
     }
 
     if (typeof propEntry === 'string' && reservedProps.includes(propEntry)) {
-      // All custom properties are stored on the `value` property object.
-      // If you try to unset any of the other top-level properties it's a
-      // no-op.
       return false
     }
 
-    const value =
-      'value' in child.node && typeof child.node.value === 'object'
-        ? child.node.value
-        : {}
-
-    const newValue = applyAll(value, [
+    const newNode = applyAll(child.node, [
       {
         ...patch,
         path: patch.path.slice(3),
       },
     ])
 
+    const newKeys = Object.keys(newNode)
+    const removedProperties = Object.keys(child.node).filter(
+      (property) => !newKeys.includes(property),
+    )
+
+    const unsetProps: Record<string, null> = {}
+    for (const prop of removedProperties) {
+      unsetProps[prop] = null
+    }
+
     applySetNode(
       editor,
-      {...(child.node as unknown as Record<string, unknown>), value: newValue},
+      {...(newNode as unknown as Record<string, unknown>), ...unsetProps},
       [block.index, child.index],
     )
 
@@ -564,20 +542,27 @@ function unsetPatch(editor: PortableTextSlateEditor, patch: UnsetPatch) {
   }
 
   if (!child) {
-    if ('value' in block.node) {
-      const newVal = applyAll(block.node.value, [
+    if (!editor.isTextBlock(block.node)) {
+      const newNode = applyAll(block.node, [
         {
           ...patch,
           path: patch.path.slice(1),
         },
       ])
 
+      const newKeys = Object.keys(newNode)
+      const removedProperties = Object.keys(block.node).filter(
+        (property) => !newKeys.includes(property),
+      )
+
+      const unsetProps: Record<string, null> = {}
+      for (const prop of removedProperties) {
+        unsetProps[prop] = null
+      }
+
       applySetNode(
         editor,
-        {
-          ...(block.node as unknown as Record<string, unknown>),
-          value: newVal,
-        },
+        {...(newNode as unknown as Record<string, unknown>), ...unsetProps},
         [block.index],
       )
 

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -56,8 +56,7 @@ const createDefaultChildren = () =>
         {
           _key: '773866318fa8',
           _type: 'someObject',
-          value: {title: 'The Object'},
-          __inline: true,
+          title: 'The Object',
           children: [{_type: 'span', _key: 'bogus', text: '', marks: []}],
         },
         {_type: 'span', _key: 'fd9b4a4e6c0b', text: '', marks: []},
@@ -76,7 +75,7 @@ const createDefaultValue = () =>
         {
           _key: '773866318fa8',
           _type: 'someObject',
-          value: {title: 'The Object'},
+          title: 'The Object',
         },
         {_type: 'span', _key: 'fd9b4a4e6c0b', text: '', marks: []},
       ],
@@ -100,7 +99,6 @@ describe(insertNodePatch.name, () => {
                 text: '',
               },
             ],
-            value: {},
           },
         ],
         {
@@ -117,7 +115,6 @@ describe(insertNodePatch.name, () => {
                 text: '',
               },
             ],
-            value: {},
           },
         },
         [],
@@ -222,8 +219,7 @@ describe('operationToPatches', () => {
           node: {
             _type: 'someObject',
             _key: 'c130395c640c',
-            value: {title: 'The Object'},
-            __inline: false,
+            title: 'The Object',
             children: [{_key: '1', _type: 'span', text: '', marks: []}],
           },
         },
@@ -264,8 +260,6 @@ describe('operationToPatches', () => {
           node: {
             _type: 'someObject',
             _key: 'c130395c640c',
-            value: {},
-            __inline: false,
             children: [{_key: '1', _type: 'span', text: '', marks: []}],
           },
         },
@@ -307,8 +301,7 @@ describe('operationToPatches', () => {
           node: {
             _type: 'someObject',
             _key: 'c130395c640c',
-            value: {title: 'The Object'},
-            __inline: true,
+            title: 'The Object',
             children: [{_key: '1', _type: 'span', text: '', marks: []}],
           },
         },
@@ -430,8 +423,7 @@ describe('operationToPatches', () => {
           node: {
             _key: '773866318fa8',
             _type: 'someObject',
-            value: {title: 'The object'},
-            __inline: true,
+            title: 'The object',
             children: [{_type: 'span', _key: 'bogus', text: '', marks: []}],
           },
         },
@@ -583,8 +575,7 @@ describe('defensive setIfMissing patches', () => {
           node: {
             _type: 'someObject',
             _key: 'new-object',
-            value: {title: 'New Object'},
-            __inline: true,
+            title: 'New Object',
             children: [{_key: '1', _type: 'span', text: '', marks: []}],
           },
         },

--- a/packages/editor/src/internal-utils/values.test.ts
+++ b/packages/editor/src/internal-utils/values.test.ts
@@ -95,8 +95,7 @@ describe(toSlateBlock.name, () => {
                   marks: [],
                 },
               ],
-              value: {text: 'foo'},
-              __inline: true,
+              text: 'foo',
             },
           ],
         })
@@ -129,7 +128,6 @@ describe(toSlateBlock.name, () => {
           _key: blockKey,
           children: [
             {
-              __inline: true,
               _key: stockTickerKey,
               _type: 'stock-ticker',
               children: [
@@ -140,9 +138,7 @@ describe(toSlateBlock.name, () => {
                   marks: [],
                 },
               ],
-              value: {
-                symbol: 'AAPL',
-              },
+              symbol: 'AAPL',
             },
           ],
         })
@@ -171,7 +167,6 @@ describe(toSlateBlock.name, () => {
           _key: blockKey,
           children: [
             {
-              __inline: true,
               _key: stockTickerKey,
               _type: 'stock-ticker',
               children: [
@@ -182,9 +177,7 @@ describe(toSlateBlock.name, () => {
                   marks: [],
                 },
               ],
-              value: {
-                symbol: 'AAPL',
-              },
+              symbol: 'AAPL',
             },
           ],
         })
@@ -217,7 +210,6 @@ describe(toSlateBlock.name, () => {
           _key: blockKey,
           children: [
             {
-              __inline: true,
               _key: stockTickerKey,
               _type: 'stock-ticker',
               children: [
@@ -228,9 +220,7 @@ describe(toSlateBlock.name, () => {
                   marks: [],
                 },
               ],
-              value: {
-                text: 'foo',
-              },
+              text: 'foo',
             },
           ],
         })
@@ -259,7 +249,6 @@ describe(toSlateBlock.name, () => {
           _key: blockKey,
           children: [
             {
-              __inline: true,
               _key: stockTickerKey,
               _type: 'stock-ticker',
               children: [
@@ -270,9 +259,7 @@ describe(toSlateBlock.name, () => {
                   marks: [],
                 },
               ],
-              value: {
-                text: 'foo',
-              },
+              text: 'foo',
             },
           ],
         })

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -95,7 +95,7 @@ export const blockSetOperationImplementation: OperationImplementation<
     }
 
     const patches = Object.entries(filteredProps).map(([key, value]) =>
-      key === '_key' ? set(value, ['_key']) : set(value, ['value', key]),
+      set(value, [key]),
     )
 
     const updatedSlateBlock = applyAll(slateBlock, patches) as Partial<Node>

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -1,7 +1,4 @@
-import {applyAll, set, unset} from '@portabletext/patches'
-import {isTextBlock} from '@portabletext/schema'
 import {applySetNode} from '../internal-utils/apply-set-node'
-import type {Node} from '../slate'
 import type {OperationImplementation} from './operation.types'
 
 export const blockUnsetOperationImplementation: OperationImplementation<
@@ -23,37 +20,20 @@ export const blockUnsetOperationImplementation: OperationImplementation<
     throw new Error(`Unable to find block at ${JSON.stringify(operation.at)}`)
   }
 
-  if (isTextBlock(context, slateBlock)) {
-    const propsToRemove = operation.props.filter(
-      (prop) => prop !== '_type' && prop !== '_key' && prop !== 'children',
-    )
-
-    const unsetProps: Record<string, null> = {}
-    for (const prop of propsToRemove) {
-      unsetProps[prop] = null
-    }
-    applySetNode(operation.editor, unsetProps, [blockIndex])
-
-    if (operation.props.includes('_key')) {
-      applySetNode(operation.editor, {_key: context.keyGenerator()}, [
-        blockIndex,
-      ])
-    }
-
-    return
-  }
-
-  const patches = operation.props.flatMap((key) =>
-    key === '_type'
-      ? []
-      : key === '_key'
-        ? set(context.keyGenerator(), ['_key'])
-        : unset(['value', key]),
+  const propsToRemove = operation.props.filter(
+    (prop) => prop !== '_type' && prop !== '_key' && prop !== 'children',
   )
 
-  const updatedSlateBlock = applyAll(slateBlock, patches) as Partial<Node>
+  const unsetProps: Record<string, null> = {}
+  for (const prop of propsToRemove) {
+    unsetProps[prop] = null
+  }
 
-  applySetNode(operation.editor, updatedSlateBlock as Record<string, unknown>, [
-    blockIndex,
-  ])
+  if (Object.keys(unsetProps).length > 0) {
+    applySetNode(operation.editor, unsetProps, [blockIndex])
+  }
+
+  if (operation.props.includes('_key')) {
+    applySetNode(operation.editor, {_key: context.keyGenerator()}, [blockIndex])
+  }
 }

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -76,8 +76,6 @@ export const childSetOperationImplementation: OperationImplementation<
       )
     }
 
-    const value =
-      'value' in child && typeof child.value === 'object' ? child.value : {}
     const {_type, _key, ...rest} = operation.props
 
     for (const prop in rest) {
@@ -91,10 +89,7 @@ export const childSetOperationImplementation: OperationImplementation<
       {
         ...child,
         _key: typeof _key === 'string' ? _key : child._key,
-        value: {
-          ...value,
-          ...rest,
-        },
+        ...rest,
       },
       childPath,
     )

--- a/packages/editor/src/operations/operation.child.unset.ts
+++ b/packages/editor/src/operations/operation.child.unset.ts
@@ -1,4 +1,3 @@
-import {applyAll} from '@portabletext/patches'
 import {isTextBlock} from '@portabletext/schema'
 import {applySetNode} from '../internal-utils/apply-set-node'
 import {Editor, Element} from '../slate'
@@ -88,25 +87,20 @@ export const childUnsetOperationImplementation: OperationImplementation<
   }
 
   if (Element.isElement(child)) {
-    const value =
-      'value' in child && typeof child.value === 'object' ? child.value : {}
-    const patches = operation.props.map((prop) => ({
-      type: 'unset' as const,
-      path: [prop],
-    }))
-    const newValue = applyAll(value, patches)
-
-    applySetNode(
-      operation.editor,
-      {
-        ...child,
-        _key: operation.props.includes('_key')
-          ? context.keyGenerator()
-          : child._key,
-        value: newValue,
-      },
-      childPath,
+    const propsToRemove = operation.props.filter(
+      (prop) => prop !== '_type' && prop !== '_key' && prop !== 'children',
     )
+
+    const unsetProps: Record<string, unknown> = {}
+    for (const prop of propsToRemove) {
+      unsetProps[prop] = null
+    }
+
+    if (operation.props.includes('_key')) {
+      unsetProps['_key'] = context.keyGenerator()
+    }
+
+    applySetNode(operation.editor, unsetProps, childPath)
 
     return
   }

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -1,6 +1,5 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {toSlateRange} from '../internal-utils/to-slate-range'
-import {VOID_CHILD_KEY} from '../internal-utils/values'
 import {
   deleteText,
   Editor,
@@ -66,11 +65,16 @@ export const deleteOperationImplementation: OperationImplementation<
   }
 
   if (operation.unit === 'child') {
+    const inlineObjectTypeNames = context.schema.inlineObjects.map(
+      (obj) => obj.name,
+    )
     const childMatches = Editor.nodes(operation.editor, {
       at,
       match: (node) =>
-        (isSpan(context, node) && node._key !== VOID_CHILD_KEY) ||
-        ('__inline' in node && node.__inline === true),
+        isSpan(context, node) ||
+        ('_type' in node &&
+          typeof node._type === 'string' &&
+          inlineObjectTypeNames.includes(node._type)),
     })
     const childPathRefs = Array.from(childMatches, ([, p]) =>
       Editor.pathRef(operation.editor, p),

--- a/packages/editor/src/operations/operation.insert.child.ts
+++ b/packages/editor/src/operations/operation.insert.child.ts
@@ -84,8 +84,7 @@ export const insertChildOperationImplementation: OperationImplementation<
           marks: [],
         },
       ],
-      value: rest,
-      __inline: true,
+      ...rest,
     } as unknown as Node
 
     const [focusSpan] = getFocusSpan({editor: operation.editor})

--- a/packages/editor/src/slate-plugins/slate-plugin.schema.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.schema.ts
@@ -64,14 +64,29 @@ export function createSchemaPlugin({editorActor}: {editorActor: EditorActor}) {
         return false
       }
 
-      const inlineSchemaTypes = editorActor
+      const isInlineType = editorActor
         .getSnapshot()
         .context.schema.inlineObjects.map((obj) => obj.name)
-      return (
-        inlineSchemaTypes.includes(element._type) &&
-        '__inline' in element &&
-        element.__inline === true
-      )
+        .includes(element._type)
+
+      if (!isInlineType) {
+        return false
+      }
+
+      const isAlsoBlockType = editorActor
+        .getSnapshot()
+        .context.schema.blockObjects.map((obj) => obj.name)
+        .includes(element._type)
+
+      if (isAlsoBlockType) {
+        for (const child of editor.children) {
+          if (child === element) {
+            return false
+          }
+        }
+      }
+
+      return true
     }
 
     // Extend Slate's default normalization

--- a/packages/editor/src/slate/interfaces/text.ts
+++ b/packages/editor/src/slate/interfaces/text.ts
@@ -92,7 +92,11 @@ export const Text: TextInterface = {
   },
 
   isText(value: any): value is Text {
-    return isObject(value) && typeof value.text === 'string'
+    return (
+      isObject(value) &&
+      typeof value.text === 'string' &&
+      !Array.isArray(value.children)
+    )
   },
 
   isTextList(value: any): value is Text[] {

--- a/packages/editor/src/slate/interfaces/transforms/general.ts
+++ b/packages/editor/src/slate/interfaces/transforms/general.ts
@@ -230,9 +230,14 @@ export const GeneralTransforms: GeneralTransforms = {
 
         modifyDescendant(editor, path, (node) => {
           const newNode = {...node}
+          const isElement = 'children' in node && Array.isArray(node.children)
 
           for (const key in newProperties) {
-            if (key === 'children' || key === 'text') {
+            if (key === 'children') {
+              throw new Error(`Cannot set the "${key}" property of nodes!`)
+            }
+
+            if (key === 'text' && !isElement) {
               throw new Error(`Cannot set the "${key}" property of nodes!`)
             }
 

--- a/packages/editor/src/types/slate.ts
+++ b/packages/editor/src/types/slate.ts
@@ -6,14 +6,6 @@ import type {BaseEditor, Descendant} from '../slate'
 import type {ReactEditor} from '../slate-react'
 import type {PortableTextSlateEditor} from './slate-editor'
 
-export interface VoidElement {
-  _type: string
-  _key: string
-  children: Descendant[]
-  __inline: boolean
-  value: Record<string, unknown>
-}
-
 export interface SlateTextBlock extends Omit<
   PortableTextTextBlock,
   'children'
@@ -21,10 +13,17 @@ export interface SlateTextBlock extends Omit<
   children: Descendant[]
 }
 
+export interface ObjectElement {
+  _type: string
+  _key: string
+  children: Descendant[]
+  [key: string]: unknown
+}
+
 declare module '../slate/index' {
   interface CustomTypes {
     Editor: BaseEditor & ReactEditor & PortableTextSlateEditor
-    Element: SlateTextBlock | VoidElement
+    Element: SlateTextBlock | ObjectElement
     Text: PortableTextSpan
   }
 }

--- a/packages/editor/tests/event.block.set.test.tsx
+++ b/packages/editor/tests/event.block.set.test.tsx
@@ -195,7 +195,6 @@ describe('event.block.set', () => {
         },
       ])
       expect(patches.slice(4)).toEqual([
-        set('https://www.sanity.io', [{_key: urlBlockKey}, 'href']),
         set('Sanity is a headless CMS', [{_key: urlBlockKey}, 'description']),
       ])
     })

--- a/packages/editor/tests/event.child.set.test.tsx
+++ b/packages/editor/tests/event.child.set.test.tsx
@@ -197,15 +197,6 @@ describe('event.child.set', () => {
           type: 'set',
           value: true,
         },
-        {
-          origin: 'local',
-          path: [{_key: blockKey}, 'children', {_key: cellKey}, 'abilities'],
-          type: 'set',
-          value: {
-            fly: true,
-            swim: false,
-          },
-        },
       ])
     })
   })
@@ -308,26 +299,6 @@ describe('event.child.set', () => {
           path: [{_key: blockKey}, 'children', 1, '_key'],
           type: 'set',
           value: 'new-cell-key',
-        },
-        {
-          origin: 'local',
-          path: [{_key: blockKey}, 'children', {_key: 'new-cell-key'}, 'alive'],
-          type: 'set',
-          value: false,
-        },
-        {
-          origin: 'local',
-          path: [
-            {_key: blockKey},
-            'children',
-            {_key: 'new-cell-key'},
-            'abilities',
-          ],
-          type: 'set',
-          value: {
-            fly: true,
-            swim: false,
-          },
         },
       ])
     })

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -1495,16 +1495,6 @@ describe('event.patches', () => {
             'children',
           ],
         },
-        {
-          type: 'unset',
-          origin: 'remote',
-          path: [
-            {_key: blockKey},
-            'children',
-            {_key: stockTickerKey},
-            '__inline',
-          ],
-        },
       ],
       snapshot: undefined,
     })


### PR DESCRIPTION
### What changed

Removes the `value` wrapper and `__inline` flag from block objects and inline objects in the Slate tree. PT properties now live directly on Slate nodes.

```typescript
// Before:
{ _type: 'image', _key: 'abc', children: [void-child], value: { asset: {...} }, __inline: false }

// After:
{ _type: 'image', _key: 'abc', children: [void-child], asset: {...} }
```

The void-child span stays in Slate's tree for cursor behavior — that's a Slate rendering concern, not a data concern. Everything else is pure PT.

### Why

Foundation for container (nested block) support. With the tree PT-native, a container block is just an element with real `children` — no special wrapping, no void model to work around.

### How

- `types/slate.ts` — `VoidElement` replaced with `ObjectElement` (no `value`, no `__inline`, just `[key: string]: unknown`)
- `values.ts` — `toSlateBlock`/`fromSlateBlock` spread PT properties directly instead of wrapping in `value`
- `apply-operation-to-portable-text.ts` — removed all `value`/`__inline` unwrapping
- `operation-to-patches.ts` — properties read directly from nodes, not from `.value`
- `applyPatch.ts` — patches applied directly to nodes, not to `.value`
- `slate-plugin.schema.ts` — `isInline` uses schema only, no `__inline` check
- `render.element.tsx` / `render.inline-object.tsx` — schema-based inline detection, direct property access
- 4 operation files — insert/set/unset/delete all work with direct properties

18 files changed, 151 insertions, 339 deletions (net -188 lines). 317/317 unit tests pass.