### PR TITLE
fix(editor): fire correct behavior events for Android diff-path deletions

### DIFF
--- a/packages/editor/src/slate-react/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/editor/src/slate-react/hooks/android-input-manager/android-input-manager.ts
@@ -19,7 +19,6 @@ import {
   EDITOR_TO_USER_MARKS,
   IS_COMPOSING,
   IS_NODE_MAP_DIRTY,
-  isDOMSelection,
   isTrackedMutation,
   mergeStringDiffs,
   normalizePoint,
@@ -509,19 +508,6 @@ export function createAndroidInputManager({
 
       case 'deleteContent':
       case 'deleteContentForward': {
-        const {anchor} = targetRange
-        if (canStoreDiff && Range.isCollapsed(targetRange)) {
-          const targetNode = Node.leaf(editor, anchor.path)
-
-          if (anchor.offset < targetNode.text.length) {
-            return storeDiff(anchor.path, {
-              text: '',
-              start: anchor.offset,
-              end: anchor.offset + 1,
-            })
-          }
-        }
-
         return scheduleAction(
           () =>
             editorActor.send({
@@ -534,28 +520,6 @@ export function createAndroidInputManager({
       }
 
       case 'deleteContentBackward': {
-        const {anchor} = targetRange
-
-        // If we have a mismatch between the native and slate selection being collapsed
-        // we are most likely deleting a zero-width placeholder and thus should perform it
-        // as an action to ensure correct behavior (mostly happens with mark placeholders)
-        const nativeCollapsed = isDOMSelection(nativeTargetRange)
-          ? nativeTargetRange.isCollapsed
-          : !!nativeTargetRange?.collapsed
-
-        if (
-          canStoreDiff &&
-          nativeCollapsed &&
-          Range.isCollapsed(targetRange) &&
-          anchor.offset > 0
-        ) {
-          return storeDiff(anchor.path, {
-            text: '',
-            start: anchor.offset - 1,
-            end: anchor.offset,
-          })
-        }
-
         return scheduleAction(
           () =>
             editorActor.send({


### PR DESCRIPTION
## Fix: Fire correct behavior events for Android deletions

### Problem

On Android, the `deleteContentBackward` and `deleteContentForward` input types were using the "diff path" — an optimization that batches rapid text changes into a single diff and flushes them later. This works great for insertions, but for deletions the flush sends `{type: 'delete', direction: 'forward'}` regardless of the original input type. This means any behavior listening for `delete.backward` or `delete.forward` never fires.

### Fix

Remove the diff path for `deleteContentBackward` and `deleteContentForward` entirely. Always use `scheduleAction` for these input types, which sends the correct `delete.backward` / `delete.forward` behavior events.

The diff path remains in use for insertions (`insertText`, `insertCompositionText`, etc.) where it works correctly.

### Changes

- `android-input-manager.ts`: Remove the `storeDiff` branches from `deleteContentBackward` and `deleteContentForward` cases — always use `scheduleAction` instead
- Remove unused `isDOMSelection` import (was only used in the deleted `deleteContentBackward` diff path)