### PR TITLE
chore: add `apps/docs/.astro` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ lib
 CHANGELOG.md
 pnpm-lock.yaml
 
+apps/docs/.astro
 apps/docs/src/content/docs/api
 packages/block-tools/test/**/*.html
 .changeset/*.md


### PR DESCRIPTION
### What changed

Added `apps/docs/.astro` to `.prettierignore`.

### Why

The `apps/docs/.astro/` directory contains 5 auto-generated Astro files (`collections/docs.schema.json`, `content-assets.mjs`, `content-modules.mjs`, `content.d.ts`, `types.d.ts`) that fail `pnpm check:format`. These are generated files that shouldn't be format-checked.

This was causing `check:format` CI to fail on every PR.