### PR TITLE
fix: merge consecutive text ops when one undoStepId is undefined

### DIFF
--- a/.changeset/fix-undo-step-id-leak-undefined.md
+++ b/.changeset/fix-undo-step-id-leak-undefined.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: merge consecutive text ops when one undoStepId is undefined

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -117,6 +117,40 @@ export function createUndoSteps({
     }
   }
 
+  // Handle case when the current operation has no undoStepId but the previous
+  // one did. This can happen when a forward-only behavior intercepts an event,
+  // causing the operation to be applied with an undoStepId, followed by a
+  // subsequent operation without one. We still want to merge consecutive text
+  // operations in this case.
+  //
+  // Note: the reverse case (current has ID, previous doesn't) is intentionally
+  // not merged. When a behavior claims an event with an undoStepId, it signals
+  // an intentional undo step boundary (e.g., input rules).
+  if (currentUndoStepId === undefined && previousUndoStepId !== undefined) {
+    const lastOp = lastStep.operations.at(-1)
+
+    if (
+      lastOp &&
+      op.type === 'insert_text' &&
+      lastOp.type === 'insert_text' &&
+      op.offset === lastOp.offset + lastOp.text.length &&
+      Path.equals(op.path, lastOp.path) &&
+      op.text !== ' '
+    ) {
+      return mergeIntoLastStep(steps, lastStep, op)
+    }
+
+    if (
+      lastOp &&
+      op.type === 'remove_text' &&
+      lastOp.type === 'remove_text' &&
+      op.offset + op.text.length === lastOp.offset &&
+      Path.equals(op.path, lastOp.path)
+    ) {
+      return mergeIntoLastStep(steps, lastStep, op)
+    }
+  }
+
   return createNewStep(steps, op, editor)
 }
 

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -853,7 +853,7 @@ describe('event.history.undo', () => {
       decorator: 'strong',
     })
 
-    // After adding: "f" + "oob" (strong) + "ar" — three spans
+    // After adding: "f" + "oob" (strong) + "ar" - three spans
     await vi.waitFor(() => {
       expect(getTersePt(editor.getSnapshot().context)).toEqual(['f,oob,ar'])
     })
@@ -919,7 +919,7 @@ describe('event.history.undo', () => {
       },
     })
 
-    // After adding: "f" + "oob" (link) + "ar" — three spans
+    // After adding: "f" + "oob" (link) + "ar" - three spans
     await vi.waitFor(() => {
       expect(getTersePt(editor.getSnapshot().context)).toEqual(['f,oob,ar'])
     })
@@ -929,6 +929,37 @@ describe('event.history.undo', () => {
     // After undo: back to original value
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: forward-only behavior should not break consecutive typing merge', async () => {
+    const {editor, locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [({event}) => [forward(event)]],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.type(locator, 'a')
+    await userEvent.type(locator, 'b')
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['ab'])
+    })
+
+    // If the undoStepId leak is fixed, these should be one undo step
+    // (consecutive insert_text, same path, adjacent offsets)
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
     })
   })
 })


### PR DESCRIPTION
Companion to #2243. That PR fixed the case where both undoStepIds are defined but different (consecutive forwarded events). This PR fixes the remaining case where the current operation has no undoStepId but the previous one did.

This happens when a forward-only behavior intercepts one keystroke (giving it an undoStepId from the send entry) but the next keystroke has no matching behavior (so its undoStepId is undefined). The mismatch prevented the consecutive insert_text merge heuristic from running, making each keystroke its own undo step.

The reverse case (current has ID, previous doesn't) is intentionally not merged. When a behavior claims an event and gets an undoStepId, that signals an intentional undo step boundary, like input rules replacing `->` with `→`.