### PR TITLE
fix: stable span key

### DIFF
--- a/.changeset/cyan-shoes-try.md
+++ b/.changeset/cyan-shoes-try.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stabilize span keys when writing between marks

--- a/.changeset/cyan-shoes-try.md
+++ b/.changeset/cyan-shoes-try.md
@@ -1,0 +1,14 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stabilize span keys when writing between marks
+
+Typing next to decorated or annotated text no longer replaces the span
+the character lands in. Previously, when the active marks matched the
+span at the caret (or the span right after it, when typing at a span
+boundary), the editor inserted a fresh span with a fresh `_key` and
+merged it away; anything keyed on span identity (diff views,
+content-lake patches, presence and comment anchors) saw a span vanish
+and an unfamiliar one appear. The character now flows into the existing
+span, and its `_key` is preserved.

--- a/packages/editor/src/behaviors/behavior.core.insert.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert.ts
@@ -1,3 +1,5 @@
+import {isEqualMarks} from '../internal-utils/equality'
+import {getNextSpan} from '../selectors'
 import {getActiveAnnotationsMarks} from '../selectors/selector.get-active-annotation-marks'
 import {getActiveDecorators} from '../selectors/selector.get-active-decorators'
 import {getFocusSpan} from '../selectors/selector.get-focus-span'
@@ -34,19 +36,51 @@ export const coreInsertBehaviors = [
         }
       }
 
-      return {activeDecorators, activeAnnotations}
+      const activeMarks = [...activeDecorators, ...activeAnnotations]
+
+      if (isEqualMarks(focusSpan.node.marks ?? [], activeMarks)) {
+        return false
+      }
+
+      const atEndOfFocusSpan =
+        snapshot.context.selection?.focus.offset === focusSpan.node.text.length
+
+      const nextSpan = atEndOfFocusSpan ? getNextSpan(snapshot) : undefined
+
+      return {activeMarks, nextSpan}
     },
     actions: [
-      ({snapshot, event}, {activeDecorators, activeAnnotations}) => [
-        raise({
-          type: 'insert.child',
-          child: {
-            _type: snapshot.context.schema.span.name,
-            text: event.text,
-            marks: [...activeDecorators, ...activeAnnotations],
-          },
-        }),
-      ],
+      ({snapshot, event}, {activeMarks, nextSpan}) => {
+        if (nextSpan && isEqualMarks(nextSpan.node.marks, activeMarks)) {
+          return [
+            raise({
+              type: 'select',
+              at: {
+                anchor: {
+                  path: nextSpan.path,
+                  offset: 0,
+                },
+                focus: {
+                  path: nextSpan.path,
+                  offset: 0,
+                },
+              },
+            }),
+            raise(event),
+          ]
+        }
+
+        return [
+          raise({
+            type: 'insert.child',
+            child: {
+              _type: snapshot.context.schema.span.name,
+              text: event.text,
+              marks: activeMarks,
+            },
+          }),
+        ]
+      },
     ],
   }),
 ]

--- a/packages/editor/src/behaviors/behavior.core.insert.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert.ts
@@ -1,8 +1,11 @@
+import {isSpan} from '@portabletext/schema'
+import {isEqualMarkSet} from '../internal-utils/equality'
 import {getActiveAnnotationsMarks} from '../selectors/selector.get-active-annotation-marks'
 import {getActiveDecorators} from '../selectors/selector.get-active-decorators'
 import {getFocusSpan} from '../selectors/selector.get-focus-span'
 import {getMarkState} from '../selectors/selector.get-mark-state'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
+import {getSibling} from '../traversal/get-sibling'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -36,19 +39,57 @@ export const coreInsertBehaviors = [
         }
       }
 
-      return {activeDecorators, activeAnnotations}
+      const activeMarks = [...activeDecorators, ...activeAnnotations]
+
+      if (isEqualMarkSet(focusSpan.node.marks ?? [], activeMarks)) {
+        return false
+      }
+
+      const atEndOfFocusSpan =
+        snapshot.context.selection?.focus.offset === focusSpan.node.text.length
+
+      const nextSibling = atEndOfFocusSpan
+        ? getSibling(snapshot, focusSpan.path, {direction: 'next'})
+        : undefined
+      const nextSpan =
+        nextSibling && isSpan(snapshot.context, nextSibling.node)
+          ? {node: nextSibling.node, path: nextSibling.path}
+          : undefined
+
+      return {activeMarks, nextSpan}
     },
     actions: [
-      ({snapshot, event}, {activeDecorators, activeAnnotations}) => [
-        raise({
-          type: 'insert.child',
-          child: {
-            _type: snapshot.context.schema.span.name,
-            text: event.text,
-            marks: [...activeDecorators, ...activeAnnotations],
-          },
-        }),
-      ],
+      ({snapshot, event}, {activeMarks, nextSpan}) => {
+        if (nextSpan && isEqualMarkSet(nextSpan.node.marks, activeMarks)) {
+          return [
+            raise({
+              type: 'select',
+              at: {
+                anchor: {
+                  path: nextSpan.path,
+                  offset: 0,
+                },
+                focus: {
+                  path: nextSpan.path,
+                  offset: 0,
+                },
+              },
+            }),
+            raise(event),
+          ]
+        }
+
+        return [
+          raise({
+            type: 'insert.child',
+            child: {
+              _type: snapshot.context.schema.span.name,
+              text: event.text,
+              marks: activeMarks,
+            },
+          }),
+        ]
+      },
     ],
   }),
 ]

--- a/packages/editor/src/internal-utils/equality.test.ts
+++ b/packages/editor/src/internal-utils/equality.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, test} from 'vitest'
+import {isEqualMarkSet, isEqualMarks} from './equality'
+
+describe(isEqualMarks.name, () => {
+  test('order matters: value sync must write reordered marks through', () => {
+    expect(isEqualMarks(['strong', 'link-key'], ['link-key', 'strong'])).toBe(
+      false,
+    )
+    expect(isEqualMarks(['strong', 'link-key'], ['strong', 'link-key'])).toBe(
+      true,
+    )
+  })
+
+  test('`undefined` only equals `undefined`', () => {
+    expect(isEqualMarks(undefined, undefined)).toBe(true)
+    expect(isEqualMarks(undefined, [])).toBe(false)
+    expect(isEqualMarks([], undefined)).toBe(false)
+  })
+})
+
+describe(isEqualMarkSet.name, () => {
+  test('order does not matter: marks from different provenances disagree on order', () => {
+    expect(isEqualMarkSet(['strong', 'link-key'], ['link-key', 'strong'])).toBe(
+      true,
+    )
+    expect(isEqualMarkSet([], [])).toBe(true)
+  })
+
+  test('differing sets are not equal', () => {
+    expect(isEqualMarkSet(['strong'], ['em'])).toBe(false)
+    expect(isEqualMarkSet(['strong'], ['strong', 'em'])).toBe(false)
+    expect(isEqualMarkSet(['strong', 'em'], ['strong'])).toBe(false)
+  })
+
+  test('`undefined` only equals `undefined`', () => {
+    expect(isEqualMarkSet(undefined, undefined)).toBe(true)
+    expect(isEqualMarkSet(undefined, [])).toBe(false)
+    expect(isEqualMarkSet([], undefined)).toBe(false)
+  })
+})

--- a/packages/editor/src/internal-utils/equality.ts
+++ b/packages/editor/src/internal-utils/equality.ts
@@ -169,6 +169,27 @@ export function isEqualMarks(
   return true
 }
 
+export function isEqualMarkSet(
+  a: Array<string> | undefined,
+  b: Array<string> | undefined,
+): boolean {
+  if (!a || !b) {
+    return a === b
+  }
+
+  if (a.length !== b.length) {
+    return false
+  }
+
+  for (const mark of a) {
+    if (!b.includes(mark)) {
+      return false
+    }
+  }
+
+  return true
+}
+
 function isEqualSpans(a: ChildLike, b: ChildLike): boolean {
   if (
     a._key !== b._key ||

--- a/packages/editor/tests/stable-keys.test.tsx
+++ b/packages/editor/tests/stable-keys.test.tsx
@@ -1,0 +1,83 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('Feature: Stable keys', () => {
+  test('Scenario: Typing after annotation', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const bazKey = keyGenerator()
+    const linkKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo ', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: [linkKey]},
+            {_type: 'span', _key: bazKey, text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_type: 'link', _key: linkKey, href: 'https://portabletext.org'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
+
+    // When the editor is focused
+    await userEvent.click(locator)
+
+    // And the caret is put before " baz"
+    const beforeBazSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: bazKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: blockKey}, 'children', {_key: bazKey}],
+        offset: 0,
+      },
+      backward: false,
+    }
+    editor.send({
+      type: 'select',
+      at: beforeBazSelection,
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(beforeBazSelection)
+    })
+
+    // And "new" is typed
+    await userEvent.keyboard('new')
+
+    // Then the text is "foo ,bar,new baz"
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo ', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: [linkKey]},
+            {_type: 'span', _key: bazKey, text: 'new baz', marks: []},
+          ],
+          markDefs: [
+            {_type: 'link', _key: linkKey, href: 'https://portabletext.org'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/stable-keys.test.tsx
+++ b/packages/editor/tests/stable-keys.test.tsx
@@ -2,6 +2,7 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
+import {getActiveDecorators} from '../src/selectors/selector.get-active-decorators'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('Feature: Stable keys', () => {
@@ -75,6 +76,163 @@ describe('Feature: Stable keys', () => {
           markDefs: [
             {_type: 'link', _key: linkKey, href: 'https://portabletext.org'},
           ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Typing with activated decorator at end of unmarked span absorbs into next matching span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const helloKey = keyGenerator()
+    const worldKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: helloKey, text: 'hello', marks: []},
+            {_type: 'span', _key: worldKey, text: ' world', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    // When the editor is focused
+    await userEvent.click(locator)
+
+    // And the caret is put at the end of "hello"
+    const endOfHelloSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: helloKey}],
+        offset: 5,
+      },
+      focus: {
+        path: [{_key: blockKey}, 'children', {_key: helloKey}],
+        offset: 5,
+      },
+      backward: false,
+    }
+    editor.send({
+      type: 'select',
+      at: endOfHelloSelection,
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(
+        endOfHelloSelection,
+      )
+    })
+
+    // And "strong" is activated
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+    await vi.waitFor(() => {
+      expect(getActiveDecorators(editor.getSnapshot())).toEqual(['strong'])
+    })
+
+    // And "x" is typed
+    await userEvent.keyboard('x')
+
+    // Then the next span absorbs the new character and keeps its key
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: helloKey, text: 'hello', marks: []},
+            {_type: 'span', _key: worldKey, text: 'x world', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Typing with activated decorator before an inline object does not jump past it', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const helloKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const worldKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+        inlineObjects: [{name: 'stock-ticker'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: helloKey, text: 'hello', marks: []},
+            {_type: 'stock-ticker', _key: stockTickerKey},
+            {_type: 'span', _key: worldKey, text: ' world', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    // When the editor is focused
+    await userEvent.click(locator)
+
+    // And the caret is put at the end of "hello"
+    const endOfHelloSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: helloKey}],
+        offset: 5,
+      },
+      focus: {
+        path: [{_key: blockKey}, 'children', {_key: helloKey}],
+        offset: 5,
+      },
+      backward: false,
+    }
+    editor.send({
+      type: 'select',
+      at: endOfHelloSelection,
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(
+        endOfHelloSelection,
+      )
+    })
+
+    // And "strong" is activated
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+    await vi.waitFor(() => {
+      expect(getActiveDecorators(editor.getSnapshot())).toEqual(['strong'])
+    })
+
+    // And "x" is typed
+    await userEvent.keyboard('x')
+
+    // Then the character lands before the inline object, not beyond it
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: helloKey, text: 'hello', marks: []},
+            {_type: 'span', _key: 'k6', text: 'x', marks: ['strong']},
+            {_type: 'stock-ticker', _key: stockTickerKey},
+            {_type: 'span', _key: worldKey, text: ' world', marks: ['strong']},
+          ],
+          markDefs: [],
           style: 'normal',
         },
       ])


### PR DESCRIPTION
Span `_key`s carry identity downstream (Studio diff, content-lake patches, presence cursors). Typing right next to a marked span shouldn't change that identity, but it does today — the `insert.text` core behavior always raises `insert.child`, even when the resulting span would be identical to the one already there.

This PR makes the `insert.text` behavior stand down in two cases:

1. When the active marks already match the focus span's marks, the behavior returns `false` and the engine inserts the character into the existing span. Typing directly after an annotation (caret at offset 0 of the unmarked span that follows) keeps the unmarked span's `_key`.

2. When the caret is at the end of a span whose marks differ from the active marks, but the next span's marks match the active marks, the behavior moves the caret to offset 0 of that next span and re-raises the `insert.text`. Typing with a decorator activated, just before a span that already has that decorator, absorbs into the existing decorated span and keeps its `_key`.

Both scenarios are covered by `tests/stable-keys.test.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core text-insert behavior and mark comparison at span boundaries; wrong guard logic could change where characters land or how marks apply, though scope is narrow and well-covered by tests.
> 
> **Overview**
> **Fixes span `_key` churn** when typing next to annotated or decorated text. The core `insert.text` behavior no longer always raises `insert.child` when active marks would produce the same span as one already in the document.
> 
> When **active marks match the focus span**, the behavior returns `false` so the default engine path inserts into that span (e.g. typing at the start of the unmarked span after a link keeps `bazKey`).
> 
> When the caret is **at the end of a span** whose marks differ from the active set but the **next sibling is a span with matching marks**, it selects offset 0 on that next span and re-raises `insert.text` so text merges into the existing decorated span instead of creating a throwaway span. **Non-span siblings** (e.g. inline objects) are ignored so typing does not jump past them.
> 
> Adds **`isEqualMarkSet`** (order-insensitive mark comparison, distinct from order-sensitive `isEqualMarks`) plus unit and browser tests in `stable-keys.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d7a9b2eb287e77b5edf68d4f58aa1223462170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->