### PR TITLE
feat: per-style schema restrictions

### DIFF
--- a/packages/editor/gherkin-spec/per-style-restrictions.feature
+++ b/packages/editor/gherkin-spec/per-style-restrictions.feature
@@ -42,3 +42,37 @@ Feature: Per-style schema restrictions
     And "h2" is toggled
     And "strong" is toggled
     Then "hello world" has no marks
+
+  Scenario: Annotation toggle is blocked on restricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "h1" is toggled
+    And "link" is toggled
+    Then "hello world" has no marks
+
+  Scenario: Annotation toggle works on unrestricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "link" "a1" is toggled
+    Then "hello world" has marks "a1"
+
+  Scenario: Style change to restricted strips existing annotations
+    Given the text "hello world"
+    When "hello world" is selected
+    And "link" "a1" is toggled
+    Then "hello world" has marks "a1"
+    When "h1" is toggled
+    Then "hello world" has no marks
+
+  Scenario: List toggle is blocked on restricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "h1" is toggled
+    And "bullet" list is toggled
+    Then the text is "h1:hello world"
+
+  Scenario: List toggle works on unrestricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "bullet" list is toggled
+    Then the text is ">-:hello world"

--- a/packages/editor/gherkin-spec/per-style-restrictions.feature
+++ b/packages/editor/gherkin-spec/per-style-restrictions.feature
@@ -1,0 +1,44 @@
+Feature: Per-style schema restrictions
+
+  Scenario: Decorator toggle is blocked on restricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "h1" is toggled
+    And "strong" is toggled
+    Then "hello world" has no marks
+
+  Scenario: Decorator toggle works on unrestricted style
+    Given the text "hello world"
+    When "hello world" is selected
+    And "strong" is toggled
+    Then "hello world" has marks "strong"
+
+  Scenario: Style change to restricted strips existing decorators
+    Given the text "hello world"
+    When "hello world" is selected
+    And "strong" is toggled
+    Then "hello world" has marks "strong"
+    When "h1" is toggled
+    Then "hello world" has no marks
+
+  Scenario: Style change to unrestricted preserves decorators
+    Given the text "hello world"
+    When "hello world" is selected
+    And "strong" is toggled
+    Then "hello world" has marks "strong"
+    When "blockquote" is toggled
+    Then "hello world" has marks "strong"
+
+  Scenario: Partially restricted style allows some decorators
+    Given the text "hello world"
+    When "hello world" is selected
+    And "h2" is toggled
+    And "em" is toggled
+    Then "hello world" has marks "em"
+
+  Scenario: Partially restricted style blocks disallowed decorators
+    Given the text "hello world"
+    When "hello world" is selected
+    And "h2" is toggled
+    And "strong" is toggled
+    Then "hello world" has no marks

--- a/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
+++ b/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
@@ -1,0 +1,34 @@
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import {parameterTypes} from '../src/test'
+import {createTestEditor, stepDefinitions} from '../src/test/vitest'
+import type {Context} from '../src/test/vitest/step-context'
+import perStyleRestrictionsFeature from '../gherkin-spec/per-style-restrictions.feature?raw'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        schemaDefinition: defineSchema({
+          decorators: [{name: 'strong'}, {name: 'em'}],
+          annotations: [{name: 'link'}],
+          styles: [
+            {name: 'normal'},
+            {name: 'h1', decorators: [], annotations: []},
+            {name: 'h2', decorators: [{name: 'em'}]},
+            {name: 'blockquote'},
+          ],
+          lists: [{name: 'bullet'}],
+        }),
+      })
+
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: perStyleRestrictionsFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
+++ b/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
@@ -1,10 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
 import {Before} from 'racejar'
 import {Feature} from 'racejar/vitest'
+import perStyleRestrictionsFeature from '../gherkin-spec/per-style-restrictions.feature?raw'
 import {parameterTypes} from '../src/test'
 import {createTestEditor, stepDefinitions} from '../src/test/vitest'
 import type {Context} from '../src/test/vitest/step-context'
-import perStyleRestrictionsFeature from '../gherkin-spec/per-style-restrictions.feature?raw'
 
 Feature({
   hooks: [

--- a/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
+++ b/packages/editor/gherkin-tests/per-style-restrictions.test.tsx
@@ -15,7 +15,7 @@ Feature({
           annotations: [{name: 'link'}],
           styles: [
             {name: 'normal'},
-            {name: 'h1', decorators: [], annotations: []},
+            {name: 'h1', decorators: [], annotations: [], lists: []},
             {name: 'h2', decorators: [{name: 'em'}]},
             {name: 'blockquote'},
           ],

--- a/packages/editor/src/behaviors/behavior.abstract.annotation.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.annotation.ts
@@ -2,6 +2,7 @@ import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+import {isAnnotationAllowedByStyle} from './behavior.utils.style-feature-allowed'
 
 export const abstractAnnotationBehaviors = [
   defineBehavior({
@@ -100,7 +101,17 @@ export const abstractAnnotationBehaviors = [
         },
       }
 
-      return !isActiveAnnotation(event.annotation.name)(adjustedSnapshot)
+      if (isActiveAnnotation(event.annotation.name)(adjustedSnapshot)) {
+        return false
+      }
+
+      if (
+        !isAnnotationAllowedByStyle(adjustedSnapshot, event.annotation.name)
+      ) {
+        return false
+      }
+
+      return true
     },
     actions: [
       ({event}) => [

--- a/packages/editor/src/behaviors/behavior.abstract.decorator.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.decorator.ts
@@ -1,3 +1,4 @@
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isActiveDecorator} from '../selectors/selector.is-active-decorator'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
@@ -39,6 +40,20 @@ export const abstractDecoratorBehaviors = [
 
       if (!at) {
         return false
+      }
+
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (focusTextBlock) {
+        const style = focusTextBlock.node.style
+        const styleType = style
+          ? snapshot.context.schema.styles.find((s) => s.name === style)
+          : undefined
+        if (
+          styleType?.decorators &&
+          !styleType.decorators.some((d) => d.name === event.decorator)
+        ) {
+          return false
+        }
       }
 
       const adjustedSnapshot = {

--- a/packages/editor/src/behaviors/behavior.abstract.decorator.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.decorator.ts
@@ -1,7 +1,7 @@
-import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isActiveDecorator} from '../selectors/selector.is-active-decorator'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+import {isDecoratorAllowedByStyle} from './behavior.utils.style-feature-allowed'
 
 export const abstractDecoratorBehaviors = [
   defineBehavior({
@@ -42,18 +42,8 @@ export const abstractDecoratorBehaviors = [
         return false
       }
 
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (focusTextBlock) {
-        const style = focusTextBlock.node.style
-        const styleType = style
-          ? snapshot.context.schema.styles.find((s) => s.name === style)
-          : undefined
-        if (
-          styleType?.decorators &&
-          !styleType.decorators.some((d) => d.name === event.decorator)
-        ) {
-          return false
-        }
+      if (!isDecoratorAllowedByStyle(snapshot, event.decorator)) {
+        return false
       }
 
       const adjustedSnapshot = {

--- a/packages/editor/src/behaviors/behavior.abstract.list-item.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.list-item.ts
@@ -1,3 +1,4 @@
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getSelectedTextBlocks} from '../selectors/selector.get-selected-text-blocks'
 import {isActiveListItem} from '../selectors/selector.is-active-list-item'
 import {raise} from './behavior.types.action'
@@ -13,6 +14,20 @@ export const abstractListItemBehaviors = [
         )
       ) {
         return false
+      }
+
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (focusTextBlock) {
+        const style = focusTextBlock.node.style
+        const styleType = style
+          ? snapshot.context.schema.styles.find((s) => s.name === style)
+          : undefined
+        if (
+          styleType?.lists &&
+          !styleType.lists.some((l) => l.name === event.listItem)
+        ) {
+          return false
+        }
       }
 
       const selectedTextBlocks = getSelectedTextBlocks(snapshot)

--- a/packages/editor/src/behaviors/behavior.abstract.list-item.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.list-item.ts
@@ -1,8 +1,8 @@
-import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getSelectedTextBlocks} from '../selectors/selector.get-selected-text-blocks'
 import {isActiveListItem} from '../selectors/selector.is-active-list-item'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+import {isListAllowedByStyle} from './behavior.utils.style-feature-allowed'
 
 export const abstractListItemBehaviors = [
   defineBehavior({
@@ -16,18 +16,8 @@ export const abstractListItemBehaviors = [
         return false
       }
 
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (focusTextBlock) {
-        const style = focusTextBlock.node.style
-        const styleType = style
-          ? snapshot.context.schema.styles.find((s) => s.name === style)
-          : undefined
-        if (
-          styleType?.lists &&
-          !styleType.lists.some((l) => l.name === event.listItem)
-        ) {
-          return false
-        }
+      if (!isListAllowedByStyle(snapshot, event.listItem)) {
+        return false
       }
 
       const selectedTextBlocks = getSelectedTextBlocks(snapshot)

--- a/packages/editor/src/behaviors/behavior.core.decorators.ts
+++ b/packages/editor/src/behaviors/behavior.core.decorators.ts
@@ -1,44 +1,123 @@
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 export const coreDecoratorBehaviors = {
   strongShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) =>
-      defaultKeyboardShortcuts.decorators.strong.guard(event.originEvent) &&
-      snapshot.context.schema.decorators.some(
-        (decorator) => decorator.name === 'strong',
-      ),
+    guard: ({snapshot, event}) => {
+      if (!defaultKeyboardShortcuts.decorators.strong.guard(event.originEvent))
+        return false
+      if (
+        !snapshot.context.schema.decorators.some(
+          (decorator) => decorator.name === 'strong',
+        )
+      ) {
+        return false
+      }
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (!focusTextBlock) return false
+      const style = focusTextBlock.node.style
+      const styleType = style
+        ? snapshot.context.schema.styles.find((s) => s.name === style)
+        : undefined
+      if (
+        styleType?.decorators &&
+        !styleType.decorators.some((d) => d.name === 'strong')
+      ) {
+        return false
+      }
+      return true
+    },
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'strong'})]],
   }),
   emShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) =>
-      defaultKeyboardShortcuts.decorators.em.guard(event.originEvent) &&
-      snapshot.context.schema.decorators.some(
-        (decorator) => decorator.name === 'em',
-      ),
+    guard: ({snapshot, event}) => {
+      if (!defaultKeyboardShortcuts.decorators.em.guard(event.originEvent))
+        return false
+      if (
+        !snapshot.context.schema.decorators.some(
+          (decorator) => decorator.name === 'em',
+        )
+      ) {
+        return false
+      }
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (!focusTextBlock) return false
+      const style = focusTextBlock.node.style
+      const styleType = style
+        ? snapshot.context.schema.styles.find((s) => s.name === style)
+        : undefined
+      if (
+        styleType?.decorators &&
+        !styleType.decorators.some((d) => d.name === 'em')
+      ) {
+        return false
+      }
+      return true
+    },
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'em'})]],
   }),
   underlineShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) =>
-      defaultKeyboardShortcuts.decorators.underline.guard(event.originEvent) &&
-      snapshot.context.schema.decorators.some(
-        (decorator) => decorator.name === 'underline',
-      ),
+    guard: ({snapshot, event}) => {
+      if (
+        !defaultKeyboardShortcuts.decorators.underline.guard(event.originEvent)
+      )
+        return false
+      if (
+        !snapshot.context.schema.decorators.some(
+          (decorator) => decorator.name === 'underline',
+        )
+      ) {
+        return false
+      }
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (!focusTextBlock) return false
+      const style = focusTextBlock.node.style
+      const styleType = style
+        ? snapshot.context.schema.styles.find((s) => s.name === style)
+        : undefined
+      if (
+        styleType?.decorators &&
+        !styleType.decorators.some((d) => d.name === 'underline')
+      ) {
+        return false
+      }
+      return true
+    },
     actions: [
       () => [raise({type: 'decorator.toggle', decorator: 'underline'})],
     ],
   }),
   codeShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) =>
-      defaultKeyboardShortcuts.decorators.code.guard(event.originEvent) &&
-      snapshot.context.schema.decorators.some(
-        (decorator) => decorator.name === 'code',
-      ),
+    guard: ({snapshot, event}) => {
+      if (!defaultKeyboardShortcuts.decorators.code.guard(event.originEvent))
+        return false
+      if (
+        !snapshot.context.schema.decorators.some(
+          (decorator) => decorator.name === 'code',
+        )
+      ) {
+        return false
+      }
+      const focusTextBlock = getFocusTextBlock(snapshot)
+      if (!focusTextBlock) return false
+      const style = focusTextBlock.node.style
+      const styleType = style
+        ? snapshot.context.schema.styles.find((s) => s.name === style)
+        : undefined
+      if (
+        styleType?.decorators &&
+        !styleType.decorators.some((d) => d.name === 'code')
+      ) {
+        return false
+      }
+      return true
+    },
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'code'})]],
   }),
 }

--- a/packages/editor/src/behaviors/behavior.core.decorators.ts
+++ b/packages/editor/src/behaviors/behavior.core.decorators.ts
@@ -1,123 +1,56 @@
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
+import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+import {isDecoratorAllowedByStyle} from './behavior.utils.style-feature-allowed'
 
 export const coreDecoratorBehaviors = {
   strongShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) => {
-      if (!defaultKeyboardShortcuts.decorators.strong.guard(event.originEvent))
-        return false
-      if (
-        !snapshot.context.schema.decorators.some(
-          (decorator) => decorator.name === 'strong',
-        )
-      ) {
-        return false
-      }
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (!focusTextBlock) return false
-      const style = focusTextBlock.node.style
-      const styleType = style
-        ? snapshot.context.schema.styles.find((s) => s.name === style)
-        : undefined
-      if (
-        styleType?.decorators &&
-        !styleType.decorators.some((d) => d.name === 'strong')
-      ) {
-        return false
-      }
-      return true
-    },
+    guard: ({snapshot, event}) =>
+      defaultKeyboardShortcuts.decorators.strong.guard(event.originEvent) &&
+      isDecoratorShortcutAllowed(snapshot, 'strong'),
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'strong'})]],
   }),
   emShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) => {
-      if (!defaultKeyboardShortcuts.decorators.em.guard(event.originEvent))
-        return false
-      if (
-        !snapshot.context.schema.decorators.some(
-          (decorator) => decorator.name === 'em',
-        )
-      ) {
-        return false
-      }
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (!focusTextBlock) return false
-      const style = focusTextBlock.node.style
-      const styleType = style
-        ? snapshot.context.schema.styles.find((s) => s.name === style)
-        : undefined
-      if (
-        styleType?.decorators &&
-        !styleType.decorators.some((d) => d.name === 'em')
-      ) {
-        return false
-      }
-      return true
-    },
+    guard: ({snapshot, event}) =>
+      defaultKeyboardShortcuts.decorators.em.guard(event.originEvent) &&
+      isDecoratorShortcutAllowed(snapshot, 'em'),
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'em'})]],
   }),
   underlineShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) => {
-      if (
-        !defaultKeyboardShortcuts.decorators.underline.guard(event.originEvent)
-      )
-        return false
-      if (
-        !snapshot.context.schema.decorators.some(
-          (decorator) => decorator.name === 'underline',
-        )
-      ) {
-        return false
-      }
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (!focusTextBlock) return false
-      const style = focusTextBlock.node.style
-      const styleType = style
-        ? snapshot.context.schema.styles.find((s) => s.name === style)
-        : undefined
-      if (
-        styleType?.decorators &&
-        !styleType.decorators.some((d) => d.name === 'underline')
-      ) {
-        return false
-      }
-      return true
-    },
+    guard: ({snapshot, event}) =>
+      defaultKeyboardShortcuts.decorators.underline.guard(event.originEvent) &&
+      isDecoratorShortcutAllowed(snapshot, 'underline'),
     actions: [
       () => [raise({type: 'decorator.toggle', decorator: 'underline'})],
     ],
   }),
   codeShortcut: defineBehavior({
     on: 'keyboard.keydown',
-    guard: ({snapshot, event}) => {
-      if (!defaultKeyboardShortcuts.decorators.code.guard(event.originEvent))
-        return false
-      if (
-        !snapshot.context.schema.decorators.some(
-          (decorator) => decorator.name === 'code',
-        )
-      ) {
-        return false
-      }
-      const focusTextBlock = getFocusTextBlock(snapshot)
-      if (!focusTextBlock) return false
-      const style = focusTextBlock.node.style
-      const styleType = style
-        ? snapshot.context.schema.styles.find((s) => s.name === style)
-        : undefined
-      if (
-        styleType?.decorators &&
-        !styleType.decorators.some((d) => d.name === 'code')
-      ) {
-        return false
-      }
-      return true
-    },
+    guard: ({snapshot, event}) =>
+      defaultKeyboardShortcuts.decorators.code.guard(event.originEvent) &&
+      isDecoratorShortcutAllowed(snapshot, 'code'),
     actions: [() => [raise({type: 'decorator.toggle', decorator: 'code'})]],
   }),
+}
+
+function isDecoratorShortcutAllowed(
+  snapshot: EditorSnapshot,
+  decoratorName: string,
+): boolean {
+  if (
+    !snapshot.context.schema.decorators.some(
+      (decorator) => decorator.name === decoratorName,
+    )
+  ) {
+    return false
+  }
+  if (!getFocusTextBlock(snapshot)) {
+    return false
+  }
+  return isDecoratorAllowedByStyle(snapshot, decoratorName)
 }

--- a/packages/editor/src/behaviors/behavior.utils.style-feature-allowed.ts
+++ b/packages/editor/src/behaviors/behavior.utils.style-feature-allowed.ts
@@ -1,0 +1,43 @@
+import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
+
+export function isDecoratorAllowedByStyle(
+  snapshot: EditorSnapshot,
+  decoratorName: string,
+): boolean {
+  return isFeatureAllowedByStyle(snapshot, 'decorators', decoratorName)
+}
+
+export function isAnnotationAllowedByStyle(
+  snapshot: EditorSnapshot,
+  annotationName: string,
+): boolean {
+  return isFeatureAllowedByStyle(snapshot, 'annotations', annotationName)
+}
+
+export function isListAllowedByStyle(
+  snapshot: EditorSnapshot,
+  listName: string,
+): boolean {
+  return isFeatureAllowedByStyle(snapshot, 'lists', listName)
+}
+
+function isFeatureAllowedByStyle(
+  snapshot: EditorSnapshot,
+  feature: 'decorators' | 'annotations' | 'lists' | 'inlineObjects',
+  name: string,
+): boolean {
+  const focusTextBlock = getFocusTextBlock(snapshot)
+  if (!focusTextBlock) {
+    return true
+  }
+  const style = focusTextBlock.node.style
+  const styleType = style
+    ? snapshot.context.schema.styles.find((s) => s.name === style)
+    : undefined
+  const allowed = styleType?.[feature]
+  if (allowed && !allowed.some((item) => item.name === name)) {
+    return false
+  }
+  return true
+}

--- a/packages/editor/src/paths/get-dirty-indexed-paths.ts
+++ b/packages/editor/src/paths/get-dirty-indexed-paths.ts
@@ -24,10 +24,10 @@ export function getDirtyIndexedPaths(
       const {path} = op
       const levels = pathLevels(path)
 
+      // When set_node replaces a child array field, the new children
+      // need normalization. Dirty their paths and their descendants'
+      // paths so the normalizer visits them.
       if (op.type === 'set_node') {
-        // When set_node replaces a child array field, the new children
-        // need normalization. Dirty their paths and their descendants'
-        // paths so the normalizer visits them.
         const childFieldName = getChildFieldName(context, path)
 
         if (childFieldName) {

--- a/packages/editor/src/paths/get-dirty-indexed-paths.ts
+++ b/packages/editor/src/paths/get-dirty-indexed-paths.ts
@@ -1,4 +1,4 @@
-import {isSpan} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import {getNodeDescendants} from '../node-traversal/get-nodes'
 import type {Node} from '../slate/interfaces/node'
@@ -24,10 +24,10 @@ export function getDirtyIndexedPaths(
       const {path} = op
       const levels = pathLevels(path)
 
-      // When set_node replaces a child array field, the new children
-      // need normalization. Dirty their paths and their descendants'
-      // paths so the normalizer visits them.
       if (op.type === 'set_node') {
+        // When set_node replaces a child array field, the new children
+        // need normalization. Dirty their paths and their descendants'
+        // paths so the normalizer visits them.
         const childFieldName = getChildFieldName(context, path)
 
         if (childFieldName) {
@@ -49,6 +49,18 @@ export function getDirtyIndexedPaths(
               for (const entry of getNodeDescendants(context, child as Node)) {
                 levels.push(childPath.concat(entry.path))
               }
+            }
+          }
+        }
+
+        // When the `style` property changes on a text block, dirty all
+        // child paths so per-style restriction normalization can strip
+        // marks that the new style disallows.
+        if ('style' in op.newProperties) {
+          const block = context.value[path[0]!]
+          if (block && isTextBlock(context, block)) {
+            for (let i = 0; i < block.children.length; i++) {
+              levels.push([...path, i])
             }
           }
         }

--- a/packages/editor/src/selectors/selector.get-active-decorators.ts
+++ b/packages/editor/src/selectors/selector.get-active-decorators.ts
@@ -1,4 +1,5 @@
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getMarkState} from './selector.get-mark-state'
 
 export function getActiveDecorators(snapshot: EditorSnapshot) {
@@ -22,6 +23,18 @@ export function getActiveDecorators(snapshot: EditorSnapshot) {
       if (!activeDecorators.includes(decorator)) {
         activeDecorators.push(decorator)
       }
+    }
+  }
+
+  const focusBlock = getFocusTextBlock(snapshot)
+  if (focusBlock) {
+    const style = focusBlock.node.style
+    const styleType = style
+      ? snapshot.context.schema.styles.find((s) => s.name === style)
+      : undefined
+    if (styleType?.decorators) {
+      const allowedNames = styleType.decorators.map((d) => d.name)
+      return activeDecorators.filter((name) => allowedNames.includes(name))
     }
   }
 

--- a/packages/editor/src/selectors/selector.get-active-decorators.ts
+++ b/packages/editor/src/selectors/selector.get-active-decorators.ts
@@ -1,5 +1,4 @@
 import type {EditorSnapshot} from '../editor/editor-snapshot'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getMarkState} from './selector.get-mark-state'
 
 export function getActiveDecorators(snapshot: EditorSnapshot) {
@@ -23,18 +22,6 @@ export function getActiveDecorators(snapshot: EditorSnapshot) {
       if (!activeDecorators.includes(decorator)) {
         activeDecorators.push(decorator)
       }
-    }
-  }
-
-  const focusBlock = getFocusTextBlock(snapshot)
-  if (focusBlock) {
-    const style = focusBlock.node.style
-    const styleType = style
-      ? snapshot.context.schema.styles.find((s) => s.name === style)
-      : undefined
-    if (styleType?.decorators) {
-      const allowedNames = styleType.decorators.map((d) => d.name)
-      return activeDecorators.filter((name) => allowedNames.includes(name))
     }
   }
 

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -186,6 +186,9 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
   }
 
+  /**
+   * Remove marks not allowed by the block's per-style restrictions
+   */
   if (isSpan({schema: editor.schema}, node)) {
     const blockPath = parentPath(path)
     const blockEntry = getTextBlockNode(editor, blockPath)
@@ -226,7 +229,9 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
         })
 
         if (filteredMarks.length !== marks.length) {
-          debug.normalization('removing marks not allowed by style restrictions')
+          debug.normalization(
+            'removing marks not allowed by style restrictions',
+          )
           applySetNode(editor, {marks: filteredMarks}, path)
           return
         }

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -186,6 +186,54 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
   }
 
+  if (isSpan({schema: editor.schema}, node)) {
+    const blockPath = parentPath(path)
+    const blockEntry = getTextBlockNode(editor, blockPath)
+    if (!blockEntry) {
+      return
+    }
+    const style = blockEntry.node.style
+    const styleType = style
+      ? editor.schema.styles.find((s) => s.name === style)
+      : undefined
+
+    if (styleType) {
+      const allowedDecorators = styleType.decorators
+      const allowedAnnotations = styleType.annotations
+
+      if (allowedDecorators || allowedAnnotations) {
+        const decoratorNames = editor.schema.decorators.map((d) => d.name)
+        const allowedDecoratorNames = allowedDecorators?.map((d) => d.name)
+        const allowedAnnotationNames = allowedAnnotations?.map((a) => a.name)
+
+        const marks = node.marks ?? []
+        const filteredMarks = marks.filter((mark) => {
+          const isDecorator = decoratorNames.includes(mark)
+          if (isDecorator) {
+            return allowedDecoratorNames
+              ? allowedDecoratorNames.includes(mark)
+              : true
+          }
+          if (allowedAnnotationNames) {
+            const markDef = blockEntry.node.markDefs?.find(
+              (def) => def._key === mark,
+            )
+            return markDef
+              ? allowedAnnotationNames.includes(markDef._type)
+              : true
+          }
+          return true
+        })
+
+        if (filteredMarks.length !== marks.length) {
+          debug.normalization('removing marks not allowed by style restrictions')
+          applySetNode(editor, {marks: filteredMarks}, path)
+          return
+        }
+      }
+    }
+  }
+
   /**
    * Remove orphaned annotations from child spans of block nodes
    */

--- a/packages/editor/src/test/gherkin-parameter-types.ts
+++ b/packages/editor/src/test/gherkin-parameter-types.ts
@@ -44,6 +44,10 @@ const parameterType = {
     name: 'inline-object',
     matcher: /"(stock-ticker)"/,
   }),
+  listItem: createParameterType<'bullet' | 'number'>({
+    name: 'list-item',
+    matcher: /"(bullet|number)"/,
+  }),
   key: createParameterType<'key'>({
     name: 'key',
     matcher: /"([a-z]\d)"/,
@@ -106,6 +110,7 @@ export const parameterTypes = [
   parameterType.direction,
   parameterType.index,
   parameterType.inlineObject,
+  parameterType.listItem,
   parameterType.key,
   parameterType.keyKeys,
   parameterType.marks,

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -939,6 +939,16 @@ export const stepDefinitions = [
   ),
 
   /**
+   * List item steps
+   */
+  When(
+    '{list-item} list is toggled',
+    (context: Context, listItem: Parameter['listItem']) => {
+      context.editor.send({type: 'list item.toggle', listItem})
+    },
+  ),
+
+  /**
    * Style steps
    */
   When('{style} is toggled', (context: Context, style: Parameter['style']) => {

--- a/packages/schema/src/compile-schema.test.ts
+++ b/packages/schema/src/compile-schema.test.ts
@@ -183,4 +183,89 @@ describe(compileSchema.name, () => {
       ])
     })
   })
+
+  describe('per-style restrictions', () => {
+    test('style with decorator restrictions compiles correctly', () => {
+      const schema = compileSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+        styles: [
+          {name: 'normal'},
+          {name: 'h1', decorators: [], annotations: []},
+        ],
+      })
+
+      const h1Style = schema.styles.find((s) => s.name === 'h1')
+      const normalStyle = schema.styles.find((s) => s.name === 'normal')
+
+      expect(h1Style?.decorators).toEqual([])
+      expect(h1Style?.annotations).toEqual([])
+      expect(normalStyle?.decorators).toBeUndefined()
+      expect(normalStyle?.annotations).toBeUndefined()
+    })
+
+    test('style with partial decorator restrictions compiles correctly', () => {
+      const schema = compileSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+        styles: [
+          {name: 'normal'},
+          {name: 'h2', decorators: [{name: 'em'}]},
+        ],
+      })
+
+      const h2Style = schema.styles.find((s) => s.name === 'h2')
+
+      expect(h2Style?.decorators).toEqual([
+        {name: 'em', value: 'em'},
+      ])
+    })
+
+    test('style restrictions resolve full types from top-level definitions', () => {
+      const schema = compileSchema({
+        annotations: [
+          {name: 'link', fields: [{name: 'href', type: 'string'}]},
+          {name: 'comment', fields: [{name: 'text', type: 'string'}]},
+        ],
+        styles: [
+          {name: 'normal'},
+          {name: 'blockquote', annotations: [{name: 'link'}]},
+        ],
+      })
+
+      const bqStyle = schema.styles.find((s) => s.name === 'blockquote')
+
+      expect(bqStyle?.annotations).toEqual([
+        {name: 'link', fields: [{name: 'href', type: 'string'}]},
+      ])
+    })
+
+    test('style with list and inline object restrictions', () => {
+      const schema = compileSchema({
+        lists: [{name: 'bullet'}, {name: 'number'}],
+        inlineObjects: [{name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]}],
+        styles: [
+          {name: 'normal'},
+          {name: 'h1', lists: [], inlineObjects: []},
+        ],
+      })
+
+      const h1Style = schema.styles.find((s) => s.name === 'h1')
+
+      expect(h1Style?.lists).toEqual([])
+      expect(h1Style?.inlineObjects).toEqual([])
+    })
+
+    test('styles without restrictions are unchanged', () => {
+      const schema = compileSchema({
+        decorators: [{name: 'strong'}],
+        styles: [{name: 'normal'}, {name: 'h1'}],
+      })
+
+      const normalStyle = schema.styles.find((s) => s.name === 'normal')
+      const h1Style = schema.styles.find((s) => s.name === 'h1')
+
+      expect(normalStyle?.decorators).toBeUndefined()
+      expect(h1Style?.decorators).toBeUndefined()
+    })
+  })
 })

--- a/packages/schema/src/compile-schema.test.ts
+++ b/packages/schema/src/compile-schema.test.ts
@@ -207,17 +207,12 @@ describe(compileSchema.name, () => {
     test('style with partial decorator restrictions compiles correctly', () => {
       const schema = compileSchema({
         decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
-        styles: [
-          {name: 'normal'},
-          {name: 'h2', decorators: [{name: 'em'}]},
-        ],
+        styles: [{name: 'normal'}, {name: 'h2', decorators: [{name: 'em'}]}],
       })
 
       const h2Style = schema.styles.find((s) => s.name === 'h2')
 
-      expect(h2Style?.decorators).toEqual([
-        {name: 'em', value: 'em'},
-      ])
+      expect(h2Style?.decorators).toEqual([{name: 'em', value: 'em'}])
     })
 
     test('style restrictions resolve full types from top-level definitions', () => {
@@ -242,11 +237,10 @@ describe(compileSchema.name, () => {
     test('style with list and inline object restrictions', () => {
       const schema = compileSchema({
         lists: [{name: 'bullet'}, {name: 'number'}],
-        inlineObjects: [{name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]}],
-        styles: [
-          {name: 'normal'},
-          {name: 'h1', lists: [], inlineObjects: []},
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
         ],
+        styles: [{name: 'normal'}, {name: 'h1', lists: [], inlineObjects: []}],
       })
 
       const h1Style = schema.styles.find((s) => s.name === 'h1')

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -4,6 +4,7 @@ import type {
   ObjectOfDefinition,
   OfDefinition,
   Schema,
+  StyleSchemaType,
 } from './schema'
 
 function compileOfMember(member: OfDefinition): OfDefinition {
@@ -34,13 +35,72 @@ function compileField(field: FieldDefinition): FieldDefinition {
  * @public
  */
 export function compileSchema(definition: SchemaDefinition): Schema {
-  const styles = (definition.styles ?? []).map((style) => {
-    const {decorators, annotations, lists, inlineObjects, ...rest} = style
-    return {
-      ...rest,
-      value: style.name,
-    }
-  })
+  const topLevelDecorators = (definition.decorators ?? []).map((decorator) => ({
+    ...decorator,
+    value: decorator.name,
+  }))
+  const topLevelAnnotations = (definition.annotations ?? []).map(
+    (annotation) => ({
+      ...annotation,
+      fields: annotation.fields?.map(compileField) ?? [],
+    }),
+  )
+  const topLevelLists = (definition.lists ?? []).map((list) => ({
+    ...list,
+    value: list.name,
+  }))
+  const topLevelInlineObjects = (definition.inlineObjects ?? []).map(
+    (inlineObject) => ({
+      ...inlineObject,
+      fields: inlineObject.fields?.map(compileField) ?? [],
+    }),
+  )
+
+  const styles: Array<StyleSchemaType> = (definition.styles ?? []).map(
+    (style) => {
+      const {
+        decorators: styleDecorators,
+        annotations: styleAnnotations,
+        lists: styleLists,
+        inlineObjects: styleInlineObjects,
+        ...rest
+      } = style
+
+      const compiled: StyleSchemaType = {
+        ...rest,
+        value: style.name,
+      }
+
+      if (styleDecorators) {
+        compiled.decorators = styleDecorators.map((ref) => {
+          const found = topLevelDecorators.find((d) => d.name === ref.name)
+          return found ?? {...ref, value: ref.name}
+        })
+      }
+      if (styleAnnotations) {
+        compiled.annotations = styleAnnotations.map((ref) => {
+          const found = topLevelAnnotations.find((a) => a.name === ref.name)
+          return found ?? {...ref, fields: []}
+        })
+      }
+      if (styleLists) {
+        compiled.lists = styleLists.map((ref) => {
+          const found = topLevelLists.find((l) => l.name === ref.name)
+          return found ?? {...ref, value: ref.name}
+        })
+      }
+      if (styleInlineObjects) {
+        compiled.inlineObjects = styleInlineObjects.map((ref) => {
+          const found = topLevelInlineObjects.find(
+            (io) => io.name === ref.name,
+          )
+          return found ?? {...ref, fields: []}
+        })
+      }
+
+      return compiled
+    },
+  )
 
   const blockFields: Array<FieldDefinition> = []
 
@@ -76,25 +136,13 @@ export function compileSchema(definition: SchemaDefinition): Schema {
     styles: !styles.some((style) => style.value === 'normal')
       ? [{value: 'normal', name: 'normal', title: 'Normal'}, ...styles]
       : styles,
-    lists: (definition.lists ?? []).map((list) => ({
-      ...list,
-      value: list.name,
-    })),
-    decorators: (definition.decorators ?? []).map((decorator) => ({
-      ...decorator,
-      value: decorator.name,
-    })),
-    annotations: (definition.annotations ?? []).map((annotation) => ({
-      ...annotation,
-      fields: annotation.fields?.map(compileField) ?? [],
-    })),
+    lists: topLevelLists,
+    decorators: topLevelDecorators,
+    annotations: topLevelAnnotations,
     blockObjects: (definition.blockObjects ?? []).map((blockObject) => ({
       ...blockObject,
       fields: blockObject.fields?.map(compileField) ?? [],
     })),
-    inlineObjects: (definition.inlineObjects ?? []).map((inlineObject) => ({
-      ...inlineObject,
-      fields: inlineObject.fields?.map(compileField) ?? [],
-    })),
+    inlineObjects: topLevelInlineObjects,
   }
 }

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -34,10 +34,13 @@ function compileField(field: FieldDefinition): FieldDefinition {
  * @public
  */
 export function compileSchema(definition: SchemaDefinition): Schema {
-  const styles = (definition.styles ?? []).map((style) => ({
-    ...style,
-    value: style.name,
-  }))
+  const styles = (definition.styles ?? []).map((style) => {
+    const {decorators, annotations, lists, inlineObjects, ...rest} = style
+    return {
+      ...rest,
+      value: style.name,
+    }
+  })
 
   const blockFields: Array<FieldDefinition> = []
 

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -1,6 +1,10 @@
-import type {SchemaDefinition} from './define-schema'
+import type {SchemaDefinition, StyleDefinition} from './define-schema'
 import type {
+  AnnotationSchemaType,
+  DecoratorSchemaType,
   FieldDefinition,
+  InlineObjectSchemaType,
+  ListSchemaType,
   ObjectOfDefinition,
   OfDefinition,
   Schema,
@@ -35,6 +39,8 @@ function compileField(field: FieldDefinition): FieldDefinition {
  * @public
  */
 export function compileSchema(definition: SchemaDefinition): Schema {
+  // The `value` field is a deprecated alias for `name` kept for
+  // backwards compatibility with existing consumers.
   const topLevelDecorators = (definition.decorators ?? []).map((decorator) => ({
     ...decorator,
     value: decorator.name,
@@ -56,50 +62,13 @@ export function compileSchema(definition: SchemaDefinition): Schema {
     }),
   )
 
-  const styles: Array<StyleSchemaType> = (definition.styles ?? []).map(
-    (style) => {
-      const {
-        decorators: styleDecorators,
-        annotations: styleAnnotations,
-        lists: styleLists,
-        inlineObjects: styleInlineObjects,
-        ...rest
-      } = style
-
-      const compiled: StyleSchemaType = {
-        ...rest,
-        value: style.name,
-      }
-
-      if (styleDecorators) {
-        compiled.decorators = styleDecorators.map((ref) => {
-          const found = topLevelDecorators.find((d) => d.name === ref.name)
-          return found ?? {...ref, value: ref.name}
-        })
-      }
-      if (styleAnnotations) {
-        compiled.annotations = styleAnnotations.map((ref) => {
-          const found = topLevelAnnotations.find((a) => a.name === ref.name)
-          return found ?? {...ref, fields: []}
-        })
-      }
-      if (styleLists) {
-        compiled.lists = styleLists.map((ref) => {
-          const found = topLevelLists.find((l) => l.name === ref.name)
-          return found ?? {...ref, value: ref.name}
-        })
-      }
-      if (styleInlineObjects) {
-        compiled.inlineObjects = styleInlineObjects.map((ref) => {
-          const found = topLevelInlineObjects.find(
-            (io) => io.name === ref.name,
-          )
-          return found ?? {...ref, fields: []}
-        })
-      }
-
-      return compiled
-    },
+  const styles = (definition.styles ?? []).map((style) =>
+    compileStyle(style, {
+      topLevelDecorators,
+      topLevelAnnotations,
+      topLevelLists,
+      topLevelInlineObjects,
+    }),
   )
 
   const blockFields: Array<FieldDefinition> = []
@@ -145,4 +114,56 @@ export function compileSchema(definition: SchemaDefinition): Schema {
     })),
     inlineObjects: topLevelInlineObjects,
   }
+}
+
+/**
+ * Compiles a style definition into a `StyleSchemaType`. Per-style restriction
+ * references (which only carry a `name`) are resolved against the already-
+ * compiled top-level arrays to produce the full schema types.
+ */
+function compileStyle(
+  style: StyleDefinition,
+  topLevel: {
+    topLevelDecorators: ReadonlyArray<DecoratorSchemaType>
+    topLevelAnnotations: ReadonlyArray<AnnotationSchemaType>
+    topLevelLists: ReadonlyArray<ListSchemaType>
+    topLevelInlineObjects: ReadonlyArray<InlineObjectSchemaType>
+  },
+): StyleSchemaType {
+  const {decorators, annotations, lists, inlineObjects, ...rest} = style
+
+  const compiled: StyleSchemaType = {
+    ...rest,
+    value: style.name,
+  }
+
+  if (decorators) {
+    compiled.decorators = resolveRefs(decorators, topLevel.topLevelDecorators)
+  }
+  if (annotations) {
+    compiled.annotations = resolveRefs(
+      annotations,
+      topLevel.topLevelAnnotations,
+    )
+  }
+  if (lists) {
+    compiled.lists = resolveRefs(lists, topLevel.topLevelLists)
+  }
+  if (inlineObjects) {
+    compiled.inlineObjects = resolveRefs(
+      inlineObjects,
+      topLevel.topLevelInlineObjects,
+    )
+  }
+
+  return compiled
+}
+
+function resolveRefs<T extends {name: string}>(
+  refs: ReadonlyArray<{name: string}>,
+  topLevel: ReadonlyArray<T>,
+): Array<T> {
+  return refs.map(
+    (ref) => topLevel.find((item) => item.name === ref.name) ?? (ref as T),
+  )
 }

--- a/packages/schema/src/define-schema.ts
+++ b/packages/schema/src/define-schema.ts
@@ -46,15 +46,23 @@ export function defineSchema<const TSchemaDefinition extends SchemaDefinition>(
 }
 
 /**
+ * A reference to a top-level schema feature by name. Used in per-style
+ * restriction arrays to indicate which features a style allows.
+ *
+ * @public
+ */
+export type FeatureRef = {name: string}
+
+/**
  * @public
  */
 export type StyleDefinition<
   TBaseDefinition extends BaseDefinition = BaseDefinition,
 > = TBaseDefinition & {
-  decorators?: ReadonlyArray<{name: string}>
-  annotations?: ReadonlyArray<{name: string}>
-  lists?: ReadonlyArray<{name: string}>
-  inlineObjects?: ReadonlyArray<{name: string}>
+  decorators?: ReadonlyArray<FeatureRef>
+  annotations?: ReadonlyArray<FeatureRef>
+  lists?: ReadonlyArray<FeatureRef>
+  inlineObjects?: ReadonlyArray<FeatureRef>
 }
 
 /**

--- a/packages/schema/src/define-schema.ts
+++ b/packages/schema/src/define-schema.ts
@@ -50,7 +50,12 @@ export function defineSchema<const TSchemaDefinition extends SchemaDefinition>(
  */
 export type StyleDefinition<
   TBaseDefinition extends BaseDefinition = BaseDefinition,
-> = TBaseDefinition
+> = TBaseDefinition & {
+  decorators?: ReadonlyArray<{name: string}>
+  annotations?: ReadonlyArray<{name: string}>
+  lists?: ReadonlyArray<{name: string}>
+  inlineObjects?: ReadonlyArray<{name: string}>
+}
 
 /**
  * @public

--- a/packages/schema/src/get-style-features.test.ts
+++ b/packages/schema/src/get-style-features.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, test} from 'vitest'
+import {compileSchema} from './compile-schema'
+import {getStyleFeatures} from './get-style-features'
+
+describe(getStyleFeatures.name, () => {
+  const schema = compileSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    lists: [{name: 'bullet'}, {name: 'number'}],
+    inlineObjects: [{name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]}],
+    styles: [
+      {name: 'normal'},
+      {name: 'h1', decorators: [], annotations: [], lists: [], inlineObjects: []},
+      {name: 'h2', decorators: [{name: 'em'}]},
+    ],
+  })
+
+  test('returns top-level features for unrestricted style', () => {
+    const features = getStyleFeatures(schema, 'normal')
+    expect(features.decorators).toEqual(schema.decorators)
+    expect(features.annotations).toEqual(schema.annotations)
+    expect(features.lists).toEqual(schema.lists)
+    expect(features.inlineObjects).toEqual(schema.inlineObjects)
+  })
+
+  test('returns empty arrays for fully restricted style', () => {
+    const features = getStyleFeatures(schema, 'h1')
+    expect(features.decorators).toEqual([])
+    expect(features.annotations).toEqual([])
+    expect(features.lists).toEqual([])
+    expect(features.inlineObjects).toEqual([])
+  })
+
+  test('returns partial restrictions', () => {
+    const features = getStyleFeatures(schema, 'h2')
+    expect(features.decorators.map((d) => d.name)).toEqual(['em'])
+    expect(features.annotations).toEqual(schema.annotations)
+    expect(features.lists).toEqual(schema.lists)
+    expect(features.inlineObjects).toEqual(schema.inlineObjects)
+  })
+
+  test('returns top-level features for unknown style', () => {
+    const features = getStyleFeatures(schema, 'unknown')
+    expect(features.decorators).toEqual(schema.decorators)
+    expect(features.annotations).toEqual(schema.annotations)
+  })
+
+  test('returns top-level features for undefined style', () => {
+    const features = getStyleFeatures(schema, undefined)
+    expect(features.decorators).toEqual(schema.decorators)
+    expect(features.annotations).toEqual(schema.annotations)
+  })
+})

--- a/packages/schema/src/get-style-features.test.ts
+++ b/packages/schema/src/get-style-features.test.ts
@@ -7,10 +7,18 @@ describe(getStyleFeatures.name, () => {
     decorators: [{name: 'strong'}, {name: 'em'}],
     annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
     lists: [{name: 'bullet'}, {name: 'number'}],
-    inlineObjects: [{name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]}],
+    inlineObjects: [
+      {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+    ],
     styles: [
       {name: 'normal'},
-      {name: 'h1', decorators: [], annotations: [], lists: [], inlineObjects: []},
+      {
+        name: 'h1',
+        decorators: [],
+        annotations: [],
+        lists: [],
+        inlineObjects: [],
+      },
       {name: 'h2', decorators: [{name: 'em'}]},
     ],
   })

--- a/packages/schema/src/get-style-features.ts
+++ b/packages/schema/src/get-style-features.ts
@@ -1,0 +1,30 @@
+import type {
+  AnnotationSchemaType,
+  DecoratorSchemaType,
+  InlineObjectSchemaType,
+  ListSchemaType,
+  Schema,
+} from './schema'
+
+export type StyleFeatures = {
+  decorators: ReadonlyArray<DecoratorSchemaType>
+  annotations: ReadonlyArray<AnnotationSchemaType>
+  lists: ReadonlyArray<ListSchemaType>
+  inlineObjects: ReadonlyArray<InlineObjectSchemaType>
+}
+
+export function getStyleFeatures(
+  schema: Schema,
+  styleName: string | undefined,
+): StyleFeatures {
+  const style = styleName
+    ? schema.styles.find((s) => s.name === styleName)
+    : undefined
+
+  return {
+    decorators: style?.decorators ?? schema.decorators,
+    annotations: style?.annotations ?? schema.annotations,
+    lists: style?.lists ?? schema.lists,
+    inlineObjects: style?.inlineObjects ?? schema.inlineObjects,
+  }
+}

--- a/packages/schema/src/get-style-features.ts
+++ b/packages/schema/src/get-style-features.ts
@@ -6,6 +6,9 @@ import type {
   Schema,
 } from './schema'
 
+/**
+ * @public
+ */
 export type StyleFeatures = {
   decorators: ReadonlyArray<DecoratorSchemaType>
   annotations: ReadonlyArray<AnnotationSchemaType>
@@ -13,6 +16,17 @@ export type StyleFeatures = {
   inlineObjects: ReadonlyArray<InlineObjectSchemaType>
 }
 
+/**
+ * Returns the effective decorators, annotations, lists, and inline objects
+ * allowed for a given block style. Each feature type uses the style's own
+ * override array when one is defined, and falls back to the top-level schema
+ * array when the style does not define an override (`undefined`).
+ *
+ * This means styles inherit all top-level features by default, and can
+ * restrict them by providing an explicit subset (or an empty array for none).
+ *
+ * @public
+ */
 export function getStyleFeatures(
   schema: Schema,
   styleName: string | undefined,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -5,6 +5,7 @@ export {
   type AnnotationDefinition,
   type BlockObjectDefinition,
   type DecoratorDefinition,
+  type FeatureRef,
   type InlineObjectDefinition,
   type ListDefinition,
   type SchemaDefinition,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,4 +1,5 @@
 export {compileSchema} from './compile-schema'
+export {getStyleFeatures, type StyleFeatures} from './get-style-features'
 export {
   defineSchema,
   type AnnotationDefinition,

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -26,6 +26,10 @@ export type StyleSchemaType = BaseDefinition & {
    * Use `name` instead
    */
   value: string
+  decorators?: ReadonlyArray<DecoratorSchemaType>
+  annotations?: ReadonlyArray<AnnotationSchemaType>
+  lists?: ReadonlyArray<ListSchemaType>
+  inlineObjects?: ReadonlyArray<InlineObjectSchemaType>
 }
 
 /**

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -26,9 +26,29 @@ export type StyleSchemaType = BaseDefinition & {
    * Use `name` instead
    */
   value: string
+  /**
+   * When set, overrides the top-level `schema.decorators` for blocks using
+   * this style. An empty array means no decorators are allowed. When
+   * `undefined`, the block inherits the top-level decorators.
+   */
   decorators?: ReadonlyArray<DecoratorSchemaType>
+  /**
+   * When set, overrides the top-level `schema.annotations` for blocks using
+   * this style. An empty array means no annotations are allowed. When
+   * `undefined`, the block inherits the top-level annotations.
+   */
   annotations?: ReadonlyArray<AnnotationSchemaType>
+  /**
+   * When set, overrides the top-level `schema.lists` for blocks using this
+   * style. An empty array means no list items are allowed. When `undefined`,
+   * the block inherits the top-level lists.
+   */
   lists?: ReadonlyArray<ListSchemaType>
+  /**
+   * When set, overrides the top-level `schema.inlineObjects` for blocks using
+   * this style. An empty array means no inline objects are allowed. When
+   * `undefined`, the block inherits the top-level inline objects.
+   */
   inlineObjects?: ReadonlyArray<InlineObjectSchemaType>
 }
 

--- a/packages/toolbar/src/availability-listener.ts
+++ b/packages/toolbar/src/availability-listener.ts
@@ -6,122 +6,42 @@ export type AvailabilityListenerEvent =
   | {type: 'available'}
   | {type: 'unavailable'}
 
-export const decoratorAvailabilityListener = fromCallback<
-  AnyEventObject,
-  {editor: Editor; decoratorName: string},
-  AvailabilityListenerEvent
->(({input, sendBack}) => {
-  function check() {
-    const snapshot = input.editor.getSnapshot()
-    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
-    if (!focusTextBlock) {
-      sendBack({type: 'available'})
-      return
+function createAvailabilityListener(
+  feature: 'decorators' | 'annotations' | 'lists' | 'inlineObjects',
+) {
+  return fromCallback<
+    AnyEventObject,
+    {editor: Editor; featureName: string},
+    AvailabilityListenerEvent
+  >(({input, sendBack}) => {
+    function check() {
+      const snapshot = input.editor.getSnapshot()
+      const focusTextBlock = selectors.getFocusTextBlock(snapshot)
+      if (!focusTextBlock) {
+        sendBack({type: 'available'})
+        return
+      }
+      const style = focusTextBlock.node.style
+      const styleType = style
+        ? snapshot.context.schema.styles.find((s) => s.name === style)
+        : undefined
+      const allowed = styleType?.[feature]
+      if (allowed && !allowed.some((item) => item.name === input.featureName)) {
+        sendBack({type: 'unavailable'})
+      } else {
+        sendBack({type: 'available'})
+      }
     }
-    const style = focusTextBlock.node.style
-    const styleType = style
-      ? snapshot.context.schema.styles.find((s) => s.name === style)
-      : undefined
-    if (
-      styleType?.decorators &&
-      !styleType.decorators.some((d) => d.name === input.decoratorName)
-    ) {
-      sendBack({type: 'unavailable'})
-    } else {
-      sendBack({type: 'available'})
-    }
-  }
 
-  check()
-  return input.editor.on('*', check).unsubscribe
-})
+    check()
+    return input.editor.on('*', check).unsubscribe
+  })
+}
 
-export const annotationAvailabilityListener = fromCallback<
-  AnyEventObject,
-  {editor: Editor; annotationName: string},
-  AvailabilityListenerEvent
->(({input, sendBack}) => {
-  function check() {
-    const snapshot = input.editor.getSnapshot()
-    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
-    if (!focusTextBlock) {
-      sendBack({type: 'available'})
-      return
-    }
-    const style = focusTextBlock.node.style
-    const styleType = style
-      ? snapshot.context.schema.styles.find((s) => s.name === style)
-      : undefined
-    if (
-      styleType?.annotations &&
-      !styleType.annotations.some((a) => a.name === input.annotationName)
-    ) {
-      sendBack({type: 'unavailable'})
-    } else {
-      sendBack({type: 'available'})
-    }
-  }
-
-  check()
-  return input.editor.on('*', check).unsubscribe
-})
-
-export const listAvailabilityListener = fromCallback<
-  AnyEventObject,
-  {editor: Editor; listName: string},
-  AvailabilityListenerEvent
->(({input, sendBack}) => {
-  function check() {
-    const snapshot = input.editor.getSnapshot()
-    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
-    if (!focusTextBlock) {
-      sendBack({type: 'available'})
-      return
-    }
-    const style = focusTextBlock.node.style
-    const styleType = style
-      ? snapshot.context.schema.styles.find((s) => s.name === style)
-      : undefined
-    if (
-      styleType?.lists &&
-      !styleType.lists.some((l) => l.name === input.listName)
-    ) {
-      sendBack({type: 'unavailable'})
-    } else {
-      sendBack({type: 'available'})
-    }
-  }
-
-  check()
-  return input.editor.on('*', check).unsubscribe
-})
-
-export const inlineObjectAvailabilityListener = fromCallback<
-  AnyEventObject,
-  {editor: Editor; inlineObjectName: string},
-  AvailabilityListenerEvent
->(({input, sendBack}) => {
-  function check() {
-    const snapshot = input.editor.getSnapshot()
-    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
-    if (!focusTextBlock) {
-      sendBack({type: 'available'})
-      return
-    }
-    const style = focusTextBlock.node.style
-    const styleType = style
-      ? snapshot.context.schema.styles.find((s) => s.name === style)
-      : undefined
-    if (
-      styleType?.inlineObjects &&
-      !styleType.inlineObjects.some((io) => io.name === input.inlineObjectName)
-    ) {
-      sendBack({type: 'unavailable'})
-    } else {
-      sendBack({type: 'available'})
-    }
-  }
-
-  check()
-  return input.editor.on('*', check).unsubscribe
-})
+export const decoratorAvailabilityListener =
+  createAvailabilityListener('decorators')
+export const annotationAvailabilityListener =
+  createAvailabilityListener('annotations')
+export const listAvailabilityListener = createAvailabilityListener('lists')
+export const inlineObjectAvailabilityListener =
+  createAvailabilityListener('inlineObjects')

--- a/packages/toolbar/src/availability-listener.ts
+++ b/packages/toolbar/src/availability-listener.ts
@@ -1,0 +1,127 @@
+import type {Editor} from '@portabletext/editor'
+import * as selectors from '@portabletext/editor/selectors'
+import {fromCallback, type AnyEventObject} from 'xstate'
+
+export type AvailabilityListenerEvent =
+  | {type: 'available'}
+  | {type: 'unavailable'}
+
+export const decoratorAvailabilityListener = fromCallback<
+  AnyEventObject,
+  {editor: Editor; decoratorName: string},
+  AvailabilityListenerEvent
+>(({input, sendBack}) => {
+  function check() {
+    const snapshot = input.editor.getSnapshot()
+    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      sendBack({type: 'available'})
+      return
+    }
+    const style = focusTextBlock.node.style
+    const styleType = style
+      ? snapshot.context.schema.styles.find((s) => s.name === style)
+      : undefined
+    if (
+      styleType?.decorators &&
+      !styleType.decorators.some((d) => d.name === input.decoratorName)
+    ) {
+      sendBack({type: 'unavailable'})
+    } else {
+      sendBack({type: 'available'})
+    }
+  }
+
+  check()
+  return input.editor.on('*', check).unsubscribe
+})
+
+export const annotationAvailabilityListener = fromCallback<
+  AnyEventObject,
+  {editor: Editor; annotationName: string},
+  AvailabilityListenerEvent
+>(({input, sendBack}) => {
+  function check() {
+    const snapshot = input.editor.getSnapshot()
+    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      sendBack({type: 'available'})
+      return
+    }
+    const style = focusTextBlock.node.style
+    const styleType = style
+      ? snapshot.context.schema.styles.find((s) => s.name === style)
+      : undefined
+    if (
+      styleType?.annotations &&
+      !styleType.annotations.some((a) => a.name === input.annotationName)
+    ) {
+      sendBack({type: 'unavailable'})
+    } else {
+      sendBack({type: 'available'})
+    }
+  }
+
+  check()
+  return input.editor.on('*', check).unsubscribe
+})
+
+export const listAvailabilityListener = fromCallback<
+  AnyEventObject,
+  {editor: Editor; listName: string},
+  AvailabilityListenerEvent
+>(({input, sendBack}) => {
+  function check() {
+    const snapshot = input.editor.getSnapshot()
+    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      sendBack({type: 'available'})
+      return
+    }
+    const style = focusTextBlock.node.style
+    const styleType = style
+      ? snapshot.context.schema.styles.find((s) => s.name === style)
+      : undefined
+    if (
+      styleType?.lists &&
+      !styleType.lists.some((l) => l.name === input.listName)
+    ) {
+      sendBack({type: 'unavailable'})
+    } else {
+      sendBack({type: 'available'})
+    }
+  }
+
+  check()
+  return input.editor.on('*', check).unsubscribe
+})
+
+export const inlineObjectAvailabilityListener = fromCallback<
+  AnyEventObject,
+  {editor: Editor; inlineObjectName: string},
+  AvailabilityListenerEvent
+>(({input, sendBack}) => {
+  function check() {
+    const snapshot = input.editor.getSnapshot()
+    const focusTextBlock = selectors.getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      sendBack({type: 'available'})
+      return
+    }
+    const style = focusTextBlock.node.style
+    const styleType = style
+      ? snapshot.context.schema.styles.find((s) => s.name === style)
+      : undefined
+    if (
+      styleType?.inlineObjects &&
+      !styleType.inlineObjects.some((io) => io.name === input.inlineObjectName)
+    ) {
+      sendBack({type: 'unavailable'})
+    } else {
+      sendBack({type: 'available'})
+    }
+  }
+
+  check()
+  return input.editor.on('*', check).unsubscribe
+})

--- a/packages/toolbar/src/use-annotation-button.ts
+++ b/packages/toolbar/src/use-annotation-button.ts
@@ -3,6 +3,10 @@ import {defineBehavior, effect, raise} from '@portabletext/editor/behaviors'
 import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
+import {
+  annotationAvailabilityListener,
+  type AvailabilityListenerEvent,
+} from './availability-listener'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
 import {useMutuallyExclusiveAnnotation} from './use-mutually-exclusive-annotation'
 import type {ToolbarAnnotationSchemaType} from './use-toolbar-schema'
@@ -103,6 +107,7 @@ const annotationButtonMachine = setup({
     },
     events: {} as
       | AnnotationButtonEvent
+      | AvailabilityListenerEvent
       | DisableListenerEvent
       | {type: 'set active'}
       | {type: 'set inactive'},
@@ -134,6 +139,7 @@ const annotationButtonMachine = setup({
   },
   actors: {
     'active listener': activeListener,
+    'availability listener': annotationAvailabilityListener,
     'disable listener': disableListener,
     'keyboard shortcut.remove': keyboardShortcutRemove,
     'keyboard shortcut.show insert dialog': keyboardShortcutShowInsertDialog,
@@ -153,6 +159,13 @@ const annotationButtonMachine = setup({
       }),
     },
     {
+      src: 'availability listener',
+      input: ({context}) => ({
+        editor: context.editor,
+        annotationName: context.schemaType.name,
+      }),
+    },
+    {
       src: 'disable listener',
       input: ({context}) => ({
         editor: context.editor,
@@ -167,6 +180,9 @@ const annotationButtonMachine = setup({
       states: {
         inactive: {
           on: {
+            'available': {
+              target: '#annotation button.enabled.inactive',
+            },
             'enable': {
               target: '#annotation button.enabled.inactive',
             },
@@ -177,6 +193,9 @@ const annotationButtonMachine = setup({
         },
         active: {
           on: {
+            'available': {
+              target: '#annotation button.enabled.active',
+            },
             'enable': {
               target: '#annotation button.enabled.active',
             },
@@ -193,6 +212,9 @@ const annotationButtonMachine = setup({
         inactive: {
           initial: 'idle',
           on: {
+            'unavailable': {
+              target: '#annotation button.disabled.inactive',
+            },
             'disable': {
               target: '#annotation button.disabled.inactive',
             },
@@ -238,6 +260,9 @@ const annotationButtonMachine = setup({
           on: {
             'set inactive': {
               target: '#annotation button.enabled.inactive',
+            },
+            'unavailable': {
+              target: '#annotation button.disabled.active',
             },
             'disable': {
               target: '#annotation button.disabled.active',

--- a/packages/toolbar/src/use-annotation-button.ts
+++ b/packages/toolbar/src/use-annotation-button.ts
@@ -162,7 +162,7 @@ const annotationButtonMachine = setup({
       src: 'availability listener',
       input: ({context}) => ({
         editor: context.editor,
-        annotationName: context.schemaType.name,
+        featureName: context.schemaType.name,
       }),
     },
     {

--- a/packages/toolbar/src/use-decorator-button.ts
+++ b/packages/toolbar/src/use-decorator-button.ts
@@ -6,6 +6,10 @@ import {
 import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
+import {
+  decoratorAvailabilityListener,
+  type AvailabilityListenerEvent,
+} from './availability-listener'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
 import {useDecoratorKeyboardShortcut} from './use-decorator-keyboard-shortcut'
 import {useMutuallyExclusiveDecorator} from './use-mutually-exclusive-decorator'
@@ -48,7 +52,10 @@ const decoratorButtonMachine = setup({
       editor: Editor
       schemaType: DecoratorSchemaType
     },
-    events: {} as DisableListenerEvent | DecoratorButtonEvent,
+    events: {} as
+      | AvailabilityListenerEvent
+      | DisableListenerEvent
+      | DecoratorButtonEvent,
   },
   actions: {
     toggle: ({context, event}) => {
@@ -64,6 +71,7 @@ const decoratorButtonMachine = setup({
     },
   },
   actors: {
+    'availability listener': decoratorAvailabilityListener,
     'disable listener': disableListener,
     'active listener': activeListener,
   },
@@ -82,6 +90,13 @@ const decoratorButtonMachine = setup({
         schemaType: context.schemaType,
       }),
     },
+    {
+      src: 'availability listener',
+      input: ({context}) => ({
+        editor: context.editor,
+        decoratorName: context.schemaType.name,
+      }),
+    },
   ],
   initial: 'disabled',
   states: {
@@ -90,6 +105,9 @@ const decoratorButtonMachine = setup({
       states: {
         inactive: {
           on: {
+            'available': {
+              target: '#decorator button.enabled.inactive',
+            },
             'enable': {
               target: '#decorator button.enabled.inactive',
             },
@@ -100,6 +118,9 @@ const decoratorButtonMachine = setup({
         },
         active: {
           on: {
+            'available': {
+              target: '#decorator button.enabled.active',
+            },
             'enable': {
               target: '#decorator button.enabled.active',
             },
@@ -120,6 +141,9 @@ const decoratorButtonMachine = setup({
       states: {
         inactive: {
           on: {
+            'unavailable': {
+              target: '#decorator button.disabled.inactive',
+            },
             'disable': {
               target: '#decorator button.disabled.inactive',
             },
@@ -130,6 +154,9 @@ const decoratorButtonMachine = setup({
         },
         active: {
           on: {
+            'unavailable': {
+              target: '#decorator button.disabled.active',
+            },
             'disable': {
               target: '#decorator button.disabled.active',
             },

--- a/packages/toolbar/src/use-decorator-button.ts
+++ b/packages/toolbar/src/use-decorator-button.ts
@@ -94,7 +94,7 @@ const decoratorButtonMachine = setup({
       src: 'availability listener',
       input: ({context}) => ({
         editor: context.editor,
-        decoratorName: context.schemaType.name,
+        featureName: context.schemaType.name,
       }),
     },
   ],

--- a/packages/toolbar/src/use-inline-object-button.ts
+++ b/packages/toolbar/src/use-inline-object-button.ts
@@ -2,6 +2,10 @@ import {useEditor, type Editor} from '@portabletext/editor'
 import {defineBehavior, effect} from '@portabletext/editor/behaviors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
+import {
+  inlineObjectAvailabilityListener,
+  type AvailabilityListenerEvent,
+} from './availability-listener'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
 import type {ToolbarInlineObjectSchemaType} from './use-toolbar-schema'
 
@@ -41,7 +45,10 @@ const inlineObjectButtonMachine = setup({
       editor: Editor
       schemaType: ToolbarInlineObjectSchemaType
     },
-    events: {} as DisableListenerEvent | InlineObjectButtonEvent,
+    events: {} as
+      | AvailabilityListenerEvent
+      | DisableListenerEvent
+      | InlineObjectButtonEvent,
   },
   actions: {
     insert: ({context, event}) => {
@@ -60,6 +67,7 @@ const inlineObjectButtonMachine = setup({
     },
   },
   actors: {
+    'availability listener': inlineObjectAvailabilityListener,
     'disable listener': disableListener,
     'keyboard shortcut listener': keyboardShortcutListener,
   },
@@ -74,11 +82,21 @@ const inlineObjectButtonMachine = setup({
       src: 'disable listener',
       input: ({context}) => ({editor: context.editor}),
     },
+    {
+      src: 'availability listener',
+      input: ({context}) => ({
+        editor: context.editor,
+        inlineObjectName: context.schemaType.name,
+      }),
+    },
   ],
   initial: 'disabled',
   states: {
     disabled: {
       on: {
+        available: {
+          target: 'enabled',
+        },
         enable: {
           target: 'enabled',
         },
@@ -86,6 +104,9 @@ const inlineObjectButtonMachine = setup({
     },
     enabled: {
       on: {
+        unavailable: {
+          target: 'disabled',
+        },
         disable: {
           target: 'disabled',
         },

--- a/packages/toolbar/src/use-inline-object-button.ts
+++ b/packages/toolbar/src/use-inline-object-button.ts
@@ -86,7 +86,7 @@ const inlineObjectButtonMachine = setup({
       src: 'availability listener',
       input: ({context}) => ({
         editor: context.editor,
-        inlineObjectName: context.schemaType.name,
+        featureName: context.schemaType.name,
       }),
     },
   ],

--- a/packages/toolbar/src/use-list-button.ts
+++ b/packages/toolbar/src/use-list-button.ts
@@ -46,7 +46,10 @@ const listButtonMachine = setup({
       editor: Editor
       schemaType: ListSchemaType
     },
-    events: {} as AvailabilityListenerEvent | DisableListenerEvent | ListButtonEvent,
+    events: {} as
+      | AvailabilityListenerEvent
+      | DisableListenerEvent
+      | ListButtonEvent,
   },
   actions: {
     toggle: ({context, event}) => {
@@ -85,7 +88,7 @@ const listButtonMachine = setup({
       src: 'availability listener',
       input: ({context}) => ({
         editor: context.editor,
-        listName: context.schemaType.name,
+        featureName: context.schemaType.name,
       }),
     },
   ],

--- a/packages/toolbar/src/use-list-button.ts
+++ b/packages/toolbar/src/use-list-button.ts
@@ -2,6 +2,10 @@ import {useEditor, type Editor, type ListSchemaType} from '@portabletext/editor'
 import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
+import {
+  listAvailabilityListener,
+  type AvailabilityListenerEvent,
+} from './availability-listener'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
 import type {ToolbarListSchemaType} from './use-toolbar-schema'
 
@@ -42,7 +46,7 @@ const listButtonMachine = setup({
       editor: Editor
       schemaType: ListSchemaType
     },
-    events: {} as DisableListenerEvent | ListButtonEvent,
+    events: {} as AvailabilityListenerEvent | DisableListenerEvent | ListButtonEvent,
   },
   actions: {
     toggle: ({context, event}) => {
@@ -58,6 +62,7 @@ const listButtonMachine = setup({
     },
   },
   actors: {
+    'availability listener': listAvailabilityListener,
     'disable listener': disableListener,
     'active listener': activeListener,
   },
@@ -76,6 +81,13 @@ const listButtonMachine = setup({
         schemaType: context.schemaType,
       }),
     },
+    {
+      src: 'availability listener',
+      input: ({context}) => ({
+        editor: context.editor,
+        listName: context.schemaType.name,
+      }),
+    },
   ],
   initial: 'disabled',
   states: {
@@ -84,6 +96,9 @@ const listButtonMachine = setup({
       states: {
         inactive: {
           on: {
+            'available': {
+              target: '#list button.enabled.inactive',
+            },
             'enable': {
               target: '#list button.enabled.inactive',
             },
@@ -94,6 +109,9 @@ const listButtonMachine = setup({
         },
         active: {
           on: {
+            'available': {
+              target: '#list button.enabled.active',
+            },
             'enable': {
               target: '#list button.enabled.active',
             },
@@ -114,6 +132,9 @@ const listButtonMachine = setup({
       states: {
         inactive: {
           on: {
+            'unavailable': {
+              target: '#list button.disabled.inactive',
+            },
             'disable': {
               target: '#list button.disabled.inactive',
             },
@@ -124,6 +145,9 @@ const listButtonMachine = setup({
         },
         active: {
           on: {
+            'unavailable': {
+              target: '#list button.disabled.active',
+            },
             'disable': {
               target: '#list button.disabled.active',
             },


### PR DESCRIPTION
This one might need a bit of discussion, but here goes:

**Goal:** Allow style definitions in the PTE schema to restrict which decorators, annotations, lists, and inline objects are allowed per block style, so the editor core (toolbar, paste, keyboard shortcuts, normalization) automatically respects these restrictions. This is to for instance disallow links in titles, but allow it in regular text paragraphs.

**Architecture:** Extend `StyleDefinition` and `StyleSchemaType` with optional decorators, annotations, lists, and inlineObjects override arrays. Add a `getStyleFeatures(schema, styleName)` helper that returns the effective feature set for a style (the style’s overrides if present, else the top-level schema arrays). Update all schema consumption points to use this helper when the block style is known. The toolbar already has disable/enable infrastructure - wire the availability listener to check per-style restrictions.

