### PR TITLE
feat: container rendering pipeline

### DIFF
--- a/.changeset/container-engine-awareness.md
+++ b/.changeset/container-engine-awareness.md
@@ -2,4 +2,4 @@
 "@portabletext/editor": patch
 ---
 
-feat(internal): engine awareness for editable containers
+fix(internal): normalize container child array fields

--- a/.changeset/container-engine-awareness.md
+++ b/.changeset/container-engine-awareness.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+feat(internal): engine awareness for editable containers

--- a/packages/editor/src/editor/container-scope-context.ts
+++ b/packages/editor/src/editor/container-scope-context.ts
@@ -1,0 +1,23 @@
+import type {OfDefinition} from '@portabletext/schema'
+import {createContext, useContext} from 'react'
+
+/**
+ * Tracks the current container scope as we render nested containers.
+ * The scope name accumulates type names separated by dots:
+ * - At the editor root: undefined
+ * - Inside a table: 'table'
+ * - Inside a table row: 'table.row'
+ * - Inside a table row cell: 'table.row.cell'
+ */
+export type ContainerScope = {
+  name: string
+  schemaScope: ReadonlyArray<OfDefinition> | undefined
+}
+
+export const ContainerScopeContext = createContext<ContainerScope | undefined>(
+  undefined,
+)
+
+export function useContainerScope() {
+  return useContext(ContainerScopeContext)
+}

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -5,6 +5,7 @@ import type {Editor, EditorConfig} from '../editor'
 import {debug} from '../internal-utils/debug'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
+import type {RendererConfig} from '../renderers/renderer.types'
 import type {EditableAPI} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {defaultKeyGenerator} from '../utils/key-generator'
@@ -19,6 +20,7 @@ import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export type InternalEditor = Editor & {
+  registerRenderer: (config: RendererConfig) => () => void
   _internal: {
     editable: EditableAPI
     editorActor: EditorActor
@@ -85,6 +87,19 @@ export function createInternalEditor(config: EditorConfig): {
         editorActor.send({
           type: 'remove behavior',
           behaviorConfig: behaviorConfigWithPriority,
+        })
+      }
+    },
+    registerRenderer: (config) => {
+      editorActor.send({
+        type: 'register renderer',
+        rendererConfig: config,
+      })
+
+      return () => {
+        editorActor.send({
+          type: 'unregister renderer',
+          rendererConfig: config,
         })
       }
     },

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -19,6 +19,8 @@ import type {Converter} from '../converters/converter.types'
 import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
+import {getEditableTypePaths} from '../renderers/container-schema'
+import type {RendererConfig} from '../renderers/renderer.types'
 import {ReactEditor} from '../slate/react/plugin/react-editor'
 import type {NamespaceEvent, OmitFromUnion} from '../type-utils'
 import type {EditorSelection} from '../types/editor'
@@ -112,6 +114,14 @@ type InternalEditorEvent =
     }
   | {type: 'dragend'}
   | {type: 'drop'}
+  | {
+      type: 'register renderer'
+      rendererConfig: RendererConfig
+    }
+  | {
+      type: 'unregister renderer'
+      rendererConfig: RendererConfig
+    }
   | {type: 'add slate editor'; editor: PortableTextSlateEditor}
 
 /**
@@ -165,6 +175,25 @@ export function rerouteExternalBehaviorEvent({
   }
 }
 
+function syncEditableTypes(context: {
+  schema: EditorSchema
+  renderers: Map<string, RendererConfig>
+  slateEditor?: PortableTextSlateEditor
+}) {
+  const editableTypes = new Set<string>()
+  for (const [, config] of context.renderers) {
+    for (const path of getEditableTypePaths(
+      context.schema,
+      config.renderer.type,
+    )) {
+      editableTypes.add(path)
+    }
+  }
+  if (context.slateEditor) {
+    context.slateEditor.editableTypes = editableTypes
+  }
+}
+
 /**
  * @internal
  */
@@ -177,6 +206,7 @@ export const editorMachine = setup({
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
       pendingIncomingPatchesEvents: Array<PatchesEvent>
+      renderers: Map<string, RendererConfig>
       schema: EditorSchema
       initialReadOnly: boolean
       selection: EditorSelection
@@ -223,6 +253,25 @@ export const editorMachine = setup({
           : context.slateEditor
       },
     }),
+    'register renderer': assign({
+      renderers: ({context, event}) => {
+        assertEvent(event, 'register renderer')
+        const renderers = new Map(context.renderers)
+        renderers.set(event.rendererConfig.renderer.type, event.rendererConfig)
+        return renderers
+      },
+    }),
+    'unregister renderer': assign({
+      renderers: ({context, event}) => {
+        assertEvent(event, 'unregister renderer')
+        const renderers = new Map(context.renderers)
+        renderers.delete(event.rendererConfig.renderer.type)
+        return renderers
+      },
+    }),
+    'sync editable types': ({context}) => {
+      syncEditableTypes(context)
+    },
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')
       return event
@@ -402,6 +451,7 @@ export const editorMachine = setup({
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
     pendingIncomingPatchesEvents: [],
+    renderers: new Map(),
     schema: input.schema,
     selection: null,
     initialReadOnly: input.readOnly ?? false,
@@ -410,7 +460,15 @@ export const editorMachine = setup({
   on: {
     'add behavior': {actions: 'add behavior to context'},
     'remove behavior': {actions: 'remove behavior from context'},
-    'add slate editor': {actions: 'add slate editor to context'},
+    'add slate editor': {
+      actions: ['add slate editor to context', 'sync editable types'],
+    },
+    'register renderer': {
+      actions: ['register renderer', 'sync editable types'],
+    },
+    'unregister renderer': {
+      actions: ['unregister renderer', 'sync editable types'],
+    },
     'update selection': {
       actions: [
         assign({selection: ({event}) => event.selection}),

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -7,6 +7,7 @@ import {useSelector} from '@xstate/react'
 import {useContext, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import {isInline} from '../node-traversal/is-inline'
+import type {RendererConfig} from '../renderers/renderer.types'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
 import type {
@@ -35,6 +36,10 @@ export function RenderElement(props: {
 }) {
   const editorActor = useContext(EditorActorContext)
   const schema = useSelector(editorActor, (s) => s.context.schema)
+  const rendererConfig: RendererConfig | undefined = useSelector(
+    editorActor,
+    (s) => s.context.renderers.get(props.element._type),
+  )
   const slateStatic = useSlateStatic()
 
   if (isTextBlock({schema}, props.element)) {
@@ -73,6 +78,14 @@ export function RenderElement(props: {
         {props.children}
       </RenderInlineObject>
     )
+  }
+
+  if (rendererConfig) {
+    return rendererConfig.renderer.render({
+      attributes: props.attributes,
+      children: props.children,
+      node: props.element,
+    })
   }
 
   return (

--- a/packages/editor/src/internal-utils/is-editable-type.test.ts
+++ b/packages/editor/src/internal-utils/is-editable-type.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, test} from 'vitest'
+import {isEditableType} from './is-editable-type'
+
+describe(isEditableType.name, () => {
+  test('direct match', () => {
+    const editableTypes = new Set(['table', 'table.row', 'table.row.cell'])
+    expect(isEditableType(editableTypes, 'table')).toBe(true)
+  })
+
+  test('scoped suffix match', () => {
+    const editableTypes = new Set(['table', 'table.row', 'table.row.cell'])
+    expect(isEditableType(editableTypes, 'row')).toBe(true)
+  })
+
+  test('deeply scoped suffix match', () => {
+    const editableTypes = new Set(['table', 'table.row', 'table.row.cell'])
+    expect(isEditableType(editableTypes, 'cell')).toBe(true)
+  })
+
+  test('no match', () => {
+    const editableTypes = new Set(['table', 'table.row', 'table.row.cell'])
+    expect(isEditableType(editableTypes, 'image')).toBe(false)
+  })
+
+  test('empty set', () => {
+    const editableTypes = new Set<string>()
+    expect(isEditableType(editableTypes, 'table')).toBe(false)
+  })
+
+  test('partial name does not match', () => {
+    const editableTypes = new Set(['table', 'table.row'])
+    expect(isEditableType(editableTypes, 'tab')).toBe(false)
+  })
+
+  test('suffix must follow a dot', () => {
+    const editableTypes = new Set(['notable'])
+    expect(isEditableType(editableTypes, 'table')).toBe(false)
+  })
+})

--- a/packages/editor/src/internal-utils/is-editable-type.ts
+++ b/packages/editor/src/internal-utils/is-editable-type.ts
@@ -1,0 +1,24 @@
+/**
+ * Check if a type name is an editable container type.
+ *
+ * editableTypes contains scoped names like 'table', 'table.row', 'table.row.cell'.
+ * A node's _type is unscoped like 'row'. This function checks both direct match
+ * and scoped suffix match.
+ */
+export function isEditableType(
+  editableTypes: Set<string>,
+  typeName: string,
+): boolean {
+  if (editableTypes.has(typeName)) {
+    return true
+  }
+
+  const suffix = `.${typeName}`
+  for (const editableType of editableTypes) {
+    if (editableType.endsWith(suffix)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -397,7 +397,7 @@ describe(setNodePatch.name, () => {
       ] as Array<PortableTextBlock>
       editor.onChange()
 
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [0],
         properties: {_key: '1f2e64b47787'},
@@ -414,7 +414,7 @@ describe(setNodePatch.name, () => {
     })
 
     test('produces set patch with keyed path for non-key property on text block', () => {
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [0],
         properties: {style: 'normal'},
@@ -453,7 +453,7 @@ describe(setNodePatch.name, () => {
       ] as Array<PortableTextBlock>
       editor.onChange()
 
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [{_key: '1f2e64b47787'}, 'children', 0],
         properties: {_key: 'c130395c640c'},
@@ -470,7 +470,7 @@ describe(setNodePatch.name, () => {
     })
 
     test('produces set patch with keyed path for non-key property on span', () => {
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [{_key: '1f2e64b47787'}, 'children', 0],
         properties: {marks: []},
@@ -494,7 +494,7 @@ describe(setNodePatch.name, () => {
 
   describe('keyed block segment', () => {
     test('produces set patch for style change on text block', () => {
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [{_key: '1f2e64b47787'}],
         properties: {style: 'normal'},
@@ -525,7 +525,7 @@ describe(setNodePatch.name, () => {
       ] as Array<PortableTextBlock>
       editor.onChange()
 
-      const patches = setNodePatch(schema, editor.children, {
+      const patches = setNodePatch(editor.children, {
         type: 'set_node',
         path: [{_key: '1f2e64b47787'}],
         properties: {style: 'normal', listItem: 'bullet'},
@@ -541,6 +541,91 @@ describe(setNodePatch.name, () => {
         {
           type: 'unset',
           path: [{_key: '1f2e64b47787'}, 'listItem'],
+        },
+      ])
+    })
+  })
+
+  describe('container-depth set_node', () => {
+    test('produces set patch for property change on table cell', () => {
+      editor.children = [
+        {
+          _type: 'table',
+          _key: 'table1',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell1',
+                  header: false,
+                },
+              ],
+            },
+          ],
+        },
+      ] as Array<PortableTextBlock>
+      editor.onChange()
+
+      const patches = setNodePatch(editor.children, {
+        type: 'set_node',
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+        ],
+        properties: {header: false},
+        newProperties: {header: true},
+      })
+
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [
+            {_key: 'table1'},
+            'rows',
+            {_key: 'row1'},
+            'cells',
+            {_key: 'cell1'},
+            'header',
+          ],
+          value: true,
+        },
+      ])
+    })
+
+    test('produces set patch for _key change on container child', () => {
+      editor.children = [
+        {
+          _type: 'table',
+          _key: 'table1',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'new-row-key',
+              cells: [],
+            },
+          ],
+        },
+      ] as Array<PortableTextBlock>
+      editor.onChange()
+
+      const patches = setNodePatch(editor.children, {
+        type: 'set_node',
+        path: [{_key: 'table1'}, 'rows', 0],
+        properties: {_key: 'row1'},
+        newProperties: {_key: 'new-row-key'},
+      })
+
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [{_key: 'table1'}, 'rows', 0, '_key'],
+          value: 'new-row-key',
         },
       ])
     })

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -6,7 +6,7 @@ import {
   unset,
   type Patch,
 } from '@portabletext/patches'
-import {isTextBlock, type PortableTextBlock} from '@portabletext/schema'
+import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import {getSpanNode} from '../node-traversal/get-span-node'
 import type {Node} from '../slate/interfaces/node'
@@ -45,7 +45,6 @@ export function textPatch(
 }
 
 export function setNodePatch(
-  schema: EditorSchema,
   children: Node[],
   operation: SetNodeOperation,
 ): Array<Patch> {
@@ -78,34 +77,63 @@ export function setNodePatch(
     return setNodePatches(children, block, operation)
   }
 
-  // Child-level set_node
-  if (operation.path.length === 3 && isTextBlock({schema}, block)) {
-    const childSegment = operation.path[2]
-    const newChildKey =
-      typeof operation.newProperties._key === 'string'
-        ? operation.newProperties._key
-        : undefined
+  // Child-level set_node: walk the path to find the target node and its siblings.
+  // The path alternates between field names (strings) and node segments (keyed or
+  // numeric). We walk down from the block, resolving each field name to get the
+  // children array, then finding the node within it.
+  const newChildKey =
+    typeof operation.newProperties._key === 'string'
+      ? operation.newProperties._key
+      : undefined
 
-    let child: (typeof block.children)[number] | undefined
-    if (isKeyedSegment(childSegment)) {
-      child = block.children.find(
-        (c) => c._key === (newChildKey ?? childSegment._key),
+  let currentNode: Node = block
+  let siblings: ArrayLike<Node> = children
+  let parentPath: Path = []
+
+  for (let i = 1; i < operation.path.length; i++) {
+    const segment = operation.path[i]
+
+    if (typeof segment === 'string') {
+      // Field name segment: resolve the children array
+      const fieldValue = (currentNode as Record<string, unknown>)[segment]
+      if (!Array.isArray(fieldValue)) {
+        return []
+      }
+      siblings = fieldValue as Node[]
+      parentPath = [...parentPath, {_key: currentNode._key}, segment]
+      continue
+    }
+
+    // Node segment: find the node in the current siblings array
+    const isLastSegment = i === operation.path.length - 1
+    const lookupKey = isLastSegment ? newChildKey : undefined
+
+    let node: Node | undefined
+    if (isKeyedSegment(segment)) {
+      node = Array.prototype.find.call(
+        siblings,
+        (c: Node) => c._key === (lookupKey ?? segment._key),
       )
-    } else if (typeof childSegment === 'number') {
-      child = block.children[childSegment]
-      if (newChildKey && child) {
-        child = block.children.find((c) => c._key === newChildKey) ?? child
+    } else if (typeof segment === 'number') {
+      node = (siblings as Node[])[segment]
+      if (lookupKey && node) {
+        node =
+          Array.prototype.find.call(
+            siblings,
+            (c: Node) => c._key === lookupKey,
+          ) ?? node
       }
     }
 
-    if (!child) {
+    if (!node) {
       return []
     }
 
-    return setNodePatches(block.children, child, operation, [
-      {_key: block._key},
-      'children',
-    ])
+    if (isLastSegment) {
+      return setNodePatches(siblings, node, operation, parentPath)
+    }
+
+    currentNode = node
   }
 
   return []

--- a/packages/editor/src/node-traversal/get-highest-object-node.test.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.test.ts
@@ -41,77 +41,77 @@ describe(getHighestObjectNode.name, () => {
     expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k1'}])
   })
 
-  test('table at path returns itself', () => {
-    const entry = getHighestObjectNode(testbed.context, [{_key: 'k26'}])
-    expect(entry?.node).toBe(testbed.table)
-    expect(entry?.path).toEqual([{_key: 'k26'}])
+  test('table at path returns undefined (editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [{_key: 'k26'}]),
+    ).toBeUndefined()
   })
 
-  test('span inside cell finds table as highest object node', () => {
-    const entry = getHighestObjectNode(testbed.context, [
-      {_key: 'k26'},
-      'rows',
-      {_key: 'k21'},
-      'cells',
-      {_key: 'k17'},
-      'content',
-      {_key: 'k14'},
-      'children',
-      {_key: 'k12'},
-    ])
-    expect(entry?.node).toBe(testbed.table)
-    expect(entry?.path).toEqual([{_key: 'k26'}])
+  test('span inside cell returns undefined (all ancestors editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [
+        {_key: 'k26'},
+        'rows',
+        {_key: 'k21'},
+        'cells',
+        {_key: 'k17'},
+        'content',
+        {_key: 'k14'},
+        'children',
+        {_key: 'k12'},
+      ]),
+    ).toBeUndefined()
   })
 
-  test('cell block finds table as highest object node', () => {
-    const entry = getHighestObjectNode(testbed.context, [
-      {_key: 'k26'},
-      'rows',
-      {_key: 'k21'},
-      'cells',
-      {_key: 'k17'},
-      'content',
-      {_key: 'k14'},
-    ])
-    expect(entry?.node).toBe(testbed.table)
-    expect(entry?.path).toEqual([{_key: 'k26'}])
+  test('cell block returns undefined (all ancestors editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [
+        {_key: 'k26'},
+        'rows',
+        {_key: 'k21'},
+        'cells',
+        {_key: 'k17'},
+        'content',
+        {_key: 'k14'},
+      ]),
+    ).toBeUndefined()
   })
 
-  test('cell finds table as highest object node', () => {
-    const entry = getHighestObjectNode(testbed.context, [
-      {_key: 'k26'},
-      'rows',
-      {_key: 'k21'},
-      'cells',
-      {_key: 'k17'},
-    ])
-    expect(entry?.node).toBe(testbed.table)
-    expect(entry?.path).toEqual([{_key: 'k26'}])
+  test('cell returns undefined (all ancestors editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [
+        {_key: 'k26'},
+        'rows',
+        {_key: 'k21'},
+        'cells',
+        {_key: 'k17'},
+      ]),
+    ).toBeUndefined()
   })
 
-  test('row finds table as highest object node', () => {
-    const entry = getHighestObjectNode(testbed.context, [
-      {_key: 'k26'},
-      'rows',
-      {_key: 'k21'},
-    ])
-    expect(entry?.node).toBe(testbed.table)
-    expect(entry?.path).toEqual([{_key: 'k26'}])
+  test('row returns undefined (all ancestors editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [
+        {_key: 'k26'},
+        'rows',
+        {_key: 'k21'},
+      ]),
+    ).toBeUndefined()
   })
 
-  test('code span finds code-block as highest object node', () => {
-    const entry = getHighestObjectNode(testbed.context, [
-      {_key: 'k11'},
-      'code',
-      {_key: 'k8'},
-      'children',
-      {_key: 'k7'},
-    ])
-    expect(entry?.node).toBe(testbed.codeBlock)
-    expect(entry?.path).toEqual([{_key: 'k11'}])
+  test('code span returns undefined (code-block is editable)', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [
+        {_key: 'k11'},
+        'code',
+        {_key: 'k8'},
+        'children',
+        {_key: 'k7'},
+      ]),
+    ).toBeUndefined()
   })
 
-  test('inline object in cell finds table as highest object node', () => {
+  test('inline object in cell finds stock-ticker (not editable table)', () => {
     const entry = getHighestObjectNode(testbed.context, [
       {_key: 'k26'},
       'rows',
@@ -122,6 +122,66 @@ describe(getHighestObjectNode.name, () => {
       {_key: 'k14'},
       'children',
       {_key: 'k13'},
+    ])
+    expect(entry?.node).toBe(testbed.stockTicker2)
+    expect(entry?.path).toEqual([
+      {_key: 'k26'},
+      'rows',
+      {_key: 'k21'},
+      'cells',
+      {_key: 'k17'},
+      'content',
+      {_key: 'k14'},
+      'children',
+      {_key: 'k13'},
+    ])
+  })
+
+  test('table returns undefined when editable', () => {
+    expect(
+      getHighestObjectNode(testbed.context, [{_key: 'k26'}]),
+    ).toBeUndefined()
+  })
+
+  test('image still returns itself (not editable)', () => {
+    const entry = getHighestObjectNode(testbed.context, [{_key: 'k4'}])
+    expect(entry?.node).toBe(testbed.image)
+    expect(entry?.path).toEqual([{_key: 'k4'}])
+  })
+
+  test('inline object inside editable container returns itself', () => {
+    const entry = getHighestObjectNode(testbed.context, [
+      {_key: 'k26'},
+      'rows',
+      {_key: 'k21'},
+      'cells',
+      {_key: 'k17'},
+      'content',
+      {_key: 'k14'},
+      'children',
+      {_key: 'k13'},
+    ])
+    expect(entry?.node).toBe(testbed.stockTicker2)
+    expect(entry?.path).toEqual([
+      {_key: 'k26'},
+      'rows',
+      {_key: 'k21'},
+      'cells',
+      {_key: 'k17'},
+      'content',
+      {_key: 'k14'},
+      'children',
+      {_key: 'k13'},
+    ])
+  })
+
+  test('with empty editableTypes, table returns itself', () => {
+    const contextWithNoEditableTypes = {
+      ...testbed.context,
+      editableTypes: new Set<string>(),
+    }
+    const entry = getHighestObjectNode(contextWithNoEditableTypes, [
+      {_key: 'k26'},
     ])
     expect(entry?.node).toBe(testbed.table)
     expect(entry?.path).toEqual([{_key: 'k26'}])

--- a/packages/editor/src/node-traversal/get-highest-object-node.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.ts
@@ -1,5 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import {isEditableType} from '../internal-utils/is-editable-type'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
@@ -30,7 +31,10 @@ export function getHighestObjectNode(
       continue
     }
 
-    if (isObjectNode({schema: context.schema}, ancestor.node)) {
+    if (
+      isObjectNode({schema: context.schema}, ancestor.node) &&
+      !isEditableType(context.editableTypes, ancestor.node._type)
+    ) {
       return {node: ancestor.node, path: ancestor.path}
     }
   }
@@ -42,7 +46,10 @@ export function getHighestObjectNode(
     return undefined
   }
 
-  if (!isObjectNode({schema: context.schema}, entry.node)) {
+  if (
+    !isObjectNode({schema: context.schema}, entry.node) ||
+    isEditableType(context.editableTypes, entry.node._type)
+  ) {
     return undefined
   }
 

--- a/packages/editor/src/renderers/_exports/index.ts
+++ b/packages/editor/src/renderers/_exports/index.ts
@@ -1,0 +1,1 @@
+export * from '../index'

--- a/packages/editor/src/renderers/container-schema.ts
+++ b/packages/editor/src/renderers/container-schema.ts
@@ -1,0 +1,48 @@
+import type {FieldDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+
+/**
+ * Given a registered renderer type name, walk the schema tree and return
+ * all scoped type paths that should be editable.
+ *
+ * For 'table' with schema: table > rows > row > cells > cell > content > block
+ * Returns: ['table', 'table.row', 'table.row.cell']
+ */
+export function getEditableTypePaths(
+  schema: EditorSchema,
+  typeName: string,
+): Array<string> {
+  const paths: Array<string> = [typeName]
+
+  const blockObject = schema.blockObjects.find(
+    (definition) => definition.name === typeName,
+  )
+
+  if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
+    return paths
+  }
+
+  walkFields(blockObject.fields, typeName, paths)
+  return paths
+}
+
+function walkFields(
+  fields: ReadonlyArray<FieldDefinition>,
+  currentPath: string,
+  paths: Array<string>,
+) {
+  for (const field of fields) {
+    if (field.type === 'array' && 'of' in field && field.of) {
+      for (const ofMember of field.of) {
+        if (ofMember.type === 'block') {
+          continue
+        }
+        const scopedPath = `${currentPath}.${ofMember.type}`
+        paths.push(scopedPath)
+        if ('fields' in ofMember && ofMember.fields) {
+          walkFields(ofMember.fields, scopedPath, paths)
+        }
+      }
+    }
+  }
+}

--- a/packages/editor/src/renderers/define-renderer.ts
+++ b/packages/editor/src/renderers/define-renderer.ts
@@ -1,0 +1,10 @@
+import type {Renderer} from './renderer.types'
+
+/**
+ * @internal
+ */
+export function defineRenderer<const TRenderer extends Renderer>(
+  renderer: TRenderer,
+): TRenderer {
+  return renderer
+}

--- a/packages/editor/src/renderers/index.ts
+++ b/packages/editor/src/renderers/index.ts
@@ -1,0 +1,2 @@
+export {defineRenderer} from './define-renderer'
+export type {Renderer} from './renderer.types'

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -1,0 +1,21 @@
+import type {PortableTextObject} from '@portabletext/schema'
+import type {ReactElement} from 'react'
+
+/**
+ * @internal
+ */
+export type Renderer = {
+  type: string
+  render: (props: {
+    attributes: Record<string, unknown>
+    children: ReactElement
+    node: PortableTextObject
+  }) => ReactElement
+}
+
+/**
+ * @internal
+ */
+export type RendererConfig = {
+  renderer: Renderer
+}

--- a/packages/editor/src/slate-plugins/slate-plugin.patches.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.patches.ts
@@ -151,10 +151,7 @@ export function createPatchesPlugin({
           patches = [...patches, ...insertNodePatch(operation)]
           break
         case 'set_node':
-          patches = [
-            ...patches,
-            ...setNodePatch(schema, editor.children, operation),
-          ]
+          patches = [...patches, ...setNodePatch(editor.children, operation)]
           break
         default:
         // Do nothing

--- a/packages/editor/src/slate/core/delete-text.ts
+++ b/packages/editor/src/slate/core/delete-text.ts
@@ -1,6 +1,7 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {applyMergeNode} from '../../internal-utils/apply-merge-node'
 import {applySetNode} from '../../internal-utils/apply-set-node'
+import {isEditableType} from '../../internal-utils/is-editable-type'
 import {safeStringify} from '../../internal-utils/safe-json'
 import {getAncestor} from '../../node-traversal/get-ancestor'
 import {getAncestorTextBlock} from '../../node-traversal/get-ancestor-text-block'
@@ -160,7 +161,9 @@ export function deleteText(editor: Editor, options: TextDeleteOptions = {}) {
       }
 
       if (
-        (!includeObjectNodes && isObjectNode({schema: editor.schema}, node)) ||
+        (!includeObjectNodes &&
+          isObjectNode({schema: editor.schema}, node) &&
+          !isEditableType(editor.editableTypes, node._type)) ||
         (!isCommonPath(entryPath, start.path) &&
           !isCommonPath(entryPath, end.path))
       ) {

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -9,11 +9,13 @@ import {applySetNode} from '../../internal-utils/apply-set-node'
 import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
 import {debug} from '../../internal-utils/debug'
 import {isEqualMarkDefs} from '../../internal-utils/equality'
+import {isEditableType} from '../../internal-utils/is-editable-type'
 import {getChildren} from '../../node-traversal/get-children'
 import {getNode} from '../../node-traversal/get-node'
 import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {resolveChildArrayField} from '../../schema/resolve-child-array-field'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
 import {isEditor} from '../editor/is-editor'
 import type {Editor} from '../interfaces/editor'
@@ -343,6 +345,45 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
 
     return
+  }
+
+  // Container child enforcement: ensure the child array field exists and has content.
+  // This runs before the duplicate key check so that containers always have
+  // a valid child array before any further normalization.
+  if (
+    isObjectNode({schema: editor.schema}, node) &&
+    isEditableType(editor.editableTypes, node._type)
+  ) {
+    const arrayField = resolveChildArrayField({schema: editor.schema}, node)
+
+    if (arrayField) {
+      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+
+      if (!Array.isArray(fieldValue)) {
+        debug.normalization('adding child array field to container node')
+        applySetNode(editor, {[arrayField.name]: []}, path)
+        return
+      }
+
+      if (fieldValue.length === 0) {
+        const acceptsBlocks = arrayField.of.some(
+          (definition) => definition.type === 'block',
+        )
+
+        if (acceptsBlocks) {
+          debug.normalization(
+            'adding placeholder block to empty container field',
+          )
+          editor.apply({
+            type: 'insert_node',
+            path: [...path, arrayField.name, 0],
+            node: createPlaceholderBlock(editor),
+            position: 'before',
+          })
+          return
+        }
+      }
+    }
   }
 
   // Fix duplicate _key among children of container/object nodes.

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -1,5 +1,6 @@
 import {getDomNode} from '../../../dom-traversal/get-dom-node'
 import {getDomNodePath} from '../../../dom-traversal/get-dom-node-path'
+import {isEditableType} from '../../../internal-utils/is-editable-type'
 import {safeStringify} from '../../../internal-utils/safe-json'
 import {getAncestorObjectNode} from '../../../node-traversal/get-ancestor-object-node'
 import {getHighestObjectNode} from '../../../node-traversal/get-highest-object-node'
@@ -408,7 +409,10 @@ export const DOMEditor: DOMEditorInterface = {
       pointEntry && isObjectNode({schema: editor.schema}, pointEntry.node)
         ? pointEntry
         : getAncestorObjectNode(editor, point.path)
-    if (pointObjectNode) {
+    if (
+      pointObjectNode &&
+      !isEditableType(editor.editableTypes, pointObjectNode.node._type)
+    ) {
       point = {path: point.path, offset: 0}
     }
 

--- a/packages/editor/src/slate/editor/positions.ts
+++ b/packages/editor/src/slate/editor/positions.ts
@@ -1,4 +1,5 @@
 import {isSpan} from '@portabletext/schema'
+import {isEditableType} from '../../internal-utils/is-editable-type'
 import {getNodes} from '../../node-traversal/get-nodes'
 import type {Editor} from '../interfaces/editor'
 import type {Location} from '../interfaces/location'
@@ -116,7 +117,10 @@ export function* positions(
       }
     }
 
-    if (isObjectNode({schema: editor.schema}, node)) {
+    if (
+      isObjectNode({schema: editor.schema}, node) &&
+      !isEditableType(editor.editableTypes, node._type)
+    ) {
       yield {path: nodePath, offset: 0}
       continue
     }

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -6,6 +6,13 @@ import type {
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {useCallback, useRef, type JSX} from 'react'
 import {
+  ContainerScopeContext,
+  useContainerScope,
+  type ContainerScope,
+} from '../../../editor/container-scope-context'
+import {isEditableType} from '../../../internal-utils/is-editable-type'
+import {resolveChildArrayField} from '../../../schema/resolve-child-array-field'
+import {
   isElementDecorationsEqual,
   splitDecorationsByChild,
 } from '../../dom/utils/range-list'
@@ -58,6 +65,8 @@ const useChildren = (props: {
 
   const isEditorNode = isEditor(node)
 
+  const containerScope = useContainerScope()
+
   const decorationsByChild = useDecorationsByChild(
     editor,
     node,
@@ -65,18 +74,46 @@ const useChildren = (props: {
     decorations,
   )
 
-  const children = isEditor(node)
-    ? node.children
-    : isTextBlock({schema: editor.schema}, node)
-      ? node.children
-      : []
+  let children: Array<Node> = []
+  let childFieldName = 'children'
+  let childScope: ContainerScope | undefined = containerScope
+
+  if (isEditor(node)) {
+    children = node.children
+  } else if (isTextBlock({schema: editor.schema}, node)) {
+    children = node.children
+  } else if (isObjectNode({schema: editor.schema}, node)) {
+    const scopedKey = containerScope
+      ? `${containerScope.name}.${node._type}`
+      : node._type
+
+    if (editor.editableTypes.has(scopedKey)) {
+      const arrayField = resolveChildArrayField(
+        {schema: editor.schema, scope: containerScope?.schemaScope},
+        node,
+      )
+
+      if (arrayField) {
+        const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+        if (Array.isArray(fieldValue)) {
+          children = fieldValue as Array<Node>
+          childFieldName = arrayField.name
+        }
+
+        childScope = {
+          name: scopedKey,
+          schemaScope: arrayField.of,
+        }
+      }
+    }
+  }
 
   const renderElementComponent = useCallback(
     (node: PortableTextTextBlock | PortableTextObject, i: number) => {
       const nodeDataPath =
         parentDataPath === ''
           ? `[_key=="${node._key}"]`
-          : `${parentDataPath}.children[_key=="${node._key}"]`
+          : `${parentDataPath}.${childFieldName}[_key=="${node._key}"]`
 
       return (
         <ElementContext.Provider key={`provider-${node._key}`} value={node}>
@@ -95,6 +132,7 @@ const useChildren = (props: {
       )
     },
     [
+      childFieldName,
       parentDataPath,
       decorationsByChild,
       parentIndexedPath,
@@ -144,7 +182,7 @@ const useChildren = (props: {
     const nodeDataPath =
       parentDataPath === ''
         ? `[_key=="${node._key}"]`
-        : `${parentDataPath}.children[_key=="${node._key}"]`
+        : `${parentDataPath}.${childFieldName}[_key=="${node._key}"]`
 
     return (
       <ObjectNodeComponent
@@ -159,7 +197,7 @@ const useChildren = (props: {
     )
   }
 
-  return children.map((n: Node, i: number) => {
+  const elements = children.map((n: Node, i: number) => {
     if (isTextBlock({schema: editor.schema}, n)) {
       return renderElementComponent(n, i)
     }
@@ -168,6 +206,9 @@ const useChildren = (props: {
       return null
     }
     if (isObjectNode({schema: editor.schema}, n)) {
+      if (isEditableType(editor.editableTypes, n._type)) {
+        return renderElementComponent(n, i)
+      }
       return renderObjectNodeComponent(n, i)
     }
     if (isSpan({schema: editor.schema}, n)) {
@@ -179,6 +220,16 @@ const useChildren = (props: {
     }
     throw new Error(`Unexpected node type`)
   })
+
+  if (childScope && childScope !== containerScope) {
+    return (
+      <ContainerScopeContext.Provider value={childScope}>
+        {elements}
+      </ContainerScopeContext.Provider>
+    )
+  }
+
+  return elements
 }
 
 const useDecorationsByChild = (

--- a/packages/editor/tests/tables.test.tsx
+++ b/packages/editor/tests/tables.test.tsx
@@ -1,9 +1,13 @@
 import {set, unset} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
-import React from 'react'
+import React, {useEffect} from 'react'
 import {describe, expect, test, vi} from 'vitest'
+import {page} from 'vitest/browser'
+import type {InternalEditor} from '../src/editor/create-editor'
+import {useEditor} from '../src/editor/use-editor'
 import {InternalSlateEditorRefPlugin} from '../src/plugins/plugin.internal.slate-editor-ref'
+import type {RendererConfig} from '../src/renderers/renderer.types'
 import {withoutPatching} from '../src/slate-plugins/slate-plugin.without-patching'
 import {normalize} from '../src/slate/editor/normalize'
 import {createTestEditor} from '../src/test/vitest'
@@ -49,6 +53,16 @@ const schemaDefinition = defineSchema({
     },
   ],
 })
+
+function ContainerRendererPlugin(props: {rendererConfig: RendererConfig}) {
+  const editor = useEditor() as InternalEditor
+
+  useEffect(() => {
+    return editor.registerRenderer(props.rendererConfig)
+  }, [editor, props.rendererConfig])
+
+  return null
+}
 
 async function createTableTestEditor() {
   const keyGenerator = createTestKeyGenerator()
@@ -801,6 +815,137 @@ describe('tables', () => {
         expect(children).toEqual([
           {_key: 'k6', _type: 'span', text: '', marks: []},
         ])
+      })
+    })
+  })
+
+  describe('rendering', () => {
+    test('container children render as text in the DOM', async () => {
+      const rendererConfig: RendererConfig = {
+        renderer: {
+          type: 'table',
+          render: (props) => (
+            <div data-testid="table-renderer">{props.children}</div>
+          ),
+        },
+      }
+
+      const keyGenerator = createTestKeyGenerator()
+      const tableKey = keyGenerator()
+      const rowKey = keyGenerator()
+      const cellKey = keyGenerator()
+      const blockKey = keyGenerator()
+      const spanKey = keyGenerator()
+
+      const table = {
+        _key: tableKey,
+        _type: 'table',
+        rows: [
+          {
+            _key: rowKey,
+            _type: 'row',
+            cells: [
+              {
+                _key: cellKey,
+                _type: 'cell',
+                content: [
+                  {
+                    _key: blockKey,
+                    _type: 'block',
+                    children: [
+                      {
+                        _key: spanKey,
+                        _type: 'span',
+                        text: 'foo',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      await createTestEditor({
+        keyGenerator,
+        schemaDefinition,
+        initialValue: [table],
+        children: <ContainerRendererPlugin rendererConfig={rendererConfig} />,
+      })
+
+      await vi.waitFor(() => {
+        return expect
+          .element(page.getByTestId('table-renderer'))
+          .toBeInTheDocument()
+      })
+
+      await vi.waitFor(() => {
+        return expect.element(page.getByText('foo')).toBeInTheDocument()
+      })
+    })
+
+    test('renderer receives the table node', async () => {
+      const renderFn = vi.fn((props) => (
+        <div data-testid="table-renderer">{props.children}</div>
+      ))
+
+      const rendererConfig: RendererConfig = {
+        renderer: {
+          type: 'table',
+          render: renderFn,
+        },
+      }
+
+      const keyGenerator = createTestKeyGenerator()
+      const tableKey = keyGenerator()
+      const rowKey = keyGenerator()
+      const cellKey = keyGenerator()
+      const blockKey = keyGenerator()
+      const spanKey = keyGenerator()
+
+      const table = {
+        _key: tableKey,
+        _type: 'table',
+        rows: [
+          {
+            _key: rowKey,
+            _type: 'row',
+            cells: [
+              {
+                _key: cellKey,
+                _type: 'cell',
+                content: [
+                  {
+                    _key: blockKey,
+                    _type: 'block',
+                    children: [
+                      {
+                        _key: spanKey,
+                        _type: 'span',
+                        text: 'foo',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      await createTestEditor({
+        keyGenerator,
+        schemaDefinition,
+        initialValue: [table],
+        children: <ContainerRendererPlugin rendererConfig={rendererConfig} />,
+      })
+
+      await vi.waitFor(() => {
+        expect(renderFn).toHaveBeenCalled()
+        const lastCall = renderFn.mock.calls.at(-1)![0]
+        expect(lastCall.node._type).toBe('table')
+        expect(lastCall.node._key).toBe(tableKey)
       })
     })
   })


### PR DESCRIPTION
Incremental work toward first-class editable containers (tables, callouts, etc).

The editor currently treats every block as either a text block or a void object. Containers need a third category: blocks that have editable sub-structure. This PR builds that awareness into the engine piece by piece.

## What's here so far

**`isEditableType` helper** — checks whether a node's `_type` is a registered editable container. Handles scoped name matching: a node with `_type: 'row'` matches `'table.row'` in `editableTypes`. This is the predicate that all engine code uses to distinguish void objects from editable containers.

**Container child enforcement in normalization** — when a container node is missing its child array field, set it to `[]`. When the field is empty and the schema says it accepts blocks, insert a placeholder block. Both checks are gated behind `isEditableType`, so they have zero effect until renderers are registered.

All changes are internal. `editableTypes` is not exposed on any public API.