### PR TITLE
feat: support container normalization

### DIFF
--- a/.changeset/container-normalization.md
+++ b/.changeset/container-normalization.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+feat: support container normalization

--- a/packages/editor/src/editor/container-scope-context.ts
+++ b/packages/editor/src/editor/container-scope-context.ts
@@ -1,0 +1,23 @@
+import type {OfDefinition} from '@portabletext/schema'
+import {createContext, useContext} from 'react'
+
+/**
+ * Tracks the current container scope as we render nested containers.
+ * The scope name accumulates type names separated by dots:
+ * - At the editor root: undefined
+ * - Inside a table: 'table'
+ * - Inside a table row: 'table.row'
+ * - Inside a table row cell: 'table.row.cell'
+ */
+export type ContainerScope = {
+  name: string
+  schemaScope: ReadonlyArray<OfDefinition> | undefined
+}
+
+export const ContainerScopeContext = createContext<ContainerScope | undefined>(
+  undefined,
+)
+
+export function useContainerScope() {
+  return useContext(ContainerScopeContext)
+}

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -19,6 +19,9 @@ import type {Converter} from '../converters/converter.types'
 import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
+import {getEditableTypePaths} from '../renderers/container-schema'
+import type {RendererConfig} from '../renderers/renderer.types'
+import {normalize} from '../slate/editor/normalize'
 import {ReactEditor} from '../slate/react/plugin/react-editor'
 import type {NamespaceEvent, OmitFromUnion} from '../type-utils'
 import type {EditorSelection} from '../types/editor'
@@ -112,6 +115,14 @@ type InternalEditorEvent =
     }
   | {type: 'dragend'}
   | {type: 'drop'}
+  | {
+      type: 'register renderer'
+      rendererConfig: RendererConfig
+    }
+  | {
+      type: 'unregister renderer'
+      rendererConfig: RendererConfig
+    }
   | {type: 'add slate editor'; editor: PortableTextSlateEditor}
 
 /**
@@ -165,6 +176,27 @@ export function rerouteExternalBehaviorEvent({
   }
 }
 
+function syncEditableTypes(context: {
+  schema: EditorSchema
+  renderers: Map<string, RendererConfig>
+  slateEditor?: PortableTextSlateEditor
+}) {
+  const editableTypes = new Set<string>()
+  for (const [, config] of context.renderers) {
+    for (const path of getEditableTypePaths(
+      context.schema,
+      config.renderer.type,
+    )) {
+      editableTypes.add(path)
+    }
+  }
+  if (context.slateEditor) {
+    context.slateEditor.editableTypes = editableTypes
+    normalize(context.slateEditor, {force: true})
+    context.slateEditor.onChange()
+  }
+}
+
 /**
  * @internal
  */
@@ -177,6 +209,7 @@ export const editorMachine = setup({
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
       pendingIncomingPatchesEvents: Array<PatchesEvent>
+      renderers: Map<string, RendererConfig>
       schema: EditorSchema
       initialReadOnly: boolean
       selection: EditorSelection
@@ -223,6 +256,25 @@ export const editorMachine = setup({
           : context.slateEditor
       },
     }),
+    'register renderer': assign({
+      renderers: ({context, event}) => {
+        assertEvent(event, 'register renderer')
+        const renderers = new Map(context.renderers)
+        renderers.set(event.rendererConfig.renderer.type, event.rendererConfig)
+        return renderers
+      },
+    }),
+    'unregister renderer': assign({
+      renderers: ({context, event}) => {
+        assertEvent(event, 'unregister renderer')
+        const renderers = new Map(context.renderers)
+        renderers.delete(event.rendererConfig.renderer.type)
+        return renderers
+      },
+    }),
+    'sync editable types': ({context}) => {
+      syncEditableTypes(context)
+    },
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')
       return event
@@ -402,6 +454,7 @@ export const editorMachine = setup({
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
     pendingIncomingPatchesEvents: [],
+    renderers: new Map(),
     schema: input.schema,
     selection: null,
     initialReadOnly: input.readOnly ?? false,
@@ -410,7 +463,15 @@ export const editorMachine = setup({
   on: {
     'add behavior': {actions: 'add behavior to context'},
     'remove behavior': {actions: 'remove behavior from context'},
-    'add slate editor': {actions: 'add slate editor to context'},
+    'add slate editor': {
+      actions: ['add slate editor to context', 'sync editable types'],
+    },
+    'register renderer': {
+      actions: ['register renderer', 'sync editable types'],
+    },
+    'unregister renderer': {
+      actions: ['unregister renderer', 'sync editable types'],
+    },
     'update selection': {
       actions: [
         assign({selection: ({event}) => event.selection}),

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -7,6 +7,7 @@ import {useSelector} from '@xstate/react'
 import {useContext, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import {isInline} from '../node-traversal/is-inline'
+import type {RendererConfig} from '../renderers/renderer.types'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
 import type {
@@ -35,6 +36,10 @@ export function RenderElement(props: {
 }) {
   const editorActor = useContext(EditorActorContext)
   const schema = useSelector(editorActor, (s) => s.context.schema)
+  const rendererConfig: RendererConfig | undefined = useSelector(
+    editorActor,
+    (s) => s.context.renderers.get(props.element._type),
+  )
   const slateStatic = useSlateStatic()
 
   if (isTextBlock({schema}, props.element)) {
@@ -73,6 +78,14 @@ export function RenderElement(props: {
         {props.children}
       </RenderInlineObject>
     )
+  }
+
+  if (rendererConfig) {
+    return rendererConfig.renderer.render({
+      attributes: props.attributes,
+      children: props.children,
+      node: props.element,
+    })
   }
 
   return (

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -134,10 +134,14 @@ export function getNodeChildren(
       return undefined
     }
 
+    const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+
+    if (!Array.isArray(fieldValue)) {
+      return undefined
+    }
+
     return {
-      children: (node as Record<string, unknown>)[
-        arrayField.name
-      ] as Array<Node>,
+      children: fieldValue as Array<Node>,
       scope: arrayField.of,
       scopePath: scopedKey,
       fieldName: arrayField.name,

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -1,12 +1,140 @@
-import {isSpan} from '@portabletext/schema'
+import type {OfDefinition, PortableTextObject} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import {getNodeDescendants} from '../node-traversal/get-nodes'
+import {resolveChildArrayField} from '../schema/resolve-child-array-field'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
 import type {Path} from '../slate/interfaces/path'
 import {pathLevels} from '../slate/path/path-levels'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildFieldName} from './get-child-field-name'
+
+/**
+ * Recursively collect descendant paths using numeric indices.
+ * Numeric indices avoid dedup collisions when siblings have duplicate
+ * keys (pre-normalization).
+ *
+ * Uses the schema and editableTypes to resolve child array fields
+ * rather than guessing from object properties.
+ */
+function collectDescendantPaths(
+  context: {
+    schema: EditorSchema
+    editableTypes: Set<string>
+  },
+  node: Node,
+  parentPath: Path,
+  paths: Array<Path>,
+  scope: ReadonlyArray<OfDefinition> | undefined,
+  scopePrefix: string,
+): void {
+  // Text blocks always use 'children'
+  if (isTextBlock(context, node)) {
+    const children = node.children
+    if (Array.isArray(children)) {
+      for (let i = 0; i < children.length; i++) {
+        paths.push([...parentPath, 'children', i])
+      }
+    }
+    return
+  }
+
+  // Build the scoped type name (e.g., 'table', 'table.row', 'table.row.cell')
+  const scopedName = scopePrefix ? `${scopePrefix}.${node._type}` : node._type
+
+  // For container types, resolve the child array field from the schema
+  if (context.editableTypes.has(scopedName)) {
+    const arrayField = resolveChildArrayField(
+      {schema: context.schema, scope},
+      node as PortableTextObject,
+    )
+
+    if (arrayField) {
+      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+
+      if (Array.isArray(fieldValue)) {
+        for (let i = 0; i < fieldValue.length; i++) {
+          const child = fieldValue[i] as Node
+          const childPath: Path = [...parentPath, arrayField.name, i]
+          paths.push(childPath)
+          collectDescendantPaths(
+            context,
+            child,
+            childPath,
+            paths,
+            arrayField.of,
+            scopedName,
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Build the scope context for a node at the given path by walking
+ * ancestor nodes in the tree.
+ *
+ * Returns the scope prefix (ancestor type chain) and the schema scope
+ * (of definitions from the parent's array field) needed to resolve
+ * nested container child fields.
+ */
+function buildScopeContext(
+  context: {schema: EditorSchema},
+  value: Array<Node>,
+  path: Path,
+): {scopedName: string; scope: ReadonlyArray<OfDefinition> | undefined} {
+  const types: Array<string> = []
+  let currentChildren: Array<Node> = value
+  let currentScope: ReadonlyArray<OfDefinition> | undefined
+
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i]
+
+    if (typeof segment === 'string') {
+      continue
+    }
+
+    let node: Node | undefined
+
+    if (isKeyedSegment(segment)) {
+      node = currentChildren.find((child) => child._key === segment._key)
+    } else if (typeof segment === 'number') {
+      node = currentChildren[segment]
+    }
+
+    if (!node) {
+      break
+    }
+
+    types.push(node._type)
+
+    // Resolve the child array field to get the scope for the next level
+    const arrayField = resolveChildArrayField(
+      {schema: context.schema, scope: currentScope},
+      node as PortableTextObject,
+    )
+    if (arrayField) {
+      currentScope = arrayField.of
+    }
+
+    // Look ahead for a field name segment to descend into
+    const nextSegment = path[i + 1]
+    if (typeof nextSegment === 'string') {
+      const fieldValue = (node as Record<string, unknown>)[nextSegment]
+      if (Array.isArray(fieldValue)) {
+        currentChildren = fieldValue as Array<Node>
+      }
+    }
+  }
+
+  // The full scoped name includes the node itself (e.g., 'table.row')
+  // The prefix excludes the node (e.g., 'table')
+  return {
+    scopedName: types.join('.'),
+    scope: currentScope,
+  }
+}
 
 /**
  * Get the "dirty" paths generated from an operation.
@@ -49,6 +177,12 @@ export function getDirtyPaths(
           ]
 
           if (Array.isArray(newChildren)) {
+            const {scopedName, scope} = buildScopeContext(
+              context,
+              context.value,
+              path,
+            )
+
             for (let i = 0; i < newChildren.length; i++) {
               const child = newChildren[i]
 
@@ -67,10 +201,14 @@ export function getDirtyPaths(
                 {_key: childNode._key},
               ]
               levels.push(childPath)
-
-              for (const entry of getNodeDescendants(context, childNode)) {
-                levels.push([...childPath, ...entry.path])
-              }
+              collectDescendantPaths(
+                context,
+                childNode,
+                childPath,
+                levels,
+                scope,
+                scopedName,
+              )
             }
           }
         }
@@ -100,24 +238,11 @@ export function getDirtyPaths(
         return levels
       }
 
-      // Use index-based child paths for dirty path generation to avoid
-      // dedup collisions when children have duplicate keys (pre-normalization).
-      const nodeRecord = node as Record<string, unknown>
-      const childArrays: Array<{fieldName: string; children: Array<Node>}> = []
-
-      if ('children' in nodeRecord && Array.isArray(nodeRecord['children'])) {
-        childArrays.push({
-          fieldName: 'children',
-          children: nodeRecord['children'] as Array<Node>,
-        })
-      }
-
-      for (const {fieldName, children} of childArrays) {
-        for (let i = 0; i < children.length; i++) {
-          const childPath: Path = [...nodePath, fieldName, i]
-          levels.push(childPath)
-        }
-      }
+      // Use index-based child paths to avoid dedup collisions when
+      // children have duplicate keys (pre-normalization). Walk all
+      // child array fields via the schema so container descendants
+      // are also dirtied.
+      collectDescendantPaths(context, node, nodePath, levels, undefined, '')
 
       return levels
     }

--- a/packages/editor/src/plugins/plugin.patches.tsx
+++ b/packages/editor/src/plugins/plugin.patches.tsx
@@ -1,0 +1,26 @@
+import type {Patch} from '@portabletext/patches'
+import {useEffect} from 'react'
+import {useEditor} from '../editor/use-editor'
+
+/**
+ * Collects patches emitted by the editor into the provided array.
+ * Strips the `origin` field from each patch.
+ *
+ * @internal
+ */
+export function PatchesPlugin(props: {patches: Array<Patch>}) {
+  const editor = useEditor()
+
+  useEffect(() => {
+    const subscription = editor.on('patch', (event) => {
+      const {origin: _, ...patch} = event.patch
+      props.patches.push(patch)
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [editor, props.patches])
+
+  return null
+}

--- a/packages/editor/src/plugins/plugin.renderer.tsx
+++ b/packages/editor/src/plugins/plugin.renderer.tsx
@@ -1,0 +1,31 @@
+import {useEffect} from 'react'
+import type {InternalEditor} from '../editor/create-editor'
+import {useEditor} from '../editor/use-editor'
+import type {RendererConfig} from '../renderers/renderer.types'
+
+/**
+ * @internal
+ */
+export function RendererPlugin(props: {renderers: Array<RendererConfig>}) {
+  const editor = useEditor() as unknown as InternalEditor
+
+  useEffect(() => {
+    for (const rendererConfig of props.renderers) {
+      editor._internal.editorActor.send({
+        type: 'register renderer',
+        rendererConfig,
+      })
+    }
+
+    return () => {
+      for (const rendererConfig of props.renderers) {
+        editor._internal.editorActor.send({
+          type: 'unregister renderer',
+          rendererConfig,
+        })
+      }
+    }
+  }, [editor, props.renderers])
+
+  return null
+}

--- a/packages/editor/src/renderers/container-schema.ts
+++ b/packages/editor/src/renderers/container-schema.ts
@@ -1,0 +1,48 @@
+import type {FieldDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+
+/**
+ * Given a registered renderer type name, walk the schema tree and return
+ * all scoped type paths that should be editable.
+ *
+ * For 'table' with schema: table > rows > row > cells > cell > content > block
+ * Returns: ['table', 'table.row', 'table.row.cell']
+ */
+export function getEditableTypePaths(
+  schema: EditorSchema,
+  typeName: string,
+): Array<string> {
+  const paths: Array<string> = [typeName]
+
+  const blockObject = schema.blockObjects.find(
+    (definition) => definition.name === typeName,
+  )
+
+  if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
+    return paths
+  }
+
+  walkFields(blockObject.fields, typeName, paths)
+  return paths
+}
+
+function walkFields(
+  fields: ReadonlyArray<FieldDefinition>,
+  currentPath: string,
+  paths: Array<string>,
+) {
+  for (const field of fields) {
+    if (field.type === 'array' && 'of' in field && field.of) {
+      for (const ofMember of field.of) {
+        if (ofMember.type === 'block') {
+          continue
+        }
+        const scopedPath = `${currentPath}.${ofMember.type}`
+        paths.push(scopedPath)
+        if ('fields' in ofMember && ofMember.fields) {
+          walkFields(ofMember.fields, scopedPath, paths)
+        }
+      }
+    }
+  }
+}

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -1,0 +1,21 @@
+import type {PortableTextObject} from '@portabletext/schema'
+import type {ReactElement} from 'react'
+
+/**
+ * @internal
+ */
+export type Renderer = {
+  type: string
+  render: (props: {
+    attributes: Record<string, unknown>
+    children: ReactElement
+    node: PortableTextObject
+  }) => ReactElement
+}
+
+/**
+ * @internal
+ */
+export type RendererConfig = {
+  renderer: Renderer
+}

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -1,4 +1,5 @@
 import type {
+  OfDefinition,
   PortableTextObject,
   PortableTextTextBlock,
 } from '@portabletext/schema'
@@ -14,7 +15,9 @@ import {getNode} from '../../node-traversal/get-node'
 import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {resolveChildArrayField} from '../../schema/resolve-child-array-field'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
+import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import {isEditor} from '../editor/is-editor'
 import type {Editor} from '../interfaces/editor'
 import type {Node} from '../interfaces/node'
@@ -27,6 +30,56 @@ import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
 import {removeNodes} from './remove-nodes'
+
+/**
+ * Build the scoped type name and schema scope for a container node
+ * by walking ancestor object nodes up the tree.
+ *
+ * For a 'row' at path [{_key:'t1'}, 'rows', {_key:'r1'}],
+ * the ancestor at [{_key:'t1'}] is a 'table', producing:
+ *   scopedName: 'table.row'
+ *   scope: the 'of' definitions from the 'rows' array field
+ */
+function getContainerScope(
+  editor: Editor,
+  node: Node,
+  path: Path,
+): {scopedName: string; scope: ReadonlyArray<OfDefinition> | undefined} {
+  const typeSegments: Array<string> = [node._type]
+
+  // Collect keyed segment indices (each represents a node in the tree).
+  const keyedIndices: Array<number> = []
+  for (let i = 0; i < path.length; i++) {
+    if (isKeyedSegment(path[i])) {
+      keyedIndices.push(i)
+    }
+  }
+
+  // Walk ancestor nodes from root to parent, building scope chain.
+  let currentScope: ReadonlyArray<OfDefinition> | undefined
+  for (let i = 0; i < keyedIndices.length - 1; i++) {
+    const ancestorPath = path.slice(0, keyedIndices[i]! + 1)
+    const entry = getNode(editor, ancestorPath)
+
+    if (!entry || !isObjectNode({schema: editor.schema}, entry.node)) {
+      break
+    }
+
+    // Insert before the node's own type (which is always last).
+    typeSegments.splice(typeSegments.length - 1, 0, entry.node._type)
+
+    const arrayField = resolveChildArrayField(
+      {schema: editor.schema, scope: currentScope},
+      entry.node,
+    )
+    currentScope = arrayField?.of
+  }
+
+  return {
+    scopedName: typeSegments.join('.'),
+    scope: currentScope,
+  }
+}
 
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
@@ -343,6 +396,72 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
 
     return
+  }
+
+  // Container normalization: ensure the child array field exists.
+  if (isObjectNode({schema: editor.schema}, node)) {
+    const {scopedName, scope} = getContainerScope(editor, node, path)
+    if (editor.editableTypes.has(scopedName)) {
+      const arrayField = resolveChildArrayField(
+        {schema: editor.schema, scope},
+        node,
+      )
+
+      if (arrayField) {
+        const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+
+        if (!Array.isArray(fieldValue)) {
+          applySetNode(editor, {[arrayField.name]: []}, path)
+          return
+        }
+      }
+    }
+  }
+
+  // Container normalization: ensure non-empty child array.
+  if (isObjectNode({schema: editor.schema}, node)) {
+    const {scopedName, scope} = getContainerScope(editor, node, path)
+
+    if (editor.editableTypes.has(scopedName)) {
+      const arrayField = resolveChildArrayField(
+        {schema: editor.schema, scope},
+        node,
+      )
+
+      if (arrayField) {
+        const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+
+        if (Array.isArray(fieldValue) && fieldValue.length === 0) {
+          const acceptsBlocks = arrayField.of.some(
+            (definition) => definition.type === 'block',
+          )
+
+          if (acceptsBlocks) {
+            editor.apply({
+              type: 'insert_node',
+              path: [...path, arrayField.name, 0],
+              node: createPlaceholderBlock(editor),
+              position: 'before',
+            })
+            return
+          }
+
+          const firstChildType = arrayField.of.at(0)
+          if (firstChildType && firstChildType.type !== 'block') {
+            editor.apply({
+              type: 'insert_node',
+              path: [...path, arrayField.name, 0],
+              node: {
+                _type: firstChildType.type,
+                _key: editor.keyGenerator(),
+              },
+              position: 'before',
+            })
+            return
+          }
+        }
+      }
+    }
   }
 
   // Fix duplicate _key among children of container/object nodes.

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -6,6 +6,12 @@ import type {
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {useCallback, useRef, type JSX} from 'react'
 import {
+  ContainerScopeContext,
+  useContainerScope,
+  type ContainerScope,
+} from '../../../editor/container-scope-context'
+import {resolveChildArrayField} from '../../../schema/resolve-child-array-field'
+import {
   isElementDecorationsEqual,
   splitDecorationsByChild,
 } from '../../dom/utils/range-list'
@@ -58,6 +64,8 @@ const useChildren = (props: {
 
   const isEditorNode = isEditor(node)
 
+  const containerScope = useContainerScope()
+
   const decorationsByChild = useDecorationsByChild(
     editor,
     node,
@@ -65,18 +73,46 @@ const useChildren = (props: {
     decorations,
   )
 
-  const children = isEditor(node)
-    ? node.children
-    : isTextBlock({schema: editor.schema}, node)
-      ? node.children
-      : []
+  let children: Array<Node> = []
+  let childFieldName = 'children'
+  let childScope: ContainerScope | undefined = containerScope
+
+  if (isEditor(node)) {
+    children = node.children
+  } else if (isTextBlock({schema: editor.schema}, node)) {
+    children = node.children
+  } else if (isObjectNode({schema: editor.schema}, node)) {
+    const scopedKey = containerScope
+      ? `${containerScope.name}.${node._type}`
+      : node._type
+
+    if (editor.editableTypes.has(scopedKey)) {
+      const arrayField = resolveChildArrayField(
+        {schema: editor.schema, scope: containerScope?.schemaScope},
+        node,
+      )
+
+      if (arrayField) {
+        const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+        if (Array.isArray(fieldValue)) {
+          children = fieldValue as Array<Node>
+          childFieldName = arrayField.name
+        }
+
+        childScope = {
+          name: scopedKey,
+          schemaScope: arrayField.of,
+        }
+      }
+    }
+  }
 
   const renderElementComponent = useCallback(
     (node: PortableTextTextBlock | PortableTextObject, i: number) => {
       const nodeDataPath =
         parentDataPath === ''
           ? `[_key=="${node._key}"]`
-          : `${parentDataPath}.children[_key=="${node._key}"]`
+          : `${parentDataPath}.${childFieldName}[_key=="${node._key}"]`
 
       return (
         <ElementContext.Provider key={`provider-${node._key}`} value={node}>
@@ -95,6 +131,7 @@ const useChildren = (props: {
       )
     },
     [
+      childFieldName,
       parentDataPath,
       decorationsByChild,
       parentIndexedPath,
@@ -144,7 +181,7 @@ const useChildren = (props: {
     const nodeDataPath =
       parentDataPath === ''
         ? `[_key=="${node._key}"]`
-        : `${parentDataPath}.children[_key=="${node._key}"]`
+        : `${parentDataPath}.${childFieldName}[_key=="${node._key}"]`
 
     return (
       <ObjectNodeComponent
@@ -159,7 +196,7 @@ const useChildren = (props: {
     )
   }
 
-  return children.map((n: Node, i: number) => {
+  const elements = children.map((n: Node, i: number) => {
     if (isTextBlock({schema: editor.schema}, n)) {
       return renderElementComponent(n, i)
     }
@@ -168,6 +205,9 @@ const useChildren = (props: {
       return null
     }
     if (isObjectNode({schema: editor.schema}, n)) {
+      if (editor.editableTypes.has(n._type)) {
+        return renderElementComponent(n, i)
+      }
       return renderObjectNodeComponent(n, i)
     }
     if (isSpan({schema: editor.schema}, n)) {
@@ -179,6 +219,16 @@ const useChildren = (props: {
     }
     throw new Error(`Unexpected node type`)
   })
+
+  if (childScope && childScope !== containerScope) {
+    return (
+      <ContainerScopeContext.Provider value={childScope}>
+        {elements}
+      </ContainerScopeContext.Provider>
+    )
+  }
+
+  return elements
 }
 
 const useDecorationsByChild = (

--- a/packages/editor/src/slate/utils/modify.ts
+++ b/packages/editor/src/slate/utils/modify.ts
@@ -250,7 +250,30 @@ export const modifyChildren = (
       return
     }
 
-    const childInfo = getNodeChildren(context, nodeEntry.node, undefined, '')
+    // Walk the path to build scope context for nested container types.
+    const keyedSegments = getKeyedSegments(nodeEntry.path)
+    let scope: Parameters<typeof getNodeChildren>[2]
+    let scopePath = ''
+    {
+      let currentNode: Node | {value: Array<Node>} = {value: typedRoot.children}
+      for (let i = 0; i < keyedSegments.length; i++) {
+        const result = getNodeChildren(context, currentNode, scope, scopePath)
+        if (!result) {
+          break
+        }
+        const child = result.children.find(
+          (c) => c._key === keyedSegments[i]!._key,
+        )
+        if (!child) {
+          break
+        }
+        scope = result.scope
+        scopePath = result.scopePath
+        currentNode = child
+      }
+    }
+
+    const childInfo = getNodeChildren(context, nodeEntry.node, scope, scopePath)
     const fieldName = childInfo?.fieldName ?? 'children'
 
     modifyDescendant(root, path, schema, (node) => {

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -1,0 +1,1519 @@
+import type {Patch} from '@portabletext/patches'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import type {InternalEditor} from '../src/editor/create-editor'
+import {PatchesPlugin} from '../src/plugins/plugin.patches'
+import {RendererPlugin} from '../src/plugins/plugin.renderer'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {name: 'row'},
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const tableRenderers = [
+  {
+    renderer: {
+      type: 'table' as const,
+      render: ({children}: {children: React.ReactNode}) => <>{children}</>,
+    },
+  },
+]
+
+const calloutRenderers = [
+  {
+    renderer: {
+      type: 'callout' as const,
+      render: ({children}: {children: React.ReactNode}) => <>{children}</>,
+    },
+  },
+]
+
+describe('container normalization', () => {
+  test('top-level void block is not confused with container child type', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const rowKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'row',
+          _key: rowKey,
+        },
+      ],
+      children: <RendererPlugin renderers={tableRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'row',
+          _key: rowKey,
+        },
+      ])
+    })
+  })
+
+  test('container block normalizes to cursor-ready structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+        },
+      ],
+      children: (
+        <>
+          <PatchesPlugin patches={patches} />
+          <RendererPlugin renderers={tableRenderers} />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k5',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k6',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k7',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'k8',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    // Normalization patches are deferred during setup. Trigger the dirty
+    // state so deferred patches get emitted.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: ' '})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {type: 'set', path: [{_key: tableKey}, 'rows'], value: []},
+        {type: 'setIfMissing', path: [{_key: tableKey}, 'rows'], value: []},
+        {
+          type: 'insert',
+          path: [{_key: tableKey}, 'rows', 0],
+          position: 'before',
+          items: [{_type: 'row', _key: 'k5'}],
+        },
+        {
+          type: 'set',
+          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
+          value: [],
+        },
+        {
+          type: 'setIfMissing',
+          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
+          value: [],
+        },
+        {
+          type: 'insert',
+          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells', 0],
+          position: 'before',
+          items: [{_type: 'cell', _key: 'k6'}],
+        },
+        {
+          type: 'set',
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: 'k5'},
+            'cells',
+            {_key: 'k6'},
+            'content',
+          ],
+          value: [],
+        },
+        {
+          type: 'setIfMissing',
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: 'k5'},
+            'cells',
+            {_key: 'k6'},
+            'content',
+          ],
+          value: [],
+        },
+        {
+          type: 'insert',
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: 'k5'},
+            'cells',
+            {_key: 'k6'},
+            'content',
+            0,
+          ],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k7',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+            },
+          ],
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: '@@ -1,5 +1,6 @@\n hello\n+ \n',
+        },
+      ])
+    })
+  })
+
+  test('callout container normalizes to cursor-ready structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ],
+      children: (
+        <>
+          <PatchesPlugin patches={patches} />
+          <RendererPlugin renderers={calloutRenderers} />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k6',
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: ' '})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {type: 'set', path: [{_key: calloutKey}, 'content'], value: []},
+        {
+          type: 'setIfMissing',
+          path: [{_key: calloutKey}, 'content'],
+          value: [],
+        },
+        {
+          type: 'insert',
+          path: [{_key: calloutKey}, 'content', 0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+            },
+          ],
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: '@@ -1,5 +1,6 @@\n hello\n+ \n',
+        },
+      ])
+    })
+  })
+
+  test('text block with missing children normalizes to have empty span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: 'k4',
+              text: '',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('incoming patch unsets container children restores structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+    const contentSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cellKey,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: contentBlockKey,
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: contentSpanKey,
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={tableRenderers} />,
+    })
+
+    // Verify initial value is correct
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cellKey,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: contentBlockKey,
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: contentSpanKey,
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    // Simulate a remote unset of the rows field
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          path: [{_key: tableKey}, 'rows'],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k9',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k10',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k11',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'k12',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('container with text block missing children normalizes the block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: contentBlockKey,
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <>
+          <PatchesPlugin patches={patches} />
+          <RendererPlugin renderers={calloutRenderers} />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: contentBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k6',
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 5,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: ' '})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: contentBlockKey},
+            'children',
+          ],
+          value: [],
+        },
+        {
+          type: 'setIfMissing',
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: contentBlockKey},
+            'children',
+          ],
+          value: [],
+        },
+        {
+          type: 'insert',
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: contentBlockKey},
+            'children',
+            0,
+          ],
+          position: 'before',
+          items: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: '@@ -1,5 +1,6 @@\n hello\n+ \n',
+        },
+      ])
+    })
+  })
+
+  test('duplicate keys in container children are fixed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [],
+            },
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [],
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={tableRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k10',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k11',
+                      children: [
+                        {_type: 'span', _key: 'k12', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'k6',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k7',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k8',
+                      children: [
+                        {_type: 'span', _key: 'k9', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('incoming patch unsets container field and normalization restores it', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+    const contentSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: contentBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: contentSpanKey,
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={calloutRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      const callout = value[1] as Record<string, unknown>
+      expect(Array.isArray(callout['content'])).toBe(true)
+    })
+
+    // Simulate a remote patch that removes the content field
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          path: [{_key: calloutKey}, 'content'],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('multiple containers in same document normalize independently', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ],
+      children: (
+        <RendererPlugin renderers={[...tableRenderers, ...calloutRenderers]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k6',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k7',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k8',
+                      children: [
+                        {_type: 'span', _key: 'k9', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k10',
+              children: [{_type: 'span', _key: 'k11', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('container inserted via incoming patch normalizes', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <RendererPlugin renderers={calloutRenderers} />,
+    })
+
+    // Insert a bare callout via incoming patch
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}],
+          position: 'after',
+          items: [
+            {
+              _type: 'callout',
+              _key: 'remote-callout',
+            },
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: 'remote-callout',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k4',
+              children: [{_type: 'span', _key: 'k5', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('void container with empty child array is not normalized', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [],
+        },
+      ],
+      // No RendererPlugin: table is treated as a void block object
+    })
+
+    // Give normalization time to run (it shouldn't touch the table)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [],
+        },
+      ])
+    })
+  })
+
+  test('deeply nested container block with missing children is normalized', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cellKey,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: contentBlockKey,
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={tableRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cellKey,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: contentBlockKey,
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'k8',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('remote value update with deeply nested childless block is normalized', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+    const contentSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cellKey,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: contentBlockKey,
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: contentSpanKey,
+                          text: 'world',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={tableRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toHaveLength(2)
+    })
+
+    // Simulate a remote value update that replaces the table's rows
+    // with a new row whose cell has a block missing children.
+    // This goes through sync machine -> applySetNode({rows: [...]})
+    // which triggers the set_node case in getDirtyPaths.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'new-row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'new-cell',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'new-block',
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'new-row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'new-cell',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'new-block',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'k9',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('removing last child from container triggers normalization', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const contentBlockKey = keyGenerator()
+    const contentSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: contentBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: contentSpanKey,
+                  text: 'inside',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <RendererPlugin renderers={calloutRenderers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toHaveLength(2)
+    })
+
+    // Remove the content block via incoming patch, leaving content: []
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          path: [{_key: calloutKey}, 'content', {_key: contentBlockKey}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('late renderer registration normalizes existing void container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ],
+      // No RendererPlugin initially: callout is void
+    })
+
+    // Verify the callout stays as-is (void, no normalization)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ])
+    })
+
+    // Late-register a renderer for callout
+    ;(editor as unknown as InternalEditor)._internal.editorActor.send({
+      type: 'register renderer',
+      rendererConfig: {
+        renderer: {
+          type: 'callout',
+          render: ({children}: {children: React.ReactNode}) => <>{children}</>,
+        },
+      },
+    })
+
+    // Normalization should now kick in and populate the callout
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Editable containers need the same structural guarantees as text blocks: their child array field must exist and must not be empty. Without this, a cursor can never be placed inside a container, because there's no leaf node to anchor to.

The normalization is schema-driven and scope-aware. Container types use scoped dot-separated names in `editableTypes` (e.g., `table`, `table.row`, `table.row.cell`), but nodes in the tree only carry bare type names (`row`, `cell`). Every function that needs to identify a container type must reconstruct the scoped name by walking ancestor nodes. This applies to `normalize-node.ts`, `modify.ts`, and `get-dirty-paths.ts`.

`getDirtyPaths` is the critical piece. When an operation inserts or replaces nodes, their descendants need to be dirtied so the normalizer visits them. `collectDescendantPaths` threads a `scopePrefix` through recursion, building the scoped name at each level. For `set_node` (where the sync machine replaces a container's child array atomically), `buildScopeContext` walks the tree to the target node to recover the scope. Numeric indices are used throughout instead of keyed lookups, because pre-normalization nodes can have duplicate keys.

The normalization is gated by `editableTypes`, which is only populated when a renderer is registered. This PR includes the internal rendering pipeline so the normalization can be tested. The pipeline has no public API surface. Tests configure it by sending `register renderer` events directly to the editor actor.

When a renderer is registered after the editor is already loaded (late registration), `syncEditableTypes` calls `normalize(force: true)` to visit existing container nodes, then `editor.onChange()` to flow the changes back to the machine context.

15 browser tests cover: table and callout normalization cascades, text blocks with missing children inside containers, duplicate keys, void containers left untouched, incoming patches that unset container fields, remote value updates with deeply nested childless blocks, removing the last child from a container, and late renderer registration.