### PR TITLE
fix: centralize inverse computation in apply layer

### DIFF
--- a/.changeset/centralize-inverse.md
+++ b/.changeset/centralize-inverse.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: centralize inverse computation in apply layer
+
+Inverse data for `set` and `unset` operations is now computed in the apply layer right before tree mutation, instead of at each call site. Callers no longer need to read the current node state to build inverse objects.

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -1,6 +1,6 @@
 import type {Operation} from '../slate/interfaces/operation'
 import {pathEquals} from '../slate/path/path-equals'
-import type {PortableTextSlateEditor} from '../types/slate-editor'
+import type {EditorSelection} from '../types/editor'
 
 type UndoStep = {
   operations: Array<Operation>
@@ -10,30 +10,34 @@ type UndoStep = {
 export function createUndoSteps({
   steps,
   op,
-  editor,
   currentUndoStepId,
   previousUndoStepId,
+  selectionBeforeApply,
+  operationsInProgress,
+  isNormalizingNode,
 }: {
   steps: Array<UndoStep>
   op: Operation
-  editor: PortableTextSlateEditor
   currentUndoStepId: string | undefined
   previousUndoStepId: string | undefined
+  selectionBeforeApply: EditorSelection
+  operationsInProgress: boolean
+  isNormalizingNode: boolean
 }): Array<UndoStep> {
   const lastStep = steps.at(-1)
 
   if (!lastStep) {
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
-  if (editor.operations.length > 0) {
+  if (operationsInProgress) {
     // The editor has operations in progress
 
-    if (currentUndoStepId === previousUndoStepId || editor.isNormalizingNode) {
+    if (currentUndoStepId === previousUndoStepId || isNormalizingNode) {
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
   if (
@@ -84,7 +88,7 @@ export function createUndoSteps({
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
   // Handle case when both IDs are defined but different (e.g., consecutive
@@ -118,22 +122,22 @@ export function createUndoSteps({
     }
   }
 
-  return createNewStep(steps, op, editor)
+  return createNewStep(steps, op, selectionBeforeApply)
 }
 
 function createNewStep(
   steps: Array<UndoStep>,
   op: Operation,
-  editor: PortableTextSlateEditor,
+  selection: EditorSelection,
 ): Array<UndoStep> {
   const operations =
-    editor.selection === null
+    selection === null
       ? [op]
       : [
           {
             type: 'set_selection' as const,
-            properties: {...editor.selection},
-            newProperties: {...editor.selection},
+            properties: {...selection},
+            newProperties: {...selection},
           },
           op,
         ]

--- a/packages/editor/src/internal-utils/set-node-properties.ts
+++ b/packages/editor/src/internal-utils/set-node-properties.ts
@@ -41,14 +41,10 @@ export function setNodeProperties(
   for (const key of keys) {
     if (propsRecord[key] !== nodeRecord[key]) {
       if (propsRecord[key] != null) {
-        const hadProperty = nodeRecord.hasOwnProperty(key)
         editor.apply({
           type: 'set',
           path: [...currentPath, key],
           value: propsRecord[key],
-          inverse: hadProperty
-            ? {type: 'set', path: [...currentPath, key], value: nodeRecord[key]}
-            : {type: 'unset', path: [...currentPath, key]},
         })
         // After _key changes, update the path for subsequent operations
         if (key === '_key' && typeof propsRecord[key] === 'string') {
@@ -65,11 +61,6 @@ export function setNodeProperties(
         editor.apply({
           type: 'unset',
           path: [...currentPath, key],
-          inverse: {
-            type: 'set',
-            path: [...currentPath, key],
-            value: nodeRecord[key],
-          },
         })
       }
     }

--- a/packages/editor/src/slate-plugins/slate-plugin.history.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.history.ts
@@ -105,12 +105,22 @@ export function createHistoryPlugin({
         }
       }
 
+      const selectionBeforeApply = editor.selection
+        ? {...editor.selection}
+        : null
+      const operationsInProgress = editor.operations.length > 0
+      const isNormalizingNode = editor.isNormalizingNode
+
+      apply(op)
+
       editor.history.undos = createUndoSteps({
         steps: editor.history.undos,
         op,
-        editor,
         currentUndoStepId,
         previousUndoStepId,
+        selectionBeforeApply,
+        operationsInProgress,
+        isNormalizingNode,
       })
 
       // Make sure we don't exceed the maximum number of undo steps we want
@@ -120,8 +130,6 @@ export function createHistoryPlugin({
       }
 
       previousUndoStepId = currentUndoStepId
-
-      apply(op)
     }
 
     return editor

--- a/packages/editor/src/slate/core/apply-operation.ts
+++ b/packages/editor/src/slate/core/apply-operation.ts
@@ -8,6 +8,7 @@ import {isSpan} from '@portabletext/schema'
 import {safeStringify} from '../../internal-utils/safe-json'
 import {getNode} from '../../node-traversal/get-node'
 import {getNodes} from '../../node-traversal/get-nodes'
+import {getValue} from '../../node-traversal/get-value'
 import type {EditorSelection} from '../../types/editor'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import type {Editor} from '../interfaces/editor'
@@ -256,6 +257,9 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
       // Root-level value replacement: set editor.children directly
       if (path.length === 0) {
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          op.inverse = {type: 'set', path, value: editor.children}
+        }
         if (Array.isArray(value)) {
           ;(editor as {children: Node[]}).children = value as Node[]
           // Rebuild blockIndexMap
@@ -280,8 +284,21 @@ export function applyOperation(editor: Editor, op: Operation): void {
         break
       }
 
+      const context = {
+        schema: editor.schema,
+        editableTypes: editor.editableTypes,
+        value: editor.children,
+        blockIndexMap: editor.blockIndexMap,
+      }
+
+      // Resolve node once for all sub-branches
+      const setNodeEntry = getNode(context, setNodePath)
+
       if (setPropertyPath.length === 0) {
         // Full node replacement: replace the node at setNodePath with value
+        if (!op.inverse && !editor.isProcessingRemoteChanges && setNodeEntry) {
+          op.inverse = {type: 'set', path, value: setNodeEntry.node}
+        }
         if (
           value !== null &&
           typeof value === 'object' &&
@@ -295,21 +312,21 @@ export function applyOperation(editor: Editor, op: Operation): void {
         break
       }
 
-      // Check if the node path resolves to a known node
-      const setNodeEntry = getNode(
-        {
-          schema: editor.schema,
-          editableTypes: editor.editableTypes,
-          value: editor.children,
-          blockIndexMap: editor.blockIndexMap,
-        },
-        setNodePath,
-      )
-
       if (setNodeEntry) {
         // Node found: use modifyDescendant
         if (setPropertyPath.length === 1) {
           const propertyName = setPropertyPath[0]!
+
+          // Compute inverse from data already in hand
+          if (!op.inverse && !editor.isProcessingRemoteChanges) {
+            const nodeRecord = setNodeEntry.node as Record<string, unknown>
+            if (propertyName in nodeRecord) {
+              op.inverse = {type: 'set', path, value: nodeRecord[propertyName]}
+            } else {
+              op.inverse = {type: 'unset', path}
+            }
+          }
+
           modifyDescendant(editor, setNodePath, (node) => {
             return {...node, [propertyName]: value} as typeof node
           })
@@ -340,6 +357,18 @@ export function applyOperation(editor: Editor, op: Operation): void {
           }
         } else {
           // Multiple property segments: deep set on the resolved node
+          if (!op.inverse && !editor.isProcessingRemoteChanges) {
+            const currentValue = getPropertyValue(
+              setNodeEntry.node as Record<string, unknown>,
+              setPropertyPath,
+            )
+            if (currentValue !== undefined) {
+              op.inverse = {type: 'set', path, value: currentValue}
+            } else {
+              op.inverse = {type: 'unset', path}
+            }
+          }
+
           modifyDescendant(editor, setNodePath, (node) => {
             return deepSet(node, setPropertyPath, value)
           })
@@ -361,6 +390,16 @@ export function applyOperation(editor: Editor, op: Operation): void {
           break
         }
 
+        // Compute inverse using getValue for keyed segment resolution
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          const currentValue = getValue(editor.children, path)
+          if (currentValue !== undefined) {
+            op.inverse = {type: 'set', path, value: currentValue}
+          } else {
+            op.inverse = {type: 'unset', path}
+          }
+        }
+
         const updatedBlock = applyAll(block, [
           setPatchHelper(value, path.slice(1)),
         ])
@@ -379,6 +418,9 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
       // Root-level unset: remove all children
       if (path.length === 0) {
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          op.inverse = {type: 'set', path, value: editor.children}
+        }
         ;(editor as {children: Node[]}).children = []
         editor.blockIndexMap.clear()
         transformSelection = true
@@ -408,6 +450,15 @@ export function applyOperation(editor: Editor, op: Operation): void {
         // Node found: use modifyDescendant
         if (unsetPropertyPath.length === 1) {
           const propertyName = unsetPropertyPath[0]!
+
+          // Compute inverse from data already in hand
+          if (!op.inverse && !editor.isProcessingRemoteChanges) {
+            const nodeRecord = unsetNodeEntry.node as Record<string, unknown>
+            if (propertyName in nodeRecord) {
+              op.inverse = {type: 'set', path, value: nodeRecord[propertyName]}
+            }
+          }
+
           modifyDescendant(editor, unsetNodePath, (node) => {
             const newNode = {...node}
             delete (newNode as Record<string, unknown>)[propertyName]
@@ -415,6 +466,16 @@ export function applyOperation(editor: Editor, op: Operation): void {
           })
         } else {
           // Multiple property segments: deep unset on the resolved node
+          if (!op.inverse && !editor.isProcessingRemoteChanges) {
+            const currentValue = getPropertyValue(
+              unsetNodeEntry.node as Record<string, unknown>,
+              unsetPropertyPath,
+            )
+            if (currentValue !== undefined) {
+              op.inverse = {type: 'set', path, value: currentValue}
+            }
+          }
+
           modifyDescendant(editor, unsetNodePath, (node) => {
             return deepUnset(node, unsetPropertyPath)
           })
@@ -434,6 +495,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
         const block = editor.children[blockIndex]
         if (!block) {
           break
+        }
+
+        // Compute inverse using getValue for keyed segment resolution
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          const currentValue = getValue(editor.children, path)
+          if (currentValue !== undefined) {
+            op.inverse = {type: 'set', path, value: currentValue}
+          }
         }
 
         const updatedBlock = applyAll(block, [unsetPatchHelper(path.slice(1))])
@@ -703,4 +772,26 @@ function deepUnsetObject(
     ...object,
     [head!]: deepUnsetObject(currentValue as Record<string, unknown>, tail),
   }
+}
+
+/**
+ * Walk string property segments on a plain object.
+ * No keyed segment resolution or tree traversal.
+ */
+function getPropertyValue(
+  node: Record<string, unknown>,
+  propertyPath: Array<string>,
+): unknown {
+  let current: unknown = node
+  for (const segment of propertyPath) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== 'object'
+    ) {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
 }


### PR DESCRIPTION
Inverse data for `set` and `unset` operations was previously computed at each call site (primarily in `setNodeProperties`). Every caller had to read the current node, check whether the property existed, and build the appropriate inverse object before calling `editor.apply()`.

This moves inverse computation into `apply-operation.ts`, right before tree mutation. At each branch point, the current value is read from data already resolved during path traversal:

- **Single property** (hot path): reads `nodeRecord[propertyName]` from the already-resolved node entry. Zero extra cost.
- **Root-level**: reads `editor.children` directly.
- **Full node replacement**: reads `setNodeEntry.node` from the shared `getNode` call.
- **Deep property**: walks string segments via `getPropertyValue` helper on the resolved node.
- **applyAll fallback** (markDefs): uses `getValue` for keyed segment resolution.

Inverse computation is skipped when `editor.isProcessingRemoteChanges` (remote patches bypass history) and when `op.inverse` is already present.

The history plugin now records undo steps after `apply(op)` so the operation arrives with inverse data already attached. Pre-apply editor state (selection, operation count, normalization flag) is captured before the call and passed explicitly to `createUndoSteps`, making it a pure function of its inputs.