### PR TITLE
fix: make `diffMatchPatch` container-aware

### DIFF
--- a/.changeset/container-aware-diffmatchpatch.md
+++ b/.changeset/container-aware-diffmatchpatch.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: make `diffMatchPatch` container-aware
+
+Incoming `diffMatchPatch` patches now resolve the target span at any depth using the full path, instead of assuming a root-level block with a `children` field at depth 2.

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -6,7 +6,7 @@ import type {
   SetPatch,
   UnsetPatch,
 } from '@portabletext/patches'
-import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
+import {isSpan, type PortableTextBlock} from '@portabletext/schema'
 import {
   cleanupEfficiency,
   DIFF_DELETE,
@@ -16,13 +16,11 @@ import {
   makeDiff,
   parsePatch,
 } from '@sanity/diff-match-patch'
-import type {EditorSchema} from '../editor/editor-schema'
 import type {EditorContext} from '../editor/editor-snapshot'
+import {getNode} from '../node-traversal/get-node'
 import {getValue} from '../node-traversal/get-value'
 import type {Node} from '../slate/interfaces/node'
-import type {Path} from '../types/paths'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {applyDeselect} from './apply-selection'
 import {isEqualToEmptyEditor} from './values'
 
@@ -66,48 +64,41 @@ export function createApplyPatch(
 function diffMatchPatch(
   editor: Pick<
     PortableTextSlateEditor,
-    'children' | 'apply' | 'selection' | 'onChange' | 'schema'
+    'children' | 'apply' | 'selection' | 'onChange' | 'schema' | 'editableTypes'
   >,
   patch: DiffMatchPatch,
 ): boolean {
-  const block = findBlock(editor.children, patch.path)
-
-  if (!block) {
+  const lastSegment = patch.path.at(-1)
+  if (lastSegment !== 'text') {
     return false
   }
 
-  const child = findBlockChild(block, patch.path, editor.schema)
+  const spanPath = patch.path.slice(0, -1)
+  const spanEntry = getNode(
+    {
+      schema: editor.schema,
+      editableTypes: editor.editableTypes,
+      value: editor.children,
+    },
+    spanPath,
+  )
 
-  if (!child) {
-    return false
-  }
-
-  const isSpanTextDiffMatchPatch =
-    block &&
-    isTextBlock({schema: editor.schema}, block.node) &&
-    patch.path.length === 4 &&
-    patch.path[1] === 'children' &&
-    patch.path[3] === 'text'
-
-  if (
-    !isSpanTextDiffMatchPatch ||
-    !isSpan({schema: editor.schema}, child.node)
-  ) {
+  if (!spanEntry || !isSpan({schema: editor.schema}, spanEntry.node)) {
     return false
   }
 
   const patches = parsePatch(patch.value)
-  const [newValue] = diffMatchPatchApplyPatches(patches, child.node.text, {
+  const [newValue] = diffMatchPatchApplyPatches(patches, spanEntry.node.text, {
     allowExceedingIndices: true,
   })
-  const diff = cleanupEfficiency(makeDiff(child.node.text, newValue), 5)
+  const diff = cleanupEfficiency(makeDiff(spanEntry.node.text, newValue), 5)
 
   let offset = 0
   for (const [op, text] of diff) {
     if (op === DIFF_INSERT) {
       editor.apply({
         type: 'insert_text',
-        path: [{_key: block.node._key}, 'children', {_key: child.node._key}],
+        path: spanEntry.path,
         offset,
         text,
       })
@@ -115,7 +106,7 @@ function diffMatchPatch(
     } else if (op === DIFF_DELETE) {
       editor.apply({
         type: 'remove_text',
-        path: [{_key: block.node._key}, 'children', {_key: child.node._key}],
+        path: spanEntry.path,
         offset,
         text,
       })
@@ -225,64 +216,4 @@ function unsetPatch(editor: PortableTextSlateEditor, patch: UnsetPatch) {
   editor.apply({type: 'unset', path: patch.path})
 
   return true
-}
-
-function findBlock(
-  children: Node[],
-  path: Path,
-): {node: Node; index: number} | undefined {
-  let blockIndex = -1
-
-  const block = children.find((node: Node, index: number) => {
-    const isMatch = isKeyedSegment(path[0])
-      ? node._key === path[0]._key
-      : index === path[0]
-
-    if (isMatch) {
-      blockIndex = index
-    }
-
-    return isMatch
-  })
-
-  if (!block) {
-    return undefined
-  }
-
-  return {node: block, index: blockIndex}
-}
-
-function findBlockChild(
-  block: {node: Node; index: number},
-  path: Path,
-  schema: EditorSchema,
-): {node: Node; index: number} | undefined {
-  const blockNode = block.node
-
-  if (!isTextBlock({schema}, blockNode) || path[1] !== 'children') {
-    return undefined
-  }
-
-  let childIndex = -1
-
-  const child = blockNode.children.find((node: Node, index: number) => {
-    const isMatch = isKeyedSegment(path[2])
-      ? node._key === path[2]._key
-      : index === path[2]
-
-    if (isMatch) {
-      childIndex = index
-    }
-
-    return isMatch
-  })
-
-  if (!child) {
-    return undefined
-  }
-
-  return {
-    node: child,
-    index: childIndex,
-  }
 }

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -2447,6 +2447,112 @@ describe('event.patches', () => {
         ])
       })
     })
+
+    test('Scenario: diffMatchPatch inside callout', async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const calloutKey = keyGenerator()
+      const blockKey = keyGenerator()
+      const spanKey = keyGenerator()
+
+      const editorText = 'Hello'
+      const incomingText = 'Hello there'
+
+      const {editor} = await createTestEditor({
+        keyGenerator,
+        schemaDefinition: defineSchema({
+          blockObjects: [
+            {
+              name: 'callout',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        }),
+        initialValue: [
+          {
+            _type: 'callout',
+            _key: calloutKey,
+            content: [
+              {
+                _type: 'block',
+                _key: blockKey,
+                children: [
+                  {_type: 'span', _key: spanKey, text: editorText, marks: []},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        children: (
+          <RendererPlugin
+            renderers={[
+              {
+                renderer: {
+                  type: 'callout' as const,
+                  render: ({children}: {children: React.ReactNode}) => (
+                    <>{children}</>
+                  ),
+                },
+              },
+            ]}
+          />
+        ),
+      })
+
+      editor.send({
+        type: 'patches',
+        patches: [
+          {
+            type: 'diffMatchPatch',
+            origin: 'remote',
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: blockKey},
+              'children',
+              {_key: spanKey},
+              'text',
+            ],
+            value: stringifyPatches(
+              makePatches(makeDiff(editorText, incomingText)),
+            ),
+          },
+        ],
+        snapshot: undefined,
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          {
+            _type: 'callout',
+            _key: calloutKey,
+            content: [
+              {
+                _type: 'block',
+                _key: blockKey,
+                children: [
+                  {
+                    _type: 'span',
+                    _key: spanKey,
+                    text: incomingText,
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ])
+      })
+    })
   })
 
   test('Scenario: `set` block with new markDef', async () => {


### PR DESCRIPTION
Incoming `diffMatchPatch` patches assume the target span lives at depth 2: root block → `children` → span → `text`. This breaks for containers where the span can be at any depth.

The fix replaces the manual `findBlock` + `findBlockChild` lookup with `getNode(editor, spanPath)` which resolves the span at any depth using the schema-aware node traversal. The path from the patch is used directly for `insert_text`/`remove_text` operations instead of being reconstructed from block and child keys.

`findBlock` and `findBlockChild` were only used by `diffMatchPatch` and are now deleted.