### PR TITLE
feat: expose `defineContainer` and `registerContainer` for declaring content depth

### DIFF
--- a/.changeset/expose-container-api.md
+++ b/.changeset/expose-container-api.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: expose `defineContainer` and `registerContainer` for declaring content depth

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -6,6 +6,7 @@ import type {EditorDom} from './editor/editor-dom'
 import type {ExternalEditorEvent} from './editor/editor-machine'
 import type {EditorSnapshot} from './editor/editor-snapshot'
 import type {EditorEmittedEvent} from './editor/relay-machine'
+import type {Container} from './renderers/renderer.types'
 
 /**
  * @public
@@ -41,6 +42,10 @@ export type Editor = {
    * @beta
    */
   registerBehavior: (config: {behavior: Behavior}) => () => void
+  /**
+   * @beta
+   */
+  registerContainer: (config: {container: Container}) => () => void
   send: (event: EditorEvent) => void
   on: ActorRef<Snapshot<unknown>, EventObject, EditorEmittedEvent>['on']
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -6,6 +6,8 @@ export type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
+export type {Container} from './renderers/renderer.types'
+export {defineContainer} from './renderers/define-container'
 export type {Editor, EditorConfig, EditorEvent} from './editor'
 export {PortableTextEditable} from './editor/Editable'
 export type {PortableTextEditableProps} from './editor/Editable'

--- a/packages/editor/src/renderers/define-container.ts
+++ b/packages/editor/src/renderers/define-container.ts
@@ -1,8 +1,9 @@
 import type {PortableTextBlock, SchemaDefinition} from '@portabletext/schema'
 import type {ReactElement} from 'react'
+import type {Container} from './renderer.types'
 
-/** @internal */
-type ExtractArrayFields<TFields> = TFields extends readonly [
+/** @beta */
+export type ExtractArrayFields<TFields> = TFields extends readonly [
   infer TField,
   ...infer TRest,
 ]
@@ -11,8 +12,8 @@ type ExtractArrayFields<TFields> = TFields extends readonly [
     : ExtractArrayFields<TRest>
   : never
 
-/** @internal */
-type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
+/** @beta */
+export type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
   infer TMember,
   ...infer TRest,
 ]
@@ -24,8 +25,8 @@ type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
     : ExtractOfMembers<TRest>
   : never
 
-/** @internal */
-type WalkFields<TFields> = TFields extends readonly [
+/** @beta */
+export type WalkFields<TFields> = TFields extends readonly [
   infer TField,
   ...infer TRest,
 ]
@@ -34,8 +35,8 @@ type WalkFields<TFields> = TFields extends readonly [
     : WalkFields<TRest>
   : never
 
-/** @internal */
-type CollectScopedTypes<TFields, TScope extends string> =
+/** @beta */
+export type CollectScopedTypes<TFields, TScope extends string> =
   WalkFields<TFields> extends infer TMembers
     ? TMembers extends {
         type: infer TTypeName extends string
@@ -52,11 +53,8 @@ type CollectScopedTypes<TFields, TScope extends string> =
       : never
     : never
 
-/**
- * Collect all renderer-eligible types from a schema definition.
- * Includes top-level block objects and all nested container types
-/** @internal */
-type CollectAllTypes<TSchema extends SchemaDefinition> =
+/** @beta */
+export type CollectAllTypes<TSchema extends SchemaDefinition> =
   | {scopedName: 'block'; arrayFields: 'children'}
   | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
       ? TBlockObject extends {
@@ -69,22 +67,23 @@ type CollectAllTypes<TSchema extends SchemaDefinition> =
         : never
       : never)
 
-/** @internal */
-type AllScopedNames<TSchema extends SchemaDefinition> =
+/** @beta */
+export type AllScopedNames<TSchema extends SchemaDefinition> =
   CollectAllTypes<TSchema> extends {scopedName: infer TName} ? TName : never
 
-/** @internal */
-type ScopedArrayFields<TSchema extends SchemaDefinition, TName extends string> =
+/** @beta */
+export type ScopedArrayFields<
+  TSchema extends SchemaDefinition,
+  TName extends string,
+> =
   CollectAllTypes<TSchema> extends infer TEntry
     ? TEntry extends {scopedName: TName; arrayFields: infer TFieldName}
       ? TFieldName
       : never
     : never
 
-// === Container ===
-
-/** @internal */
-type SchemaContainerConfig<TSchema extends SchemaDefinition> =
+/** @beta */
+export type SchemaContainerConfig<TSchema extends SchemaDefinition> =
   AllScopedNames<TSchema> extends infer TType extends string
     ? TType extends TType
       ? {
@@ -101,55 +100,24 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
 
 /**
  * @beta
- */
-export type Container = {
-  scope: string
-  field: string
-  render?: (props: {
-    attributes: Record<string, unknown>
-    children: ReactElement
-    node: PortableTextBlock
-  }) => ReactElement | null
-}
-
-/**
- * @beta
  *
  * Define a container for a block object type.
  *
+ * A container is a block object with an array field that holds children.
+ * Each container declares its `scope` (where it lives in the schema tree),
+ * `field` (which array field holds children), and optionally a `render`
+ * function.
+ *
  * When called with a schema type parameter, constrains `scope` to valid
- * scoped type names, `field` to array field names on that type, and
- * provides the `render` function signature:
- *
- * ```ts
- * defineContainer<typeof schema>({
- *   scope: 'table.row.cell',
- *   field: 'content',
- *   render: ({children}) => <td>{children}</td>,
- * })
- * ```
- *
- * Without a schema type parameter, accepts any string:
- *
- * ```ts
- * defineContainer({
- *   scope: 'callout',
- *   field: 'content',
- *   render: ({children}) => <div>{children}</div>,
- * })
- * ```
+ * scoped type names and `field` to array field names on that type.
  */
 export function defineContainer<TSchema extends SchemaDefinition>(
   config: SchemaContainerConfig<TSchema>,
 ): Container
+/**
+ * @beta
+ */
 export function defineContainer(config: Container): Container
 export function defineContainer(config: Container): Container {
   return config
-}
-
-/**
- * @internal
- */
-export type ContainerConfig = {
-  container: Container
 }

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -1,6 +1,7 @@
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
@@ -954,6 +955,97 @@ describe('container and renderer independence', () => {
       expect(
         blockObject!.querySelector('[contenteditable="false"]'),
       ).not.toEqual(null)
+    })
+  })
+})
+
+describe('code block container via public API', () => {
+  const codeBlockSchemaDefinition = defineSchema({
+    blockObjects: [
+      {
+        name: 'code',
+        fields: [
+          {
+            name: 'lines',
+            type: 'array',
+            of: [{type: 'block'}],
+          },
+        ],
+      },
+    ],
+  })
+
+  const codeBlockContainer = defineContainer({
+    scope: 'code',
+    field: 'lines',
+    render: ({attributes, children}) => (
+      <pre {...attributes}>
+        <code>{children}</code>
+      </pre>
+    ),
+  })
+
+  test('typing inside a code block registered via registerContainer', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineBlockKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: codeBlockSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'code',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: lineSpanKey,
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+    })
+
+    editor.registerContainer({container: codeBlockContainer})
+
+    await userEvent.click(locator)
+    editor.send({type: 'insert.text', text: 'hello world'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'code',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: lineSpanKey,
+                  text: 'hello world',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
     })
   })
 })


### PR DESCRIPTION
## Background and first-class nesting

Portable Text has always supported nested structures, but the editor treated them as opaque void blocks. You could define a table type, but the editor couldn't render or edit its contents. Users had to open a separate modal to edit nested content.

First-class nesting means the editor understands and can edit content at any depth. A table cell contains text blocks that behave like any other text block: you can type, format, split, merge, and collaborate inside them. The editor's engine, rendering pipeline, and behavior system all work at arbitrary nesting depth, driven by the schema rather than hardcoded assumptions.

In order for this to work, the engine had to be rewritten:

1. **Vendored Slate.** The editor engine is fully owned code, not a third-party dependency.
2. **Untangled Slate abstractions.** Removed layers of indirection, dead code, and over-exports.
3. **PT-native internal tree.** Tore down the translation layer between Slate's data model and Portable Text. The in-memory tree is now Portable Text directly.
4. **Patch-compliant operations.** Internal operations align with the Sanity mutation protocol, making container collaboration straightforward to support.
5. **Simplified DOM mapping.** Cleaner bridge between the PT tree and the browser DOM.
6. **Depth-agnostic traversal.** Replaced Slate's original traversal utilities with PT-native, schema-driven ones that work at any nesting depth.
7. **Container-aware normalization.** The editor self-heals container structures using the schema. Existing text block normalizations also work at any depth.
8. **Keyed paths.** Replaced indexed paths with keyed paths internally, removing another translation layer to the Sanity patch protocol.
9. **Container-ready patch layer.** Outgoing and incoming patches work at any depth. Collab just works.

This PR exposes **the Container API** that lets consumers declare content depth. There are still rough edges and text editing behaviors that don't quite work yet, but it's getting to the point where we can start trying things out in more real-world scenarios. And in order to do that, we need the public API that **unlocks first-class nesting**.

## End-to-end example: a code block plugin

A code block has a `lines` field containing text blocks, one per line:

````tsx
import {defineSchema} from '@portabletext/schema'

const schema = defineSchema({
  blockObjects: [
    {
      name: 'code',
      fields: [
        {
          name: 'lines',
          type: 'array',
          of: [{type: 'block'}],
        },
      ],
    },
  ],
})
````

To make the code block editable, define a container and register it:

````tsx
import {useEffect} from 'react'
import {defineContainer, useEditor} from '@portabletext/editor'

const codeBlockContainer = defineContainer({
  scope: 'code',
  field: 'lines',
  render: ({attributes, children}) => (
    <pre>
      <code>{children}</code>
    </pre>
  ),
})

function CodeBlockPlugin() {
  const editor = useEditor()

  useEffect(() => {
    return editor.registerContainer({container: codeBlockContainer})
  }, [editor])

  return null
}
````

Once registered, the editor traverses into the code block's `lines` field, normalizes its children (ensuring `_key` and `_type`), and renders them using the provided `render` function.

> [!NOTE]
> This API is `@beta` and not settled. Feedback on the shape, naming, and ergonomics is welcome before this merges.

## The API

A container is defined with where it lives in the schema tree (`scope`), which field holds its children (`field`), and optionally how to render it (`render`):

````tsx
import {defineContainer} from '@portabletext/editor'

const callout = defineContainer({
  scope: 'callout',
  field: 'content',
  render: ({attributes, children, node}) => (
    <div {...attributes} className="callout">
      <span className="callout-icon">💡</span>
      {children}
    </div>
  ),
})
````

Without a `render` function, the container falls back to a plain `<div>`:

````tsx
const callout = defineContainer({
  scope: 'callout',
  field: 'content',
})
````

Registration follows the same pattern as `defineBehavior`/`registerBehavior`:

````tsx
const unregister = editor.registerContainer({container: callout})
````

The config object `{container: ...}` keeps the door open for adding a `priority` field later, same as `registerBehavior` does with `{behavior: ...}`.

## Scope

The `scope` is a dot-separated path through the schema tree. It encodes where a type lives in the nesting hierarchy:

````tsx
defineContainer({scope: 'table', field: 'rows', render: ...})
defineContainer({scope: 'table.row', field: 'cells', render: ...})
defineContainer({scope: 'table.row.cell', field: 'content', render: ...})
````

`'table.row'` means "a `row` specifically inside a `table`." If the same type name appeared in multiple containers, the scoped name disambiguates.

Every level in a nested container hierarchy needs its own `defineContainer` call. Without one, the editor doesn't know which field holds children for that level. If you register `table` and `table.row.cell` but skip `table.row`, the editor has no way to find the `cells` field on row nodes, so the row level stays opaque.

### Scope specificity

Longer scopes are more specific and take priority. When the editor looks up a container config for a node, it tries the full scoped name first, then falls back to the bare type name:

````tsx
// Universal: applies to ALL text blocks everywhere
defineContainer({scope: 'block', field: 'children', render: ...})

// Specific: applies only to text blocks inside callouts
defineContainer({scope: 'callout.block', field: 'children', render: ...})
````

A text block inside a callout matches `'callout.block'` first. A text block at the root (or inside any container without a specific override) falls back to `'block'`.

This means `scope: 'block'` acts as a universal override for text block rendering across the entire editor. It replaces the default `renderBlock`/`renderStyle`/`renderListItem` pipeline, giving full control over how text blocks look.

### 💡 Scoped behaviors

An idea for the future: the scope system could extend to `defineBehavior`. Today, behaviors apply globally. With a `scope` parameter, a behavior could be restricted to a specific container context:

````tsx
// Only fires when the cursor is inside a code block
defineBehavior({
  scope: 'code',
  on: 'insert.break',
  guard: ({context}) => ...,
  actions: [() => ...],
})

// Only fires inside table cells
defineBehavior({
  scope: 'table.row.cell',
  on: 'delete.backward',
  guard: ({context}) => ...,
  actions: [() => ...],
})
````

This would let plugins define container-specific editing rules without manually checking the cursor position in every guard. A code block plugin could override Enter to insert a newline instead of splitting, and that behavior would automatically only apply when the cursor is inside a code block.

## `field`

The `field` is the field on the block object that holds the children array. For a callout it might be `'content'`, for a table it's `'rows'`. For text blocks, it's `'children'`. This is how the editor knows where to find children when traversing and rendering.

The named field doesn't have to contain text blocks. A gallery container might hold only void objects like images:

````tsx
defineContainer({
  scope: 'gallery',
  field: 'items',
  render: ({attributes, children}) => (
    <div {...attributes} className="gallery-grid">
      {children}
    </div>
  ),
})
````

The images render as non-editable block objects inside the gallery. The editor handles traversal, selection, and reordering. The container just needs to know which field holds the children.

## `render`

The render function is optional. When provided, it receives:

- `attributes`: data attributes the editor needs on the outermost element
- `children`: a single `ReactElement` containing the pre-rendered content of the named field
- `node`: the raw Portable Text block data

When omitted, the container renders in a plain `<div>` with the required attributes. When provided, returning `null` also falls back to the default `<div>`, which is useful for conditional rendering:

````tsx
defineContainer({
  scope: 'callout',
  field: 'content',
  render: ({attributes, children, node}) => {
    if (node.variant === 'warning') {
      return <div {...attributes} className="warning">{children}</div>
    }
    return null // fall back to default <div>
  },
})
````

Every container level needs a wrapper element with the `attributes` because they contain data attributes the editor uses for DOM-to-model resolution. To make a level visually invisible while keeping it functional, use `display: contents`:

````tsx
defineContainer({
  scope: 'table.row',
  field: 'cells',
  render: ({attributes, children}) => (
    <div {...attributes} style={{display: 'contents'}}>{children}</div>
  ),
})
````

The consumer controls the outermost element. This is different from `renderBlock`, where the consumer's output is wrapped in a `div.pt-block.pt-object-block` with a nested `div[contentEditable=false]`. Containers need semantic HTML (a table needs a real `<table>` element, not nested `div`s), so the render function gives full control.

## Structural integrity

The editor automatically maintains valid structure and this needs to work inside containers as well.

**All containers** get baseline enforcement:

- **`_key`**: every child node gets a unique key. If a child arrives without a `_key`, the editor generates one. If two siblings share the same key, the duplicate gets a new one.
- **`_type`**: every child node gets a type. A missing `_type` is unlikely in practice since data normally arrives with types intact, but the editor has to self-solve it when it happens. It uses context: children of text blocks default to the span type, everything else defaults to the text block type. When a container inserts a default child into an empty array, it uses the first type from the field's `of` definition (e.g. a `rows` field with `of: [{type: 'row'}]` produces a `{_type: 'row'}` node).

**Containers that accept text blocks** (their field definition includes `{type: 'block'}`) get additional enforcement to keep the structure ready for typing: empty containers get a placeholder block with an empty span, and text blocks with missing children get an empty span. This ensures the user can always click inside a container and start typing.

This cascades through all registered levels. Inserting a bare `{_type: 'table'}` with no fields at all will produce a complete table → row → cell → block → span structure, as long as every level has a `defineContainer` registration.

**Containers that only hold void objects** (like a gallery of images) get key and type enforcement but don't need the typing-ready structure since there's no text editing inside them.

## Type safety

When a schema type parameter is provided via `defineContainer<typeof schema>({...})`, TypeScript constrains both `scope` and `field` to valid values:

````tsx
const schema = defineSchema({
  blockObjects: [{
    name: 'table',
    fields: [{
      name: 'rows', type: 'array',
      of: [{
        type: 'row',
        fields: [{
          name: 'cells', type: 'array',
          of: [{
            type: 'cell',
            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
          }],
        }],
      }],
    }],
  }],
})

// scope constrained to: 'block' | 'table' | 'table.row' | 'table.row.cell' | 'table.row.cell.block'
// field constrained to array fields on the scoped type
defineContainer({
  scope: 'table.row',
  field: 'cells',     // ✓ 'cells' is an array field on row
  render: ({children}) => <tr>{children}</tr>,
})

defineContainer({
  scope: 'table.row',
  field: 'content',   // ✗ TypeScript error: 'content' is not a field on row
  render: ({children}) => <tr>{children}</tr>,
})

defineContainer({
  scope: 'block',
  field: 'children',  // ✓ text blocks have a 'children' field
  render: ({attributes, children}) => <p>{children}</p>,
})

defineContainer({
  scope: 'block',
  field: 'content',   // ✗ TypeScript error: 'content' is not a field on block
  render: ({children}) => <p>{children}</p>,
})
````

The type machinery walks the schema's `fields` → `of` → nested `fields` recursively, building scoped names via template literal types. `'block'` is always a valid scope (with `'children'` as its only valid field name), and any container type that accepts `{type: 'block'}` in its `of` array produces a scoped block variant (e.g., `'callout.block'`, `'table.row.cell.block'`). Without a schema type parameter, `defineContainer` accepts any strings for dynamic or untyped usage.

## How it works internally

Registration populates `containers`, a `Map` that maps scoped type names to their resolved array field definitions. This map is the single source of truth that gates all container-aware behavior:

- **Traversal**: `getNodeChildren` checks `containers` to know which field to read when iterating a node's children
- **Structural integrity**: enforces `_key`, `_type`, and typing-ready structure on container children
- **Dirty path tracking**: marks container child paths as dirty after mutations so the structural integrity checks can find them
- **Rendering**: `useChildren` reads the field from `containers` to know which array to render, and the container's `render` function (or default `<div>`) wraps the result

Without any registered containers, the map is empty and the editor behaves exactly as it does today. Every container-aware code path checks this map first.

For `'block'` scope, the resolver synthesizes a `ChildArrayField` for the text block's `children` array, including `span` and any inline object types from the schema.

## Misconfigurations

- **Partial hierarchy**: registering `table` and `table.row.cell` but not `table.row` leaves the row level as a non-editable block object. The editor doesn't know which field on the row holds its children, so it can't traverse into it.
- **Primitive-only fields**: if the named field's `of` array contains only primitive types (`string`, `number`, `boolean`), the container is excluded with a console warning. Primitive array members don't have `_key` properties and can't be addressed by the editor. Object types like `image`, `reference`, or custom types are valid container content even if they have no editable text inside them.
- **No container registered**: block objects render as non-editable block objects with `contentEditable={false}`, same as today.

## Where this is heading

The scope system is designed to carry forward to a broader rendering API for all node types:

| Node type | Example | Current render prop |
|---|---|---|
| Container | callout, table | `defineContainer` (this PR) |
| Text block | paragraph, heading | `renderBlock`/`renderStyle` |
| Void block object | image, video | `renderBlock` |
| Inline object | stock ticker, mention | `renderChild` |
| Span | text segment | `renderChild` |
| List item | bullet, numbered | `renderListItem` |
| Decorator | bold, italic | `renderDecorator` |
| Annotation | link, comment | `renderAnnotation` |

Down the line, the scope system could support custom rendering for any of these:

````tsx
// Void block objects
defineBlockObject({scope: 'image', render: ({attributes, node}) => ...})
defineBlockObject({scope: 'callout.image', render: ...})

// Decorators (scoped to their text block)
defineDecorator({scope: 'block.bold', render: ({attributes, children}) => ...})
defineDecorator({scope: 'callout.block.bold', render: ...})

// Annotations
defineAnnotation({scope: 'block.link', render: ({attributes, children, node}) => ...})
defineAnnotation({scope: 'callout.block.link', render: ...})
````

`defineContainer` starts with the hardest case (nodes with editable children that need engine awareness) and establishes the patterns that the simpler cases can reuse.