### PR TITLE
fix: rename internal `editableTypes` to `containers`

### DIFF
--- a/.changeset/containers-rename.md
+++ b/.changeset/containers-rename.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: rename internal `editableTypes` to `containers`

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -222,7 +222,7 @@ export function createEditableAPI(
       const result = getNode(
         {
           schema: editor.schema,
-          editableTypes: editor.editableTypes,
+          containers: editor.containers,
           value: editor.children,
         },
         path as InternalPath,

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -27,7 +27,7 @@ export function createSlateEditor(
 
   editor.schema = context.schema
   editor.keyGenerator = context.keyGenerator
-  editor.editableTypes = new Map()
+  editor.containers = new Map()
 
   editor.decoratedRanges = []
   editor.decoratorState = {}

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -20,7 +20,7 @@ import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
 import type {RendererConfig} from '../renderers/renderer.types'
-import {resolveEditableTypes} from '../schema/editable-types'
+import {resolveContainers} from '../schema/resolve-containers'
 import {normalize} from '../slate/editor/normalize'
 import {ReactEditor} from '../slate/react/plugin/react-editor'
 import type {NamespaceEvent, OmitFromUnion} from '../type-utils'
@@ -176,14 +176,14 @@ export function rerouteExternalBehaviorEvent({
   }
 }
 
-function syncEditableTypes(context: {
+function syncContainers(context: {
   schema: EditorSchema
   renderers: Map<string, RendererConfig>
   slateEditor?: PortableTextSlateEditor
 }) {
-  const editableTypes = resolveEditableTypes(context.schema, context.renderers)
+  const containers = resolveContainers(context.schema, context.renderers)
   if (context.slateEditor) {
-    context.slateEditor.editableTypes = editableTypes
+    context.slateEditor.containers = containers
     normalize(context.slateEditor, {force: true})
     context.slateEditor.onChange()
   }
@@ -265,7 +265,7 @@ export const editorMachine = setup({
       },
     }),
     'sync editable types': ({context}) => {
-      syncEditableTypes(context)
+      syncContainers(context)
     },
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -20,7 +20,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockKey,
@@ -71,7 +71,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockKey,
@@ -120,7 +120,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockObjectKey,
@@ -155,7 +155,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockKey,
@@ -196,7 +196,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockKey,
@@ -237,7 +237,7 @@ describe(resolveSelection.name, () => {
     const range = resolveSelection(
       {
         schema,
-        editableTypes: new Map(),
+        containers: new Map(),
         children: [
           {
             _key: blockKey,

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -21,7 +21,7 @@ import {
 
 type ResolveSelectionEditor = Pick<
   PortableTextSlateEditor,
-  'children' | 'schema' | 'editableTypes'
+  'children' | 'schema' | 'containers'
 >
 
 /**
@@ -91,7 +91,7 @@ function resolveSelectionPoint(
   | undefined {
   const context = {
     schema: editor.schema,
-    editableTypes: editor.editableTypes,
+    containers: editor.containers,
     value: editor.children,
   }
 

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -64,7 +64,7 @@ export function createApplyPatch(
 function diffMatchPatch(
   editor: Pick<
     PortableTextSlateEditor,
-    'children' | 'apply' | 'selection' | 'onChange' | 'schema' | 'editableTypes'
+    'children' | 'apply' | 'selection' | 'onChange' | 'schema' | 'containers'
   >,
   patch: DiffMatchPatch,
 ): boolean {
@@ -77,7 +77,7 @@ function diffMatchPatch(
   const spanEntry = getNode(
     {
       schema: editor.schema,
-      editableTypes: editor.editableTypes,
+      containers: editor.containers,
       value: editor.children,
     },
     spanPath,

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -7,7 +7,7 @@ import {
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import {getSpanNode} from '../node-traversal/get-span-node'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {
   InsertOperation,
@@ -20,10 +20,10 @@ function spanContext(
   value: Array<Node>,
 ): {
   schema: EditorSchema
-  editableTypes: EditableTypes
+  containers: Containers
   value: Array<Node>
 } {
-  return {schema, editableTypes: new Map(), value}
+  return {schema, containers: new Map(), value}
 }
 
 export function textPatch(

--- a/packages/editor/src/node-traversal/get-ancestor-object-node.ts
+++ b/packages/editor/src/node-traversal/get-ancestor-object-node.ts
@@ -1,6 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
@@ -9,7 +9,7 @@ import {getAncestor} from './get-ancestor'
 export function getAncestorObjectNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-ancestor-text-block.ts
+++ b/packages/editor/src/node-traversal/get-ancestor-text-block.ts
@@ -1,7 +1,7 @@
 import type {PortableTextTextBlock} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestor} from './get-ancestor'
@@ -9,7 +9,7 @@ import {getAncestor} from './get-ancestor'
 export function getAncestorTextBlock(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-ancestor.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestors} from './get-ancestors'
@@ -11,7 +11,7 @@ import {getAncestors} from './get-ancestors'
 export function getAncestor(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-ancestors.ts
+++ b/packages/editor/src/node-traversal/get-ancestors.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -16,7 +16,7 @@ import {getNode} from './get-node'
 export function getAncestors(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-children.test.ts
+++ b/packages/editor/src/node-traversal/get-children.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 import {getChildren} from './get-children'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
 
@@ -162,80 +162,72 @@ describe(getChildren.name, () => {
   })
 
   test('non-editable code block returns empty array', () => {
-    const tableOnly = new Map<string, Array<ChildArrayField>>([
+    const tableOnly = new Map<string, ChildArrayField>([
       [
         'table',
-        [
-          {
-            name: 'rows',
-            type: 'array',
-            of: [
-              {
-                type: 'row',
-                fields: [
-                  {
-                    name: 'cells',
-                    type: 'array',
-                    of: [
-                      {
-                        type: 'cell',
-                        fields: [
-                          {
-                            name: 'content',
-                            type: 'array',
-                            of: [{type: 'block'}],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row',
-        [
-          {
-            name: 'cells',
-            type: 'array',
-            of: [
-              {
-                type: 'cell',
-                fields: [
-                  {
-                    name: 'content',
-                    type: 'array',
-                    of: [{type: 'block'}],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'cells',
+          type: 'array',
+          of: [
+            {
+              type: 'cell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row.cell',
-        [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
       ],
     ])
     expect(
-      getChildren({...testbed.context, editableTypes: tableOnly}, [
-        {_key: 'k11'},
-      ]),
+      getChildren({...testbed.context, containers: tableOnly}, [{_key: 'k11'}]),
     ).toEqual([])
   })
 
   test('non-editable table returns empty array', () => {
-    const codeOnly = new Map<string, Array<ChildArrayField>>([
-      ['code-block', [{name: 'code', type: 'array', of: [{type: 'block'}]}]],
+    const codeOnly = new Map<string, ChildArrayField>([
+      ['code-block', {name: 'code', type: 'array', of: [{type: 'block'}]}],
     ])
     expect(
-      getChildren({...testbed.context, editableTypes: codeOnly}, [
-        {_key: 'k26'},
-      ]),
+      getChildren({...testbed.context, containers: codeOnly}, [{_key: 'k26'}]),
     ).toEqual([])
   })
 })

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -1,7 +1,7 @@
 import type {OfDefinition} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
@@ -13,14 +13,14 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 export function getChildren(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,
 ): Array<{node: Node; path: Path}> {
   const traversalContext = {
     schema: context.schema,
-    editableTypes: context.editableTypes,
+    containers: context.containers,
   }
   return getChildrenInternal(traversalContext, {value: context.value}, path)
 }
@@ -28,7 +28,7 @@ export function getChildren(
 export function getChildrenInternal(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -93,7 +93,7 @@ export function getChildrenInternal(
 export function getNodeChildren(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   node: Node | {value: Array<Node>},
   scopePath: string,
@@ -118,7 +118,7 @@ export function getNodeChildren(
   if (isObjectNode(context, node)) {
     const scopedKey = scopePath ? `${scopePath}.${node._type}` : node._type
 
-    const arrayField = context.editableTypes.get(scopedKey)?.[0]
+    const arrayField = context.containers.get(scopedKey)
 
     if (!arrayField) {
       return undefined

--- a/packages/editor/src/node-traversal/get-first-child.test.ts
+++ b/packages/editor/src/node-traversal/get-first-child.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 import {getFirstChild} from './get-first-child'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
 
@@ -51,67 +51,63 @@ describe(getFirstChild.name, () => {
   })
 
   test('first of non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, Array<ChildArrayField>>([
+    const tableOnly = new Map<string, ChildArrayField>([
       [
         'table',
-        [
-          {
-            name: 'rows',
-            type: 'array',
-            of: [
-              {
-                type: 'row',
-                fields: [
-                  {
-                    name: 'cells',
-                    type: 'array',
-                    of: [
-                      {
-                        type: 'cell',
-                        fields: [
-                          {
-                            name: 'content',
-                            type: 'array',
-                            of: [{type: 'block'}],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row',
-        [
-          {
-            name: 'cells',
-            type: 'array',
-            of: [
-              {
-                type: 'cell',
-                fields: [
-                  {
-                    name: 'content',
-                    type: 'array',
-                    of: [{type: 'block'}],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'cells',
+          type: 'array',
+          of: [
+            {
+              type: 'cell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row.cell',
-        [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
       ],
     ])
     expect(
-      getFirstChild({...testbed.context, editableTypes: tableOnly}, [
+      getFirstChild({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},
       ]),
     ).toBeUndefined()

--- a/packages/editor/src/node-traversal/get-first-child.ts
+++ b/packages/editor/src/node-traversal/get-first-child.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -10,7 +10,7 @@ import {getChildren} from './get-children'
 export function getFirstChild(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-highest-object-node.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.ts
@@ -1,6 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
@@ -16,7 +16,7 @@ import {getNode} from './get-node'
 export function getHighestObjectNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-last-child.test.ts
+++ b/packages/editor/src/node-traversal/get-last-child.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 import {getLastChild} from './get-last-child'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
 
@@ -51,67 +51,63 @@ describe(getLastChild.name, () => {
   })
 
   test('last of non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, Array<ChildArrayField>>([
+    const tableOnly = new Map<string, ChildArrayField>([
       [
         'table',
-        [
-          {
-            name: 'rows',
-            type: 'array',
-            of: [
-              {
-                type: 'row',
-                fields: [
-                  {
-                    name: 'cells',
-                    type: 'array',
-                    of: [
-                      {
-                        type: 'cell',
-                        fields: [
-                          {
-                            name: 'content',
-                            type: 'array',
-                            of: [{type: 'block'}],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row',
-        [
-          {
-            name: 'cells',
-            type: 'array',
-            of: [
-              {
-                type: 'cell',
-                fields: [
-                  {
-                    name: 'content',
-                    type: 'array',
-                    of: [{type: 'block'}],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'cells',
+          type: 'array',
+          of: [
+            {
+              type: 'cell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row.cell',
-        [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
       ],
     ])
     expect(
-      getLastChild({...testbed.context, editableTypes: tableOnly}, [
+      getLastChild({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},
       ]),
     ).toBeUndefined()

--- a/packages/editor/src/node-traversal/get-last-child.ts
+++ b/packages/editor/src/node-traversal/get-last-child.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -10,7 +10,7 @@ import {getChildren} from './get-children'
 export function getLastChild(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-leaf.ts
+++ b/packages/editor/src/node-traversal/get-leaf.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -13,7 +13,7 @@ import {getNode} from './get-node'
 export function getLeaf(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-node.test.ts
+++ b/packages/editor/src/node-traversal/get-node.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 import {getNode} from './get-node'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
 
@@ -249,67 +249,63 @@ describe(getNode.name, () => {
   })
 
   test('node inside non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, Array<ChildArrayField>>([
+    const tableOnly = new Map<string, ChildArrayField>([
       [
         'table',
-        [
-          {
-            name: 'rows',
-            type: 'array',
-            of: [
-              {
-                type: 'row',
-                fields: [
-                  {
-                    name: 'cells',
-                    type: 'array',
-                    of: [
-                      {
-                        type: 'cell',
-                        fields: [
-                          {
-                            name: 'content',
-                            type: 'array',
-                            of: [{type: 'block'}],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row',
-        [
-          {
-            name: 'cells',
-            type: 'array',
-            of: [
-              {
-                type: 'cell',
-                fields: [
-                  {
-                    name: 'content',
-                    type: 'array',
-                    of: [{type: 'block'}],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'cells',
+          type: 'array',
+          of: [
+            {
+              type: 'cell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row.cell',
-        [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
       ],
     ])
     expect(
-      getNode({...testbed.context, editableTypes: tableOnly}, [
+      getNode({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},
         'code',
         {_key: 'k8'},

--- a/packages/editor/src/node-traversal/get-node.ts
+++ b/packages/editor/src/node-traversal/get-node.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -19,7 +19,7 @@ import {getNodeChildren} from './get-children'
 export function getNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
     blockIndexMap?: Map<string, number>
   },

--- a/packages/editor/src/node-traversal/get-nodes.test.ts
+++ b/packages/editor/src/node-traversal/get-nodes.test.ts
@@ -5,7 +5,7 @@ import {
   isTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 import {getNodeDescendants, getNodes} from './get-nodes'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
 
@@ -201,66 +201,62 @@ describe(getNodes.name, () => {
   })
 
   test('skips non-editable container internals', () => {
-    const tableOnly = new Map<string, Array<ChildArrayField>>([
+    const tableOnly = new Map<string, ChildArrayField>([
       [
         'table',
-        [
-          {
-            name: 'rows',
-            type: 'array',
-            of: [
-              {
-                type: 'row',
-                fields: [
-                  {
-                    name: 'cells',
-                    type: 'array',
-                    of: [
-                      {
-                        type: 'cell',
-                        fields: [
-                          {
-                            name: 'content',
-                            type: 'array',
-                            of: [{type: 'block'}],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row',
-        [
-          {
-            name: 'cells',
-            type: 'array',
-            of: [
-              {
-                type: 'cell',
-                fields: [
-                  {
-                    name: 'content',
-                    type: 'array',
-                    of: [{type: 'block'}],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
+        {
+          name: 'cells',
+          type: 'array',
+          of: [
+            {
+              type: 'cell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
       ],
       [
         'table.row.cell',
-        [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
       ],
     ])
-    const nodes = [...getNodes({...testbed.context, editableTypes: tableOnly})]
+    const nodes = [...getNodes({...testbed.context, containers: tableOnly})]
     const nodeValues = nodes.map((entry) => entry.node)
 
     // code-block itself appears (it's a root child) but its children don't
@@ -843,10 +839,10 @@ describe(getNodes.name, () => {
         ...getNodeDescendants(
           {
             schema,
-            editableTypes: new Map<string, Array<ChildArrayField>>([
+            containers: new Map<string, ChildArrayField>([
               [
                 'accordion',
-                [{name: 'value', type: 'array', of: [{type: 'block'}]}],
+                {name: 'value', type: 'array', of: [{type: 'block'}]},
               ],
             ]),
           },

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
@@ -24,7 +24,7 @@ import {getChildrenInternal} from './get-children'
 export function* getNodes(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   options: {
@@ -38,7 +38,7 @@ export function* getNodes(
   const {at = [], from, to, match, reverse = false} = options
   const traversalContext = {
     schema: context.schema,
-    editableTypes: context.editableTypes,
+    containers: context.containers,
   }
   const root = {value: context.value}
 
@@ -63,7 +63,7 @@ export function* getNodes(
 export function* getNodeDescendants(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   node: Node | {value: Array<Node>},
 ): Generator<{node: Node; path: Path}, void, undefined> {
@@ -77,7 +77,7 @@ export function* getNodeDescendants(
 function* getNodesSimple(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -111,7 +111,7 @@ function* getNodesSimple(
 function comparePathsInTree(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   pathA: Path,
@@ -185,7 +185,7 @@ function comparePathsInTree(
 function* getNodesInRange(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -228,7 +228,7 @@ function* getNodesInRange(
 function isInRange(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,
@@ -263,7 +263,7 @@ function isInRange(
 function couldContainInRangeNodes(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,
@@ -291,7 +291,7 @@ function couldContainInRangeNodes(
 function canStopTraversal(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,

--- a/packages/editor/src/node-traversal/get-parent.ts
+++ b/packages/editor/src/node-traversal/get-parent.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getParent(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-sibling.ts
+++ b/packages/editor/src/node-traversal/get-sibling.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
@@ -12,7 +12,7 @@ import {getChildren} from './get-children'
 export function getSibling(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-span-node.ts
+++ b/packages/editor/src/node-traversal/get-span-node.ts
@@ -1,6 +1,6 @@
 import {isSpan, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getSpanNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-text-block-node.ts
+++ b/packages/editor/src/node-traversal/get-text-block-node.ts
@@ -1,6 +1,6 @@
 import {isTextBlock, type PortableTextTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getTextBlockNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-text.ts
+++ b/packages/editor/src/node-traversal/get-text.ts
@@ -1,6 +1,6 @@
 import {isSpan} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -12,7 +12,7 @@ import {getNodes} from './get-nodes'
 export function getText(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/has-node.ts
+++ b/packages/editor/src/node-traversal/has-node.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -10,7 +10,7 @@ import {getNode} from './get-node'
 export function hasNode(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
     blockIndexMap?: Map<string, number>
   },

--- a/packages/editor/src/node-traversal/is-block.ts
+++ b/packages/editor/src/node-traversal/is-block.ts
@@ -1,6 +1,6 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isSpanNode} from '../slate/node/is-span-node'
@@ -19,7 +19,7 @@ import {getParent} from './get-parent'
 export function isBlock(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,
@@ -42,7 +42,7 @@ export function isBlock(
 export function getBlock(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/is-inline.ts
+++ b/packages/editor/src/node-traversal/is-inline.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isBlock} from './is-block'
@@ -13,7 +13,7 @@ import {isBlock} from './is-block'
 export function isInline(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/is-leaf.ts
+++ b/packages/editor/src/node-traversal/is-leaf.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -14,7 +14,7 @@ import {getNodeChildren} from './get-children'
 export function isLeaf(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,
@@ -25,7 +25,7 @@ export function isLeaf(
 
   const traversalContext = {
     schema: context.schema,
-    editableTypes: context.editableTypes,
+    containers: context.containers,
   }
 
   let currentChildren: Array<Node> = context.value

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -1,6 +1,6 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
-import type {ChildArrayField} from '../schema/editable-types'
+import type {ChildArrayField} from '../schema/resolve-containers'
 
 /**
  * A comprehensive test fixture for node traversal tests.
@@ -41,62 +41,58 @@ import type {ChildArrayField} from '../schema/editable-types'
  *                     └── emptyBlock            [4, 1, 0, 0]
  *                         └── emptySpan ""      [4, 1, 0, 0, 0]
  */
-const allEditableTypes = new Map<string, Array<ChildArrayField>>([
-  ['code-block', [{name: 'code', type: 'array', of: [{type: 'block'}]}]],
+const allContainers = new Map<string, ChildArrayField>([
+  ['code-block', {name: 'code', type: 'array', of: [{type: 'block'}]}],
   [
     'table',
-    [
-      {
-        name: 'rows',
-        type: 'array',
-        of: [
-          {
-            type: 'row',
-            fields: [
-              {
-                name: 'cells',
-                type: 'array',
-                of: [
-                  {
-                    type: 'cell',
-                    fields: [
-                      {
-                        name: 'content',
-                        type: 'array',
-                        of: [{type: 'block'}],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    {
+      name: 'rows',
+      type: 'array',
+      of: [
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'cells',
+              type: 'array',
+              of: [
+                {
+                  type: 'cell',
+                  fields: [
+                    {
+                      name: 'content',
+                      type: 'array',
+                      of: [{type: 'block'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
   [
     'table.row',
-    [
-      {
-        name: 'cells',
-        type: 'array',
-        of: [
-          {
-            type: 'cell',
-            fields: [
-              {
-                name: 'content',
-                type: 'array',
-                of: [{type: 'block'}],
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    {
+      name: 'cells',
+      type: 'array',
+      of: [
+        {
+          type: 'cell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    },
   ],
-  ['table.row.cell', [{name: 'content', type: 'array', of: [{type: 'block'}]}]],
+  ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
 ])
 
 export function createNodeTraversalTestbed() {
@@ -255,7 +251,7 @@ export function createNodeTraversalTestbed() {
 
   const context = {
     schema,
-    editableTypes: allEditableTypes,
+    containers: allContainers,
     value: [textBlock1, image, textBlock2, codeBlock, table],
   }
 

--- a/packages/editor/src/paths/get-child-field-name.ts
+++ b/packages/editor/src/paths/get-child-field-name.ts
@@ -1,6 +1,6 @@
 import type {EditorSchema} from '../editor/editor-schema'
 import {getNodeChildren} from '../node-traversal/get-children'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -15,13 +15,13 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 export function getChildFieldName(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   path: Path,
 ): string | undefined {
   let nodeChildren = getNodeChildren(
-    {schema: context.schema, editableTypes: context.editableTypes},
+    {schema: context.schema, containers: context.containers},
     {value: context.value},
     '',
   )
@@ -51,7 +51,7 @@ export function getChildFieldName(
 
     if (i === path.length - 1) {
       const targetInfo = getNodeChildren(
-        {schema: context.schema, editableTypes: context.editableTypes},
+        {schema: context.schema, containers: context.containers},
         node,
         nodeChildren.scopePath,
       )
@@ -59,7 +59,7 @@ export function getChildFieldName(
     }
 
     nodeChildren = getNodeChildren(
-      {schema: context.schema, editableTypes: context.editableTypes},
+      {schema: context.schema, containers: context.containers},
       node,
       nodeChildren.scopePath,
     )

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -1,6 +1,6 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import {getDirtyPaths} from './get-dirty-paths'
 
@@ -18,16 +18,16 @@ const schemaDefinition = defineSchema({
 
 const schema = compileSchema(schemaDefinition)
 
-const emptyEditableTypes: EditableTypes = new Map()
+const emptyContainers: Containers = new Map()
 
-const containerEditableTypes: EditableTypes = new Map([
-  ['callout', [{name: 'content', type: 'array', of: [{type: 'block'}]}]],
+const containerContainers: Containers = new Map([
+  ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
 ])
 
-const tableEditableTypes: EditableTypes = new Map([
-  ['table', [{name: 'rows', type: 'array', of: [{type: 'row'}]}]],
-  ['table.row', [{name: 'cells', type: 'array', of: [{type: 'cell'}]}]],
-  ['table.row.cell', [{name: 'content', type: 'array', of: [{type: 'block'}]}]],
+const tableContainers: Containers = new Map([
+  ['table', {name: 'rows', type: 'array', of: [{type: 'row'}]}],
+  ['table.row', {name: 'cells', type: 'array', of: [{type: 'cell'}]}],
+  ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
 ])
 
 describe(getDirtyPaths.name, () => {
@@ -37,7 +37,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -55,7 +55,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -73,7 +73,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -102,7 +102,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -150,7 +150,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -173,7 +173,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -190,7 +190,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -218,7 +218,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [replacementNode],
           },
           {
@@ -251,7 +251,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [blockNode],
           },
           {
@@ -290,7 +290,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -312,7 +312,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -329,7 +329,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -367,7 +367,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [calloutNode],
           },
           {
@@ -404,7 +404,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [calloutNode],
           },
           {
@@ -430,7 +430,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: tableEditableTypes,
+            containers: tableContainers,
             value: [],
           },
           {
@@ -472,7 +472,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -488,7 +488,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -521,7 +521,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value,
           },
           {
@@ -537,7 +537,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -553,7 +553,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -569,7 +569,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -608,7 +608,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: calloutValue,
           },
           {
@@ -626,7 +626,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -660,7 +660,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: emptyEditableTypes,
+            containers: emptyContainers,
             value: [],
           },
           {
@@ -698,7 +698,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -722,7 +722,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -763,7 +763,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: containerEditableTypes,
+            containers: containerContainers,
             value: [],
           },
           {
@@ -796,7 +796,7 @@ describe(getDirtyPaths.name, () => {
         getDirtyPaths(
           {
             schema,
-            editableTypes: tableEditableTypes,
+            containers: tableContainers,
             value: [],
           },
           {

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
 import type {Path} from '../slate/interfaces/path'
@@ -13,13 +13,13 @@ import {getChildFieldName} from './get-child-field-name'
  * Numeric indices avoid dedup collisions when siblings have duplicate
  * keys (pre-normalization).
  *
- * Uses the schema and editableTypes to resolve child array fields
+ * Uses the schema and containers to resolve child array fields
  * rather than guessing from object properties.
  */
 function collectDescendantPaths(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
   },
   node: Node,
   parentPath: Path,
@@ -40,7 +40,7 @@ function collectDescendantPaths(
   // For container types, resolve the child array field from the schema
   const scopedName = scopePrefix ? `${scopePrefix}.${node._type}` : node._type
 
-  const arrayField = context.editableTypes.get(scopedName)?.[0]
+  const arrayField = context.containers.get(scopedName)
 
   if (arrayField) {
     const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -107,7 +107,7 @@ function buildScopedName(value: Array<Node>, path: Path): string {
 export function getDirtyPaths(
   context: {
     schema: EditorSchema
-    editableTypes: EditableTypes
+    containers: Containers
     value: Array<Node>
   },
   op: Operation,

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -1,8 +1,8 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import {resolveEditableTypes} from './editable-types'
+import {resolveContainers} from './resolve-containers'
 
-describe(resolveEditableTypes.name, () => {
+describe(resolveContainers.name, () => {
   test('resolves a single-level container', () => {
     const schema = compileSchema(
       defineSchema({
@@ -18,14 +18,13 @@ describe(resolveEditableTypes.name, () => {
     )
 
     expect(
-      resolveEditableTypes(
+      resolveContainers(
         schema,
         new Map([['code', {renderer: {type: 'code'}}]]),
       ),
     ).toEqual(
       new Map([
-        ['code', [{name: 'content', type: 'array', of: [{type: 'codeLine'}]}]],
-        ['code.codeLine', []],
+        ['code', {name: 'content', type: 'array', of: [{type: 'codeLine'}]}],
       ]),
     )
   })
@@ -71,7 +70,7 @@ describe(resolveEditableTypes.name, () => {
     )
 
     expect(
-      resolveEditableTypes(
+      resolveContainers(
         schema,
         new Map([['table', {renderer: {type: 'table'}}]]),
       ),
@@ -79,60 +78,56 @@ describe(resolveEditableTypes.name, () => {
       new Map([
         [
           'table',
-          [
-            {
-              name: 'rows',
-              type: 'array',
-              of: [
-                {
-                  type: 'row',
-                  fields: [
-                    {
-                      name: 'cells',
-                      type: 'array',
-                      of: [
-                        {
-                          type: 'cell',
-                          fields: [
-                            {
-                              name: 'content',
-                              type: 'array',
-                              of: [{type: 'block'}],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          {
+            name: 'rows',
+            type: 'array',
+            of: [
+              {
+                type: 'row',
+                fields: [
+                  {
+                    name: 'cells',
+                    type: 'array',
+                    of: [
+                      {
+                        type: 'cell',
+                        fields: [
+                          {
+                            name: 'content',
+                            type: 'array',
+                            of: [{type: 'block'}],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
         ],
         [
           'table.row.cell',
-          [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          {name: 'content', type: 'array', of: [{type: 'block'}]},
         ],
         [
           'table.row',
-          [
-            {
-              name: 'cells',
-              type: 'array',
-              of: [
-                {
-                  type: 'cell',
-                  fields: [
-                    {
-                      name: 'content',
-                      type: 'array',
-                      of: [{type: 'block'}],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          {
+            name: 'cells',
+            type: 'array',
+            of: [
+              {
+                type: 'cell',
+                fields: [
+                  {
+                    name: 'content',
+                    type: 'array',
+                    of: [{type: 'block'}],
+                  },
+                ],
+              },
+            ],
+          },
         ],
       ]),
     )
@@ -141,10 +136,10 @@ describe(resolveEditableTypes.name, () => {
   test('returns empty Map when no renderers are registered', () => {
     const schema = compileSchema(defineSchema({}))
 
-    expect(resolveEditableTypes(schema, new Map())).toEqual(new Map())
+    expect(resolveContainers(schema, new Map())).toEqual(new Map())
   })
 
-  test('collects multiple array fields on the same type', () => {
+  test('uses the first array field when multiple exist on the same type', () => {
     const schema = compileSchema(
       defineSchema({
         blockObjects: [
@@ -160,21 +155,12 @@ describe(resolveEditableTypes.name, () => {
     )
 
     expect(
-      resolveEditableTypes(
+      resolveContainers(
         schema,
         new Map([['table', {renderer: {type: 'table'}}]]),
       ),
     ).toEqual(
-      new Map([
-        [
-          'table',
-          [
-            {name: 'rows', type: 'array', of: [{type: 'row'}]},
-            {name: 'alternateRows', type: 'array', of: [{type: 'row'}]},
-          ],
-        ],
-        ['table.row', []],
-      ]),
+      new Map([['table', {name: 'rows', type: 'array', of: [{type: 'row'}]}]]),
     )
   })
 
@@ -197,7 +183,7 @@ describe(resolveEditableTypes.name, () => {
     )
 
     expect(
-      resolveEditableTypes(
+      resolveContainers(
         schema,
         new Map([
           ['code', {renderer: {type: 'code'}}],
@@ -206,9 +192,8 @@ describe(resolveEditableTypes.name, () => {
       ),
     ).toEqual(
       new Map([
-        ['code', [{name: 'content', type: 'array', of: [{type: 'codeLine'}]}]],
-        ['code.codeLine', []],
-        ['callout', [{name: 'content', type: 'array', of: [{type: 'block'}]}]],
+        ['code', {name: 'content', type: 'array', of: [{type: 'codeLine'}]}],
+        ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
       ]),
     )
   })

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -7,51 +7,53 @@ export type ChildArrayField = FieldDefinition & {
 }
 
 /**
- * Maps scoped type names to their resolved editable array fields.
+ * Maps scoped type names to their resolved editable array field.
  *
  * Key: scoped type name (e.g., 'table', 'table.row', 'table.row.cell')
- * Value: resolved array field definitions with name and of scope
+ * Value: resolved array field definition with name and of scope
  */
-export type EditableTypes = Map<string, Array<ChildArrayField>>
+export type Containers = Map<string, ChildArrayField>
 
 /**
- * Resolve the complete EditableTypes Map from a schema and a set of
+ * Resolve the complete Containers Map from a schema and a set of
  * registered renderers. Walks the schema once per renderer type,
  * collecting all scoped type paths and their editable array fields.
  */
-export function resolveEditableTypes(
+export function resolveContainers(
   schema: EditorSchema,
   renderers: Map<string, {renderer: {type: string}}>,
-): EditableTypes {
-  const editableTypes: EditableTypes = new Map()
+): Containers {
+  const containers: Containers = new Map()
 
   for (const [, config] of renderers) {
     for (const entry of resolveTypePaths(schema, config.renderer.type)) {
-      editableTypes.set(entry.path, entry.fields)
+      if (entry.field) {
+        containers.set(entry.path, entry.field)
+      }
     }
   }
 
-  return editableTypes
+  return containers
 }
 
 function resolveTypePaths(
   schema: EditorSchema,
   typeName: string,
-): Array<{path: string; fields: Array<ChildArrayField>}> {
-  const entries: Array<{path: string; fields: Array<ChildArrayField>}> = []
+): Array<{path: string; field: ChildArrayField | undefined}> {
+  const entries: Array<{path: string; field: ChildArrayField | undefined}> = []
 
   const blockObject = schema.blockObjects.find(
     (definition) => definition.name === typeName,
   )
 
   if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
-    entries.push({path: typeName, fields: []})
+    entries.push({path: typeName, field: undefined})
     return entries
   }
 
-  const rootFields: Array<ChildArrayField> = []
-  walkFields(blockObject.fields, typeName, entries, rootFields)
-  entries.unshift({path: typeName, fields: rootFields})
+  const rootField = resolveFirstChildArrayField(blockObject.fields)
+  walkFields(blockObject.fields, typeName, entries)
+  entries.unshift({path: typeName, field: rootField})
   return entries
 }
 
@@ -59,25 +61,30 @@ function isChildArrayField(field: FieldDefinition): field is ChildArrayField {
   return field.type === 'array' && 'of' in field && Array.isArray(field.of)
 }
 
+function resolveFirstChildArrayField(
+  fields: ReadonlyArray<FieldDefinition>,
+): ChildArrayField | undefined {
+  return fields.find(isChildArrayField)
+}
+
 function walkFields(
   fields: ReadonlyArray<FieldDefinition>,
   currentPath: string,
-  entries: Array<{path: string; fields: Array<ChildArrayField>}>,
-  parentFields: Array<ChildArrayField>,
+  entries: Array<{path: string; field: ChildArrayField | undefined}>,
 ) {
   for (const field of fields) {
     if (isChildArrayField(field)) {
-      parentFields.push(field)
       for (const ofMember of field.of) {
         if (ofMember.type === 'block') {
           continue
         }
         const scopedPath = `${currentPath}.${ofMember.type}`
-        const childFields: Array<ChildArrayField> = []
+        let childField: ChildArrayField | undefined
         if ('fields' in ofMember && ofMember.fields) {
-          walkFields(ofMember.fields, scopedPath, entries, childFields)
+          childField = resolveFirstChildArrayField(ofMember.fields)
+          walkFields(ofMember.fields, scopedPath, entries)
         }
-        entries.push({path: scopedPath, fields: childFields})
+        entries.push({path: scopedPath, field: childField})
       }
     }
   }

--- a/packages/editor/src/slate/core/apply-operation.ts
+++ b/packages/editor/src/slate/core/apply-operation.ts
@@ -202,7 +202,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       const setNodeEntry = getNode(
         {
           schema: editor.schema,
-          editableTypes: editor.editableTypes,
+          containers: editor.containers,
           value: editor.children,
           blockIndexMap: editor.blockIndexMap,
         },
@@ -423,7 +423,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       const unsetNodeEntry = getNode(
         {
           schema: editor.schema,
-          editableTypes: editor.editableTypes,
+          containers: editor.containers,
           value: editor.children,
           blockIndexMap: editor.blockIndexMap,
         },

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -453,7 +453,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Container normalization: ensure the child array field exists.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.editableTypes.get(scopedName)?.[0]
+    const arrayField = editor.containers.get(scopedName)
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -468,7 +468,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Container normalization: ensure non-empty child array.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.editableTypes.get(scopedName)?.[0]
+    const arrayField = editor.containers.get(scopedName)
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -508,7 +508,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Fix duplicate _key among children of container/object nodes.
   // The sibling-level handler above catches duplicates when each child is
   // visited individually, but container children may not be visited if
-  // editableTypes gates traversal. Handle it at the parent level as well.
+  // containers gates traversal. Handle it at the parent level as well.
   if (isObjectNode({schema: editor.schema}, node)) {
     const children = [...getChildren(editor, path)]
 

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -85,7 +85,7 @@ const useChildren = (props: {
       ? `${containerScope.name}.${node._type}`
       : node._type
 
-    const arrayField = editor.editableTypes.get(scopedKey)?.[0]
+    const arrayField = editor.containers.get(scopedKey)
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -199,7 +199,7 @@ const useChildren = (props: {
       return null
     }
     if (isObjectNode({schema: editor.schema}, n)) {
-      if (editor.editableTypes.has(n._type)) {
+      if (editor.containers.has(n._type)) {
         return renderElementComponent(n, i)
       }
       return renderObjectNodeComponent(n, i)

--- a/packages/editor/src/slate/utils/modify.ts
+++ b/packages/editor/src/slate/utils/modify.ts
@@ -57,7 +57,7 @@ export const modifyDescendant = <N extends Node>(
 
   const context = {
     schema: editor.schema,
-    editableTypes: editor.editableTypes,
+    containers: editor.containers,
   }
   const nodeEntry = getNode(
     {
@@ -227,7 +227,7 @@ export const modifyChildren = (
   } else {
     const context = {
       schema: editor.schema,
-      editableTypes: editor.editableTypes,
+      containers: editor.containers,
     }
 
     const nodeEntry = getNode(

--- a/packages/editor/src/types/slate-editor.ts
+++ b/packages/editor/src/types/slate-editor.ts
@@ -2,7 +2,7 @@ import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
-import type {EditableTypes} from '../schema/editable-types'
+import type {Containers} from '../schema/resolve-containers'
 import type {Operation as SlateOperation} from '../slate/interfaces/operation'
 import type {ReactEditor} from '../slate/react/plugin/react-editor'
 
@@ -29,7 +29,7 @@ export interface PortableTextSlateEditor extends ReactEditor {
 
   schema: EditorSchema
   keyGenerator: () => string
-  editableTypes: EditableTypes
+  containers: Containers
 
   decoratedRanges: Array<DecoratedRange>
   decoratorState: Record<string, boolean | undefined>

--- a/packages/editor/tests/tables.test.tsx
+++ b/packages/editor/tests/tables.test.tsx
@@ -4,7 +4,7 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {InternalSlateEditorRefPlugin} from '../src/plugins/plugin.internal.slate-editor-ref'
-import type {EditableTypes} from '../src/schema/editable-types'
+import type {Containers} from '../src/schema/resolve-containers'
 import {withoutPatching} from '../src/slate-plugins/slate-plugin.without-patching'
 import {normalize} from '../src/slate/editor/normalize'
 import {createTestEditor} from '../src/test/vitest'
@@ -51,65 +51,58 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-function tableEditableTypes(): EditableTypes {
+function tableContainers(): Containers {
   return new Map([
     [
       'table',
-      [
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      {
+        name: 'rows',
+        type: 'array',
+        of: [
+          {
+            type: 'row',
+            fields: [
+              {
+                name: 'cells',
+                type: 'array',
+                of: [
+                  {
+                    type: 'cell',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
     ],
     [
       'table.row',
-      [
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      {
+        name: 'cells',
+        type: 'array',
+        of: [
+          {
+            type: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      },
     ],
-    [
-      'table.row.cell',
-      [{name: 'content', type: 'array', of: [{type: 'block'}]}],
-    ],
+    ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
   ])
 }
 
@@ -488,10 +481,10 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      // Set editableTypes so normalization traverses into containers
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      // Set containers so normalization traverses into containers
+      slateEditorRef.current!.containers = tableContainers()
 
-      // Force normalization with editableTypes set
+      // Force normalization with containers set
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})
       })
@@ -553,7 +546,7 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      slateEditorRef.current!.containers = tableContainers()
 
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})
@@ -616,7 +609,7 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      slateEditorRef.current!.containers = tableContainers()
 
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})
@@ -697,7 +690,7 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      slateEditorRef.current!.containers = tableContainers()
 
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})
@@ -768,7 +761,7 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      slateEditorRef.current!.containers = tableContainers()
 
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})
@@ -826,7 +819,7 @@ describe('tables', () => {
         children: <InternalSlateEditorRefPlugin ref={slateEditorRef} />,
       })
 
-      slateEditorRef.current!.editableTypes = tableEditableTypes()
+      slateEditorRef.current!.containers = tableContainers()
 
       withoutPatching(slateEditorRef.current!, () => {
         normalize(slateEditorRef.current!, {force: true})


### PR DESCRIPTION
The internal type that tracks which block objects have editable children is called `editableTypes`. That name made sense when it was a feature flag for "is this type editable?", but the concept has grown into something more specific: a map of container configurations that the editor uses for traversal, normalization, dirty path tracking, and rendering.

This renames `editableTypes` to `containers` throughout the codebase and simplifies the value type from `Array<ChildArrayField>` to `ChildArrayField`. Each scoped type name maps to exactly one child array field, so the array wrapper was unnecessary indirection that every consumer had to unwrap with `?.[0]`.

### What changed

- `EditableTypes` type → `Containers`
- `editor.editableTypes` → `editor.containers` on `PortableTextSlateEditor`
- `resolveEditableTypes` → `resolveContainers`
- `syncEditableTypes` → `syncContainers` in the editor machine
- `editable-types.ts` → `resolve-containers.ts`
- All `.get(key)?.[0]` patterns simplified to `.get(key)`

45 files touched, purely mechanical. No behavior changes. The `containers` map is still empty in production.