### PR TITLE
fix: add internal `defineContainer` API for declaring content depth

### DIFF
--- a/.changeset/container-prep.md
+++ b/.changeset/container-prep.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: rename internal renderer types to container types

--- a/.changeset/register-renderer.md
+++ b/.changeset/register-renderer.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: add internal `defineContainer` API for declaring content depth

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -5,6 +5,7 @@ import type {Editor, EditorConfig} from '../editor'
 import {debug} from '../internal-utils/debug'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
+import type {Container} from '../renderers/renderer.types'
 import type {EditableAPI} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {defaultKeyGenerator} from '../utils/key-generator'
@@ -19,6 +20,7 @@ import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export type InternalEditor = Editor & {
+  registerContainer: (config: {container: Container}) => () => void
   _internal: {
     editable: EditableAPI
     editorActor: EditorActor
@@ -85,6 +87,18 @@ export function createInternalEditor(config: EditorConfig): {
         editorActor.send({
           type: 'remove behavior',
           behaviorConfig: behaviorConfigWithPriority,
+        })
+      }
+    },
+    registerContainer: (config) => {
+      editorActor.send({
+        type: 'register container',
+        containerConfig: config,
+      })
+      return () => {
+        editorActor.send({
+          type: 'unregister container',
+          containerConfig: config,
         })
       }
     },

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -197,11 +197,11 @@ export const editorMachine = setup({
     context: {} as {
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
+      containerConfigs: Map<string, ContainerConfig>
       converters: Set<Converter>
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
       pendingIncomingPatchesEvents: Array<PatchesEvent>
-      containerConfigs: Map<string, ContainerConfig>
       schema: EditorSchema
       initialReadOnly: boolean
       selection: EditorSelection
@@ -253,7 +253,7 @@ export const editorMachine = setup({
         assertEvent(event, 'register container')
         const containerConfigs = new Map(context.containerConfigs)
         containerConfigs.set(
-          event.containerConfig.renderer.type,
+          event.containerConfig.container.scope,
           event.containerConfig,
         )
         return containerConfigs
@@ -263,11 +263,11 @@ export const editorMachine = setup({
       containerConfigs: ({context, event}) => {
         assertEvent(event, 'unregister container')
         const containerConfigs = new Map(context.containerConfigs)
-        containerConfigs.delete(event.containerConfig.renderer.type)
+        containerConfigs.delete(event.containerConfig.container.scope)
         return containerConfigs
       },
     }),
-    'sync editable types': ({context}) => {
+    'sync containers': ({context}) => {
       syncContainers(context)
     },
     'emit patch event': emit(({event}) => {
@@ -445,11 +445,11 @@ export const editorMachine = setup({
   context: ({input}) => ({
     behaviors: new Set(coreBehaviorsConfig),
     behaviorsSorted: false,
+    containerConfigs: new Map(),
     converters: new Set(input.converters ?? []),
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
     pendingIncomingPatchesEvents: [],
-    containerConfigs: new Map(),
     schema: input.schema,
     selection: null,
     initialReadOnly: input.readOnly ?? false,
@@ -459,13 +459,13 @@ export const editorMachine = setup({
     'add behavior': {actions: 'add behavior to context'},
     'remove behavior': {actions: 'remove behavior from context'},
     'add slate editor': {
-      actions: ['add slate editor to context', 'sync editable types'],
+      actions: ['add slate editor to context', 'sync containers'],
     },
     'register container': {
-      actions: ['register container', 'sync editable types'],
+      actions: ['register container', 'sync containers'],
     },
     'unregister container': {
-      actions: ['unregister container', 'sync editable types'],
+      actions: ['unregister container', 'sync containers'],
     },
     'update selection': {
       actions: [

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -1,0 +1,25 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {ReactElement} from 'react'
+import type {ContainerConfig} from '../renderers/renderer.types'
+import type {RenderElementProps} from '../slate/react/components/editable'
+
+export function RenderContainer(props: {
+  attributes: RenderElementProps['attributes']
+  children: ReactElement
+  element: PortableTextBlock
+  containerConfig: ContainerConfig
+}) {
+  if (props.containerConfig.container.render) {
+    const rendered = props.containerConfig.container.render({
+      attributes: props.attributes,
+      children: props.children,
+      node: props.element,
+    })
+
+    if (rendered !== null) {
+      return rendered
+    }
+  }
+
+  return <div {...props.attributes}>{props.children}</div>
+}

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -7,7 +7,6 @@ import {useSelector} from '@xstate/react'
 import {useContext, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import {isInline} from '../node-traversal/is-inline'
-import type {ContainerConfig} from '../renderers/renderer.types'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
 import type {
@@ -16,8 +15,10 @@ import type {
   RenderListItemFunction,
   RenderStyleFunction,
 } from '../types/editor'
+import {ContainerScopeContext} from './container-scope-context'
 import {EditorActorContext} from './editor-actor-context'
 import {RenderBlockObject} from './render.block-object'
+import {RenderContainer} from './render.container'
 import {RenderInlineObject} from './render.inline-object'
 import {RenderTextBlock} from './render.text-block'
 
@@ -36,11 +37,36 @@ export function RenderElement(props: {
 }) {
   const editorActor = useContext(EditorActorContext)
   const schema = useSelector(editorActor, (s) => s.context.schema)
-  const containerConfig: ContainerConfig | undefined = useSelector(
-    editorActor,
-    (s) => s.context.containerConfigs.get(props.element._type),
-  )
+  const containerScope = useContext(ContainerScopeContext)
   const slateStatic = useSlateStatic()
+
+  const scopedTypeName = containerScope
+    ? `${containerScope}.${props.element._type}`
+    : props.element._type
+
+  const containerConfig = useSelector(editorActor, (s) => {
+    const configs = s.context.containerConfigs
+    const exact = configs.get(scopedTypeName)
+    if (exact) {
+      return exact
+    }
+    const bareType = scopedTypeName.includes('.')
+      ? scopedTypeName.split('.').pop()!
+      : undefined
+    return bareType ? configs.get(bareType) : undefined
+  })
+
+  if (containerConfig) {
+    return (
+      <RenderContainer
+        attributes={props.attributes}
+        element={props.element}
+        containerConfig={containerConfig}
+      >
+        {props.children}
+      </RenderContainer>
+    )
+  }
 
   if (isTextBlock({schema}, props.element)) {
     return (
@@ -78,14 +104,6 @@ export function RenderElement(props: {
         {props.children}
       </RenderInlineObject>
     )
-  }
-
-  if (containerConfig) {
-    return containerConfig.renderer.render({
-      attributes: props.attributes,
-      children: props.children,
-      node: props.element,
-    })
   }
 
   return (

--- a/packages/editor/src/plugins/plugin.container.tsx
+++ b/packages/editor/src/plugins/plugin.container.tsx
@@ -1,23 +1,26 @@
 import {useContext, useEffect} from 'react'
 import {EditorActorContext} from '../editor/editor-actor-context'
-import type {ContainerConfig} from '../renderers/renderer.types'
+import type {Container} from '../renderers/renderer.types'
 
 /**
  * @internal
  */
-export function ContainerPlugin(props: {containers: Array<ContainerConfig>}) {
+export function ContainerPlugin(props: {
+  containers: Array<{container: Container}>
+}) {
   const editorActor = useContext(EditorActorContext)
 
   useEffect(() => {
-    for (const containerConfig of props.containers) {
+    const containerConfigs = props.containers.map((containerConfig) => {
       editorActor.send({
         type: 'register container',
         containerConfig,
       })
-    }
+      return containerConfig
+    })
 
     return () => {
-      for (const containerConfig of props.containers) {
+      for (const containerConfig of containerConfigs) {
         editorActor.send({
           type: 'unregister container',
           containerConfig,

--- a/packages/editor/src/renderers/renderer.types.test-d.ts
+++ b/packages/editor/src/renderers/renderer.types.test-d.ts
@@ -1,0 +1,186 @@
+import {defineSchema} from '@portabletext/schema'
+import type {ReactElement} from 'react'
+import {describe, test} from 'vitest'
+import {defineContainer} from './renderer.types'
+
+describe(defineContainer.name, () => {
+  test('accepts scope, field, and render', () => {
+    defineContainer({
+      scope: 'callout',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+})
+
+const schema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+    {
+      name: 'figure',
+      fields: [
+        {name: 'caption', type: 'array', of: [{type: 'block'}]},
+        {name: 'alt', type: 'string'},
+        {name: 'tags', type: 'array', of: [{type: 'string'}]},
+      ],
+    },
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+type Schema = typeof schema
+
+describe('schema-aware defineContainer', () => {
+  test('constrains scope to scoped type names', () => {
+    defineContainer<Schema>({
+      scope: 'callout',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects scope not in schema', () => {
+    defineContainer<Schema>({
+      // @ts-expect-error - 'unknown' is not a scoped type name in schema
+      scope: 'unknown',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects field not on the type', () => {
+    // @ts-expect-error - 'tags' is not an array field on callout
+    defineContainer<Schema>({
+      scope: 'callout',
+      field: 'tags',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects non-array fields', () => {
+    defineContainer<Schema>({
+      type: 'figure',
+      // @ts-expect-error - 'alt' is type: 'string', not type: 'array'
+      field: 'alt',
+      render: ({children}) => children,
+    })
+  })
+
+  test('allows valid array field', () => {
+    defineContainer<Schema>({
+      scope: 'figure',
+      field: 'caption',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts nested scoped type', () => {
+    defineContainer<Schema>({
+      scope: 'table.row',
+      field: 'cells',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts deeply nested scoped type', () => {
+    defineContainer<Schema>({
+      scope: 'table.row.cell',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects bare nested type name', () => {
+    defineContainer<Schema>({
+      // @ts-expect-error - 'row' is not valid, must use 'table.row'
+      scope: 'row',
+      field: 'cells',
+      render: ({children}) => children,
+    })
+  })
+
+  test('constrains field to the scoped type', () => {
+    // @ts-expect-error - 'content' is not a field on table.row (cells is)
+    defineContainer<Schema>({
+      scope: 'table.row',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects bare deeply nested type name', () => {
+    defineContainer<Schema>({
+      // @ts-expect-error - 'cell' is not valid, must use 'table.row.cell'
+      scope: 'cell',
+      field: 'content',
+      render: () => null as unknown as ReactElement,
+    })
+  })
+
+  test('accepts block scope for text block children', () => {
+    defineContainer<Schema>({
+      scope: 'block',
+      field: 'children',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts scoped block scope inside container', () => {
+    defineContainer<Schema>({
+      scope: 'callout.block',
+      field: 'children',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts deeply scoped block scope', () => {
+    defineContainer<Schema>({
+      scope: 'table.row.cell.block',
+      field: 'children',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects invalid field on block scope', () => {
+    // @ts-expect-error - 'content' is not valid on block scope, must be 'children'
+    defineContainer<Schema>({
+      scope: 'block',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+})

--- a/packages/editor/src/renderers/renderer.types.test.tsx
+++ b/packages/editor/src/renderers/renderer.types.test.tsx
@@ -1,0 +1,19 @@
+import {describe, expect, test} from 'vitest'
+import {defineContainer} from './renderer.types'
+
+describe(defineContainer.name, () => {
+  test('returns the config as-is', () => {
+    const render = ({children}: {children: unknown}) => children
+    expect(
+      defineContainer({
+        scope: 'callout',
+        field: 'content',
+        render: render as any,
+      }),
+    ).toEqual({
+      scope: 'callout',
+      field: 'content',
+      render,
+    })
+  })
+})

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -1,21 +1,155 @@
-import type {PortableTextObject} from '@portabletext/schema'
+import type {PortableTextBlock, SchemaDefinition} from '@portabletext/schema'
 import type {ReactElement} from 'react'
+
+/** @internal */
+type ExtractArrayFields<TFields> = TFields extends readonly [
+  infer TField,
+  ...infer TRest,
+]
+  ? TField extends {name: infer TName extends string; type: 'array'}
+    ? TName | ExtractArrayFields<TRest>
+    : ExtractArrayFields<TRest>
+  : never
+
+/** @internal */
+type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
+  infer TMember,
+  ...infer TRest,
+]
+  ? TMember extends {
+      type: infer TTypeName extends string
+      fields?: infer TFields
+    }
+    ? {type: TTypeName; fields: TFields} | ExtractOfMembers<TRest>
+    : ExtractOfMembers<TRest>
+  : never
+
+/** @internal */
+type WalkFields<TFields> = TFields extends readonly [
+  infer TField,
+  ...infer TRest,
+]
+  ? TField extends {type: 'array'; of?: infer TOf}
+    ? ExtractOfMembers<TOf> | WalkFields<TRest>
+    : WalkFields<TRest>
+  : never
+
+/** @internal */
+type CollectScopedTypes<TFields, TScope extends string> =
+  WalkFields<TFields> extends infer TMembers
+    ? TMembers extends {
+        type: infer TTypeName extends string
+        fields: infer TNestedFields
+      }
+      ? TTypeName extends 'block'
+        ? {scopedName: `${TScope}.block`; arrayFields: 'children'}
+        :
+            | {
+                scopedName: `${TScope}.${TTypeName}`
+                arrayFields: ExtractArrayFields<TNestedFields>
+              }
+            | CollectScopedTypes<TNestedFields, `${TScope}.${TTypeName}`>
+      : never
+    : never
+
+/**
+ * Collect all renderer-eligible types from a schema definition.
+ * Includes top-level block objects and all nested container types
+/** @internal */
+type CollectAllTypes<TSchema extends SchemaDefinition> =
+  | {scopedName: 'block'; arrayFields: 'children'}
+  | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
+      ? TBlockObject extends {
+          name: infer TName extends string
+          fields?: infer TFields
+        }
+        ?
+            | {scopedName: TName; arrayFields: ExtractArrayFields<TFields>}
+            | CollectScopedTypes<TFields, TName>
+        : never
+      : never)
+
+/** @internal */
+type AllScopedNames<TSchema extends SchemaDefinition> =
+  CollectAllTypes<TSchema> extends {scopedName: infer TName} ? TName : never
+
+/** @internal */
+type ScopedArrayFields<TSchema extends SchemaDefinition, TName extends string> =
+  CollectAllTypes<TSchema> extends infer TEntry
+    ? TEntry extends {scopedName: TName; arrayFields: infer TFieldName}
+      ? TFieldName
+      : never
+    : never
+
+// === Container ===
+
+/** @internal */
+type SchemaContainerConfig<TSchema extends SchemaDefinition> =
+  AllScopedNames<TSchema> extends infer TType extends string
+    ? TType extends TType
+      ? {
+          scope: TType
+          field: ScopedArrayFields<TSchema, TType>
+          render?: (props: {
+            attributes: Record<string, unknown>
+            children: ReactElement
+            node: PortableTextBlock
+          }) => ReactElement | null
+        }
+      : never
+    : never
 
 /**
  * @internal
  */
-export type Renderer = {
-  type: string
-  render: (props: {
+export type Container = {
+  scope: string
+  field: string
+  render?: (props: {
     attributes: Record<string, unknown>
     children: ReactElement
-    node: PortableTextObject
-  }) => ReactElement
+    node: PortableTextBlock
+  }) => ReactElement | null
+}
+
+/**
+ * @internal
+ *
+ * Define a container for a block object type.
+ *
+ * When called with a schema type parameter, constrains `scope` to valid
+ * scoped type names, `field` to array field names on that type, and
+ * provides the `render` function signature:
+ *
+ * ```ts
+ * defineContainer<typeof schema>({
+ *   scope: 'table.row.cell',
+ *   field: 'content',
+ *   render: ({children}) => <td>{children}</td>,
+ * })
+ * ```
+ *
+ * Without a schema type parameter, accepts any string:
+ *
+ * ```ts
+ * defineContainer({
+ *   scope: 'callout',
+ *   field: 'content',
+ *   render: ({children}) => <div>{children}</div>,
+ * })
+ * ```
+ */
+export function defineContainer<TSchema extends SchemaDefinition>(
+  config: SchemaContainerConfig<TSchema>,
+): Container
+export function defineContainer(config: Container): Container
+export function defineContainer(config: Container): Container {
+  return config
 }
 
 /**
  * @internal
  */
 export type ContainerConfig = {
-  renderer: Renderer
+  container: Container
 }

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -20,7 +20,18 @@ describe(resolveContainers.name, () => {
     expect(
       resolveContainers(
         schema,
-        new Map([['code', {renderer: {type: 'code'}}]]),
+        new Map([
+          [
+            'code',
+            {
+              container: {
+                scope: 'code',
+                field: 'content',
+                render: ({children}) => children,
+              },
+            },
+          ],
+        ]),
       ),
     ).toEqual(
       new Map([
@@ -69,10 +80,43 @@ describe(resolveContainers.name, () => {
       }),
     )
 
+    const render = ({children}: {children: unknown}) => children
+
     expect(
       resolveContainers(
         schema,
-        new Map([['table', {renderer: {type: 'table'}}]]),
+        new Map([
+          [
+            'table',
+            {
+              container: {
+                scope: 'table',
+                field: 'rows',
+                render: render as any,
+              },
+            },
+          ],
+          [
+            'table.row',
+            {
+              container: {
+                scope: 'table.row',
+                field: 'cells',
+                render: render as any,
+              },
+            },
+          ],
+          [
+            'table.row.cell',
+            {
+              container: {
+                scope: 'table.row.cell',
+                field: 'content',
+                render: render as any,
+              },
+            },
+          ],
+        ]),
       ),
     ).toEqual(
       new Map([
@@ -107,10 +151,6 @@ describe(resolveContainers.name, () => {
           },
         ],
         [
-          'table.row.cell',
-          {name: 'content', type: 'array', of: [{type: 'block'}]},
-        ],
-        [
           'table.row',
           {
             name: 'cells',
@@ -129,6 +169,10 @@ describe(resolveContainers.name, () => {
             ],
           },
         ],
+        [
+          'table.row.cell',
+          {name: 'content', type: 'array', of: [{type: 'block'}]},
+        ],
       ]),
     )
   })
@@ -139,32 +183,7 @@ describe(resolveContainers.name, () => {
     expect(resolveContainers(schema, new Map())).toEqual(new Map())
   })
 
-  test('uses the first array field when multiple exist on the same type', () => {
-    const schema = compileSchema(
-      defineSchema({
-        blockObjects: [
-          {
-            name: 'table',
-            fields: [
-              {name: 'rows', type: 'array', of: [{type: 'row'}]},
-              {name: 'alternateRows', type: 'array', of: [{type: 'row'}]},
-            ],
-          },
-        ],
-      }),
-    )
-
-    expect(
-      resolveContainers(
-        schema,
-        new Map([['table', {renderer: {type: 'table'}}]]),
-      ),
-    ).toEqual(
-      new Map([['table', {name: 'rows', type: 'array', of: [{type: 'row'}]}]]),
-    )
-  })
-
-  test('merges types from multiple containers', () => {
+  test('merges types from multiple container configs', () => {
     const schema = compileSchema(
       defineSchema({
         blockObjects: [
@@ -182,18 +201,200 @@ describe(resolveContainers.name, () => {
       }),
     )
 
+    const render = ({children}: {children: unknown}) => children
+
     expect(
       resolveContainers(
         schema,
         new Map([
-          ['code', {renderer: {type: 'code'}}],
-          ['callout', {renderer: {type: 'callout'}}],
+          [
+            'code',
+            {
+              container: {
+                scope: 'code',
+                field: 'content',
+                render: render as any,
+              },
+            },
+          ],
+          [
+            'callout',
+            {
+              container: {
+                scope: 'callout',
+                field: 'content',
+                render: render as any,
+              },
+            },
+          ],
         ]),
       ),
     ).toEqual(
       new Map([
         ['code', {name: 'content', type: 'array', of: [{type: 'codeLine'}]}],
         ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
+      ]),
+    )
+  })
+
+  test('resolves bare block scope to synthesized children field', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+        inlineObjects: [{name: 'stock-ticker'}],
+      }),
+    )
+
+    const render = ({children}: {children: unknown}) => children
+
+    expect(
+      resolveContainers(
+        schema,
+        new Map([
+          [
+            'block',
+            {
+              container: {
+                scope: 'block',
+                field: 'children',
+                render: render as any,
+              },
+            },
+          ],
+        ]),
+      ),
+    ).toEqual(
+      new Map([
+        [
+          'block',
+          {
+            name: 'children',
+            type: 'array',
+            of: [{type: 'span'}, {type: 'stock-ticker'}],
+          },
+        ],
+      ]),
+    )
+  })
+
+  test('resolves scoped block scope like callout.block', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+    )
+
+    const render = ({children}: {children: unknown}) => children
+
+    expect(
+      resolveContainers(
+        schema,
+        new Map([
+          [
+            'callout',
+            {
+              container: {
+                scope: 'callout',
+                field: 'content',
+                render: render as any,
+              },
+            },
+          ],
+          [
+            'callout.block',
+            {
+              container: {
+                scope: 'callout.block',
+                field: 'children',
+                render: render as any,
+              },
+            },
+          ],
+        ]),
+      ),
+    ).toEqual(
+      new Map([
+        ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
+        [
+          'callout.block',
+          {name: 'children', type: 'array', of: [{type: 'span'}]},
+        ],
+      ]),
+    )
+  })
+
+  test('resolves block scope without inline objects', () => {
+    const schema = compileSchema(defineSchema({}))
+
+    const render = ({children}: {children: unknown}) => children
+
+    expect(
+      resolveContainers(
+        schema,
+        new Map([
+          [
+            'block',
+            {
+              container: {
+                scope: 'block',
+                field: 'children',
+                render: render as any,
+              },
+            },
+          ],
+        ]),
+      ),
+    ).toEqual(
+      new Map([
+        ['block', {name: 'children', type: 'array', of: [{type: 'span'}]}],
+      ]),
+    )
+  })
+
+  test('ignores fields not matching the declared name', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'figure',
+            fields: [
+              {name: 'caption', type: 'array', of: [{type: 'block'}]},
+              {name: 'tags', type: 'array', of: [{type: 'string'}]},
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(
+      resolveContainers(
+        schema,
+        new Map([
+          [
+            'figure',
+            {
+              container: {
+                scope: 'figure',
+                field: 'caption',
+                render: ({children}) => children,
+              },
+            },
+          ],
+        ]),
+      ),
+    ).toEqual(
+      new Map([
+        ['figure', {name: 'caption', type: 'array', of: [{type: 'block'}]}],
       ]),
     )
   })

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -1,5 +1,6 @@
 import type {FieldDefinition, OfDefinition} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import type {ContainerConfig} from '../renderers/renderer.types'
 
 export type ChildArrayField = FieldDefinition & {
   type: 'array'
@@ -16,76 +17,126 @@ export type Containers = Map<string, ChildArrayField>
 
 /**
  * Resolve the complete Containers Map from a schema and a set of
- * registered containers. Walks the schema once per container type,
- * collecting all scoped type paths and their editable array fields.
+ * registered container configs. Each config declares a scope and
+ * a field (the child array field). The resolver walks the schema to find the
+ * matching field definition.
  */
 export function resolveContainers(
   schema: EditorSchema,
-  containerConfigs: Map<string, {renderer: {type: string}}>,
+  containerConfigs: Map<string, ContainerConfig>,
 ): Containers {
   const containers: Containers = new Map()
 
   for (const [, config] of containerConfigs) {
-    for (const entry of resolveTypePaths(schema, config.renderer.type)) {
-      if (entry.field) {
-        containers.set(entry.path, entry.field)
-      }
+    const resolved = resolveContainerField(schema, {
+      scope: config.container.scope,
+      field: config.container.field,
+    })
+    if (resolved) {
+      containers.set(resolved.scope, resolved.field)
     }
   }
 
   return containers
 }
 
-function resolveTypePaths(
-  schema: EditorSchema,
-  typeName: string,
-): Array<{path: string; field: ChildArrayField | undefined}> {
-  const entries: Array<{path: string; field: ChildArrayField | undefined}> = []
-
-  const blockObject = schema.blockObjects.find(
-    (definition) => definition.name === typeName,
-  )
-
-  if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
-    entries.push({path: typeName, field: undefined})
-    return entries
-  }
-
-  const rootField = resolveFirstChildArrayField(blockObject.fields)
-  walkFields(blockObject.fields, typeName, entries)
-  entries.unshift({path: typeName, field: rootField})
-  return entries
-}
-
 function isChildArrayField(field: FieldDefinition): field is ChildArrayField {
   return field.type === 'array' && 'of' in field && Array.isArray(field.of)
 }
 
-function resolveFirstChildArrayField(
-  fields: ReadonlyArray<FieldDefinition>,
-): ChildArrayField | undefined {
-  return fields.find(isChildArrayField)
+/**
+ * JSON primitive type names. Arrays containing only primitive types don't
+ * have `_key` properties on their members and can't be used as editable
+ * container content.
+ */
+const PRIMITIVE_TYPES = new Set(['string', 'number', 'boolean'])
+
+function containsOnlyPrimitiveTypes(field: ChildArrayField): boolean {
+  return field.of.every((member) => PRIMITIVE_TYPES.has(member.type))
 }
 
-function walkFields(
-  fields: ReadonlyArray<FieldDefinition>,
-  currentPath: string,
-  entries: Array<{path: string; field: ChildArrayField | undefined}>,
-) {
-  for (const field of fields) {
-    if (isChildArrayField(field)) {
-      for (const ofMember of field.of) {
-        if (ofMember.type === 'block') {
-          continue
-        }
-        const scopedPath = `${currentPath}.${ofMember.type}`
-        let childField: ChildArrayField | undefined
-        if ('fields' in ofMember && ofMember.fields) {
-          childField = resolveFirstChildArrayField(ofMember.fields)
-          walkFields(ofMember.fields, scopedPath, entries)
-        }
-        entries.push({path: scopedPath, field: childField})
-      }
+function resolveContainerField(
+  schema: EditorSchema,
+  containerConfig: {scope: string; field: string},
+): {scope: string; field: ChildArrayField} | undefined {
+  // Split the scope into segments to find the type definition
+  const segments = containerConfig.scope.split('.')
+  const lastSegment = segments[segments.length - 1]
+
+  // Handle 'block' scope (text block children)
+  if (lastSegment === 'block') {
+    if (containerConfig.field !== 'children') {
+      return undefined
+    }
+    return {
+      scope: containerConfig.scope,
+      field: synthesizeBlockChildrenField(schema),
     }
   }
+
+  // The first segment is always a block object name
+  const blockObject = schema.blockObjects.find(
+    (definition) => definition.name === segments[0],
+  )
+
+  if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
+    return undefined
+  }
+
+  // Walk nested types for multi-segment scopes (e.g., 'table.row.cell')
+  let currentFields: ReadonlyArray<FieldDefinition> = blockObject.fields
+
+  for (let i = 1; i < segments.length; i++) {
+    const segmentType = segments[i]!
+    let found = false
+
+    for (const field of currentFields) {
+      if (isChildArrayField(field)) {
+        for (const ofMember of field.of) {
+          if (
+            ofMember.type === segmentType &&
+            'fields' in ofMember &&
+            ofMember.fields
+          ) {
+            currentFields = ofMember.fields
+            found = true
+            break
+          }
+        }
+      }
+      if (found) {
+        break
+      }
+    }
+
+    if (!found) {
+      return undefined
+    }
+  }
+
+  // Find the declared name (child array field) in the resolved fields
+  const childField = currentFields.find(
+    (field) => field.name === containerConfig.field,
+  )
+
+  if (!childField || !isChildArrayField(childField)) {
+    return undefined
+  }
+
+  if (containsOnlyPrimitiveTypes(childField)) {
+    console.warn(
+      `Field '${childField.name}' on '${containerConfig.scope}' doesn't contain block or container types and will be excluded`,
+    )
+    return undefined
+  }
+
+  return {scope: containerConfig.scope, field: childField}
+}
+
+function synthesizeBlockChildrenField(schema: EditorSchema): ChildArrayField {
+  const ofMembers: Array<OfDefinition> = [{type: 'span'}]
+  for (const inlineObject of schema.inlineObjects) {
+    ofMembers.push({type: inlineObject.name})
+  }
+  return {name: 'children', type: 'array', of: ofMembers}
 }

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -92,7 +92,8 @@ import {RestoreDOM} from './restore-dom/restore-dom'
 type DeferredOperation = () => void
 
 const Children = (props: Parameters<typeof useChildren>[0]) => {
-  return <React.Fragment>{useChildren(props)}</React.Fragment>
+  const children = useChildren(props)
+  return <React.Fragment>{children}</React.Fragment>
 }
 
 /**

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -4,7 +4,7 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import {isSpan, isTextBlock} from '@portabletext/schema'
-import {useCallback, useRef, type JSX} from 'react'
+import React, {useCallback, useRef, type JSX} from 'react'
 import {
   ContainerScopeContext,
   useContainerScope,
@@ -46,7 +46,7 @@ const useChildren = (props: {
   renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
-}) => {
+}): React.ReactNode => {
   const {
     parentDataPath,
     decorations,
@@ -105,7 +105,7 @@ const useChildren = (props: {
           : `${parentDataPath}.${childFieldName}[_key=="${node._key}"]`
 
       return (
-        <ElementContext.Provider key={`provider-${node._key}`} value={node}>
+        <ElementContext key={`provider-${node._key}`} value={node}>
           <ElementComponent
             dataPath={nodeDataPath}
             decorations={decorationsByChild[i] ?? []}
@@ -117,7 +117,7 @@ const useChildren = (props: {
             renderLeaf={renderLeaf}
             renderText={renderText}
           />
-        </ElementContext.Provider>
+        </ElementContext>
       )
     },
     [
@@ -213,13 +213,13 @@ const useChildren = (props: {
 
   if (childScope && childScope !== containerScope) {
     return (
-      <ContainerScopeContext.Provider value={childScope}>
+      <ContainerScopeContext value={childScope}>
         {elements}
-      </ContainerScopeContext.Provider>
+      </ContainerScopeContext>
     )
   }
 
-  return elements
+  return <>{elements}</>
 }
 
 const useDecorationsByChild = (

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -5,6 +5,7 @@ import {describe, expect, test, vi} from 'vitest'
 import type {InternalEditor} from '../src/editor/create-editor'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {PatchesPlugin} from '../src/plugins/plugin.patches'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 const schemaDefinition = defineSchema({
@@ -55,21 +56,37 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-const tableRenderers = [
+const tableContainers = [
   {
-    renderer: {
-      type: 'table' as const,
-      render: ({children}: {children: React.ReactNode}) => <>{children}</>,
-    },
+    container: defineContainer({
+      scope: 'table',
+      field: 'rows',
+      render: ({children}) => <>{children}</>,
+    }),
+  },
+  {
+    container: defineContainer({
+      scope: 'table.row',
+      field: 'cells',
+      render: ({children}) => <>{children}</>,
+    }),
+  },
+  {
+    container: defineContainer({
+      scope: 'table.row.cell',
+      field: 'content',
+      render: ({children}) => <>{children}</>,
+    }),
   },
 ]
 
-const calloutRenderers = [
+const calloutContainers = [
   {
-    renderer: {
-      type: 'callout' as const,
-      render: ({children}: {children: React.ReactNode}) => <>{children}</>,
-    },
+    container: defineContainer({
+      scope: 'callout',
+      field: 'content',
+      render: ({children}) => <>{children}</>,
+    }),
   },
 ]
 
@@ -96,7 +113,7 @@ describe('container normalization', () => {
           _key: rowKey,
         },
       ],
-      children: <ContainerPlugin containers={tableRenderers} />,
+      children: <ContainerPlugin containers={tableContainers} />,
     })
 
     await vi.waitFor(() => {
@@ -143,7 +160,7 @@ describe('container normalization', () => {
       children: (
         <>
           <PatchesPlugin patches={patches} />
-          <ContainerPlugin containers={tableRenderers} />
+          <ContainerPlugin containers={tableContainers} />
         </>
       ),
     })
@@ -317,7 +334,7 @@ describe('container normalization', () => {
       children: (
         <>
           <PatchesPlugin patches={patches} />
-          <ContainerPlugin containers={calloutRenderers} />
+          <ContainerPlugin containers={calloutContainers} />
         </>
       ),
     })
@@ -491,7 +508,7 @@ describe('container normalization', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={tableRenderers} />,
+      children: <ContainerPlugin containers={tableContainers} />,
     })
 
     // Verify initial value is correct
@@ -633,7 +650,7 @@ describe('container normalization', () => {
       children: (
         <>
           <PatchesPlugin patches={patches} />
-          <ContainerPlugin containers={calloutRenderers} />
+          <ContainerPlugin containers={calloutContainers} />
         </>
       ),
     })
@@ -763,7 +780,7 @@ describe('container normalization', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={tableRenderers} />,
+      children: <ContainerPlugin containers={tableContainers} />,
     })
 
     await vi.waitFor(() => {
@@ -867,7 +884,7 @@ describe('container normalization', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={calloutRenderers} />,
+      children: <ContainerPlugin containers={calloutContainers} />,
     })
 
     await vi.waitFor(() => {
@@ -944,7 +961,7 @@ describe('container normalization', () => {
       ],
       children: (
         <ContainerPlugin
-          containers={[...tableRenderers, ...calloutRenderers]}
+          containers={[...tableContainers, ...calloutContainers]}
         />
       ),
     })
@@ -1019,7 +1036,7 @@ describe('container normalization', () => {
           style: 'normal',
         },
       ],
-      children: <ContainerPlugin containers={calloutRenderers} />,
+      children: <ContainerPlugin containers={calloutContainers} />,
     })
 
     // Insert a bare callout via incoming patch
@@ -1158,7 +1175,7 @@ describe('container normalization', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={tableRenderers} />,
+      children: <ContainerPlugin containers={tableContainers} />,
     })
 
     await vi.waitFor(() => {
@@ -1189,153 +1206,6 @@ describe('container normalization', () => {
                         {
                           _type: 'span',
                           _key: 'k8',
-                          text: '',
-                          marks: [],
-                        },
-                      ],
-                      markDefs: [],
-                      style: 'normal',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ])
-    })
-  })
-
-  test('remote value update with deeply nested childless block is normalized', async () => {
-    const keyGenerator = createTestKeyGenerator()
-    const blockKey = keyGenerator()
-    const spanKey = keyGenerator()
-    const tableKey = keyGenerator()
-    const rowKey = keyGenerator()
-    const cellKey = keyGenerator()
-    const contentBlockKey = keyGenerator()
-    const contentSpanKey = keyGenerator()
-
-    const {editor} = await createTestEditor({
-      keyGenerator,
-      schemaDefinition,
-      initialValue: [
-        {
-          _type: 'block',
-          _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
-          markDefs: [],
-          style: 'normal',
-        },
-        {
-          _type: 'table',
-          _key: tableKey,
-          rows: [
-            {
-              _type: 'row',
-              _key: rowKey,
-              cells: [
-                {
-                  _type: 'cell',
-                  _key: cellKey,
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: contentBlockKey,
-                      children: [
-                        {
-                          _type: 'span',
-                          _key: contentSpanKey,
-                          text: 'world',
-                          marks: [],
-                        },
-                      ],
-                      markDefs: [],
-                      style: 'normal',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      children: <ContainerPlugin containers={tableRenderers} />,
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toHaveLength(2)
-    })
-
-    // Simulate a remote value update that replaces the table's rows
-    // with a new row whose cell has a block missing children.
-    // This goes through sync machine -> applySetNode({rows: [...]})
-    // which triggers the set_node case in getDirtyPaths.
-    editor.send({
-      type: 'update value',
-      value: [
-        {
-          _type: 'block',
-          _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
-          markDefs: [],
-          style: 'normal',
-        },
-        {
-          _type: 'table',
-          _key: tableKey,
-          rows: [
-            {
-              _type: 'row',
-              _key: 'new-row',
-              cells: [
-                {
-                  _type: 'cell',
-                  _key: 'new-cell',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'new-block',
-                      markDefs: [],
-                      style: 'normal',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual([
-        {
-          _type: 'block',
-          _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
-          markDefs: [],
-          style: 'normal',
-        },
-        {
-          _type: 'table',
-          _key: tableKey,
-          rows: [
-            {
-              _type: 'row',
-              _key: 'new-row',
-              cells: [
-                {
-                  _type: 'cell',
-                  _key: 'new-cell',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'new-block',
-                      children: [
-                        {
-                          _type: 'span',
-                          _key: 'k9',
                           text: '',
                           marks: [],
                         },
@@ -1393,7 +1263,7 @@ describe('container normalization', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={calloutRenderers} />,
+      children: <ContainerPlugin containers={calloutContainers} />,
     })
 
     await vi.waitFor(() => {
@@ -1439,7 +1309,7 @@ describe('container normalization', () => {
     })
   })
 
-  test('late renderer registration normalizes existing void container', async () => {
+  test('late container registration normalizes existing void container', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
     const spanKey = keyGenerator()
@@ -1485,9 +1355,10 @@ describe('container normalization', () => {
     ;(editor as unknown as InternalEditor)._internal.editorActor.send({
       type: 'register container',
       containerConfig: {
-        renderer: {
-          type: 'callout',
-          render: ({children}: {children: React.ReactNode}) => <>{children}</>,
+        container: {
+          scope: 'callout',
+          field: 'content',
+          render: ({children}) => children,
         },
       },
     })
@@ -1519,116 +1390,6 @@ describe('container normalization', () => {
     })
   })
 
-  test('Scenario: container child with `_type` unset gets the default block type', async () => {
-    const patches: Array<Patch> = []
-    const keyGenerator = createTestKeyGenerator()
-    const blockKey = keyGenerator()
-    const spanKey = keyGenerator()
-    const calloutKey = keyGenerator()
-    const contentBlockKey = keyGenerator()
-    const contentSpanKey = keyGenerator()
-
-    const {editor} = await createTestEditor({
-      keyGenerator,
-      schemaDefinition,
-      initialValue: [
-        {
-          _type: 'block',
-          _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
-          markDefs: [],
-          style: 'normal',
-        },
-        {
-          _type: 'callout',
-          _key: calloutKey,
-          content: [
-            {
-              _type: 'block',
-              _key: contentBlockKey,
-              children: [
-                {
-                  _type: 'span',
-                  _key: contentSpanKey,
-                  text: '',
-                  marks: [],
-                },
-              ],
-              markDefs: [],
-              style: 'normal',
-            },
-          ],
-        },
-      ],
-      children: (
-        <>
-          <PatchesPlugin patches={patches} />
-          <ContainerPlugin containers={calloutRenderers} />
-        </>
-      ),
-    })
-
-    editor.send({
-      type: 'patches',
-      patches: [
-        {
-          type: 'unset',
-          path: [
-            {_key: calloutKey},
-            'content',
-            {_key: contentBlockKey},
-            '_type',
-          ],
-        },
-      ],
-      snapshot: undefined,
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual([
-        {
-          _type: 'block',
-          _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
-          markDefs: [],
-          style: 'normal',
-        },
-        {
-          _type: 'callout',
-          _key: calloutKey,
-          content: [
-            {
-              _type: 'block',
-              _key: contentBlockKey,
-              children: [
-                {
-                  _type: 'span',
-                  _key: contentSpanKey,
-                  text: '',
-                  marks: [],
-                },
-              ],
-              markDefs: [],
-              style: 'normal',
-            },
-          ],
-        },
-      ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [
-            {_key: calloutKey},
-            'content',
-            {_key: contentBlockKey},
-            '_type',
-          ],
-          value: 'block',
-        },
-      ])
-    })
-  })
-
   test('container block with no `_key` gets a key via numeric index', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
@@ -1652,7 +1413,7 @@ describe('container normalization', () => {
       children: (
         <>
           <PatchesPlugin patches={patches} />
-          <ContainerPlugin containers={calloutRenderers} />
+          <ContainerPlugin containers={calloutContainers} />
         </>
       ),
     })
@@ -1718,6 +1479,592 @@ describe('container normalization', () => {
           type: 'set',
           path: [{_key: calloutKey}, 'content', 0, '_key'],
           value: 'k6',
+        },
+      ])
+    })
+  })
+
+  test('non-block editable field produces warning and is excluded', async () => {
+    const cardSchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'card',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+            {
+              name: 'tags',
+              type: 'array',
+              of: [{type: 'string'}],
+            },
+          ],
+        },
+      ],
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const cardKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: cardSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'card',
+          _key: cardKey,
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: defineContainer({
+                scope: 'card',
+                field: 'tags',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    // The card should NOT be normalized because 'tags' is excluded
+    // (primitive types only)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'card',
+          _key: cardKey,
+        },
+      ])
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Field 'tags' on 'card' doesn't contain block or container types and will be excluded",
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  test('three independent containers normalize without interference', async () => {
+    const multiContainerSchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+        {
+          name: 'row',
+        },
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'row',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'cell',
+                          fields: [
+                            {
+                              name: 'content',
+                              type: 'array',
+                              of: [{type: 'block'}],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'figure',
+          fields: [
+            {
+              name: 'caption',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    })
+
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const figureKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: multiContainerSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+        },
+        {
+          _type: 'figure',
+          _key: figureKey,
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: {
+                scope: 'callout',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              },
+            },
+            {
+              container: {
+                scope: 'table',
+                field: 'rows',
+                render: ({children}) => <>{children}</>,
+              },
+            },
+            {
+              container: {
+                scope: 'table.row',
+                field: 'cells',
+                render: ({children}) => <>{children}</>,
+              },
+            },
+            {
+              container: {
+                scope: 'table.row.cell',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              },
+            },
+            {
+              container: {
+                scope: 'figure',
+                field: 'caption',
+                render: ({children}) => <>{children}</>,
+              },
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k9',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k10',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k11',
+                      children: [
+                        {_type: 'span', _key: 'k12', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'figure',
+          _key: figureKey,
+          caption: [
+            {
+              _type: 'block',
+              _key: 'k13',
+              children: [{_type: 'span', _key: 'k14', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('full hierarchy normalizes all levels', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const tableKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: defineContainer({
+                scope: 'table',
+                field: 'rows',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+            {
+              container: defineContainer({
+                scope: 'table.row',
+                field: 'cells',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+            {
+              container: defineContainer({
+                scope: 'table.row.cell',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k5',
+                      children: [
+                        {_type: 'span', _key: 'k6', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('shallow table normalizes to full cursor-ready structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: defineContainer({
+                scope: 'table',
+                field: 'rows',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+            {
+              container: defineContainer({
+                scope: 'table.row',
+                field: 'cells',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+            {
+              container: defineContainer({
+                scope: 'table.row.cell',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}],
+          position: 'after',
+          items: [{_type: 'table'}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: 'k4',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k5',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k6',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k7',
+                      children: [
+                        {_type: 'span', _key: 'k8', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('unregistering container reverts container to void', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainers} />,
+    })
+
+    // Verify normalization happened
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    // Unregister the container via the internal editor actor
+    ;(editor as unknown as InternalEditor)._internal.editorActor.send({
+      type: 'unregister container',
+      containerConfig: {
+        container: {
+          scope: 'callout',
+          field: 'content',
+          render: ({children}) => children,
+        },
+      },
+    })
+
+    // Send a new value with a callout with empty content
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: calloutKey}, 'content'],
+          value: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    // The empty content array should NOT be normalized because the type
+    // is no longer editable
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [],
         },
       ])
     })

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -1,0 +1,959 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const calloutContainer = defineContainer({
+  scope: 'callout',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <div data-testid="callout" {...attributes}>
+      {children}
+    </div>
+  ),
+})
+
+describe('container rendering', () => {
+  test('callout renders with correct DOM structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'content-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'content-span',
+                  text: 'inside callout',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin containers={[{container: calloutContainer}]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          // root text block
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;]"',
+          ' class="pt-block pt-text-block pt-text-block-style-normal"',
+          ' data-block-key="k0"',
+          ' data-block-name="block"',
+          ' data-block-type="text"',
+          ' data-style="normal"',
+          '>',
+          // text block inner wrapper
+          '<div>',
+          // span
+          '<span data-slate-node="text"',
+          ' data-pt-path="[_key==&quot;k0&quot;].children[_key==&quot;k1&quot;]"',
+          ' data-child-key="k1"',
+          ' data-child-name="span"',
+          ' data-child-type="span"',
+          '>',
+          // leaf
+          '<span data-slate-leaf="true">',
+          '<span data-slate-string="true">hello</span>',
+          '</span>',
+          // /span
+          '</span>',
+          // /text block inner wrapper
+          '</div>',
+          // /root text block
+          '</div>',
+          // callout container
+          '<div data-testid="callout"',
+          ' data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k2&quot;]"',
+          '>',
+          // inner text block
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k2&quot;].content[_key==&quot;content-block&quot;]"',
+          ' class="pt-block pt-text-block pt-text-block-style-normal"',
+          ' data-block-key="content-block"',
+          ' data-block-name="block"',
+          ' data-block-type="text"',
+          ' data-style="normal"',
+          '>',
+          // inner text block wrapper
+          '<div>',
+          // inner span
+          '<span data-slate-node="text"',
+          ' data-pt-path="[_key==&quot;k2&quot;].content[_key==&quot;content-block&quot;].children[_key==&quot;content-span&quot;]"',
+          ' data-child-key="content-span"',
+          ' data-child-name="span"',
+          ' data-child-type="span"',
+          '>',
+          // inner leaf
+          '<span data-slate-leaf="true">',
+          '<span data-slate-string="true">inside callout</span>',
+          '</span>',
+          // /inner span
+          '</span>',
+          // /inner text block wrapper
+          '</div>',
+          // /inner text block
+          '</div>',
+          // /callout container
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
+
+  test('node prop receives the raw node data', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const receivedNodes: Array<{_type: string; _key: string}> = []
+
+    const trackingContainer = defineContainer({
+      scope: 'callout',
+      field: 'content',
+      render: ({attributes, children, node}) => {
+        receivedNodes.push({_type: node._type, _key: node._key})
+        return (
+          <div data-testid="callout" {...attributes}>
+            {children}
+          </div>
+        )
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'content-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'content-span',
+                  text: 'inside callout',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin containers={[{container: trackingContainer}]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(receivedNodes.at(-1)).toEqual({
+        _type: 'callout',
+        _key: calloutKey,
+      })
+    })
+  })
+})
+
+describe('table with nested rows and cells', () => {
+  const tableSchemaDefinition = defineSchema({
+    blockObjects: [
+      {
+        name: 'table',
+        fields: [
+          {
+            name: 'rows',
+            type: 'array',
+            of: [
+              {
+                type: 'row',
+                fields: [
+                  {
+                    name: 'cells',
+                    type: 'array',
+                    of: [
+                      {
+                        type: 'cell',
+                        fields: [
+                          {
+                            name: 'content',
+                            type: 'array',
+                            of: [{type: 'block'}],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  const tableContainer = defineContainer({
+    scope: 'table',
+    field: 'rows',
+    render: ({attributes, children}) => (
+      <table data-testid="table" {...attributes}>
+        <tbody>{children}</tbody>
+      </table>
+    ),
+  })
+
+  const rowContainer = defineContainer({
+    scope: 'table.row',
+    field: 'cells',
+    render: ({attributes, children}) => (
+      <tr data-testid="row" {...attributes}>
+        {children}
+      </tr>
+    ),
+  })
+
+  const cellContainer = defineContainer({
+    scope: 'table.row.cell',
+    field: 'content',
+    render: ({attributes, children}) => (
+      <td data-testid="cell" {...attributes}>
+        {children}
+      </td>
+    ),
+  })
+
+  test('renders three levels of nesting with correct DOM structure', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'block-0',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'span-0',
+                          text: 'cell text',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {container: tableContainer},
+            {container: rowContainer},
+            {container: cellContainer},
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          // table container
+          '<table data-testid="table"',
+          ' data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;]"',
+          '>',
+          '<tbody>',
+          // row container
+          '<tr data-testid="row"',
+          ' data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;]"',
+          '>',
+          // cell container
+          '<td data-testid="cell"',
+          ' data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;]"',
+          '>',
+          // text block inside cell
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;]"',
+          ' class="pt-block pt-text-block pt-text-block-style-normal"',
+          ' data-block-key="block-0"',
+          ' data-block-name="block"',
+          ' data-block-type="text"',
+          ' data-style="normal"',
+          '>',
+          // text block inner wrapper
+          '<div>',
+          // span
+          '<span data-slate-node="text"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;].children[_key==&quot;span-0&quot;]"',
+          ' data-child-key="span-0"',
+          ' data-child-name="span"',
+          ' data-child-type="span"',
+          '>',
+          // leaf
+          '<span data-slate-leaf="true">',
+          '<span data-slate-string="true">cell text</span>',
+          '</span>',
+          // /span
+          '</span>',
+          // /text block inner wrapper
+          '</div>',
+          // /text block inside cell
+          '</div>',
+          // /cell container
+          '</td>',
+          // /row container
+          '</tr>',
+          '</tbody>',
+          // /table container
+          '</table>',
+        ].join(''),
+      )
+    })
+  })
+})
+
+describe('container with non-editable fields', () => {
+  const cardSchemaDefinition = defineSchema({
+    blockObjects: [
+      {
+        name: 'card',
+        fields: [
+          {
+            name: 'body',
+            type: 'array',
+            of: [{type: 'block'}],
+          },
+          {
+            name: 'tags',
+            type: 'array',
+            of: [{type: 'string'}],
+          },
+        ],
+      },
+    ],
+  })
+
+  const cardContainer = defineContainer({
+    scope: 'card',
+    field: 'body',
+    render: ({attributes, children}) => (
+      <div data-testid="card" {...attributes}>
+        {children}
+      </div>
+    ),
+  })
+
+  test('only editable fields render in the DOM', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const cardKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: cardSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'card',
+          _key: cardKey,
+          body: [
+            {
+              _type: 'block',
+              _key: 'body-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'body-span',
+                  text: 'card body',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: ['tag1', 'tag2'],
+        },
+      ],
+      children: <ContainerPlugin containers={[{container: cardContainer}]} />,
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          // card container
+          '<div data-testid="card"',
+          ' data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;]"',
+          '>',
+          // body text block
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;].body[_key==&quot;body-block&quot;]"',
+          ' class="pt-block pt-text-block pt-text-block-style-normal"',
+          ' data-block-key="body-block"',
+          ' data-block-name="block"',
+          ' data-block-type="text"',
+          ' data-style="normal"',
+          '>',
+          // body text block inner wrapper
+          '<div>',
+          // body span
+          '<span data-slate-node="text"',
+          ' data-pt-path="[_key==&quot;k0&quot;].body[_key==&quot;body-block&quot;].children[_key==&quot;body-span&quot;]"',
+          ' data-child-key="body-span"',
+          ' data-child-name="span"',
+          ' data-child-type="span"',
+          '>',
+          // body leaf
+          '<span data-slate-leaf="true">',
+          '<span data-slate-string="true">card body</span>',
+          '</span>',
+          // /body span
+          '</span>',
+          // /body text block inner wrapper
+          '</div>',
+          // /body text block
+          '</div>',
+          // /card container (no tags in DOM)
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
+})
+
+describe('block scope and specificity', () => {
+  test('block scope overrides text block rendering', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: defineContainer({
+                scope: 'block',
+                field: 'children',
+                render: ({attributes, children}) => (
+                  <p data-testid="custom-block" {...attributes}>
+                    {children}
+                  </p>
+                ),
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+      const customBlock = editorElement!.querySelector(
+        '[data-testid="custom-block"]',
+      )
+      expect(customBlock).not.toEqual(null)
+      expect(customBlock!.textContent).toEqual('hello')
+    })
+  })
+
+  test('scoped block overrides universal block inside container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'root-block',
+          children: [
+            {
+              _type: 'span',
+              _key: 'root-span',
+              text: 'root text',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'callout-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'callout-span',
+                  text: 'callout text',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {container: calloutContainer},
+            {
+              container: defineContainer({
+                scope: 'block',
+                field: 'children',
+                render: ({attributes, children}) => (
+                  <p data-testid="universal-block" {...attributes}>
+                    {children}
+                  </p>
+                ),
+              }),
+            },
+            {
+              container: defineContainer({
+                scope: 'callout.block',
+                field: 'children',
+                render: ({attributes, children}) => (
+                  <p data-testid="callout-block" {...attributes}>
+                    {children}
+                  </p>
+                ),
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      const universalBlock = editorElement!.querySelector(
+        '[data-testid="universal-block"]',
+      )
+      expect(universalBlock).not.toEqual(null)
+      expect(universalBlock!.textContent).toEqual('root text')
+
+      const calloutBlock = editorElement!.querySelector(
+        '[data-testid="callout-block"]',
+      )
+      expect(calloutBlock).not.toEqual(null)
+      expect(calloutBlock!.textContent).toEqual('callout text')
+    })
+  })
+
+  test('universal block fallback applies inside container when no scoped override', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'root-block',
+          children: [
+            {
+              _type: 'span',
+              _key: 'root-span',
+              text: 'root text',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'callout-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'callout-span',
+                  text: 'callout text',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {container: calloutContainer},
+            {
+              container: defineContainer({
+                scope: 'block',
+                field: 'children',
+                render: ({attributes, children}) => (
+                  <p data-testid="universal-block" {...attributes}>
+                    {children}
+                  </p>
+                ),
+              }),
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      const universalBlocks = editorElement!.querySelectorAll(
+        '[data-testid="universal-block"]',
+      )
+      expect(universalBlocks.length).toEqual(2)
+      expect(universalBlocks[0]!.textContent).toEqual('root text')
+      expect(universalBlocks[1]!.textContent).toEqual('callout text')
+    })
+  })
+})
+
+describe('container with only void objects', () => {
+  const gallerySchemaDefinition = defineSchema({
+    blockObjects: [
+      {
+        name: 'gallery',
+        fields: [
+          {
+            name: 'items',
+            type: 'array',
+            of: [{type: 'image'}],
+          },
+        ],
+      },
+      {
+        name: 'image',
+        fields: [{name: 'url', type: 'string'}],
+      },
+    ],
+  })
+
+  const galleryContainer = defineContainer({
+    scope: 'gallery',
+    field: 'items',
+    render: ({attributes, children}) => (
+      <div data-testid="gallery" {...attributes}>
+        {children}
+      </div>
+    ),
+  })
+
+  test('gallery renders with void block objects inside', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const galleryKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: gallerySchemaDefinition,
+      initialValue: [
+        {
+          _type: 'gallery',
+          _key: galleryKey,
+          items: [
+            {
+              _type: 'image',
+              _key: 'img-0',
+              url: 'https://example.com/photo.jpg',
+            },
+            {
+              _type: 'image',
+              _key: 'img-1',
+              url: 'https://example.com/photo2.jpg',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin containers={[{container: galleryContainer}]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      // Gallery container renders with custom renderer
+      const gallery = editorElement!.querySelector('[data-testid="gallery"]')
+      expect(gallery).not.toEqual(null)
+
+      // Images render as void block objects inside the gallery
+      const blockObjects = gallery!.querySelectorAll(
+        '[data-block-type="object"]',
+      )
+      expect(blockObjects.length).toEqual(2)
+      expect(blockObjects[0]!.getAttribute('data-block-name')).toEqual('image')
+      expect(blockObjects[1]!.getAttribute('data-block-name')).toEqual('image')
+
+      // Void block objects have contentEditable=false
+      expect(
+        blockObjects[0]!.querySelector('[contenteditable="false"]'),
+      ).not.toEqual(null)
+      expect(
+        blockObjects[1]!.querySelector('[contenteditable="false"]'),
+      ).not.toEqual(null)
+    })
+  })
+})
+
+describe('container and renderer independence', () => {
+  test('container without renderer falls back to default div', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'content-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'content-span',
+                  text: 'inside callout',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            {
+              container: {
+                ...calloutContainer,
+                render: ({attributes, children}) => (
+                  <div {...attributes}>{children}</div>
+                ),
+              },
+            },
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          // callout default div wrapper
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;]"',
+          '>',
+          // inner text block
+          '<div data-slate-node="element"',
+          ' data-pt-path="[_key==&quot;k0&quot;].content[_key==&quot;content-block&quot;]"',
+          ' class="pt-block pt-text-block pt-text-block-style-normal"',
+          ' data-block-key="content-block"',
+          ' data-block-name="block"',
+          ' data-block-type="text"',
+          ' data-style="normal"',
+          '>',
+          // inner text block wrapper
+          '<div>',
+          // inner span
+          '<span data-slate-node="text"',
+          ' data-pt-path="[_key==&quot;k0&quot;].content[_key==&quot;content-block&quot;].children[_key==&quot;content-span&quot;]"',
+          ' data-child-key="content-span"',
+          ' data-child-name="span"',
+          ' data-child-type="span"',
+          '>',
+          // inner leaf
+          '<span data-slate-leaf="true">',
+          '<span data-slate-string="true">inside callout</span>',
+          '</span>',
+          // /inner span
+          '</span>',
+          // /inner text block wrapper
+          '</div>',
+          // /inner text block
+          '</div>',
+          // /callout default div wrapper
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
+
+  test('renderer without container renders as void block object', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'content-block',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'content-span',
+                  text: 'inside callout',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[]} />,
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-slate-editor]')
+      expect(editorElement).not.toEqual(null)
+
+      // The callout renders as a void block object, not using the custom renderer
+      const calloutTestId = editorElement!.querySelector(
+        '[data-testid="callout"]',
+      )
+      expect(calloutTestId).toEqual(null)
+
+      // Verify it renders as a void block object with contentEditable=false
+      const blockObject = editorElement!.querySelector(
+        '[data-block-type="object"]',
+      )
+      expect(blockObject).not.toEqual(null)
+      expect(
+        blockObject!.querySelector('[contenteditable="false"]'),
+      ).not.toEqual(null)
+    })
+  })
+})

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -14,6 +14,7 @@ import {userEvent} from 'vitest/browser'
 import {defineSchema, type EditorEmittedEvent} from '../src'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor, createTestEditors} from '../src/test/vitest'
 
 describe('event.patches', () => {
@@ -2494,12 +2495,11 @@ describe('event.patches', () => {
           <ContainerPlugin
             containers={[
               {
-                renderer: {
-                  type: 'callout' as const,
-                  render: ({children}: {children: React.ReactNode}) => (
-                    <>{children}</>
-                  ),
-                },
+                container: defineContainer({
+                  scope: 'callout',
+                  field: 'content',
+                  render: ({children}) => <>{children}</>,
+                }),
               },
             ]}
           />
@@ -4639,21 +4639,37 @@ describe('event.patches', () => {
       ],
     })
 
-    const calloutRenderers = [
+    const calloutContainers = [
       {
-        renderer: {
-          type: 'callout' as const,
-          render: ({children}: {children: React.ReactNode}) => <>{children}</>,
-        },
+        container: defineContainer({
+          scope: 'callout',
+          field: 'content',
+          render: ({children}) => <>{children}</>,
+        }),
       },
     ]
 
-    const tableRenderers = [
+    const tableContainers = [
       {
-        renderer: {
-          type: 'table' as const,
-          render: ({children}: {children: React.ReactNode}) => <>{children}</>,
-        },
+        container: defineContainer({
+          scope: 'table',
+          field: 'rows',
+          render: ({children}) => <>{children}</>,
+        }),
+      },
+      {
+        container: defineContainer({
+          scope: 'table.row',
+          field: 'cells',
+          render: ({children}) => <>{children}</>,
+        }),
+      },
+      {
+        container: defineContainer({
+          scope: 'table.row.cell',
+          field: 'content',
+          render: ({children}) => <>{children}</>,
+        }),
       },
     ]
 
@@ -4699,7 +4715,7 @@ describe('event.patches', () => {
             ],
           },
         ],
-        children: <ContainerPlugin containers={calloutRenderers} />,
+        children: <ContainerPlugin containers={calloutContainers} />,
       })
 
       editor.send({
@@ -4822,7 +4838,7 @@ describe('event.patches', () => {
             ],
           },
         ],
-        children: <ContainerPlugin containers={calloutRenderers} />,
+        children: <ContainerPlugin containers={calloutContainers} />,
       })
 
       editor.send({
@@ -4944,7 +4960,7 @@ describe('event.patches', () => {
             ],
           },
         ],
-        children: <ContainerPlugin containers={tableRenderers} />,
+        children: <ContainerPlugin containers={tableContainers} />,
       })
 
       editor.send({
@@ -5070,7 +5086,7 @@ describe('event.patches', () => {
             content: [],
           },
         ],
-        children: <ContainerPlugin containers={calloutRenderers} />,
+        children: <ContainerPlugin containers={calloutContainers} />,
       })
 
       // Normalization adds a placeholder block (k5/k6) to the empty content


### PR DESCRIPTION
Internal machinery for the container API. Adds `defineContainer`, `registerContainer`, the rendering pipeline, scope specificity, resolver logic, and tests. Nothing is exported from the package index. `registerContainer` lives on `InternalEditor` only.

A follow-up PR will expose the public API: export `defineContainer` and `Container`, move `registerContainer` to `Editor`.