### PR TITLE
fix: preserve cursor offset inside editable containers

### DIFF
--- a/.changeset/fix-container-typing-offset.md
+++ b/.changeset/fix-container-typing-offset.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: preserve cursor offset inside editable containers

--- a/packages/editor/src/schema/get-container-scoped-name.ts
+++ b/packages/editor/src/schema/get-container-scoped-name.ts
@@ -1,0 +1,38 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isObjectNode} from '../slate/node/is-object-node'
+import type {Containers} from './resolve-containers'
+
+/**
+ * Build the scoped type name for a node at a given path.
+ *
+ * Walks ancestor object nodes from root to parent, collecting type names.
+ * For a 'cell' at path [{_key:'t1'}, 'rows', {_key:'r1'}, 'cells', {_key:'c1'}],
+ * the ancestors are a 'table' and a 'row', producing: 'table.row.cell'
+ */
+export function getContainerScopedName(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): string {
+  const ancestors = getAncestors(context, path)
+
+  const typeSegments: Array<string> = []
+
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const ancestor = ancestors[i]!
+    if (isObjectNode({schema: context.schema}, ancestor.node)) {
+      typeSegments.push(ancestor.node._type)
+    }
+  }
+
+  typeSegments.push(node._type)
+
+  return typeSegments.join('.')
+}

--- a/packages/editor/src/schema/is-editable-container.ts
+++ b/packages/editor/src/schema/is-editable-container.ts
@@ -1,0 +1,25 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getContainerScopedName} from './get-container-scoped-name'
+import type {Containers} from './resolve-containers'
+
+/**
+ * Check if a node at the given path is a registered editable container.
+ */
+export function isEditableContainer(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): boolean {
+  if (context.containers.size === 0) {
+    return false
+  }
+
+  const scopedName = getContainerScopedName(context, node, path)
+  return context.containers.has(scopedName)
+}

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -14,6 +14,7 @@ import {getNode} from '../../node-traversal/get-node'
 import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {getContainerScopedName} from '../../schema/get-container-scoped-name'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import {isEditor} from '../editor/is-editor'
@@ -27,44 +28,6 @@ import {isTextBlockNode} from '../node/is-text-block-node'
 import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
-
-/**
- * Build the scoped type name for a container node by walking ancestor
- * object nodes up the tree.
- *
- * For a 'row' at path [{_key:'t1'}, 'rows', {_key:'r1'}],
- * the ancestor at [{_key:'t1'}] is a 'table', producing: 'table.row'
- */
-function getContainerScopedName(
-  editor: Editor,
-  node: Node,
-  path: Path,
-): string {
-  const typeSegments: Array<string> = [node._type]
-
-  // Collect keyed segment indices (each represents a node in the tree).
-  const keyedIndices: Array<number> = []
-  for (let i = 0; i < path.length; i++) {
-    if (isKeyedSegment(path[i])) {
-      keyedIndices.push(i)
-    }
-  }
-
-  // Walk ancestor nodes from root to parent, collecting type names.
-  for (let i = 0; i < keyedIndices.length - 1; i++) {
-    const ancestorPath = path.slice(0, keyedIndices[i]! + 1)
-    const entry = getNode(editor, ancestorPath)
-
-    if (!entry || !isObjectNode({schema: editor.schema}, entry.node)) {
-      break
-    }
-
-    // Insert before the node's own type (which is always last).
-    typeSegments.splice(typeSegments.length - 1, 0, entry.node._type)
-  }
-
-  return typeSegments.join('.')
-}
 
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -5,6 +5,7 @@ import {getAncestorObjectNode} from '../../../node-traversal/get-ancestor-object
 import {getHighestObjectNode} from '../../../node-traversal/get-highest-object-node'
 import {getNode} from '../../../node-traversal/get-node'
 import {hasNode} from '../../../node-traversal/has-node'
+import {isEditableContainer} from '../../../schema/is-editable-container'
 import {path as editorPath} from '../../editor/path'
 import {start as editorStart} from '../../editor/start'
 import {unhangRange} from '../../editor/unhang-range'
@@ -381,7 +382,11 @@ export const DOMEditor: DOMEditorInterface = {
 
     let domPoint: DOMPoint | undefined
 
-    if (nodeEntry && isObjectNode({schema: editor.schema}, nodeEntry.node)) {
+    if (
+      nodeEntry &&
+      isObjectNode({schema: editor.schema}, nodeEntry.node) &&
+      !isEditableContainer(editor, nodeEntry.node, point.path)
+    ) {
       const spacer = el.querySelector('[data-slate-zero-width]')
       if (spacer) {
         const domText = spacer.childNodes[0]
@@ -408,7 +413,10 @@ export const DOMEditor: DOMEditorInterface = {
       pointEntry && isObjectNode({schema: editor.schema}, pointEntry.node)
         ? pointEntry
         : getAncestorObjectNode(editor, point.path)
-    if (pointObjectNode) {
+    if (
+      pointObjectNode &&
+      !isEditableContainer(editor, pointObjectNode.node, pointObjectNode.path)
+    ) {
       point = {path: point.path, offset: 0}
     }
 
@@ -795,7 +803,8 @@ export const DOMEditor: DOMEditorInterface = {
 
       if (
         parentEntry &&
-        isObjectNode({schema: editor.schema}, parentEntry.node)
+        isObjectNode({schema: editor.schema}, parentEntry.node) &&
+        !isEditableContainer(editor, parentEntry.node, parentPath)
       ) {
         return {path: parentPath, offset: 0}
       }

--- a/packages/editor/tests/container-typing.test.tsx
+++ b/packages/editor/tests/container-typing.test.tsx
@@ -1,0 +1,105 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const calloutContainer = defineContainer({
+  scope: 'callout',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <div data-testid="callout" {...attributes}>
+      {children}
+    </div>
+  ),
+})
+
+describe('typing inside containers', () => {
+  test('multi-character keyboard input inside a container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: blockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: spanKey,
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin containers={[{container: calloutContainer}]} />
+      ),
+    })
+
+    const calloutElement = await vi.waitFor(() => {
+      const element = document.querySelector('[data-testid="callout"]')
+      expect(element).not.toEqual(null)
+      return element!
+    })
+
+    await userEvent.click(calloutElement)
+    await userEvent.keyboard('hello')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: blockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: spanKey,
+                  text: 'hello',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
When typing multiple characters inside a container, each character was inserted at offset 0, producing reversed text. Typing `hello` produced `olleh`.

The DOM-to-model bridge (`toDOMPoint` and `toSlatePoint`) treats all object nodes as void: it forces the cursor offset to 0 and returns the spacer element instead of the actual text node. This is correct for void block objects like images, but wrong for editable containers where the cursor should track normally through the text.

Three independent `isObjectNode` checks in `dom-editor.ts` needed container guards:

1. **Direct object node check** (`toDOMPoint` ~line 384): returns the zero-width spacer for void objects. Editable containers should fall through to the normal text resolution path.

2. **Ancestor object node offset clamping** (`toDOMPoint` ~line 407): forces `offset: 0` when any ancestor is an object node. This is what caused the backwards typing: after each keystroke, the cursor reset to offset 0, so the next character was inserted at the beginning.

3. **Parent object node path truncation** (`toSlatePoint` ~line 798): truncates the path and forces `offset: 0` when the parent is an object node. Editable containers need the full path preserved.

The fix adds an `isEditableContainer` helper that builds the scoped type name from the node's path (walking ancestor nodes) and checks the `containers` map. Each of the three guards now skips the void-object behavior when the node is a registered editable container.