### PR TITLE
test: add textspec step definitions for Gherkin tests

### DIFF
--- a/packages/editor/gherkin-spec/removing-blocks.feature
+++ b/packages/editor/gherkin-spec/removing-blocks.feature
@@ -5,23 +5,15 @@ Feature: Removing Blocks
     And a global keymap
 
   Scenario: Pressing Delete in empty block with text below
-    Given the text "foo" in block "b1"
-    And the text "bar" in block "b2"
-    And the text "baz" in block "b3"
+    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": bar;;B _key=\"b3\": baz"
     When the editor is focused
-    And the caret is put before "bar"
+    And the selection is "B: foo;;B: |bar;;B: baz"
     And "{Delete}" is pressed 4 times
-    Then the text is "foo|baz"
-    And "foo" is in block "b1"
-    And "baz" is in block "b3"
+    Then the editor state is "B _key=\"b1\": foo;;B _key=\"b3\": |baz"
 
   Scenario: Pressing Backspace in empty block with text below
-    Given the text "foo" in block "b1"
-    And the text "bar" in block "b2"
-    And the text "baz" in block "b3"
+    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": bar;;B _key=\"b3\": baz"
     When the editor is focused
-    And the caret is put after "bar"
+    And the selection is "B: foo;;B: bar|;;B: baz"
     And "{Backspace}" is pressed 4 times
-    Then the text is "foo|baz"
-    And "foo" is in block "b1"
-    And "baz" is in block "b3"
+    Then the editor state is "B _key=\"b1\": foo|;;B _key=\"b3\": baz"

--- a/packages/editor/gherkin-spec/splitting-blocks.feature
+++ b/packages/editor/gherkin-spec/splitting-blocks.feature
@@ -5,185 +5,142 @@ Feature: Splitting Blocks
     And a global keymap
 
   Scenario: Splitting block at the beginning
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
-    And the caret is put before "foo"
+    And the selection is "B: |foo"
     And "{Enter}" is pressed
-    Then the text is "|foo"
-    And "foo" is in block "b1"
+    Then the editor state is "B: ;;B _key=\"b1\": |foo"
 
   Scenario: Splitting block in the middle
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
-    And the caret is put after "fo"
+    And the selection is "B: fo|o"
     And "{Enter}" is pressed
-    Then the text is "fo|o"
-    And "fo" is in block "b1"
+    Then the editor state is "B _key=\"b1\": fo;;B: |o"
 
   Scenario: Splitting block at the end
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
+    And the selection is "B: foo|"
     And "{Enter}" is pressed
-    Then the text is "foo|"
-    And "foo" is in block "b1"
+    Then the editor state is "B _key=\"b1\": foo;;B: |"
 
   Scenario: Splitting empty block creates a new block below
+    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": "
     When the editor is focused
-    Given blocks "auto"
-      ```
-      [
-        {
-          "_key": "b1",
-          "_type": "block",
-          "children": [
-            {
-              "_type": "span",
-              "text": "foo"
-            }
-          ]
-        },
-        {
-          "_key": "b2",
-          "_type": "block",
-          "children": [
-            {
-              "_type": "span",
-              "text": ""
-            }
-          ]
-        }
-      ]
-      ```
-    When "{Enter}" is pressed
+    And the selection is "B: foo;;B: |"
+    And "{Enter}" is pressed
     And "baz" is typed
-    Then the text is "foo||baz"
-    And "foo" is in block "b1"
-    And "" is in block "b2"
+    Then the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": ;;B: baz|"
 
   Scenario: Soft-splitting block at the beginning
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
-    And the caret is put before "foo"
+    And the selection is "B: |foo"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "\nfoo"
-    And "\nfoo" is in block "b1"
+    Then the editor state is "B _key=\"b1\": \n|foo"
 
   Scenario: Soft-splitting block in the middle
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
-    And the caret is put after "fo"
+    And the selection is "B: fo|o"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "fo\no"
-    And "fo\no" is in block "b1"
+    Then the editor state is "B _key=\"b1\": fo\n|o"
 
   Scenario: Soft-splitting block at the end
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\": foo"
     When the editor is focused
+    And the selection is "B: foo|"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "foo\n"
-    And "foo\n" is in block "b1"
+    Then the editor state is "B _key=\"b1\": foo\n|"
 
   Scenario: Splitting styled block at the beginning
-    Given a block "b1" with text "foo"
+    Given the editor state is "B style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put before "foo"
+    And the selection is "B style=\"h1\": |foo"
     And "{Enter}" is pressed
-    Then the text is "|h1:foo"
+    Then the editor state is "B: ;;B style=\"h1\": |foo"
 
   Scenario: Splitting styled block in the middle
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\" style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put after "fo"
+    And the selection is "B style=\"h1\": fo|o"
     And "{Enter}" is pressed
-    Then the text is "h1:fo|h1:o"
-    And "fo" is in block "b1"
+    Then the editor state is "B _key=\"b1\" style=\"h1\": fo;;B style=\"h1\": |o"
 
   Scenario: Splitting styled block at the end
-    Given a block "b1" with text "foo"
+    Given the editor state is "B _key=\"b1\" style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
+    And the selection is "B style=\"h1\": foo|"
     And "{Enter}" is pressed
-    Then the text is "h1:foo|"
-    And "foo" is in block "b1"
+    Then the editor state is "B _key=\"b1\" style=\"h1\": foo;;B: |"
 
   Scenario: Soft-splitting styled block at the beginning
-    Given the text "foo"
+    Given the editor state is "B style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put before "foo"
+    And the selection is "B style=\"h1\": |foo"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "h1:\nfoo"
+    Then the editor state is "B style=\"h1\": \n|foo"
 
   Scenario: Soft-splitting styled block in the middle
-    Given the text "foo"
+    Given the editor state is "B style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put after "fo"
+    And the selection is "B style=\"h1\": fo|o"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "h1:fo\no"
+    Then the editor state is "B style=\"h1\": fo\n|o"
 
   Scenario: Soft-splitting styled block at the end
-    Given the text "foo"
+    Given the editor state is "B style=\"h1\": foo"
     When the editor is focused
-    And "h1" is toggled
+    And the selection is "B style=\"h1\": foo|"
     And "{Shift>}{Enter}{/Shift}" is pressed
-    Then the text is "h1:foo\n"
+    Then the editor state is "B style=\"h1\": foo\n|"
 
   Scenario: Splitting decorated styled block at the beginning
-    Given the text "h1:foo bar baz"
-    And "strong" around "foo"
+    Given the editor state is "B style=\"h1\": [strong:foo] bar baz"
     When the editor is focused
-    And the caret is put before "foo"
+    And the selection is "B style=\"h1\": |[strong:foo] bar baz"
     And "{Enter}" is pressed
     And "new" is typed
-    Then the text is "|h1:newfoo, bar baz"
-    And "newfoo" has marks "strong"
+    Then the editor state is "B: [strong:];;B style=\"h1\": [strong:new|foo] bar baz"
 
   Scenario Outline: Splitting decorated styled block in the middle
-    Given the text "foo bar baz"
-    And "strong" around <decorated>
+    Given the editor state is <initial>
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put <position>
+    And the selection is <selection>
     And "{Enter}" is pressed
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | decorated | position      | new text                  |
-      | "foo"     | after "foo"   | "h1:foo\|h1:new bar baz"  |
-      | "bar"     | after "foo "  | "h1:foo \|h1:newbar, baz" |
-      | "bar"     | before "bar"  | "h1:foo \|h1:newbar, baz" |
-      | "bar"     | after "bar"   | "h1:foo ,bar\|h1:new baz" |
-      | "bar"     | before " baz" | "h1:foo ,bar\|h1:new baz" |
-      | "baz"     | before "baz"  | "h1:foo bar \|h1:newbaz"  |
-      | "baz"     | after "bar "  | "h1:foo bar \|h1:newbaz"  |
+      | initial                                | selection                                | new text                                                      |
+      | "B style=\"h1\": [strong:foo] bar baz" | "B style=\"h1\": [strong:foo\|] bar baz" | "B style=\"h1\": [strong:foo];;B style=\"h1\": new\| bar baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo \|[strong:bar] baz" | "B style=\"h1\": foo ;;B style=\"h1\": [strong:new\|bar] baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:\|bar] baz" | "B style=\"h1\": foo ;;B style=\"h1\": [strong:new\|bar] baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:bar\|] baz" | "B style=\"h1\": foo [strong:bar];;B style=\"h1\": new\| baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:bar]\| baz" | "B style=\"h1\": foo [strong:bar];;B style=\"h1\": new\| baz" |
+      | "B style=\"h1\": foo bar [strong:baz]" | "B style=\"h1\": foo bar [strong:\|baz]" | "B style=\"h1\": foo bar ;;B style=\"h1\": [strong:new\|baz]" |
+      | "B style=\"h1\": foo bar [strong:baz]" | "B style=\"h1\": foo bar \|[strong:baz]" | "B style=\"h1\": foo bar ;;B style=\"h1\": [strong:new\|baz]" |
 
   Scenario: Splitting decorated styled block at the end
-    Given the text "foo bar baz"
-    And "strong" around "baz"
+    Given the editor state is "B style=\"h1\": foo bar [strong:baz]"
     When the editor is focused
-    And "h1" is toggled
-    And the caret is put after "baz"
+    And the selection is "B style=\"h1\": foo bar [strong:baz|]"
     And "{Enter}" is pressed
     And "new" is typed
-    Then the text is "h1:foo bar ,baz|new"
-    And "new" has no marks
+    Then the editor state is "B style=\"h1\": foo bar [strong:baz];;B: new|"
 
   Scenario Outline: Splitting block with an expanded selection
-    Given a block "b1" with text "foo"
-    And a block "b2" with text "bar"
+    Given the editor state is "B: foo;;B: bar"
     When the editor is focused
     And <selection> is selected
     And "{Enter}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | selection | new text |
-      | "foobar"  | ""       |
-      | "ooba"    | "f\|r"   |
+      | selection | new text       |
+      | "foobar"  | "B: \|"        |
+      | "ooba"    | "B: f;;B: \|r" |
 
   Scenario: Pressing Enter when selecting multiple block objects
     Given blocks "auto"
@@ -202,4 +159,4 @@ Feature: Splitting Blocks
     When the editor is focused
     And everything is selected
     And "{Enter}" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"

--- a/packages/editor/gherkin-tests/removing-blocks.test.ts
+++ b/packages/editor/gherkin-tests/removing-blocks.test.ts
@@ -1,0 +1,10 @@
+import {Feature} from 'racejar/vitest'
+import removingBlocksFeature from '../gherkin-spec/removing-blocks.feature?raw'
+import {parameterTypes} from '../src/test'
+import {stepDefinitions} from '../src/test/vitest'
+
+Feature({
+  featureText: removingBlocksFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -100,6 +100,7 @@
     "@sanity/diff-match-patch": "^3.2.0",
     "@sanity/pkg-utils": "^10.2.1",
     "@sanity/tsconfig": "^2.1.0",
+    "@textspec/notation": "^1.0.1",
     "@types/debug": "^4.1.12",
     "@types/node": "^20",
     "@types/react": "^19.2.14",

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -4,6 +4,10 @@ import {Given, Then, When} from 'racejar'
 import {assert, expect, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {getEditorSelection} from '../../../test-utils/editor-selection'
+import {
+  fromTextspec,
+  selectionFromTextspec,
+} from '../../../test-utils/from-textspec'
 import {getSelectionText} from '../../../test-utils/selection-text'
 import {getTextBlockKey} from '../../../test-utils/text-block-key'
 import {getTextMarks} from '../../../test-utils/text-marks'
@@ -12,7 +16,9 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../../../test-utils/text-selection'
+import {toTextspec} from '../../../test-utils/to-textspec'
 import {getValueAnnotations} from '../../../test-utils/value-annotations'
+import type {InternalEditor} from '../../editor/create-editor'
 import {IS_MAC} from '../../internal-utils/is-hotkey'
 import {safeParse} from '../../internal-utils/safe-json'
 import {createTestEditor, createTestEditors} from '../../test/vitest'
@@ -95,6 +101,63 @@ export const stepDefinitions = [
         blocks,
         placement: 'auto',
         select: 'end',
+      })
+    },
+  ),
+
+  Given(
+    'the editor state is {string}',
+    (context: Context, textspec: string) => {
+      const {schema, keyGenerator} = context.editor.getSnapshot().context
+      const {containers} = (context.editor as InternalEditor)._internal
+        .slateEditor
+
+      const normalized = textspec.replace(/\\n/g, '\n').replace(/;;/g, '\n')
+
+      const {blocks} = fromTextspec(
+        {schema, keyGenerator, containers},
+        normalized,
+      )
+
+      context.editor.send({
+        type: 'insert.blocks',
+        blocks,
+        placement: 'auto',
+        select: 'end',
+      })
+    },
+  ),
+
+  When(
+    'the selection is {string}',
+    async (context: Context, textspec: string) => {
+      const normalized = textspec.replace(/\\n/g, '\n').replace(/;;/g, '\n')
+
+      await vi.waitFor(() => {
+        const {schema, value} = context.editor.getSnapshot().context
+        const {containers} = (context.editor as InternalEditor)._internal
+          .slateEditor
+
+        const selection = selectionFromTextspec(
+          {schema, containers},
+          normalized,
+          value ?? [],
+        )
+
+        if (!selection) {
+          throw new Error(
+            `Could not resolve selection from textspec: ${textspec}`,
+          )
+        }
+
+        context.editor.send({
+          type: 'select',
+          at: selection,
+        })
+
+        const currentSelection = context.editor.getSnapshot().context.selection
+        expect(currentSelection?.anchor).toEqual(selection.anchor)
+        expect(currentSelection?.focus).toEqual(selection.focus)
       })
     },
   ),
@@ -669,6 +732,30 @@ export const stepDefinitions = [
           getTersePt(context.editor.getSnapshot().context),
           'Unexpected editor text',
         ).toEqual(tersePt)
+      })
+    },
+  ),
+  Then(
+    'the editor state is {string}',
+    async (context: Context, textspec: string) => {
+      await vi.waitFor(() => {
+        const {schema, value, selection} = context.editor.getSnapshot().context
+        const {containers} = (context.editor as InternalEditor)._internal
+          .slateEditor
+
+        const expected = textspec.replace(/\\n/g, '\n')
+        const keys = new Set<string>()
+        for (const match of expected.matchAll(/_key="([^"]+)"/g)) {
+          keys.add(match[1]!)
+        }
+
+        expect(
+          toTextspec(
+            {schema, value, selection, containers},
+            {singleLine: true, keys: keys.size > 0 ? keys : undefined},
+          ),
+          'Unexpected editor state',
+        ).toBe(expected)
       })
     },
   ),

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -27,7 +27,6 @@ import {
   parseInlineObject,
   parseSpan,
 } from '../../utils/parse-blocks'
-import {spanSelectionPointToBlockOffset} from '../../utils/util.block-offset'
 import {reverseSelection} from '../../utils/util.reverse-selection'
 import type {Parameter} from '../gherkin-parameter-types'
 import type {Context} from './step-context'
@@ -235,21 +234,6 @@ export const stepDefinitions = [
   /**
    * Text steps
    */
-  Given(
-    'a block {key} with text {text}',
-    (context: Context, key: string, text: Parameter['text']) => {
-      context.editor.send({
-        type: 'insert.block',
-        block: {
-          _key: key,
-          _type: 'block',
-          children: [{_type: 'span', text, marks: []}],
-        },
-        placement: 'auto',
-        select: 'end',
-      })
-    },
-  ),
   When('{string} is typed', async (context: Context, text: string) => {
     if (!context.editor.getSnapshot().context.selection) {
       // Avoid browser compatibility issue. Seems like Chromium and Firefox
@@ -943,51 +927,6 @@ export const stepDefinitions = [
       })
     },
   ),
-  When(
-    '{string} is marked with {decorator}',
-    async (
-      context: Context,
-      text: string,
-      decorator: Parameter['decorator'],
-    ) => {
-      await vi.waitFor(() => {
-        const selection = getTextSelection(
-          context.editor.getSnapshot().context,
-          text,
-        )
-        const anchorOffset = selection
-          ? spanSelectionPointToBlockOffset({
-              context: {
-                schema: context.editor.getSnapshot().context.schema,
-                value: context.editor.getSnapshot().context.value,
-              },
-              selectionPoint: selection.anchor,
-            })
-          : undefined
-        const focusOffset = selection
-          ? spanSelectionPointToBlockOffset({
-              context: {
-                schema: context.editor.getSnapshot().context.schema,
-                value: context.editor.getSnapshot().context.value,
-              },
-              selectionPoint: selection.focus,
-            })
-          : undefined
-
-        assert(anchorOffset !== undefined)
-        assert(focusOffset !== undefined)
-
-        context.editor.send({
-          type: 'decorator.toggle',
-          decorator,
-          at: {
-            anchor: anchorOffset!,
-            focus: focusOffset!,
-          },
-        })
-      })
-    },
-  ),
 
   /**
    * Mark steps
@@ -1012,18 +951,6 @@ export const stepDefinitions = [
       expect(textMarks).toEqual([])
     })
   }),
-  Then(
-    '{string} and {string} have the same marks',
-    (context: Context, textA: string, textB: string) => {
-      const marksA = getTextMarks(context.editor.getSnapshot().context, textA)
-      const marksB = getTextMarks(context.editor.getSnapshot().context, textB)
-
-      expect(
-        marksA,
-        `Expected "${textA}" and "${textB}" to have the same marks`,
-      ).toEqual(marksB)
-    },
-  ),
 
   /**
    * Style steps

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -1,0 +1,480 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import type {Containers} from '../src/schema/resolve-containers'
+import {fromTextspec} from './from-textspec'
+import {toTextspec} from './to-textspec'
+
+const schemaDefinition = defineSchema({
+  annotations: [{name: 'comment'}, {name: 'link'}],
+  decorators: [{name: 'em'}, {name: 'strong'}],
+  blockObjects: [
+    {name: 'image'},
+    {name: 'break'},
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'tableRow',
+              name: 'tableRow',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'tableCell',
+                      name: 'tableCell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  inlineObjects: [{name: 'stock-ticker'}],
+  lists: [{name: 'bullet'}, {name: 'number'}],
+  styles: [
+    {name: 'normal'},
+    {name: 'h1'},
+    {name: 'h2'},
+    {name: 'h3'},
+    {name: 'h4'},
+    {name: 'h5'},
+    {name: 'h6'},
+    {name: 'blockquote'},
+  ],
+})
+
+const schema = compileSchema(schemaDefinition)
+
+const tableContainers: Containers = new Map([
+  [
+    'table',
+    {name: 'rows', type: 'array', of: [{type: 'tableRow', name: 'tableRow'}]},
+  ],
+  [
+    'table.tableRow',
+    {
+      name: 'cells',
+      type: 'array',
+      of: [{type: 'tableCell', name: 'tableCell'}],
+    },
+  ],
+  [
+    'table.tableRow.tableCell',
+    {name: 'content', type: 'array', of: [{type: 'block'}]},
+  ],
+])
+
+describe(fromTextspec.name, () => {
+  test('simple paragraph', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: Hello|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: 'Hello', marks: []}],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('heading', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'H1: Hello|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: 'Hello', marks: []}],
+        style: 'h1',
+      },
+    ])
+  })
+
+  test('bold text (decorator)', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: [strong:bold]|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [
+          {_key: 'k1', _type: 'span', text: 'bold', marks: ['strong']},
+        ],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('annotation (link)', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: [@link href="https://example.com":click here]|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [
+          {_key: 'k2', _type: 'span', text: 'click here', marks: ['k1']},
+        ],
+        markDefs: [{_type: 'link', _key: 'k1', href: 'https://example.com'}],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('mixed plain and marked text', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: Hello [strong:world]|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [
+          {_key: 'k1', _type: 'span', text: 'Hello ', marks: []},
+          {_key: 'k2', _type: 'span', text: 'world', marks: ['strong']},
+        ],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('block object', () => {
+    expect(
+      fromTextspec({schema, keyGenerator: createTestKeyGenerator()}, '{IMAGE}|')
+        .blocks,
+    ).toEqual([{_type: 'image', _key: 'k0'}])
+  })
+
+  test('simple bullet list', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'UL:\n  LI: first\n  LI: second|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: 'first', marks: []}],
+        style: 'normal',
+        listItem: 'bullet',
+        level: 1,
+      },
+      {
+        _type: 'block',
+        _key: 'k2',
+        children: [{_key: 'k3', _type: 'span', text: 'second', marks: []}],
+        style: 'normal',
+        listItem: 'bullet',
+        level: 1,
+      },
+    ])
+  })
+
+  test('collapsed selection', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: Hello|',
+      ).selection,
+    ).toEqual({
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
+    })
+  })
+
+  test('range selection', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'P: ^Hello|',
+      ).selection,
+    ).toEqual({
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
+    })
+  })
+
+  test('table with one cell', () => {
+    expect(
+      fromTextspec(
+        {
+          schema,
+          keyGenerator: createTestKeyGenerator(),
+          containers: tableContainers,
+        },
+        'TABLE:\n  TABLEROW:\n    TABLECELL:\n      B: hello',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'table',
+        _key: 'k4',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'k3',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'k2',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'k0',
+                    children: [
+                      {
+                        _key: 'k1',
+                        _type: 'span',
+                        text: 'hello',
+                        marks: [],
+                      },
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe('round-trip', () => {
+  test('simple paragraph', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: Hello|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: Hello',
+    )
+  })
+
+  test('heading', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'H1: Hello|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B style="h1": Hello',
+    )
+  })
+
+  test('bold text', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: [strong:bold]|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: [strong:bold]',
+    )
+  })
+
+  test('mixed text', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: Hello [strong:world]|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: Hello [strong:world]',
+    )
+  })
+
+  test('multiple blocks', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: first|\nP: second',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: first\nB: second',
+    )
+  })
+
+  test('bullet list', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'UL:\n  LI: first\n  LI: second|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B listItem="bullet": first\nB listItem="bullet": second',
+    )
+  })
+
+  test('block object', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      '{IMAGE}|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe('{IMAGE}')
+  })
+
+  test('annotation', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: [@link href="https://example.com":click here]|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: [@link href="https://example.com":click here]',
+    )
+  })
+
+  test('inline object', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'P: text {stock-ticker} more|',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: text {stock-ticker} more',
+    )
+  })
+
+  test('table with one cell', () => {
+    const {blocks} = fromTextspec(
+      {
+        schema,
+        keyGenerator: createTestKeyGenerator(),
+        containers: tableContainers,
+      },
+      'TABLE:\n  TABLEROW:\n    TABLECELL:\n      B: hello',
+    )
+    expect(
+      toTextspec({
+        schema,
+        value: blocks,
+        selection: null,
+        containers: tableContainers,
+      }),
+    ).toBe('TABLE:\n  TABLEROW:\n    TABLECELL:\n      B: hello')
+  })
+
+  test('explicit block key via B attrs', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B _key="b1": Hello',
+    )
+    expect(blocks).toEqual([
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_key: 'k0', _type: 'span', text: 'Hello', marks: []}],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('heading via B attrs', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B style="h1": Hello',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B style="h1": Hello',
+    )
+  })
+
+  test('list item via B attrs', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B listItem="bullet": item',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B listItem="bullet": item',
+    )
+  })
+
+  test('nested list item via B attrs', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B level=2 listItem="bullet": child',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B level=2 listItem="bullet": child',
+    )
+  })
+
+  test('decorator', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B: [strong:Hello]',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B: [strong:Hello]',
+    )
+  })
+
+  test('style with decorator', () => {
+    const {blocks} = fromTextspec(
+      {schema, keyGenerator: createTestKeyGenerator()},
+      'B style="h1": [strong:Hello] world',
+    )
+    expect(toTextspec({schema, value: blocks, selection: null})).toBe(
+      'B style="h1": [strong:Hello] world',
+    )
+  })
+
+  test('table with multiple cells', () => {
+    const input = [
+      'TABLE:',
+      '  TABLEROW:',
+      '    TABLECELL:',
+      '      B: a',
+      '    TABLECELL:',
+      '      B: b',
+      '  TABLEROW:',
+      '    TABLECELL:',
+      '      B: c',
+      '    TABLECELL:',
+      '      B: d',
+    ].join('\n')
+    const {blocks} = fromTextspec(
+      {
+        schema,
+        keyGenerator: createTestKeyGenerator(),
+        containers: tableContainers,
+      },
+      input,
+    )
+    expect(
+      toTextspec({
+        schema,
+        value: blocks,
+        selection: null,
+        containers: tableContainers,
+      }),
+    ).toBe(input)
+  })
+})

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -1,0 +1,847 @@
+import type {
+  PortableTextBlock,
+  PortableTextObject,
+  PortableTextSpan,
+  PortableTextTextBlock,
+  Schema,
+} from '@portabletext/schema'
+import {isTextBlock} from '@portabletext/schema'
+import type {
+  Block,
+  ContainerBlock,
+  InlineNode,
+  TextBlock,
+  Block as TextspecBlock,
+} from '@textspec/notation'
+import {parse} from '@textspec/notation'
+import type {Containers} from '../src/schema/resolve-containers'
+import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
+
+/**
+ * Parse a textspec notation string into PTE blocks and selection.
+ */
+export function fromTextspec(
+  context: {
+    schema: Schema
+    keyGenerator: () => string
+    containers?: Containers
+  },
+  textspec: string,
+): {
+  blocks: Array<PortableTextBlock>
+  selection: EditorSelection
+} {
+  // If no selection markers are present, add a cursor at the end
+  // to satisfy the parser's requirement for a selection marker.
+  const hasSelection = /(?<!\\)[|^]/.test(textspec)
+  const input = hasSelection ? textspec : `${textspec}|`
+  const state = parse(input)
+  const containers = context.containers ?? new Map()
+  const blocks: Array<PortableTextBlock> = []
+
+  for (const block of state.blocks) {
+    const pteBlocks = convertBlockToPTE(
+      context.schema,
+      containers,
+      block,
+      context.keyGenerator,
+      '',
+    )
+    for (const pteBlock of pteBlocks) {
+      blocks.push(pteBlock)
+    }
+  }
+
+  const selection = convertSelectionToPTE(
+    context.schema,
+    containers,
+    blocks,
+    state,
+  )
+
+  return {blocks, selection}
+}
+
+function blockTypeToStyle(type: string): string {
+  switch (type) {
+    case 'P':
+    case 'B':
+      return 'normal'
+    case 'BLOCKQUOTE':
+      return 'blockquote'
+    default:
+      return type.toLowerCase()
+  }
+}
+
+function containerTypeToListItem(type: string): string {
+  switch (type) {
+    case 'UL':
+      return 'bullet'
+    case 'OL':
+      return 'number'
+    default:
+      return type.toLowerCase()
+  }
+}
+
+/**
+ * Flatten nested textspec marks into PTE's flat marks array + markDefs.
+ * Returns an array of PTE children (spans and inline objects).
+ */
+function flattenInlineNode(
+  node: InlineNode,
+  keyGenerator: () => string,
+  parentMarks: Array<string>,
+  markDefs: Array<PortableTextObject>,
+): Array<PortableTextSpan | PortableTextObject> {
+  switch (node.kind) {
+    case 'text': {
+      return [
+        {
+          _key: keyGenerator(),
+          _type: 'span',
+          text: node.text,
+          marks: [...parentMarks],
+        },
+      ]
+    }
+
+    case 'mark': {
+      let markId: string
+
+      if (node.mode === 'decorator') {
+        markId = node.type
+      } else {
+        // Annotation or overlay: create a markDef
+        markId = keyGenerator()
+        markDefs.push({
+          _type: node.type,
+          _key: markId,
+          ...node.attrs,
+        })
+      }
+
+      const childMarks = [...parentMarks, markId]
+      const results: Array<PortableTextSpan | PortableTextObject> = []
+
+      for (const child of node.children) {
+        const flattened = flattenInlineNode(
+          child,
+          keyGenerator,
+          childMarks,
+          markDefs,
+        )
+        for (const item of flattened) {
+          results.push(item)
+        }
+      }
+
+      return results
+    }
+
+    case 'inlineObject': {
+      return [
+        {
+          _type: node.type,
+          _key: keyGenerator(),
+          ...node.attrs,
+        },
+      ]
+    }
+  }
+}
+
+function convertTextBlockToPTE(
+  schema: Schema,
+  block: TextBlock,
+  keyGenerator: () => string,
+  style: string,
+  listItem?: string,
+  level?: number,
+  explicitKey?: string,
+): PortableTextTextBlock {
+  const blockKey = explicitKey ?? keyGenerator()
+  const markDefs: Array<PortableTextObject> = []
+  const children: Array<PortableTextSpan | PortableTextObject> = []
+
+  for (const child of block.children) {
+    const flattened = flattenInlineNode(child, keyGenerator, [], markDefs)
+    for (const item of flattened) {
+      children.push(item)
+    }
+  }
+
+  const result: PortableTextTextBlock = {
+    _type: schema.block.name,
+    _key: blockKey,
+    children,
+    ...(markDefs.length > 0 ? {markDefs} : {}),
+    style,
+    ...(listItem ? {listItem} : {}),
+    ...(level ? {level} : {}),
+  }
+
+  return result
+}
+
+/**
+ * Flatten a textspec container block (UL/OL) into PTE's flat list blocks.
+ */
+function flattenContainer(
+  schema: Schema,
+  container: ContainerBlock,
+  keyGenerator: () => string,
+  level: number,
+): Array<PortableTextTextBlock> {
+  const listItem = containerTypeToListItem(container.type)
+  const results: Array<PortableTextTextBlock> = []
+
+  for (const child of container.children) {
+    if (child.kind === 'textBlock' && child.type === 'LI') {
+      // Simple LI: LI is a text block directly (e.g., "LI: text")
+      results.push(
+        convertTextBlockToPTE(
+          schema,
+          child,
+          keyGenerator,
+          'normal',
+          listItem,
+          level,
+        ),
+      )
+    } else if (child.kind === 'containerBlock' && child.type === 'LI') {
+      // LI container: can contain a text block and/or nested containers
+      for (const liChild of child.children) {
+        if (liChild.kind === 'textBlock') {
+          results.push(
+            convertTextBlockToPTE(
+              schema,
+              liChild,
+              keyGenerator,
+              blockTypeToStyle(liChild.type),
+              listItem,
+              level,
+            ),
+          )
+        } else if (liChild.kind === 'containerBlock') {
+          // Nested list
+          const nested = flattenContainer(
+            schema,
+            liChild,
+            keyGenerator,
+            level + 1,
+          )
+          for (const nestedBlock of nested) {
+            results.push(nestedBlock)
+          }
+        }
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Convert a textspec block to PTE blocks.
+ * A single textspec container block may produce multiple PTE blocks (flat list model).
+ */
+function convertBlockToPTE(
+  schema: Schema,
+  containers: Containers,
+  block: Block,
+  keyGenerator: () => string,
+  scopePath: string,
+): Array<PortableTextBlock> {
+  switch (block.kind) {
+    case 'textBlock': {
+      let style = blockTypeToStyle(block.type)
+      let listItem: string | undefined
+      let level: number | undefined
+
+      if (block.type === 'B' && block.attrs) {
+        if (typeof block.attrs['style'] === 'string') {
+          style = block.attrs['style']
+        }
+        if (typeof block.attrs['listItem'] === 'string') {
+          listItem = block.attrs['listItem']
+        }
+        if (typeof block.attrs['level'] === 'number') {
+          level = block.attrs['level']
+        }
+      }
+
+      const explicitKey =
+        block.attrs && typeof block.attrs['_key'] === 'string'
+          ? block.attrs['_key']
+          : undefined
+
+      return [
+        convertTextBlockToPTE(
+          schema,
+          block,
+          keyGenerator,
+          style,
+          listItem,
+          level,
+          explicitKey,
+        ),
+      ]
+    }
+
+    case 'containerBlock': {
+      if (isListContainer(block.type)) {
+        return flattenContainer(schema, block, keyGenerator, 1)
+      }
+
+      const resolvedScopePath = resolveContainerScopePath(
+        containers,
+        scopePath,
+        block.type,
+      )
+
+      if (resolvedScopePath) {
+        return [
+          convertContainerToPTE(
+            schema,
+            containers,
+            block,
+            keyGenerator,
+            resolvedScopePath,
+          ),
+        ]
+      }
+
+      // Fallback: unknown container type
+      return [
+        {
+          _type: block.type.toLowerCase(),
+          _key: keyGenerator(),
+        },
+      ]
+    }
+
+    case 'blockObject':
+    case 'rawBlock': {
+      const obj: PortableTextObject = {
+        _type: block.type.toLowerCase(),
+        _key: keyGenerator(),
+        ...block.attrs,
+      }
+      return [obj]
+    }
+  }
+}
+
+function isListContainer(type: string): boolean {
+  return type === 'UL' || type === 'OL'
+}
+
+/**
+ * Resolve the scope path for a container block type.
+ *
+ * For root-level containers, finds the matching key in the containers map
+ * by comparing uppercased type names.
+ *
+ * For nested containers, looks through the parent container's `of` array
+ * to find a member whose uppercased type matches the textspec type,
+ * then builds the scoped name.
+ */
+function resolveContainerScopePath(
+  containers: Containers,
+  parentScopePath: string,
+  textspecType: string,
+): string | undefined {
+  if (parentScopePath === '') {
+    // Root-level: find a container key whose uppercased form matches
+    for (const key of containers.keys()) {
+      // Root-level keys have no dots
+      if (!key.includes('.') && key.toUpperCase() === textspecType) {
+        return key
+      }
+    }
+    return undefined
+  }
+
+  // Nested: look through parent container's `of` array
+  const parentField = containers.get(parentScopePath)
+
+  if (!parentField) {
+    return undefined
+  }
+
+  for (const ofMember of parentField.of) {
+    const memberType = ofMember.name ?? ofMember.type
+    if (memberType.toUpperCase() === textspecType) {
+      const childScopePath = `${parentScopePath}.${memberType}`
+      if (containers.has(childScopePath)) {
+        return childScopePath
+      }
+    }
+  }
+
+  return undefined
+}
+
+function convertContainerToPTE(
+  schema: Schema,
+  containers: Containers,
+  container: ContainerBlock,
+  keyGenerator: () => string,
+  scopePath: string,
+): PortableTextObject {
+  const containerField = containers.get(scopePath)
+
+  if (!containerField) {
+    return {
+      _type: container.type.toLowerCase(),
+      _key: keyGenerator(),
+    }
+  }
+
+  // Extract the actual PTE type name from the scope path
+  // (last segment for nested, full path for root)
+  const segments = scopePath.split('.')
+  const typeName = segments[segments.length - 1]!
+
+  const items: Array<PortableTextBlock> = []
+
+  for (const child of container.children) {
+    const pteBlocks = convertBlockToPTE(
+      schema,
+      containers,
+      child,
+      keyGenerator,
+      scopePath,
+    )
+    for (const pteBlock of pteBlocks) {
+      items.push(pteBlock)
+    }
+  }
+
+  return {
+    _type: typeName,
+    _key: keyGenerator(),
+    [containerField.name]: items,
+  }
+}
+
+/**
+ * Parse a textspec pattern (including its selection markers) and resolve
+ * the selection against an actual PTE value. Use this to apply a
+ * textspec-defined selection to an editor that already has content.
+ *
+ * The pattern is a full textspec string (matching the editor's content)
+ * with `|` marking caret position or `^...|` marking a range.
+ */
+/**
+ * Parse a textspec pattern (including its selection markers) and resolve
+ * the selection against an actual PTE value. Use this to apply a
+ * textspec-defined selection to an editor that already has content.
+ *
+ * The pattern must be a full textspec string matching the editor's content
+ * (including blocks and marks), with `|` marking caret position or `^...|`
+ * marking a range.
+ *
+ * The pattern's mark structure may differ from the PTE value's flat spans.
+ * We resolve by computing the character offset within each block from the
+ * pattern, then walking the PTE value to find the span at that offset.
+ */
+export function selectionFromTextspec(
+  context: {
+    schema: Schema
+    containers?: Containers
+  },
+  pattern: string,
+  value: Array<PortableTextBlock>,
+): EditorSelection {
+  const state = parse(pattern)
+
+  if (!state.selection) {
+    return null
+  }
+
+  const schemaContext = {schema: context.schema}
+  const containers = context.containers ?? new Map()
+
+  const anchor = resolveIndexedPoint(
+    schemaContext,
+    containers,
+    state.blocks,
+    value,
+    state.selection.anchor,
+  )
+  const focus = resolveIndexedPoint(
+    schemaContext,
+    containers,
+    state.blocks,
+    value,
+    state.selection.focus,
+  )
+
+  if (!anchor || !focus) {
+    return null
+  }
+
+  return {anchor, focus}
+}
+
+/**
+ * Resolve an indexed point from the textspec parse tree to a keyed point
+ * against the PTE value. For text blocks, flattens the pattern's marks to
+ * compute a block-local character offset, then walks the PTE block's flat
+ * spans to find the span and offset.
+ */
+function resolveIndexedPoint(
+  schemaContext: {schema: Schema},
+  containers: Containers,
+  patternBlocks: ReadonlyArray<TextspecBlock>,
+  value: Array<PortableTextBlock>,
+  point: {path: Array<number>; offset: number},
+): EditorSelectionPoint | undefined {
+  const [blockIndex, ...rest] = point.path
+
+  if (typeof blockIndex !== 'number') {
+    return undefined
+  }
+
+  const patternBlock = patternBlocks[blockIndex]
+  const valueBlock = value[blockIndex] as Record<string, unknown> | undefined
+
+  if (!patternBlock || !valueBlock) {
+    return undefined
+  }
+
+  const valueKey =
+    typeof valueBlock['_key'] === 'string' ? valueBlock['_key'] : undefined
+
+  if (!valueKey) {
+    return undefined
+  }
+
+  if (patternBlock.kind === 'textBlock') {
+    if (!isTextBlock(schemaContext, valueBlock as PortableTextBlock)) {
+      return undefined
+    }
+
+    const textOffset = computeTextOffset(
+      patternBlock.children,
+      rest,
+      point.offset,
+    )
+
+    if (textOffset === undefined) {
+      return undefined
+    }
+
+    return locateSpanAtOffset(
+      valueKey,
+      (valueBlock['children'] ?? []) as Array<Record<string, unknown>>,
+      textOffset,
+    )
+  }
+
+  // Non-text block (container or void). Walk by index.
+  return resolveContainerPoint(
+    schemaContext,
+    containers,
+    valueBlock,
+    rest,
+    point.offset,
+  )
+}
+
+/**
+ * Sum text lengths up to the point's leaf, using the parse tree's children.
+ * The path walks down the parse tree (including mark nodes). The final
+ * offset is added to reach the character offset within the block.
+ */
+function computeTextOffset(
+  children: ReadonlyArray<Record<string, unknown>> | ReadonlyArray<unknown>,
+  path: Array<number>,
+  leafOffset: number,
+): number | undefined {
+  let offset = 0
+  let currentChildren = children as ReadonlyArray<Record<string, unknown>>
+
+  for (let i = 0; i < path.length; i++) {
+    const index = path[i]
+
+    if (typeof index !== 'number') {
+      return undefined
+    }
+
+    // Empty children: pattern block is empty (e.g. `B: `). Treat the point
+    // as the start of the block. PTE normalizes empty blocks with a single
+    // placeholder span at offset 0.
+    if (currentChildren.length === 0) {
+      return offset
+    }
+
+    for (let j = 0; j < index; j++) {
+      offset += measureNodeText(currentChildren[j])
+    }
+
+    const node = currentChildren[index]
+
+    if (!node) {
+      return undefined
+    }
+
+    if (node['kind'] === 'text') {
+      return offset + leafOffset
+    }
+
+    const nextChildren = node['children']
+
+    if (Array.isArray(nextChildren)) {
+      currentChildren = nextChildren as ReadonlyArray<Record<string, unknown>>
+      continue
+    }
+
+    return undefined
+  }
+
+  return offset + leafOffset
+}
+
+function measureNodeText(node: Record<string, unknown> | undefined): number {
+  if (!node) {
+    return 0
+  }
+
+  if (node['kind'] === 'text' && typeof node['text'] === 'string') {
+    return node['text'].length
+  }
+
+  const children = node['children']
+
+  if (!Array.isArray(children)) {
+    return 0
+  }
+
+  let total = 0
+  for (const child of children) {
+    total += measureNodeText(child as Record<string, unknown>)
+  }
+  return total
+}
+
+/**
+ * Walk a PTE text block's flat children to find the span at the given
+ * character offset. Returns a keyed selection point on that span.
+ */
+function locateSpanAtOffset(
+  blockKey: string,
+  children: Array<Record<string, unknown>>,
+  textOffset: number,
+): EditorSelectionPoint | undefined {
+  // Empty text block in PTE always has at least one placeholder span after
+  // normalization. If there are no spans yet, the block is still being set
+  // up — bail out so the caller can retry.
+  if (children.length === 0) {
+    return undefined
+  }
+
+  let remaining = textOffset
+
+  for (const child of children) {
+    const spanKey = child['_key']
+
+    if (typeof spanKey !== 'string') {
+      continue
+    }
+
+    const text = typeof child['text'] === 'string' ? child['text'] : ''
+
+    if (remaining <= text.length) {
+      return {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: remaining,
+      }
+    }
+
+    remaining -= text.length
+  }
+
+  // Offset overflows: place at end of last span if possible.
+  const last = children[children.length - 1]
+  const lastKey = last ? last['_key'] : undefined
+  const lastText = last && typeof last['text'] === 'string' ? last['text'] : ''
+
+  if (typeof lastKey === 'string') {
+    return {
+      path: [{_key: blockKey}, 'children', {_key: lastKey}],
+      offset: lastText.length,
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Resolve a point inside a container or void block by walking indices.
+ */
+function resolveContainerPoint(
+  schemaContext: {schema: Schema},
+  containers: Containers,
+  block: Record<string, unknown>,
+  path: Array<number>,
+  leafOffset: number,
+): EditorSelectionPoint | undefined {
+  const keyedPath: EditorSelectionPoint['path'] = []
+  const blockKey = block['_key']
+
+  if (typeof blockKey !== 'string') {
+    return undefined
+  }
+
+  keyedPath.push({_key: blockKey})
+
+  let currentNode: Record<string, unknown> = block
+
+  for (const index of path) {
+    let childFieldName: string | undefined
+
+    if (isTextBlock(schemaContext, currentNode as PortableTextBlock)) {
+      childFieldName = 'children'
+    } else if (typeof currentNode['_type'] === 'string') {
+      for (const [, containerField] of containers) {
+        if (currentNode[containerField.name] !== undefined) {
+          childFieldName = containerField.name
+          break
+        }
+      }
+    }
+
+    if (!childFieldName) {
+      break
+    }
+
+    const field = currentNode[childFieldName]
+
+    if (!Array.isArray(field)) {
+      return undefined
+    }
+
+    keyedPath.push(childFieldName)
+
+    const child = field[index] as Record<string, unknown> | undefined
+
+    if (!child || typeof child['_key'] !== 'string') {
+      return undefined
+    }
+
+    keyedPath.push({_key: child['_key']})
+    currentNode = child
+  }
+
+  return {path: keyedPath, offset: leafOffset}
+}
+
+function convertSelectionToPTE(
+  schema: Schema,
+  containers: Containers,
+  blocks: Array<PortableTextBlock>,
+  state: {
+    selection: {
+      anchor: {path: Array<number>; offset: number}
+      focus: {path: Array<number>; offset: number}
+    } | null
+  },
+): EditorSelection {
+  if (!state.selection) {
+    return null
+  }
+
+  const anchor = resolvePointToPTE(
+    schema,
+    containers,
+    blocks,
+    state.selection.anchor,
+  )
+  const focus = resolvePointToPTE(
+    schema,
+    containers,
+    blocks,
+    state.selection.focus,
+  )
+
+  if (!anchor || !focus) {
+    return null
+  }
+
+  return {anchor, focus}
+}
+
+function resolvePointToPTE(
+  schema: Schema,
+  containers: Containers,
+  blocks: Array<PortableTextBlock>,
+  point: {path: Array<number>; offset: number},
+): EditorSelectionPoint | undefined {
+  const keyedPath = indexedPathToKeyedPath(
+    point.path,
+    schema,
+    containers,
+    blocks as Array<Record<string, unknown>>,
+  )
+
+  if (!keyedPath) {
+    return undefined
+  }
+
+  return {path: keyedPath, offset: point.offset}
+}
+
+function indexedPathToKeyedPath(
+  indexedPath: Array<number>,
+  schema: Schema,
+  containers: Containers,
+  children: Array<Record<string, unknown>>,
+): EditorSelectionPoint['path'] | undefined {
+  const schemaContext = {schema}
+  const keyedPath: EditorSelectionPoint['path'] = []
+  let currentChildren = children
+
+  for (const index of indexedPath) {
+    const node = currentChildren[index]
+
+    if (!node || !('_key' in node) || typeof node['_key'] !== 'string') {
+      return undefined
+    }
+
+    keyedPath.push({_key: node['_key']})
+
+    let childFieldName: string | undefined
+
+    if (isTextBlock(schemaContext, node as PortableTextBlock)) {
+      childFieldName = 'children'
+    } else if (typeof node['_type'] === 'string') {
+      // Look up the field name from the containers map
+      for (const [, containerField] of containers) {
+        if (node[containerField.name] !== undefined) {
+          childFieldName = containerField.name
+          break
+        }
+      }
+    }
+
+    if (childFieldName) {
+      const field = node[childFieldName]
+
+      if (Array.isArray(field)) {
+        keyedPath.push(childFieldName)
+        currentChildren = field as Array<Record<string, unknown>>
+      }
+    } else {
+      // Leaf node (e.g., span). Remaining indices are mark nesting depth
+      // from the textspec parser and should be ignored since PTE uses
+      // flat marks.
+      break
+    }
+  }
+
+  return keyedPath
+}

--- a/packages/editor/test-utils/to-textspec.test.ts
+++ b/packages/editor/test-utils/to-textspec.test.ts
@@ -1,0 +1,466 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import type {
+  PortableTextBlock,
+  PortableTextTextBlock,
+} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {Containers} from '../src/schema/resolve-containers'
+import {toTextspec} from './to-textspec'
+
+const schemaDefinition = defineSchema({
+  annotations: [{name: 'comment'}, {name: 'link'}],
+  decorators: [{name: 'em'}, {name: 'strong'}],
+  blockObjects: [
+    {name: 'image'},
+    {name: 'break'},
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'tableRow',
+              name: 'tableRow',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'tableCell',
+                      name: 'tableCell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  inlineObjects: [{name: 'stock-ticker'}],
+  lists: [{name: 'bullet'}, {name: 'number'}],
+  styles: [
+    {name: 'normal'},
+    {name: 'h1'},
+    {name: 'h2'},
+    {name: 'h3'},
+    {name: 'h4'},
+    {name: 'h5'},
+    {name: 'h6'},
+    {name: 'blockquote'},
+  ],
+})
+
+const schema = compileSchema(schemaDefinition)
+
+const tableContainers: Containers = new Map([
+  [
+    'table',
+    {name: 'rows', type: 'array', of: [{type: 'tableRow', name: 'tableRow'}]},
+  ],
+  [
+    'table.tableRow',
+    {
+      name: 'cells',
+      type: 'array',
+      of: [{type: 'tableCell', name: 'tableCell'}],
+    },
+  ],
+  [
+    'table.tableRow.tableCell',
+    {name: 'content', type: 'array', of: [{type: 'block'}]},
+  ],
+])
+
+function block(
+  props: Partial<PortableTextTextBlock> & {
+    children: PortableTextTextBlock['children']
+  },
+): PortableTextTextBlock {
+  return {
+    _type: 'block',
+    _key: 'b0',
+    style: 'normal',
+    markDefs: [],
+    ...props,
+  }
+}
+
+function span(text: string, marks: Array<string> = []) {
+  return {_type: 'span' as const, _key: 's0', text, marks}
+}
+
+describe(toTextspec.name, () => {
+  test('simple paragraph', () => {
+    const value: Array<PortableTextBlock> = [block({children: [span('Hello')]})]
+    expect(toTextspec({schema, value, selection: null})).toBe('B: Hello')
+  })
+
+  test('heading h1', () => {
+    const value: Array<PortableTextBlock> = [
+      block({_key: 'b0', style: 'h1', children: [span('Hello')]}),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B style="h1": Hello',
+    )
+  })
+
+  test('blockquote', () => {
+    const value: Array<PortableTextBlock> = [
+      block({style: 'blockquote', children: [span('Quote')]}),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B style="blockquote": Quote',
+    )
+  })
+
+  test('bold text (decorator)', () => {
+    const value: Array<PortableTextBlock> = [
+      block({children: [span('Hello', ['strong'])]}),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: [strong:Hello]',
+    )
+  })
+
+  test('multiple decorators', () => {
+    const value: Array<PortableTextBlock> = [
+      block({children: [span('Hello', ['strong', 'em'])]}),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: [strong:[em:Hello]]',
+    )
+  })
+
+  test('link annotation', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        children: [span('Hello', ['abc'])],
+        markDefs: [{_type: 'link', _key: 'abc', href: 'https://example.com'}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: [@link href="https://example.com":Hello]',
+    )
+  })
+
+  test('decorator + annotation combined', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        children: [span('Hello', ['strong', 'abc'])],
+        markDefs: [{_type: 'link', _key: 'abc', href: 'https://example.com'}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: [strong:[@link href="https://example.com":Hello]]',
+    )
+  })
+
+  test('mixed plain and marked text', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        children: [
+          {_type: 'span', _key: 's0', text: 'Hello ', marks: []},
+          {_type: 'span', _key: 's1', text: 'world', marks: ['strong']},
+        ],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: Hello [strong:world]',
+    )
+  })
+
+  test('block object', () => {
+    const value: Array<PortableTextBlock> = [{_type: 'image', _key: 'b0'}]
+    expect(toTextspec({schema, value, selection: null})).toBe('{IMAGE}')
+  })
+
+  test('inline object', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        children: [
+          {_type: 'span', _key: 's0', text: 'text ', marks: []},
+          {_type: 'stock-ticker', _key: 'i0'},
+          {_type: 'span', _key: 's1', text: ' more', marks: []},
+        ],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: text {stock-ticker} more',
+    )
+  })
+
+  test('simple bullet list', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        _key: 'b0',
+        listItem: 'bullet',
+        level: 1,
+        children: [span('first')],
+      }),
+      block({
+        _key: 'b1',
+        listItem: 'bullet',
+        level: 1,
+        children: [{_type: 'span', _key: 's1', text: 'second', marks: []}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B listItem="bullet": first\nB listItem="bullet": second',
+    )
+  })
+
+  test('numbered list', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        _key: 'b0',
+        listItem: 'number',
+        level: 1,
+        children: [span('one')],
+      }),
+      block({
+        _key: 'b1',
+        listItem: 'number',
+        level: 1,
+        children: [{_type: 'span', _key: 's1', text: 'two', marks: []}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B listItem="number": one\nB listItem="number": two',
+    )
+  })
+
+  test('nested list', () => {
+    const value: Array<PortableTextBlock> = [
+      block({
+        _key: 'b0',
+        listItem: 'bullet',
+        level: 1,
+        children: [span('parent')],
+      }),
+      block({
+        _key: 'b1',
+        listItem: 'bullet',
+        level: 2,
+        children: [{_type: 'span', _key: 's1', text: 'child', marks: []}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B listItem="bullet": parent\nB level=2 listItem="bullet": child',
+    )
+  })
+
+  test('multiple blocks', () => {
+    const value: Array<PortableTextBlock> = [
+      block({_key: 'b0', children: [span('first')]}),
+      block({
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: 'second', marks: []}],
+      }),
+    ]
+    expect(toTextspec({schema, value, selection: null})).toBe(
+      'B: first\nB: second',
+    )
+  })
+
+  test('selection - collapsed cursor', () => {
+    const value: Array<PortableTextBlock> = [block({children: [span('Hello')]})]
+    const selection = {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 5},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 5},
+    }
+    expect(toTextspec({schema, value, selection})).toBe('B: Hello|')
+  })
+
+  test('selection - range', () => {
+    const value: Array<PortableTextBlock> = [block({children: [span('Hello')]})]
+    const selection = {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 5},
+    }
+    expect(toTextspec({schema, value, selection})).toBe('B: ^Hello|')
+  })
+
+  test('empty span text', () => {
+    const value: Array<PortableTextBlock> = [block({children: [span('')]})]
+    expect(toTextspec({schema, value, selection: null})).toBe('B: ')
+  })
+
+  test('table without containers is void', () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b0',
+                    children: [
+                      {_type: 'span', _key: 's0', text: 'hello', marks: []},
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    expect(toTextspec({schema, value, selection: null})).toBe('{TABLE}')
+  })
+
+  test('table with one cell', () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b0',
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: 's0',
+                        text: 'hello',
+                        marks: [],
+                      },
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    expect(
+      toTextspec({schema, value, selection: null, containers: tableContainers}),
+    ).toBe('TABLE:\n  TABLEROW:\n    TABLECELL:\n      B: hello')
+  })
+
+  test('table with multiple cells', () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b0',
+                    children: [
+                      {_type: 'span', _key: 's0', text: 'a', marks: []},
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+              {
+                _type: 'tableCell',
+                _key: 'c1',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b1',
+                    children: [
+                      {_type: 'span', _key: 's1', text: 'b', marks: []},
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'tableRow',
+            _key: 'r1',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c2',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b2',
+                    children: [
+                      {_type: 'span', _key: 's2', text: 'c', marks: []},
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+              {
+                _type: 'tableCell',
+                _key: 'c3',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b3',
+                    children: [
+                      {_type: 'span', _key: 's3', text: 'd', marks: []},
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    expect(
+      toTextspec({schema, value, selection: null, containers: tableContainers}),
+    ).toBe(
+      [
+        'TABLE:',
+        '  TABLEROW:',
+        '    TABLECELL:',
+        '      B: a',
+        '    TABLECELL:',
+        '      B: b',
+        '  TABLEROW:',
+        '    TABLECELL:',
+        '      B: c',
+        '    TABLECELL:',
+        '      B: d',
+      ].join('\n'),
+    )
+  })
+})

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -1,0 +1,431 @@
+import {isSpan, isTextBlock} from '@portabletext/schema'
+import type {
+  PortableTextBlock,
+  PortableTextObject,
+  PortableTextTextBlock,
+  Schema,
+} from '@portabletext/schema'
+import {serialize} from '@textspec/notation'
+import type {
+  Block,
+  ContainerBlock,
+  EditorState,
+  InlineNode,
+  TextBlock,
+  Selection as TextspecSelection,
+} from '@textspec/notation'
+import type {Containers} from '../src/schema/resolve-containers'
+import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
+
+/**
+ * Serialize PTE state to a textspec notation string.
+ */
+export function toTextspec(
+  context: {
+    schema: Schema
+    value: Array<PortableTextBlock>
+    selection: EditorSelection
+    containers?: Containers
+  },
+  options?: {singleLine?: boolean; keys?: boolean | Set<string>},
+): string {
+  const containers = context.containers ?? new Map()
+  const textspecBlocks: Array<Block> = []
+
+  for (const block of context.value) {
+    const converted = convertBlockToTextspec(context.schema, containers, block)
+    if (options?.keys) {
+      addKeys(block as Record<string, unknown>, converted, options.keys)
+    }
+    textspecBlocks.push(converted)
+  }
+
+  const selection = convertSelection(
+    context.schema,
+    context.value,
+    context.selection,
+  )
+
+  const state: EditorState = {
+    blocks: textspecBlocks,
+    selection,
+  }
+
+  return serialize(state, options?.singleLine ? {singleLine: true} : undefined)
+}
+
+function extractPrimitiveAttrs(
+  obj: Record<string, unknown>,
+): Record<string, string | number | boolean> {
+  const attrs: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === '_type' || key === '_key') {
+      continue
+    }
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      attrs[key] = value
+    }
+  }
+  return attrs
+}
+
+/**
+ * Add a `_key` attribute to a top-level block in the converted textspec
+ * tree. When `keys` is `true`, all blocks get their keys emitted. When
+ * `keys` is a Set, only blocks whose key is in the set get it emitted —
+ * this lets callers assert preservation of specific keys without churn
+ * from every other block.
+ */
+function addKeys(
+  source: Record<string, unknown>,
+  target: Block | InlineNode,
+  keys: true | Set<string>,
+): void {
+  const key = source['_key']
+  if (typeof key !== 'string') {
+    return
+  }
+
+  if (keys !== true && !keys.has(key)) {
+    return
+  }
+
+  if (
+    target.kind === 'textBlock' ||
+    target.kind === 'blockObject' ||
+    target.kind === 'containerBlock' ||
+    target.kind === 'inlineObject'
+  ) {
+    target.attrs = {_key: key, ...(target.attrs ?? {})}
+  }
+}
+
+function isDecoratorMark(schema: Schema, mark: string): boolean {
+  return schema.decorators.some((d) => d.name === mark)
+}
+
+function findMarkDef(
+  block: PortableTextTextBlock,
+  key: string,
+): PortableTextObject | undefined {
+  return block.markDefs?.find((md) => md._key === key)
+}
+
+/**
+ * Convert a PTE span's flat marks into nested textspec Mark nodes wrapping a Text node.
+ * Decorators wrap outermost, annotations wrap innermost.
+ */
+function wrapInMarks(
+  schema: Schema,
+  block: PortableTextTextBlock,
+  marks: ReadonlyArray<string>,
+  inner: InlineNode,
+): InlineNode {
+  if (marks.length === 0) {
+    return inner
+  }
+
+  const decorators: Array<string> = []
+  const annotations: Array<PortableTextObject> = []
+
+  for (const mark of marks) {
+    if (isDecoratorMark(schema, mark)) {
+      decorators.push(mark)
+    } else {
+      const markDef = findMarkDef(block, mark)
+      if (markDef) {
+        annotations.push(markDef)
+      }
+    }
+  }
+
+  let result = inner
+
+  // Annotations innermost
+  for (let i = annotations.length - 1; i >= 0; i--) {
+    const markDef = annotations[i]
+    if (!markDef) {
+      continue
+    }
+
+    const attrs = extractPrimitiveAttrs(markDef)
+
+    result = {
+      kind: 'mark',
+      type: markDef._type,
+      mode: 'annotation',
+      ...(Object.keys(attrs).length > 0 ? {attrs} : {}),
+      children: [result],
+    }
+  }
+
+  // Decorators outermost
+  for (let i = decorators.length - 1; i >= 0; i--) {
+    const decorator = decorators[i]
+    if (!decorator) {
+      continue
+    }
+
+    result = {
+      kind: 'mark',
+      type: decorator,
+      mode: 'decorator',
+      children: [result],
+    }
+  }
+
+  return result
+}
+
+function convertChildren(
+  schema: Schema,
+  block: PortableTextTextBlock,
+): Array<InlineNode> {
+  const ctx = {schema}
+  const result: Array<InlineNode> = []
+
+  for (const child of block.children) {
+    if (isSpan(ctx, child)) {
+      const textNode: InlineNode = {kind: 'text', text: child.text}
+      const marks = child.marks ?? []
+      result.push(
+        marks.length > 0
+          ? wrapInMarks(schema, block, marks, textNode)
+          : textNode,
+      )
+    } else {
+      result.push({
+        kind: 'inlineObject',
+        type: child._type,
+        attrs: extractPrimitiveAttrs(child),
+      })
+    }
+  }
+
+  return result
+}
+
+function convertTextBlock(
+  schema: Schema,
+  block: PortableTextTextBlock,
+): TextBlock {
+  const attrs: Record<string, string | number | boolean> = {}
+
+  if (block['style'] && block['style'] !== 'normal') {
+    attrs['style'] = block['style']
+  }
+
+  if (block['listItem']) {
+    attrs['listItem'] = block['listItem']
+  }
+
+  if (block['level'] !== undefined && block['level'] > 1) {
+    attrs['level'] = block['level']
+  }
+
+  return {
+    kind: 'textBlock',
+    type: 'B',
+    ...(Object.keys(attrs).length > 0 ? {attrs} : {}),
+    children: convertChildren(schema, block),
+  }
+}
+
+function resolveSelectionPoint(
+  schema: Schema,
+  blocks: Array<PortableTextBlock>,
+  point: EditorSelectionPoint,
+): {path: Array<number>; offset: number} | undefined {
+  const indexedPath = keyedPathToIndexedPath(
+    point.path,
+    blocks as Array<Record<string, unknown>>,
+  )
+
+  if (!indexedPath) {
+    return undefined
+  }
+
+  // Account for mark nesting depth in textspec.
+  // PTE has flat spans with marks array. Textspec nests marks as wrapper nodes.
+  // Each mark on a span adds one level of nesting, so the text node is
+  // at depth = number of marks below the child index.
+  const markDepth = getMarkDepth(schema, blocks, indexedPath)
+
+  for (let i = 0; i < markDepth; i++) {
+    indexedPath.push(0)
+  }
+
+  return {path: indexedPath, offset: point.offset}
+}
+
+function getMarkDepth(
+  schema: Schema,
+  blocks: Array<PortableTextBlock>,
+  indexedPath: Array<number>,
+): number {
+  if (indexedPath.length < 2) {
+    return 0
+  }
+
+  const blockIndex = indexedPath[0]
+  const childIndex = indexedPath[1]
+
+  if (blockIndex === undefined || childIndex === undefined) {
+    return 0
+  }
+
+  const block = blocks[blockIndex]
+
+  if (!block || !isTextBlock({schema}, block)) {
+    return 0
+  }
+
+  const child = block.children[childIndex]
+
+  if (!child || !isSpan({schema}, child)) {
+    return 0
+  }
+
+  return child.marks?.length ?? 0
+}
+
+function keyedPathToIndexedPath(
+  keyedPath: EditorSelectionPoint['path'],
+  children: Array<Record<string, unknown>>,
+): Array<number> | undefined {
+  const indexedPath: Array<number> = []
+  let currentChildren = children
+  let currentNode: Record<string, unknown> | undefined
+
+  for (const segment of keyedPath) {
+    if (typeof segment === 'object' && segment !== null && '_key' in segment) {
+      const index = currentChildren.findIndex(
+        (child) => child['_key'] === segment._key,
+      )
+
+      if (index === -1) {
+        return undefined
+      }
+
+      indexedPath.push(index)
+      currentNode = currentChildren[index]
+    } else if (typeof segment === 'string' && currentNode) {
+      const field = currentNode[segment]
+
+      if (Array.isArray(field)) {
+        currentChildren = field as Array<Record<string, unknown>>
+      } else {
+        return undefined
+      }
+    } else {
+      return undefined
+    }
+  }
+
+  return indexedPath
+}
+
+function convertBlockToTextspec(
+  schema: Schema,
+  containers: Containers,
+  block: PortableTextBlock,
+): Block {
+  if (isTextBlock({schema}, block)) {
+    return convertTextBlock(schema, block)
+  }
+
+  if (containers.has(block._type)) {
+    return convertContainerBlock(schema, containers, block, block._type)
+  }
+
+  return {
+    kind: 'blockObject',
+    type: block._type.toUpperCase(),
+    attrs: extractPrimitiveAttrs(block),
+  }
+}
+
+function convertContainerBlock(
+  schema: Schema,
+  containers: Containers,
+  block: Record<string, unknown>,
+  scopePath: string,
+): ContainerBlock {
+  const containerField = containers.get(scopePath)
+
+  if (!containerField) {
+    return {
+      kind: 'containerBlock',
+      type:
+        typeof block['_type'] === 'string' ? block['_type'].toUpperCase() : '',
+      children: [],
+    }
+  }
+
+  const fieldValue = block[containerField.name]
+  const children: Array<Block> = []
+  const schemaContext = {schema}
+
+  if (Array.isArray(fieldValue)) {
+    for (const item of fieldValue) {
+      if (isTextBlock(schemaContext, item)) {
+        children.push(convertTextBlock(schema, item))
+      } else if (
+        typeof item === 'object' &&
+        item !== null &&
+        '_type' in item &&
+        typeof item._type === 'string'
+      ) {
+        const typedItem = item as Record<string, unknown>
+        const childScopePath = `${scopePath}.${item._type}`
+
+        if (containers.has(childScopePath)) {
+          children.push(
+            convertContainerBlock(
+              schema,
+              containers,
+              typedItem,
+              childScopePath,
+            ),
+          )
+        } else {
+          children.push({
+            kind: 'blockObject',
+            type: item._type.toUpperCase(),
+            attrs: extractPrimitiveAttrs(typedItem),
+          })
+        }
+      }
+    }
+  }
+
+  return {
+    kind: 'containerBlock',
+    type:
+      typeof block['_type'] === 'string' ? block['_type'].toUpperCase() : '',
+    children,
+  }
+}
+
+function convertSelection(
+  schema: Schema,
+  blocks: Array<PortableTextBlock>,
+  selection: EditorSelection,
+): TextspecSelection | null {
+  if (!selection) {
+    return null
+  }
+
+  const anchor = resolveSelectionPoint(schema, blocks, selection.anchor)
+  const focus = resolveSelectionPoint(schema, blocks, selection.focus)
+
+  if (!anchor || !focus) {
+    return null
+  }
+
+  return {anchor, focus}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,10 +89,10 @@ importers:
         version: 5.0.2(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       '@astrojs/starlight':
         specifier: ^0.38.2
-        version: 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
-        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(tailwindcss@4.1.18)
+        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(tailwindcss@4.1.18)
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../../packages/editor
@@ -131,7 +131,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -140,7 +140,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       astro:
         specifier: ^6.1.3
-        version: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -161,13 +161,13 @@ importers:
         version: 0.34.5
       starlight-links-validator:
         specifier: ^0.21.0
-        version: 0.21.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.21.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       starlight-package-managers:
         specifier: ^0.12.0
-        version: 0.12.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))
+        version: 0.12.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))
       starlight-typedoc:
         specifier: ^0.21.5
-        version: 0.21.5(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.9.3)))(typedoc@0.28.15(typescript@5.9.3))
+        version: 0.21.5(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.9.3)))(typedoc@0.28.15(typescript@5.9.3))
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.16
-        version: 4.1.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -282,7 +282,7 @@ importers:
         version: 19.2.0
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -315,7 +315,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   examples/basic:
     dependencies:
@@ -401,7 +401,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/editor:
     dependencies:
@@ -448,6 +448,9 @@ importers:
       '@sanity/tsconfig':
         specifier: ^2.1.0
         version: 2.1.0
+      '@textspec/notation':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -462,13 +465,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/coverage-istanbul':
         specifier: ^4.1.3
         version: 4.1.3(vitest@4.1.3)
@@ -504,10 +507,10 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.3)
@@ -544,7 +547,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/keyboard-shortcuts:
     devDependencies:
@@ -559,7 +562,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/markdown:
     dependencies:
@@ -596,7 +599,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/patches:
     dependencies:
@@ -615,7 +618,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-character-pair-decorator:
     dependencies:
@@ -658,7 +661,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-emoji-picker:
     dependencies:
@@ -692,13 +695,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -725,7 +728,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-input-rule:
     dependencies:
@@ -753,13 +756,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -786,7 +789,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-markdown-shortcuts:
     dependencies:
@@ -808,13 +811,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -838,7 +841,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-one-line:
     devDependencies:
@@ -883,13 +886,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -913,7 +916,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-sdk-value:
     dependencies:
@@ -956,13 +959,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -989,7 +992,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.3)
@@ -1026,13 +1029,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1059,7 +1062,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-typography:
     dependencies:
@@ -1084,13 +1087,13 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.3
-        version: 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.3
-        version: 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+        version: 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1117,7 +1120,7 @@ importers:
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/racejar:
     dependencies:
@@ -1148,7 +1151,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/sanity-bridge:
     dependencies:
@@ -1173,7 +1176,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/schema:
     devDependencies:
@@ -1188,7 +1191,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/test:
     devDependencies:
@@ -1572,28 +1575,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.10':
     resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.10':
     resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.10':
     resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.10':
     resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
@@ -1762,12 +1761,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -1782,12 +1775,6 @@ packages:
 
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1810,12 +1797,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -1830,12 +1811,6 @@ packages:
 
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1858,12 +1833,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -1878,12 +1847,6 @@ packages:
 
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1906,12 +1869,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -1926,12 +1883,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1954,12 +1905,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -1974,12 +1919,6 @@ packages:
 
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2002,12 +1941,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -2022,12 +1955,6 @@ packages:
 
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2050,12 +1977,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -2070,12 +1991,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2098,12 +2013,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -2118,12 +2027,6 @@ packages:
 
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2146,12 +2049,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/netbsd-arm64@0.27.1':
     resolution: {integrity: sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==}
     engines: {node: '>=18'}
@@ -2160,12 +2057,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2188,12 +2079,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/openbsd-arm64@0.27.1':
     resolution: {integrity: sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==}
     engines: {node: '>=18'}
@@ -2202,12 +2087,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2230,12 +2109,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openharmony-arm64@0.27.1':
     resolution: {integrity: sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==}
     engines: {node: '>=18'}
@@ -2244,12 +2117,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2272,12 +2139,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -2292,12 +2153,6 @@ packages:
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2320,12 +2175,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -2340,12 +2189,6 @@ packages:
 
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2497,105 +2340,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2755,9 +2582,6 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@napi-rs/wasm-runtime@1.1.0':
-    resolution: {integrity: sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==}
-
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -2833,56 +2657,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.120.0':
     resolution: {integrity: sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.120.0':
     resolution: {integrity: sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.120.0':
     resolution: {integrity: sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.120.0':
     resolution: {integrity: sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.120.0':
     resolution: {integrity: sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.120.0':
     resolution: {integrity: sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.120.0':
     resolution: {integrity: sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.120.0':
     resolution: {integrity: sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA==}
@@ -2961,49 +2777,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -4095,56 +3903,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.54':
     resolution: {integrity: sha512-pY8N2X5C+/ZQcy0eRdfOzOP//OFngP1TaIqDjFwfBPws2UNavKS8SpxhPEgUaYIaT0keVBd/TB+eVy9z+CIOtw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
     resolution: {integrity: sha512-ENLmSQCWqSA/+YN45V2FqTIemg7QspaiTjlm327eUAMeOLdqmSOVVyrQexJGNTQ5M8sDYCgVAig2Kk01Ggmqaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.54':
     resolution: {integrity: sha512-cgTooAFm2MUmFriB7IYaWBNyqrGlRPKG+yaK2rGFl2rcdOcO24urY4p3eyB0ogqsRLvJbIxwjjYiWiIP7Eo1Cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
     resolution: {integrity: sha512-klahlb2EIFltSUubn/VLjuc3qxp1E7th8ukayPfdkcKvvYcQ5rJztgx8JsJSuAKVzKtNTqUGOhy4On71BuyV8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.54':
     resolution: {integrity: sha512-nGyLT1Qau0W+kEL44V2jhHmvfS3wyJW08E4WEu2E6NuIy+uChKN1X0aoxzFIDi2owDsYaZYez/98/f268EupIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
     resolution: {integrity: sha512-UuA+JqQIgqtkgGN2c/AQ5wi8M6mJHrahz/wciENPTeI6zEIbbLGoth5XN+sQe2pJDejEVofN9aOAp0kaazwnVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.54':
     resolution: {integrity: sha512-KH374P0TUjDXssROT/orvzaWrzGOptD13PTrltgKwbDprJTMknoLiYsOD6Ttz92O2VuAcCtFuJ1xbyFM2Uo/Xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
     resolution: {integrity: sha512-1BNQW8u4ro8bsN1+tgKENJiqmvc+WfuaUhXzMImOVSMw28pkBKdfZtX2qJPADV3terx+vNJtlsgSGeb3+W6Jiw==}
@@ -4291,8 +4091,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
     os: [android]
 
@@ -4301,8 +4101,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
     cpu: [arm64]
     os: [android]
 
@@ -4311,8 +4111,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4321,8 +4121,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  '@rollup/rollup-darwin-x64@4.60.0':
+    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
     cpu: [x64]
     os: [darwin]
 
@@ -4331,8 +4131,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
     cpu: [arm64]
     os: [freebsd]
 
@@ -4341,8 +4141,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
     cpu: [x64]
     os: [freebsd]
 
@@ -4350,148 +4150,124 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
     cpu: [x64]
     os: [openbsd]
 
@@ -4500,8 +4276,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -4510,8 +4286,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -4520,8 +4296,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
     cpu: [ia32]
     os: [win32]
 
@@ -4530,8 +4306,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
     cpu: [x64]
     os: [win32]
 
@@ -4540,8 +4316,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
@@ -4773,9 +4549,6 @@ packages:
   '@sinonjs/fake-timers@15.3.0':
     resolution: {integrity: sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4820,28 +4593,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -4875,6 +4644,10 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@textspec/notation@1.0.1':
+    resolution: {integrity: sha512-XADhtctcXBykcJ+hlsNPmKG5I2YHmF4eDtahZUUOSR1w/tZUk346uznnntm+FhWXCr9bCSht5PTeHry1m1TC4w==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
@@ -5438,10 +5211,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@6.2.1:
-    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
-    engines: {node: '>=18'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -5803,11 +5572,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -6114,9 +5878,6 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
-
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -6638,28 +6399,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7722,8 +7479,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+  rollup@4.60.0:
+    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8530,46 +8287,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vitefu@1.1.2:
     resolution: {integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==}
     peerDependencies:
@@ -8893,12 +8610,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -8947,22 +8664,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(tailwindcss@4.1.18)':
+  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(tailwindcss@4.1.18)':
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       tailwindcss: 4.1.18
 
-  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
+  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -9564,9 +9281,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
@@ -9574,9 +9288,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -9588,9 +9299,6 @@ snapshots:
   '@esbuild/android-arm@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-x64@0.21.5':
     optional: true
 
@@ -9598,9 +9306,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.4':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -9612,9 +9317,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
@@ -9622,9 +9324,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -9636,9 +9335,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
@@ -9646,9 +9342,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -9660,9 +9353,6 @@ snapshots:
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
@@ -9670,9 +9360,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -9684,9 +9371,6 @@ snapshots:
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
@@ -9694,9 +9378,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -9708,9 +9389,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
@@ -9718,9 +9396,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -9732,9 +9407,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -9742,9 +9414,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -9756,16 +9425,10 @@ snapshots:
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.27.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -9777,16 +9440,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.27.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -9798,16 +9455,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.27.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -9819,9 +9470,6 @@ snapshots:
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
@@ -9829,9 +9477,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -9843,9 +9488,6 @@ snapshots:
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
@@ -9853,9 +9495,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
@@ -10362,13 +10001,6 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@napi-rs/wasm-runtime@1.1.0':
-    dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -10393,6 +10025,12 @@ snapshots:
       '@optimize-lodash/transform': 4.0.0
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       rollup: 4.53.3
+
+  '@optimize-lodash/rollup-plugin@6.0.0(rollup@4.60.0)':
+    dependencies:
+      '@optimize-lodash/transform': 4.0.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+      rollup: 4.60.0
 
   '@optimize-lodash/transform@4.0.0':
     dependencies:
@@ -12009,12 +11647,12 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.0
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.54':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.0
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.52':
@@ -12044,6 +11682,10 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.3
 
+  '@rollup/plugin-alias@6.0.0(rollup@4.60.0)':
+    optionalDependencies:
+      rollup: 4.60.0
+
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.53.3)':
     dependencies:
       '@babel/core': 7.29.0
@@ -12052,6 +11694,17 @@ snapshots:
     optionalDependencies:
       '@types/babel__core': 7.20.5
       rollup: 4.53.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
+      rollup: 4.60.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12067,11 +11720,29 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.3
 
+  '@rollup/plugin-commonjs@29.0.0(rollup@4.60.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.0
+
   '@rollup/plugin-json@6.1.0(rollup@4.53.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
     optionalDependencies:
       rollup: 4.53.3
+
+  '@rollup/plugin-json@6.1.0(rollup@4.60.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+    optionalDependencies:
+      rollup: 4.60.0
 
   '@rollup/plugin-node-resolve@16.0.3(rollup@4.53.3)':
     dependencies:
@@ -12083,12 +11754,29 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.3
 
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.60.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.11
+    optionalDependencies:
+      rollup: 4.60.0
+
   '@rollup/plugin-replace@6.0.3(rollup@4.53.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.53.3
+
+  '@rollup/plugin-replace@6.0.3(rollup@4.60.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.0
 
   '@rollup/plugin-terser@0.4.4(rollup@4.53.3)':
     dependencies:
@@ -12098,6 +11786,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.3
 
+  '@rollup/plugin-terser@0.4.4(rollup@4.60.0)':
+    dependencies:
+      serialize-javascript: 6.0.2
+      smob: 1.5.0
+      terser: 5.44.1
+    optionalDependencies:
+      rollup: 4.60.0
+
   '@rollup/pluginutils@5.3.0(rollup@4.53.3)':
     dependencies:
       '@types/estree': 1.0.8
@@ -12106,153 +11802,153 @@ snapshots:
     optionalDependencies:
       rollup: 4.53.3
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
+  '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.60.1
+      rollup: 4.60.0
 
   '@rollup/rollup-android-arm-eabi@4.53.3':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  '@rollup/rollup-darwin-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.53.3':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  '@rollup/rollup-freebsd-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.53.3':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
+  '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
+  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
+  '@rollup/rollup-openharmony-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
   '@rushstack/node-core-library@5.19.1(@types/node@20.19.25)':
@@ -12404,33 +12100,33 @@ snapshots:
 
   '@sanity/parse-package-json@2.0.0':
     dependencies:
-      zod: 4.1.13
+      zod: 4.3.6
 
   '@sanity/pkg-utils@10.2.1(@types/babel__core@7.20.5)(@types/node@20.19.25)(babel-plugin-react-compiler@1.0.0)(debug@4.4.3)(oxc-resolver@11.19.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/types': 7.29.0
       '@microsoft/api-extractor': 7.55.2(@types/node@20.19.25)
       '@microsoft/tsdoc-config': 0.18.0
-      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.53.3)
-      '@rollup/plugin-alias': 6.0.0(rollup@4.53.3)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.53.3)
-      '@rollup/plugin-commonjs': 29.0.0(rollup@4.53.3)
-      '@rollup/plugin-json': 6.1.0(rollup@4.53.3)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.53.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.53.3)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.53.3)
+      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.60.0)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.0)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.0)
+      '@rollup/plugin-commonjs': 29.0.0(rollup@4.60.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.0)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.0)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.60.0)
       '@sanity/browserslist-config': 1.0.5
       '@sanity/parse-package-json': 2.0.0
-      '@vanilla-extract/rollup-plugin': 1.5.0(rollup@4.53.3)
+      '@vanilla-extract/rollup-plugin': 1.5.0(rollup@4.60.0)
       browserslist: 4.28.1
       cac: 6.7.14
       chalk: 5.6.2
       chokidar: 5.0.0
       empathic: 2.0.0
-      esbuild: 0.27.1
+      esbuild: 0.27.4
       find-config: 1.0.0
       get-latest-version: 5.1.0(debug@4.4.3)
       git-url-parse: 16.1.0
@@ -12446,15 +12142,15 @@ snapshots:
       rimraf: 6.1.2
       rolldown: 1.0.0-beta.54
       rolldown-plugin-dts: 0.18.3(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.54)(typescript@5.9.3)
-      rollup: 4.53.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.1)(rollup@4.53.3)
+      rollup: 4.60.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.4)(rollup@4.60.0)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.21.0
       typescript: 5.9.3
       uuid: 13.0.0
-      zod: 4.1.13
-      zod-validation-error: 5.0.0(zod@4.1.13)
+      zod: 4.3.6
+      zod-validation-error: 5.0.0(zod@4.3.6)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
     transitivePeerDependencies:
@@ -12471,28 +12167,28 @@ snapshots:
   '@sanity/pkg-utils@10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/types': 7.29.0
       '@microsoft/api-extractor': 7.55.2(@types/node@24.12.2)
       '@microsoft/tsdoc-config': 0.18.0
-      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.53.3)
-      '@rollup/plugin-alias': 6.0.0(rollup@4.53.3)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.53.3)
-      '@rollup/plugin-commonjs': 29.0.0(rollup@4.53.3)
-      '@rollup/plugin-json': 6.1.0(rollup@4.53.3)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.53.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.53.3)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.53.3)
+      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.60.0)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.0)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.0)
+      '@rollup/plugin-commonjs': 29.0.0(rollup@4.60.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.0)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.0)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.60.0)
       '@sanity/browserslist-config': 1.0.5
       '@sanity/parse-package-json': 2.0.0
-      '@vanilla-extract/rollup-plugin': 1.5.0(rollup@4.53.3)
+      '@vanilla-extract/rollup-plugin': 1.5.0(rollup@4.60.0)
       browserslist: 4.28.1
       cac: 6.7.14
       chalk: 5.6.2
       chokidar: 5.0.0
       empathic: 2.0.0
-      esbuild: 0.27.1
+      esbuild: 0.27.4
       find-config: 1.0.0
       get-latest-version: 5.1.0(debug@4.4.3)
       git-url-parse: 16.1.0
@@ -12508,15 +12204,15 @@ snapshots:
       rimraf: 6.1.2
       rolldown: 1.0.0-beta.54
       rolldown-plugin-dts: 0.18.3(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.54)(typescript@5.9.3)
-      rollup: 4.53.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.1)(rollup@4.53.3)
+      rollup: 4.60.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.4)(rollup@4.60.0)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.21.0
       typescript: 5.9.3
       uuid: 13.0.0
-      zod: 4.1.13
-      zod-validation-error: 5.0.0(zod@4.1.13)
+      zod: 4.3.6
+      zod-validation-error: 5.0.0(zod@4.3.6)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
     transitivePeerDependencies:
@@ -12792,8 +12488,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.17':
@@ -12861,12 +12555,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@textspec/notation@1.0.1': {}
 
   '@ts-morph/common@0.28.1':
     dependencies:
@@ -13154,7 +12850,7 @@ snapshots:
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
       '@vanilla-extract/css': 1.17.5
       dedent: 1.7.0
-      esbuild: 0.27.7
+      esbuild: 0.27.4
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -13174,6 +12870,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  '@vanilla-extract/rollup-plugin@1.5.0(rollup@4.60.0)':
+    dependencies:
+      '@vanilla-extract/integration': 8.0.6
+      magic-string: 0.30.21
+      rollup: 4.60.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   '@vercel/stega@1.1.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@24.12.2)(lightningcss@1.30.2)(terser@5.44.1))':
@@ -13185,6 +12890,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.21(@types/node@24.12.2)(lightningcss@1.30.2)(terser@5.44.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -13200,34 +12917,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/browser-playwright@4.0.18(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/browser-playwright@4.0.18(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
       vitest: 4.0.18(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -13238,35 +12931,35 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
+  '@vitest/browser-playwright@4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
     dependencies:
-      '@vitest/browser': 4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
+  '@vitest/browser-playwright@4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
     dependencies:
-      '@vitest/browser': 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
@@ -13282,16 +12975,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
+  '@vitest/browser@4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13299,16 +12992,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
+  '@vitest/browser@4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -13328,7 +13021,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -13344,17 +13037,17 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+      '@vitest/browser': 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
 
   '@vitest/expect@4.0.18':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
-      chai: 6.2.1
+      chai: 6.2.2
       tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.3':
@@ -13366,29 +13059,29 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -13545,12 +13238,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       rehype-expressive-code: 0.41.7
 
-  astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -13559,7 +13252,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
       aria-query: 5.3.2
       axobject-query: 4.1.0
       ci-info: 4.4.0
@@ -13743,8 +13436,6 @@ snapshots:
   caniuse-lite@1.0.30001759: {}
 
   ccount@2.0.1: {}
-
-  chai@6.2.1: {}
 
   chai@6.2.2: {}
 
@@ -14114,35 +13805,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
@@ -14485,10 +14147,6 @@ snapshots:
   get-package-type@0.1.0: {}
 
   get-stream@8.0.1: {}
-
-  get-tsconfig@4.13.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -16659,12 +16317,12 @@ snapshots:
   rolldown-plugin-dts@0.18.1(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.52)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
       dts-resolver: 2.1.3(oxc-resolver@11.19.1)
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.13.6
       magic-string: 0.30.21
       obug: 2.1.1
       rolldown: 1.0.0-beta.52
@@ -16676,12 +16334,12 @@ snapshots:
   rolldown-plugin-dts@0.18.3(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.54)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 3.0.0
       dts-resolver: 2.1.3(oxc-resolver@11.19.1)
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.13.6
       magic-string: 0.30.21
       obug: 2.1.1
       rolldown: 1.0.0-beta.54
@@ -16734,8 +16392,19 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       esbuild: 0.27.1
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.13.6
       rollup: 4.53.3
+      unplugin-utils: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.4)(rollup@4.60.0):
+    dependencies:
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+      rollup: 4.60.0
       unplugin-utils: 0.2.5
     transitivePeerDependencies:
       - supports-color
@@ -16768,35 +16437,35 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
-  rollup@4.60.1:
+  rollup@4.60.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
+      '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
+      '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
+      '@rollup/rollup-win32-x64-gnu': 4.60.0
+      '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -16992,11 +16661,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-links-validator@0.21.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  starlight-links-validator@0.21.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@types/picomatch': 4.0.3
-      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0
@@ -17009,13 +16678,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-package-managers@0.12.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))):
+  starlight-package-managers@0.12.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))):
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
 
-  starlight-typedoc@0.21.5(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.9.3)))(typedoc@0.28.15(typescript@5.9.3)):
+  starlight-typedoc@0.21.5(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.9.0(typedoc@0.28.15(typescript@5.9.3)))(typedoc@0.28.15(typescript@5.9.3)):
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       github-slugger: 2.0.0
       typedoc: 0.28.15(typescript@5.9.3)
       typedoc-plugin-markdown: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
@@ -17229,8 +16898,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.7
-      get-tsconfig: 4.13.0
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -17468,13 +17137,30 @@ snapshots:
   vite@5.4.21(@types/node@24.12.2)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.8
-      rollup: 4.60.1
+      postcss: 8.5.6
+      rollup: 4.53.3
     optionalDependencies:
       '@types/node': 24.12.2
       fsevents: 2.3.3
       lightningcss: 1.30.2
       terser: 5.44.1
+
+  vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.1
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.25
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      terser: 5.44.1
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -17493,40 +17179,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.25
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
-  vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vitefu@1.1.2(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -17535,7 +17187,7 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17543,7 +17195,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -17560,11 +17212,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
-      '@vitest/browser-playwright': 4.0.18(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)
       jsdom: 27.2.0
     transitivePeerDependencies:
       - jiti
@@ -17579,10 +17231,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.3(@types/node@20.19.25)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.3
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.3
       '@vitest/runner': 4.1.3
       '@vitest/snapshot': 4.1.3
@@ -17599,21 +17251,21 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.25
-      '@vitest/browser-playwright': 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+      '@vitest/browser-playwright': 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       '@vitest/coverage-v8': 4.1.3(@vitest/browser@4.1.3)(vitest@4.1.3)
       jsdom: 27.2.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.3(@types/node@24.12.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(@vitest/coverage-v8@4.1.3)(jsdom@27.2.0)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.3
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.3
       '@vitest/runner': 4.1.3
       '@vitest/snapshot': 4.1.3
@@ -17630,11 +17282,11 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
-      '@vitest/browser-playwright': 4.1.3(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
+      '@vitest/browser-playwright': 4.1.3(playwright@1.59.1)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.3)
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       '@vitest/coverage-v8': 4.1.3(@vitest/browser@4.1.3)(vitest@4.1.3)
       jsdom: 27.2.0
@@ -17732,6 +17384,10 @@ snapshots:
   zod-validation-error@5.0.0(zod@4.1.13):
     dependencies:
       zod: 4.1.13
+
+  zod-validation-error@5.0.0(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.1.13: {}
 


### PR DESCRIPTION
Gherkin tests currently assert editor state using terse-pt notation, which is lossy: it strips marks, hides block types, and represents multi-block content as pipe-separated arrays. This makes it impossible to write assertions that verify marks, styles, or list structure. Setting up test state requires multiple steps: insert text, toggle style, place caret.

This adds a `toTextspec` serializer and a `fromTextspec` parser in `test-utils/`, plus two Gherkin step definitions:

- `Then the editor state is "..."` asserts the full editor state (value + selection)
- `Given the editor state is "..."` sets up editor state from a textspec string

All text blocks use `B:` as the universal block marker. Non-default properties are written out explicitly as attributes:

```
B: Hello [strong:world]
B style="h1": Title
B listItem="bullet": first item
B level=2 listItem="bullet": nested item
```

Selection is embedded in the notation using `|` for cursor and `^...|` for ranges:

```
B style="h1": fo|o
B: ^Hello| world
```

Containers are opt-in via the `containers` parameter (same `Containers` map the editor uses internally). Without it, block objects serialize as void. With it, they serialize as nested containers.

Both `{terse-pt}` and textspec coexist. The `splitting-blocks.feature` file is partially converted: all `Then` assertions use textspec, and scenarios without block key dependencies use `Given the editor state is` for setup.