### PR TITLE
fix: guard debug calls to avoid eager serialization

### DIFF
--- a/.changeset/lazy-debug-serialization.md
+++ b/.changeset/lazy-debug-serialization.md
@@ -2,4 +2,4 @@
 '@portabletext/editor': patch
 ---
 
-Guard debug logging calls to avoid eager `JSON.stringify` serialization when debug namespaces are disabled.
+fix: guard debug calls to avoid eager serialization

--- a/.changeset/lazy-debug-serialization.md
+++ b/.changeset/lazy-debug-serialization.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+Guard debug logging calls to avoid eager `JSON.stringify` serialization when debug namespaces are disabled.

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -66,7 +66,12 @@ export function performEvent({
     editor.undoStepId = defaultKeyGenerator()
   }
 
-  debug.behaviors(`(${mode}:${eventCategory(event)})`, safeStringify(event, 2))
+  if (debug.behaviors.enabled) {
+    debug.behaviors(
+      `(${mode}:${eventCategory(event)})`,
+      safeStringify(event, 2),
+    )
+  }
 
   const eventBehaviors = [
     ...remainingEventBehaviors,
@@ -116,7 +121,9 @@ export function performEvent({
     }
 
     withPerformingBehaviorOperation(editor, () => {
-      debug.operation(safeStringify(event, 2))
+      if (debug.operation.enabled) {
+        debug.operation(safeStringify(event, 2))
+      }
 
       performOperation({
         context: {
@@ -358,7 +365,9 @@ export function performEvent({
     }
 
     withPerformingBehaviorOperation(editor, () => {
-      debug.operation(safeStringify(event, 2))
+      if (debug.operation.enabled) {
+        debug.operation(safeStringify(event, 2))
+      }
 
       performOperation({
         context: {keyGenerator, schema},

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -234,12 +234,16 @@ export const PortableTextEditable = forwardRef<
 
   const restoreSelectionFromProps = useCallback(() => {
     if (propsSelection) {
-      debug.selection(`Selection from props ${safeStringify(propsSelection)}`)
+      if (debug.selection.enabled) {
+        debug.selection(`Selection from props ${safeStringify(propsSelection)}`)
+      }
       const resolvedSelection = resolveSelection(slateEditor, propsSelection)
       if (resolvedSelection) {
-        debug.selection(
-          `Resolved selection from props ${safeStringify(resolvedSelection)}`,
-        )
+        if (debug.selection.enabled) {
+          debug.selection(
+            `Resolved selection from props ${safeStringify(resolvedSelection)}`,
+          )
+        }
         slateEditor.select(resolvedSelection)
         // Output selection here in those cases where the editor selection was the same, and there are no set_selection operations made.
         // The selection is usually automatically emitted by the withPortableTextSelections plugin whenever there is a set_selection operation applied.

--- a/packages/editor/src/slate-plugins/slate-plugin.patches.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.patches.ts
@@ -64,10 +64,12 @@ export function createPatchesPlugin({
                 try {
                   changed = applyPatch(editor, patch)
 
-                  if (changed) {
-                    debug.syncPatch(`(applied) ${safeStringify(patch, 2)}`)
-                  } else {
-                    debug.syncPatch(`(ignored) ${safeStringify(patch, 2)}`)
+                  if (debug.syncPatch.enabled) {
+                    if (changed) {
+                      debug.syncPatch(`(applied) ${safeStringify(patch, 2)}`)
+                    } else {
+                      debug.syncPatch(`(ignored) ${safeStringify(patch, 2)}`)
+                    }
                   }
                 } catch (error) {
                   console.error(

--- a/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
@@ -12,7 +12,9 @@ export function updateValuePlugin(
 
   editor.apply = (operation) => {
     if (editor.isNormalizingNode) {
-      debug.normalization(`(slate operation)\n${safeStringify(operation, 2)}`)
+      if (debug.normalization.enabled) {
+        debug.normalization(`(slate operation)\n${safeStringify(operation, 2)}`)
+      }
     }
 
     if (operation.type === 'set_selection') {


### PR DESCRIPTION
`safeStringify` (`JSON.stringify`) was called eagerly as a function argument to debug loggers, even when the debug namespace was disabled. Every call to `performEvent`, `applyPatch`, and normalization operations paid the cost of serializing event and operation objects to pretty-printed JSON strings that were immediately discarded.

For a 1000-block insert, this meant 2000+ `JSON.stringify` calls on non-trivial objects (blocks with children, markDefs, styles) with no consumer.

Each call site is now guarded with `debug.<namespace>.enabled` so serialization only happens when someone is actively debugging.

**Call sites fixed:**
- `performEvent`: `debug.behaviors` (1 site), `debug.operation` (2 sites)
- `Editable.tsx`: `debug.selection` (2 sites)
- `slate-plugin.patches.ts`: `debug.syncPatch` (2 sites)
- `slate-plugin.update-value.ts`: `debug.normalization` (1 site)