### PR TITLE
fix: read schema from editor instead of actor selector

### DIFF
--- a/.changeset/remove-schema-selectors.md
+++ b/.changeset/remove-schema-selectors.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: read schema from editor instead of actor selector

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -137,6 +137,7 @@ export const PortableTextEditable = forwardRef<
 
   const editorActor = useContext(EditorActorContext)
   const relayActor = useContext(RelayActorContext)
+  const schema = editorActor.getSnapshot().context.schema
   const readOnly = useSelector(editorActor, (s) =>
     s.matches({'edit mode': 'read only'}),
   )
@@ -151,7 +152,7 @@ export const PortableTextEditable = forwardRef<
     input: {
       rangeDecorations: rangeDecorations ?? [],
       readOnly,
-      schema: editorActor.getSnapshot().context.schema,
+      schema,
       slateEditor,
       skipSetup: !editorActor.getSnapshot().matches({setup: 'setting up'}),
     },
@@ -186,11 +187,13 @@ export const PortableTextEditable = forwardRef<
         renderChild={renderChild}
         renderListItem={renderListItem}
         renderStyle={renderStyle}
+        schema={schema}
         spellCheck={spellCheck}
       />
     ),
     [
       dropPosition,
+      schema,
       spellCheck,
       readOnly,
       renderBlock,
@@ -216,6 +219,7 @@ export const PortableTextEditable = forwardRef<
         renderChild={renderChild}
         renderDecorator={renderDecorator}
         renderPlaceholder={renderPlaceholder}
+        schema={schema}
       />
     ),
     [
@@ -224,6 +228,7 @@ export const PortableTextEditable = forwardRef<
       renderChild,
       renderDecorator,
       renderPlaceholder,
+      schema,
     ],
   )
 

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -18,6 +18,7 @@ import type {
 } from '../types/editor'
 import {ContainerScopeContext} from './container-scope-context'
 import {EditorActorContext} from './editor-actor-context'
+import type {EditorSchema} from './editor-schema'
 import {RenderBlockObject} from './render.block-object'
 import {RenderContainer} from './render.container'
 import {RenderInlineObject} from './render.inline-object'
@@ -34,12 +35,13 @@ export function RenderElement(props: {
   renderChild?: RenderChildFunction
   renderListItem?: RenderListItemFunction
   renderStyle?: RenderStyleFunction
+  schema: EditorSchema
   spellCheck?: boolean
 }) {
   const editorActor = useContext(EditorActorContext)
-  const schema = useSelector(editorActor, (s) => s.context.schema)
   const containerScope = useContext(ContainerScopeContext)
   const slateStatic = useSlateStatic()
+  const schema = props.schema
 
   const scopedTypeName = containerScope
     ? `${containerScope}.${props.element._type}`

--- a/packages/editor/src/editor/render.leaf.tsx
+++ b/packages/editor/src/editor/render.leaf.tsx
@@ -1,6 +1,5 @@
 import type {PortableTextSpan} from '@portabletext/schema'
-import {useSelector} from '@xstate/react'
-import {useContext, type CSSProperties} from 'react'
+import type {CSSProperties} from 'react'
 import type {RenderLeafProps} from '../slate/react/components/editable'
 import type {
   RangeDecoration,
@@ -9,7 +8,7 @@ import type {
   RenderDecoratorFunction,
   RenderPlaceholderFunction,
 } from '../types/editor'
-import {EditorActorContext} from './editor-actor-context'
+import type {EditorSchema} from './editor-schema'
 import {RenderSpan} from './render.span'
 
 const PLACEHOLDER_STYLE: CSSProperties = {
@@ -31,10 +30,10 @@ export function RenderLeaf(
     renderChild?: RenderChildFunction
     renderDecorator?: RenderDecoratorFunction
     renderPlaceholder?: RenderPlaceholderFunction
+    schema: EditorSchema
   },
 ) {
-  const editorActor = useContext(EditorActorContext)
-  const schema = useSelector(editorActor, (s) => s.context.schema)
+  const schema = props.schema
 
   if (props.leaf._type !== schema.span.name) {
     return props.children

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -1,10 +1,8 @@
 import type {InlineObjectSchemaType} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
-import {useSelector} from '@xstate/react'
 import {useContext, useRef, type ReactElement} from 'react'
 import {serializePath} from '../paths/serialize-path'
 import type {RenderLeafProps} from '../slate/react/components/editable'
-import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
 import type {
   BlockAnnotationRenderProps,
   BlockChildRenderProps,
@@ -13,7 +11,7 @@ import type {
   RenderChildFunction,
   RenderDecoratorFunction,
 } from '../types/editor'
-import {EditorActorContext} from './editor-actor-context'
+import type {EditorSchema} from './editor-schema'
 import {SelectionStateContext} from './selection-state-context'
 
 interface RenderSpanProps extends RenderLeafProps {
@@ -22,12 +20,11 @@ interface RenderSpanProps extends RenderLeafProps {
   renderChild?: RenderChildFunction
   renderDecorator?: RenderDecoratorFunction
   readOnly: boolean
+  schema: EditorSchema
 }
 
 export function RenderSpan(props: RenderSpanProps) {
-  const slateEditor = useSlateStatic()
-  const editorActor = useContext(EditorActorContext)
-  const schema = useSelector(editorActor, (s) => s.context.schema)
+  const schema = props.schema
   const spanRef = useRef<HTMLElement>(null)
   const schemaType = {
     name: schema.span.name,
@@ -35,19 +32,16 @@ export function RenderSpan(props: RenderSpanProps) {
   } satisfies InlineObjectSchemaType
 
   const parent = props.children.props.parent
-  const block =
-    parent && isTextBlock({schema: slateEditor.schema}, parent)
-      ? parent
-      : undefined
+  const block = parent && isTextBlock({schema}, parent) ? parent : undefined
 
   const selectionState = useContext(SelectionStateContext)
   const serializedPath = serializePath(props.path)
   const focused = selectionState.focusedChildPath === serializedPath
   const selected = selectionState.selectedChildPaths.has(serializedPath)
 
-  const decoratorSchemaTypes = editorActor
-    .getSnapshot()
-    .context.schema.decorators.map((decorator) => decorator.name)
+  const decoratorSchemaTypes = schema.decorators.map(
+    (decorator) => decorator.name,
+  )
 
   const decorators = [
     ...new Set(


### PR DESCRIPTION
The schema never changes after editor creation, but three render components subscribe to the xstate actor to read it via `useSelector`:

- `RenderElement`
- `RenderLeaf`
- `RenderSpan`

Each `useSelector` subscribes to the actor and re-evaluates its selector on every state transition. For a document with 1000 blocks, that's 3000 subscriptions firing on every keystroke to read a static value.

This replaces those subscriptions with `editor.schema` from `useSlateStatic()`, which is a plain context read with no subscription overhead.

Also cleans up `RenderSpan` which was reading schema from the actor snapshot directly (`editorActor.getSnapshot().context.schema.decorators`) in addition to the selector, making the selector doubly redundant.