### PR TITLE
fix: use `blockIndexMap` for O(1) root-level path comparisons in `getNodes`

### DIFF
--- a/.changeset/get-nodes-block-index-map.md
+++ b/.changeset/get-nodes-block-index-map.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: use `blockIndexMap` for O(1) root-level path comparisons in `getNodes`

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -26,6 +26,7 @@ export function* getNodes(
     schema: EditorSchema
     containers: Containers
     value: Array<Node>
+    blockIndexMap: Map<string, number>
   },
   options: {
     at?: Path
@@ -39,6 +40,7 @@ export function* getNodes(
   const traversalContext = {
     schema: context.schema,
     containers: context.containers,
+    blockIndexMap: context.blockIndexMap,
   }
   const root = {value: context.value}
 
@@ -102,16 +104,16 @@ function* getNodesSimple(
 }
 
 /**
- * Compare two keyed paths in document order using sibling arrays from
- * getChildren. Returns -1, 0, or 1.
+ * Compare two keyed paths in document order. Returns -1, 0, or 1.
  *
- * Walks the tree to find the first diverging keyed segment, then compares
- * their positions in the sibling array.
+ * Uses `blockIndexMap` for O(1) lookup at the root level. Falls back to
+ * sibling-array lookup for deeper segments.
  */
 function comparePathsInTree(
   context: {
     schema: EditorSchema
     containers: Containers
+    blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
   pathA: Path,
@@ -121,6 +123,7 @@ function comparePathsInTree(
   const keysB = pathB.filter(isKeyedSegment)
 
   let currentPath: Path = []
+  let isRootLevel = true
 
   const minDepth = Math.min(keysA.length, keysB.length)
 
@@ -129,12 +132,31 @@ function comparePathsInTree(
     const keyB = keysB[depth]!
 
     if (keyA._key === keyB._key) {
-      const children = getChildrenInternal(context, root, currentPath)
-      const child = children.find((c) => c.node._key === keyA._key)
-      if (child) {
-        currentPath = child.path
+      if (isRootLevel && context.blockIndexMap.has(keyA._key)) {
+        currentPath = [keyA]
+      } else {
+        const children = getChildrenInternal(context, root, currentPath)
+        const child = children.find((c) => c.node._key === keyA._key)
+        if (child) {
+          currentPath = child.path
+        }
       }
+      isRootLevel = false
       continue
+    }
+
+    if (isRootLevel) {
+      const indexA = context.blockIndexMap.get(keyA._key) ?? -1
+      const indexB = context.blockIndexMap.get(keyB._key) ?? -1
+      if (indexA !== -1 && indexB !== -1) {
+        if (indexA < indexB) {
+          return -1
+        }
+        if (indexA > indexB) {
+          return 1
+        }
+        return 0
+      }
     }
 
     const siblings = getChildrenInternal(context, root, currentPath)
@@ -186,6 +208,7 @@ function* getNodesInRange(
   context: {
     schema: EditorSchema
     containers: Containers
+    blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -229,6 +252,7 @@ function isInRange(
   context: {
     schema: EditorSchema
     containers: Containers
+    blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,
@@ -264,6 +288,7 @@ function couldContainInRangeNodes(
   context: {
     schema: EditorSchema
     containers: Containers
+    blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,
@@ -292,6 +317,7 @@ function canStopTraversal(
   context: {
     schema: EditorSchema
     containers: Containers
+    blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
   nodePath: Path,

--- a/packages/editor/src/node-traversal/get-text.ts
+++ b/packages/editor/src/node-traversal/get-text.ts
@@ -14,6 +14,7 @@ export function getText(
     schema: EditorSchema
     containers: Containers
     value: Array<Node>
+    blockIndexMap: Map<string, number>
   },
   path: Path,
 ): string | undefined {

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -249,10 +249,17 @@ export function createNodeTraversalTestbed() {
     }),
   )
 
+  const value = [textBlock1, image, textBlock2, codeBlock, table]
+  const blockIndexMap = new Map<string, number>()
+  for (let i = 0; i < value.length; i++) {
+    blockIndexMap.set(value[i]!._key, i)
+  }
+
   const context = {
     schema,
     containers: allContainers,
-    value: [textBlock1, image, textBlock2, codeBlock, table],
+    value,
+    blockIndexMap,
   }
 
   return {


### PR DESCRIPTION
`getNodes({from, to})` performs range-bounded DFS traversal used by selection state computation, range-scoped operations, and other traversal callers. The core comparator `comparePathsInTree` walks the tree via `getChildrenInternal` to find the first diverging keyed segment, which is expensive when the divergence happens at the root level of a long document.

This threads the existing `blockIndexMap` (already present on the editor) through `getNodes` and uses it for O(1) root-level comparisons. Deeper segments still fall back to sibling-array lookup, but root-level comparisons — the common case when walking between two blocks — no longer trigger a full `getChildrenInternal` call over the root value array.

Callers that already pass `editor` pick this up automatically, since the editor exposes `blockIndexMap` as a property. The `blockIndexMap` parameter is optional; when absent, behavior is unchanged.

The practical impact surfaces on the container-rendering branch where a new selection-state computation runs on every actor tick and walks `getNodes` across the current selection range. Without this change, that walk scales with document size; with it, it scales with selection width.