### PR TITLE
fix: remove unused internal placeholder logic

### DIFF
--- a/.changeset/remove-slate-placeholder.md
+++ b/.changeset/remove-slate-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: remove unused internal placeholder logic

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -999,9 +999,6 @@ export const PortableTextEditable = forwardRef<
         onKeyUp={handleKeyUp}
         onPaste={handlePaste}
         readOnly={readOnly}
-        // We have implemented our own placeholder logic with decorations.
-        // This 'renderPlaceholder' should not be used.
-        renderPlaceholder={undefined}
         renderElement={renderElement}
         renderLeaf={renderLeaf}
         renderText={renderText}

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -62,8 +62,6 @@ export interface DOMEditor extends BaseEditor {
   isNodeMapDirty: boolean
   domWindow: Window | null
   domElement: HTMLElement | null
-  domPlaceholder: string
-  domPlaceholderElement: HTMLElement | null
 
   readOnly: boolean
   focused: boolean

--- a/packages/editor/src/slate/dom/plugin/with-dom.ts
+++ b/packages/editor/src/slate/dom/plugin/with-dom.ts
@@ -21,8 +21,6 @@ export const withDOM = <T extends Editor>(editor: T): T & DOMEditor => {
   e.isNodeMapDirty = false
   e.domWindow = null
   e.domElement = null
-  e.domPlaceholder = ''
-  e.domPlaceholderElement = null
 
   e.readOnly = false
   e.focused = false

--- a/packages/editor/src/slate/dom/utils/range-list.ts
+++ b/packages/editor/src/slate/dom/utils/range-list.ts
@@ -9,7 +9,6 @@ import type {DecoratedRange} from '../../interfaces/text'
 import {rangeEdges} from '../../range/range-edges'
 import {rangeEquals} from '../../range/range-equals'
 import {rangeIntersection} from '../../range/range-intersection'
-import {PLACEHOLDER_SYMBOL} from './symbols'
 
 const shallowCompare = (
   obj1: {[key: string]: unknown},
@@ -24,10 +23,7 @@ const isDecorationFlagsEqual = (range: Range, other: Range) => {
   const {anchor: _rangeAnchor, focus: _rangeFocus, ...rangeOwnProps} = range
   const {anchor: _otherAnchor, focus: _otherFocus, ...otherOwnProps} = other
 
-  return (
-    (range as any)[PLACEHOLDER_SYMBOL] === (other as any)[PLACEHOLDER_SYMBOL] &&
-    shallowCompare(rangeOwnProps, otherOwnProps)
-  )
+  return shallowCompare(rangeOwnProps, otherOwnProps)
 }
 
 /**

--- a/packages/editor/src/slate/dom/utils/symbols.ts
+++ b/packages/editor/src/slate/dom/utils/symbols.ts
@@ -2,7 +2,6 @@
  * Symbols.
  */
 
-export const PLACEHOLDER_SYMBOL = Symbol('placeholder') as unknown as string
 export const MARK_PLACEHOLDER_SYMBOL = Symbol(
   'mark-placeholder',
 ) as unknown as string

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -22,7 +22,6 @@ import type {EditorActor} from '../../../editor/editor-machine'
 import {getAncestorObjectNode} from '../../../node-traversal/get-ancestor-object-node'
 import {getAncestorTextBlock} from '../../../node-traversal/get-ancestor-text-block'
 import {getNode} from '../../../node-traversal/get-node'
-import {getNodes} from '../../../node-traversal/get-nodes'
 import {getText} from '../../../node-traversal/get-text'
 import {collapse} from '../../core/collapse'
 import {deselect} from '../../core/deselect'
@@ -54,10 +53,7 @@ import {
   IS_WECHATBROWSER,
 } from '../../dom/utils/environment'
 import Hotkeys from '../../dom/utils/hotkeys'
-import {
-  MARK_PLACEHOLDER_SYMBOL,
-  PLACEHOLDER_SYMBOL,
-} from '../../dom/utils/symbols'
+import {MARK_PLACEHOLDER_SYMBOL} from '../../dom/utils/symbols'
 import {end as editorEnd} from '../../editor/end'
 import {range as editorRange} from '../../editor/range'
 import {rangeRef} from '../../editor/range-ref'
@@ -156,14 +152,12 @@ type EditableProps = {
   decorate?: (entry: NodeEntry) => DecoratedRange[]
   editorActor: EditorActor
   onDOMBeforeInput?: (event: InputEvent) => void
-  placeholder?: string
   readOnly?: boolean
   role?: string
   style?: React.CSSProperties
   renderElement?: (props: RenderElementProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
-  renderPlaceholder?: (props: RenderPlaceholderProps) => JSX.Element
   scrollSelectionIntoView?: (editor: ReactEditor, domRange: DOMRange) => void
   as?: React.ElementType
   disableDefaultStyles?: boolean
@@ -175,21 +169,15 @@ type EditableProps = {
 
 export const Editable = forwardRef(
   (props: EditableProps, forwardedRef: ForwardedRef<HTMLDivElement>) => {
-    const defaultRenderPlaceholder = useCallback(
-      (props: RenderPlaceholderProps) => <DefaultPlaceholder {...props} />,
-      [],
-    )
     const {
       autoFocus,
       decorate = defaultDecorate,
       editorActor,
       onDOMBeforeInput: propsOnDOMBeforeInput,
-      placeholder,
       readOnly = false,
       renderElement,
       renderLeaf,
       renderText,
-      renderPlaceholder = defaultRenderPlaceholder,
       scrollSelectionIntoView = defaultScrollSelectionIntoView,
       style: userStyle = {},
       as: Component = 'div',
@@ -201,9 +189,6 @@ export const Editable = forwardRef(
     const [isComposing, setIsComposing] = useState(false)
     const ref = useRef<HTMLDivElement | null>(null)
     const deferredOperations = useRef<DeferredOperation[]>([])
-    const [placeholderHeight, setPlaceholderHeight] = useState<
-      number | undefined
-    >()
     const processing = useRef(false)
 
     const {onUserInput, receivedUserInput} = useTrackUserInput()
@@ -1027,48 +1012,6 @@ export const Editable = forwardRef(
     const decorations = decorate([editor as any, []])
     const decorateContext = useDecorateContext(decorate)
 
-    const showPlaceholder =
-      placeholder &&
-      editor.children.length === 1 &&
-      (() => {
-        let spanCount = 0
-
-        for (const entry of getNodes(editor)) {
-          if (isSpan({schema: editor.schema}, entry.node)) {
-            spanCount++
-
-            if (spanCount > 1 || entry.node.text !== '') {
-              return false
-            }
-          }
-        }
-
-        return spanCount === 1
-      })() &&
-      !isComposing
-
-    const placeHolderResizeHandler = useCallback(
-      (placeholderEl: HTMLElement | null) => {
-        if (placeholderEl && showPlaceholder) {
-          setPlaceholderHeight(placeholderEl.getBoundingClientRect()?.height)
-        } else {
-          setPlaceholderHeight(undefined)
-        }
-      },
-      [showPlaceholder],
-    )
-
-    if (showPlaceholder) {
-      const placeholderStart = editorStart(editor, [])
-      decorations.push({
-        [PLACEHOLDER_SYMBOL]: true,
-        placeholder,
-        onPlaceholderResize: placeHolderResizeHandler,
-        anchor: placeholderStart,
-        focus: placeholderStart,
-      } as any)
-    }
-
     const {marks} = editor
     state.hasMarkPlaceholder = false
 
@@ -1176,10 +1119,6 @@ export const Editable = forwardRef(
                         whiteSpace: 'pre-wrap',
                         // Allow words to break if they are too long.
                         wordWrap: 'break-word',
-                        // Make the minimum height that of the placeholder.
-                        ...(placeholderHeight
-                          ? {minHeight: placeholderHeight}
-                          : {}),
                       }),
                   // Allow for passed-in styles to override anything.
                   ...userStyle,
@@ -1949,7 +1888,6 @@ export const Editable = forwardRef(
                   node={editor}
                   path={[]}
                   renderElement={renderElement}
-                  renderPlaceholder={renderPlaceholder}
                   renderLeaf={renderLeaf}
                   renderText={renderText}
                 />
@@ -1960,33 +1898,6 @@ export const Editable = forwardRef(
       </ReadOnlyContext.Provider>
     )
   },
-)
-
-/**
- * The props that get passed to renderPlaceholder
- */
-export type RenderPlaceholderProps = {
-  children: any
-  attributes: {
-    'data-slate-placeholder': boolean
-    'dir'?: 'rtl'
-    'contentEditable': boolean
-    'ref': React.RefCallback<any>
-    'style': React.CSSProperties
-  }
-}
-
-/**
- * The default placeholder element
- */
-
-const DefaultPlaceholder = ({attributes, children}: RenderPlaceholderProps) => (
-  // COMPAT: Artificially add a line-break to the end on the placeholder element
-  // to prevent Android IMEs to pick up its content in autocorrect and to auto-capitalize the first letter
-  <span {...attributes}>
-    {children}
-    {IS_ANDROID && <br />}
-  </span>
 )
 
 /**

--- a/packages/editor/src/slate/react/components/element.tsx
+++ b/packages/editor/src/slate/react/components/element.tsx
@@ -18,7 +18,6 @@ import getDirection from '../utils/direction'
 import type {
   RenderElementProps,
   RenderLeafProps,
-  RenderPlaceholderProps,
   RenderTextProps,
 } from './editable'
 
@@ -35,7 +34,6 @@ const Element = (props: {
   element: PortableTextTextBlock | PortableTextObject
   path: Path
   renderElement?: (props: RenderElementProps) => JSX.Element
-  renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
 }) => {
@@ -43,7 +41,6 @@ const Element = (props: {
     decorations: parentDecorations,
     element,
     renderElement = defaultRenderElement,
-    renderPlaceholder,
     renderLeaf,
     renderText,
   } = props
@@ -56,7 +53,6 @@ const Element = (props: {
     node: element,
     path: props.path,
     renderElement,
-    renderPlaceholder,
     renderLeaf,
     renderText,
   })
@@ -105,7 +101,6 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
     prev.renderElement === next.renderElement &&
     prev.renderText === next.renderText &&
     prev.renderLeaf === next.renderLeaf &&
-    prev.renderPlaceholder === next.renderPlaceholder &&
     isElementDecorationsEqual(prev.decorations, next.decorations)
   )
 })

--- a/packages/editor/src/slate/react/components/leaf.tsx
+++ b/packages/editor/src/slate/react/components/leaf.tsx
@@ -3,47 +3,12 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type JSX,
-  type MutableRefObject,
-} from 'react'
-import {IS_ANDROID, IS_WEBKIT} from '../../dom/utils/environment'
-import {PLACEHOLDER_SYMBOL} from '../../dom/utils/symbols'
+import React, {type JSX} from 'react'
 import type {Path} from '../../interfaces/path'
 import type {LeafPosition} from '../../interfaces/text'
 import {textEquals} from '../../text/text-equals'
-import {useSlateStatic} from '../hooks/use-slate-static'
-import type {RenderLeafProps, RenderPlaceholderProps} from './editable'
+import type {RenderLeafProps} from './editable'
 import SlateString from './string'
-
-// Delay the placeholder on Android to prevent the keyboard from closing.
-// (https://github.com/ianstormtaylor/slate/pull/5368)
-const PLACEHOLDER_DELAY = IS_ANDROID ? 300 : 0
-
-function disconnectPlaceholderResizeObserver(
-  placeholderResizeObserver: MutableRefObject<ResizeObserver | null>,
-  releaseObserver: boolean,
-) {
-  if (placeholderResizeObserver.current) {
-    placeholderResizeObserver.current.disconnect()
-    if (releaseObserver) {
-      placeholderResizeObserver.current = null
-    }
-  }
-}
-
-type TimerId = ReturnType<typeof setTimeout> | null
-
-function clearTimeoutRef(timeoutRef: MutableRefObject<TimerId>) {
-  if (timeoutRef.current) {
-    clearTimeout(timeoutRef.current)
-    timeoutRef.current = null
-  }
-}
 
 const defaultRenderLeaf = (props: RenderLeafProps) => <DefaultLeaf {...props} />
 
@@ -55,7 +20,6 @@ const Leaf = (props: {
   leaf: PortableTextSpan
   parent: PortableTextTextBlock | PortableTextObject
   path: Path
-  renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   text: PortableTextSpan
   leafPosition?: LeafPosition
@@ -66,43 +30,11 @@ const Leaf = (props: {
     text,
     path,
     parent,
-    renderPlaceholder,
     renderLeaf = defaultRenderLeaf,
     leafPosition,
   } = props
 
-  const editor = useSlateStatic()
-  const placeholderResizeObserver = useRef<ResizeObserver | null>(null)
-  const placeholderRef = useRef<HTMLElement | null>(null)
-  const [showPlaceholder, setShowPlaceholder] = useState(false)
-  const showPlaceholderTimeoutRef = useRef<TimerId>(null)
-
-  const callbackPlaceholderRef = useCallback(
-    (placeholderEl: HTMLElement | null) => {
-      disconnectPlaceholderResizeObserver(
-        placeholderResizeObserver,
-        placeholderEl == null,
-      )
-
-      if (placeholderEl == null) {
-        editor.domPlaceholderElement = null
-        ;(leaf as any).onPlaceholderResize?.(null)
-      } else {
-        editor.domPlaceholderElement = placeholderEl
-
-        if (!placeholderResizeObserver.current) {
-          placeholderResizeObserver.current = new ResizeObserver(() => {
-            ;(leaf as any).onPlaceholderResize?.(placeholderEl)
-          })
-        }
-        placeholderResizeObserver.current.observe(placeholderEl)
-        placeholderRef.current = placeholderEl
-      }
-    },
-    [placeholderRef, leaf, editor],
-  )
-
-  let children = (
+  const children = (
     <SlateString
       isLast={isLast}
       leaf={leaf}
@@ -111,54 +43,6 @@ const Leaf = (props: {
       text={text}
     />
   )
-
-  const leafIsPlaceholder = Boolean((leaf as any)[PLACEHOLDER_SYMBOL])
-  useEffect(() => {
-    if (leafIsPlaceholder) {
-      if (!showPlaceholderTimeoutRef.current) {
-        // Delay the placeholder, so it will not render in a selection
-        showPlaceholderTimeoutRef.current = setTimeout(() => {
-          setShowPlaceholder(true)
-          showPlaceholderTimeoutRef.current = null
-        }, PLACEHOLDER_DELAY)
-      }
-    } else {
-      clearTimeoutRef(showPlaceholderTimeoutRef)
-      setShowPlaceholder(false)
-    }
-    return () => clearTimeoutRef(showPlaceholderTimeoutRef)
-  }, [leafIsPlaceholder, setShowPlaceholder])
-
-  if (leafIsPlaceholder && showPlaceholder) {
-    const placeholderProps: RenderPlaceholderProps = {
-      children: (leaf as any).placeholder,
-      attributes: {
-        'data-slate-placeholder': true,
-        'style': {
-          position: 'absolute',
-          top: 0,
-          pointerEvents: 'none',
-          width: '100%',
-          maxWidth: '100%',
-          display: 'block',
-          opacity: '0.333',
-          userSelect: 'none',
-          textDecoration: 'none',
-          // Fixes https://github.com/udecode/plate/issues/2315
-          WebkitUserModify: IS_WEBKIT ? 'inherit' : undefined,
-        },
-        'contentEditable': false,
-        'ref': callbackPlaceholderRef,
-      },
-    }
-
-    children = (
-      <React.Fragment>
-        {children}
-        {renderPlaceholder(placeholderProps)}
-      </React.Fragment>
-    )
-  }
 
   // COMPAT: Having the `data-` attributes on these leaf elements ensures that
   // in certain misbehaving browsers they aren't weirdly cloned/destroyed by
@@ -184,11 +68,8 @@ const MemoizedLeaf = React.memo(Leaf, (prev, next) => {
     next.parent === prev.parent &&
     next.isLast === prev.isLast &&
     next.renderLeaf === prev.renderLeaf &&
-    next.renderPlaceholder === prev.renderPlaceholder &&
     next.text === prev.text &&
-    textEquals(next.leaf, prev.leaf) &&
-    (next.leaf as any)[PLACEHOLDER_SYMBOL] ===
-      (prev.leaf as any)[PLACEHOLDER_SYMBOL]
+    textEquals(next.leaf, prev.leaf)
   )
 })
 

--- a/packages/editor/src/slate/react/components/text.tsx
+++ b/packages/editor/src/slate/react/components/text.tsx
@@ -10,11 +10,7 @@ import type {DecoratedRange} from '../../interfaces/text'
 import {pathEquals} from '../../path/path-equals'
 import {getTextDecorations} from '../../text/get-text-decorations'
 import {useDecorations} from '../hooks/use-decorations'
-import type {
-  RenderLeafProps,
-  RenderPlaceholderProps,
-  RenderTextProps,
-} from './editable'
+import type {RenderLeafProps, RenderTextProps} from './editable'
 import Leaf from './leaf'
 
 const defaultRenderText = (props: RenderTextProps) => <DefaultText {...props} />
@@ -28,7 +24,6 @@ const Text = (props: {
   isLast: boolean
   parent: PortableTextTextBlock
   path: Path
-  renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   text: PortableTextSpan
@@ -38,7 +33,6 @@ const Text = (props: {
     isLast,
     parent,
     path,
-    renderPlaceholder,
     renderLeaf,
     renderText = defaultRenderText,
     text,
@@ -55,7 +49,6 @@ const Text = (props: {
       <Leaf
         isLast={isLast && i === decoratedLeaves.length - 1}
         key={`${text._key}-${i}`}
-        renderPlaceholder={renderPlaceholder}
         leaf={leaf}
         leafPosition={position}
         text={text}
@@ -90,7 +83,6 @@ const MemoizedText = React.memo(Text, (prev, next) => {
     pathEquals(next.path, prev.path) &&
     next.renderText === prev.renderText &&
     next.renderLeaf === prev.renderLeaf &&
-    next.renderPlaceholder === prev.renderPlaceholder &&
     next.text === prev.text &&
     isTextDecorationsEqual(next.decorations, prev.decorations)
   )

--- a/packages/editor/src/slate/react/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/editor/src/slate/react/hooks/android-input-manager/android-input-manager.ts
@@ -283,20 +283,6 @@ export function createAndroidInputManager({
     }
   }
 
-  const updatePlaceholderVisibility = (forceHide = false) => {
-    const placeholderElement = editor.domPlaceholderElement
-    if (!placeholderElement) {
-      return
-    }
-
-    if (hasPendingDiffs() || forceHide) {
-      placeholderElement.style.display = 'none'
-      return
-    }
-
-    placeholderElement.style.removeProperty('display')
-  }
-
   const storeDiff = (path: Path, diff: StringDiff) => {
     debug('storeDiff', path, diff)
 
@@ -319,14 +305,12 @@ export function createAndroidInputManager({
         pendingDiffs.push({path, diff, id: idCounter++})
       }
 
-      updatePlaceholderVisibility()
       return
     }
 
     const merged = mergeStringDiffs(target.text, pendingDiffs[idx]!.diff, diff)
     if (!merged) {
       pendingDiffs.splice(idx, 1)
-      updatePlaceholderVisibility()
       return
     }
 
@@ -936,17 +920,7 @@ export function createAndroidInputManager({
     }
   }
 
-  const handleKeyDown = (_: React.KeyboardEvent) => {
-    // COMPAT: Swiftkey closes the keyboard when typing inside a empty node
-    // directly next to a non-contenteditable element (= the placeholder).
-    // The only event fired soon enough for us to allow hiding the placeholder
-    // without swiftkey picking it up is the keydown event, so we have to hide it
-    // here. See https://github.com/ianstormtaylor/slate/pull/4988#issuecomment-1201050535
-    if (!hasPendingDiffs()) {
-      updatePlaceholderVisibility(true)
-      setTimeout(updatePlaceholderVisibility)
-    }
-  }
+  const handleKeyDown = (_: React.KeyboardEvent) => {}
 
   const scheduleFlush = () => {
     if (!hasPendingAction()) {

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -24,7 +24,6 @@ import {isTextBlockNode} from '../../node/is-text-block-node'
 import type {
   RenderElementProps,
   RenderLeafProps,
-  RenderPlaceholderProps,
   RenderTextProps,
 } from '../components/editable'
 import ElementComponent from '../components/element'
@@ -42,7 +41,6 @@ const useChildren = (props: {
   node: Editor | Node
   path: Path
   renderElement?: (props: RenderElementProps) => JSX.Element
-  renderPlaceholder: (props: RenderPlaceholderProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
 }): React.ReactNode => {
@@ -51,7 +49,6 @@ const useChildren = (props: {
     node,
     path: parentPath,
     renderElement,
-    renderPlaceholder,
     renderText,
     renderLeaf,
   } = props
@@ -108,7 +105,6 @@ const useChildren = (props: {
             key={node._key}
             path={nodePath}
             renderElement={renderElement}
-            renderPlaceholder={renderPlaceholder}
             renderLeaf={renderLeaf}
             renderText={renderText}
           />
@@ -120,7 +116,6 @@ const useChildren = (props: {
       decorationsByChild,
       parentPath,
       renderElement,
-      renderPlaceholder,
       renderLeaf,
       renderText,
     ],
@@ -149,7 +144,6 @@ const useChildren = (props: {
         isLast={index === children.length - 1}
         parent={textBlockParent}
         path={nodePath}
-        renderPlaceholder={renderPlaceholder}
         renderLeaf={renderLeaf}
         renderText={renderText}
         text={node}


### PR DESCRIPTION
The editor implements its own placeholder via range decorations (see `range-decorations-machine.ts` and `render.leaf.tsx`). A parallel internal placeholder system still lived in the codebase — `placeholder`/`renderPlaceholder` props on the core `<Editable>`, a `DefaultPlaceholder` component, a placeholder decoration symbol threaded through leaf/element/text/range-list, a `ResizeObserver` for minimum-height calculations, `domPlaceholder`/`domPlaceholderElement` fields on the DOM editor, and an Android Swiftkey workaround that hid the non-contenteditable placeholder element on keydown.

None of this was ever used — `PortableTextEditable` passed `renderPlaceholder={undefined}` and rendered its own placeholder through a decoration instead. Remove the dead code.

Mark-placeholder (`MARK_PLACEHOLDER_SYMBOL`, `data-slate-mark-placeholder`, `hasMarkPlaceholder`) is a different feature — a zero-width span inserted for correct selection/IME behavior at mark boundaries while typing. Unchanged.

The editor's own placeholder API (`renderPlaceholder` prop on `PortableTextEditable`, `RenderPlaceholderFunction` type, `createPlaceholderBlock` empty-block factory, and the `placeholder: true` range decoration) is also unchanged.