### PR TITLE
fix: remove unused internal APIs

### DIFF
--- a/.changeset/remove-more-unused.md
+++ b/.changeset/remove-more-unused.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: remove unused internal APIs

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -130,16 +130,6 @@ interface DOMEditorInterface {
   hasTarget: (editor: Editor, target: EventTarget | null) => target is DOMNode
 
   /**
-   * Check if the user is currently composing inside the editor.
-   */
-  isComposing: (editor: Editor) => boolean
-
-  /**
-   * Check if the editor is focused.
-   */
-  isFocused: (editor: Editor) => boolean
-
-  /**
    * Check if the target is inside void and in an non-readonly editor.
    */
   isTargetInsideNonReadonlyVoid: (
@@ -349,12 +339,6 @@ export const DOMEditor: DOMEditorInterface = {
 
   hasTarget: (editor, target): target is DOMNode =>
     isDOMNode(target) && DOMEditor.hasDOMNode(editor, target),
-
-  isComposing: (editor) => {
-    return !!editor.composing
-  },
-
-  isFocused: (editor) => !!editor.focused,
 
   isTargetInsideNonReadonlyVoid: (editor, target) => {
     if (editor.readOnly) {

--- a/packages/editor/src/slate/interfaces/operation.ts
+++ b/packages/editor/src/slate/interfaces/operation.ts
@@ -27,7 +27,7 @@ export type RemoveTextOperation = {
 /**
  * Data for a `set` inverse (no nested inverse field).
  */
-export type SetOperationData = {
+type SetOperationData = {
   type: 'set'
   path: Path
   value: unknown
@@ -36,7 +36,7 @@ export type SetOperationData = {
 /**
  * Data for an `insert` inverse (no nested inverse field).
  */
-export type InsertOperationData = {
+type InsertOperationData = {
   type: 'insert'
   path: Path
   node: Node
@@ -46,7 +46,7 @@ export type InsertOperationData = {
 /**
  * Data for an `unset` inverse (no nested inverse field).
  */
-export type UnsetOperationData = {
+type UnsetOperationData = {
   type: 'unset'
   path: Path
 }
@@ -58,7 +58,7 @@ export type UnsetOperationData = {
  * (applied via `withRemoteChanges`) skip the history plugin and do not need
  * inverse data.
  */
-export type SetOperation = {
+type SetOperation = {
   type: 'set'
   path: Path
   value: unknown
@@ -72,7 +72,7 @@ export type SetOperation = {
  * Node removal: path is `[...parentPath, childFieldName, {_key: nodeKey}]`
  * (last segment is a keyed segment pointing to the node to remove).
  */
-export type UnsetOperation = {
+type UnsetOperation = {
   type: 'unset'
   path: Path
   inverse?: SetOperationData | InsertOperationData

--- a/packages/editor/src/slate/node/is-text-block-node.ts
+++ b/packages/editor/src/slate/node/is-text-block-node.ts
@@ -2,7 +2,7 @@ import type {PortableTextObject, PortableTextSpan} from '@portabletext/schema'
 import type {EditorSchema} from '../../editor/editor-schema'
 import {isTypedObject} from '../../utils/asserters'
 
-export type TextBlockNode = {
+type TextBlockNode = {
   _type: string
   _key: string
   children?: Array<PortableTextSpan | PortableTextObject>

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -262,7 +262,7 @@ export const Editable = forwardRef(
 
           const androidInputManager = androidInputManagerRef.current
           if (
-            (IS_ANDROID || !DOMEditor.isComposing(editor)) &&
+            (IS_ANDROID || !editor.composing) &&
             (!state.isUpdatingSelection || androidInputManager?.isFlushing())
           ) {
             const root = DOMEditor.findDocumentOrShadowRoot(editor)
@@ -303,7 +303,7 @@ export const Editable = forwardRef(
 
               if (range) {
                 if (
-                  !DOMEditor.isComposing(editor) &&
+                  !editor.composing &&
                   !androidInputManager?.hasPendingChanges() &&
                   !androidInputManager?.isFlushing()
                 ) {
@@ -353,7 +353,7 @@ export const Editable = forwardRef(
 
       if (
         !domSelection ||
-        !DOMEditor.isFocused(editor) ||
+        !editor.focused ||
         androidInputManagerRef.current?.hasPendingAction()
       ) {
         return
@@ -459,7 +459,7 @@ export const Editable = forwardRef(
         }
 
         if (newDomRange) {
-          if (DOMEditor.isComposing(editor) && !IS_ANDROID) {
+          if (editor.composing && !IS_ANDROID) {
             domSelection.collapseToEnd()
           } else if (isBackwardRange(selection!)) {
             domSelection.setBaseAndExtent(
@@ -605,7 +605,7 @@ export const Editable = forwardRef(
 
           // COMPAT: use composition change events as a hint to where we should insert
           // composition text if we aren't composing to work around https://github.com/ianstormtaylor/slate/issues/5038
-          if (isCompositionChange && DOMEditor.isComposing(editor)) {
+          if (isCompositionChange && editor.composing) {
             return
           }
 
@@ -869,7 +869,7 @@ export const Editable = forwardRef(
                 // then we will abort because we're still composing and the selection
                 // won't be updated properly.
                 // https://www.w3.org/TR/input-events-2/
-                if (DOMEditor.isComposing(editor)) {
+                if (editor.composing) {
                   editor.composing = false
                 }
               }
@@ -1123,7 +1123,7 @@ export const Editable = forwardRef(
                     DOMEditor.hasSelectableTarget(editor, event.target)
                   ) {
                     event.preventDefault()
-                    if (!DOMEditor.isComposing(editor)) {
+                    if (!editor.composing) {
                       const text = (event as any).data as string
                       editorActor.send({
                         type: 'behavior event',
@@ -1160,7 +1160,7 @@ export const Editable = forwardRef(
                   // This means undo can be triggered even when the div is not focused,
                   // and it only triggers the input event for the node. (2024/10/09)
                   if (
-                    !DOMEditor.isFocused(editor) &&
+                    !editor.focused &&
                     isDOMNode(event.target) &&
                     DOMEditor.hasEditableTarget(editor, event.target)
                   ) {
@@ -1335,7 +1335,7 @@ export const Editable = forwardRef(
                     return
                   }
                   if (DOMEditor.hasSelectableTarget(editor, event.target)) {
-                    if (DOMEditor.isComposing(editor)) {
+                    if (editor.composing) {
                       Promise.resolve().then(() => {
                         editor.composing = false
                       })
@@ -1397,7 +1397,7 @@ export const Editable = forwardRef(
                     !isEventHandled(event, attributes.onCompositionUpdate) &&
                     !isDOMEventTargetInput(event)
                   ) {
-                    if (!DOMEditor.isComposing(editor)) {
+                    if (!editor.composing) {
                       editor.composing = true
                     }
                   }
@@ -1483,16 +1483,13 @@ export const Editable = forwardRef(
                     // COMPAT: The composition end event isn't fired reliably in all browsers,
                     // so we sometimes might end up stuck in a composition state even though we
                     // aren't composing any more.
-                    if (
-                      DOMEditor.isComposing(editor) &&
-                      nativeEvent.isComposing === false
-                    ) {
+                    if (editor.composing && nativeEvent.isComposing === false) {
                       editor.composing = false
                     }
 
                     if (
                       isEventHandled(event, attributes.onKeyDown) ||
-                      DOMEditor.isComposing(editor)
+                      editor.composing
                     ) {
                       return
                     }


### PR DESCRIPTION
Follow-up to #2509. More dead surface area removed from the vendored Slate fork.

- `DOMEditor.isComposing(editor)` was a one-line wrapper around `!!editor.composing`. Inlined at the 10 call sites and removed from the interface. Same for `DOMEditor.isFocused(editor)` / `!!editor.focused` (2 call sites).
- `SetOperationData`, `InsertOperationData`, `UnsetOperationData`, `SetOperation`, `UnsetOperation` in `operation.ts` are only referenced within the same file. Dropped the `export` keyword.
- `TextBlockNode` in `is-text-block-node.ts` is only used as the return type of its own guard. Dropped the `export`.
