### PR TITLE
test: migrate gherkin features to textspec

### DIFF
--- a/packages/editor/gherkin-spec/annotations-across-blocks.feature
+++ b/packages/editor/gherkin-spec/annotations-across-blocks.feature
@@ -5,26 +5,32 @@ Feature: Annotations Across Blocks
     And a global keymap
 
   Scenario: Adding annotation across blocks
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And "{Enter}" is pressed
     And "bar" is typed
     And "foobar" is selected
     And "link" "l1,l2" is toggled
-    Then "foo" has marks "l1"
-    And "bar" has marks "l2"
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]
+      B: [@link _key="l2":bar|]
+      """
 
   Scenario: Adding annotation across blocks (backwards selection)
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And "{Enter}" is pressed
     And "bar" is typed
     And "foobar" is selected backwards
     And "link" "l1,l2" is toggled
-    Then "foo" has marks "l1"
-    And "bar" has marks "l2"
+    Then the editor state is
+      """
+      B: [@link _key="l1":|foo]
+      B: [@link _key="l2":bar^]
+      """
 
   Scenario: Adding annotation across an image
     When the editor is focused
@@ -33,9 +39,12 @@ Feature: Annotations Across Blocks
     And "bar" is typed
     And "foobar" is selected
     And "link" "l1,l2" is toggled
-    Then "foo" has marks "l1"
-    And "bar" has marks "l2"
-    And "foo|{image}|bar" is selected
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]
+      {IMAGE}
+      B: [@link _key="l2":bar|]
+      """
 
   Scenario: Adding annotation across an image (backwards selection)
     When the editor is focused
@@ -44,101 +53,108 @@ Feature: Annotations Across Blocks
     And "bar" is typed
     And "foobar" is selected backwards
     And "link" "l1,l2" is toggled
-    Then "foo" has marks "l1"
-    And "bar" has marks "l2"
-    And "foo|{image}|bar" is selected
+    Then the editor state is
+      """
+      B: [@link _key="l1":|foo]
+      {IMAGE}
+      B: [@link _key="l2":bar^]
+      """
 
   Scenario: Splitting an annotation across blocks
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "foobar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
-    Then the text is "foo|bar"
-    And "foo" has marks "l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]
+      B: [@link _key="l1":bar]
+      """
 
   Scenario: Splitting an annotation across blocks using a selection
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     When the editor is focused
     And "bar" is selected
     And "{Enter}" is pressed
-    Then the text is "foo | baz"
-    And "foo " has marks "l1"
-    And " baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ]
+      B: [@link _key="l1": baz]
+      """
 
   Scenario: Splitting a split annotation across blocks
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
-    Then the text is "foo| ,bar, baz"
-    And "foo" has marks "l1"
-    And " " has marks "l1"
-    And "bar" has marks "l1,strong"
-    And " baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]
+      B: [@link _key="l1": ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
 
   Scenario: Splitting text after annotation doesn't touch the annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "bar"
     And "{Enter}" is pressed
-    Then the text is "foo, bar| baz"
-    And "foo" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo] bar
+      B:  baz
+      """
 
   # Warning: Possible wrong behaviour
   # "foo" and "bar" should rejoin as one link
   # Fixing this is possibly a breaking change
   Scenario: Splitting and merging an annotation across blocks
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "foobar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
     And "{Backspace}" is pressed
-    Then the text is "foo,bar"
-    And "foo" has marks "l1"
-    And "bar" has an annotation different than "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][@link _key="l2":bar]
+      """
 
   # Warning: Possible wrong behaviour
   # The " baz" link should have a unique key
   # Fixing this is possibly a breaking change
   Scenario: Toggling part of an annotation off
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     When "bar" is selected
     And "link" is toggled
-    Then the text is "foo ,bar, baz"
-    And "foo " has marks "l1"
-    And "bar" has no marks
-    And " baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ]bar[@link _key="l1": baz]
+      """
 
   Scenario: Splitting block before annotation
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put before "foo"
     And "{Enter}" is pressed
-    Then the text is "|foo"
-    And "" has no marks
-    And "foo" has marks "l1"
+    Then the editor state is "B: ;;B: [@link _key=\"l1\":foo]"
 
   Scenario: Splitting block after annotation
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
-    Then the text is "foo|"
-    And "foo" has marks "l1"
-    And "" has no marks
+    Then the editor state is "B: [@link _key=\"l1\":foo];;B: "
 
   Scenario: Merging blocks with annotations
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
@@ -148,6 +164,7 @@ Feature: Annotations Across Blocks
     And "link" "l2" is toggled
     And the caret is put before "bar"
     And "{Backspace}" is pressed
-    Then the text is "foo,bar"
-    And "foo" has marks "l1"
-    And "bar" has marks "l2"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][@link _key="l2":bar]
+      """

--- a/packages/editor/gherkin-spec/annotations-edge-cases.feature
+++ b/packages/editor/gherkin-spec/annotations-edge-cases.feature
@@ -5,34 +5,35 @@ Feature: Annotations Edge Cases
     And a global keymap
 
   Scenario: Deleting emphasised paragraph with comment in the middle
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "em" around "foo bar baz"
     And a "comment" "c1" around "bar"
     When the editor is focused
     And "foo bar baz" is selected
     And "{Backspace}" is pressed
-    Then "" has marks "em"
+    Then the editor state is "B: [em:]"
 
   Scenario: Deleting half of annotated text
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "comment" "c1" around "foo bar baz"
     When the editor is focused
     And " baz" is selected
     And "{Backspace}" is pressed
-    Then the text is "foo bar"
-    And "foo bar" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo bar]
+      """
 
   Scenario: Deleting annotation in the middle of text
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "comment" "c1" around "bar"
     When the editor is focused
     And "bar " is selected
     And "{Backspace}" is pressed
-    Then the text is "foo baz"
-    And "foo baz" has no marks
+    Then the editor state is "B: foo baz"
 
   Scenario: Deleting across annotated blocks
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And "{Enter}" is pressed
@@ -43,6 +44,7 @@ Feature: Annotations Edge Cases
     And "link" "l2" is toggled
     And "ooba" is selected
     And "{Backspace}" is pressed
-    Then the text is "f,r"
-    And "f" has marks "l1"
-    And "r" has marks "l2"
+    Then the editor state is
+      """
+      B: [@link _key="l1":f][@link _key="l2":r]
+      """

--- a/packages/editor/gherkin-spec/annotations-overlapping-decorators.feature
+++ b/packages/editor/gherkin-spec/annotations-overlapping-decorators.feature
@@ -5,33 +5,33 @@ Feature: Annotations Overlapping Decorators
     And a global keymap
 
   Scenario Outline: Inserting text at the edge of a decorated annotation
-    Given the text <text>
+    Given the editor state is <text>
     And a "link" "l1" around <annotated>
     And "strong" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | annotated     | decorated     | position      | new text           |
-      | "foo bar baz" | "bar"         | "bar"         | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"         | "bar"         | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"         | "bar"         | after "bar"   | "foo ,bar,new baz" |
-      | "foo bar baz" | "bar"         | "bar"         | before " baz" | "foo ,bar,new baz" |
-      | "foo"         | "foo"         | "foo"         | before "foo"  | "new,foo"          |
-      | "foo"         | "foo"         | "foo"         | after "foo"   | "foo,new"          |
-      | "foo bar baz" | "foo bar baz" | "bar"         | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"         | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"         | after "bar"   | "foo ,barnew, baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"         | before " baz" | "foo ,barnew, baz" |
-      | "foo bar baz" | "bar"         | "foo bar baz" | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"         | "foo bar baz" | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"         | "foo bar baz" | after "bar"   | "foo ,bar,new baz" |
-      | "foo bar baz" | "bar"         | "foo bar baz" | before " baz" | "foo ,bar,new baz" |
+      | text             | annotated     | decorated     | position      | new text                                                                                 |
+      | "B: foo bar baz" | "bar"         | "bar"         | after "foo "  | "B: foo new[strong:[@link _key=\"l1\":bar]] baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | before "bar"  | "B: foo new[strong:[@link _key=\"l1\":bar]] baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | after "bar"   | "B: foo [strong:[@link _key=\"l1\":bar]]new baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | before " baz" | "B: foo [strong:[@link _key=\"l1\":bar]]new baz"                                         |
+      | "B: foo"         | "foo"         | "foo"         | before "foo"  | "B: new[strong:[@link _key=\"l1\":foo]]"                                                 |
+      | "B: foo"         | "foo"         | "foo"         | after "foo"   | "B: [strong:[@link _key=\"l1\":foo]]new"                                                 |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | after "foo "  | "B: [@link _key=\"l1\":foo new][strong:[@link _key=\"l1\":bar]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | before "bar"  | "B: [@link _key=\"l1\":foo new][strong:[@link _key=\"l1\":bar]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | after "bar"   | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":barnew]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | before " baz" | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":barnew]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | after "foo "  | "B: [strong:foo new][strong:[@link _key=\"l1\":bar]][strong: baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | before "bar"  | "B: [strong:foo new][strong:[@link _key=\"l1\":bar]][strong: baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | after "bar"   | "B: [strong:foo ][strong:[@link _key=\"l1\":bar]][strong:new baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | before " baz" | "B: [strong:foo ][strong:[@link _key=\"l1\":bar]][strong:new baz]"                       |
 
   Scenario Outline: Toggling decorator at the edge of a decorated annotation
-    Given the text <text>
+    Given the editor state is <text>
     And a "link" "l1" around <annotated>
     And "strong" around <decorated>
     When the editor is focused
@@ -44,132 +44,134 @@ Feature: Annotations Overlapping Decorators
     # against the default behavior and produce bold text.
     And "strong" is toggled
     And "new" is typed
-    Then the text is <new text>
-    And "new" has marks <marks>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | annotated | decorated | position      | new text            | marks    |
-      | "foo bar baz" | "bar"     | "bar"     | after "foo "  | "foo ,new,bar, baz" | "strong" |
-      | "foo bar baz" | "bar"     | "bar"     | before "bar"  | "foo ,new,bar, baz" | "strong" |
-      | "foo bar baz" | "bar"     | "bar"     | after "bar"   | "foo ,bar,new, baz" | "strong" |
-      | "foo bar baz" | "bar"     | "bar"     | before " baz" | "foo ,bar,new, baz" | "strong" |
+      | text             | annotated | decorated | position      | new text                                                    |
+      | "B: foo bar baz" | "bar"     | "bar"     | after "foo "  | "B: foo [strong:new\|][strong:[@link _key=\"l1\":bar]] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | before "bar"  | "B: foo [strong:new\|][strong:[@link _key=\"l1\":bar]] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | after "bar"   | "B: foo [strong:[@link _key=\"l1\":bar]][strong:new\|] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | before " baz" | "B: foo [strong:[@link _key=\"l1\":bar]][strong:new\|] baz" |
 
   Scenario Outline: Writing on top of a decorated annotation
     When the editor is focused
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around <annotated>
     And "strong" around <decorated>
     When <selection>
     And "removed" is typed
-    Then the text is <new text>
-    And "removed" has marks <marks>
+    Then the editor state is <new text>
 
     Examples:
-      | annotated     | decorated | selection                   | new text            | marks       |
-      | "bar"         | "bar"     | "bar" is selected           | "foo ,removed, baz" | "strong"    |
-      | "bar"         | "bar"     | "bar" is selected backwards | "foo ,removed, baz" | "strong"    |
-      | "foo bar baz" | "bar"     | "bar" is selected           | "foo ,removed, baz" | "l1,strong" |
-      | "foo bar baz" | "bar"     | "bar" is selected backwards | "foo ,removed, baz" | "l1,strong" |
+      | annotated     | decorated | selection                   | new text                                                                                  |
+      | "bar"         | "bar"     | "bar" is selected           | "B: foo [strong:removed] baz"                                                             |
+      | "bar"         | "bar"     | "bar" is selected backwards | "B: foo [strong:removed] baz"                                                             |
+      | "foo bar baz" | "bar"     | "bar" is selected           | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":removed]][@link _key=\"l1\": baz]" |
+      | "foo bar baz" | "bar"     | "bar" is selected backwards | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":removed]][@link _key=\"l1\": baz]" |
 
   Scenario: Splitting block before a decorated annotation
-    Given the text "bar"
+    Given the editor state is "B: bar"
     And a "link" "l1" around "bar"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put before "bar"
     And "{Enter}" is pressed
-    Then the text is "|bar"
-    And "" has no marks
-    And "bar" has marks "l1,strong"
+    Then the editor state is "B: ;;B: [strong:[@link _key=\"l1\":bar]]"
 
   Scenario: Splitting block after a decorated annotation
-    Given the text "bar"
+    Given the editor state is "B: bar"
     And a "link" "l1" around "bar"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put after "bar"
     And "{Enter}" is pressed
     And "baz" is typed
-    Then the text is "bar|baz"
-    And the caret is after "baz"
-    And "baz" has no marks
+    Then the editor state is
+      """
+      B: [strong:[@link _key="l1":bar]]
+      B: baz|
+      """
 
   Scenario: Splitting block after a decorated annotation #2
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "bar"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put after "bar"
     And "{Enter}" is pressed
     And "baz" is typed
-    Then the text is "foo,bar|baz"
-    And the caret is after "baz"
-    And "baz" has no marks
+    Then the editor state is
+      """
+      B: foo[strong:[@link _key="l1":bar]]
+      B: baz|
+      """
 
   Scenario: Annotation and decorator on the same text
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When "bar" is selected
     And "strong" is toggled
     And "link" "l1" is toggled
-    Then the text is "foo ,bar, baz"
-    And "bar" has marks "strong,l1"
+    Then the editor state is
+      """
+      B: foo [strong:[@link _key="l1":bar]] baz
+      """
 
   Scenario: Adding decorator inside annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     When "bar" is selected
     And "strong" is toggled
-    Then the text is "foo ,bar, baz"
-    And "foo " has marks "l1"
-    And "bar" has marks "l1,strong"
-    And " baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
 
   Scenario: Adding an annotation across a decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When "foo bar baz" is selected
     And "link" "l1" is toggled
-    Then the text is "foo ,bar, baz"
-    And "foo " has marks "l1"
-    And "bar" has marks "strong,l1"
-    And " baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
 
   Scenario: Annotation overlapping decorator
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "bar"
     When "foob" is selected
     And "link" "l1" is toggled
-    Then the text is "foo,b,ar"
-    And "foo" has marks "l1"
-    And "b" has marks "strong,l1"
-    And "ar" has marks "strong"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][strong:[@link _key="l1":b]][strong:ar]
+      """
 
   Scenario: Annotation overlapping decorator (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "bar"
     When "foob" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "foo,b,ar"
-    And "foo" has marks "l1"
-    And "b" has marks "strong,l1"
-    And "ar" has marks "strong"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][strong:[@link _key="l1":b]][strong:ar]
+      """
 
   Scenario: Annotation overlapping decorator from behind
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "foo"
     When "obar" is selected
     And "link" "l1" is toggled
-    Then the text is "fo,o,bar"
-    Then "fo" has marks "strong"
-    And "o" has marks "strong,l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [strong:fo][strong:[@link _key="l1":o]][@link _key="l1":bar]
+      """
 
   Scenario: Annotation overlapping decorator from behind (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "foo"
     When "obar" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "fo,o,bar"
-    Then "fo" has marks "strong"
-    And "o" has marks "strong,l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [strong:fo][strong:[@link _key="l1":o]][@link _key="l1":bar]
+      """

--- a/packages/editor/gherkin-spec/annotations-overlapping.feature
+++ b/packages/editor/gherkin-spec/annotations-overlapping.feature
@@ -5,95 +5,99 @@ Feature: Overlapping Annotations
     And a global keymap
 
   Scenario Outline: Inserting text at the edge of overlapping annotations
-    Given the text <text>
+    Given the editor state is <text>
     And a "link" "l1" around <link>
     And a "comment" "c1" around <comment>
     When the editor is focused
     And the caret is put <position>
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | link          | comment | position      | new text           |
-      | "foo bar baz" | "foo bar baz" | "bar"   | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"   | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"   | after "bar"   | "foo ,bar,new baz" |
-      | "foo bar baz" | "foo bar baz" | "bar"   | before " baz" | "foo ,bar,new baz" |
-      | "foo"         | "foo"         | "foo"   | before "foo"  | "new,foo"          |
-      | "foo"         | "foo"         | "foo"   | after "foo"   | "foo,new"          |
+      | text             | link          | comment | position      | new text                                                                                                 |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | after "foo "  | "B: [@link _key=\"l1\":foo new][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\": baz]"   |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | before "bar"  | "B: [@link _key=\"l1\":foo new][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\": baz]"   |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | after "bar"   | "B: [@link _key=\"l1\":foo ][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\":new\| baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | before " baz" | "B: [@link _key=\"l1\":foo ][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\":new\| baz]" |
+      | "B: foo"         | "foo"         | "foo"   | before "foo"  | "B: new\|[@link _key=\"l1\":[@comment _key=\"c1\":foo]]"                                                 |
+      | "B: foo"         | "foo"         | "foo"   | after "foo"   | "B: [@link _key=\"l1\":[@comment _key=\"c1\":foo]]new\|"                                                 |
 
   Scenario: Overlapping annotation
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "bar"
     When "foob" is selected
     And "comment" "c1" is toggled
-    Then the text is "foo,b,ar"
-    And "foo" has marks "c1"
-    And "b" has marks "l1,c1"
-    And "ar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo][@link _key="l1":[@comment _key="c1":b]][@link _key="l1":ar]
+      """
 
   Scenario: Overlapping annotation (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "bar"
     When "foob" is selected backwards
     And "comment" "c1" is toggled
-    Then the text is "foo,b,ar"
-    And "foo" has marks "c1"
-    And "b" has marks "l1,c1"
-    And "ar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo][@link _key="l1":[@comment _key="c1":b]][@link _key="l1":ar]
+      """
 
   Scenario: Overlapping annotation from behind
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected
     And "link" "l1" is toggled
-    Then the text is "fo,o,bar"
-    Then "fo" has marks "c1"
-    And "o" has marks "c1,l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c1":[@link _key="l1":^o]][@link _key="l1":bar|]
+      """
 
   Scenario: Overlapping annotation from behind (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected backwards
     And "link" "l1" is toggled
-    Then the text is "fo,o,bar"
-    Then "fo" has marks "c1"
-    And "o" has marks "c1,l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c1":[@link _key="l1":|o]][@link _key="l1":bar^]
+      """
 
   Scenario: Overlapping same-type annotation
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "bar"
     When "foob" is selected
     And "comment" "c2" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "c2"
-    And "ar" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c2":foob][@comment _key="c1":ar]
+      """
 
   Scenario: Overlapping same-type annotation (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "bar"
     When "foob" is selected backwards
     And "comment" "c2" is toggled
-    Then the text is "foob,ar"
-    And "foob" has marks "c2"
-    And "ar" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c2":foob][@comment _key="c1":ar]
+      """
 
   Scenario: Overlapping same-type annotation from behind
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected
     And "comment" "c2" is toggled
-    Then the text is "fo,obar"
-    And "fo" has marks "c1"
-    And "obar" has marks "c2"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c2":obar]
+      """
 
   Scenario: Overlapping same-type annotation from behind (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And a "comment" "c1" around "foo"
     When "obar" is selected backwards
     And "comment" "c2" is toggled
-    Then the text is "fo,obar"
-    And "fo" has marks "c1"
-    And "obar" has marks "c2"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c2":obar]
+      """

--- a/packages/editor/gherkin-spec/annotations.feature
+++ b/packages/editor/gherkin-spec/annotations.feature
@@ -6,174 +6,171 @@ Feature: Annotations
     And a global keymap
 
   Scenario: Selection after adding an annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When "bar" is selected
     And "link" "l1" is toggled
-    Then "bar" has marks "l1"
-    And "bar" is selected
+    Then the editor state is
+      """
+      B: foo [@link _key="l1":^bar|] baz
+      """
 
   Scenario: Inserting text after an annotation
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "foo"
     And "bar" is typed
-    Then "foo" has marks "l1"
-    And "bar" has no marks
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]bar|
+      """
 
   Scenario Outline: Toggling annotation on with a collapsed selection
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When the caret is put <position>
     And "link" "l1" is toggled
-    Then "bar" has marks "l1"
+    Then the editor state is <new text>
 
     Examples:
-      | position     |
-      | before "bar" |
-      | after "bar"  |
-      | after "ar"   |
+      | position     | new text                                |
+      | before "bar" | "B: foo [@link _key=\"l1\":^bar\|] baz" |
+      | after "bar"  | "B: foo [@link _key=\"l1\":^bar\|] baz" |
+      | after "ar"   | "B: foo [@link _key=\"l1\":^bar\|] baz" |
 
   Scenario: Toggling annotation on with a collapsed selection inside split block
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the caret is put before "az"
     And "link" "l1" is toggled
-    Then the text is "foo ,bar, ,baz"
-    And "foo " has no marks
-    And "bar" has marks "strong"
-    And " " has no marks
-    And "baz" has marks "l1"
+    Then the editor state is
+      """
+      B: foo [strong:bar] [@link _key="l1":^baz|]
+      """
 
   Scenario: Toggling annotation off with a part-selection inside split block
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     And "strong" around "bar"
     When "baz" is selected
     And "link" is toggled
-    Then the text is "foo ,bar, ,baz"
-    And "foo " has marks "l1"
-    And "bar" has marks "l1,strong"
-    And " " has marks "l1"
-    And "baz" has no marks
-    And "baz" is selected
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": ]^baz|
+      """
 
   Scenario: Toggling annotation off with a part-selection does not remove sibling annotations
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo "
     And a "link" "l2" around "bar baz"
     And "strong" around "bar"
     When "baz" is selected
     And "link" is toggled
-    Then the text is "foo ,bar, ,baz"
-    And "foo " has marks "l1"
-    And "bar" has marks "l2,strong"
-    And " " has marks "l2"
-    And "baz" has no marks
-    And "baz" is selected
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l2":bar]][@link _key="l2": ]^baz|
+      """
 
   Scenario: Toggling annotation off with a collapsed selection inside split block
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     And "strong" around "bar"
     When the caret is put before "baz"
     And "link" is toggled
-    Then the text is "foo ,bar, baz"
-    And "foo " has no marks
-    And "bar" has marks "strong"
-    And " baz" has no marks
-    And the caret is before "baz"
+    Then the editor state is "B: foo [strong:bar] |baz"
 
   Scenario: Toggling annotation off with a collapsed selection does not remove sibling annotations to the left
-    Given the text "foo bar baz boo baa"
+    Given the editor state is "B: foo bar baz boo baa"
     And a "link" "l1" around "foo bar baz boo baa"
     And "strong" around "bar"
     When "boo" is selected
     And "link" is toggled
     And the caret is put before "aa"
     And "link" is toggled
-    Then the text is "foo ,bar, baz ,boo baa"
-    And "foo " has marks "l1"
-    And "bar" has marks "l1,strong"
-    And " baz " has marks "l1"
-    And "boo baa" has no marks
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz ]boo b|aa
+      """
 
   Scenario: Toggling annotation off with a collapsed selection does not remove sibling annotations to the right
-    Given the text "foo bar baz boo baa"
+    Given the editor state is "B: foo bar baz boo baa"
     And a "link" "l1" around "foo bar baz boo baa"
     And "strong" around "boo"
     When "bar" is selected
     And "link" is toggled
     And the caret is put before "oo "
     And "link" is toggled
-    Then the text is "foo bar, baz ,boo, baa"
-    And "foo bar" has no marks
-    And " baz " has marks "l1"
-    And "boo" has marks "l1,strong"
-    And " baa" has marks "l1"
+    Then the editor state is
+      """
+      B: f|oo bar[@link _key="l1": baz ][strong:[@link _key="l1":boo]][@link _key="l1": baa]
+      """
 
   Scenario Outline: Toggling annotation off with a collapsed selection
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "foo bar baz"
     When the caret is put <position>
     And "link" is toggled
-    Then "foo bar baz" has no marks
+    Then the editor state is <new text>
 
     Examples:
-      | position    |
-      | before "oo" |
-      | after "o b" |
-      | after "ba"  |
+      | position    | new text         |
+      | before "oo" | "B: foo bar baz" |
+      | after "o b" | "B: foo bar baz" |
+      | after "ba"  | "B: foo bar baz" |
 
   Scenario Outline: Writing on top of annotation
     When the editor is focused
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "comment" "c1" around "bar"
     When <selection>
     And "removed" is typed
-    Then the text is <new text>
-    And "removed" has no marks
+    Then the editor state is <new text>
 
     Examples:
-      | selection                   | new text             |
-      | "bar" is selected           | "foo removed baz"    |
-      | "bar" is selected backwards | "foo removed baz"    |
-      | "ar" is selected            | "foo ,b,removed baz" |
-      | "ar" is selected backwards  | "foo ,b,removed baz" |
+      | selection                   | new text                                       |
+      | "bar" is selected           | "B: foo removed\| baz"                         |
+      | "bar" is selected backwards | "B: foo removed\| baz"                         |
+      | "ar" is selected            | "B: foo [@comment _key=\"c1\":b]removed\| baz" |
+      | "ar" is selected backwards  | "B: foo [@comment _key=\"c1\":b]removed\| baz" |
 
   Scenario: Writing inside an annotation
-    Given the text "foo baz"
+    Given the editor state is "B: foo baz"
     And a "link" "l1" around "foo baz"
     When the editor is focused
     And the caret is put after "foo"
     And " bar" is typed
-    Then the text is "foo bar baz"
-    And "foo bar baz" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo bar| baz]
+      """
 
   Scenario Outline: Inserting text at the edge of an annotation
-    Given the text <text>
+    Given the editor state is <text>
     And a "link" "l1" around <annotated>
     When the editor is focused
     And the caret is put <position>
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | annotated | position      | new text           |
-      | "foo bar baz" | "bar"     | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"     | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"     | after "bar"   | "foo ,bar,new baz" |
-      | "foo bar baz" | "bar"     | before " baz" | "foo ,bar,new baz" |
-      | "foo"         | "foo"     | before "foo"  | "new,foo"          |
-      | "foo"         | "foo"     | after "foo"   | "foo,new"          |
+      | text             | annotated | position      | new text                                  |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo new[@link _key=\"l1\":bar] baz"   |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo new[@link _key=\"l1\":bar] baz"   |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [@link _key=\"l1\":bar]new\| baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [@link _key=\"l1\":bar]new\| baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: new\|[@link _key=\"l1\":foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [@link _key=\"l1\":foo]new\|"         |
 
-  Scenario Outline: Inserting text between annotations
-    Given the text "foobar"
+  Scenario: Inserting text between annotations
+    Given the editor state is "B: foobar"
     And a "link" "l1" around "foo"
     And a "link" "l2" around "bar"
     When the editor is focused
     And the caret is put after "foo"
     And "n" is typed
-    Then the text is "foo,n,bar"
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]n|[@link _key="l2":bar]
+      """
 
   Scenario: Inserting text after inline object, before annotation
     When the editor is focused
@@ -184,23 +181,25 @@ Feature: Annotations
     And "link" "l1" is toggled
     And the caret is put before "bar"
     And "foo " is typed
-    Then the text is ",{stock-ticker},foo ,bar"
+    Then the editor state is
+      """
+      B: {stock-ticker}foo |[@link _key="l1":bar]
+      """
 
   Scenario Outline: Toggling decorator at the edge of an annotation
-    Given the text <text>
+    Given the editor state is <text>
     And a "link" "l1" around <annotated>
     When the editor is focused
     And the caret is put <position>
     And "strong" is toggled
     And "new" is typed
-    Then the text is <new text>
-    And "new" has marks "strong"
+    Then the editor state is <new text>
 
     Examples:
-      | text          | annotated | position      | new text            |
-      | "foo bar baz" | "bar"     | after "foo "  | "foo ,new,bar, baz" |
-      | "foo bar baz" | "bar"     | before "bar"  | "foo ,new,bar, baz" |
-      | "foo bar baz" | "bar"     | after "bar"   | "foo ,bar,new, baz" |
-      | "foo bar baz" | "bar"     | before " baz" | "foo ,bar,new, baz" |
-      | "foo"         | "foo"     | before "foo"  | "new,foo"           |
-      | "foo"         | "foo"     | after "foo"   | "foo,new"           |
+      | text             | annotated | position      | new text                                           |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo [strong:new\|][@link _key=\"l1\":bar] baz" |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo [strong:new\|][@link _key=\"l1\":bar] baz" |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [@link _key=\"l1\":bar][strong:new\|] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [@link _key=\"l1\":bar][strong:new\|] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [strong:new\|][@link _key=\"l1\":foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [@link _key=\"l1\":foo][strong:new\|]"         |

--- a/packages/editor/gherkin-spec/block-objects.feature
+++ b/packages/editor/gherkin-spec/block-objects.feature
@@ -6,73 +6,126 @@ Feature: Block Objects
     And a global keymap
 
   Scenario: Pressing ArrowUp on a lonely image
-    Given the text "{image}"
+    Given the editor state is "{IMAGE}"
     When the editor is focused
     And "{ArrowUp}" is pressed
-    Then the text is "|{image}"
+    Then the editor state is
+      """
+      B: |
+      {IMAGE}
+      """
 
   Scenario: Pressing ArrowDown on a lonely image
-    Given the text "{image}"
+    Given the editor state is "{IMAGE}"
     When the editor is focused
     And "{ArrowDown}" is pressed
-    Then the text is "{image}|"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      """
 
   Scenario: Pressing ArrowDown on image at the bottom
     When the editor is focused
     And "foo|{image}" is inserted at "auto" and selected at the "end"
     And "{ArrowDown}" is pressed
-    Then the text is "foo|{image}|"
+    Then the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: |
+      """
 
   Scenario: ArrowRight before an image selects it
-    Given the text "foo|{image}"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      """
     When the editor is focused
     And the caret is put after "foo"
     And "{ArrowRight}" is pressed
     Then "{image}" is selected
 
   Scenario: ArrowLeft after an image selects it
-    Given the text "{image}|bar"
+    Given the editor state is
+      """
+      {IMAGE}
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "{ArrowLeft}" is pressed
     Then "{image}" is selected
 
   Scenario: Pressing Delete before an image
-    Given the text "foo|{image}|bar"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
     When the editor is focused
     And the caret is put after "foo"
     And "{Delete}" is pressed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo|
+      B: bar
+      """
 
   Scenario: Pressing Delete in an empty paragraph before an image
-    Given the text "foo|{image}|bar"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "foo"
     And "{Delete}" is pressed 4 times
     And "{Enter}" is pressed
-    Then the text is "{image}||bar"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      B: bar
+      """
 
   Scenario: Pressing Backspace after an image
-    Given the text "foo|{image}|bar"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "{Backspace}" is pressed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
 
   Scenario: Pressing Backspace in an empty paragraph after an image
     When the editor is focused
     And "foo|{image}" is inserted at "auto" and selected at the "end"
     And "{Enter}" is pressed
     And "{Backspace}" is pressed
-    Then the text is "foo|{image}"
+    Then the editor state is
+      """
+      B: foo
+      ^{IMAGE}|
+      """
     And "{image}" is selected
 
   Scenario Outline: Deleting a lonely image
-    Given the text "{image}"
+    Given the editor state is "{IMAGE}"
     When the editor is focused
     And <button> is pressed
     And "foo" is typed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
     Examples:
       | button        |
@@ -80,13 +133,18 @@ Feature: Block Objects
       | "{Delete}"    |
 
   Scenario Outline: Deleting an image with text above
-    Given the text "foo|{image}|b"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: b
+      """
     When the editor is focused
     And the caret is put after "b"
     And "{Backspace}" is pressed 2 times
     And <button> is pressed
     And "bar" is typed
-    Then the text is "foobar"
+    Then the editor state is "B: foobar|"
 
     Examples:
       | button        |
@@ -94,13 +152,18 @@ Feature: Block Objects
       | "{Delete}"    |
 
   Scenario Outline: Deleting an image with text below
-    Given the text "b|{image}|foo"
+    Given the editor state is
+      """
+      B: b
+      {IMAGE}
+      B: foo
+      """
     When the editor is focused
     And the caret is put before "b"
     And "{Delete}" is pressed 2 times
     And <button> is pressed
     And "bar" is typed
-    Then the text is "barfoo"
+    Then the editor state is "B: bar|foo"
 
     Examples:
       | button        |

--- a/packages/editor/gherkin-spec/decorators-overlapping.feature
+++ b/packages/editor/gherkin-spec/decorators-overlapping.feature
@@ -4,33 +4,29 @@ Feature: Overlapping Decorators
     Given one editor
 
   Scenario: Overlapping same-type decorator
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "bar"
     When "foob" is selected
     And "strong" is toggled
-    Then the text is "foobar"
-    And "foobar" has marks "strong"
+    Then the editor state is "B: [strong:^foob|ar]"
 
   Scenario: Overlapping same-type decorator (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "bar"
     When "foob" is selected backwards
     And "strong" is toggled
-    Then the text is "foobar"
-    And "foobar" has marks "strong"
+    Then the editor state is "B: [strong:|foob^ar]"
 
   Scenario: Overlapping same-type annotation from behind
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "foo"
     When "obar" is selected
     And "strong" is toggled
-    Then the text is "foobar"
-    And "foobar" has marks "strong"
+    Then the editor state is "B: [strong:fo^obar|]"
 
   Scenario: Overlapping same-type annotation from behind (backwards selection)
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "foo"
     When "obar" is selected backwards
     And "strong" is toggled
-    Then the text is "foobar"
-    And "foobar" has marks "strong"
+    Then the editor state is "B: [strong:fo|obar^]"

--- a/packages/editor/gherkin-spec/decorators.feature
+++ b/packages/editor/gherkin-spec/decorators.feature
@@ -5,80 +5,71 @@ Feature: Decorators
     Given one editor
 
   Scenario Outline: Inserting text at the edge of a decorator
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And <decorated> is selected
     And "strong" is toggled
     And the caret is put <position>
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | decorated | position      | new text           |
-      | "foo bar baz" | "bar"     | after "foo "  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"     | before "bar"  | "foo new,bar, baz" |
-      | "foo bar baz" | "bar"     | after "bar"   | "foo ,barnew, baz" |
-      | "foo bar baz" | "bar"     | before " baz" | "foo ,barnew, baz" |
-      | "foo"         | "foo"     | before "foo"  | "newfoo"           |
-      | "foo"         | "foo"     | after "foo"   | "foonew"           |
+      | text             | decorated | position      | new text                     |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo new[strong:bar] baz" |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo new[strong:bar] baz" |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [strong:barnew] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [strong:barnew] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [strong:newfoo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [strong:foonew]"         |
 
   Scenario Outline: Toggling decorator at the edge of a decorator
-    Given the text <text>
+    Given the editor state is <text>
     And "em" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And "strong" is toggled
     And "new" is typed
-    Then the text is <new text>
-    And "new" has marks <marks>
+    Then the editor state is <new text>
 
     Examples:
-      | text          | decorated | position      | new text            | marks       |
-      | "foo bar baz" | "bar"     | after "foo "  | "foo ,new,bar, baz" | "strong"    |
-      | "foo bar baz" | "bar"     | before "bar"  | "foo ,new,bar, baz" | "strong"    |
-      | "foo bar baz" | "bar"     | after "bar"   | "foo ,bar,new, baz" | "em,strong" |
-      | "foo bar baz" | "bar"     | before " baz" | "foo ,bar,new, baz" | "em,strong" |
-      | "foo"         | "foo"     | before "foo"  | "new,foo"           | "em,strong" |
-      | "foo"         | "foo"     | after "foo"   | "foo,new"           | "em,strong" |
+      | text             | decorated | position      | new text                                 |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo [strong:new\|][em:bar] baz"      |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo [strong:new\|][em:bar] baz"      |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [em:bar][em:[strong:new\|]] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [em:bar][em:[strong:new\|]] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [em:[strong:new\|]][em:foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [em:foo][em:[strong:new\|]]"         |
 
   Scenario: Writing on top of a decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When the editor is focused
     And "bar" is selected
     And "strong" is toggled
     And "removed" is typed
-    Then the text is "foo ,removed, baz"
-    And "removed" has marks "strong"
+    Then the editor state is "B: foo [strong:removed|] baz"
 
   Scenario: Toggling bold inside italic
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When "foo bar baz" is selected
     And "em" is toggled
     And "bar" is selected
     And "strong" is toggled
-    Then the text is "foo ,bar, baz"
-    And "bar" has marks "em,strong"
-    And "foo " has marks "em"
-    And "bar" has marks "em,strong"
-    And " baz" has marks "em"
+    Then the editor state is "B: [em:foo ][em:[strong:^bar|]][em: baz]"
     When "bar" is selected
     And "strong" is toggled
-    Then the text is "foo bar baz"
-    And "foo bar baz" has marks "em"
+    Then the editor state is "B: [em:foo ^bar| baz]"
 
   Scenario: Toggling bold as you write
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And the caret is put after ""
     And "foo" is typed
     And "strong" is toggled
     And "bar" is typed
-    Then the text is "foo,bar"
-    And "foo" has no marks
-    And "bar" has marks "strong"
+    Then the editor state is "B: foo[strong:bar|]"
 
   Scenario: Toggling bold inside italic as you write
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And the caret is put after ""
     And "em" is toggled
@@ -87,88 +78,85 @@ Feature: Decorators
     And "bar" is typed
     And "strong" is toggled
     And " baz" is typed
-    Then the text is "foo ,bar, baz"
-    Then "foo " has marks "em"
-    And "bar" has marks "em,strong"
-    And " baz" has marks "em"
+    Then the editor state is "B: [em:foo ][em:[strong:bar]][em: baz|]"
 
   Scenario: Toggling decorator mid-text and navigating left to clear it
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "strong" is toggled
     And "{ArrowLeft}" is pressed
     And "{ArrowRight}" is pressed
     And "bar" is typed
-    Then the text is "foobar"
-    And "foobar" has no marks
+    Then the editor state is "B: foobar|"
 
   Scenario: Deleting marked text and writing again, marked
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And the caret is put after ""
     And "strong" is toggled
     And "foo" is typed
     And "{Backspace}" is pressed 3 times
     And "bar" is typed
-    Then "bar" has marks "strong"
+    Then the editor state is "B: [strong:bar]"
 
   Scenario Outline: Deleting expanded selection ending in a decorator
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And "bar" is selected
     And "strong" is toggled
     And "foobar" is selected <direction>
     And <button> is pressed
-    Then the text is ""
+    Then the editor state is <new text>
     And the caret is before ""
-    And "" has no marks
 
     Examples:
-      | text                | direction   | button        |
-      | "foo\|bar"          | "forwards"  | "{Backspace}" |
-      | "foo\|bar"          | "forwards"  | "{Delete}"    |
-      | "foo\|bar"          | "backwards" | "{Backspace}" |
-      | "foo\|bar"          | "backwards" | "{Delete}"    |
-      | "foo\|{image}\|bar" | "forwards"  | "{Backspace}" |
-      | "foo\|{image}\|bar" | "forwards"  | "{Delete}"    |
-      | "foo\|{image}\|bar" | "backwards" | "{Backspace}" |
-      | "foo\|{image}\|bar" | "backwards" | "{Delete}"    |
+      | text                      | direction   | button        | new text |
+      | "B: foo;;B: bar"          | "forwards"  | "{Backspace}" | "B: \|"  |
+      | "B: foo;;B: bar"          | "forwards"  | "{Delete}"    | "B: \|"  |
+      | "B: foo;;B: bar"          | "backwards" | "{Backspace}" | "B: \|"  |
+      | "B: foo;;B: bar"          | "backwards" | "{Delete}"    | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Backspace}" | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Delete}"    | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Backspace}" | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Delete}"    | "B: \|"  |
 
   Scenario Outline: Deleting expanded selection starting in a decorator
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And "foo" is selected
     And "strong" is toggled
     And "foobar" is selected <direction>
     And <button> is pressed
-    Then the text is ""
+    Then the editor state is <new text>
     And the caret is before ""
-    And "" has marks "strong"
 
     Examples:
-      | text                | direction   | button        |
-      | "foo\|bar"          | "forwards"  | "{Backspace}" |
-      | "foo\|bar"          | "forwards"  | "{Delete}"    |
-      | "foo\|bar"          | "backwards" | "{Backspace}" |
-      | "foo\|bar"          | "backwards" | "{Delete}"    |
-      | "foo\|{image}\|bar" | "forwards"  | "{Backspace}" |
-      | "foo\|{image}\|bar" | "forwards"  | "{Delete}"    |
-      | "foo\|{image}\|bar" | "backwards" | "{Backspace}" |
-      | "foo\|{image}\|bar" | "backwards" | "{Delete}"    |
+      | text                      | direction   | button        | new text         |
+      | "B: foo;;B: bar"          | "forwards"  | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "forwards"  | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "backwards" | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "backwards" | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Delete}"    | "B: [strong:\|]" |
 
   Scenario: Deleting expanded selection with decorator toggled on
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put after "bar"
     And "strong" is toggled
     And "foobar" is selected
     And "{Backspace}" is pressed
     And "baz" is typed
-    Then the text is "baz"
-    And "baz" has no marks
+    Then the editor state is "B: baz|"
 
   Scenario: Adding bold across an empty block and typing in the same
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed 2 times
     And "bar" is typed
@@ -177,122 +165,125 @@ Feature: Decorators
     And the caret is put after "foo"
     And "{ArrowRight}" is pressed
     And "bar" is typed
-    Then "bar" has marks "strong"
+    Then the editor state is
+      """
+      B: [strong:foo]
+      B: [strong:bar]
+      B: [strong:bar]
+      """
 
   Scenario: Toggling bold across an empty block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed 2 times
     And "bar" is typed
-    Then the text is "foo||bar"
+    Then the editor state is "B: foo;;B: ;;B: bar|"
     When "ooba" is selected
     And "strong" is toggled
-    Then the text is "f,oo||ba,r"
-    And "oo" has marks "strong"
-    And "ba" has marks "strong"
+    Then the editor state is
+      """
+      B: f[strong:^oo]
+      B: [strong:]
+      B: [strong:ba|]r
+      """
     When "strong" is toggled
-    Then the text is "foo||bar"
+    Then the editor state is "B: f^oo;;B: ;;B: ba|r"
 
   Scenario Outline: Toggling bold on a cross-selection with the first line empty
-    Given the text "|foo"
+    Given the editor state is "B: ;;B: foo"
     When everything is <selection>
     And "strong" is toggled
-    Then the text is "|foo"
-    And "" has marks "strong"
-    And "foo" has marks "strong"
+    Then the editor state is <toggled>
     When "strong" is toggled
-    Then the text is "|foo"
-    And "" has no marks
-    And "foo" has no marks
+    Then the editor state is <untoggled>
 
     Examples:
-      | selection          |
-      | selected           |
-      | selected backwards |
+      | selection          | toggled                            | untoggled        |
+      | selected           | "B: [strong:^];;B: [strong:foo\|]" | "B: ^;;B: foo\|" |
+      | selected backwards | "B: [strong:\|];;B: [strong:foo^]" | "B: \|;;B: foo^" |
 
   Scenario Outline: Toggling bold on a cross-selection with the last line empty
-    Given the text "foo|"
+    Given the editor state is "B: foo;;B: "
     When everything is <selection>
     And "strong" is toggled
-    Then the text is "foo|"
-    And "foo" has marks "strong"
-    And "" has marks "strong"
+    Then the editor state is <toggled>
     When "strong" is toggled
-    Then the text is "foo|"
-    And "foo" has no marks
-    And "" has no marks
+    Then the editor state is <untoggled>
 
     Examples:
-      | selection          |
-      | selected           |
-      | selected backwards |
+      | selection          | toggled                            | untoggled        |
+      | selected           | "B: [strong:^foo];;B: [strong:\|]" | "B: ^foo;;B: \|" |
+      | selected backwards | "B: [strong:\|foo];;B: [strong:^]" | "B: \|foo;;B: ^" |
 
   Scenario: Splitting block before decorator
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And "strong" around "foo"
     When the editor is focused
     And the caret is put before "foo"
     And "{Enter}" is pressed
-    Then the text is "|foo"
-    And "" has marks "strong"
-    And "foo" has marks "strong"
+    Then the editor state is
+      """
+      B: [strong:]
+      B: [strong:|foo]
+      """
 
   Scenario Outline: Splitting block at the edge of decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
     And "{Enter}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new text>
     And the caret is <new position>
 
     Examples:
-      | position      | new text         | new position  |
-      | after "foo "  | "foo \|bar, baz" | before "bar"  |
-      | before "bar"  | "foo \|bar, baz" | before "bar"  |
-      | after "bar"   | "foo ,bar\| baz" | before " baz" |
-      | before " baz" | "foo ,bar\| baz" | before " baz" |
+      | position      | new text                         | new position  |
+      | after "foo "  | "B: foo ;;B: [strong:\|bar] baz" | before "bar"  |
+      | before "bar"  | "B: foo ;;B: [strong:\|bar] baz" | before "bar"  |
+      | after "bar"   | "B: foo [strong:bar];;B: \| baz" | before " baz" |
+      | before " baz" | "B: foo [strong:bar];;B: \| baz" | before " baz" |
 
   Scenario: Toggling decorators in empty block
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And "{Backspace}" is pressed 3 times
     And "strong" is toggled
-    Then the text is ""
-    And "" has marks "strong"
+    Then the editor state is "B: [strong:|]"
 
   Scenario: Splitting empty decorated block
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And the caret is put after ""
     And "strong" is toggled
     And "{Enter}" is pressed
     And "foo" is typed
-    Then the text is "|foo"
-    And "" has marks "strong"
-    And "foo" has no marks
+    Then the editor state is
+      """
+      B: [strong:]
+      B: foo|
+      """
 
   Scenario: Merging spans with same but different-ordered decorators
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     And "strong" around "foo"
     And "em" around "bar"
-    Then the text is "foo,bar"
-    And "foo" has marks "strong"
-    And "bar" has marks "em"
+    Then the editor state is "B: [strong:foo][em:bar|]"
     When "foo" is selected
     And "em" is toggled
     And "bar" is selected
     And "strong" is toggled
-    Then the text is "foobar"
-    And "foobar" has marks "strong,em"
+    Then the editor state is "B: [strong:[em:foo^bar|]]"
 
   Scenario: Toggling decorator with leading block object and trailing empty text
-    Given the text "{image}|foo|"
+    Given the editor state is "{IMAGE};;B: foo;;B: "
     When everything is selected
     And "strong" is toggled
-    Then "foo" has marks "strong"
-    And "" has marks "strong"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: [strong:foo]
+      B: [strong:]
+      """
     When "strong" is toggled
-    Then "foo" has no marks
-    And "" has no marks
+    Then the editor state is "{IMAGE};;B: foo;;B: "

--- a/packages/editor/gherkin-spec/delete.feature
+++ b/packages/editor/gherkin-spec/delete.feature
@@ -4,153 +4,203 @@ Feature: Delete
     Given one editor
 
   Scenario Outline: Deleting expanded selection
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And <selection> is selected
     And "{Delete}" is pressed
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text            | selection | new text   |
-      | "foo\|bar"      | "foo"     | "new\|bar" |
-      | "foo\|bar\|baz" | "foobar"  | "new\|baz" |
+      | text                     | selection | new text           |
+      | "B: foo;;B: bar"         | "foo"     | "B: new\|;;B: bar" |
+      | "B: foo;;B: bar;;B: baz" | "foobar"  | "B: new\|;;B: baz" |
 
   Scenario Outline: Deleting word
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And the caret is put <position>
     And <shortcut> is pressed
-    Then the text is <final text>
+    Then the editor state is <final text>
 
     Examples:
-      | text          | position        | shortcut              | final text  |
-      | "foo bar baz" | after "bar"     | "deleteWord.backward" | "foo  baz"  |
-      | "foo bar baz" | after "bar "    | "deleteWord.backward" | "foo baz"   |
-      | "foo bar baz" | after "foo ba"  | "deleteWord.backward" | "foo r baz" |
-      | "foo bar baz" | before "bar"    | "deleteWord.forward"  | "foo  baz"  |
-      | "foo bar baz" | before " bar"   | "deleteWord.forward"  | "foo baz"   |
-      | "foo bar baz" | before "ar baz" | "deleteWord.forward"  | "foo b baz" |
+      | text             | position        | shortcut              | final text       |
+      | "B: foo bar baz" | after "bar"     | "deleteWord.backward" | "B: foo \| baz"  |
+      | "B: foo bar baz" | after "bar "    | "deleteWord.backward" | "B: foo \|baz"   |
+      | "B: foo bar baz" | after "foo ba"  | "deleteWord.backward" | "B: foo \|r baz" |
+      | "B: foo bar baz" | before "bar"    | "deleteWord.forward"  | "B: foo \| baz"  |
+      | "B: foo bar baz" | before " bar"   | "deleteWord.forward"  | "B: foo\| baz"   |
+      | "B: foo bar baz" | before "ar baz" | "deleteWord.forward"  | "B: foo b\| baz" |
 
   Scenario Outline: Deleting code points in complex scripts
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
-    And the caret is put after <text>
+    And the caret is put after <orig>
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final text>
 
     Examples:
       # Hindi (Devanagari) - "कि" is क (ka) + ि (vowel i), two code points
-      | text | final text |
-      | "कि" | "क"        |
+      | text    | orig | final text |
+      | "B: कि" | "कि" | "B: क\|"   |
       # Bengali - "কি" is ক (ka) + ি (vowel i)
-      | "কি" | "ক"        |
+      | "B: কি" | "কি" | "B: ক\|"   |
       # Thai - "กิ" is ก (ko kai) + ิ (sara i)
-      | "กิ" | "ก"        |
+      | "B: กิ" | "กิ" | "B: ก\|"   |
 
   Scenario Outline: Deleting line backward
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And the caret is put <position>
     And "deleteLine.backward" is pressed
-    Then the text is <final text>
+    Then the editor state is <final text>
     When undo is performed
-    Then the text is <text>
+    Then the editor state is <undone>
 
     Examples:
-      | text          | position     | final text |
-      | "foo bar baz" | after "bar"  | " baz"     |
-      | "foo bar baz" | after "baz"  | ""         |
-      | "foo bar baz" | after "foo " | "bar baz"  |
+      | text             | position     | final text     | undone             |
+      | "B: foo bar baz" | after "bar"  | "B: \| baz"    | "B: foo bar\| baz" |
+      | "B: foo bar baz" | after "baz"  | "B: \|"        | "B: foo bar baz\|" |
+      | "B: foo bar baz" | after "foo " | "B: \|bar baz" | "B: foo \|bar baz" |
 
   Scenario: Deleting line backward at start of block merges blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "deleteLine.backward" is pressed
-    Then the text is "foobar"
+    Then the editor state is "B: foo|bar"
     When undo is performed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
 
   Scenario: Cutting selected text
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When the editor is focused
     And "bar" is selected
     And cut is performed
-    Then the text is "foo  baz"
+    Then the editor state is "B: foo | baz"
     When undo is performed
-    Then the text is "foo bar baz"
+    Then the editor state is "B: foo ^bar| baz"
 
   Scenario: Cutting across blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And "foobar" is selected
     And cut is performed
-    Then the text is ""
+    Then the editor state is "B: |"
     When undo is performed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: ^foo
+      B: bar|
+      """
 
   Scenario: Deleting word backward at block boundary merges blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "deleteWord.backward" is pressed
-    Then the text is "foobar"
+    Then the editor state is "B: foo|bar"
     When undo is performed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
 
   Scenario: Deleting word forward at block boundary merges blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put after "foo"
     And "deleteWord.forward" is pressed
-    Then the text is "foobar"
+    Then the editor state is "B: foo|bar"
     When undo is performed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo|
+      B: bar
+      """
 
   Scenario: Cutting with collapsed selection is a no-op
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When the editor is focused
     And the caret is put after "bar"
     And cut is performed
-    Then the text is "foo bar baz"
+    Then the editor state is "B: foo bar| baz"
 
   Scenario: Deleting line backward in empty block
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "deleteLine.backward" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"
 
   Scenario: Deleting line backward only affects current block
-    Given the text "foo|bar baz"
+    Given the editor state is
+      """
+      B: foo
+      B: bar baz
+      """
     When the editor is focused
     And the caret is put after "bar"
     And "deleteLine.backward" is pressed
-    Then the text is "foo| baz"
+    Then the editor state is
+      """
+      B: foo
+      B: | baz
+      """
     When undo is performed
-    Then the text is "foo|bar baz"
+    Then the editor state is
+      """
+      B: foo
+      B: bar| baz
+      """
 
   Scenario Outline: Merging blocks preserves marks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
     And <button> is pressed
-    Then the text is "foo,bar"
-    And "foo" has no marks
-    And "bar" has marks "strong"
+    Then the editor state is <text>
 
     Examples:
-      | position     | button        |
-      | before "bar" | "{Backspace}" |
-      | after "foo"  | "{Delete}"    |
+      | position     | button        | text                   |
+      | before "bar" | "{Backspace}" | "B: foo[strong:\|bar]" |
+      | after "foo"  | "{Delete}"    | "B: foo\|[strong:bar]" |
 
   Scenario Outline: Merging blocks triggers span normalization
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put <position>
     And <button> is pressed
-    Then the text is "foobar"
+    Then the editor state is "B: foo|bar"
 
     Examples:
       | position     | button        |

--- a/packages/editor/gherkin-spec/inline-objects.feature
+++ b/packages/editor/gherkin-spec/inline-objects.feature
@@ -6,48 +6,45 @@ Feature: Inline Objects
     And a global keymap
 
   Scenario: Writing after inserting an inline object
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And a "stock-ticker" is inserted
     And "{ArrowRight}" is pressed
     And "bar" is typed
-    Then the text is "foo,{stock-ticker},bar"
+    Then the editor state is "B: foo{stock-ticker}bar|"
 
   Scenario: Pressing Delete before an inline object
-    Given the text "foo,{stock-ticker},"
+    Given the editor state is "B: foo{stock-ticker}"
     When the editor is focused
     And the caret is put after "foo"
     And "{Delete}" is pressed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Pressing Backspace after an inline object
-    Given the text "foo,{stock-ticker},"
+    Given the editor state is "B: foo{stock-ticker}"
     When the editor is focused
     And "{Backspace}" is pressed
     Then the caret is after "foo"
 
   Scenario: Adding a decorator across an inline object
-    Given the text "foo,{stock-ticker},bar"
+    Given the editor state is "B: foo{stock-ticker}bar"
     When "foobar" is selected
     And "strong" is toggled
-    Then the text is "foo,{stock-ticker},bar"
-    And "foo" has marks "strong"
-    And "bar" has marks "strong"
+    Then the editor state is "B: [strong:^foo]{stock-ticker}[strong:bar|]"
 
   Scenario: Adding an annotation across an inline object
-    Given the text "foo,{stock-ticker},bar"
+    Given the editor state is "B: foo{stock-ticker}bar"
     When "foobar" is selected
     And "link" "l1" is toggled
-    Then the text is "foo,{stock-ticker},bar"
-    And "foo" has marks "l1"
-    And "bar" has marks "l1"
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]{stock-ticker}[@link _key="l1":bar|]
+      """
 
   Scenario: Removing an annotation across an inline block
-    Given the text "foo,{stock-ticker},bar"
+    Given the editor state is "B: foo{stock-ticker}bar"
     When "foobar" is selected
     And "link" is toggled
     And "link" is toggled
-    Then the text is "foo,{stock-ticker},bar"
-    And "foo" has no marks
-    And "bar" has no marks
+    Then the editor state is "B: ^foo{stock-ticker}bar|"

--- a/packages/editor/gherkin-spec/insert.block.feature
+++ b/packages/editor/gherkin-spec/insert.block.feature
@@ -5,249 +5,236 @@ Feature: Insert Block
 
   Scenario Outline: Inserting block object on an empty editor without selecting it
     When "{image}" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
     And nothing is selected
 
     Examples:
-      | placement | text        |
-      | "before"  | "{image}\|" |
-      | "after"   | "\|{image}" |
-      | "auto"    | "{image}"   |
+      | placement | text           |
+      | "before"  | "{IMAGE};;B: " |
+      | "after"   | "B: ;;{IMAGE}" |
+      | "auto"    | "{IMAGE}"      |
 
   Scenario Outline: Inserting block object on an empty editor and selecting it
     When the editor is focused
     And "{image}" is inserted at <placement> and selected at the <position>
     And "bar" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | position | text        |
-      | "before"  | "start"  | "{image}\|" |
-      | "after"   | "start"  | "\|{image}" |
-      | "auto"    | "start"  | "{image}"   |
-      | "before"  | "end"    | "{image}\|" |
-      | "after"   | "end"    | "\|{image}" |
-      | "auto"    | "end"    | "{image}"   |
+      | placement | position | text              |
+      | "before"  | "start"  | "^{IMAGE}\|;;B: " |
+      | "after"   | "start"  | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "start"  | "^{IMAGE}\|"      |
+      | "before"  | "end"    | "^{IMAGE}\|;;B: " |
+      | "after"   | "end"    | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "end"    | "^{IMAGE}\|"      |
 
   Scenario Outline: Inserting block object on an empty text block
-    Given the text "f"
+    Given the editor state is "B: f"
     When the editor is focused
     And "{Backspace}" is pressed
     And "{image}" is inserted at <placement> and selected at the <position>
     And "bar" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | position | text           |
-      | "before"  | "none"   | "{image}\|bar" |
-      | "after"   | "none"   | "bar\|{image}" |
-      | "auto"    | "none"   | "{image}"      |
-      | "before"  | "start"  | "{image}\|"    |
-      | "after"   | "start"  | "\|{image}"    |
-      | "auto"    | "start"  | "{image}"      |
-      | "before"  | "end"    | "{image}\|"    |
-      | "after"   | "end"    | "\|{image}"    |
-      | "auto"    | "end"    | "{image}"      |
+      | placement | position | text                |
+      | "before"  | "none"   | "{IMAGE};;B: bar\|" |
+      | "after"   | "none"   | "B: bar\|;;{IMAGE}" |
+      | "auto"    | "none"   | "^{IMAGE}\|"        |
+      | "before"  | "start"  | "^{IMAGE}\|;;B: "   |
+      | "after"   | "start"  | "B: ;;^{IMAGE}\|"   |
+      | "auto"    | "start"  | "^{IMAGE}\|"        |
+      | "before"  | "end"    | "^{IMAGE}\|;;B: "   |
+      | "after"   | "end"    | "B: ;;^{IMAGE}\|"   |
+      | "auto"    | "end"    | "^{IMAGE}\|"        |
 
   Scenario Outline: Inserting block object on empty heading
     When "h1:" is inserted at "auto" and selected at the "none"
     When "{image}" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | text           |
-      | "auto"    | "{image}"      |
-      | "before"  | "{image}\|h1:" |
-      | "after"   | "h1:\|{image}" |
+      | placement | text                        |
+      | "auto"    | "{IMAGE}"                   |
+      | "before"  | "{IMAGE};;B style=\"h1\": " |
+      | "after"   | "B style=\"h1\": ;;{IMAGE}" |
 
   Scenario Outline: Inserting block object on empty list item
     When ">-:" is inserted at "auto" and selected at the "none"
     When "{image}" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | text           |
-      | "auto"    | "{image}"      |
-      | "before"  | "{image}\|>-:" |
-      | "after"   | ">-:\|{image}" |
+      | placement | text                               |
+      | "auto"    | "{IMAGE}"                          |
+      | "before"  | "{IMAGE};;B listItem=\"bullet\": " |
+      | "after"   | "B listItem=\"bullet\": ;;{IMAGE}" |
 
   Scenario Outline: Inserting and selecting block object on text selection
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When <selection> is selected
     And "{image}" is inserted at <placement> and selected at the <position>
-    Then the text is <text>
+    Then the editor state is <text>
     And "{image}" is selected
 
     Examples:
-      | selection | placement | position | text           |
-      | "foo"     | "auto"    | "start"  | "{image}"      |
-      | "f"       | "auto"    | "start"  | "{image}\|oo"  |
-      | "oo"      | "auto"    | "start"  | "f\|{image}"   |
-      | "foo"     | "auto"    | "end"    | "{image}"      |
-      | "f"       | "auto"    | "end"    | "{image}\|oo"  |
-      | "oo"      | "auto"    | "end"    | "f\|{image}"   |
-      | "foo"     | "before"  | "start"  | "{image}\|foo" |
-      | "f"       | "before"  | "start"  | "{image}\|foo" |
-      | "oo"      | "before"  | "start"  | "{image}\|foo" |
-      | "foo"     | "before"  | "end"    | "{image}\|foo" |
-      | "f"       | "before"  | "end"    | "{image}\|foo" |
-      | "oo"      | "before"  | "end"    | "{image}\|foo" |
-      | "foo"     | "after"   | "start"  | "foo\|{image}" |
-      | "f"       | "after"   | "start"  | "foo\|{image}" |
-      | "oo"      | "after"   | "start"  | "foo\|{image}" |
-      | "foo"     | "after"   | "end"    | "foo\|{image}" |
-      | "f"       | "after"   | "end"    | "foo\|{image}" |
-      | "oo"      | "after"   | "end"    | "foo\|{image}" |
+      | selection | placement | position | text                 |
+      | "foo"     | "auto"    | "start"  | "^{IMAGE}\|"         |
+      | "f"       | "auto"    | "start"  | "^{IMAGE}\|;;B: oo"  |
+      | "oo"      | "auto"    | "start"  | "B: f;;^{IMAGE}\|"   |
+      | "foo"     | "auto"    | "end"    | "^{IMAGE}\|"         |
+      | "f"       | "auto"    | "end"    | "^{IMAGE}\|;;B: oo"  |
+      | "oo"      | "auto"    | "end"    | "B: f;;^{IMAGE}\|"   |
+      | "foo"     | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "f"       | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "oo"      | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "foo"     | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "f"       | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "oo"      | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "foo"     | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "f"       | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "oo"      | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "foo"     | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
+      | "f"       | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
+      | "oo"      | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
 
   Scenario Outline: Inserting block object on text selection without selecting it
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And <selection> is selected
     And "{image}" is inserted at <placement> and selected at the "none"
     And "bar" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | selection | placement | text             |
-      | "f"       | "auto"    | "{image}\|baroo" |
-      | "oo"      | "auto"    | "fbar\|{image}"  |
-      | "foo"     | "auto"    | "{image}"        |
-      | "f"       | "before"  | "{image}\|baroo" |
-      | "oo"      | "before"  | "{image}\|fbar"  |
-      | "foo"     | "before"  | "{image}\|bar"   |
-      | "f"       | "after"   | "baroo\|{image}" |
-      | "oo"      | "after"   | "fbar\|{image}"  |
-      | "foo"     | "after"   | "bar\|{image}"   |
+      | selection | placement | text                  |
+      | "f"       | "auto"    | "{IMAGE};;B: bar\|oo" |
+      | "oo"      | "auto"    | "B: fbar\|;;{IMAGE}"  |
+      | "foo"     | "auto"    | "^{IMAGE}\|"          |
+      | "f"       | "before"  | "{IMAGE};;B: bar\|oo" |
+      | "oo"      | "before"  | "{IMAGE};;B: fbar\|"  |
+      | "foo"     | "before"  | "{IMAGE};;B: bar\|"   |
+      | "f"       | "after"   | "B: bar\|oo;;{IMAGE}" |
+      | "oo"      | "after"   | "B: fbar\|;;{IMAGE}"  |
+      | "foo"     | "after"   | "B: bar\|;;{IMAGE}"   |
 
   Scenario Outline: Inserting and selecting block object on cross-block selection
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
     And <selection> is selected
     And "{image}" is inserted at <placement> and selected at the <position>
-    Then the text is <text>
+    Then the editor state is <text>
     And "{image}" is selected
 
     Examples:
-      | selection | placement | position | text                |
-      | "foob"    | "auto"    | "start"  | "{image}\|ar"       |
-      | "obar"    | "auto"    | "start"  | "fo\|{image}"       |
-      | "foob"    | "auto"    | "end"    | "{image}\|ar"       |
-      | "foob"    | "before"  | "start"  | "{image}\|foo\|bar" |
-      | "obar"    | "before"  | "start"  | "{image}\|foo\|bar" |
-      | "foob"    | "before"  | "end"    | "{image}\|foo\|bar" |
-      | "obar"    | "before"  | "end"    | "{image}\|foo\|bar" |
-      | "foob"    | "after"   | "start"  | "foo\|bar\|{image}" |
-      | "obar"    | "after"   | "start"  | "foo\|bar\|{image}" |
-      | "foob"    | "after"   | "end"    | "foo\|bar\|{image}" |
-      | "obar"    | "after"   | "end"    | "foo\|bar\|{image}" |
+      | selection | placement | position | text                         |
+      | "foob"    | "auto"    | "start"  | "^{IMAGE}\|;;B: ar"          |
+      | "obar"    | "auto"    | "start"  | "B: fo;;^{IMAGE}\|"          |
+      | "foob"    | "auto"    | "end"    | "^{IMAGE}\|;;B: ar"          |
+      | "foob"    | "before"  | "start"  | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "start"  | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "end"    | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "end"    | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "foob"    | "after"   | "start"  | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "obar"    | "after"   | "start"  | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "foob"    | "after"   | "end"    | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "obar"    | "after"   | "end"    | "B: foo;;B: bar;;^{IMAGE}\|" |
 
   Scenario Outline: Inserting a block object on a cross-block selection without selecting it
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
     And <selection> is selected
     And "{image}" is inserted at <placement> and selected at the "none"
     And "baz" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | selection | placement | text             |
-      | "foob"    | "auto"    | "{image}\|bazar" |
-      | "obar"    | "auto"    | "fobaz\|{image}" |
-      | "foobar"  | "auto"    | "{image}"        |
+      | selection | placement | text                  |
+      | "foob"    | "auto"    | "{IMAGE};;B: baz\|ar" |
+      | "obar"    | "auto"    | "B: fobaz\|;;{IMAGE}" |
+      | "foobar"  | "auto"    | "^{IMAGE}\|"          |
 
   Scenario Outline: Inserting text block on an empty editor
     When "foo" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
     And nothing is selected
 
     Examples:
-      | placement | text    |
-      | "before"  | "foo\|" |
-      | "after"   | "\|foo" |
-      | "auto"    | "foo"   |
+      | placement | text          |
+      | "before"  | "B: foo;;B: " |
+      | "after"   | "B: ;;B: foo" |
+      | "auto"    | "B: foo"      |
 
   Scenario Outline: Inserting and selecting text block on an empty editor
     When the editor is focused
     When "foo" is inserted at <placement> and selected at the <position>
     And "bar" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | position | text       |
-      | "before"  | "start"  | "barfoo\|" |
-      | "before"  | "end"    | "foobar\|" |
-      | "before"  | "none"   | "foo\|bar" |
-      | "after"   | "start"  | "\|barfoo" |
-      | "after"   | "end"    | "\|foobar" |
-      | "after"   | "none"   | "bar\|foo" |
-      | "auto"    | "start"  | "barfoo"   |
-      | "auto"    | "end"    | "foobar"   |
-      | "auto"    | "none"   | "barfoo"   |
+      | placement | position | text               |
+      | "before"  | "start"  | "B: bar\|foo;;B: " |
+      | "before"  | "end"    | "B: foobar\|;;B: " |
+      | "before"  | "none"   | "B: foo;;B: bar\|" |
+      | "after"   | "start"  | "B: ;;B: bar\|foo" |
+      | "after"   | "end"    | "B: ;;B: foobar\|" |
+      | "after"   | "none"   | "B: bar\|;;B: foo" |
+      | "auto"    | "start"  | "B: bar\|foo"      |
+      | "auto"    | "end"    | "B: foobar\|"      |
+      | "auto"    | "none"   | "B: bar\|foo"      |
 
   Scenario Outline: Inserting and selecting text block on an empty selected editor
     When the editor is focused
     And "foo" is inserted at <placement> and selected at the <position>
     And "bar" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | position | text       |
-      | "before"  | "start"  | "barfoo\|" |
-      | "before"  | "end"    | "foobar\|" |
-      | "before"  | "none"   | "foo\|bar" |
-      | "after"   | "start"  | "\|barfoo" |
-      | "after"   | "end"    | "\|foobar" |
-      | "after"   | "none"   | "bar\|foo" |
-      | "auto"    | "start"  | "barfoo"   |
-      | "auto"    | "end"    | "foobar"   |
-      | "auto"    | "none"   | "barfoo"   |
+      | placement | position | text               |
+      | "before"  | "start"  | "B: bar\|foo;;B: " |
+      | "before"  | "end"    | "B: foobar\|;;B: " |
+      | "before"  | "none"   | "B: foo;;B: bar\|" |
+      | "after"   | "start"  | "B: ;;B: bar\|foo" |
+      | "after"   | "end"    | "B: ;;B: foobar\|" |
+      | "after"   | "none"   | "B: bar\|;;B: foo" |
+      | "auto"    | "start"  | "B: bar\|foo"      |
+      | "auto"    | "end"    | "B: foobar\|"      |
+      | "auto"    | "none"   | "B: bar\|foo"      |
 
   Scenario Outline: Inserting block object on block object
     When "{image}" is inserted at "auto" and selected at the <block selection>
     And "{break}" is inserted at <new block placement> and selected at the <new block selection>
-    Then the text is <text>
+    Then the editor state is <text>
     And <selection> is selected
 
     Examples:
-      | block selection | new block placement | new block selection | text               | selection |
-      | "start"         | "before"            | "start"             | "{break}\|{image}" | "{break}" |
-      # | "start"         | "after"             | "start"             | "{image}\|{break}" | block "k-b" |
-      # | "start"         | "auto"              | "start"             | "{image}\|{break}" | block "k-b" |
-      | "start"         | "before"            | "end"               | "{break}\|{image}" | "{break}" |
-      # | "start"         | "after"             | "end"               | "{image}\|{break}" | block "k-b" |
-      # | "start"         | "auto"              | "end"               | "{image}\|{break}" | block "k-b" |
-      | "start"         | "before"            | "none"              | "{break}\|{image}" | "{image}" |
-      # | "start"         | "after"             | "none"              | "{image}\|{break}" | block "k-i" |
-      # | "start"         | "auto"              | "none"              | "{image}\|{break}" | block "k-i" |
-      # | "start"         | "after"             | "start"             | "{image}\|{break}" | block "k-b" |
-      # | "start"         | "auto"              | "start"             | "{image}\|{break}" | block "k-b" |
-      | "end"           | "before"            | "start"             | "{break}\|{image}" | "{break}" |
-      | "end"           | "before"            | "end"               | "{break}\|{image}" | "{break}" |
-      | "end"           | "before"            | "none"              | "{break}\|{image}" | "{image}" |
-      | "none"          | "before"            | "start"             | "{break}\|{image}" | "{break}" |
-      | "none"          | "after"             | "start"             | "{image}\|{break}" | "{break}" |
-      | "none"          | "auto"              | "start"             | "{image}\|{break}" | "{break}" |
-      | "none"          | "before"            | "end"               | "{break}\|{image}" | "{break}" |
-      | "none"          | "after"             | "end"               | "{image}\|{break}" | "{break}" |
-      | "none"          | "auto"              | "end"               | "{image}\|{break}" | "{break}" |
-      | "none"          | "before"            | "none"              | "{break}\|{image}" | nothing   |
-      | "none"          | "after"             | "none"              | "{image}\|{break}" | nothing   |
-      | "none"          | "auto"              | "none"              | "{image}\|{break}" | nothing   |
+      | block selection | new block placement | new block selection | text                  | selection |
+      | "start"         | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "start"         | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "start"         | "before"            | "none"              | "{BREAK};;^{IMAGE}\|" | "{image}" |
+      | "end"           | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "end"           | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "end"           | "before"            | "none"              | "{BREAK};;^{IMAGE}\|" | "{image}" |
+      | "none"          | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "none"          | "after"             | "start"             | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "auto"              | "start"             | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "none"          | "after"             | "end"               | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "auto"              | "end"               | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "before"            | "none"              | "{BREAK};;{IMAGE}"    | nothing   |
+      | "none"          | "after"             | "none"              | "{IMAGE};;{BREAK}"    | nothing   |
+      | "none"          | "auto"              | "none"              | "{IMAGE};;{BREAK}"    | nothing   |
 
   Scenario Outline: Inserting and selecting block object on block object
-    Given the text "{image}"
-    # When "{image}" is inserted at "auto" and selected at the "none"
+    Given the editor state is "{IMAGE}"
     When "{break}" is inserted at <placement> and selected at the <position>
     Then <selection> is selected
 
-    # When the editor is focused
-    # And "{Enter}" is pressed
-    # And "foo" is typed
-    # Then the text is <text>
     Examples:
       | placement | position | selection |
       | "before"  | "start"  | "{break}" |
@@ -261,204 +248,208 @@ Feature: Insert Block
       | "auto"    | "none"   | "{image}" |
 
   Scenario Outline: Inserting block object on block objects
-    Given the text "{image}|{image}"
+    Given the editor state is
+      """
+      {IMAGE}
+      {IMAGE}
+      """
     When the editor is focused
     And everything is selected
     And "{break}" is inserted at <placement> and selected at the <position>
     And "{Enter}" is pressed
     And "foo" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | position | text                             |
-      | "before"  | "start"  | "{break}\|foo\|{image}\|{image}" |
-      | "before"  | "end"    | "{break}\|foo\|{image}\|{image}" |
-      | "before"  | "none"   | "{break}\|foo"                   |
-      | "after"   | "start"  | "{image}\|{image}\|{break}\|foo" |
-      | "after"   | "end"    | "{image}\|{image}\|{break}\|foo" |
-      | "after"   | "none"   | "foo\|{break}"                   |
+      | placement | position | text                                  |
+      | "before"  | "start"  | "{BREAK};;B: foo\|;;{IMAGE};;{IMAGE}" |
+      | "before"  | "end"    | "{BREAK};;B: foo\|;;{IMAGE};;{IMAGE}" |
+      | "before"  | "none"   | "{BREAK};;B: foo\|"                   |
+      | "after"   | "start"  | "{IMAGE};;{IMAGE};;{BREAK};;B: foo\|" |
+      | "after"   | "end"    | "{IMAGE};;{IMAGE};;{BREAK};;B: foo\|" |
+      | "after"   | "none"   | "B: foo\|;;{BREAK}"                   |
 
   Scenario Outline: Inserting block object on text block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
     And the caret is put <position>
     And "{image}" is inserted at <placement> and selected at the "none"
     And "baz" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | position     | placement | text                     |
-      | before "foo" | "before"  | "{image}\|bazfoo\|bar"   |
-      | after "f"    | "before"  | "{image}\|fbazoo\|bar"   |
-      | after "foo"  | "before"  | "{image}\|foobaz\|bar"   |
-      | before "foo" | "after"   | "bazfoo\|{image}\|bar"   |
-      | after "f"    | "after"   | "fbazoo\|{image}\|bar"   |
-      | after "foo"  | "after"   | "foobaz\|{image}\|bar"   |
-      | before "foo" | "auto"    | "{image}\|bazfoo\|bar"   |
-      | after "f"    | "auto"    | "fbaz\|{image}\|oo\|bar" |
-      | after "foo"  | "auto"    | "foobaz\|{image}\|bar"   |
+      | position     | placement | text                                |
+      | before "foo" | "before"  | "{IMAGE};;B: baz\|foo;;B: bar"      |
+      | after "f"    | "before"  | "{IMAGE};;B: fbaz\|oo;;B: bar"      |
+      | after "foo"  | "before"  | "{IMAGE};;B: foobaz\|;;B: bar"      |
+      | before "foo" | "after"   | "B: baz\|foo;;{IMAGE};;B: bar"      |
+      | after "f"    | "after"   | "B: fbaz\|oo;;{IMAGE};;B: bar"      |
+      | after "foo"  | "after"   | "B: foobaz\|;;{IMAGE};;B: bar"      |
+      | before "foo" | "auto"    | "{IMAGE};;B: baz\|foo;;B: bar"      |
+      | after "f"    | "auto"    | "B: fbaz\|;;{IMAGE};;B: oo;;B: bar" |
+      | after "foo"  | "auto"    | "B: foobaz\|;;{IMAGE};;B: bar"      |
 
   Scenario Outline: Inserting text block on block object
     When "{image}" is inserted at "auto" and selected at the "none"
     When "foo" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
     And nothing is selected
 
     Examples:
-      | placement | text           |
-      | "before"  | "foo\|{image}" |
-      | "after"   | "{image}\|foo" |
-      | "auto"    | "{image}\|foo" |
+      | placement | text              |
+      | "before"  | "B: foo;;{IMAGE}" |
+      | "after"   | "{IMAGE};;B: foo" |
+      | "auto"    | "{IMAGE};;B: foo" |
 
   Scenario Outline: Inserting text block on text block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the caret is put <position>
     And "bar" is inserted at <placement> and selected at the "none"
-    Then the text is <text>
+    Then the editor state is <text>
     And the caret is <position>
 
     Examples:
-      | position     | placement | text       |
-      | after "foo"  | "before"  | "bar\|foo" |
-      | after "foo"  | "after"   | "foo\|bar" |
-      | after "foo"  | "auto"    | "foobar"   |
-      | before "foo" | "before"  | "bar\|foo" |
-      | before "foo" | "after"   | "foo\|bar" |
-      | before "foo" | "auto"    | "barfoo"   |
-      | after "f"    | "before"  | "bar\|foo" |
-      | after "f"    | "after"   | "foo\|bar" |
-      | after "f"    | "auto"    | "fbaroo"   |
+      | position     | placement | text               |
+      | after "foo"  | "before"  | "B: bar;;B: foo\|" |
+      | after "foo"  | "after"   | "B: foo\|;;B: bar" |
+      | after "foo"  | "auto"    | "B: foo\|bar"      |
+      | before "foo" | "before"  | "B: bar;;B: \|foo" |
+      | before "foo" | "after"   | "B: \|foo;;B: bar" |
+      | before "foo" | "auto"    | "B: bar\|foo"      |
+      | after "f"    | "before"  | "B: bar;;B: f\|oo" |
+      | after "f"    | "after"   | "B: f\|oo;;B: bar" |
+      | after "f"    | "auto"    | "B: f\|baroo"      |
 
   Scenario Outline: Inserting and selecting text block on text block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put <position>
     And "bar" is inserted at <placement> and selected at the <select-position>
     And "baz" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | position     | placement | select-position | text          |
-      | after "foo"  | "before"  | "start"         | "bazbar\|foo" |
-      | after "foo"  | "before"  | "end"           | "barbaz\|foo" |
-      | after "foo"  | "before"  | "none"          | "bar\|foobaz" |
-      | after "foo"  | "after"   | "start"         | "foo\|bazbar" |
-      | after "foo"  | "after"   | "end"           | "foo\|barbaz" |
-      | after "foo"  | "after"   | "none"          | "foobaz\|bar" |
-      | after "foo"  | "auto"    | "start"         | "foobazbar"   |
-      | after "foo"  | "auto"    | "end"           | "foobarbaz"   |
-      | after "foo"  | "auto"    | "none"          | "foobazbar"   |
-      | before "foo" | "before"  | "start"         | "bazbar\|foo" |
-      | before "foo" | "before"  | "end"           | "barbaz\|foo" |
-      | before "foo" | "before"  | "none"          | "bar\|bazfoo" |
-      | before "foo" | "after"   | "start"         | "foo\|bazbar" |
-      | before "foo" | "after"   | "end"           | "foo\|barbaz" |
-      | before "foo" | "after"   | "none"          | "bazfoo\|bar" |
-      | before "foo" | "auto"    | "start"         | "bazbarfoo"   |
-      | before "foo" | "auto"    | "end"           | "barbazfoo"   |
-      | before "foo" | "auto"    | "none"          | "barbazfoo"   |
-      | after "f"    | "before"  | "start"         | "bazbar\|foo" |
-      | after "f"    | "before"  | "end"           | "barbaz\|foo" |
-      | after "f"    | "before"  | "none"          | "bar\|fbazoo" |
-      | after "f"    | "after"   | "start"         | "foo\|bazbar" |
-      | after "f"    | "after"   | "end"           | "foo\|barbaz" |
-      | after "f"    | "after"   | "none"          | "fbazoo\|bar" |
-      | after "f"    | "auto"    | "start"         | "fbazbaroo"   |
-      | after "f"    | "auto"    | "end"           | "fbarbazoo"   |
-      | after "f"    | "auto"    | "none"          | "fbazbaroo"   |
+      | position     | placement | select-position | text                  |
+      | after "foo"  | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | after "foo"  | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | after "foo"  | "before"  | "none"          | "B: bar;;B: foobaz\|" |
+      | after "foo"  | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | after "foo"  | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | after "foo"  | "after"   | "none"          | "B: foobaz\|;;B: bar" |
+      | after "foo"  | "auto"    | "start"         | "B: foobaz\|bar"      |
+      | after "foo"  | "auto"    | "end"           | "B: foobarbaz\|"      |
+      | after "foo"  | "auto"    | "none"          | "B: foobaz\|bar"      |
+      | before "foo" | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | before "foo" | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | before "foo" | "before"  | "none"          | "B: bar;;B: baz\|foo" |
+      | before "foo" | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | before "foo" | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | before "foo" | "after"   | "none"          | "B: baz\|foo;;B: bar" |
+      | before "foo" | "auto"    | "start"         | "B: baz\|barfoo"      |
+      | before "foo" | "auto"    | "end"           | "B: barbaz\|foo"      |
+      | before "foo" | "auto"    | "none"          | "B: barbaz\|foo"      |
+      | after "f"    | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | after "f"    | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | after "f"    | "before"  | "none"          | "B: bar;;B: fbaz\|oo" |
+      | after "f"    | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | after "f"    | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | after "f"    | "after"   | "none"          | "B: fbaz\|oo;;B: bar" |
+      | after "f"    | "auto"    | "start"         | "B: fbaz\|baroo"      |
+      | after "f"    | "auto"    | "end"           | "B: fbarbaz\|oo"      |
+      | after "f"    | "auto"    | "none"          | "B: fbaz\|baroo"      |
 
   Scenario Outline: Inserting text block on text selection
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And <selection> is selected
     And "bar" is inserted at <placement> and selected at the <position>
     And "baz" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | selection | placement | position | text          |
-      | "foo"     | "before"  | "start"  | "bazbar\|foo" |
-      | "f"       | "before"  | "start"  | "bazbar\|foo" |
-      | "oo"      | "before"  | "start"  | "bazbar\|foo" |
-      | "foo"     | "before"  | "end"    | "barbaz\|foo" |
-      | "f"       | "before"  | "end"    | "barbaz\|foo" |
-      | "oo"      | "before"  | "end"    | "barbaz\|foo" |
-      | "foo"     | "after"   | "start"  | "foo\|bazbar" |
-      | "f"       | "after"   | "start"  | "foo\|bazbar" |
-      | "oo"      | "after"   | "start"  | "foo\|bazbar" |
-      | "foo"     | "after"   | "end"    | "foo\|barbaz" |
-      | "f"       | "after"   | "end"    | "foo\|barbaz" |
-      | "oo"      | "after"   | "end"    | "foo\|barbaz" |
-      | "foo"     | "auto"    | "start"  | "bazbar"      |
-      | "f"       | "auto"    | "start"  | "bazbaroo"    |
-      | "oo"      | "auto"    | "start"  | "fbazbar"     |
-      | "foo"     | "auto"    | "end"    | "barbaz"      |
-      | "f"       | "auto"    | "end"    | "barbazoo"    |
-      | "oo"      | "auto"    | "end"    | "fbarbaz"     |
+      | selection | placement | position | text                  |
+      | "foo"     | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "f"       | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "oo"      | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "foo"     | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "f"       | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "oo"      | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "foo"     | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "f"       | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "oo"      | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "foo"     | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "f"       | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "oo"      | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "foo"     | "auto"    | "start"  | "B: baz\|bar"         |
+      | "f"       | "auto"    | "start"  | "B: baz\|baroo"       |
+      | "oo"      | "auto"    | "start"  | "B: fbaz\|bar"        |
+      | "foo"     | "auto"    | "end"    | "B: barbaz\|"         |
+      | "f"       | "auto"    | "end"    | "B: barbaz\|oo"       |
+      | "oo"      | "auto"    | "end"    | "B: fbarbaz\|"        |
 
   Scenario Outline: Inserting text block on cross-block text selection
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
     And <selection> is selected
     And "baz" is inserted at <placement> and selected at the <position>
     And "new" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | selection | placement | position | text               |
-      | "foob"    | "before"  | "start"  | "newbaz\|foo\|bar" |
-      | "obar"    | "before"  | "start"  | "newbaz\|foo\|bar" |
-      | "foob"    | "before"  | "end"    | "baznew\|foo\|bar" |
-      | "obar"    | "before"  | "end"    | "baznew\|foo\|bar" |
-      | "foob"    | "before"  | "none"   | "baz\|newar"       |
-      | "obar"    | "before"  | "none"   | "baz\|fonew"       |
-      | "foob"    | "after"   | "start"  | "foo\|bar\|newbaz" |
-      | "obar"    | "after"   | "start"  | "foo\|bar\|newbaz" |
-      | "foob"    | "after"   | "end"    | "foo\|bar\|baznew" |
-      | "obar"    | "after"   | "end"    | "foo\|bar\|baznew" |
-      | "foob"    | "after"   | "none"   | "newar\|baz"       |
+      | selection | placement | position | text                          |
+      | "foob"    | "before"  | "start"  | "B: new\|baz;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "start"  | "B: new\|baz;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "end"    | "B: baznew\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "end"    | "B: baznew\|;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "none"   | "B: baz;;B: new\|ar"          |
+      | "obar"    | "before"  | "none"   | "B: baz;;B: fonew\|"          |
+      | "foob"    | "after"   | "start"  | "B: foo;;B: bar;;B: new\|baz" |
+      | "obar"    | "after"   | "start"  | "B: foo;;B: bar;;B: new\|baz" |
+      | "foob"    | "after"   | "end"    | "B: foo;;B: bar;;B: baznew\|" |
+      | "obar"    | "after"   | "end"    | "B: foo;;B: bar;;B: baznew\|" |
+      | "foob"    | "after"   | "none"   | "B: new\|ar;;B: baz"          |
       # Fails on Firefox
-      # | "obar"    | "after"   | "none"   | "fonew\|baz"       |
-      | "foob"    | "auto"    | "start"  | "newbazar"         |
-      | "obar"    | "auto"    | "start"  | "fonewbaz"         |
-      | "foob"    | "auto"    | "end"    | "baznewar"         |
-      | "obar"    | "auto"    | "end"    | "fobaznew"         |
-      | "foob"    | "auto"    | "none"   | "newbazar"         |
-      | "obar"    | "auto"    | "none"   | "fonewbaz"         |
+      # | "obar"    | "after"   | "none"   | "B: fonew;;B: baz"           |
+      | "foob"    | "auto"    | "start"  | "B: new\|bazar"               |
+      | "obar"    | "auto"    | "start"  | "B: fonew\|baz"               |
+      | "foob"    | "auto"    | "end"    | "B: baznew\|ar"               |
+      | "obar"    | "auto"    | "end"    | "B: fobaznew\|"               |
+      | "foob"    | "auto"    | "none"   | "B: new\|bazar"               |
+      | "obar"    | "auto"    | "none"   | "B: fonew\|baz"               |
 
   Scenario Outline: Inserting inline object on block object
     When "{image}" is inserted at "auto"
     And ",{stock-ticker}," is inserted at <placement>
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | text                        |
-      | "before"  | ",{stock-ticker},\|{image}" |
-      | "after"   | "{image}\|,{stock-ticker}," |
-      | "auto"    | "{image}\|,{stock-ticker}," |
+      | placement | text                           |
+      | "before"  | "B: {stock-ticker}\|;;{IMAGE}" |
+      | "after"   | "{IMAGE};;B: {stock-ticker}\|" |
+      | "auto"    | "{IMAGE};;B: {stock-ticker}\|" |
 
   Scenario Outline: Inserting block object on inline object
     When ",{stock-ticker}," is inserted at "auto"
     And "{image}" is inserted at <placement>
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | text                        |
-      | "before"  | "{image}\|,{stock-ticker}," |
-      | "after"   | ",{stock-ticker},\|{image}" |
-      | "auto"    | ",{stock-ticker},\|{image}" |
+      | placement | text                            |
+      | "before"  | "^{IMAGE}\|;;B: {stock-ticker}" |
+      | "after"   | "B: {stock-ticker};;^{IMAGE}\|" |
+      | "auto"    | "B: {stock-ticker};;^{IMAGE}\|" |
 
   Scenario Outline: Inserting text block on inline object
     When ",{stock-ticker}," is inserted at "auto"
     And "foo" is inserted at <placement> and selected at the <select position>
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | select position | text                    |
-      | "before"  | "end"           | "foo\|,{stock-ticker}," |
-      | "after"   | "start"         | ",{stock-ticker},\|foo" |
-      | "auto"    | "start"         | ",{stock-ticker},foo"   |
+      | placement | select position | text                          |
+      | "before"  | "end"           | "B: foo\|;;B: {stock-ticker}" |
+      | "after"   | "start"         | "B: {stock-ticker};;B: \|foo" |
+      | "auto"    | "start"         | "B: {stock-ticker}\|foo"      |

--- a/packages/editor/gherkin-spec/insert.blocks.feature
+++ b/packages/editor/gherkin-spec/insert.blocks.feature
@@ -7,84 +7,94 @@ Feature: Insert Blocks
     When the editor is focused
     And "foo|bar" is inserted at <placement> and selected at the <selection>
     And "baz" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | selection | text            |
-      | "before"  | "none"    | "foo\|bar\|baz" |
-      | "before"  | "start"   | "bazfoo\|bar\|" |
-      | "before"  | "end"     | "foo\|barbaz\|" |
-      | "after"   | "none"    | "baz\|foo\|bar" |
-      | "after"   | "start"   | "\|bazfoo\|bar" |
-      | "after"   | "end"     | "\|foo\|barbaz" |
-      | "auto"    | "none"    | "foo\|bar"      |
-      | "auto"    | "start"   | "bazfoo\|bar"   |
+      | placement | selection | text                       |
+      | "before"  | "none"    | "B: foo;;B: bar;;B: baz\|" |
+      | "before"  | "start"   | "B: baz\|foo;;B: bar;;B: " |
+      | "before"  | "end"     | "B: foo;;B: barbaz\|;;B: " |
+      | "after"   | "none"    | "B: baz\|;;B: foo;;B: bar" |
+      | "after"   | "start"   | "B: ;;B: baz\|foo;;B: bar" |
+      | "after"   | "end"     | "B: ;;B: foo;;B: barbaz\|" |
+      | "auto"    | "none"    | "B: foo;;B: bar"           |
+      | "auto"    | "start"   | "B: baz\|foo;;B: bar"      |
 
   Scenario Outline: Inserting block objects an empty editor
     When "{image}" is inserted at <placement>
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | placement | text        |
-      | "before"  | "{image}\|" |
-      | "after"   | "\|{image}" |
-      | "auto"    | "{image}"   |
+      | placement | text              |
+      | "before"  | "^{IMAGE}\|;;B: " |
+      | "after"   | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "^{IMAGE}\|"      |
 
   Scenario Outline: Inserting blocks on a block object
     When "{image}" is inserted at "auto" and selected at the "end"
     And "foo|{break}|bar" is inserted at "auto"
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | text                         |
-      | "{image}\|foo\|{break}\|bar" |
+      | text                                 |
+      | "{IMAGE};;B: foo;;{BREAK};;B: bar\|" |
 
   Scenario: Inserting text blocks on a block object
     When "{image}" is inserted at "auto" and selected at the "end"
     And "foo|bar" is inserted at "auto"
-    Then the text is <text>
-
-    Examples:
-      | text                |
-      | "{image}\|foo\|bar" |
+    Then the editor state is
+      """
+      {IMAGE}
+      B: foo
+      B: bar|
+      """
 
   Scenario Outline: Inserting blocks on a text block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put <position>
     And "bar|{image}|baz" is inserted at <placement> and selected at the <select-position>
     And "new" is typed
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | position     | placement | select-position | text                        |
-      | before "foo" | "before"  | "start"         | "newbar\|{image}\|baz\|foo" |
-      | before "foo" | "before"  | "end"           | "bar\|{image}\|baznew\|foo" |
-      | before "foo" | "after"   | "start"         | "foo\|newbar\|{image}\|baz" |
-      | before "foo" | "after"   | "end"           | "foo\|bar\|{image}\|baznew" |
-      | before "foo" | "auto"    | "start"         | "newbar\|{image}\|bazfoo"   |
-      | before "foo" | "auto"    | "end"           | "bar\|{image}\|baznewfoo"   |
-      | after "f"    | "before"  | "start"         | "newbar\|{image}\|baz\|foo" |
-      | after "f"    | "before"  | "end"           | "bar\|{image}\|baznew\|foo" |
-      | after "f"    | "after"   | "start"         | "foo\|newbar\|{image}\|baz" |
-      | after "f"    | "after"   | "end"           | "foo\|bar\|{image}\|baznew" |
-      | after "f"    | "auto"    | "start"         | "fnewbar\|{image}\|bazoo"   |
-      | after "f"    | "auto"    | "end"           | "fbar\|{image}\|baznewoo"   |
-      | after "foo"  | "before"  | "start"         | "newbar\|{image}\|baz\|foo" |
-      | after "foo"  | "before"  | "end"           | "bar\|{image}\|baznew\|foo" |
-      | after "foo"  | "after"   | "start"         | "foo\|newbar\|{image}\|baz" |
-      | after "foo"  | "after"   | "end"           | "foo\|bar\|{image}\|baznew" |
-      | after "foo"  | "auto"    | "start"         | "foonewbar\|{image}\|baz"   |
-      | after "foo"  | "auto"    | "end"           | "foobar\|{image}\|baznew"   |
+      | position     | placement | select-position | text                                   |
+      | before "foo" | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | before "foo" | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | before "foo" | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | before "foo" | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | before "foo" | "auto"    | "start"         | "B: new\|bar;;{IMAGE};;B: bazfoo"      |
+      | before "foo" | "auto"    | "end"           | "B: bar;;{IMAGE};;B: baznew\|foo"      |
+      | after "f"    | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | after "f"    | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | after "f"    | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | after "f"    | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | after "f"    | "auto"    | "start"         | "B: fnew\|bar;;{IMAGE};;B: bazoo"      |
+      | after "f"    | "auto"    | "end"           | "B: fbar;;{IMAGE};;B: baznew\|oo"      |
+      | after "foo"  | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | after "foo"  | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | after "foo"  | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | after "foo"  | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | after "foo"  | "auto"    | "start"         | "B: foonew\|bar;;{IMAGE};;B: baz"      |
+      | after "foo"  | "auto"    | "end"           | "B: foobar;;{IMAGE};;B: baznew\|"      |
 
   Scenario: Pasting text blocks between two text blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the caret is put after "foo"
     And "fizz|buzz" is inserted at "auto"
-    Then the text is "foofizz|buzz|bar"
+    Then the editor state is
+      """
+      B: foofizz
+      B: buzz|
+      B: bar
+      """
 
   Scenario Outline: Inserting text block with annotation
-    Given the text <text>
+    Given the editor state is <text>
     When <selection>
     And blocks are inserted at "auto" and selected at the <select-position>
       ```
@@ -116,13 +126,13 @@ Feature: Insert Blocks
         }
       ]
       ```
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text             | selection                 | select-position | new text               |
-      | ""               | the caret is put after "" | "start"         | "foo ,bar, baz"        |
-      | ""               | the caret is put after "" | "end"           | "foo ,bar, baz"        |
-      | "existing"       | "is" is selected          | "start"         | "exfoo ,bar, bazting"  |
-      | "existing"       | "is" is selected          | "end"           | "exfoo ,bar, bazting"  |
-      | "existing\|text" | "ingte" is selected       | "start"         | "existfoo ,bar, bazxt" |
-      | "existing\|text" | "ingte" is selected       | "end"           | "existfoo ,bar, bazxt" |
+      | text                   | selection                 | select-position | new text                          |
+      | "B: "                  | the caret is put after "" | "start"         | "B: \|foo [@link:bar] baz"        |
+      | "B: "                  | the caret is put after "" | "end"           | "B: foo [@link:bar] baz\|"        |
+      | "B: existing"          | "is" is selected          | "start"         | "B: ex\|foo [@link:bar] bazting"  |
+      | "B: existing"          | "is" is selected          | "end"           | "B: exfoo [@link:bar] baz\|ting"  |
+      | "B: existing;;B: text" | "ingte" is selected       | "start"         | "B: exist\|foo [@link:bar] bazxt" |
+      | "B: existing;;B: text" | "ingte" is selected       | "end"           | "B: existfoo [@link:bar] baz\|xt" |

--- a/packages/editor/gherkin-spec/insert.break.feature
+++ b/packages/editor/gherkin-spec/insert.break.feature
@@ -4,60 +4,86 @@ Feature: Insert Break
     Given one editor
 
   Scenario Outline: Breaking text block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put <position>
     And "{Enter}" is pressed
     And "bar" is inserted
-    Then the text is <text>
+    Then the editor state is <text>
     And the caret is <new position>
 
     Examples:
-      | position     | text       | new position |
-      | before "foo" | "\|barfoo" | before "foo" |
-      | after "foo"  | "foo\|bar" | after "bar"  |
-      | after "f"    | "f\|baroo" | after "bar"  |
+      | position     | text               | new position |
+      | before "foo" | "B: ;;B: bar\|foo" | before "foo" |
+      | after "foo"  | "B: foo;;B: bar\|" | after "bar"  |
+      | after "f"    | "B: f;;B: bar\|oo" | after "bar"  |
 
   Scenario Outline: Breaking second text block
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put <position>
     And "{Enter}" is pressed
     And "baz" is inserted
-    Then the text is <text>
+    Then the editor state is <text>
     And the caret is <new position>
     When undo is performed
     And undo is performed
-    Then the text is "foo|bar"
+    Then the editor state is <undone>
 
     Examples:
-      | position     | text            | new position |
-      | before "bar" | "foo\|\|bazbar" | before "bar" |
-      | after "bar"  | "foo\|bar\|baz" | after "baz"  |
-      | after "b"    | "foo\|b\|bazar" | after "baz"  |
+      | position     | text                       | new position | undone             |
+      | before "bar" | "B: foo;;B: ;;B: baz\|bar" | before "bar" | "B: foo;;B: \|bar" |
+      | after "bar"  | "B: foo;;B: bar;;B: baz\|" | after "baz"  | "B: foo;;B: bar\|" |
+      | after "b"    | "B: foo;;B: b;;B: baz\|ar" | after "baz"  | "B: foo;;B: b\|ar" |
 
   Scenario: Breaking before inline object
-    Given the text "foo,{stock-ticker},bar"
+    Given the editor state is "B: foo{stock-ticker}bar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
     And "baz" is inserted
-    Then the text is "foo|baz,{stock-ticker},bar"
-    And the caret is after "baz"
+    Then the editor state is
+      """
+      B: foo
+      B: baz|{stock-ticker}bar
+      """
 
   Scenario: Pressing Enter when selecting the entire content
-    Given the text "foo|{image}|bar"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
     When the editor is focused
     And everything is selected
     And "{Enter}" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"
     When undo is performed
-    Then the text is "foo|{image}|bar"
+    Then the editor state is
+      """
+      B: ^foo
+      {IMAGE}
+      B: bar|
+      """
 
   Scenario: Pressing Enter on a block object
-    Given the text "foo|{image}"
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      """
     When the editor is focused
     And the caret is put after "foo"
     And "{ArrowRight}" is pressed
     And "{Enter}" is pressed
-    Then the text is "foo|{image}|"
+    Then the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: |
+      """

--- a/packages/editor/gherkin-spec/insert.child.feature
+++ b/packages/editor/gherkin-spec/insert.child.feature
@@ -4,7 +4,7 @@ Feature: Insert Child
     Given one editor
 
   Scenario Outline: Inserting span on span
-    Given the text <text>
+    Given the editor state is <text>
     When the caret is put <position>
     When a child is inserted
       ```
@@ -13,15 +13,15 @@ Feature: Insert Child
         "text": "new"
       }
       ```
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text  | position    | new text |
-      | ""    | after ""    | "new"    |
-      | "foo" | after "foo" | "foonew" |
+      | text     | position    | new text      |
+      | "B: "    | after ""    | "B: new\|"    |
+      | "B: foo" | after "foo" | "B: foonew\|" |
 
   Scenario: Inserting inline object in span
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     When the caret is put after "foo"
     And a child is inserted
       ```
@@ -30,10 +30,10 @@ Feature: Insert Child
         "symbol": "AAPL"
       }
       ```
-    Then the text is "foo,{stock-ticker}, bar baz"
+    Then the editor state is "B: foo|{stock-ticker} bar baz"
 
   Scenario: Inserting span on block object
-    Given the text "{image}"
+    Given the editor state is "{IMAGE}"
     When the editor is focused
     When a child is inserted
       ```
@@ -42,7 +42,11 @@ Feature: Insert Child
         "text": "new"
       }
       ```
-    Then the text is "{image}|new"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: new|
+      """
 
   Scenario: Inserting span on block object without selection
     When "{image}" is inserted at "auto" and selected at the "none"
@@ -54,7 +58,11 @@ Feature: Insert Child
         "text": "new"
       }
       ```
-    Then the text is "{image}|new"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: new|
+      """
 
   Scenario: Inserting span on text block without selection
     When "foo" is inserted at "auto" and selected at the "none"
@@ -66,4 +74,4 @@ Feature: Insert Child
         "text": "new"
       }
       ```
-    Then the text is "foonew"
+    Then the editor state is "B: foonew|"

--- a/packages/editor/gherkin-spec/insert.text.feature
+++ b/packages/editor/gherkin-spec/insert.text.feature
@@ -4,15 +4,15 @@ Feature: Insert text
     Given one editor
 
   Scenario Outline: Inserting text on expanded selection
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
-    And <selection> is selected
+    And the selection is <selection>
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text       | selection | new text     |
-      | "foo\|bar" | "oo"      | "fnew\|bar"  |
-      | "foo\|bar" | "b"       | "foo\|newar" |
-      | "foo\|bar" | "ooba"    | "fnewr"      |
-      | "foo\|bar" | "foobar"  | "new"        |
+      | text             | selection           | new text             |
+      | "B: foo;;B: bar" | "B: f^oo\|;;B: bar" | "B: fnew\|;;B: bar"  |
+      | "B: foo;;B: bar" | "B: foo;;B: ^b\|ar" | "B: foo;;B: new\|ar" |
+      | "B: foo;;B: bar" | "B: f^oo;;B: ba\|r" | "B: fnew\|r"         |
+      | "B: foo;;B: bar" | "B: ^foo;;B: bar\|" | "B: new\|"           |

--- a/packages/editor/gherkin-spec/lists.feature
+++ b/packages/editor/gherkin-spec/lists.feature
@@ -4,191 +4,293 @@ Feature: Lists
     Given one editor
 
   Scenario: Clearing list item on Enter
-    Given the text ">#:foo|>#:"
+    Given the editor state is "B listItem=\"number\": foo;;B listItem=\"number\": "
     When the editor is focused
     And the caret is put after ""
     And "{Enter}" is pressed
     And "bar" is typed
-    Then the text is ">#:foo|bar"
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B: bar|
+      """
 
   Scenario: Indenting list item on Tab
-    Given the text ">#:foo|>#:"
+    Given the editor state is "B listItem=\"number\": foo;;B listItem=\"number\": "
     When the editor is focused
     And the caret is put after ""
     And "{Tab}" is pressed
     And "bar" is typed
-    Then the text is ">#:foo|>>#:bar"
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar|
+      """
 
   Scenario: Unindenting list item on Shift+Tab
-    Given the text ">#:foo|>>#:bar"
+    Given the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "{Shift>}{Tab}{/Shift}" is pressed
-    Then the text is ">#:foo|>#:bar"
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B listItem="number": |bar
+      """
 
   Scenario: Pressing Delete in an empty list item
-    Given the text ">#:f|h1:bar"
+    Given the editor state is
+      """
+      B listItem="number": f
+      B style="h1": bar
+      """
     When the editor is focused
     And the caret is put before "f"
     And "{Delete}" is pressed 2 times
-    Then the text is ">#h1:bar"
+    Then the editor state is
+      """
+      B listItem="number" style="h1": |bar
+      """
 
   Scenario: Pressing Backspace in an empty list item
-    Given the text ">#:"
+    Given the editor state is "B listItem=\"number\": "
     When the editor is focused
     And the caret is put after ""
     And "{Backspace}" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"
 
   Scenario: Pressing Backspace in an empty list item after a block object
-    Given the text "{image}|>#:"
+    Given the editor state is "{IMAGE};;B listItem=\"number\": "
     When the editor is focused
     And the caret is put after ""
     And "{Backspace}" is pressed
-    Then the text is "{image}|"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      """
 
   Scenario Outline: Pressing Backspace after an empty list item
     When the editor is focused
-    Given the text <text>
+    Given the editor state is <text>
     When the caret is put <caret position>
     And "{Backspace}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text                  | caret position | new text             |
-      | ">#:\|h1:foo"         | before "foo"   | ">#h1:foo"           |
-      | ">#:foo\|>#:\|>#:bar" | after "bar"    | ">#:foo\|>#:\|>#:ba" |
+      | text                                                                              | caret position | new text                                                                           |
+      | "B listItem=\"number\": ;;B style=\"h1\": foo"                                    | before "foo"   | "B listItem=\"number\" style=\"h1\": \|foo"                                        |
+      | "B listItem=\"number\": foo;;B listItem=\"number\": ;;B listItem=\"number\": bar" | after "bar"    | "B listItem=\"number\": foo;;B listItem=\"number\": ;;B listItem=\"number\": ba\|" |
 
   Scenario: Inserting indented numbered list in empty text block
-    Given the text ""
+    Given the editor state is "B: "
     When ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
-    Then the text is ">#:foo|>>#:bar|>>>#:baz"
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      B level=3 listItem="number": baz|
+      """
 
   Scenario Outline: Inserting list on list item
-    Given the text <text>
+    Given the editor state is <text>
     When the caret is put <position>
     And <blocks> is inserted at "auto"
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text     | position    | blocks                    | new text                     |
-      | ">#:"    | after ""    | ">#:foo\|>#:bar\|>#:baz"  | ">#:foo\|>#:bar\|>#:baz"     |
-      | ">#:"    | after ""    | ">-:foo\|>-:bar\|>-:baz"  | ">-:foo\|>-:bar\|>-:baz"     |
-      | ">#:foo" | after "foo" | ">#:foo\|>#:bar\|>#:baz"  | ">#:foofoo\|>#:bar\|>#:baz"  |
-      | ">#:foo" | after "foo" | ">-:foo\|>-:bar\|>-:baz"  | ">#:foofoo\|>#:bar\|>#:baz"  |
-      | ">#:foo" | after "foo" | ">-:foo\|>>#:bar\|>-:baz" | ">#:foofoo\|>>#:bar\|>#:baz" |
-      | ">#:foo" | after "foo" | ">-:foo\|>>-:bar\|>-:baz" | ">#:foofoo\|>>-:bar\|>#:baz" |
+      | text                         | position    | blocks                    | new text                                                                                          |
+      | "B listItem=\"number\": "    | after ""    | ">#:foo\|>#:bar\|>#:baz"  | "B listItem=\"number\": foo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"            |
+      | "B listItem=\"number\": "    | after ""    | ">-:foo\|>-:bar\|>-:baz"  | "B listItem=\"bullet\": foo;;B listItem=\"bullet\": bar;;B listItem=\"bullet\": baz\|"            |
+      | "B listItem=\"number\": foo" | after "foo" | ">#:foo\|>#:bar\|>#:baz"  | "B listItem=\"number\": foofoo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"         |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>-:bar\|>-:baz"  | "B listItem=\"number\": foofoo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"         |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>>#:bar\|>-:baz" | "B listItem=\"number\": foofoo;;B level=2 listItem=\"number\": bar;;B listItem=\"number\": baz\|" |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>>-:bar\|>-:baz" | "B listItem=\"number\": foofoo;;B level=2 listItem=\"bullet\": bar;;B listItem=\"number\": baz\|" |
 
   Scenario Outline: Inserting lower-level list on list item
-    Given the text ">>#:"
+    Given the editor state is "B level=2 listItem=\"number\": "
     When the caret is put after ""
     And ">#:foo|>#:bar|>#:baz" is inserted at "auto"
-    Then the text is ">>#:foo|>>#:bar|>>#:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      B level=2 listItem="number": bar
+      B level=2 listItem="number": baz|
+      """
 
   Scenario: Inserting different lower-level list type on list item
-    Given the text ">>#:"
+    Given the editor state is "B level=2 listItem=\"number\": "
     When the caret is put after ""
     And ">-:foo|>-:bar|>-:baz" is inserted at "auto"
-    Then the text is ">>-:foo|>>-:bar|>>-:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B level=2 listItem="bullet": bar
+      B level=2 listItem="bullet": baz|
+      """
 
   Scenario: Inserting inverse-indented list on list item
-    Given the text ">>#:"
+    Given the editor state is "B level=2 listItem=\"number\": "
     When the caret is put after ""
     And ">>-:foo|>-:bar|>>-:baz" is inserted at "auto"
-    Then the text is ">>-:foo|>-:bar|>>-:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B listItem="bullet": bar
+      B level=2 listItem="bullet": baz|
+      """
 
   Scenario: Inserting lower-level inverse-indented list on list item
-    Given the text ">>>#:"
+    Given the editor state is "B level=3 listItem=\"number\": "
     When the caret is put after ""
     And ">>-:foo|>-:bar|>>-:baz" is inserted at "auto"
-    Then the text is ">>>-:foo|>>-:bar|>>>-:baz"
+    Then the editor state is
+      """
+      B level=3 listItem="bullet": foo
+      B level=2 listItem="bullet": bar
+      B level=3 listItem="bullet": baz|
+      """
 
   Scenario: Inserting lower-level, indented list on list item
-    Given the text ">>#:"
+    Given the editor state is "B level=2 listItem=\"number\": "
     When the caret is put after ""
     And ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
-    Then the text is ">>#:foo|>>>#:bar|>>>>#:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      B level=3 listItem="number": bar
+      B level=4 listItem="number": baz|
+      """
 
   Scenario: Inserting list that will exceed the maximum level (10)
-    Given the text ">>>>>>>>>#:"
+    Given the editor state is "B level=9 listItem=\"number\": "
     When the caret is put after ""
     And ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
-    Then the text is ">>>>>>>>>#:foo|>>>>>>>>>>#:bar|>>>>>>>>>>#:baz"
+    Then the editor state is
+      """
+      B level=9 listItem="number": foo
+      B level=10 listItem="number": bar
+      B level=10 listItem="number": baz|
+      """
 
   Scenario: Inserting list that exceeds the maximum level (10)
-    Given the text ">>>>>>>>>#:"
+    Given the editor state is "B level=9 listItem=\"number\": "
     When the caret is put after ""
     And ">>>>>>>>>>>#:foo|>>>>>>>>>>>>#:bar|>>>>>>>>>>>>>#:baz" is inserted at "auto"
-    Then the text is ">>>>>>>>>#:foo|>>>>>>>>>>#:bar|>>>>>>>>>>#:baz"
+    Then the editor state is
+      """
+      B level=9 listItem="number": foo
+      B level=10 listItem="number": bar
+      B level=10 listItem="number": baz|
+      """
 
   Scenario: Inserting mixed blocks starting with a list item
-    Given the text ">>-:"
+    Given the editor state is "B level=2 listItem=\"bullet\": "
     When the caret is put after ""
     And ">#:foo|{image}|>>#:baz" is inserted at "auto"
-    Then the text is ">>#:foo|{image}|>>#:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      {IMAGE}
+      B level=2 listItem="number": baz|
+      """
 
   Scenario: Inserting mixed blocks not starting with a list item
-    Given the text ">>-:"
+    Given the editor state is "B level=2 listItem=\"bullet\": "
     When the caret is put after ""
     And "foo|>#:bar|>>#:baz" is inserted at "auto"
-    Then the text is ">>-:foo|>>#:bar|>>>#:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B level=2 listItem="number": bar
+      B level=3 listItem="number": baz|
+      """
 
   Scenario: Inserting mixed blocks not starting with list items
-    Given the text ">>-:"
+    Given the editor state is "B level=2 listItem=\"bullet\": "
     When the caret is put after ""
     And "foo|bar|>#:baz" is inserted at "auto"
-    Then the text is ">>-:foo|bar|>#:baz"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B: bar
+      B listItem="number": baz|
+      """
 
   Scenario Outline: Inserting two lists preceded by a paragraph
-    Given the text <text>
+    Given the editor state is <text>
     When the caret is put after ""
     And <blocks> is inserted at "auto"
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text   | blocks                                | new text                                    |
-      | ">>-:" | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | ">>-:foo\|>>-:bar\|>>>-:baz\|fizz\|>-:buzz" |
-      | ">>-:" | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | ">>-:foo\|>>#:bar\|>>>#:baz\|fizz\|>#:buzz" |
-      | ">>#:" | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | ">>#:foo\|>>#:bar\|>>>#:baz\|fizz\|>#:buzz" |
-      | ">>#:" | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | ">>#:foo\|>>-:bar\|>>>-:baz\|fizz\|>-:buzz" |
+      | text                              | blocks                                | new text                                                                                                                                             |
+      | "B level=2 listItem=\"bullet\": " | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | "B level=2 listItem=\"bullet\": foo;;B level=2 listItem=\"bullet\": bar;;B level=3 listItem=\"bullet\": baz;;B: fizz;;B listItem=\"bullet\": buzz\|" |
+      | "B level=2 listItem=\"bullet\": " | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | "B level=2 listItem=\"bullet\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz;;B: fizz;;B listItem=\"number\": buzz\|" |
+      | "B level=2 listItem=\"number\": " | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | "B level=2 listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz;;B: fizz;;B listItem=\"number\": buzz\|" |
+      | "B level=2 listItem=\"number\": " | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | "B level=2 listItem=\"number\": foo;;B level=2 listItem=\"bullet\": bar;;B level=3 listItem=\"bullet\": baz;;B: fizz;;B listItem=\"bullet\": buzz\|" |
 
   Scenario: Inserting heading on empty list item
-    Given the text ">-:"
+    Given the editor state is "B listItem=\"bullet\": "
     When the caret is put after ""
     And "h1:foo" is inserted at "auto"
-    Then the text is ">-h1:foo"
+    Then the editor state is
+      """
+      B listItem="bullet" style="h1": foo|
+      """
 
   Scenario: Inserting heading on non-empty list item
-    Given the text ">-:foo"
+    Given the editor state is
+      """
+      B listItem="bullet": foo
+      """
     When the caret is put before "foo"
     And "h1:bar" is inserted at "auto"
-    Then the text is ">-:barfoo"
+    Then the editor state is
+      """
+      B listItem="bullet": bar|foo
+      """
 
   Scenario: Inserting image on empty list item
-    Given the text ">-:"
+    Given the editor state is "B listItem=\"bullet\": "
     When the caret is put after ""
     And "{image}" is inserted at "auto"
-    Then the text is "{image}"
+    Then the editor state is "^{IMAGE}|"
 
   Scenario Outline: Deleting list
-    Given the text <text>
+    Given the editor state is <text>
     When the editor is focused
     And <selection> is selected
     And "{Backspace}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new text>
 
     Examples:
-      | text                        | selection   | new text |
-      | ">#:foo\|>>#:bar\|>>>#:baz" | "foobarbaz" | ">#:"    |
-      | ">#:foo\|>>#:bar\|>>>#:baz" | "oobarbaz"  | ">#:f"   |
-      | ">#:foo\|>>#:bar\|>>>#:baz" | "oobarba"   | ">#:fz"  |
-      | ">#:foo\|>>#:bar\|>>>#:baz" | "foobarba"  | ">#:z"   |
+      | text                                                                                                 | selection   | new text                      |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "foobarbaz" | "B listItem=\"number\": \|"   |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "oobarbaz"  | "B listItem=\"number\": f\|"  |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "oobarba"   | "B listItem=\"number\": f\|z" |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "foobarba"  | "B listItem=\"number\": \|z"  |
 
   Scenario: Undo after deleting list
-    Given the text ">#:foo|>>#:bar"
+    Given the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      """
     When the editor is focused
     And "fooba" is selected
     And "{Backspace}" is pressed
-    Then the text is ">#:r"
+    Then the editor state is
+      """
+      B listItem="number": |r
+      """
     When undo is performed
-    Then the text is ">#:foo|>>#:bar"
+    Then the editor state is
+      """
+      B listItem="number": ^foo
+      B level=2 listItem="number": ba|r
+      """

--- a/packages/editor/gherkin-spec/paste.feature
+++ b/packages/editor/gherkin-spec/paste.feature
@@ -4,7 +4,7 @@ Feature: Paste
     Given one editor
 
   Scenario Outline: Pasting text block into a text block
-    Given the text "foo bar buz"
+    Given the editor state is "B: foo bar buz"
     And "strong" around "bar"
     When <selection>
     And x-portable-text is pasted
@@ -20,27 +20,27 @@ Feature: Paste
         }
       ]
       ```
-    Then the text is <text>
+    Then the editor state is <text>
 
     Examples:
-      | selection                     | text                           |
-      | the caret is put after "buz"  | "foo ,bar, buzfoo ,bar, buz"   |
-      | the caret is put before "foo" | "foo ,bar, buzfoo ,bar, buz"   |
-      | the caret is put after "ba"   | "foo ,ba,foo ,bar, buz,r, buz" |
-      | "foo bar buz" is selected     | "foo ,bar, buz"                |
+      | selection                     | text                                                     |
+      | the caret is put after "buz"  | "B: foo [strong:bar] buzfoo [strong:bar] buz\|"          |
+      | the caret is put before "foo" | "B: foo [strong:bar] buz\|foo [strong:bar] buz"          |
+      | the caret is put after "ba"   | "B: foo [strong:ba]foo [strong:bar] buz[strong:\|r] buz" |
+      | "foo bar buz" is selected     | "B: foo [strong:bar] buz\|"                              |
 
   Scenario: Pasting text/plain into a text block
-    Given the text "foo bar buz"
+    Given the editor state is "B: foo bar buz"
     And "strong" around "bar"
     When the caret is put after "ba"
     And data is pasted
       | text/plain | new |
-    Then the text is "foo ,banewr, buz"
+    Then the editor state is "B: foo [strong:banew|r] buz"
 
   Scenario: Pasting text/html into a text block
-    Given the text "foo bar buz"
+    Given the editor state is "B: foo bar buz"
     And "strong" around "bar"
     When the caret is put after "ba"
     And data is pasted
       | text/html | <p>new</p> |
-    Then the text is "foo ,ba,new,r, buz"
+    Then the editor state is "B: foo [strong:ba]new[strong:|r] buz"

--- a/packages/editor/gherkin-spec/removing-blocks.feature
+++ b/packages/editor/gherkin-spec/removing-blocks.feature
@@ -5,15 +5,43 @@ Feature: Removing Blocks
     And a global keymap
 
   Scenario: Pressing Delete in empty block with text below
-    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": bar;;B _key=\"b3\": baz"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      B _key="b2": bar
+      B _key="b3": baz
+      """
     When the editor is focused
-    And the selection is "B: foo;;B: |bar;;B: baz"
+    And the selection is
+      """
+      B: foo
+      B: |bar
+      B: baz
+      """
     And "{Delete}" is pressed 4 times
-    Then the editor state is "B _key=\"b1\": foo;;B _key=\"b3\": |baz"
+    Then the editor state is
+      """
+      B _key="b1": foo
+      B _key="b3": |baz
+      """
 
   Scenario: Pressing Backspace in empty block with text below
-    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": bar;;B _key=\"b3\": baz"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      B _key="b2": bar
+      B _key="b3": baz
+      """
     When the editor is focused
-    And the selection is "B: foo;;B: bar|;;B: baz"
+    And the selection is
+      """
+      B: foo
+      B: bar|
+      B: baz
+      """
     And "{Backspace}" is pressed 4 times
-    Then the editor state is "B _key=\"b1\": foo|;;B _key=\"b3\": baz"
+    Then the editor state is
+      """
+      B _key="b1": foo|
+      B _key="b3": baz
+      """

--- a/packages/editor/gherkin-spec/selection.feature
+++ b/packages/editor/gherkin-spec/selection.feature
@@ -4,7 +4,7 @@ Feature: Selection
     Given one editor
 
   Scenario: Expanding collapsed selection backwards from empty line
-    Given the text "foo|"
+    Given the editor state is "B: foo;;B: "
     When the editor is focused
     And the caret is put before ""
     And "{Shift>}{ArrowLeft}{/Shift}" is pressed
@@ -12,7 +12,11 @@ Feature: Selection
     Then "o|" is selected
 
   Scenario: Expanding selection backwards, then forwards
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "{Shift>}{ArrowLeft}{/Shift}" is pressed
@@ -24,7 +28,11 @@ Feature: Selection
     Then "b" is selected
 
   Scenario: Reducing hanging selection
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "foo"
     And "{Shift>}{ArrowRight}{/Shift}" is pressed
@@ -36,7 +44,7 @@ Feature: Selection
     Then "foo" is selected
 
   Scenario: Reducing selection hanging onto empty line
-    Given the text "foo|"
+    Given the editor state is "B: foo;;B: "
     When the editor is focused
     And the caret is put before "foo"
     And "{Shift>}{ArrowRight}{/Shift}" is pressed

--- a/packages/editor/gherkin-spec/splitting-blocks.feature
+++ b/packages/editor/gherkin-spec/splitting-blocks.feature
@@ -5,104 +5,167 @@ Feature: Splitting Blocks
     And a global keymap
 
   Scenario: Splitting block at the beginning
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: |foo"
     And "{Enter}" is pressed
     Then the editor state is "B: ;;B _key=\"b1\": |foo"
 
   Scenario: Splitting block in the middle
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: fo|o"
     And "{Enter}" is pressed
-    Then the editor state is "B _key=\"b1\": fo;;B: |o"
+    Then the editor state is
+      """
+      B _key="b1": fo
+      B: |o
+      """
 
   Scenario: Splitting block at the end
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: foo|"
     And "{Enter}" is pressed
-    Then the editor state is "B _key=\"b1\": foo;;B: |"
+    Then the editor state is
+      """
+      B _key="b1": foo
+      B: |
+      """
 
   Scenario: Splitting empty block creates a new block below
     Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": "
     When the editor is focused
-    And the selection is "B: foo;;B: |"
+    And the selection is
+      """
+      B: foo
+      B: |
+      """
     And "{Enter}" is pressed
     And "baz" is typed
     Then the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": ;;B: baz|"
 
   Scenario: Soft-splitting block at the beginning
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: |foo"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B _key=\"b1\": \n|foo"
 
   Scenario: Soft-splitting block in the middle
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: fo|o"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B _key=\"b1\": fo\n|o"
 
   Scenario: Soft-splitting block at the end
-    Given the editor state is "B _key=\"b1\": foo"
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
     When the editor is focused
     And the selection is "B: foo|"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B _key=\"b1\": foo\n|"
 
   Scenario: Splitting styled block at the beginning
-    Given the editor state is "B style=\"h1\": foo"
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": |foo"
     And "{Enter}" is pressed
     Then the editor state is "B: ;;B style=\"h1\": |foo"
 
   Scenario: Splitting styled block in the middle
-    Given the editor state is "B _key=\"b1\" style=\"h1\": foo"
+    Given the editor state is
+      """
+      B _key="b1" style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": fo|o"
     And "{Enter}" is pressed
-    Then the editor state is "B _key=\"b1\" style=\"h1\": fo;;B style=\"h1\": |o"
+    Then the editor state is
+      """
+      B _key="b1" style="h1": fo
+      B style="h1": |o
+      """
 
   Scenario: Splitting styled block at the end
-    Given the editor state is "B _key=\"b1\" style=\"h1\": foo"
+    Given the editor state is
+      """
+      B _key="b1" style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": foo|"
     And "{Enter}" is pressed
-    Then the editor state is "B _key=\"b1\" style=\"h1\": foo;;B: |"
+    Then the editor state is
+      """
+      B _key="b1" style="h1": foo
+      B: |
+      """
 
   Scenario: Soft-splitting styled block at the beginning
-    Given the editor state is "B style=\"h1\": foo"
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": |foo"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B style=\"h1\": \n|foo"
 
   Scenario: Soft-splitting styled block in the middle
-    Given the editor state is "B style=\"h1\": foo"
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": fo|o"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B style=\"h1\": fo\n|o"
 
   Scenario: Soft-splitting styled block at the end
-    Given the editor state is "B style=\"h1\": foo"
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": foo|"
     And "{Shift>}{Enter}{/Shift}" is pressed
     Then the editor state is "B style=\"h1\": foo\n|"
 
   Scenario: Splitting decorated styled block at the beginning
-    Given the editor state is "B style=\"h1\": [strong:foo] bar baz"
+    Given the editor state is
+      """
+      B style="h1": [strong:foo] bar baz
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": |[strong:foo] bar baz"
     And "{Enter}" is pressed
     And "new" is typed
-    Then the editor state is "B: [strong:];;B style=\"h1\": [strong:new|foo] bar baz"
+    Then the editor state is
+      """
+      B: [strong:]
+      B style="h1": [strong:new|foo] bar baz
+      """
 
   Scenario Outline: Splitting decorated styled block in the middle
     Given the editor state is <initial>
@@ -123,15 +186,26 @@ Feature: Splitting Blocks
       | "B style=\"h1\": foo bar [strong:baz]" | "B style=\"h1\": foo bar \|[strong:baz]" | "B style=\"h1\": foo bar ;;B style=\"h1\": [strong:new\|baz]" |
 
   Scenario: Splitting decorated styled block at the end
-    Given the editor state is "B style=\"h1\": foo bar [strong:baz]"
+    Given the editor state is
+      """
+      B style="h1": foo bar [strong:baz]
+      """
     When the editor is focused
     And the selection is "B style=\"h1\": foo bar [strong:baz|]"
     And "{Enter}" is pressed
     And "new" is typed
-    Then the editor state is "B style=\"h1\": foo bar [strong:baz];;B: new|"
+    Then the editor state is
+      """
+      B style="h1": foo bar [strong:baz]
+      B: new|
+      """
 
   Scenario Outline: Splitting block with an expanded selection
-    Given the editor state is "B: foo;;B: bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And <selection> is selected
     And "{Enter}" is pressed

--- a/packages/editor/gherkin-spec/undo-redo.feature
+++ b/packages/editor/gherkin-spec/undo-redo.feature
@@ -4,170 +4,205 @@ Feature: Undo/Redo
     Given a global keymap
 
   Scenario: Undoing writing two words
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And " bar" is typed
     And undo is performed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Selection change does not affect the undo stack
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And "foo" is typed
     And "{ArrowLeft}" is pressed
     And "bar" is typed
-    Then the text is "fobaro"
+    Then the editor state is "B: fobar|o"
     When undo is performed
-    Then the text is "foo"
+    Then the editor state is "B: fo|o"
 
   Scenario: Undoing annotation
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When "foo" is selected
     And "link" is toggled
     And undo is performed
-    Then the text is "foo"
-    And "foo" has no marks
+    Then the editor state is "B: ^foo|"
 
   Scenario: Undoing the deletion of the last char of annotated text
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And "{ArrowRight}" is pressed
     And "{Backspace}" is pressed
     And undo is performed
-    Then the text is "foo"
-    And "foo" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
 
   Scenario: Redoing the deletion of the last char of annotated text
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And "{ArrowRight}" is pressed
     And "{Backspace}" is pressed
     And undo is performed
     When redo is performed
-    Then the text is "fo"
-    And "fo" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo|]
+      """
 
   Scenario: Undoing inserting text after annotated text
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And "{ArrowRight}" is pressed
     And "{Space}" is pressed
-    Then the text is "foo, "
-    And "foo" has marks "c1"
-    And " " has no marks
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo] |
+      """
     When undo is performed
-    Then the text is "foo"
-    And "foo" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
 
   Scenario: Undoing and redoing inserting text after annotated text
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And "{ArrowRight}" is pressed
     And "{Space}" is pressed
     And undo is performed
-    Then the text is "foo"
-    And "foo" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
     When redo is performed
-    Then the text is "foo, "
-    And "foo" has marks "c1"
-    And " " has no marks
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo] |
+      """
 
   Scenario: Undoing the deletion of block with annotation at the end
-    Given the text "foo bar"
+    Given the editor state is "B: foo bar"
     And a "comment" "c1" around "bar"
     When the editor is focused
     And "foo bar" is selected
     And "{Backspace}" is pressed
     And undo is performed
-    Then the text is "foo ,bar"
-    And "bar" has marks "c1"
+    Then the editor state is
+      """
+      B: ^foo [@comment _key="c1":bar|]
+      """
 
   Scenario: Undoing deletion of annotated block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And "{Backspace}" is pressed
     And undo is performed
-    Then the text is "foo"
-    And "foo" has marks "c1"
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
 
   Scenario: Undoing annotation across text blocks
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And "{Enter}" is pressed
     And "bar" is typed
     And "foobar" is selected
     And "link" is toggled
     And undo is performed
-    Then the text is "foo|bar"
-    And "foo" has no marks
-    And "bar" has no marks
+    Then the editor state is
+      """
+      B: ^foo
+      B: bar|
+      """
 
   Scenario: Undoing action step
-    Given the text "-"
+    Given the editor state is "B: -"
     When the editor is focused
     And ">" is typed
     And "new" is typed
-    Then the text is "→new"
+    Then the editor state is "B: →new|"
     When undo is performed
     And undo is performed
-    Then the text is "->"
+    Then the editor state is "B: ->"
 
   Scenario: Consecutive undo after selection change
-    Given the text "-"
+    Given the editor state is "B: -"
     When the editor is focused
     And ">" is typed
     And undo is performed
     And "{ArrowLeft}" is pressed
     And undo is performed
-    Then the text is "-"
+    Then the editor state is "B: -|"
 
   Scenario: Undo after transform on expanded selection
-    Given the text "(cf"
+    Given the editor state is "B: (cf"
     When "f" is selected
     And ")" is inserted
-    Then the text is "©"
+    Then the editor state is "B: |©"
     When undo is performed
-    Then the text is "(c)"
+    Then the editor state is "B: (c)|"
     When undo is performed
-    Then the text is "(cf"
+    Then the editor state is "B: (c^f|"
 
   Scenario: Undoing break in the middle of text
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
     And "x" is typed
-    Then the text is "foo|xbar"
+    Then the editor state is
+      """
+      B: foo
+      B: x|bar
+      """
     When undo is performed
     And undo is performed
     And "y" is typed
-    Then the text is "fooybar"
+    Then the editor state is "B: fooy|bar"
 
   Scenario: Undoing delete backward across blocks
-    Given the text "foo|bar"
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
     When the editor is focused
     And the caret is put before "bar"
     And "{Backspace}" is pressed
     And "x" is typed
-    Then the text is "fooxbar"
+    Then the editor state is "B: foox|bar"
     When undo is performed
     And undo is performed
     And "y" is typed
-    Then the text is "foo|ybar"
+    Then the editor state is
+      """
+      B: foo
+      B: y|bar
+      """
 
   Scenario: Undoing and redoing break
-    Given the text "foobar"
+    Given the editor state is "B: foobar"
     When the editor is focused
     And the caret is put after "foo"
     And "{Enter}" is pressed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
     When undo is performed
-    Then the text is "foobar"
+    Then the editor state is "B: foo|bar"
     When redo is performed
-    Then the text is "foo|bar"
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -52,6 +52,121 @@ const schemaDefinition = defineSchema({
 /**
  * @internal
  */
+
+function setEditorState(context: Context, textspec: string): void {
+  const {schema, keyGenerator} = context.editor.getSnapshot().context
+  const {containers} = (context.editor as InternalEditor)._internal.slateEditor
+
+  const {blocks} = fromTextspec({schema, keyGenerator, containers}, textspec)
+
+  context.editor.send({
+    type: 'insert.blocks',
+    blocks,
+    placement: 'auto',
+    select: 'end',
+  })
+}
+
+async function assertEditorState(
+  context: Context,
+  textspec: string,
+  options: {singleLine: boolean},
+): Promise<void> {
+  await vi.waitFor(() => {
+    const {schema, value, selection} = context.editor.getSnapshot().context
+    const {containers} = (context.editor as InternalEditor)._internal
+      .slateEditor
+
+    const expected = options.singleLine
+      ? textspec.replace(/\\n/g, '\n')
+      : textspec
+    const keys = new Set<string>()
+    for (const match of expected.matchAll(/_key="([^"]+)"/g)) {
+      keys.add(match[1]!)
+    }
+    const assertsSelection = /(?<!\\)[|^]/.test(expected)
+
+    const annotationKeys = new Map<string, string>()
+    if (context.keyMap) {
+      for (const [symbolic, actual] of context.keyMap.entries()) {
+        annotationKeys.set(actual, symbolic)
+      }
+    }
+    // If the expected string asks for `_key` anywhere, auto-assign symbolic
+    // names (e.g. `l2`, `c3`) to any markDef keys the editor produced that
+    // aren't in the user-defined keyMap. This lets assertions express
+    // "annotation with a different key" structurally.
+    if (keys.size > 0) {
+      const counters = new Map<string, number>()
+      for (const symbolic of annotationKeys.values()) {
+        const m = symbolic.match(/^([a-z]+)(\d+)$/i)
+        if (m) {
+          const [, prefix, num] = m
+          const n = parseInt(num!, 10)
+          if (n > (counters.get(prefix!) ?? 0)) {
+            counters.set(prefix!, n)
+          }
+        }
+      }
+      for (const block of value) {
+        const markDefs = (
+          block as {markDefs?: Array<{_key: string; _type: string}>}
+        ).markDefs
+        if (!markDefs) {
+          continue
+        }
+        for (const md of markDefs) {
+          if (annotationKeys.has(md._key)) {
+            continue
+          }
+          const prefix = (md._type ?? 'k').charAt(0)
+          const next = (counters.get(prefix) ?? 0) + 1
+          counters.set(prefix, next)
+          annotationKeys.set(md._key, `${prefix}${next}`)
+        }
+      }
+    }
+
+    expect(
+      toTextspec(
+        {
+          schema,
+          value,
+          selection: assertsSelection ? selection : null,
+          containers,
+          annotationKeys,
+        },
+        options.singleLine
+          ? {singleLine: true, keys: keys.size > 0 ? keys : undefined}
+          : {keys: keys.size > 0 ? keys : undefined},
+      ),
+      'Unexpected editor state',
+    ).toBe(expected)
+  })
+}
+
+async function selectionFromInput(context: Context, textspec: string) {
+  const normalized = textspec.replace(/\\n/g, '\n').replace(/;;/g, '\n')
+
+  await vi.waitFor(() => {
+    const {schema, value} = context.editor.getSnapshot().context
+    const {containers} = (context.editor as InternalEditor)._internal
+      .slateEditor
+
+    const selection = selectionFromTextspec(
+      {schema, containers},
+      normalized,
+      value ?? [],
+    )
+
+    if (!selection) {
+      throw new Error(`Could not resolve selection from textspec: ${textspec}`)
+    }
+
+    context.editor.send({type: 'select', at: selection})
+  })
+}
+
 export const stepDefinitions = [
   Given('one editor', async (context: Context) => {
     const {editor, locator} = await createTestEditor({
@@ -107,26 +222,14 @@ export const stepDefinitions = [
   Given(
     'the editor state is {string}',
     (context: Context, textspec: string) => {
-      const {schema, keyGenerator} = context.editor.getSnapshot().context
-      const {containers} = (context.editor as InternalEditor)._internal
-        .slateEditor
-
-      const normalized = textspec.replace(/\\n/g, '\n').replace(/;;/g, '\n')
-
-      const {blocks} = fromTextspec(
-        {schema, keyGenerator, containers},
-        normalized,
-      )
-
-      context.editor.send({
-        type: 'insert.blocks',
-        blocks,
-        placement: 'auto',
-        select: 'end',
-      })
+      setEditorState(context, textspec.replace(/;;/g, '\n'))
     },
   ),
+  Given('the editor state is', (context: Context, textspec: string) => {
+    setEditorState(context, textspec)
+  }),
 
+  When('the selection is', selectionFromInput),
   When(
     'the selection is {string}',
     async (context: Context, textspec: string) => {
@@ -722,27 +825,12 @@ export const stepDefinitions = [
   Then(
     'the editor state is {string}',
     async (context: Context, textspec: string) => {
-      await vi.waitFor(() => {
-        const {schema, value, selection} = context.editor.getSnapshot().context
-        const {containers} = (context.editor as InternalEditor)._internal
-          .slateEditor
-
-        const expected = textspec.replace(/\\n/g, '\n')
-        const keys = new Set<string>()
-        for (const match of expected.matchAll(/_key="([^"]+)"/g)) {
-          keys.add(match[1]!)
-        }
-
-        expect(
-          toTextspec(
-            {schema, value, selection, containers},
-            {singleLine: true, keys: keys.size > 0 ? keys : undefined},
-          ),
-          'Unexpected editor state',
-        ).toBe(expected)
-      })
+      await assertEditorState(context, textspec, {singleLine: true})
     },
   ),
+  Then('the editor state is', async (context: Context, textspec: string) => {
+    await assertEditorState(context, textspec, {singleLine: false})
+  }),
 
   /**
    * Annotation steps

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -110,6 +110,56 @@ describe(fromTextspec.name, () => {
     ])
   })
 
+  test('empty text block has an empty placeholder span', () => {
+    expect(
+      fromTextspec({schema, keyGenerator: createTestKeyGenerator()}, 'B: |')
+        .blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: '', marks: []}],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('empty list item has an empty placeholder span', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'B listItem="number": |',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: '', marks: []}],
+        style: 'normal',
+        listItem: 'number',
+        level: 1,
+      },
+    ])
+  })
+
+  test('list item defaults to level 1 when no level is specified', () => {
+    expect(
+      fromTextspec(
+        {schema, keyGenerator: createTestKeyGenerator()},
+        'B listItem="bullet": foo|',
+      ).blocks,
+    ).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_key: 'k1', _type: 'span', text: 'foo', marks: []}],
+        style: 'normal',
+        listItem: 'bullet',
+        level: 1,
+      },
+    ])
+  })
+
   test('heading', () => {
     expect(
       fromTextspec(

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -763,18 +763,28 @@ function convertSelectionToPTE(
     return null
   }
 
-  const anchor = resolvePointToPTE(
-    schema,
-    containers,
-    blocks,
-    state.selection.anchor,
-  )
-  const focus = resolvePointToPTE(
-    schema,
-    containers,
-    blocks,
-    state.selection.focus,
-  )
+  // Textspec represents a selected block object as a range from offset 0
+  // to offset 1 on a non-text block. PTE represents it as a collapsed
+  // selection at offset 0. Translate when the textspec selection points
+  // resolve to the same path of a non-text block.
+  let {anchor: anchorPoint, focus: focusPoint} = state.selection
+  if (
+    anchorPoint.offset === 0 &&
+    focusPoint.offset === 1 &&
+    anchorPoint.path.length === 1 &&
+    focusPoint.path.length === 1 &&
+    anchorPoint.path[0] === focusPoint.path[0]
+  ) {
+    const blockIndex = anchorPoint.path[0]
+    const block = blockIndex !== undefined ? blocks[blockIndex] : undefined
+
+    if (block && !isTextBlock({schema}, block)) {
+      focusPoint = {path: focusPoint.path, offset: 0}
+    }
+  }
+
+  const anchor = resolvePointToPTE(schema, containers, blocks, anchorPoint)
+  const focus = resolvePointToPTE(schema, containers, blocks, focusPoint)
 
   if (!anchor || !focus) {
     return null

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -172,14 +172,22 @@ function convertTextBlockToPTE(
     }
   }
 
+  if (children.length === 0) {
+    children.push({
+      _key: keyGenerator(),
+      _type: 'span',
+      text: '',
+      marks: [],
+    })
+  }
+
   const result: PortableTextTextBlock = {
     _type: schema.block.name,
     _key: blockKey,
     children,
     ...(markDefs.length > 0 ? {markDefs} : {}),
     style,
-    ...(listItem ? {listItem} : {}),
-    ...(level ? {level} : {}),
+    ...(listItem ? {listItem, level: level ?? 1} : level ? {level} : {}),
   }
 
   return result

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -113,12 +113,19 @@ function flattenInlineNode(
       if (node.mode === 'decorator') {
         markId = node.type
       } else {
-        // Annotation or overlay: create a markDef
-        markId = keyGenerator()
+        // Annotation or overlay: create a markDef. Honour an explicit `_key`
+        // attribute so tests can reference specific annotation keys in both
+        // setup and assertions.
+        const providedKey =
+          typeof node.attrs?.['_key'] === 'string'
+            ? node.attrs['_key']
+            : undefined
+        markId = providedKey ?? keyGenerator()
+        const {_key: _discardedKey, ...restAttrs} = node.attrs ?? {}
         markDefs.push({
           _type: node.type,
           _key: markId,
-          ...node.attrs,
+          ...restAttrs,
         })
       }
 

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -427,5 +427,24 @@ function convertSelection(
     return null
   }
 
+  // PTE represents a selected block object as a collapsed selection at
+  // offset 0 of the block's path. Textspec represents it as a range from
+  // offset 0 to offset 1. Translate when both points resolve to the same
+  // path of a non-text block.
+  if (
+    anchor.offset === 0 &&
+    focus.offset === 0 &&
+    anchor.path.length === 1 &&
+    focus.path.length === 1 &&
+    anchor.path[0] === focus.path[0]
+  ) {
+    const blockIndex = anchor.path[0]
+    const block = blockIndex !== undefined ? blocks[blockIndex] : undefined
+
+    if (block && !isTextBlock({schema}, block)) {
+      return {anchor, focus: {path: focus.path, offset: 1}}
+    }
+  }
+
   return {anchor, focus}
 }

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -26,14 +26,21 @@ export function toTextspec(
     value: Array<PortableTextBlock>
     selection: EditorSelection
     containers?: Containers
+    annotationKeys?: Map<string, string>
   },
   options?: {singleLine?: boolean; keys?: boolean | Set<string>},
 ): string {
   const containers = context.containers ?? new Map()
+  const annotationKeys = context.annotationKeys
   const textspecBlocks: Array<Block> = []
 
   for (const block of context.value) {
-    const converted = convertBlockToTextspec(context.schema, containers, block)
+    const converted = convertBlockToTextspec(
+      context.schema,
+      containers,
+      annotationKeys,
+      block,
+    )
     if (options?.keys) {
       addKeys(block as Record<string, unknown>, converted, options.keys)
     }
@@ -123,6 +130,7 @@ function wrapInMarks(
   schema: Schema,
   block: PortableTextTextBlock,
   marks: ReadonlyArray<string>,
+  annotationKeys: Map<string, string> | undefined,
   inner: InlineNode,
 ): InlineNode {
   if (marks.length === 0) {
@@ -152,7 +160,14 @@ function wrapInMarks(
       continue
     }
 
-    const attrs = extractPrimitiveAttrs(markDef)
+    const attrs: Record<string, string | number | boolean> = {
+      ...extractPrimitiveAttrs(markDef),
+    }
+
+    const symbolicKey = annotationKeys?.get(markDef._key)
+    if (symbolicKey !== undefined) {
+      attrs['_key'] = symbolicKey
+    }
 
     result = {
       kind: 'mark',
@@ -184,6 +199,7 @@ function wrapInMarks(
 function convertChildren(
   schema: Schema,
   block: PortableTextTextBlock,
+  annotationKeys: Map<string, string> | undefined,
 ): Array<InlineNode> {
   const ctx = {schema}
   const result: Array<InlineNode> = []
@@ -194,7 +210,7 @@ function convertChildren(
       const marks = child.marks ?? []
       result.push(
         marks.length > 0
-          ? wrapInMarks(schema, block, marks, textNode)
+          ? wrapInMarks(schema, block, marks, annotationKeys, textNode)
           : textNode,
       )
     } else {
@@ -212,6 +228,7 @@ function convertChildren(
 function convertTextBlock(
   schema: Schema,
   block: PortableTextTextBlock,
+  annotationKeys: Map<string, string> | undefined,
 ): TextBlock {
   const attrs: Record<string, string | number | boolean> = {}
 
@@ -231,7 +248,7 @@ function convertTextBlock(
     kind: 'textBlock',
     type: 'B',
     ...(Object.keys(attrs).length > 0 ? {attrs} : {}),
-    children: convertChildren(schema, block),
+    children: convertChildren(schema, block, annotationKeys),
   }
 }
 
@@ -332,14 +349,21 @@ function keyedPathToIndexedPath(
 function convertBlockToTextspec(
   schema: Schema,
   containers: Containers,
+  annotationKeys: Map<string, string> | undefined,
   block: PortableTextBlock,
 ): Block {
   if (isTextBlock({schema}, block)) {
-    return convertTextBlock(schema, block)
+    return convertTextBlock(schema, block, annotationKeys)
   }
 
   if (containers.has(block._type)) {
-    return convertContainerBlock(schema, containers, block, block._type)
+    return convertContainerBlock(
+      schema,
+      containers,
+      annotationKeys,
+      block,
+      block._type,
+    )
   }
 
   return {
@@ -352,6 +376,7 @@ function convertBlockToTextspec(
 function convertContainerBlock(
   schema: Schema,
   containers: Containers,
+  annotationKeys: Map<string, string> | undefined,
   block: Record<string, unknown>,
   scopePath: string,
 ): ContainerBlock {
@@ -373,7 +398,7 @@ function convertContainerBlock(
   if (Array.isArray(fieldValue)) {
     for (const item of fieldValue) {
       if (isTextBlock(schemaContext, item)) {
-        children.push(convertTextBlock(schema, item))
+        children.push(convertTextBlock(schema, item, annotationKeys))
       } else if (
         typeof item === 'object' &&
         item !== null &&
@@ -388,6 +413,7 @@ function convertContainerBlock(
             convertContainerBlock(
               schema,
               containers,
+              annotationKeys,
               typedItem,
               childScopePath,
             ),


### PR DESCRIPTION
Our gherkin scenarios use the terse-pt notation. It cannot express selection, mark boundaries are ambiguous, list level is implied, annotation keys are invisible, and block-object selection serializes the same as caret-before-the-block. Scenarios that depend on any of these axes have to compensate with extra `is selected` / `has marks` / `caret is put` steps, side notes about what an assertion also covers, or simply cannot be written.

Textspec ([`@textspec/notation`](https://github.com/textspec/textspec)) is a notation purpose-built for editor assertions. Same blocks, but with explicit selection markers (`|` for caret, `^...|` for range, `^{IMAGE}|` for selected block object), nested mark notation (`[strong:[em:bar]]`), annotation keys (`[@link _key="l1":bar]`), block attributes (`H1 listItem="bullet" level=2: foo`), and multi-block scenarios as readable doc strings.

This PR migrates 22 of 24 gherkin feature files from terse-pt to textspec.

### What changed in the editor codebase

- Two new step definitions — `the editor state is {string}` (Given/Then) and `the selection is {string}` (When), both supporting doc strings — alongside a small bridge in `test-utils/` (`toTextspec`, `fromTextspec`, `selectionFromTextspec`) that round-trips PTE state through textspec.
- `the editor state is` skips the selection check when the assertion has no selection marker, so authors can opt in scenario-by-scenario without giving up scenarios that don't care about caret position.
- Symbolic annotation keys are auto-assigned (`l2`, `c2`, …) when the editor produces fresh markDef keys, so assertions that include `_key="..."` stay deterministic across runs.
- `toTextspec`/`fromTextspec` translate selected block objects between PTE's collapsed-offset-0 form and textspec's `^{X}|` range form.

The existing helper steps (`"X" is selected`, `the caret is put before/after "X"`, `"strong" around "X"`, `a "link" "l1" around "X"`, typed-key steps) are unchanged. Only the value/expected arguments swap from terse-pt to textspec.

### Out of scope

- `annotations-collaboration.feature` — multi-editor scenarios need their own textspec step definitions (cross-editor selection, applied patches).
- `selection-adjustment.feature` — caret-put-relative scenarios don't translate mechanically; they need a textspec equivalent of the terse-pt position parser.
