### PR TITLE
fix: make selection state depth-agnostic

### DIFF
--- a/.changeset/selection-state-depth-agnostic.md
+++ b/.changeset/selection-state-depth-agnostic.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: make selection state depth-agnostic

--- a/packages/editor/src/editor/get-selection-state.test.ts
+++ b/packages/editor/src/editor/get-selection-state.test.ts
@@ -1,0 +1,488 @@
+import {describe, expect, test} from 'vitest'
+import {createNodeTraversalTestbed} from '../node-traversal/node-traversal-testbed'
+import {serializePath} from '../paths/serialize-path'
+import {getSelectionState} from './get-selection-state'
+
+describe(getSelectionState.name, () => {
+  test('returns defaults when selection is null', () => {
+    const testbed = createNodeTraversalTestbed()
+
+    expect(getSelectionState(testbed.context, null)).toEqual({
+      focusedLeafPath: undefined,
+      selectedLeafPaths: new Set(),
+      focusedContainerPath: undefined,
+      selectedContainerPaths: new Set(),
+    })
+  })
+
+  describe('collapsed selection on a root text block span', () => {
+    const testbed = createNodeTraversalTestbed()
+    const focusPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span1._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath: focusPath,
+      focusPath,
+      backward: false,
+      isCollapsed: true,
+    })
+
+    test('focused leaf is the span', () => {
+      expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
+    })
+
+    test('focused container is the text block', () => {
+      expect(result.focusedContainerPath).toEqual(
+        serializePath([{_key: testbed.textBlock1._key}]),
+      )
+    })
+
+    test('selected leaves contain only the span', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([serializePath(focusPath)]),
+      )
+    })
+
+    test('selected containers contain only the text block', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
+      )
+    })
+  })
+
+  describe('collapsed selection on a root void block object', () => {
+    const testbed = createNodeTraversalTestbed()
+    const focusPath = [{_key: testbed.image._key}]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath: focusPath,
+      focusPath,
+      backward: false,
+      isCollapsed: true,
+    })
+
+    test('focused leaf is the image', () => {
+      expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
+    })
+
+    test('no focused container (image is root-level leaf)', () => {
+      expect(result.focusedContainerPath).toBeUndefined()
+    })
+
+    test('selected leaves contain the image', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([serializePath(focusPath)]),
+      )
+    })
+
+    test('no selected containers', () => {
+      expect(result.selectedContainerPaths).toEqual(new Set())
+    })
+  })
+
+  describe('collapsed selection on an inline object in a text block', () => {
+    const testbed = createNodeTraversalTestbed()
+    const focusPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.stockTicker1._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath: focusPath,
+      focusPath,
+      backward: false,
+      isCollapsed: true,
+    })
+
+    test('focused leaf is the inline object', () => {
+      expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
+    })
+
+    test('focused container is the text block', () => {
+      expect(result.focusedContainerPath).toEqual(
+        serializePath([{_key: testbed.textBlock1._key}]),
+      )
+    })
+  })
+
+  describe('collapsed selection inside a table cell', () => {
+    const testbed = createNodeTraversalTestbed()
+    const focusPath = [
+      {_key: testbed.table._key},
+      'rows',
+      {_key: testbed.row1._key},
+      'cells',
+      {_key: testbed.cell1._key},
+      'content',
+      {_key: testbed.cellBlock1._key},
+      'children',
+      {_key: testbed.cellSpan1._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath: focusPath,
+      focusPath,
+      backward: false,
+      isCollapsed: true,
+    })
+
+    test('focused leaf is the span', () => {
+      expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
+    })
+
+    test('focused container is the nearest ancestor (text block)', () => {
+      expect(result.focusedContainerPath).toEqual(
+        serializePath([
+          {_key: testbed.table._key},
+          'rows',
+          {_key: testbed.row1._key},
+          'cells',
+          {_key: testbed.cell1._key},
+          'content',
+          {_key: testbed.cellBlock1._key},
+        ]),
+      )
+    })
+
+    test('all container ancestors are in selectedContainerPaths', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.table._key}]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock1._key},
+          ]),
+        ]),
+      )
+    })
+
+    test('the span is in selectedLeafPaths', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([serializePath(focusPath)]),
+      )
+    })
+  })
+
+  describe('collapsed selection on an inline object inside a table cell', () => {
+    const testbed = createNodeTraversalTestbed()
+    const focusPath = [
+      {_key: testbed.table._key},
+      'rows',
+      {_key: testbed.row1._key},
+      'cells',
+      {_key: testbed.cell1._key},
+      'content',
+      {_key: testbed.cellBlock1._key},
+      'children',
+      {_key: testbed.stockTicker2._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath: focusPath,
+      focusPath,
+      backward: false,
+      isCollapsed: true,
+    })
+
+    test('focused leaf is the inline object', () => {
+      expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
+    })
+
+    test('focused container is the nearest text block', () => {
+      expect(result.focusedContainerPath).toEqual(
+        serializePath([
+          {_key: testbed.table._key},
+          'rows',
+          {_key: testbed.row1._key},
+          'cells',
+          {_key: testbed.cell1._key},
+          'content',
+          {_key: testbed.cellBlock1._key},
+        ]),
+      )
+    })
+  })
+
+  describe('expanded selection within a text block', () => {
+    const testbed = createNodeTraversalTestbed()
+    const anchorPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span1._key},
+    ]
+    const focusPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span2._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath,
+      focusPath,
+      backward: false,
+      isCollapsed: false,
+    })
+
+    test('no focused leaf (selection is expanded)', () => {
+      expect(result.focusedLeafPath).toBeUndefined()
+    })
+
+    test('no focused container (selection is expanded)', () => {
+      expect(result.focusedContainerPath).toBeUndefined()
+    })
+
+    test('selected leaves include all three children of the text block', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([
+          serializePath(anchorPath),
+          serializePath([
+            {_key: testbed.textBlock1._key},
+            'children',
+            {_key: testbed.stockTicker1._key},
+          ]),
+          serializePath(focusPath),
+        ]),
+      )
+    })
+
+    test('selected containers include the text block', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
+      )
+    })
+  })
+
+  describe('expanded selection across two root text blocks', () => {
+    const testbed = createNodeTraversalTestbed()
+    const anchorPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span1._key},
+    ]
+    const focusPath = [
+      {_key: testbed.textBlock2._key},
+      'children',
+      {_key: testbed.span3._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath,
+      focusPath,
+      backward: false,
+      isCollapsed: false,
+    })
+
+    test('selected containers include both text blocks', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.textBlock1._key}]),
+          serializePath([{_key: testbed.textBlock2._key}]),
+        ]),
+      )
+    })
+
+    test('selected leaves include all children of both text blocks plus the image between them', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([
+          serializePath(anchorPath),
+          serializePath([
+            {_key: testbed.textBlock1._key},
+            'children',
+            {_key: testbed.stockTicker1._key},
+          ]),
+          serializePath([
+            {_key: testbed.textBlock1._key},
+            'children',
+            {_key: testbed.span2._key},
+          ]),
+          serializePath([{_key: testbed.image._key}]),
+          serializePath(focusPath),
+        ]),
+      )
+    })
+  })
+
+  describe('expanded selection across table cells', () => {
+    const testbed = createNodeTraversalTestbed()
+    const anchorPath = [
+      {_key: testbed.table._key},
+      'rows',
+      {_key: testbed.row1._key},
+      'cells',
+      {_key: testbed.cell1._key},
+      'content',
+      {_key: testbed.cellBlock1._key},
+      'children',
+      {_key: testbed.cellSpan1._key},
+    ]
+    const focusPath = [
+      {_key: testbed.table._key},
+      'rows',
+      {_key: testbed.row1._key},
+      'cells',
+      {_key: testbed.cell2._key},
+      'content',
+      {_key: testbed.cellBlock3._key},
+      'children',
+      {_key: testbed.cellSpan3._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath,
+      focusPath,
+      backward: false,
+      isCollapsed: false,
+    })
+
+    test('selected containers include the table, row, both cells, and text blocks in range', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.table._key}]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock2._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell2._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell2._key},
+            'content',
+            {_key: testbed.cellBlock3._key},
+          ]),
+        ]),
+      )
+    })
+
+    test('selected leaves include spans and inline objects across both cells', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([
+          serializePath(anchorPath),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock1._key},
+            'children',
+            {_key: testbed.stockTicker2._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock2._key},
+            'children',
+            {_key: testbed.cellSpan2._key},
+          ]),
+          serializePath(focusPath),
+        ]),
+      )
+    })
+  })
+
+  describe('backward selection across an inline object (shift+left from after inline)', () => {
+    const testbed = createNodeTraversalTestbed()
+    // Caret sits at offset 0 of span2 (the span after the inline object).
+    // Shift+Left extends the focus backwards to the end of span1,
+    // so anchor=span2 and focus=span1 — i.e. anchor is LATER than focus
+    // in document order.
+    const anchorPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span2._key},
+    ]
+    const focusPath = [
+      {_key: testbed.textBlock1._key},
+      'children',
+      {_key: testbed.span1._key},
+    ]
+
+    const result = getSelectionState(testbed.context, {
+      anchorPath,
+      focusPath,
+      backward: true,
+      isCollapsed: false,
+    })
+
+    test('inline object between anchor and focus is in selectedLeafPaths', () => {
+      expect(result.selectedLeafPaths).toEqual(
+        new Set([
+          serializePath(focusPath),
+          serializePath([
+            {_key: testbed.textBlock1._key},
+            'children',
+            {_key: testbed.stockTicker1._key},
+          ]),
+          serializePath(anchorPath),
+        ]),
+      )
+    })
+
+    test('text block is in selectedContainerPaths', () => {
+      expect(result.selectedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
+      )
+    })
+  })
+})

--- a/packages/editor/src/editor/get-selection-state.ts
+++ b/packages/editor/src/editor/get-selection-state.ts
@@ -1,0 +1,126 @@
+import {isTextBlock} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import {getNodes} from '../node-traversal/get-nodes'
+import {serializePath} from '../paths/serialize-path'
+import {isEditableContainer} from '../schema/is-editable-container'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+
+export type SelectionState = {
+  /**
+   * Serialized path of the focused leaf (span, inline object, or block
+   * object). Set when the selection is collapsed and resolves to a leaf.
+   */
+  focusedLeafPath: string | undefined
+  /**
+   * Set of serialized paths of leaves within the current selection.
+   */
+  selectedLeafPaths: Set<string>
+  /**
+   * Serialized path of the focused container (text block or editable
+   * container). Set when the selection is collapsed and has a container
+   * ancestor.
+   */
+  focusedContainerPath: string | undefined
+  /**
+   * Set of serialized paths of containers within the current selection.
+   */
+  selectedContainerPaths: Set<string>
+}
+
+const emptySet = new Set<string>()
+
+const emptyState: SelectionState = {
+  focusedLeafPath: undefined,
+  selectedLeafPaths: emptySet,
+  focusedContainerPath: undefined,
+  selectedContainerPaths: emptySet,
+}
+
+/**
+ * Compute which nodes are focused and selected from a range of paths.
+ *
+ * A node is a container if it is a text block or a registered editable
+ * container. All other nodes (spans, inline objects, block objects) are
+ * leaves.
+ *
+ * For a collapsed selection:
+ * - `focusedLeafPath` is the focus path when it resolves to a leaf.
+ * - `focusedContainerPath` is the nearest ancestor container of the focus.
+ */
+export function getSelectionState(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+    blockIndexMap: Map<string, number>
+  },
+  selection: {
+    anchorPath: Path
+    focusPath: Path
+    backward: boolean
+    isCollapsed: boolean
+  } | null,
+): SelectionState {
+  if (!selection) {
+    return emptyState
+  }
+
+  const selectedContainerPaths = new Set<string>()
+  const selectedLeafPaths = new Set<string>()
+
+  // getNodes expects `from` and `to` in document order. Backward selections
+  // (e.g. shift+left) have anchor after focus, so swap for traversal.
+  const from = selection.backward ? selection.focusPath : selection.anchorPath
+  const to = selection.backward ? selection.anchorPath : selection.focusPath
+
+  for (const {node, path} of getNodes(context, {
+    from,
+    to,
+  })) {
+    const serialized = serializePath(path)
+
+    if (
+      isTextBlock({schema: context.schema}, node) ||
+      isEditableContainer(context, node, path)
+    ) {
+      selectedContainerPaths.add(serialized)
+    } else {
+      selectedLeafPaths.add(serialized)
+    }
+  }
+
+  let focusedLeafPath: string | undefined
+  let focusedContainerPath: string | undefined
+
+  if (selection.isCollapsed) {
+    const serializedFocusPath = serializePath(selection.focusPath)
+
+    if (selectedLeafPaths.has(serializedFocusPath)) {
+      focusedLeafPath = serializedFocusPath
+    }
+
+    for (const {path: ancestorPath} of getAncestors(
+      context,
+      selection.focusPath,
+    )) {
+      const serializedAncestorPath = serializePath(ancestorPath)
+
+      if (selectedContainerPaths.has(serializedAncestorPath)) {
+        focusedContainerPath = serializedAncestorPath
+        break
+      }
+    }
+  }
+
+  return {
+    focusedLeafPath,
+    selectedLeafPaths:
+      selectedLeafPaths.size > 0 ? selectedLeafPaths : emptySet,
+    focusedContainerPath,
+    selectedContainerPaths:
+      selectedContainerPaths.size > 0 ? selectedContainerPaths : emptySet,
+  }
+}

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -1,6 +1,8 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import {useContext, useRef, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
+import {serializePath} from '../paths/serialize-path'
+import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import type {BlockRenderProps, RenderBlockFunction} from '../types/editor'
 import type {EditorSchema} from './editor-schema'
@@ -14,15 +16,17 @@ export function RenderBlockObject(props: {
   dropPosition?: DropPosition['positionBlock']
   children: ReactElement
   element: PortableTextObject
+  path: Path
   readOnly: boolean
   renderBlock?: RenderBlockFunction
   schema: EditorSchema
 }) {
   const blockObjectRef = useRef<HTMLDivElement>(null)
 
-  const {selectedBlockKeys, focusedBlockKey} = useContext(SelectionStateContext)
-  const selected = selectedBlockKeys.has(props.element._key)
-  const focused = focusedBlockKey === props.element._key
+  const {selectedLeafPaths, focusedLeafPath} = useContext(SelectionStateContext)
+  const serializedPath = serializePath(props.path)
+  const selected = selectedLeafPaths.has(serializedPath)
+  const focused = focusedLeafPath === serializedPath
 
   const blockObjectSchemaType = props.schema.blockObjects.find(
     (schemaType) => schemaType.name === props.element._type,

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -81,6 +81,7 @@ export function RenderElement(props: {
             : undefined
         }
         element={props.element}
+        path={props.path}
         readOnly={props.readOnly}
         renderBlock={props.renderBlock}
         renderListItem={props.renderListItem}
@@ -119,6 +120,7 @@ export function RenderElement(props: {
           : undefined
       }
       element={props.element}
+      path={props.path}
       readOnly={props.readOnly}
       renderBlock={props.renderBlock}
       schema={schema}

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -31,8 +31,8 @@ export function RenderInlineObject(props: {
 
   const selectionState = useContext(SelectionStateContext)
   const serializedPath = serializePath(props.path)
-  const selected = selectionState.selectedChildPaths.has(serializedPath)
-  const focused = selectionState.focusedChildPath === serializedPath
+  const selected = selectionState.selectedLeafPaths.has(serializedPath)
+  const focused = selectionState.focusedLeafPath === serializedPath
 
   const inlineObject = props.element as unknown as PortableTextChild
 

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -36,8 +36,8 @@ export function RenderSpan(props: RenderSpanProps) {
 
   const selectionState = useContext(SelectionStateContext)
   const serializedPath = serializePath(props.path)
-  const focused = selectionState.focusedChildPath === serializedPath
-  const selected = selectionState.selectedChildPaths.has(serializedPath)
+  const focused = selectionState.focusedLeafPath === serializedPath
+  const selected = selectionState.selectedLeafPaths.has(serializedPath)
 
   const decoratorSchemaTypes = schema.decorators.map(
     (decorator) => decorator.name,

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -4,6 +4,8 @@ import type {
 } from '@portabletext/schema'
 import {useContext, useRef, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
+import {serializePath} from '../paths/serialize-path'
+import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateSelector} from '../slate/react/hooks/use-slate-selector'
 import type {
@@ -23,6 +25,7 @@ export function RenderTextBlock(props: {
   children: ReactElement
   dropPosition?: DropPosition['positionBlock']
   element: PortableTextTextBlock
+  path: Path
   readOnly: boolean
   renderBlock?: RenderBlockFunction
   renderListItem?: RenderListItemFunction
@@ -36,9 +39,12 @@ export function RenderTextBlock(props: {
     name: props.schema.block.name,
     fields: props.schema.block.fields ?? [],
   } satisfies BlockObjectSchemaType
-  const {selectedBlockKeys, focusedBlockKey} = useContext(SelectionStateContext)
-  const selected = selectedBlockKeys.has(props.textBlock._key)
-  const focused = focusedBlockKey === props.textBlock._key
+  const {selectedContainerPaths, focusedContainerPath} = useContext(
+    SelectionStateContext,
+  )
+  const serializedPath = serializePath(props.path)
+  const selected = selectedContainerPaths.has(serializedPath)
+  const focused = focusedContainerPath === serializedPath
   const listIndex = useSlateSelector((editor) =>
     editor.listIndexMap.get(props.textBlock._key),
   )

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -1,49 +1,18 @@
 import {useSelector} from '@xstate/react'
 import {createContext, useContext} from 'react'
-import {serializePath} from '../paths/serialize-path'
-import {getFocusChild} from '../selectors'
-import {getSelectedChildren} from '../selectors/selector.get-selected-children'
-import {getSelectionEndPoint} from '../selectors/selector.get-selection-end-point'
-import {getSelectionStartPoint} from '../selectors/selector.get-selection-start-point'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 import {EditorActorContext} from './editor-actor-context'
 import {getEditorSnapshot} from './editor-selector'
-
-/**
- * Selection state computed once per selection change, shared across all components.
- */
-type SelectionState = {
-  /**
-   * Serialized path of the child (span or inline object) that has the caret
-   * (when selection is collapsed). Format: "blockKey.children.childKey".
-   * `undefined` if selection is expanded or there is no selection.
-   */
-  focusedChildPath: string | undefined
-  /**
-   * Set of serialized child paths (spans and inline objects) that are within
-   * the current selection. Format: "blockKey.children.childKey".
-   */
-  selectedChildPaths: Set<string>
-  /**
-   * The _key of the block that has the caret (when selection is collapsed).
-   * `undefined` if selection is expanded or there is no selection.
-   */
-  focusedBlockKey: string | undefined
-  /**
-   * Set of block _keys that are within the current selection.
-   */
-  selectedBlockKeys: Set<string>
-}
+import {getSelectionState, type SelectionState} from './get-selection-state'
 
 const emptySet = new Set<string>()
 
 const defaultSelectionState: SelectionState = {
-  focusedChildPath: undefined,
-  selectedChildPaths: emptySet,
-  focusedBlockKey: undefined,
-  selectedBlockKeys: emptySet,
+  focusedLeafPath: undefined,
+  selectedLeafPaths: emptySet,
+  focusedContainerPath: undefined,
+  selectedContainerPaths: emptySet,
 }
 
 export const SelectionStateContext = createContext<SelectionState>(
@@ -69,103 +38,55 @@ export function SelectionStateProvider({
         slateEditorInstance: slateEditor,
       })
 
-      if (!snapshot.context.selection) {
-        return defaultSelectionState
-      }
-
-      const isCollapsed = isSelectionCollapsed(snapshot)
-
-      let focusedChildPath: string | undefined
-
-      if (isCollapsed) {
-        const focusChild = getFocusChild(snapshot)
-        if (focusChild) {
-          focusedChildPath = serializePath(focusChild.path)
-        }
-      }
-
-      const selectedChildren = getSelectedChildren()(snapshot)
-      let selectedChildPaths =
-        selectedChildren.length > 0
-          ? new Set(selectedChildren.map((child) => serializePath(child.path)))
-          : emptySet
-
-      if (
-        isCollapsed &&
-        focusedChildPath &&
-        !selectedChildPaths.has(focusedChildPath)
-      ) {
-        selectedChildPaths = new Set(selectedChildPaths)
-        selectedChildPaths.add(focusedChildPath)
-      }
-
-      const startPoint = getSelectionStartPoint(snapshot)
-      const endPoint = getSelectionEndPoint(snapshot)
-      const startBlockKey = startPoint
-        ? getBlockKeyFromSelectionPoint(startPoint)
-        : undefined
-      const endBlockKey = endPoint
-        ? getBlockKeyFromSelectionPoint(endPoint)
-        : undefined
-
-      let selectedBlockKeys: Set<string> = emptySet
-
-      if (startBlockKey && endBlockKey) {
-        const startBlockIndex = snapshot.blockIndexMap.get(startBlockKey)
-        const endBlockIndex = snapshot.blockIndexMap.get(endBlockKey)
-
-        if (startBlockIndex !== undefined && endBlockIndex !== undefined) {
-          const minIndex = Math.min(startBlockIndex, endBlockIndex)
-          const maxIndex = Math.max(startBlockIndex, endBlockIndex)
-          selectedBlockKeys = new Set<string>()
-
-          for (const [key, index] of snapshot.blockIndexMap) {
-            if (index >= minIndex && index <= maxIndex) {
-              selectedBlockKeys.add(key)
-            }
+      const selection = snapshot.context.selection
+        ? {
+            anchorPath: snapshot.context.selection.anchor.path,
+            focusPath: snapshot.context.selection.focus.path,
+            backward: snapshot.context.selection.backward ?? false,
+            isCollapsed: isSelectionCollapsed(snapshot),
           }
-        }
-      }
+        : null
 
-      const focusedBlockKey = isCollapsed ? startBlockKey : undefined
-
-      return {
-        focusedChildPath,
-        selectedChildPaths:
-          selectedChildPaths.size > 0 ? selectedChildPaths : emptySet,
-        focusedBlockKey,
-        selectedBlockKeys:
-          selectedBlockKeys.size > 0 ? selectedBlockKeys : emptySet,
-      }
+      return getSelectionState(
+        {
+          schema: snapshot.context.schema,
+          containers: slateEditor.containers,
+          value: snapshot.context.value,
+          blockIndexMap: slateEditor.blockIndexMap,
+        },
+        selection,
+      )
     },
     (prev, next) => {
-      if (prev.focusedChildPath !== next.focusedChildPath) {
+      if (prev.focusedLeafPath !== next.focusedLeafPath) {
         return false
       }
 
-      if (prev.selectedChildPaths !== next.selectedChildPaths) {
-        if (prev.selectedChildPaths.size !== next.selectedChildPaths.size) {
+      if (prev.focusedContainerPath !== next.focusedContainerPath) {
+        return false
+      }
+
+      if (prev.selectedLeafPaths !== next.selectedLeafPaths) {
+        if (prev.selectedLeafPaths.size !== next.selectedLeafPaths.size) {
           return false
         }
 
-        for (const path of prev.selectedChildPaths) {
-          if (!next.selectedChildPaths.has(path)) {
+        for (const path of prev.selectedLeafPaths) {
+          if (!next.selectedLeafPaths.has(path)) {
             return false
           }
         }
       }
 
-      if (prev.focusedBlockKey !== next.focusedBlockKey) {
-        return false
-      }
-
-      if (prev.selectedBlockKeys !== next.selectedBlockKeys) {
-        if (prev.selectedBlockKeys.size !== next.selectedBlockKeys.size) {
+      if (prev.selectedContainerPaths !== next.selectedContainerPaths) {
+        if (
+          prev.selectedContainerPaths.size !== next.selectedContainerPaths.size
+        ) {
           return false
         }
 
-        for (const key of prev.selectedBlockKeys) {
-          if (!next.selectedBlockKeys.has(key)) {
+        for (const path of prev.selectedContainerPaths) {
+          if (!next.selectedContainerPaths.has(path)) {
             return false
           }
         }


### PR DESCRIPTION
The editor's selection state context was built around root-level assumptions: `focusedBlockKey`/`selectedBlockKeys` for blocks (via `blockIndexMap`, root only) and `focusedChildPath`/`selectedChildPaths` for children (depth-2 paths only). This made "is this node focused/selected?" unanswerable for anything inside a container — nested text blocks, container children, deeper structures all fell through.

This PR replaces the state with a depth-agnostic classification:

- **Containers**: text blocks and registered editable containers
- **Leaves**: everything else — spans, inline objects, **and block objects**

The context now exposes `focusedContainerPath`/`selectedContainerPaths` and `focusedLeafPath`/`selectedLeafPaths` as sets of serialized paths. Each render component (`RenderTextBlock`, `RenderBlockObject`, `RenderInlineObject`, `RenderSpan`) classifies itself and looks up its own path — no more special casing root vs deeper, no more key-based lookup that only works at depth 2.

A deliberate classification change: **block objects are leaves**, not containers. From the engine's perspective a block object is a terminal render — it has no editable children to route selection through. Text blocks are containers because they contain spans/inline objects; editable containers are containers by definition.

### Scope

Internal plumbing only. No consumer-facing API changes. No changes to container rendering, `defineContainer`, `defineLeaf`, or DOM attributes. Behavior is identical at root level.