### PR TITLE
fix: make `insert.block` depth-agnostic

### DIFF
--- a/.changeset/insert-block-depth-agnostic.md
+++ b/.changeset/insert-block-depth-agnostic.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: make `insert.block` depth-agnostic

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -1,12 +1,13 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
+import {applyInsertNodeAtPath} from '../internal-utils/apply-insert-node'
 import {applyMergeNode} from '../internal-utils/apply-merge-node'
-import {resolveSelection} from '../internal-utils/apply-selection'
+import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {isEqualChildren, isEqualMarks} from '../internal-utils/equality'
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {toSlateBlock} from '../internal-utils/values'
-import {getChildren} from '../node-traversal/get-children'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNode} from '../node-traversal/get-node'
 import {getSibling} from '../node-traversal/get-sibling'
 import {getSpanNode} from '../node-traversal/get-span-node'
@@ -14,20 +15,16 @@ import {getTextBlockNode} from '../node-traversal/get-text-block-node'
 import {isBlock} from '../node-traversal/is-block'
 import {end as editorEnd} from '../slate/editor/end'
 import {pathRef} from '../slate/editor/path-ref'
-import {pointRef} from '../slate/editor/point-ref'
 import {rangeRef} from '../slate/editor/range-ref'
 import {start as editorStart} from '../slate/editor/start'
-import {withoutNormalizing} from '../slate/editor/without-normalizing'
 import type {Node} from '../slate/interfaces/node'
 import type {InsertOperation} from '../slate/interfaces/operation'
 import type {Path} from '../slate/interfaces/path'
 import type {Point} from '../slate/interfaces/point'
 import type {Range} from '../slate/interfaces/range'
-import {isObjectNode} from '../slate/node/is-object-node'
 import {parentPath} from '../slate/path/parent-path'
 import {pathEquals} from '../slate/path/path-equals'
 import {pointEquals} from '../slate/point/point-equals'
-import {isCollapsedRange} from '../slate/range/is-collapsed-range'
 import {isExpandedRange} from '../slate/range/is-expanded-range'
 import {rangeEdges} from '../slate/range/range-edges'
 import {rangeEnd} from '../slate/range/range-end'
@@ -40,22 +37,17 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationContext, OperationImplementation} from './operation.types'
 
 /**
- * Resolve a path segment to a numeric child index within a parent's children.
- * Keyed segments are looked up by _key, numbers are returned as-is.
- * Returns -1 if the segment cannot be resolved.
+ * Describes a concrete insertion strategy resolved from the operation's
+ * inputs (editor value, current selection, block being inserted, placement).
  */
-function resolveChildIndex(
-  children: Array<{_key: string}>,
-  segment: import('../slate/interfaces/path').PathSegment,
-): number {
-  if (typeof segment === 'number') {
-    return segment
-  }
-  if (isKeyedSegment(segment)) {
-    return children.findIndex((child) => child._key === segment._key)
-  }
-  return -1
-}
+type InsertTarget =
+  | {kind: 'empty-editor'}
+  | {kind: 'before'; blockPath: Path}
+  | {kind: 'after'; blockPath: Path}
+  | {kind: 'replace'; blockPath: Path}
+  | {kind: 'split-insert'; blockPath: Path; splitAt: Point}
+  | {kind: 'fragment'; at: Point; endBlockPath: Path}
+  | {kind: 'delete-then-insert'; range: Range; startBlockPath: Path}
 
 export const insertBlockOperationImplementation: OperationImplementation<
   'insert.block'
@@ -75,775 +67,759 @@ export const insertBlockOperationImplementation: OperationImplementation<
   }
 
   const block = toSlateBlock(parsedBlock, {schemaTypes: context.schema})
+  const editor = operation.editor
+  const at = operation.at
+    ? resolveSelection(editor, operation.at)
+    : editor.selection
 
-  insertBlock({
+  const target = resolveTarget({
+    editor,
+    block,
+    at: at ?? undefined,
+    placement: operation.placement,
+  })
+
+  if (!target) {
+    throw new Error(`Unable to insert block ${safeStringify(operation.block)}`)
+  }
+
+  dispatchInsert({
+    editor,
     context,
     block,
-    placement: operation.placement,
+    target,
     select: operation.select ?? 'start',
-    at: operation.at,
-    editor: operation.editor,
+    selectionAtEntry: editor.selection,
   })
 }
 
-function insertBlock(options: {
-  context: OperationContext
-  block: Node
-  placement: 'auto' | 'after' | 'before'
-  select: 'start' | 'end' | 'none'
-  at?: NonNullable<EditorSelection>
-  editor: PortableTextSlateEditor
-}) {
-  const {context, block, placement, select, editor} = options
-  const at = options.at
-    ? resolveSelection(editor, options.at)
-    : editor.selection
+// ---------------------------------------------------------------------------
+// Phase 1: resolve intent
+// ---------------------------------------------------------------------------
 
-  // Handle empty editor case
+/**
+ * Resolve the insertion intent into a concrete InsertTarget. Pure: performs
+ * no mutations on the editor.
+ */
+function resolveTarget(args: {
+  editor: PortableTextSlateEditor
+  block: Node
+  at: Range | undefined
+  placement: 'auto' | 'before' | 'after'
+}): InsertTarget | undefined {
+  const {editor, block, at, placement} = args
+
   if (editor.children.length === 0) {
-    insertNodeAt(editor, [0], block, select)
-    return
+    return {kind: 'empty-editor'}
   }
 
-  // Fall back to the start and end of the editor if neither an editor
-  // selection nor an `at` range is provided
-  const start = at ? rangeStart(at, editor) : editorStart(editor, [])
-  const end = at ? rangeEnd(at, editor) : editorEnd(editor, [])
+  const [startPoint, endPoint] = at
+    ? rangeEdges(at, {}, editor)
+    : [editorStart(editor, []), editorEnd(editor, [])]
 
-  const findContainingBlock = (
-    pointPath: Path,
-  ): {node: Node; path: Path} | undefined => {
-    // Check each prefix of the path from longest to shortest (deepest first)
-    // to find the closest containing block.
-    for (let length = pointPath.length; length >= 1; length--) {
-      const candidatePath = pointPath.slice(0, length)
-      if (typeof candidatePath[candidatePath.length - 1] === 'string') {
-        continue
-      }
-      const entry = getNode(editor, candidatePath)
-      if (entry && isBlock(editor, candidatePath)) {
-        return entry
-      }
-    }
+  const startBlockEntry = findContainingBlock(editor, startPoint.path)
+  const endBlockEntry = findContainingBlock(editor, endPoint.path)
+
+  if (!startBlockEntry || !endBlockEntry) {
     return undefined
   }
 
-  const startBlockEntry = findContainingBlock(start.path)
-  const startBlock = startBlockEntry?.node
-  const startBlockPath = startBlockEntry?.path
-  const endBlockEntry = findContainingBlock(end.path)
-  let endBlock = endBlockEntry?.node
-  let endBlockPath = endBlockEntry?.path
-
-  if (!startBlock || !startBlockPath || !endBlock || !endBlockPath) {
-    throw new Error('Unable to insert block without a start and end block')
-  }
+  const startBlockPath = startBlockEntry.path
+  const endBlock = endBlockEntry.node
+  const endBlockPath = endBlockEntry.path
 
   if (placement === 'before') {
-    insertNodeAt(editor, startBlockPath, block, select)
-    return
+    return {kind: 'before', blockPath: startBlockPath}
   }
 
   if (placement === 'after') {
-    insertNodeAt(editor, endBlockPath, block, select, 'after')
-    return
+    return {kind: 'after', blockPath: endBlockPath}
   }
+
+  const schemaContext = {schema: editor.schema}
 
   if (!at) {
-    if (isEmptyTextBlock(context, endBlock)) {
-      replaceEmptyTextBlock(editor, endBlockPath, block, select)
+    if (isEmptyTextBlock(schemaContext, endBlock)) {
+      return {kind: 'replace', blockPath: endBlockPath}
+    }
+    return {kind: 'after', blockPath: endBlockPath}
+  }
+
+  if (isExpandedRange(at)) {
+    return {kind: 'delete-then-insert', range: at, startBlockPath}
+  }
+
+  const collapsedPoint = rangeStart(at, editor)
+
+  if (isEmptyTextBlock(schemaContext, endBlock)) {
+    return {kind: 'replace', blockPath: endBlockPath}
+  }
+
+  const blockIsText = isTextBlock(schemaContext, block)
+  const endBlockIsText = isTextBlock(schemaContext, endBlock)
+
+  if (!endBlockIsText) {
+    return {kind: 'after', blockPath: endBlockPath}
+  }
+
+  const blockStartPoint = editorStart(editor, endBlockPath)
+  const blockEndPoint = editorEnd(editor, endBlockPath)
+  const atBlockStart = pointEquals(collapsedPoint, blockStartPoint)
+  const atBlockEnd = pointEquals(collapsedPoint, blockEndPoint)
+
+  if (blockIsText) {
+    return {kind: 'fragment', at: collapsedPoint, endBlockPath}
+  }
+
+  if (atBlockStart) {
+    return {kind: 'before', blockPath: endBlockPath}
+  }
+
+  if (atBlockEnd) {
+    return {kind: 'after', blockPath: endBlockPath}
+  }
+
+  return {
+    kind: 'split-insert',
+    blockPath: endBlockPath,
+    splitAt: collapsedPoint,
+  }
+}
+
+/**
+ * Find the closest ancestor block that contains the given point path. Walks
+ * up prefix-by-prefix (deepest first) so it works at any depth.
+ */
+function findContainingBlock(
+  editor: PortableTextSlateEditor,
+  pointPath: Path,
+): {node: Node; path: Path} | undefined {
+  for (let length = pointPath.length; length >= 1; length--) {
+    const candidatePath = pointPath.slice(0, length)
+    if (typeof candidatePath[candidatePath.length - 1] === 'string') {
+      continue
+    }
+    const entry = getNode(editor, candidatePath)
+    if (entry && isBlock(editor, candidatePath)) {
+      return entry
+    }
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: dispatch to a pseudo-behavior
+// ---------------------------------------------------------------------------
+
+function dispatchInsert(args: {
+  editor: PortableTextSlateEditor
+  context: OperationContext
+  block: Node
+  target: InsertTarget
+  select: 'start' | 'end' | 'none'
+  selectionAtEntry: EditorSelection
+  wasCrossBlock?: boolean
+}): void {
+  const {
+    editor,
+    context,
+    block,
+    target,
+    select,
+    selectionAtEntry,
+    wasCrossBlock,
+  } = args
+
+  switch (target.kind) {
+    case 'empty-editor': {
+      const insertedPath = insertBlockIntoEmptyEditor(editor, block)
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
       return
     }
 
-    if (
-      isTextBlock({schema: editor.schema}, block) &&
-      isTextBlock({schema: editor.schema}, endBlock)
-    ) {
-      const selectionBefore = editorEnd(editor, endBlockPath)
-      insertTextBlockFragment(editor, block, selectionBefore)
-
-      if (select === 'start') {
-        setSelectionToPoint(editor, selectionBefore)
-      } else if (select === 'none') {
-        clearSelection(editor)
-      }
+    case 'before': {
+      const insertedPath = insertSiblingBlock(
+        editor,
+        block,
+        target.blockPath,
+        'before',
+      )
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
       return
     }
 
-    insertNodeAt(editor, endBlockPath, block, select, 'after')
+    case 'after': {
+      const insertedPath = insertSiblingBlock(
+        editor,
+        block,
+        target.blockPath,
+        'after',
+      )
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
+      return
+    }
+
+    case 'replace': {
+      const insertedPath = replaceBlock(editor, block, target.blockPath)
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
+      return
+    }
+
+    case 'split-insert': {
+      const insertedPath = splitBlockAndInsert(
+        editor,
+        block,
+        target.blockPath,
+        target.splitAt,
+      )
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
+      return
+    }
+
+    case 'fragment': {
+      mergeTextBlockFragment({
+        editor,
+        context,
+        block,
+        at: target.at,
+        endBlockPath: target.endBlockPath,
+        select,
+        wasCrossBlock,
+      })
+      return
+    }
+
+    case 'delete-then-insert': {
+      executeDeleteThenInsert({
+        editor,
+        context,
+        block,
+        range: target.range,
+        select,
+        selectionAtEntry,
+      })
+      return
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pseudo-behaviors
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a block into an editor with no existing children. Returns the path
+ * of the inserted block.
+ */
+function insertBlockIntoEmptyEditor(
+  editor: PortableTextSlateEditor,
+  block: Node,
+): Path {
+  applyInsertNodeAtPath(editor, block, [0])
+  return [{_key: block._key}]
+}
+
+/**
+ * Insert a block as a sibling of the block at siblingPath (before or after).
+ * Uses a pathRef on the container field path so the returned inserted path
+ * is valid at any depth.
+ */
+function insertSiblingBlock(
+  editor: PortableTextSlateEditor,
+  block: Node,
+  siblingPath: Path,
+  position: 'before' | 'after',
+): Path {
+  const containerFieldPath = parentPath(siblingPath)
+  const containerFieldPathRef = pathRef(editor, containerFieldPath)
+
+  const operation: InsertOperation = {
+    type: 'insert',
+    path: siblingPath,
+    node: block,
+    position,
+  }
+  editor.apply(operation)
+
+  const resolvedContainerFieldPath =
+    containerFieldPathRef.unref() ?? containerFieldPath
+
+  return [...resolvedContainerFieldPath, {_key: operation.node._key}]
+}
+
+/**
+ * Replace the block at targetPath with a new block. Inserts the new block
+ * before the existing one and unsets the old one. Returns the path of the
+ * inserted block.
+ */
+function replaceBlock(
+  editor: PortableTextSlateEditor,
+  block: Node,
+  targetPath: Path,
+): Path {
+  const insertedPath = insertSiblingBlock(editor, block, targetPath, 'before')
+  editor.apply({type: 'unset', path: targetPath})
+  return insertedPath
+}
+
+/**
+ * Split a text block at a point and insert a block object between the two
+ * halves. Returns the path of the inserted block.
+ */
+function splitBlockAndInsert(
+  editor: PortableTextSlateEditor,
+  block: Node,
+  blockPath: Path,
+  splitAt: Point,
+): Path {
+  const blockPathRef = pathRef(editor, blockPath, {affinity: 'backward'})
+
+  if (splitAt.offset > 0) {
+    const spanEntry = getSpanNode(editor, splitAt.path)
+    if (spanEntry && splitAt.offset < spanEntry.node.text.length) {
+      applySplitNode(editor, splitAt.path, splitAt.offset)
+    }
+  }
+
+  const currentBlockPath = blockPathRef.current ?? blockPath
+  const blockEntry = getTextBlockNode(editor, currentBlockPath)
+
+  if (blockEntry) {
+    const childSegment = splitAt.path[blockPath.length + 1]
+    const childIndex = resolveChildIndex(blockEntry.node.children, childSegment)
+    const splitAtIndex = splitAt.offset > 0 ? childIndex + 1 : childIndex
+
+    if (splitAtIndex > 0 && splitAtIndex < blockEntry.node.children.length) {
+      applySplitNode(editor, currentBlockPath, splitAtIndex)
+    }
+  }
+
+  const firstHalfPath = blockPathRef.unref() ?? currentBlockPath
+
+  return insertSiblingBlock(editor, block, firstHalfPath, 'after')
+}
+
+/**
+ * Merge a text block's children into an existing text block at a point.
+ * Reassigns colliding keys, unions markDefs, optionally splits the target
+ * span, then prepends or inserts the fragment's children. Applies its own
+ * post-insert selection because the correct caret position depends on state
+ * captured before the insert.
+ */
+function mergeTextBlockFragment(args: {
+  editor: PortableTextSlateEditor
+  context: OperationContext
+  block: Node
+  at: Point
+  endBlockPath: Path
+  select: 'start' | 'end' | 'none'
+  wasCrossBlock?: boolean
+}): void {
+  const {editor, context, block, at, endBlockPath, select, wasCrossBlock} = args
+
+  const endBlockEntry = getTextBlockNode(editor, endBlockPath)
+
+  if (!endBlockEntry) {
     return
   }
 
-  if (isExpandedRange(at) && !isTextBlock({schema: editor.schema}, block)) {
-    const atBeforeDelete = rangeRef(editor, at, {affinity: 'inward'})
+  const endBlock = endBlockEntry.node
 
-    // Remember if the selection started at the beginning of the block
-    const start = rangeStart(at, editor)
-    const startBlockEntry = getTextBlockNode(editor, [start.path[0]!])
-    const startOfBlock = editorStart(editor, [start.path[0]!])
-    const isAtStartOfBlock =
-      startBlockEntry !== undefined && pointEquals(start, startOfBlock)
+  const {adjustedBlock, adjustedMarkDefs} = adjustFragmentKeys({
+    context,
+    block,
+    endBlock,
+  })
 
-    // Delete the expanded range
-    deleteExpandedRange(editor, at)
+  setNodeProperties(
+    editor,
+    {
+      markDefs: [...(endBlock.markDefs ?? []), ...(adjustedMarkDefs ?? [])],
+    },
+    endBlockPath,
+  )
 
-    const atAfterDelete = atBeforeDelete.unref() ?? editor.selection
+  const atPathRef = pathRef(editor, at.path)
 
-    const atBeforeInsert = atAfterDelete
-      ? rangeRef(editor, atAfterDelete, {affinity: 'inward'})
-      : undefined
+  const endBlockStartPoint = editorStart(editor, endBlockPath)
+  const atBlockStart = pointEquals(at, endBlockStartPoint)
+  const firstInsertedKey = insertFragmentChildren(editor, adjustedBlock, at)
 
-    // Insert the block at the position after delete
-    if (atAfterDelete) {
-      // If selection was at start of block, insert before; otherwise insert after
-      const insertPath: Path = [atAfterDelete.anchor.path[0]!]
-      const insertPosition: 'before' | 'after' = isAtStartOfBlock
-        ? 'before'
-        : 'after'
-      const op: InsertOperation = {
-        type: 'insert',
-        path: insertPath,
-        node: block,
-        position: insertPosition,
-      }
-      editor.apply(op)
+  const resolvedAtPath = atPathRef.unref()
 
-      if (select !== 'none') {
-        const insertedBlockPath: Path = [{_key: op.node._key}]
-        const point = editorStart(editor, insertedBlockPath)
-        editor.apply({
-          type: 'set_selection',
-          properties: editor.selection,
-          newProperties: {anchor: point, focus: point},
-        })
-      }
+  if (select === 'none') {
+    if (wasCrossBlock || !atBlockStart) {
+      applySelect(editor, at)
+    }
+    return
+  }
+
+  if (select === 'end') {
+    return
+  }
+
+  if (select === 'start' && firstInsertedKey && resolvedAtPath) {
+    const firstInsertedPath: Path = [
+      ...parentPath(resolvedAtPath),
+      'children',
+      {_key: firstInsertedKey},
+    ]
+    const startPoint = editorStart(editor, firstInsertedPath)
+    applySelect(editor, startPoint)
+  }
+}
+
+/**
+ * Delete the contents of an expanded range. Handles same-block and
+ * cross-block ranges. Leaves the editor selection collapsed at the range
+ * start.
+ */
+function deleteRange(editor: PortableTextSlateEditor, range: Range): void {
+  const [start, end] = rangeEdges(range, {}, editor)
+
+  const sameRootBlock =
+    isKeyedSegment(start.path[0]!) && isKeyedSegment(end.path[0]!)
+      ? start.path[0]!._key === end.path[0]!._key
+      : start.path[0] === end.path[0]
+
+  if (sameRootBlock) {
+    deleteSameBlockRange(editor, start, end)
+  } else {
+    deleteCrossBlockRange(editor, start, end)
+  }
+}
+
+/**
+ * Apply the appropriate selection after a block has been inserted at
+ * insertedBlockPath. For select === 'none', restores the selection that was
+ * active when the operation started.
+ */
+function applyPostInsertSelection(
+  editor: PortableTextSlateEditor,
+  insertedBlockPath: Path,
+  select: 'start' | 'end' | 'none',
+  selectionAtEntry: EditorSelection,
+): void {
+  if (select === 'none') {
+    if (selectionAtEntry) {
+      applySelect(editor, selectionAtEntry)
+      return
     }
 
-    const atAfterInsert = atBeforeInsert?.unref() ?? editor.selection
-
-    if (select === 'none' && atAfterInsert) {
+    if (editor.selection) {
       editor.apply({
         type: 'set_selection',
         properties: editor.selection,
-        newProperties: atAfterInsert,
+        newProperties: null,
       })
     }
-
-    // Check if we need to remove an empty text block that was left after insertion
-    if (!isTextBlock({schema: editor.schema}, block) && atAfterDelete) {
-      // If we inserted before (isAtStartOfBlock), check the block that was pushed down
-      // Otherwise, check the block before the insertion
-      const emptyBlockPath: Path = isAtStartOfBlock
-        ? [atAfterDelete.anchor.path[0]!]
-        : [atAfterDelete.anchor.path[0]!]
-      const potentiallyEmptyBlockEntry = getTextBlockNode(
-        editor,
-        emptyBlockPath,
-      )
-      if (
-        potentiallyEmptyBlockEntry &&
-        isEmptyTextBlock(context, potentiallyEmptyBlockEntry.node)
-      ) {
-        editor.apply({
-          type: 'unset',
-          path: potentiallyEmptyBlockEntry.path,
-        })
-      }
-    }
-
     return
   }
 
-  // Handle collapsed selection with block object insertion in the middle of a text block
-  if (
-    !isTextBlock({schema: editor.schema}, block) &&
-    isTextBlock({schema: editor.schema}, endBlock) &&
-    !isExpandedRange(at)
-  ) {
-    const selectionPoint = rangeStart(at, editor)
-    const blockPath: Path = [selectionPoint.path[0]!]
-    const blockStartPoint = editorStart(editor, blockPath)
-    const blockEndPoint = editorEnd(editor, blockPath)
-
-    // Check if we're in the middle of the block (not at start or end)
-    const isAtBlockStart = pointEquals(selectionPoint, blockStartPoint)
-    const isAtBlockEnd = pointEquals(selectionPoint, blockEndPoint)
-
-    if (!isAtBlockStart && !isAtBlockEnd) {
-      // We need to split the block at the selection point
-      const currentBlockEntry = getTextBlockNode(editor, blockPath)
-      if (!currentBlockEntry) {
-        return
-      }
-      // Find the child index and offset within that child
-      const childSegment = selectionPoint.path[2]
-      const childIndex = childSegment
-        ? resolveChildIndex(currentBlockEntry.node.children, childSegment)
-        : -1
-      const childOffset = selectionPoint.offset
-
-      // Split the text node at the offset if needed
-      if (childOffset > 0) {
-        const textNodeEntry = getSpanNode(editor, selectionPoint.path)
-        if (textNodeEntry) {
-          if (childOffset < textNodeEntry.node.text.length) {
-            applySplitNode(editor, selectionPoint.path, childOffset)
-          }
-        }
-      }
-
-      // Now split the block itself
-      const splitAtIndex = childOffset > 0 ? childIndex + 1 : childIndex
-      applySplitNode(editor, blockPath, splitAtIndex)
-
-      // Insert the block object between the two split blocks
-      const middleInsertOp: InsertOperation = {
-        type: 'insert',
-        path: blockPath,
-        node: block,
-        position: 'after',
-      }
-      editor.apply(middleInsertOp)
-
-      // Handle selection based on select parameter
-      if (select === 'none') {
-        // Restore selection to end of first block (where the user was typing)
-        const firstBlockEndPoint = editorEnd(editor, blockPath)
-        editor.apply({
-          type: 'set_selection',
-          properties: editor.selection,
-          newProperties: {
-            anchor: firstBlockEndPoint,
-            focus: firstBlockEndPoint,
-          },
-        })
-      } else if (select === 'start') {
-        const insertedBlockPath: Path = [{_key: middleInsertOp.node._key}]
-        const point = editorStart(editor, insertedBlockPath)
-        editor.apply({
-          type: 'set_selection',
-          properties: editor.selection,
-          newProperties: {anchor: point, focus: point},
-        })
-      } else if (select === 'end') {
-        const insertedBlockPath: Path = [{_key: middleInsertOp.node._key}]
-        const point = editorEnd(editor, insertedBlockPath)
-        editor.apply({
-          type: 'set_selection',
-          properties: editor.selection,
-          newProperties: {anchor: point, focus: point},
-        })
-      }
-
-      return
-    }
-  }
-
-  if (
-    isTextBlock({schema: editor.schema}, endBlock) &&
-    isTextBlock({schema: editor.schema}, block)
-  ) {
-    let selectionStartPoint = rangeStart(at, editor)
-    let wasCrossBlockDeletion = false
-
-    // If there's an expanded selection, delete it first
-    if (isExpandedRange(at)) {
-      const [start, end] = rangeEdges(at, {}, editor)
-      const isCrossBlock =
-        isKeyedSegment(start.path[0]!) && isKeyedSegment(end.path[0]!)
-          ? start.path[0]!._key !== end.path[0]!._key
-          : start.path[0] !== end.path[0]
-
-      deleteExpandedRange(editor, at)
-
-      // For cross-block deletion, set selection to the merge point
-      if (isCrossBlock) {
-        wasCrossBlockDeletion = true
-        const startBlockPath: Path = [start.path[0]!]
-        const mergedBlockEntry = getTextBlockNode(editor, startBlockPath)
-        if (mergedBlockEntry) {
-          // Find the merge position (where blocks were joined)
-          const mergePoint: Point = {
-            path: [...startBlockPath, 'children', start.path[2]!],
-            offset: start.offset,
-          }
-          setSelectionToPoint(editor, mergePoint)
-          // Update selectionStartPoint to the merge point for later use
-          selectionStartPoint = mergePoint
-        }
-      }
-
-      // After deletion, refetch the end block since paths may have changed
-      const lastIndex = editor.children.length - 1
-      const lastBlock = lastIndex >= 0 ? editor.children[lastIndex] : undefined
-      const newEndBlock = lastBlock
-      const newEndBlockPath: Path | undefined = lastBlock?._key
-        ? [{_key: lastBlock._key}]
-        : undefined
-
-      if (
-        newEndBlock &&
-        newEndBlockPath &&
-        (isTextBlock({schema: editor.schema}, newEndBlock) ||
-          isObjectNode({schema: editor.schema}, newEndBlock))
-      ) {
-        endBlock = newEndBlock
-        endBlockPath = newEndBlockPath
-      }
-    }
-
-    // After potential reassignment, verify endBlock is still a text block
-    if (!isTextBlock({schema: editor.schema}, endBlock)) {
-      return
-    }
-
-    if (isEmptyTextBlock(context, endBlock)) {
-      replaceEmptyTextBlock(editor, endBlockPath, block, select)
-      return
-    }
-
-    const endBlockChildKeys = endBlock.children.map((child) => child._key)
-    const endBlockMarkDefsKeys =
-      endBlock.markDefs?.map((markDef) => markDef._key) ?? []
-
-    // Assign new keys to markDefs with duplicate keys and keep track of
-    // the mapping between the old and new keys
-    const markDefKeyMap = new Map<string, string>()
-    const adjustedMarkDefs = block.markDefs?.map((markDef) => {
-      if (endBlockMarkDefsKeys.includes(markDef._key)) {
-        const newKey = context.keyGenerator()
-        markDefKeyMap.set(markDef._key, newKey)
-        return {
-          ...markDef,
-          _key: newKey,
-        }
-      }
-
-      return markDef
-    })
-
-    // Assign new keys to spans with duplicate keys and update any markDef
-    // key if needed
-    const adjustedChildren = block.children.map((child) => {
-      if (isSpan(context, child)) {
-        const marks =
-          child.marks?.map((mark) => {
-            const markDefKey = markDefKeyMap.get(mark)
-
-            if (markDefKey) {
-              return markDefKey
-            }
-
-            return mark
-          }) ?? []
-
-        if (!isEqualMarks(child.marks, marks)) {
-          return {
-            ...child,
-            _key: endBlockChildKeys.includes(child._key)
-              ? context.keyGenerator()
-              : child._key,
-            marks,
-          }
-        }
-      }
-
-      if (endBlockChildKeys.includes(child._key)) {
-        return {
-          ...child,
-          _key: context.keyGenerator(),
-        }
-      }
-
-      return child
-    })
-
-    // Carry over the markDefs from the incoming block to the end block
-    const endBlockNodeEntry = getTextBlockNode(editor, endBlockPath)
-
-    if (endBlockNodeEntry) {
-      setNodeProperties(
-        editor,
-        {
-          markDefs: [...(endBlock.markDefs ?? []), ...(adjustedMarkDefs ?? [])],
-        },
-        endBlockPath,
-      )
-    }
-
-    // If the children have changed, we need to create a new block with
-    // the adjusted children
-    const adjustedBlock = !isEqualChildren(
-      block.children,
-      adjustedChildren,
-      context.schema.span.name,
-    )
-      ? {
-          ...block,
-          children: adjustedChildren,
-        }
-      : block
-
-    if (select === 'end') {
-      const insertAt = editor.selection
-        ? rangeEnd(editor.selection)
-        : editorEnd(editor, endBlockPath)
-
-      insertTextBlockFragment(editor, adjustedBlock, insertAt)
-
-      return
-    }
-
-    // Use selectionStartPoint (updated after any deletion) instead of stale rangeStart(at, editor)
-    const firstInsertedKey = insertTextBlockFragment(
-      editor,
-      adjustedBlock,
-      selectionStartPoint,
-    )
-
-    if (select === 'start' && firstInsertedKey) {
-      const firstInsertedPath: Path = [
-        ...parentPath(selectionStartPoint.path),
-        'children',
-        {_key: firstInsertedKey},
-      ]
-      const point = editorStart(editor, firstInsertedPath)
-      setSelectionToPoint(editor, point)
-    } else if (select === 'none') {
-      // For cross-block deletion, always set to insertion point
-      // Otherwise, only set if not at block start (to keep cursor at end of inserted content)
-      if (wasCrossBlockDeletion) {
-        setSelectionToPoint(editor, selectionStartPoint)
-      } else {
-        const endBlockStartPoint = editorStart(editor, endBlockPath)
-        if (!pointEquals(selectionStartPoint, endBlockStartPoint)) {
-          setSelectionToPoint(editor, selectionStartPoint)
-        }
-      }
-    }
-    // For 'end', selection is already at the right place after insertTextBlockFragment
-  } else {
-    // Inserting block object (not text block) into an existing block
-    if (!isTextBlock({schema: editor.schema}, endBlock)) {
-      // End block is not a text block - just insert after it
-      insertNodeAt(editor, endBlockPath, block, select, 'after')
-      return
-    }
-
-    const endBlockStartPoint = editorStart(editor, endBlockPath)
-    const endBlockEndPoint = editorEnd(editor, endBlockPath)
-    const selectionStartPoint = rangeStart(at, editor)
-    const selectionEndPoint = rangeEnd(at, editor)
-
-    // Collapsed selection at start of block - insert before
-    if (
-      isCollapsedRange(at) &&
-      pointEquals(selectionStartPoint, endBlockStartPoint)
-    ) {
-      const insertBeforeOp: InsertOperation = {
-        type: 'insert',
-        path: endBlockPath,
-        node: block,
-        position: 'before',
-      }
-      editor.apply(insertBeforeOp)
-      if (isEmptyTextBlock(context, endBlock)) {
-        removeNodeAt(editor, endBlockPath)
-        if (select !== 'none') {
-          setSelection(editor, [{_key: insertBeforeOp.node._key}], 'start')
-        }
-      } else {
-        if (select !== 'none') {
-          setSelection(editor, endBlockPath, 'start')
-        }
-      }
-      return
-    }
-
-    // Collapsed selection at end of block - insert after
-    if (
-      isCollapsedRange(at) &&
-      pointEquals(selectionEndPoint, endBlockEndPoint)
-    ) {
-      const insertAfterOp: InsertOperation = {
-        type: 'insert',
-        path: endBlockPath,
-        node: block,
-        position: 'after',
-      }
-      editor.apply(insertAfterOp)
-      if (select !== 'none') {
-        setSelection(editor, [{_key: insertAfterOp.node._key}], 'start')
-      }
-      return
-    }
-    // General case: selection in the middle of the block
-    const focusChildSegment = editor.selection?.focus.path.at(2)
-    const focusBlockPath = editor.selection?.focus.path.slice(0, 1)
-    const focusChild =
-      focusChildSegment !== undefined && focusBlockPath
-        ? getChildren(editor, focusBlockPath).find(
-            (entry) =>
-              isKeyedSegment(focusChildSegment) &&
-              entry.node._key === focusChildSegment._key,
-          )?.node
-        : undefined
-
-    if (focusChild && isSpan({schema: editor.schema}, focusChild)) {
-      const startPoint = rangeStart(at, editor)
-
-      if (isTextBlock({schema: editor.schema}, block)) {
-        // Inserting text block: split the text node and insert fragment
-        const nodeToSplitEntry = getSpanNode(editor, startPoint.path)
-        if (nodeToSplitEntry) {
-          applySplitNode(editor, startPoint.path, startPoint.offset)
-        }
-
-        insertTextBlockFragment(editor, block, startPoint)
-
-        if (select === 'none') {
-          setSelectionToRange(editor, at)
-        } else {
-          const nextBlock = getSibling(editor, endBlockPath, 'next')
-          if (nextBlock) {
-            setSelection(editor, nextBlock.path, 'start')
-          }
-        }
-      } else {
-        // Inserting block object: split the entire block and insert between
-        // First split all ancestor nodes up to the block level
-        let currentPath = startPoint.path
-        let currentOffset = startPoint.offset
-
-        // Create a point ref to track where the cursor should be after operations
-        const cursorPositionRef = pointRef(editor, startPoint, {
-          affinity: 'backward',
-        })
-
-        // Create a path ref to track the first block's path as it changes
-        const blockPath: Path = [currentPath[0]!]
-        const firstBlockPathRef = pathRef(editor, blockPath)
-
-        // Split text node first
-        const textNodeEntry = getSpanNode(editor, currentPath)
-        if (
-          textNodeEntry &&
-          currentOffset > 0 &&
-          currentOffset < textNodeEntry.node.text.length
-        ) {
-          applySplitNode(editor, currentPath, currentOffset)
-          const nextSpan = getSibling(editor, currentPath, 'next')
-          if (nextSpan) {
-            currentPath = nextSpan.path
-          }
-          currentOffset = 0
-        }
-
-        // Split the block, preserving block properties
-        const blockToSplitEntry = getTextBlockNode(editor, blockPath)
-        const currentChildSegment = currentPath[2]
-        const currentChildIndex =
-          blockToSplitEntry && currentChildSegment
-            ? resolveChildIndex(
-                blockToSplitEntry.node.children,
-                currentChildSegment,
-              )
-            : -1
-        const splitAtIndex =
-          currentOffset > 0 ? currentChildIndex + 1 : currentChildIndex
-
-        if (
-          blockToSplitEntry &&
-          splitAtIndex >= 0 &&
-          splitAtIndex < blockToSplitEntry.node.children.length
-        ) {
-          // Get the properties to preserve in the split
-          applySplitNode(editor, blockPath, splitAtIndex)
-        }
-
-        // Get the current path of the first block after splits
-        const currentFirstBlockPath = firstBlockPathRef.unref()
-
-        // Insert block object between the split blocks
-        const insertAfterPath: Path = currentFirstBlockPath ?? blockPath
-        const splitInsertOp: InsertOperation = {
-          type: 'insert',
-          path: insertAfterPath,
-          node: block,
-          position: 'after',
-        }
-        editor.apply(splitInsertOp)
-
-        if (select === 'start' || select === 'end') {
-          const insertedBlockPath: Path = [{_key: splitInsertOp.node._key}]
-          const point = editorStart(editor, insertedBlockPath)
-          editor.apply({
-            type: 'set_selection',
-            properties: editor.selection,
-            newProperties: {anchor: point, focus: point},
-          })
-        } else {
-          // For select: 'none', use the cursor position ref which tracks through operations
-          const point = cursorPositionRef.unref()
-          if (point) {
-            editor.apply({
-              type: 'set_selection',
-              properties: editor.selection,
-              newProperties: {anchor: point, focus: point},
-            })
-          }
-        }
-      }
-    } else {
-      // Not on a text span - just insert after
-      const insertAfterOp: InsertOperation = {
-        type: 'insert',
-        path: endBlockPath,
-        node: block,
-        position: 'after',
-      }
-      editor.apply(insertAfterOp)
-      const insertedBlockPath: Path = [{_key: insertAfterOp.node._key}]
-      if (select === 'none') {
-        setSelectionToRange(editor, at)
-      } else {
-        setSelection(editor, insertedBlockPath, select)
-      }
-    }
-  }
-}
-
-/**
- * Sets the editor selection to a point at the given path.
- * @param position - 'start' sets to beginning, 'end' sets to end of the path
- */
-function setSelection(
-  editor: PortableTextSlateEditor,
-  path: Path,
-  position: 'start' | 'end',
-) {
-  const point =
-    position === 'start' ? editorStart(editor, path) : editorEnd(editor, path)
-  editor.apply({
-    type: 'set_selection',
-    properties: editor.selection,
-    newProperties: {anchor: point, focus: point},
-  })
-}
-
-/**
- * Clears the current selection (sets it to null).
- */
-function clearSelection(editor: PortableTextSlateEditor) {
-  if (editor.selection) {
-    editor.apply({
-      type: 'set_selection',
-      properties: editor.selection,
-      newProperties: null,
-    })
-  }
-}
-
-/**
- * Sets the selection to a specific point.
- */
-function setSelectionToPoint(editor: PortableTextSlateEditor, point: Point) {
-  editor.apply({
-    type: 'set_selection',
-    properties: editor.selection,
-    newProperties: {anchor: point, focus: point},
-  })
-}
-
-/**
- * Sets the selection to a specific range.
- */
-function setSelectionToRange(editor: PortableTextSlateEditor, range: Range) {
-  editor.apply({
-    type: 'set_selection',
-    properties: editor.selection,
-    newProperties: range,
-  })
-}
-
-/**
- * Inserts a node at the given path and optionally sets selection.
- */
-function insertNodeAt(
-  editor: PortableTextSlateEditor,
-  path: Path,
-  node: Node,
-  select: 'start' | 'end' | 'none',
-  position: 'before' | 'after' = 'before',
-) {
-  const op: InsertOperation = {type: 'insert', path, node, position}
-  editor.apply(op)
-  // Use op.node._key because apply-operation may have re-keyed the node
-  // to resolve duplicate keys
-  const insertedPath: Path = [{_key: op.node._key}]
-  if (select !== 'none') {
-    setSelection(editor, insertedPath, select)
-  }
-}
-
-/**
- * Removes a node at the given path.
- */
-function removeNodeAt(editor: PortableTextSlateEditor, path: Path) {
-  const nodeEntry = getNode(editor, path)
-
-  if (!nodeEntry) {
-    return
-  }
-
-  const {path: nodePath} = nodeEntry
-  editor.apply({
-    type: 'unset',
-    path: nodePath,
-  })
-}
-
-/**
- * Replaces an empty text block with a new block and handles selection.
- */
-function replaceEmptyTextBlock(
-  editor: PortableTextSlateEditor,
-  blockPath: Path,
-  newBlock: Node,
-  select: 'start' | 'end' | 'none',
-) {
-  const hadSelection = editor.selection !== null
-
-  const op: InsertOperation = {
-    type: 'insert',
-    path: blockPath,
-    node: newBlock,
-    position: 'before',
-  }
-  editor.apply(op)
-  removeNodeAt(editor, blockPath)
-
-  if (select === 'none' && !hadSelection) {
-    return
-  }
-
-  const newBlockPath: Path = [{_key: op.node._key}]
   const point =
     select === 'end'
-      ? editorEnd(editor, newBlockPath)
-      : editorStart(editor, newBlockPath)
+      ? editorEnd(editor, insertedBlockPath)
+      : editorStart(editor, insertedBlockPath)
 
-  clearSelection(editor)
-  editor.apply({
-    type: 'set_selection',
-    properties: null,
-    newProperties: {anchor: point, focus: point},
-  })
+  applySelect(editor, point)
+}
+
+// ---------------------------------------------------------------------------
+// delete-then-insert: delete the range, re-resolve, recurse into dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete an expanded range, re-resolve the insertion target against the
+ * post-delete (collapsed) state, then recurse into the dispatcher. The
+ * cross-block status of the original range is threaded through so that the
+ * fragment pseudo-behavior can restore the caret correctly.
+ */
+function executeDeleteThenInsert(args: {
+  editor: PortableTextSlateEditor
+  context: OperationContext
+  block: Node
+  range: Range
+  select: 'start' | 'end' | 'none'
+  selectionAtEntry: EditorSelection
+}): void {
+  const {editor, context, block, range, select, selectionAtEntry} = args
+
+  const rangeStartPoint = rangeStart(range, editor)
+  const rangeEndPoint = rangeEnd(range, editor)
+
+  const startBlockEntry = findContainingBlock(editor, rangeStartPoint.path)
+  const endBlockEntry = findContainingBlock(editor, rangeEndPoint.path)
+  const wasCrossBlock =
+    startBlockEntry !== undefined &&
+    endBlockEntry !== undefined &&
+    !pathEquals(startBlockEntry.path, endBlockEntry.path)
+
+  const startBlockPath = startBlockEntry?.path
+  const startOfStartBlock = startBlockPath
+    ? editorStart(editor, startBlockPath)
+    : undefined
+  const isAtStartOfBlock = startOfStartBlock
+    ? pointEquals(rangeStartPoint, startOfStartBlock)
+    : false
+
+  const collapsedRangeRef = rangeRef(editor, range, {affinity: 'inward'})
+
+  deleteRange(editor, range)
+
+  const collapsedRange = collapsedRangeRef.unref() ?? editor.selection
+  const collapsedPoint = collapsedRange
+    ? rangeStart(collapsedRange, editor)
+    : undefined
+
+  if (!collapsedPoint) {
+    return
+  }
+
+  const resolvedBlock = getAncestorTextBlock(editor, collapsedPoint.path)
+  const blockIsText = isTextBlock({schema: editor.schema}, block)
+
+  // For `select: 'none'`, the desired restored selection is the collapsed
+  // post-delete range (not the original expanded range). Track it through
+  // the subsequent insert so paths/offsets remain valid.
+  const postDeleteSelection: EditorSelection =
+    select === 'none' ? collapsedRange : selectionAtEntry
+
+  if (blockIsText && resolvedBlock) {
+    // Only treat the block as "empty target to replace" when the range was
+    // within a single block (i.e. the delete emptied it). Cross-block
+    // deletes always merge into a fragment even if the result looks empty
+    // at this instant.
+    if (!wasCrossBlock && isEmptyTextBlock(context, resolvedBlock.node)) {
+      dispatchInsert({
+        editor,
+        context,
+        block,
+        target: {kind: 'replace', blockPath: resolvedBlock.path},
+        select,
+        selectionAtEntry: postDeleteSelection,
+      })
+      return
+    }
+
+    dispatchInsert({
+      editor,
+      context,
+      block,
+      target: {
+        kind: 'fragment',
+        at: collapsedPoint,
+        endBlockPath: resolvedBlock.path,
+      },
+      select,
+      selectionAtEntry: postDeleteSelection,
+      wasCrossBlock,
+    })
+    return
+  }
+
+  const containingBlockEntry =
+    resolvedBlock ?? findContainingBlock(editor, collapsedPoint.path)
+
+  if (!containingBlockEntry) {
+    return
+  }
+
+  const insertedPath = insertSiblingBlock(
+    editor,
+    block,
+    containingBlockEntry.path,
+    isAtStartOfBlock ? 'before' : 'after',
+  )
+
+  applyPostInsertSelection(editor, insertedPath, select, postDeleteSelection)
+
+  // If inserting an object block next to a text block that is now empty,
+  // remove the empty text block.
+  if (!blockIsText) {
+    removeAdjacentEmptyTextBlock({
+      editor,
+      context,
+      insertedPath,
+    })
+  }
 }
 
 /**
- * Deletes content within a single block (same block deletion).
+ * After inserting a non-text block, remove the adjacent empty text block
+ * if one is left behind.
  */
+function removeAdjacentEmptyTextBlock(args: {
+  editor: PortableTextSlateEditor
+  context: OperationContext
+  insertedPath: Path
+}): void {
+  const {editor, context, insertedPath} = args
+
+  for (const direction of ['next', 'previous'] as const) {
+    const sibling = getSibling(editor, insertedPath, direction)
+    if (sibling && isEmptyTextBlock(context, sibling.node)) {
+      editor.apply({type: 'unset', path: sibling.path})
+      return
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a path segment (keyed or numeric) to a child index within a
+ * parent's children array. Returns -1 if the segment cannot be resolved.
+ */
+function resolveChildIndex(
+  children: Array<{_key: string}>,
+  segment: unknown,
+): number {
+  if (typeof segment === 'number') {
+    return segment
+  }
+  if (isKeyedSegment(segment)) {
+    return children.findIndex((child) => child._key === segment._key)
+  }
+  return -1
+}
+
+/**
+ * Reassign keys on spans, inline objects and markDefs that collide with the
+ * end block's existing keys. Returns the adjusted block and the adjusted
+ * markDefs (to be merged into the end block).
+ */
+function adjustFragmentKeys(args: {
+  context: OperationContext
+  block: Node
+  endBlock: Node
+}): {adjustedBlock: Node; adjustedMarkDefs: Array<{_key: string}> | undefined} {
+  const {context, block, endBlock} = args
+
+  if (!isTextBlock({schema: context.schema}, block)) {
+    return {adjustedBlock: block, adjustedMarkDefs: undefined}
+  }
+
+  if (!isTextBlock({schema: context.schema}, endBlock)) {
+    return {adjustedBlock: block, adjustedMarkDefs: block.markDefs}
+  }
+
+  const endBlockChildKeys = endBlock.children.map((child) => child._key)
+  const endBlockMarkDefsKeys =
+    endBlock.markDefs?.map((markDef) => markDef._key) ?? []
+
+  const markDefKeyMap = new Map<string, string>()
+  const adjustedMarkDefs = block.markDefs?.map((markDef) => {
+    if (endBlockMarkDefsKeys.includes(markDef._key)) {
+      const newKey = context.keyGenerator()
+      markDefKeyMap.set(markDef._key, newKey)
+      return {...markDef, _key: newKey}
+    }
+    return markDef
+  })
+
+  const adjustedChildren = block.children.map((child) => {
+    if (isSpan(context, child)) {
+      const marks =
+        child.marks?.map((mark) => markDefKeyMap.get(mark) ?? mark) ?? []
+
+      if (!isEqualMarks(child.marks, marks)) {
+        return {
+          ...child,
+          _key: endBlockChildKeys.includes(child._key)
+            ? context.keyGenerator()
+            : child._key,
+          marks,
+        }
+      }
+    }
+
+    if (endBlockChildKeys.includes(child._key)) {
+      return {...child, _key: context.keyGenerator()}
+    }
+
+    return child
+  })
+
+  const adjustedBlock = !isEqualChildren(
+    block.children,
+    adjustedChildren,
+    context.schema.span.name,
+  )
+    ? {...block, children: adjustedChildren}
+    : block
+
+  return {adjustedBlock, adjustedMarkDefs}
+}
+
+/**
+ * Insert a text block's children at a point within another text block.
+ * Prepending a single span at offset 0 uses insert_text so React's DOM
+ * selection stays valid through deferred normalization.
+ */
+function insertFragmentChildren(
+  editor: PortableTextSlateEditor,
+  block: Node,
+  at: Point,
+): string | undefined {
+  if (!isTextBlock({schema: editor.schema}, block)) {
+    return undefined
+  }
+
+  if (at.offset > 0) {
+    const textNodeEntry = getSpanNode(editor, at.path)
+
+    if (textNodeEntry) {
+      applySplitNode(editor, at.path, at.offset)
+    }
+  }
+
+  const parent = parentPath(at.path)
+  let firstInsertedKey: string | undefined
+
+  if (at.offset === 0 && block.children.length === 1) {
+    const firstChild = block.children[0]!
+    const existingEntry = getSpanNode(editor, at.path)
+
+    if (existingEntry && isSpan({schema: editor.schema}, firstChild)) {
+      if (firstChild.text.length > 0) {
+        editor.apply({
+          type: 'insert_text',
+          path: at.path,
+          offset: 0,
+          text: firstChild.text,
+        })
+      }
+      return existingEntry.node._key
+    }
+  }
+
+  let insertAfterPath = at.path
+
+  for (const child of block.children) {
+    const operation: InsertOperation = {
+      type: 'insert',
+      path: insertAfterPath,
+      node: child,
+      position:
+        at.offset > 0 || child !== block.children[0] ? 'after' : 'before',
+    }
+    editor.apply(operation)
+    insertAfterPath = [...parent, 'children', {_key: operation.node._key}]
+    if (firstInsertedKey === undefined) {
+      firstInsertedKey = operation.node._key
+    }
+  }
+
+  return firstInsertedKey
+}
+
+// ---------------------------------------------------------------------------
+// Range-delete helpers (depth-2 assumptions; kept as-is, out of scope for
+// this refactor).
+// ---------------------------------------------------------------------------
+
 function deleteSameBlockRange(
   editor: PortableTextSlateEditor,
   start: Point,
@@ -852,7 +828,6 @@ function deleteSameBlockRange(
   const blockPath: Path = [start.path[0]!]
 
   if (pathEquals(start.path, end.path)) {
-    // Same text node - simple text removal
     const textEntry = getSpanNode(editor, start.path)
     if (!textEntry) {
       return
@@ -867,8 +842,6 @@ function deleteSameBlockRange(
     return
   }
 
-  // Different nodes in same block
-  // Remove from start node to end
   const startNodeEntry = getSpanNode(editor, start.path)
   if (startNodeEntry && start.offset < startNodeEntry.node.text.length) {
     const textToRemove = startNodeEntry.node.text.slice(start.offset)
@@ -880,7 +853,6 @@ function deleteSameBlockRange(
     })
   }
 
-  // Remove nodes between start and end
   const blockEntry = getTextBlockNode(editor, blockPath)
   if (blockEntry) {
     const startChildIndex = resolveChildIndex(
@@ -900,7 +872,6 @@ function deleteSameBlockRange(
     }
   }
 
-  // Remove from beginning of end node
   const endNodeSibling = getSibling(editor, start.path, 'next')
   const newEndPath: Path = endNodeSibling ? endNodeSibling.path : start.path
   const endNodeEntry = getSpanNode(editor, newEndPath)
@@ -914,7 +885,6 @@ function deleteSameBlockRange(
     })
   }
 
-  // Merge adjacent text nodes
   const startNodeAfterEntry = getSpanNode(editor, start.path)
   const endNodeAfterEntry = getSpanNode(editor, newEndPath)
   if (startNodeAfterEntry && endNodeAfterEntry) {
@@ -922,10 +892,6 @@ function deleteSameBlockRange(
   }
 }
 
-/**
- * Deletes content across multiple blocks (cross-block deletion).
- * Handles removal and merging of blocks.
- */
 function deleteCrossBlockRange(
   editor: PortableTextSlateEditor,
   start: Point,
@@ -933,7 +899,6 @@ function deleteCrossBlockRange(
 ) {
   const startBlockPath: Path = [start.path[0]!]
 
-  // Remove from start position to end of start block
   if (start.path.length > 1) {
     const startNodeEntry = getSpanNode(editor, start.path)
     if (startNodeEntry && start.offset < startNodeEntry.node.text.length) {
@@ -946,7 +911,6 @@ function deleteCrossBlockRange(
       })
     }
 
-    // Remove remaining nodes in start block
     const startBlockEntry = getTextBlockNode(editor, startBlockPath)
     if (startBlockEntry) {
       const startChildIndex = resolveChildIndex(
@@ -967,7 +931,6 @@ function deleteCrossBlockRange(
     }
   }
 
-  // Remove all blocks between start and end
   const startBlockKey = isKeyedSegment(start.path[0]!)
     ? start.path[0]!._key
     : undefined
@@ -982,13 +945,11 @@ function deleteCrossBlockRange(
     }
   }
 
-  // Remove from beginning of end block to end position
   const endBlockSibling = getSibling(editor, startBlockPath, 'next')
   const adjustedEndBlockPath: Path = endBlockSibling
     ? endBlockSibling.path
     : startBlockPath
   if (end.path.length > 1) {
-    // Remove nodes before end position
     const endBlockNodeEntry = getTextBlockNode(editor, adjustedEndBlockPath)
     if (endBlockNodeEntry) {
       const endChildIndex = resolveChildIndex(
@@ -1008,7 +969,6 @@ function deleteCrossBlockRange(
       }
     }
 
-    // Remove text from end node
     const endBlockRefetched = getTextBlockNode(editor, adjustedEndBlockPath)
     const firstChild = endBlockRefetched?.node.children[0]
     const endNodePath = firstChild
@@ -1026,126 +986,38 @@ function deleteCrossBlockRange(
     }
   }
 
-  // Merge the blocks if both are text blocks
   const startBlockEntry = getTextBlockNode(editor, startBlockPath)
   const endBlockEntry = getTextBlockNode(editor, adjustedEndBlockPath)
   if (startBlockEntry && endBlockEntry) {
     const startBlockNode = startBlockEntry.node
     const endBlockNode = endBlockEntry.node
-    // Wrap in withoutNormalizing so normalization doesn't strip the copied
-    // markDefs before the merge moves the children that reference them.
-    withoutNormalizing(editor, () => {
-      if (
-        Array.isArray(endBlockNode.markDefs) &&
-        endBlockNode.markDefs.length > 0
-      ) {
-        const oldDefs =
-          (Array.isArray(startBlockNode.markDefs) && startBlockNode.markDefs) ||
-          []
-        const newMarkDefs = [
-          ...new Map(
-            [...oldDefs, ...endBlockNode.markDefs].map((def) => [
-              def._key,
-              def,
-            ]),
-          ).values(),
-        ]
-        setNodeProperties(editor, {markDefs: newMarkDefs}, startBlockPath)
-      }
-      applyMergeNode(
-        editor,
-        adjustedEndBlockPath,
-        startBlockNode.children.length,
-      )
-    })
+    if (
+      Array.isArray(endBlockNode.markDefs) &&
+      endBlockNode.markDefs.length > 0
+    ) {
+      const oldDefs =
+        (Array.isArray(startBlockNode.markDefs) && startBlockNode.markDefs) ||
+        []
+      const newMarkDefs = [
+        ...new Map(
+          [...oldDefs, ...endBlockNode.markDefs].map((def) => [def._key, def]),
+        ).values(),
+      ]
+      setNodeProperties(editor, {markDefs: newMarkDefs}, startBlockPath)
+    }
+    applyMergeNode(editor, adjustedEndBlockPath, startBlockNode.children.length)
   }
 }
 
-/**
- * Deletes an expanded range, handling both same-block and cross-block cases.
- */
-function deleteExpandedRange(
-  editor: PortableTextSlateEditor,
-  range: Range,
-): void {
-  const [start, end] = rangeEdges(range, {}, editor)
+function removeNodeAt(editor: PortableTextSlateEditor, path: Path) {
+  const nodeEntry = getNode(editor, path)
 
-  if (
-    isKeyedSegment(start.path[0]!) && isKeyedSegment(end.path[0]!)
-      ? start.path[0]!._key === end.path[0]!._key
-      : start.path[0] === end.path[0]
-  ) {
-    deleteSameBlockRange(editor, start, end)
-  } else {
-    deleteCrossBlockRange(editor, start, end)
-  }
-}
-
-/**
- * Inserts a text block's children at a point within another text block.
- */
-function insertTextBlockFragment(
-  editor: PortableTextSlateEditor,
-  block: Node,
-  at: Point,
-): string | undefined {
-  if (!isTextBlock({schema: editor.schema}, block)) {
-    return undefined
+  if (!nodeEntry) {
+    return
   }
 
-  // Split the text node at the insertion point if needed
-  if (at.offset > 0) {
-    const textNodeEntry = getSpanNode(editor, at.path)
-
-    if (textNodeEntry) {
-      applySplitNode(editor, at.path, at.offset)
-    }
-  }
-
-  const parent = parentPath(at.path)
-  let firstInsertedKey: string | undefined
-
-  // When inserting a single child at offset 0, prepend its text into the
-  // existing span using insert_text instead of insert. This avoids
-  // creating a new DOM element that React hasn't rendered yet, which would
-  // cause the DOM selection to become stale during deferred normalization.
-  // Only safe with a single child because multiple children need to go
-  // BEFORE the existing span, and insert_text can't reorder spans.
-  if (at.offset === 0 && block.children.length === 1) {
-    const firstChild = block.children[0]!
-    const existingEntry = getSpanNode(editor, at.path)
-
-    if (existingEntry && isSpan({schema: editor.schema}, firstChild)) {
-      if (firstChild.text.length > 0) {
-        editor.apply({
-          type: 'insert_text',
-          path: at.path,
-          offset: 0,
-          text: firstChild.text,
-        })
-      }
-      return existingEntry.node._key
-    }
-  }
-
-  // Fallback: insert each child as a node (used when offset > 0 or
-  // when the first child can't be merged into the existing span)
-  let insertAfterPath = at.path
-
-  for (const child of block.children) {
-    const op: InsertOperation = {
-      type: 'insert',
-      path: insertAfterPath,
-      node: child,
-      position:
-        at.offset > 0 || child !== block.children[0] ? 'after' : 'before',
-    }
-    editor.apply(op)
-    insertAfterPath = [...parent, 'children', {_key: op.node._key}]
-    if (firstInsertedKey === undefined) {
-      firstInsertedKey = op.node._key
-    }
-  }
-
-  return firstInsertedKey
+  editor.apply({
+    type: 'unset',
+    path: nodeEntry.path,
+  })
 }

--- a/packages/editor/tests/container-insert-block.test.tsx
+++ b/packages/editor/tests/container-insert-block.test.tsx
@@ -1,0 +1,506 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const calloutContainer = [
+  defineContainer({
+    scope: '$..callout',
+    field: 'content',
+    render: ({children}) => <>{children}</>,
+  }),
+]
+
+describe('insert.block inside a container', () => {
+  test('placement: after — inserts a sibling block AFTER the focused block inside the container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainer} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'world'}],
+      },
+      placement: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [{_type: 'span', _key: 'k6', text: 'world', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('placement: before — inserts a sibling block BEFORE the focused block inside the container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainer} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'before'}],
+      },
+      placement: 'before',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [
+                {_type: 'span', _key: 'k6', text: 'before', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('placement: auto, collapsed caret at end of block — merges the inserted text block fragment into the existing one', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainer} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'world'}],
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanKey,
+                  text: 'helloworld',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('placement: auto, empty target block — replaces the empty block inside the container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainer} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'filled'}],
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [
+                {_type: 'span', _key: 'k6', text: 'filled', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('placement: auto, collapsed caret in middle of text block — splits block and inserts block object between', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image'},
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}, {type: 'image'}],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanKey,
+                  text: 'helloworld',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={calloutContainer} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: innerBlockKey},
+            'children',
+            {_key: innerSpanKey},
+          ],
+          offset: 5,
+        },
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'image',
+      },
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'hello', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'image',
+              _key: 'k5',
+            },
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k6', text: 'world', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Containers are coming, and `insert.block` was the biggest remaining block-level operation that assumed everything lives at depth 2. Forty-some sites reconstructed block paths as `[path[0]]` or `[{_key: X}]` from root, iterated `editor.children[i]` directly, and pulled child segments out of `point.path[2]`. As soon as a block lived inside a container like a callout or a table cell, none of that worked: selections came back null, inserts landed in the wrong place, fragments merged into the wrong target.

The rewrite reshapes the operation around two ideas.

First, the operation decides *what to do* before it does anything. `resolveTarget` is a pure function that takes the editor, the block being inserted, the `at` selection, and the `placement` mode, and returns one of seven `InsertTarget` descriptors: `empty-editor`, `before`, `after`, `replace`, `split-insert`, `fragment`, or `delete-then-insert`. No mutation, no ambiguity, no branching inside the execution phase on things the resolver could have answered.

Second, each target kind executes as a named pseudo-behavior. These are small functions shaped the way a real behavior would be shaped: they take `(editor, ...)` and emit primitive events (`insert`, `insert_text`, `remove_text`, `set`, `unset`, `set_selection`). The full set is `insertBlockIntoEmptyEditor`, `insertSiblingBlock`, `replaceBlock`, `splitBlockAndInsert`, `mergeTextBlockFragment`, `deleteRange`, and `applyPostInsertSelection`. The dispatcher is a switch over the target kind that calls the right one. Delete-then-insert composes `deleteRange` with a recursive dispatch call on the target re-resolved from the post-delete state.

Every path now travels through keyed paths produced by `findContainingBlock`, which walks up from a point's path and returns the enclosing block entry at whatever depth it lives. No more `[path[0]]` reconstruction. Composition uses the same traversal utilities the rest of the editor uses: `getAncestorTextBlock`, `getBlock`, `getChildren`, `parentPath`, `getSibling`.

The shape is deliberate setup for a later move. `insert.block` and most of the other `operations/*` files predate primitive events. They hand-rolled tree mutation in one big implementation because that was the only vocabulary at the time. Now that primitives exist, this operation is no longer a primitive wrapper: it's a classifier plus a fixed set of primitive compositions. The next step, for a follow-up PR, is to move those compositions into the behavior pipeline and delete the operation entry point entirely. This PR stops short of that move so the depth-agnostic fix can land on its own.

The range-delete helpers at the bottom of the file (`deleteSameBlockRange`, `deleteCrossBlockRange`) are kept as-is. They have their own depth-2 assumptions and are reachable only through the named `deleteRange` pseudo-behavior now, so they're a self-contained follow-up rather than scope creep here.

Five new browser tests in `tests/container-insert-block.test.tsx` exercise `insert.block` inside a `callout` container with a `content` array field. They cover placement `before`, `after`, `auto` at block end (which merges into the existing block as a fragment), `auto` on an empty block (which replaces), and `auto` in the middle of a text block (which splits and inserts between).
