### PR TITLE
fix: add `ContainerScope` and `LeafScope` type utilities for JSONPath-grammar scopes

### DIFF
--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -93,12 +93,12 @@ export function createInternalEditor(config: EditorConfig): {
     registerContainer: (config) => {
       editorActor.send({
         type: 'register container',
-        containerConfig: config,
+        container: config.container,
       })
       return () => {
         editorActor.send({
           type: 'unregister container',
-          containerConfig: config,
+          container: config.container,
         })
       }
     },

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -19,8 +19,13 @@ import type {Converter} from '../converters/converter.types'
 import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
-import type {ContainerConfig} from '../renderers/renderer.types'
-import {resolveContainers} from '../schema/resolve-containers'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {
+  resolveContainerField,
+  resolveContainers,
+  type Containers,
+} from '../schema/resolve-containers'
+import {parseScope} from '../scope/parse-scope'
 import {DOMEditor} from '../slate/dom/plugin/dom-editor'
 import {normalize} from '../slate/editor/normalize'
 import type {NamespaceEvent, OmitFromUnion} from '../type-utils'
@@ -35,6 +40,22 @@ import type {
 } from './relay-machine'
 
 export * from 'xstate/guards'
+
+/**
+ * Extract the set of registered container configs from a resolved
+ * `containers` map. A single config may match multiple candidate chains
+ * (appearing in multiple `containers` entries); this produces one entry
+ * per distinct scope string.
+ */
+function collectRegisteredConfigs(
+  containers: Containers,
+): Map<string, ContainerConfig> {
+  const configs = new Map<string, ContainerConfig>()
+  for (const config of containers.values()) {
+    configs.set(config.container.scope, config)
+  }
+  return configs
+}
 
 /**
  * @public
@@ -117,11 +138,11 @@ type InternalEditorEvent =
   | {type: 'drop'}
   | {
       type: 'register container'
-      containerConfig: ContainerConfig
+      container: Container
     }
   | {
       type: 'unregister container'
-      containerConfig: ContainerConfig
+      container: Container
     }
   | {type: 'add slate editor'; editor: PortableTextSlateEditor}
 
@@ -176,19 +197,6 @@ export function rerouteExternalBehaviorEvent({
   }
 }
 
-function syncContainers(context: {
-  schema: EditorSchema
-  containerConfigs: Map<string, ContainerConfig>
-  slateEditor?: PortableTextSlateEditor
-}) {
-  const containers = resolveContainers(context.schema, context.containerConfigs)
-  if (context.slateEditor) {
-    context.slateEditor.containers = containers
-    normalize(context.slateEditor, {force: true})
-    context.slateEditor.onChange()
-  }
-}
-
 /**
  * @internal
  */
@@ -197,7 +205,7 @@ export const editorMachine = setup({
     context: {} as {
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
-      containerConfigs: Map<string, ContainerConfig>
+      containers: Containers
       converters: Set<Converter>
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
@@ -248,28 +256,65 @@ export const editorMachine = setup({
           : context.slateEditor
       },
     }),
-    'register container': assign({
-      containerConfigs: ({context, event}) => {
-        assertEvent(event, 'register container')
-        const containerConfigs = new Map(context.containerConfigs)
-        containerConfigs.set(
-          event.containerConfig.container.scope,
-          event.containerConfig,
+    'register container': assign(({context, event}) => {
+      assertEvent(event, 'register container')
+      const parsedScope = parseScope(event.container.scope)
+      if (!parsedScope) {
+        console.warn(
+          `registerContainer: invalid scope "${event.container.scope}". Container not registered.`,
         )
-        return containerConfigs
-      },
+        return {}
+      }
+      const field = resolveContainerField(
+        context.schema,
+        event.container.scope,
+        event.container.field,
+      )
+      if (!field) {
+        console.warn(
+          `registerContainer: field "${event.container.field}" not found on terminal type of scope "${event.container.scope}". Container not registered.`,
+        )
+        return {}
+      }
+      const containerConfig: ContainerConfig = {
+        container: event.container,
+        parsedScope,
+        field,
+      }
+      const nextConfigs = collectRegisteredConfigs(context.containers)
+      nextConfigs.set(event.container.scope, containerConfig)
+      const containers = resolveContainers(context.schema, nextConfigs)
+      if (context.slateEditor) {
+        context.slateEditor.containers = containers
+        normalize(context.slateEditor, {force: true})
+        context.slateEditor.onChange()
+      }
+      return {containers}
     }),
-    'unregister container': assign({
-      containerConfigs: ({context, event}) => {
-        assertEvent(event, 'unregister container')
-        const containerConfigs = new Map(context.containerConfigs)
-        containerConfigs.delete(event.containerConfig.container.scope)
-        return containerConfigs
-      },
+    'unregister container': assign(({context, event}) => {
+      assertEvent(event, 'unregister container')
+      const nextConfigs = collectRegisteredConfigs(context.containers)
+      nextConfigs.delete(event.container.scope)
+      const containers = resolveContainers(context.schema, nextConfigs)
+      if (context.slateEditor) {
+        context.slateEditor.containers = containers
+        normalize(context.slateEditor, {force: true})
+        context.slateEditor.onChange()
+      }
+      return {containers}
     }),
-    'sync containers': ({context}) => {
-      syncContainers(context)
-    },
+    'sync containers': assign(({context}) => {
+      const containers = resolveContainers(
+        context.schema,
+        collectRegisteredConfigs(context.containers),
+      )
+      if (context.slateEditor) {
+        context.slateEditor.containers = containers
+        normalize(context.slateEditor, {force: true})
+        context.slateEditor.onChange()
+      }
+      return {containers}
+    }),
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')
       return event
@@ -445,7 +490,7 @@ export const editorMachine = setup({
   context: ({input}) => ({
     behaviors: new Set(coreBehaviorsConfig),
     behaviorsSorted: false,
-    containerConfigs: new Map(),
+    containers: new Map(),
     converters: new Set(input.converters ?? []),
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
@@ -462,10 +507,10 @@ export const editorMachine = setup({
       actions: ['add slate editor to context', 'sync containers'],
     },
     'register container': {
-      actions: ['register container', 'sync containers'],
+      actions: ['register container'],
     },
     'unregister container': {
-      actions: ['unregister container', 'sync containers'],
+      actions: ['unregister container'],
     },
     'update selection': {
       actions: [

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -47,17 +47,9 @@ export function RenderElement(props: {
     ? `${containerScope}.${props.element._type}`
     : props.element._type
 
-  const containerConfig = useSelector(editorActor, (s) => {
-    const configs = s.context.containerConfigs
-    const exact = configs.get(scopedTypeName)
-    if (exact) {
-      return exact
-    }
-    const bareType = scopedTypeName.includes('.')
-      ? scopedTypeName.split('.').pop()!
-      : undefined
-    return bareType ? configs.get(bareType) : undefined
-  })
+  const containerConfig = useSelector(editorActor, (state) =>
+    state.context.containers.get(scopedTypeName),
+  )
 
   if (containerConfig) {
     return (

--- a/packages/editor/src/node-traversal/get-children.test.ts
+++ b/packages/editor/src/node-traversal/get-children.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/resolve-containers'
 import {getChildren} from './get-children'
-import {createNodeTraversalTestbed} from './node-traversal-testbed'
+import {
+  codeBlockContainer,
+  createNodeTraversalTestbed,
+  resolveTestbedContainers,
+  tableContainers,
+} from './node-traversal-testbed'
 
 describe(getChildren.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -162,69 +166,18 @@ describe(getChildren.name, () => {
   })
 
   test('non-editable code block returns empty array', () => {
-    const tableOnly = new Map<string, ChildArrayField>([
-      [
-        'table',
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row',
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row.cell',
-        {name: 'content', type: 'array', of: [{type: 'block'}]},
-      ],
-    ])
+    const tableOnly = resolveTestbedContainers(
+      testbed.context.schema,
+      tableContainers,
+    )
     expect(
       getChildren({...testbed.context, containers: tableOnly}, [{_key: 'k11'}]),
     ).toEqual([])
   })
 
   test('non-editable table returns empty array', () => {
-    const codeOnly = new Map<string, ChildArrayField>([
-      ['code-block', {name: 'code', type: 'array', of: [{type: 'block'}]}],
+    const codeOnly = resolveTestbedContainers(testbed.context.schema, [
+      codeBlockContainer,
     ])
     expect(
       getChildren({...testbed.context, containers: codeOnly}, [{_key: 'k26'}]),

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -118,7 +118,7 @@ export function getNodeChildren(
   if (isObjectNode(context, node)) {
     const scopedKey = scopePath ? `${scopePath}.${node._type}` : node._type
 
-    const arrayField = context.containers.get(scopedKey)
+    const arrayField = context.containers.get(scopedKey)?.field
 
     if (!arrayField) {
       return undefined

--- a/packages/editor/src/node-traversal/get-first-child.test.ts
+++ b/packages/editor/src/node-traversal/get-first-child.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/resolve-containers'
 import {getFirstChild} from './get-first-child'
-import {createNodeTraversalTestbed} from './node-traversal-testbed'
+import {
+  createNodeTraversalTestbed,
+  resolveTestbedContainers,
+  tableContainers,
+} from './node-traversal-testbed'
 
 describe(getFirstChild.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -51,61 +54,10 @@ describe(getFirstChild.name, () => {
   })
 
   test('first of non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, ChildArrayField>([
-      [
-        'table',
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row',
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row.cell',
-        {name: 'content', type: 'array', of: [{type: 'block'}]},
-      ],
-    ])
+    const tableOnly = resolveTestbedContainers(
+      testbed.context.schema,
+      tableContainers,
+    )
     expect(
       getFirstChild({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},

--- a/packages/editor/src/node-traversal/get-last-child.test.ts
+++ b/packages/editor/src/node-traversal/get-last-child.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/resolve-containers'
 import {getLastChild} from './get-last-child'
-import {createNodeTraversalTestbed} from './node-traversal-testbed'
+import {
+  createNodeTraversalTestbed,
+  resolveTestbedContainers,
+  tableContainers,
+} from './node-traversal-testbed'
 
 describe(getLastChild.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -51,61 +54,10 @@ describe(getLastChild.name, () => {
   })
 
   test('last of non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, ChildArrayField>([
-      [
-        'table',
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row',
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row.cell',
-        {name: 'content', type: 'array', of: [{type: 'block'}]},
-      ],
-    ])
+    const tableOnly = resolveTestbedContainers(
+      testbed.context.schema,
+      tableContainers,
+    )
     expect(
       getLastChild({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},

--- a/packages/editor/src/node-traversal/get-node.test.ts
+++ b/packages/editor/src/node-traversal/get-node.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/resolve-containers'
 import {getNode} from './get-node'
-import {createNodeTraversalTestbed} from './node-traversal-testbed'
+import {
+  createNodeTraversalTestbed,
+  resolveTestbedContainers,
+  tableContainers,
+} from './node-traversal-testbed'
 
 describe(getNode.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -249,61 +252,10 @@ describe(getNode.name, () => {
   })
 
   test('node inside non-editable container returns undefined', () => {
-    const tableOnly = new Map<string, ChildArrayField>([
-      [
-        'table',
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row',
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row.cell',
-        {name: 'content', type: 'array', of: [{type: 'block'}]},
-      ],
-    ])
+    const tableOnly = resolveTestbedContainers(
+      testbed.context.schema,
+      tableContainers,
+    )
     expect(
       getNode({...testbed.context, containers: tableOnly}, [
         {_key: 'k11'},

--- a/packages/editor/src/node-traversal/get-nodes.test.ts
+++ b/packages/editor/src/node-traversal/get-nodes.test.ts
@@ -5,9 +5,14 @@ import {
   isTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {ChildArrayField} from '../schema/resolve-containers'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
 import {getNodeDescendants, getNodes} from './get-nodes'
-import {createNodeTraversalTestbed} from './node-traversal-testbed'
+import {
+  createNodeTraversalTestbed,
+  resolveTestbedContainers,
+  tableContainers,
+} from './node-traversal-testbed'
 
 describe(getNodes.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -201,61 +206,10 @@ describe(getNodes.name, () => {
   })
 
   test('skips non-editable container internals', () => {
-    const tableOnly = new Map<string, ChildArrayField>([
-      [
-        'table',
-        {
-          name: 'rows',
-          type: 'array',
-          of: [
-            {
-              type: 'row',
-              fields: [
-                {
-                  name: 'cells',
-                  type: 'array',
-                  of: [
-                    {
-                      type: 'cell',
-                      fields: [
-                        {
-                          name: 'content',
-                          type: 'array',
-                          of: [{type: 'block'}],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row',
-        {
-          name: 'cells',
-          type: 'array',
-          of: [
-            {
-              type: 'cell',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      [
-        'table.row.cell',
-        {name: 'content', type: 'array', of: [{type: 'block'}]},
-      ],
-    ])
+    const tableOnly = resolveTestbedContainers(
+      testbed.context.schema,
+      tableContainers,
+    )
     const nodes = [...getNodes({...testbed.context, containers: tableOnly})]
     const nodeValues = nodes.map((entry) => entry.node)
 
@@ -839,12 +793,18 @@ describe(getNodes.name, () => {
         ...getNodeDescendants(
           {
             schema,
-            containers: new Map<string, ChildArrayField>([
-              [
-                'accordion',
-                {name: 'value', type: 'array', of: [{type: 'block'}]},
-              ],
-            ]),
+            containers: resolveContainers(
+              schema,
+              new Map([
+                [
+                  '$..accordion',
+                  makeContainerConfig(schema, {
+                    scope: '$..accordion',
+                    field: 'value',
+                  }),
+                ],
+              ]),
+            ),
           },
           accordion,
         ),

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -1,6 +1,43 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
-import type {ChildArrayField} from '../schema/resolve-containers'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
+
+/**
+ * Container definitions for the testbed's table structure
+ * (`table` → `rows`, `row` → `cells`, `cell` → `content`).
+ */
+export const tableContainers: ReadonlyArray<Container> = [
+  {scope: '$..table', field: 'rows'},
+  {scope: '$..table.row', field: 'cells'},
+  {scope: '$..table.row.cell', field: 'content'},
+]
+
+/**
+ * Container definition for the testbed's code block
+ * (`code-block` → `code`).
+ */
+export const codeBlockContainer: Container = {
+  scope: '$..code-block',
+  field: 'code',
+}
+
+/**
+ * Resolve the testbed's containers with a custom set of container
+ * definitions. Useful for tests that vary which containers are registered.
+ */
+export function resolveTestbedContainers(
+  schema: EditorSchema,
+  containers: ReadonlyArray<Container>,
+) {
+  const configs = new Map<string, ContainerConfig>()
+  for (const container of containers) {
+    configs.set(container.scope, makeContainerConfig(schema, container))
+  }
+  return resolveContainers(schema, configs)
+}
 
 /**
  * A comprehensive test fixture for node traversal tests.
@@ -41,60 +78,6 @@ import type {ChildArrayField} from '../schema/resolve-containers'
  *                     └── emptyBlock            [4, 1, 0, 0]
  *                         └── emptySpan ""      [4, 1, 0, 0, 0]
  */
-const allContainers = new Map<string, ChildArrayField>([
-  ['code-block', {name: 'code', type: 'array', of: [{type: 'block'}]}],
-  [
-    'table',
-    {
-      name: 'rows',
-      type: 'array',
-      of: [
-        {
-          type: 'row',
-          fields: [
-            {
-              name: 'cells',
-              type: 'array',
-              of: [
-                {
-                  type: 'cell',
-                  fields: [
-                    {
-                      name: 'content',
-                      type: 'array',
-                      of: [{type: 'block'}],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  [
-    'table.row',
-    {
-      name: 'cells',
-      type: 'array',
-      of: [
-        {
-          type: 'cell',
-          fields: [
-            {
-              name: 'content',
-              type: 'array',
-              of: [{type: 'block'}],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
-])
-
 export function createNodeTraversalTestbed() {
   const keyGenerator = createTestKeyGenerator()
 
@@ -255,9 +238,14 @@ export function createNodeTraversalTestbed() {
     blockIndexMap.set(value[i]!._key, i)
   }
 
+  const containers = resolveTestbedContainers(schema, [
+    codeBlockContainer,
+    ...tableContainers,
+  ])
+
   const context = {
     schema,
-    containers: allContainers,
+    containers,
     value,
     blockIndexMap,
   }

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {Containers} from '../schema/resolve-containers'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers, type Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import {getDirtyPaths} from './get-dirty-paths'
 
@@ -13,6 +14,38 @@ const schemaDefinition = defineSchema({
       name: 'callout',
       fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
     },
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 })
 
@@ -20,15 +53,45 @@ const schema = compileSchema(schemaDefinition)
 
 const emptyContainers: Containers = new Map()
 
-const containerContainers: Containers = new Map([
-  ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
-])
+const containerContainers: Containers = resolveContainers(
+  schema,
+  new Map([
+    [
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+      }),
+    ],
+  ]),
+)
 
-const tableContainers: Containers = new Map([
-  ['table', {name: 'rows', type: 'array', of: [{type: 'row'}]}],
-  ['table.row', {name: 'cells', type: 'array', of: [{type: 'cell'}]}],
-  ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
-])
+const tableContainers: Containers = resolveContainers(
+  schema,
+  new Map([
+    [
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+      }),
+    ],
+    [
+      '$..table.row',
+      makeContainerConfig(schema, {
+        scope: '$..table.row',
+        field: 'cells',
+      }),
+    ],
+    [
+      '$..table.row.cell',
+      makeContainerConfig(schema, {
+        scope: '$..table.row.cell',
+        field: 'content',
+      }),
+    ],
+  ]),
+)
 
 describe(getDirtyPaths.name, () => {
   describe('insert_text / remove_text', () => {

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -40,7 +40,7 @@ function collectDescendantPaths(
   // For container types, resolve the child array field from the schema
   const scopedName = scopePrefix ? `${scopePrefix}.${node._type}` : node._type
 
-  const arrayField = context.containers.get(scopedName)
+  const arrayField = context.containers.get(scopedName)?.field
 
   if (arrayField) {
     const fieldValue = (node as Record<string, unknown>)[arrayField.name]

--- a/packages/editor/src/plugins/plugin.container.tsx
+++ b/packages/editor/src/plugins/plugin.container.tsx
@@ -1,5 +1,6 @@
-import {useContext, useEffect} from 'react'
-import {EditorActorContext} from '../editor/editor-actor-context'
+import {useEffect} from 'react'
+import type {InternalEditor} from '../editor/create-editor'
+import {useEditor} from '../editor/use-editor'
 import type {Container} from '../renderers/renderer.types'
 
 /**
@@ -8,26 +9,19 @@ import type {Container} from '../renderers/renderer.types'
 export function ContainerPlugin(props: {
   containers: Array<{container: Container}>
 }) {
-  const editorActor = useContext(EditorActorContext)
+  const editor = useEditor() as InternalEditor
 
   useEffect(() => {
-    const containerConfigs = props.containers.map((containerConfig) => {
-      editorActor.send({
-        type: 'register container',
-        containerConfig,
-      })
-      return containerConfig
-    })
+    const unregisters = props.containers.map((config) =>
+      editor.registerContainer(config),
+    )
 
     return () => {
-      for (const containerConfig of containerConfigs) {
-        editorActor.send({
-          type: 'unregister container',
-          containerConfig,
-        })
+      for (const unregister of unregisters) {
+        unregister()
       }
     }
-  }, [editorActor, props.containers])
+  }, [editor, props.containers])
 
   return null
 }

--- a/packages/editor/src/renderers/renderer.types.test-d.ts
+++ b/packages/editor/src/renderers/renderer.types.test-d.ts
@@ -1,12 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import type {ReactElement} from 'react'
 import {describe, test} from 'vitest'
 import {defineContainer} from './renderer.types'
 
 describe(defineContainer.name, () => {
-  test('accepts scope, field, and render', () => {
+  test('accepts scope, field, and render (no schema)', () => {
     defineContainer({
-      scope: 'callout',
+      scope: '$..callout',
       field: 'content',
       render: ({children}) => children,
     })
@@ -65,60 +64,59 @@ const schema = defineSchema({
 type Schema = typeof schema
 
 describe('schema-aware defineContainer', () => {
-  test('constrains scope to scoped type names', () => {
+  test('accepts descendant scope on top-level container', () => {
     defineContainer<Schema>({
+      scope: '$..callout',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts root-anchored scope on top-level container', () => {
+    defineContainer<Schema>({
+      scope: '$.callout',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects unknown type in scope', () => {
+    defineContainer<Schema>({
+      // @ts-expect-error - 'unknown' is not a type in schema
+      scope: '$..unknown',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects bare (unanchored) scope', () => {
+    defineContainer<Schema>({
+      // @ts-expect-error - bare scope missing $ anchor
       scope: 'callout',
       field: 'content',
       render: ({children}) => children,
     })
   })
 
-  test('rejects scope not in schema', () => {
+  test('accepts nested container scope', () => {
     defineContainer<Schema>({
-      // @ts-expect-error - 'unknown' is not a scoped type name in schema
-      scope: 'unknown',
-      field: 'content',
-      render: ({children}) => children,
-    })
-  })
-
-  test('rejects field not on the type', () => {
-    // @ts-expect-error - 'tags' is not an array field on callout
-    defineContainer<Schema>({
-      scope: 'callout',
-      field: 'tags',
-      render: ({children}) => children,
-    })
-  })
-
-  test('rejects non-array fields', () => {
-    defineContainer<Schema>({
-      type: 'figure',
-      // @ts-expect-error - 'alt' is type: 'string', not type: 'array'
-      field: 'alt',
-      render: ({children}) => children,
-    })
-  })
-
-  test('allows valid array field', () => {
-    defineContainer<Schema>({
-      scope: 'figure',
-      field: 'caption',
-      render: ({children}) => children,
-    })
-  })
-
-  test('accepts nested scoped type', () => {
-    defineContainer<Schema>({
-      scope: 'table.row',
+      scope: '$..table.row',
       field: 'cells',
       render: ({children}) => children,
     })
   })
 
-  test('accepts deeply nested scoped type', () => {
+  test('accepts deeply nested container scope', () => {
     defineContainer<Schema>({
-      scope: 'table.row.cell',
+      scope: '$..table.row.cell',
+      field: 'content',
+      render: ({children}) => children,
+    })
+  })
+
+  test('accepts middle-descendant scope', () => {
+    defineContainer<Schema>({
+      scope: '$..table..cell',
       field: 'content',
       render: ({children}) => children,
     })
@@ -126,34 +124,24 @@ describe('schema-aware defineContainer', () => {
 
   test('rejects bare nested type name', () => {
     defineContainer<Schema>({
-      // @ts-expect-error - 'row' is not valid, must use 'table.row'
+      // @ts-expect-error - 'row' without $ prefix is invalid
       scope: 'row',
       field: 'cells',
       render: ({children}) => children,
     })
   })
 
-  test('constrains field to the scoped type', () => {
-    // @ts-expect-error - 'content' is not a field on table.row (cells is)
+  test('accepts block scope for text block children', () => {
     defineContainer<Schema>({
-      scope: 'table.row',
-      field: 'content',
+      scope: '$..block',
+      field: 'children',
       render: ({children}) => children,
     })
   })
 
-  test('rejects bare deeply nested type name', () => {
+  test('accepts root-anchored block scope', () => {
     defineContainer<Schema>({
-      // @ts-expect-error - 'cell' is not valid, must use 'table.row.cell'
-      scope: 'cell',
-      field: 'content',
-      render: () => null as unknown as ReactElement,
-    })
-  })
-
-  test('accepts block scope for text block children', () => {
-    defineContainer<Schema>({
-      scope: 'block',
+      scope: '$.block',
       field: 'children',
       render: ({children}) => children,
     })
@@ -161,7 +149,7 @@ describe('schema-aware defineContainer', () => {
 
   test('accepts scoped block scope inside container', () => {
     defineContainer<Schema>({
-      scope: 'callout.block',
+      scope: '$..callout.block',
       field: 'children',
       render: ({children}) => children,
     })
@@ -169,16 +157,42 @@ describe('schema-aware defineContainer', () => {
 
   test('accepts deeply scoped block scope', () => {
     defineContainer<Schema>({
-      scope: 'table.row.cell.block',
+      scope: '$..table.row.cell.block',
       field: 'children',
       render: ({children}) => children,
     })
   })
 
-  test('rejects invalid field on block scope', () => {
-    // @ts-expect-error - 'content' is not valid on block scope, must be 'children'
+  test('accepts figure caption (valid array field of blocks)', () => {
     defineContainer<Schema>({
-      scope: 'block',
+      scope: '$..figure',
+      field: 'caption',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects field not on the scoped type', () => {
+    // @ts-expect-error - 'tags' is not a field on callout
+    defineContainer<Schema>({
+      scope: '$..callout',
+      field: 'tags',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects non-array field', () => {
+    defineContainer<Schema>({
+      scope: '$..figure',
+      // @ts-expect-error - 'alt' is type: 'string', not an array
+      field: 'alt',
+      render: ({children}) => children,
+    })
+  })
+
+  test('rejects wrong field for block scope', () => {
+    // @ts-expect-error - block scope's field must be 'children'
+    defineContainer<Schema>({
+      scope: '$..block',
       field: 'content',
       render: ({children}) => children,
     })

--- a/packages/editor/src/renderers/renderer.types.test.tsx
+++ b/packages/editor/src/renderers/renderer.types.test.tsx
@@ -6,12 +6,12 @@ describe(defineContainer.name, () => {
     const render = ({children}: {children: unknown}) => children
     expect(
       defineContainer({
-        scope: 'callout',
+        scope: '$..callout',
         field: 'content',
         render: render as any,
       }),
     ).toEqual({
-      scope: 'callout',
+      scope: '$..callout',
       field: 'content',
       render,
     })

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -1,103 +1,8 @@
 import type {PortableTextBlock, SchemaDefinition} from '@portabletext/schema'
 import type {ReactElement} from 'react'
-
-/** @internal */
-type ExtractArrayFields<TFields> = TFields extends readonly [
-  infer TField,
-  ...infer TRest,
-]
-  ? TField extends {name: infer TName extends string; type: 'array'}
-    ? TName | ExtractArrayFields<TRest>
-    : ExtractArrayFields<TRest>
-  : never
-
-/** @internal */
-type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
-  infer TMember,
-  ...infer TRest,
-]
-  ? TMember extends {
-      type: infer TTypeName extends string
-      fields?: infer TFields
-    }
-    ? {type: TTypeName; fields: TFields} | ExtractOfMembers<TRest>
-    : ExtractOfMembers<TRest>
-  : never
-
-/** @internal */
-type WalkFields<TFields> = TFields extends readonly [
-  infer TField,
-  ...infer TRest,
-]
-  ? TField extends {type: 'array'; of?: infer TOf}
-    ? ExtractOfMembers<TOf> | WalkFields<TRest>
-    : WalkFields<TRest>
-  : never
-
-/** @internal */
-type CollectScopedTypes<TFields, TScope extends string> =
-  WalkFields<TFields> extends infer TMembers
-    ? TMembers extends {
-        type: infer TTypeName extends string
-        fields: infer TNestedFields
-      }
-      ? TTypeName extends 'block'
-        ? {scopedName: `${TScope}.block`; arrayFields: 'children'}
-        :
-            | {
-                scopedName: `${TScope}.${TTypeName}`
-                arrayFields: ExtractArrayFields<TNestedFields>
-              }
-            | CollectScopedTypes<TNestedFields, `${TScope}.${TTypeName}`>
-      : never
-    : never
-
-/**
- * Collect all renderer-eligible types from a schema definition.
- * Includes top-level block objects and all nested container types
-/** @internal */
-type CollectAllTypes<TSchema extends SchemaDefinition> =
-  | {scopedName: 'block'; arrayFields: 'children'}
-  | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
-      ? TBlockObject extends {
-          name: infer TName extends string
-          fields?: infer TFields
-        }
-        ?
-            | {scopedName: TName; arrayFields: ExtractArrayFields<TFields>}
-            | CollectScopedTypes<TFields, TName>
-        : never
-      : never)
-
-/** @internal */
-type AllScopedNames<TSchema extends SchemaDefinition> =
-  CollectAllTypes<TSchema> extends {scopedName: infer TName} ? TName : never
-
-/** @internal */
-type ScopedArrayFields<TSchema extends SchemaDefinition, TName extends string> =
-  CollectAllTypes<TSchema> extends infer TEntry
-    ? TEntry extends {scopedName: TName; arrayFields: infer TFieldName}
-      ? TFieldName
-      : never
-    : never
-
-// === Container ===
-
-/** @internal */
-type SchemaContainerConfig<TSchema extends SchemaDefinition> =
-  AllScopedNames<TSchema> extends infer TType extends string
-    ? TType extends TType
-      ? {
-          scope: TType
-          field: ScopedArrayFields<TSchema, TType>
-          render?: (props: {
-            attributes: Record<string, unknown>
-            children: ReactElement
-            node: PortableTextBlock
-          }) => ReactElement | null
-        }
-      : never
-    : never
+import type {ChildArrayField} from '../schema/resolve-containers'
+import type {ParsedScope} from '../scope/parse-scope'
+import type {AllContainers, ContainerScope} from '../scope/scope.types'
 
 /**
  * @internal
@@ -113,31 +18,87 @@ export type Container = {
 }
 
 /**
+ * Terminal (last dot-separated) segment of a chain.
+ *
+ * `'table.row.cell'` → `'cell'`, `'cell'` → `'cell'`.
+ */
+type TerminalSegment<TChain extends string> =
+  TChain extends `${string}.${infer TRest}` ? TerminalSegment<TRest> : TChain
+
+/**
+ * Terminal type name of a scope string, stripping the `$.` or `$..` anchor.
+ */
+type TerminalType<TScope extends string> = TScope extends `$.${infer TRest}`
+  ? TerminalSegment<TRest>
+  : TScope extends `$..${infer TRest}`
+    ? TerminalSegment<TRest>
+    : never
+
+/**
+ * Array field names available on the terminal type of a scope.
+ */
+type ScopedArrayFields<
+  TSchema extends SchemaDefinition,
+  TScope extends string,
+> =
+  TerminalType<TScope> extends infer TTerminal extends string
+    ? AllContainers<TSchema> extends infer TEntry
+      ? TEntry extends {
+          chain: infer TChain extends string
+          arrayFields: infer TFields
+        }
+        ? TerminalSegment<TChain> extends TTerminal
+          ? TFields
+          : never
+        : never
+      : never
+    : never
+
+/**
  * @internal
  *
- * Define a container for a block object type.
+ * Schema-constrained container config. `scope` is narrowed to valid JSONPath
+ * container scopes; `field` is narrowed to the array field names on the
+ * scope's terminal type.
+ */
+type SchemaContainerConfig<TSchema extends SchemaDefinition> =
+  // Only activate the narrowed shape when the caller provides a concrete
+  // schema. With the default `SchemaDefinition`, collapse to never so the
+  // overload falls through to the plain `Container` signature.
+  SchemaDefinition extends TSchema
+    ? never
+    : ContainerScope<TSchema> extends infer TScope
+      ? TScope extends string
+        ? {
+            scope: TScope
+            field: ScopedArrayFields<TSchema, TScope>
+            render?: (props: {
+              attributes: Record<string, unknown>
+              children: ReactElement
+              node: PortableTextBlock
+            }) => ReactElement | null
+          }
+        : never
+      : never
+
+/**
+ * @internal
  *
- * When called with a schema type parameter, constrains `scope` to valid
- * scoped type names, `field` to array field names on that type, and
- * provides the `render` function signature:
+ * Define a container.
+ *
+ * With a schema type parameter, `scope` is constrained to valid JSONPath
+ * container scopes, and `field` is constrained to the array field names on
+ * the scope's terminal type:
  *
  * ```ts
  * defineContainer<typeof schema>({
- *   scope: 'table.row.cell',
+ *   scope: '$..table.row.cell',
  *   field: 'content',
  *   render: ({children}) => <td>{children}</td>,
  * })
  * ```
  *
- * Without a schema type parameter, accepts any string:
- *
- * ```ts
- * defineContainer({
- *   scope: 'callout',
- *   field: 'content',
- *   render: ({children}) => <div>{children}</div>,
- * })
- * ```
+ * Without a schema type parameter, accepts any string.
  */
 export function defineContainer<TSchema extends SchemaDefinition>(
   config: SchemaContainerConfig<TSchema>,
@@ -152,4 +113,6 @@ export function defineContainer(config: Container): Container {
  */
 export type ContainerConfig = {
   container: Container
+  parsedScope: ParsedScope
+  field: ChildArrayField
 }

--- a/packages/editor/src/schema/make-container-config.ts
+++ b/packages/editor/src/schema/make-container-config.ts
@@ -1,0 +1,28 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {parseScope} from '../scope/parse-scope'
+import {resolveContainerField} from './resolve-containers'
+
+/**
+ * Build a `ContainerConfig` from a `Container` definition, parsing the scope
+ * and resolving the field against the schema.
+ *
+ * Intended for unit tests that drive `resolveContainers` directly without
+ * going through the `ContainerPlugin` React wrapper.
+ */
+export function makeContainerConfig(
+  schema: EditorSchema,
+  container: Container,
+): ContainerConfig {
+  const parsedScope = parseScope(container.scope)
+  if (!parsedScope) {
+    throw new Error(`Invalid scope: ${container.scope}`)
+  }
+  const field = resolveContainerField(schema, container.scope, container.field)
+  if (!field) {
+    throw new Error(
+      `Field "${container.field}" not found on terminal type of scope "${container.scope}"`,
+    )
+  }
+  return {container, parsedScope, field}
+}

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -1,6 +1,32 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {makeContainerConfig} from './make-container-config'
+import type {ChildArrayField, Containers} from './resolve-containers'
 import {resolveContainers} from './resolve-containers'
+
+const testRender: Container['render'] = ({children}) => children
+
+function makeConfigs(
+  schema: EditorSchema,
+  containers: Array<Container>,
+): Map<string, ContainerConfig> {
+  const map = new Map<string, ContainerConfig>()
+  for (const container of containers) {
+    map.set(container.scope, makeContainerConfig(schema, container))
+  }
+  return map
+}
+
+/** Extract the `field` shape from a resolved containers map for easier testing. */
+function fields(containers: Containers): Map<string, ChildArrayField> {
+  const out = new Map<string, ChildArrayField>()
+  for (const [key, config] of containers) {
+    out.set(key, config.field)
+  }
+  return out
+}
 
 describe(resolveContainers.name, () => {
   test('resolves a single-level container', () => {
@@ -18,20 +44,17 @@ describe(resolveContainers.name, () => {
     )
 
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'code',
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
             {
-              container: {
-                scope: 'code',
-                field: 'content',
-                render: ({children}) => children,
-              },
+              scope: '$..code',
+              field: 'content',
+              render: ({children}) => children,
             },
-          ],
-        ]),
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -79,44 +102,20 @@ describe(resolveContainers.name, () => {
         ],
       }),
     )
-
-    const render = ({children}: {children: unknown}) => children
-
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'table',
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$..table', field: 'rows', render: testRender},
+            {scope: '$..table.row', field: 'cells', render: testRender},
             {
-              container: {
-                scope: 'table',
-                field: 'rows',
-                render: render as any,
-              },
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: testRender,
             },
-          ],
-          [
-            'table.row',
-            {
-              container: {
-                scope: 'table.row',
-                field: 'cells',
-                render: render as any,
-              },
-            },
-          ],
-          [
-            'table.row.cell',
-            {
-              container: {
-                scope: 'table.row.cell',
-                field: 'content',
-                render: render as any,
-              },
-            },
-          ],
-        ]),
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -180,7 +179,7 @@ describe(resolveContainers.name, () => {
   test('returns empty Map when no containers are registered', () => {
     const schema = compileSchema(defineSchema({}))
 
-    expect(resolveContainers(schema, new Map())).toEqual(new Map())
+    expect(fields(resolveContainers(schema, new Map()))).toEqual(new Map())
   })
 
   test('merges types from multiple container configs', () => {
@@ -200,34 +199,15 @@ describe(resolveContainers.name, () => {
         ],
       }),
     )
-
-    const render = ({children}: {children: unknown}) => children
-
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'code',
-            {
-              container: {
-                scope: 'code',
-                field: 'content',
-                render: render as any,
-              },
-            },
-          ],
-          [
-            'callout',
-            {
-              container: {
-                scope: 'callout',
-                field: 'content',
-                render: render as any,
-              },
-            },
-          ],
-        ]),
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$..code', field: 'content', render: testRender},
+            {scope: '$..callout', field: 'content', render: testRender},
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -249,24 +229,14 @@ describe(resolveContainers.name, () => {
         inlineObjects: [{name: 'stock-ticker'}],
       }),
     )
-
-    const render = ({children}: {children: unknown}) => children
-
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'block',
-            {
-              container: {
-                scope: 'block',
-                field: 'children',
-                render: render as any,
-              },
-            },
-          ],
-        ]),
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$..block', field: 'children', render: testRender},
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -278,11 +248,19 @@ describe(resolveContainers.name, () => {
             of: [{type: 'span'}, {type: 'stock-ticker'}],
           },
         ],
+        [
+          'callout.block',
+          {
+            name: 'children',
+            type: 'array',
+            of: [{type: 'span'}, {type: 'stock-ticker'}],
+          },
+        ],
       ]),
     )
   })
 
-  test('resolves scoped block scope like callout.block', () => {
+  test('root-anchored block scope only resolves root blocks', () => {
     const schema = compileSchema(
       defineSchema({
         blockObjects: [
@@ -293,34 +271,46 @@ describe(resolveContainers.name, () => {
         ],
       }),
     )
-
-    const render = ({children}: {children: unknown}) => children
-
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'callout',
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$.block', field: 'children', render: testRender},
+          ]),
+        ),
+      ),
+    ).toEqual(
+      new Map([
+        ['block', {name: 'children', type: 'array', of: [{type: 'span'}]}],
+      ]),
+    )
+  })
+
+  test('resolves scoped block scope like $..callout.block', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+    )
+    expect(
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$..callout', field: 'content', render: testRender},
             {
-              container: {
-                scope: 'callout',
-                field: 'content',
-                render: render as any,
-              },
+              scope: '$..callout.block',
+              field: 'children',
+              render: testRender,
             },
-          ],
-          [
-            'callout.block',
-            {
-              container: {
-                scope: 'callout.block',
-                field: 'children',
-                render: render as any,
-              },
-            },
-          ],
-        ]),
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -335,24 +325,14 @@ describe(resolveContainers.name, () => {
 
   test('resolves block scope without inline objects', () => {
     const schema = compileSchema(defineSchema({}))
-
-    const render = ({children}: {children: unknown}) => children
-
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'block',
-            {
-              container: {
-                scope: 'block',
-                field: 'children',
-                render: render as any,
-              },
-            },
-          ],
-        ]),
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
+            {scope: '$..block', field: 'children', render: testRender},
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([
@@ -377,20 +357,17 @@ describe(resolveContainers.name, () => {
     )
 
     expect(
-      resolveContainers(
-        schema,
-        new Map([
-          [
-            'figure',
+      fields(
+        resolveContainers(
+          schema,
+          makeConfigs(schema, [
             {
-              container: {
-                scope: 'figure',
-                field: 'caption',
-                render: ({children}) => children,
-              },
+              scope: '$..figure',
+              field: 'caption',
+              render: ({children}) => children,
             },
-          ],
-        ]),
+          ]),
+        ),
       ),
     ).toEqual(
       new Map([

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -1,6 +1,8 @@
 import type {FieldDefinition, OfDefinition} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {ContainerConfig} from '../renderers/renderer.types'
+import {compareSpecificity} from '../scope/compare-specificity'
+import {matchScope} from '../scope/match-scope'
 
 export type ChildArrayField = FieldDefinition & {
   type: 'array'
@@ -8,18 +10,28 @@ export type ChildArrayField = FieldDefinition & {
 }
 
 /**
- * Maps scoped type names to their resolved editable array field.
+ * Maps scoped type names (type chain joined by '.') to registered container
+ * configs.
  *
- * Key: scoped type name (e.g., 'table', 'table.row', 'table.row.cell')
- * Value: resolved array field definition with name and of scope
+ * Key: scoped type name (e.g., 'block', 'callout.block', 'table.row.cell').
  */
-export type Containers = Map<string, ChildArrayField>
+export type Containers = Map<string, ContainerConfig>
 
 /**
- * Resolve the complete Containers Map from a schema and a set of
- * registered container configs. Each config declares a scope and
- * a field (the child array field). The resolver walks the schema to find the
- * matching field definition.
+ * Candidate type chain discoverable from the schema with an editable array
+ * field. A single type with multiple array fields produces multiple candidates.
+ */
+type Candidate = {
+  chain: Array<string>
+  field: ChildArrayField
+}
+
+/**
+ * Resolve the `Containers` map for a schema and a set of registered configs.
+ *
+ * For each candidate position discoverable in the schema, picks the
+ * most-specific matching config. Registration order breaks exact-duplicate
+ * ties (last-wins).
  */
 export function resolveContainers(
   schema: EditorSchema,
@@ -27,17 +39,138 @@ export function resolveContainers(
 ): Containers {
   const containers: Containers = new Map()
 
-  for (const [, config] of containerConfigs) {
-    const resolved = resolveContainerField(schema, {
-      scope: config.container.scope,
-      field: config.container.field,
-    })
-    if (resolved) {
-      containers.set(resolved.scope, resolved.field)
+  if (containerConfigs.size === 0) {
+    return containers
+  }
+
+  const configs = Array.from(containerConfigs.values()).sort(
+    (leftConfig, rightConfig) =>
+      -compareSpecificity(leftConfig.parsedScope, rightConfig.parsedScope),
+  )
+  const candidates = discoverCandidates(schema)
+
+  for (const candidate of candidates) {
+    const matching = configs.find(
+      (config) =>
+        config.field.name === candidate.field.name &&
+        matchScope(config.parsedScope, candidate.chain),
+    )
+    if (!matching) {
+      continue
     }
+
+    containers.set(candidate.chain.join('.'), matching)
   }
 
   return containers
+}
+
+/**
+ * Resolve the `ChildArrayField` on a schema for a container registration.
+ * Returns `undefined` when the registration is invalid: unknown type in
+ * scope, missing field, non-array field, or primitive-only array field.
+ * Warns on primitive-only fields.
+ */
+export function resolveContainerField(
+  schema: EditorSchema,
+  scope: string,
+  fieldName: string,
+): ChildArrayField | undefined {
+  const candidates = discoverCandidates(schema)
+  for (const candidate of candidates) {
+    if (candidate.field.name !== fieldName) {
+      continue
+    }
+    if (candidate.chain[candidate.chain.length - 1] !== terminalTypeOf(scope)) {
+      continue
+    }
+    if (containsOnlyPrimitiveTypes(candidate.field)) {
+      console.warn(
+        `Field '${candidate.field.name}' on '${candidate.chain.join('.')}' doesn't contain block or container types and will be excluded`,
+      )
+      return undefined
+    }
+    return candidate.field
+  }
+  return undefined
+}
+
+function terminalTypeOf(scope: string): string {
+  const withoutAnchor = scope.startsWith('$..')
+    ? scope.slice(3)
+    : scope.startsWith('$.')
+      ? scope.slice(2)
+      : scope
+  const segments = withoutAnchor.split('.')
+  return segments[segments.length - 1] ?? ''
+}
+
+/**
+ * Discover every container-candidate type chain in the schema, along with
+ * its editable array fields. A single type with multiple array fields
+ * produces multiple candidates (one per field).
+ *
+ * Always includes `['block']` as a candidate, since text blocks are the
+ * universal container for span / inline-object children.
+ */
+function discoverCandidates(schema: EditorSchema): Array<Candidate> {
+  const candidates: Array<Candidate> = [
+    {chain: ['block'], field: synthesizeBlockChildrenField(schema)},
+  ]
+
+  for (const blockObject of schema.blockObjects) {
+    if (!('fields' in blockObject) || !blockObject.fields) {
+      continue
+    }
+    walkTypeForCandidates(
+      schema,
+      blockObject.fields,
+      [blockObject.name],
+      candidates,
+    )
+  }
+
+  return candidates
+}
+
+function walkTypeForCandidates(
+  schema: EditorSchema,
+  fields: ReadonlyArray<FieldDefinition>,
+  chain: Array<string>,
+  out: Array<Candidate>,
+): void {
+  for (const field of fields) {
+    if (!isChildArrayField(field)) {
+      continue
+    }
+
+    out.push({chain, field})
+
+    if (containsOnlyPrimitiveTypes(field)) {
+      continue
+    }
+
+    for (const member of field.of) {
+      if (member.type === 'block') {
+        // A text block inside a container: emit as a candidate so that
+        // scopes like `$..callout.block` can match. The field is the
+        // synthesized text-block children array.
+        out.push({
+          chain: [...chain, 'block'],
+          field: synthesizeBlockChildrenField(schema),
+        })
+        continue
+      }
+      if ('fields' in member && member.fields) {
+        walkTypeForCandidates(
+          schema,
+          member.fields,
+          [...chain, member.type],
+          out,
+        )
+      }
+    }
+  }
 }
 
 function isChildArrayField(field: FieldDefinition): field is ChildArrayField {
@@ -53,84 +186,6 @@ const PRIMITIVE_TYPES = new Set(['string', 'number', 'boolean'])
 
 function containsOnlyPrimitiveTypes(field: ChildArrayField): boolean {
   return field.of.every((member) => PRIMITIVE_TYPES.has(member.type))
-}
-
-function resolveContainerField(
-  schema: EditorSchema,
-  containerConfig: {scope: string; field: string},
-): {scope: string; field: ChildArrayField} | undefined {
-  // Split the scope into segments to find the type definition
-  const segments = containerConfig.scope.split('.')
-  const lastSegment = segments[segments.length - 1]
-
-  // Handle 'block' scope (text block children)
-  if (lastSegment === 'block') {
-    if (containerConfig.field !== 'children') {
-      return undefined
-    }
-    return {
-      scope: containerConfig.scope,
-      field: synthesizeBlockChildrenField(schema),
-    }
-  }
-
-  // The first segment is always a block object name
-  const blockObject = schema.blockObjects.find(
-    (definition) => definition.name === segments[0],
-  )
-
-  if (!blockObject || !('fields' in blockObject) || !blockObject.fields) {
-    return undefined
-  }
-
-  // Walk nested types for multi-segment scopes (e.g., 'table.row.cell')
-  let currentFields: ReadonlyArray<FieldDefinition> = blockObject.fields
-
-  for (let i = 1; i < segments.length; i++) {
-    const segmentType = segments[i]!
-    let found = false
-
-    for (const field of currentFields) {
-      if (isChildArrayField(field)) {
-        for (const ofMember of field.of) {
-          if (
-            ofMember.type === segmentType &&
-            'fields' in ofMember &&
-            ofMember.fields
-          ) {
-            currentFields = ofMember.fields
-            found = true
-            break
-          }
-        }
-      }
-      if (found) {
-        break
-      }
-    }
-
-    if (!found) {
-      return undefined
-    }
-  }
-
-  // Find the declared name (child array field) in the resolved fields
-  const childField = currentFields.find(
-    (field) => field.name === containerConfig.field,
-  )
-
-  if (!childField || !isChildArrayField(childField)) {
-    return undefined
-  }
-
-  if (containsOnlyPrimitiveTypes(childField)) {
-    console.warn(
-      `Field '${childField.name}' on '${containerConfig.scope}' doesn't contain block or container types and will be excluded`,
-    )
-    return undefined
-  }
-
-  return {scope: containerConfig.scope, field: childField}
 }
 
 function synthesizeBlockChildrenField(schema: EditorSchema): ChildArrayField {

--- a/packages/editor/src/scope/compare-specificity.test.ts
+++ b/packages/editor/src/scope/compare-specificity.test.ts
@@ -112,17 +112,17 @@ describe(compareSpecificity.name, () => {
 
   describe('worked example from spec', () => {
     test('C (root + longest) > B (longer descendant) > A (shorter descendant)', () => {
-      const a = parse('$..block.span')
-      const b = parse('$..callout.block.span')
-      const c = parse('$.callout.block.span')
+      const shortestDescendant = parse('$..block.span')
+      const longerDescendant = parse('$..callout.block.span')
+      const rootAnchored = parse('$.callout.block.span')
 
-      expect(compareSpecificity(c, b)).toBe(1)
-      expect(compareSpecificity(b, a)).toBe(1)
-      expect(compareSpecificity(c, a)).toBe(1)
+      expect(compareSpecificity(rootAnchored, longerDescendant)).toBe(1)
+      expect(compareSpecificity(longerDescendant, shortestDescendant)).toBe(1)
+      expect(compareSpecificity(rootAnchored, shortestDescendant)).toBe(1)
 
-      expect(compareSpecificity(b, c)).toBe(-1)
-      expect(compareSpecificity(a, b)).toBe(-1)
-      expect(compareSpecificity(a, c)).toBe(-1)
+      expect(compareSpecificity(longerDescendant, rootAnchored)).toBe(-1)
+      expect(compareSpecificity(shortestDescendant, longerDescendant)).toBe(-1)
+      expect(compareSpecificity(shortestDescendant, rootAnchored)).toBe(-1)
     })
   })
 

--- a/packages/editor/src/scope/compare-specificity.test.ts
+++ b/packages/editor/src/scope/compare-specificity.test.ts
@@ -1,0 +1,146 @@
+import {describe, expect, test} from 'vitest'
+import {compareSpecificity} from './compare-specificity'
+import {parseScope} from './parse-scope'
+
+function parse(scope: string) {
+  const parsed = parseScope(scope)
+  if (!parsed) {
+    throw new Error(`Test setup error: scope "${scope}" failed to parse`)
+  }
+  return parsed
+}
+
+describe(compareSpecificity.name, () => {
+  describe('rule 1: root-anchored beats descendant', () => {
+    test('root-anchored vs descendant, same chain', () => {
+      expect(compareSpecificity(parse('$.block'), parse('$..block'))).toBe(1)
+      expect(compareSpecificity(parse('$..block'), parse('$.block'))).toBe(-1)
+    })
+
+    test('root-anchored wins over longer descendant', () => {
+      expect(
+        compareSpecificity(parse('$.block'), parse('$..callout.block')),
+      ).toBe(1)
+    })
+
+    test('root-anchored wins over all-exact descendant', () => {
+      expect(compareSpecificity(parse('$.block'), parse('$..block'))).toBe(1)
+    })
+  })
+
+  describe('rule 2: longer chain beats shorter when anchor matches', () => {
+    test('both descendant, different lengths', () => {
+      expect(
+        compareSpecificity(
+          parse('$..callout.block.span'),
+          parse('$..block.span'),
+        ),
+      ).toBe(1)
+      expect(
+        compareSpecificity(
+          parse('$..block.span'),
+          parse('$..callout.block.span'),
+        ),
+      ).toBe(-1)
+    })
+
+    test('both root-anchored, different lengths', () => {
+      expect(
+        compareSpecificity(
+          parse('$.callout.block.span'),
+          parse('$.block.span'),
+        ),
+      ).toBe(1)
+    })
+  })
+
+  describe('rule 3: more exact segments beat fewer when anchor and length match', () => {
+    test('middle any-descent loses to exact chain', () => {
+      expect(
+        compareSpecificity(
+          parse('$..callout.block.span'),
+          parse('$..callout..block.span'),
+        ),
+      ).toBe(1)
+    })
+
+    test('two exact-chain segments beat one', () => {
+      expect(
+        compareSpecificity(
+          parse('$..table..row.cell'),
+          parse('$..table..row..cell'),
+        ),
+      ).toBe(1)
+    })
+  })
+
+  describe('equal specificity', () => {
+    test('identical scopes', () => {
+      expect(
+        compareSpecificity(parse('$..block.span'), parse('$..block.span')),
+      ).toBe(0)
+    })
+
+    test('different terminal types, same shape', () => {
+      expect(
+        compareSpecificity(parse('$..block.span'), parse('$..block.image')),
+      ).toBe(0)
+    })
+  })
+
+  describe('rule ordering: anchor beats length', () => {
+    test('short root-anchored beats long descendant', () => {
+      expect(
+        compareSpecificity(
+          parse('$.block'),
+          parse('$..table.row.cell.block.span'),
+        ),
+      ).toBe(1)
+    })
+  })
+
+  describe('rule ordering: length beats exact-count', () => {
+    test('longer chain wins even with fewer exact segments', () => {
+      expect(
+        compareSpecificity(
+          parse('$..callout..block..span'),
+          parse('$..block.span'),
+        ),
+      ).toBe(1)
+    })
+  })
+
+  describe('worked example from spec', () => {
+    test('C (root + longest) > B (longer descendant) > A (shorter descendant)', () => {
+      const a = parse('$..block.span')
+      const b = parse('$..callout.block.span')
+      const c = parse('$.callout.block.span')
+
+      expect(compareSpecificity(c, b)).toBe(1)
+      expect(compareSpecificity(b, a)).toBe(1)
+      expect(compareSpecificity(c, a)).toBe(1)
+
+      expect(compareSpecificity(b, c)).toBe(-1)
+      expect(compareSpecificity(a, b)).toBe(-1)
+      expect(compareSpecificity(a, c)).toBe(-1)
+    })
+  })
+
+  describe('sortable via Array.sort', () => {
+    test('ascending sort yields least-to-most specific', () => {
+      const scopes = [
+        parse('$..block.span'),
+        parse('$.callout.block.span'),
+        parse('$..callout.block.span'),
+      ]
+
+      const sorted = [...scopes].sort(compareSpecificity)
+
+      expect(sorted).toEqual([
+        parse('$..block.span'),
+        parse('$..callout.block.span'),
+        parse('$.callout.block.span'),
+      ])
+    })
+  })
+})

--- a/packages/editor/src/scope/compare-specificity.ts
+++ b/packages/editor/src/scope/compare-specificity.ts
@@ -1,0 +1,55 @@
+import type {ParsedScope} from './parse-scope'
+
+/**
+ * Compares two parsed scopes by specificity.
+ *
+ * When multiple registered scopes match the same position, the more specific
+ * one wins. Specificity is determined by three rules applied lexicographically:
+ *
+ * 1. Root-anchored (`$.`) beats descendant (`$..`).
+ * 2. Longer chain beats shorter.
+ * 3. More exact-descent segments beat fewer.
+ *
+ * Returns a standard comparator result:
+ *
+ * - `-1` when `a` is less specific than `b` (a should sort before b).
+ * - `1` when `a` is more specific than `b` (a should sort after b).
+ * - `0` when the two scopes have equal specificity.
+ *
+ * Exact-duplicate registrations (same scope, different configs) produce equal
+ * specificity; resolution between them is a registration-order policy applied
+ * by the caller, not a comparator concern.
+ *
+ * @internal
+ */
+export function compareSpecificity(a: ParsedScope, b: ParsedScope): -1 | 0 | 1 {
+  const aRooted = a.anchor === '$.'
+  const bRooted = b.anchor === '$.'
+
+  if (aRooted !== bRooted) {
+    return aRooted ? 1 : -1
+  }
+
+  if (a.segments.length !== b.segments.length) {
+    return a.segments.length > b.segments.length ? 1 : -1
+  }
+
+  const aExact = countExactSegments(a)
+  const bExact = countExactSegments(b)
+
+  if (aExact !== bExact) {
+    return aExact > bExact ? 1 : -1
+  }
+
+  return 0
+}
+
+function countExactSegments(scope: ParsedScope): number {
+  let count = 0
+  for (const segment of scope.segments) {
+    if (segment.descent === 'exact') {
+      count++
+    }
+  }
+  return count
+}

--- a/packages/editor/src/scope/compare-specificity.ts
+++ b/packages/editor/src/scope/compare-specificity.ts
@@ -12,8 +12,8 @@ import type {ParsedScope} from './parse-scope'
  *
  * Returns a standard comparator result:
  *
- * - `-1` when `a` is less specific than `b` (a should sort before b).
- * - `1` when `a` is more specific than `b` (a should sort after b).
+ * - `-1` when `left` is less specific than `right` (left should sort before right).
+ * - `1` when `left` is more specific than `right` (left should sort after right).
  * - `0` when the two scopes have equal specificity.
  *
  * Exact-duplicate registrations (same scope, different configs) produce equal
@@ -22,23 +22,26 @@ import type {ParsedScope} from './parse-scope'
  *
  * @internal
  */
-export function compareSpecificity(a: ParsedScope, b: ParsedScope): -1 | 0 | 1 {
-  const aRooted = a.anchor === '$.'
-  const bRooted = b.anchor === '$.'
+export function compareSpecificity(
+  left: ParsedScope,
+  right: ParsedScope,
+): -1 | 0 | 1 {
+  const leftRooted = left.anchor === '$.'
+  const rightRooted = right.anchor === '$.'
 
-  if (aRooted !== bRooted) {
-    return aRooted ? 1 : -1
+  if (leftRooted !== rightRooted) {
+    return leftRooted ? 1 : -1
   }
 
-  if (a.segments.length !== b.segments.length) {
-    return a.segments.length > b.segments.length ? 1 : -1
+  if (left.segments.length !== right.segments.length) {
+    return left.segments.length > right.segments.length ? 1 : -1
   }
 
-  const aExact = countExactSegments(a)
-  const bExact = countExactSegments(b)
+  const leftExact = countExactSegments(left)
+  const rightExact = countExactSegments(right)
 
-  if (aExact !== bExact) {
-    return aExact > bExact ? 1 : -1
+  if (leftExact !== rightExact) {
+    return leftExact > rightExact ? 1 : -1
   }
 
   return 0

--- a/packages/editor/src/scope/match-scope.test.ts
+++ b/packages/editor/src/scope/match-scope.test.ts
@@ -1,0 +1,261 @@
+import {describe, expect, test} from 'vitest'
+import {matchScope} from './match-scope'
+import {parseScope} from './parse-scope'
+
+function parse(scope: string) {
+  const parsed = parseScope(scope)
+  if (!parsed) {
+    throw new Error(`Test setup error: scope "${scope}" failed to parse`)
+  }
+  return parsed
+}
+
+describe(matchScope.name, () => {
+  describe('root-anchored single segment', () => {
+    test('matches root block', () => {
+      expect(matchScope(parse('$.block'), ['block'])).toBe(true)
+    })
+
+    test('does not match nested block', () => {
+      expect(matchScope(parse('$.block'), ['callout', 'block'])).toBe(false)
+    })
+
+    test('does not match when terminal type differs', () => {
+      expect(matchScope(parse('$.block'), ['callout'])).toBe(false)
+    })
+  })
+
+  describe('descendant single segment', () => {
+    test('matches root block', () => {
+      expect(matchScope(parse('$..block'), ['block'])).toBe(true)
+    })
+
+    test('matches nested block', () => {
+      expect(matchScope(parse('$..block'), ['callout', 'block'])).toBe(true)
+    })
+
+    test('matches deeply nested block', () => {
+      expect(
+        matchScope(parse('$..block'), ['table', 'row', 'cell', 'block']),
+      ).toBe(true)
+    })
+
+    test('does not match when terminal type differs', () => {
+      expect(matchScope(parse('$..block'), ['callout', 'span'])).toBe(false)
+    })
+
+    test('does not match when type is not terminal', () => {
+      expect(matchScope(parse('$..block'), ['block', 'span'])).toBe(false)
+    })
+  })
+
+  describe('root-anchored exact chain', () => {
+    test('matches exact path from root', () => {
+      expect(
+        matchScope(parse('$.callout.block.span'), ['callout', 'block', 'span']),
+      ).toBe(true)
+    })
+
+    test('does not match when chain is deeper than scope', () => {
+      expect(
+        matchScope(parse('$.callout.block.span'), [
+          'table',
+          'callout',
+          'block',
+          'span',
+        ]),
+      ).toBe(false)
+    })
+
+    test('does not match when intermediate type differs', () => {
+      expect(
+        matchScope(parse('$.callout.block.span'), ['callout', 'list', 'span']),
+      ).toBe(false)
+    })
+
+    test('does not match when root type differs', () => {
+      expect(
+        matchScope(parse('$.callout.block.span'), ['table', 'block', 'span']),
+      ).toBe(false)
+    })
+  })
+
+  describe('descendant exact chain', () => {
+    test('matches at root', () => {
+      expect(
+        matchScope(parse('$..callout.block.span'), [
+          'callout',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('matches nested', () => {
+      expect(
+        matchScope(parse('$..callout.block.span'), [
+          'table',
+          'callout',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('matches deeply nested', () => {
+      expect(
+        matchScope(parse('$..callout.block.span'), [
+          'table',
+          'row',
+          'cell',
+          'callout',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('does not match when exact chain is broken', () => {
+      expect(
+        matchScope(parse('$..callout.block.span'), [
+          'callout',
+          'list',
+          'block',
+          'span',
+        ]),
+      ).toBe(false)
+    })
+  })
+
+  describe('middle any-descent', () => {
+    test('any-descent spans intermediate segments', () => {
+      expect(
+        matchScope(parse('$..table..span'), [
+          'table',
+          'row',
+          'cell',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('any-descent spans zero intermediate segments', () => {
+      expect(matchScope(parse('$..table..span'), ['table', 'span'])).toBe(true)
+    })
+
+    test('any-descent requires the ancestor to appear', () => {
+      expect(
+        matchScope(parse('$..table..span'), ['callout', 'block', 'span']),
+      ).toBe(false)
+    })
+
+    test('any-descent followed by exact chain', () => {
+      expect(
+        matchScope(parse('$..callout..block.span'), [
+          'callout',
+          'list',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('any-descent followed by exact chain requires adjacency after descent', () => {
+      expect(
+        matchScope(parse('$..callout..block.span'), [
+          'callout',
+          'block',
+          'list',
+          'span',
+        ]),
+      ).toBe(false)
+    })
+
+    test('multiple any-descents', () => {
+      expect(
+        matchScope(parse('$..table..row..cell..span'), [
+          'table',
+          'foo',
+          'row',
+          'bar',
+          'cell',
+          'baz',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('root-anchored with middle any-descent', () => {
+      expect(
+        matchScope(parse('$.callout..span'), ['callout', 'block', 'span']),
+      ).toBe(true)
+    })
+
+    test('root-anchored with middle any-descent rejects non-root callout', () => {
+      expect(
+        matchScope(parse('$.callout..span'), [
+          'table',
+          'callout',
+          'block',
+          'span',
+        ]),
+      ).toBe(false)
+    })
+  })
+
+  describe('terminal constraint', () => {
+    test('does not match when scope is shorter than typePath and terminal is not last', () => {
+      expect(
+        matchScope(parse('$..callout'), ['callout', 'block', 'span']),
+      ).toBe(false)
+    })
+
+    test('does not match when scope is longer than typePath', () => {
+      expect(
+        matchScope(parse('$..callout.block.span'), ['block', 'span']),
+      ).toBe(false)
+    })
+
+    test('empty typePath rejects any scope', () => {
+      expect(matchScope(parse('$.block'), [])).toBe(false)
+      expect(matchScope(parse('$..block'), [])).toBe(false)
+    })
+  })
+
+  describe('worked examples from spec', () => {
+    test('spec example: span in callout-block, various scopes', () => {
+      const typePath = ['callout', 'block', 'span']
+      expect(matchScope(parse('$..block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$.block.span'), typePath)).toBe(false)
+      expect(matchScope(parse('$..callout.block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$.callout.block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$..callout..block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$..table.block.span'), typePath)).toBe(false)
+      expect(matchScope(parse('$..block'), typePath)).toBe(false)
+    })
+
+    test('spec example: span in root block', () => {
+      const typePath = ['block', 'span']
+      expect(matchScope(parse('$.block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$..block.span'), typePath)).toBe(true)
+      expect(matchScope(parse('$..callout.block.span'), typePath)).toBe(false)
+    })
+
+    test('spec example: gallery image', () => {
+      const typePath = ['gallery', 'image']
+      expect(matchScope(parse('$..image'), typePath)).toBe(true)
+      expect(matchScope(parse('$..gallery.image'), typePath)).toBe(true)
+      expect(matchScope(parse('$.gallery.image'), typePath)).toBe(true)
+      expect(matchScope(parse('$.image'), typePath)).toBe(false)
+    })
+
+    test('spec example: root image', () => {
+      const typePath = ['image']
+      expect(matchScope(parse('$.image'), typePath)).toBe(true)
+      expect(matchScope(parse('$..image'), typePath)).toBe(true)
+      expect(matchScope(parse('$..gallery.image'), typePath)).toBe(false)
+    })
+  })
+})

--- a/packages/editor/src/scope/match-scope.ts
+++ b/packages/editor/src/scope/match-scope.ts
@@ -1,0 +1,59 @@
+import type {ParsedScope} from './parse-scope'
+
+/**
+ * Checks whether a parsed scope matches a type-path from the root of the
+ * editor down to the node being rendered.
+ *
+ * The match is terminal: the scope's last segment must align with the last
+ * element of `typePath`. This is the semantics used by `defineContainer` and
+ * `defineLeaf`.
+ *
+ * The algorithm walks the scope's segments left-to-right over `typePath`:
+ *
+ * - An `exact` segment must sit at the current cursor position in the path.
+ * - An `any` segment can skip over zero or more path positions to find a match.
+ * - After processing all segments, the cursor must have consumed the entire
+ *   path (so the last segment aligns with the last path element).
+ *
+ * The scope's anchor (`$.` vs `$..`) is encoded in the first segment's
+ * descent: `$.` produces an `exact` first segment (must start at position 0),
+ * `$..` produces an `any` first segment (may start anywhere).
+ *
+ * @internal
+ */
+export function matchScope(
+  scope: ParsedScope,
+  typePath: ReadonlyArray<string>,
+): boolean {
+  if (scope.segments.length === 0) {
+    return false
+  }
+
+  let pathIdx = 0
+
+  for (const segment of scope.segments) {
+    if (segment.descent === 'exact') {
+      if (pathIdx >= typePath.length || typePath[pathIdx] !== segment.type) {
+        return false
+      }
+      pathIdx++
+      continue
+    }
+
+    let found = -1
+    for (let i = pathIdx; i < typePath.length; i++) {
+      if (typePath[i] === segment.type) {
+        found = i
+        break
+      }
+    }
+
+    if (found === -1) {
+      return false
+    }
+
+    pathIdx = found + 1
+  }
+
+  return pathIdx === typePath.length
+}

--- a/packages/editor/src/scope/parse-scope.test.ts
+++ b/packages/editor/src/scope/parse-scope.test.ts
@@ -1,0 +1,183 @@
+import {describe, expect, test} from 'vitest'
+import {parseScope} from './parse-scope'
+
+describe(parseScope.name, () => {
+  describe('accepts valid scopes', () => {
+    test('root-anchored single segment', () => {
+      expect(parseScope('$.block')).toEqual({
+        anchor: '$.',
+        segments: [{type: 'block', descent: 'exact'}],
+      })
+    })
+
+    test('descendant single segment', () => {
+      expect(parseScope('$..block')).toEqual({
+        anchor: '$..',
+        segments: [{type: 'block', descent: 'any'}],
+      })
+    })
+
+    test('root-anchored exact chain', () => {
+      expect(parseScope('$.callout.block.span')).toEqual({
+        anchor: '$.',
+        segments: [
+          {type: 'callout', descent: 'exact'},
+          {type: 'block', descent: 'exact'},
+          {type: 'span', descent: 'exact'},
+        ],
+      })
+    })
+
+    test('descendant exact chain', () => {
+      expect(parseScope('$..callout.block.span')).toEqual({
+        anchor: '$..',
+        segments: [
+          {type: 'callout', descent: 'any'},
+          {type: 'block', descent: 'exact'},
+          {type: 'span', descent: 'exact'},
+        ],
+      })
+    })
+
+    test('descendant with middle any-descent', () => {
+      expect(parseScope('$..table..span')).toEqual({
+        anchor: '$..',
+        segments: [
+          {type: 'table', descent: 'any'},
+          {type: 'span', descent: 'any'},
+        ],
+      })
+    })
+
+    test('root-anchored with middle any-descent', () => {
+      expect(parseScope('$.callout..span')).toEqual({
+        anchor: '$.',
+        segments: [
+          {type: 'callout', descent: 'exact'},
+          {type: 'span', descent: 'any'},
+        ],
+      })
+    })
+
+    test('multiple middle any-descents', () => {
+      expect(parseScope('$..table..row..cell..span')).toEqual({
+        anchor: '$..',
+        segments: [
+          {type: 'table', descent: 'any'},
+          {type: 'row', descent: 'any'},
+          {type: 'cell', descent: 'any'},
+          {type: 'span', descent: 'any'},
+        ],
+      })
+    })
+
+    test('mixed exact and any descents', () => {
+      expect(parseScope('$..callout..block.span')).toEqual({
+        anchor: '$..',
+        segments: [
+          {type: 'callout', descent: 'any'},
+          {type: 'block', descent: 'any'},
+          {type: 'span', descent: 'exact'},
+        ],
+      })
+    })
+
+    test('type names with hyphens', () => {
+      expect(parseScope('$..block.stock-ticker')).toEqual({
+        anchor: '$..',
+        segments: [
+          {type: 'block', descent: 'any'},
+          {type: 'stock-ticker', descent: 'exact'},
+        ],
+      })
+    })
+
+    test('type names with underscores', () => {
+      expect(parseScope('$..block_quote')).toEqual({
+        anchor: '$..',
+        segments: [{type: 'block_quote', descent: 'any'}],
+      })
+    })
+
+    test('type names with digits after initial letter', () => {
+      expect(parseScope('$..h1')).toEqual({
+        anchor: '$..',
+        segments: [{type: 'h1', descent: 'any'}],
+      })
+    })
+  })
+
+  describe('rejects syntactically invalid scopes', () => {
+    test('empty string', () => {
+      expect(parseScope('')).toBe(null)
+    })
+
+    test('root alone', () => {
+      expect(parseScope('$')).toBe(null)
+    })
+
+    test('root-anchor alone', () => {
+      expect(parseScope('$.')).toBe(null)
+    })
+
+    test('descendant-anchor alone', () => {
+      expect(parseScope('$..')).toBe(null)
+    })
+
+    test('bare segment without anchor', () => {
+      expect(parseScope('block')).toBe(null)
+    })
+
+    test('bare chain without anchor', () => {
+      expect(parseScope('block.span')).toBe(null)
+    })
+
+    test('dollar without dot', () => {
+      expect(parseScope('$block')).toBe(null)
+    })
+
+    test('three consecutive dots', () => {
+      expect(parseScope('$...block')).toBe(null)
+    })
+
+    test('trailing dot', () => {
+      expect(parseScope('$..block.')).toBe(null)
+    })
+
+    test('trailing double dot', () => {
+      expect(parseScope('$..block..')).toBe(null)
+    })
+
+    test('segment starting with digit', () => {
+      expect(parseScope('$..123')).toBe(null)
+    })
+
+    test('segment starting with hyphen', () => {
+      expect(parseScope('$..-block')).toBe(null)
+    })
+
+    test('segment starting with underscore', () => {
+      expect(parseScope('$.._block')).toBe(null)
+    })
+
+    test('segment with space', () => {
+      expect(parseScope('$..block quote')).toBe(null)
+    })
+
+    test('segment with dollar', () => {
+      expect(parseScope('$..block$extra')).toBe(null)
+    })
+
+    test('segment with slash', () => {
+      expect(parseScope('$..block/child')).toBe(null)
+    })
+
+    test('empty segment between dots', () => {
+      expect(parseScope('$..block...span')).toBe(null)
+    })
+
+    test('leading dot without dollar', () => {
+      expect(parseScope('.block')).toBe(null)
+    })
+  })
+})

--- a/packages/editor/src/scope/parse-scope.ts
+++ b/packages/editor/src/scope/parse-scope.ts
@@ -1,0 +1,88 @@
+/**
+ * Parses a scope string into a structured form.
+ *
+ * A scope is a JSONPath-inspired expression that identifies positions in the
+ * schema tree. The grammar is documented in `/specs/scope-grammar.md` on the
+ * board; see `ContainerScope` and `LeafScope` in `./scope.types.ts` for the
+ * type-level enumeration.
+ *
+ * Parsing is purely syntactic: it validates shape, not schema. Schema-aware
+ * checks (unknown types, the `block.` rule for spans and inline objects)
+ * happen later at registration time.
+ *
+ * @internal
+ */
+
+const typeSegmentPattern = /^[a-zA-Z][a-zA-Z0-9\-_]*$/
+
+export type ScopeAnchor = '$.' | '$..'
+
+export type ScopeDescent = 'exact' | 'any'
+
+export type ScopeSegment = {
+  type: string
+  descent: ScopeDescent
+}
+
+export type ParsedScope = {
+  anchor: ScopeAnchor
+  segments: Array<ScopeSegment>
+}
+
+export function parseScope(scope: string): ParsedScope | null {
+  if (scope.length === 0) {
+    return null
+  }
+
+  let anchor: ScopeAnchor
+  let remainder: string
+
+  if (scope.startsWith('$..')) {
+    anchor = '$..'
+    remainder = scope.slice(3)
+  } else if (scope.startsWith('$.')) {
+    anchor = '$.'
+    remainder = scope.slice(2)
+  } else {
+    return null
+  }
+
+  if (remainder.length === 0) {
+    return null
+  }
+
+  const segments: Array<ScopeSegment> = []
+  let cursor = 0
+  let pendingDescent: ScopeDescent = anchor === '$..' ? 'any' : 'exact'
+
+  while (cursor < remainder.length) {
+    const nextDot = remainder.indexOf('.', cursor)
+    const typeEnd = nextDot === -1 ? remainder.length : nextDot
+    const type = remainder.slice(cursor, typeEnd)
+
+    if (!typeSegmentPattern.test(type)) {
+      return null
+    }
+
+    segments.push({type, descent: pendingDescent})
+
+    if (nextDot === -1) {
+      return {anchor, segments}
+    }
+
+    if (remainder[nextDot + 1] === '.') {
+      pendingDescent = 'any'
+      cursor = nextDot + 2
+    } else {
+      pendingDescent = 'exact'
+      cursor = nextDot + 1
+    }
+
+    if (cursor >= remainder.length) {
+      return null
+    }
+  }
+
+  /* c8 ignore next */
+  return null
+}

--- a/packages/editor/src/scope/scope.types.test-d.ts
+++ b/packages/editor/src/scope/scope.types.test-d.ts
@@ -1,0 +1,451 @@
+import {defineSchema} from '@portabletext/schema'
+import {describe, test} from 'vitest'
+import type {ContainerScope, LeafScope} from './scope.types'
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+const minimalSchema = defineSchema({})
+type MinimalSchema = typeof minimalSchema
+
+const calloutSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+    {name: 'image'},
+  ],
+  inlineObjects: [{name: 'stock-ticker'}],
+})
+type CalloutSchema = typeof calloutSchema
+
+const gallerySchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'gallery',
+      fields: [
+        {name: 'images', type: 'array', of: [{type: 'image', fields: []}]},
+      ],
+    },
+  ],
+})
+type GallerySchema = typeof gallerySchema
+
+const tableSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+type TableSchema = typeof tableSchema
+
+const fullSchema = defineSchema({
+  blockObjects: [
+    {name: 'image'},
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}, {type: 'image'}],
+        },
+      ],
+    },
+  ],
+  inlineObjects: [{name: 'stock-ticker'}],
+})
+type FullSchema = typeof fullSchema
+
+// ============================================================================
+// ContainerScope
+// ============================================================================
+
+describe('ContainerScope', () => {
+  describe('minimal schema (no blockObjects)', () => {
+    test('accepts root text block', () => {
+      '$.block' satisfies ContainerScope<MinimalSchema>
+    })
+
+    test('accepts descendant text block', () => {
+      '$..block' satisfies ContainerScope<MinimalSchema>
+    })
+
+    test('rejects unknown container type', () => {
+      // @ts-expect-error — callout not in schema
+      '$.callout' satisfies ContainerScope<MinimalSchema>
+    })
+
+    test('rejects leaf terminal (span)', () => {
+      // @ts-expect-error — span is a leaf, not a container
+      '$..span' satisfies ContainerScope<MinimalSchema>
+    })
+  })
+
+  describe('callout schema', () => {
+    test('accepts root text block', () => {
+      '$.block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts descendant text block', () => {
+      '$..block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts root callout', () => {
+      '$.callout' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts descendant callout', () => {
+      '$..callout' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts callout with block chain (root)', () => {
+      '$.callout.block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts callout with block chain (descendant)', () => {
+      '$..callout.block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts callout middle-`..` to block (root)', () => {
+      '$.callout..block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('accepts callout middle-`..` to block (descendant)', () => {
+      '$..callout..block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects image as container (void block object)', () => {
+      // @ts-expect-error — image is a leaf, not a container
+      '$..image' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects inline object as container', () => {
+      // @ts-expect-error — stock-ticker is a leaf, not a container
+      '$..stock-ticker' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects leaf scope as container', () => {
+      // @ts-expect-error — span is a leaf
+      '$..block.span' satisfies ContainerScope<CalloutSchema>
+    })
+  })
+
+  describe('gallery schema (container with void-only children)', () => {
+    test('accepts root gallery', () => {
+      '$.gallery' satisfies ContainerScope<GallerySchema>
+    })
+
+    test('accepts descendant gallery', () => {
+      '$..gallery' satisfies ContainerScope<GallerySchema>
+    })
+
+    test('accepts root text block', () => {
+      '$.block' satisfies ContainerScope<GallerySchema>
+    })
+
+    test('rejects image as container', () => {
+      // @ts-expect-error — image is a leaf
+      '$..image' satisfies ContainerScope<GallerySchema>
+    })
+  })
+
+  describe('table schema (deep nesting)', () => {
+    test('accepts root table', () => {
+      '$.table' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts descendant table', () => {
+      '$..table' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table.row', () => {
+      '$..table.row' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table.row.cell', () => {
+      '$..table.row.cell' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table.row.cell.block', () => {
+      '$..table.row.cell.block' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table..cell middle-`..`', () => {
+      '$..table..cell' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table..block middle-`..`', () => {
+      '$..table..block' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts table..cell.block middle-`..` with exact tail', () => {
+      '$..table..cell.block' satisfies ContainerScope<TableSchema>
+    })
+
+    test('accepts row..cell middle-`..`', () => {
+      '$..row..cell' satisfies ContainerScope<TableSchema>
+    })
+
+    test('rejects bare row (not at chain root)', () => {
+      // @ts-expect-error — row only appears inside table
+      '$.row' satisfies ContainerScope<TableSchema>
+    })
+
+    test('rejects bare cell (not at chain root)', () => {
+      // @ts-expect-error — cell only appears inside table.row
+      '$.cell' satisfies ContainerScope<TableSchema>
+    })
+  })
+
+  describe('syntax errors', () => {
+    test('rejects bare scope (no anchor)', () => {
+      // @ts-expect-error — missing $. or $..
+      'block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects missing dot after $', () => {
+      // @ts-expect-error — need $. or $..
+      '$block' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects bare root anchor', () => {
+      // @ts-expect-error — no segment after $.
+      '$.' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects bare descendant anchor', () => {
+      // @ts-expect-error — no segment after $..
+      '$..' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects root alone', () => {
+      // @ts-expect-error — no segment after $
+      '$' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects empty string', () => {
+      // @ts-expect-error — must start with $. or $..
+      '' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects field name in scope', () => {
+      // @ts-expect-error — fields are not types
+      '$..callout.content' satisfies ContainerScope<CalloutSchema>
+    })
+
+    test('rejects unknown type', () => {
+      // @ts-expect-error — foo is not in the schema
+      '$..foo' satisfies ContainerScope<CalloutSchema>
+    })
+  })
+})
+
+// ============================================================================
+// LeafScope
+// ============================================================================
+
+describe('LeafScope', () => {
+  describe('minimal schema (just spans)', () => {
+    test('accepts span in root text block', () => {
+      '$.block.span' satisfies LeafScope<MinimalSchema>
+    })
+
+    test('accepts span in any text block', () => {
+      '$..block.span' satisfies LeafScope<MinimalSchema>
+    })
+
+    test('rejects span without block. parent', () => {
+      // @ts-expect-error — span must have block. parent
+      '$..span' satisfies LeafScope<MinimalSchema>
+    })
+
+    test('rejects span at root without block. parent', () => {
+      // @ts-expect-error — span must have block. parent
+      '$.span' satisfies LeafScope<MinimalSchema>
+    })
+  })
+
+  describe('callout schema', () => {
+    test('accepts void block object at root', () => {
+      '$.image' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts void block object anywhere', () => {
+      '$..image' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts span in root text block', () => {
+      '$.block.span' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts span in any text block', () => {
+      '$..block.span' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts span in callout text block', () => {
+      '$..callout.block.span' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts span in root callout text block', () => {
+      '$.callout.block.span' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts span with middle-`..` inside callout', () => {
+      '$..callout..block.span' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts inline object in text block', () => {
+      '$..block.stock-ticker' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts inline object in root text block', () => {
+      '$.block.stock-ticker' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('accepts inline object in callout text block', () => {
+      '$..callout.block.stock-ticker' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('rejects inline object without block. parent', () => {
+      // @ts-expect-error — stock-ticker must have block. parent
+      '$..stock-ticker' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('rejects inline object with callout parent (no block.)', () => {
+      // @ts-expect-error — must be $..callout.block.stock-ticker
+      '$..callout.stock-ticker' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('rejects container as leaf', () => {
+      // @ts-expect-error — callout is a container
+      '$..callout' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('rejects block as leaf', () => {
+      // @ts-expect-error — block is a container
+      '$..block' satisfies LeafScope<CalloutSchema>
+    })
+
+    test('rejects unknown leaf type', () => {
+      // @ts-expect-error
+      '$..unknown' satisfies LeafScope<CalloutSchema>
+    })
+  })
+
+  describe('gallery schema (image inside container)', () => {
+    test('accepts image in gallery', () => {
+      '$.gallery.image' satisfies LeafScope<GallerySchema>
+    })
+
+    test('accepts image anywhere in gallery', () => {
+      '$..gallery.image' satisfies LeafScope<GallerySchema>
+    })
+
+    test('accepts span in root block (always valid for any schema)', () => {
+      '$.block.span' satisfies LeafScope<GallerySchema>
+    })
+
+    test('rejects gallery as leaf', () => {
+      // @ts-expect-error — gallery is a container
+      '$..gallery' satisfies LeafScope<GallerySchema>
+    })
+  })
+
+  describe('table schema (deep leaves)', () => {
+    test('accepts span in deep chain', () => {
+      '$..table.row.cell.block.span' satisfies LeafScope<TableSchema>
+    })
+
+    test('accepts span with middle-`..`', () => {
+      '$..table..block.span' satisfies LeafScope<TableSchema>
+    })
+
+    test('accepts span in root table chain', () => {
+      '$.table.row.cell.block.span' satisfies LeafScope<TableSchema>
+    })
+
+    test('rejects middle-`..` before span (not a block parent)', () => {
+      // @ts-expect-error — span must have block. immediate parent
+      '$..table..span' satisfies LeafScope<TableSchema>
+    })
+  })
+
+  describe('full schema walkthrough', () => {
+    test('accepts $..image', () => {
+      '$..image' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $.image', () => {
+      '$.image' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..callout.image', () => {
+      '$..callout.image' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $.callout.image', () => {
+      '$.callout.image' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..callout..image', () => {
+      '$..callout..image' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..block.span', () => {
+      '$..block.span' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $.block.span', () => {
+      '$.block.span' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..callout.block.span', () => {
+      '$..callout.block.span' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..block.stock-ticker', () => {
+      '$..block.stock-ticker' satisfies LeafScope<FullSchema>
+    })
+
+    test('accepts $..callout.block.stock-ticker', () => {
+      '$..callout.block.stock-ticker' satisfies LeafScope<FullSchema>
+    })
+
+    test('rejects $..callout..block.stock-ticker when in middle-..`', () => {
+      '$..callout..block.stock-ticker' satisfies LeafScope<FullSchema>
+    })
+  })
+})

--- a/packages/editor/src/scope/scope.types.test-d.ts
+++ b/packages/editor/src/scope/scope.types.test-d.ts
@@ -2,10 +2,6 @@ import {defineSchema} from '@portabletext/schema'
 import {describe, test} from 'vitest'
 import type {ContainerScope, LeafScope} from './scope.types'
 
-// ============================================================================
-// Test fixtures
-// ============================================================================
-
 const minimalSchema = defineSchema({})
 type MinimalSchema = typeof minimalSchema
 
@@ -89,10 +85,6 @@ const fullSchema = defineSchema({
 })
 type FullSchema = typeof fullSchema
 
-// ============================================================================
-// ContainerScope
-// ============================================================================
-
 describe('ContainerScope', () => {
   describe('minimal schema (no blockObjects)', () => {
     test('accepts root text block', () => {
@@ -104,12 +96,12 @@ describe('ContainerScope', () => {
     })
 
     test('rejects unknown container type', () => {
-      // @ts-expect-error — callout not in schema
+      // @ts-expect-error: callout not in schema
       '$.callout' satisfies ContainerScope<MinimalSchema>
     })
 
     test('rejects leaf terminal (span)', () => {
-      // @ts-expect-error — span is a leaf, not a container
+      // @ts-expect-error: span is a leaf, not a container
       '$..span' satisfies ContainerScope<MinimalSchema>
     })
   })
@@ -148,17 +140,17 @@ describe('ContainerScope', () => {
     })
 
     test('rejects image as container (void block object)', () => {
-      // @ts-expect-error — image is a leaf, not a container
+      // @ts-expect-error: image is a leaf, not a container
       '$..image' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects inline object as container', () => {
-      // @ts-expect-error — stock-ticker is a leaf, not a container
+      // @ts-expect-error: stock-ticker is a leaf, not a container
       '$..stock-ticker' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects leaf scope as container', () => {
-      // @ts-expect-error — span is a leaf
+      // @ts-expect-error: span is a leaf
       '$..block.span' satisfies ContainerScope<CalloutSchema>
     })
   })
@@ -177,7 +169,7 @@ describe('ContainerScope', () => {
     })
 
     test('rejects image as container', () => {
-      // @ts-expect-error — image is a leaf
+      // @ts-expect-error: image is a leaf
       '$..image' satisfies ContainerScope<GallerySchema>
     })
   })
@@ -220,62 +212,58 @@ describe('ContainerScope', () => {
     })
 
     test('rejects bare row (not at chain root)', () => {
-      // @ts-expect-error — row only appears inside table
+      // @ts-expect-error: row only appears inside table
       '$.row' satisfies ContainerScope<TableSchema>
     })
 
     test('rejects bare cell (not at chain root)', () => {
-      // @ts-expect-error — cell only appears inside table.row
+      // @ts-expect-error: cell only appears inside table.row
       '$.cell' satisfies ContainerScope<TableSchema>
     })
   })
 
   describe('syntax errors', () => {
     test('rejects bare scope (no anchor)', () => {
-      // @ts-expect-error — missing $. or $..
+      // @ts-expect-error: missing $. or $..
       'block' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects missing dot after $', () => {
-      // @ts-expect-error — need $. or $..
+      // @ts-expect-error: need $. or $..
       '$block' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects bare root anchor', () => {
-      // @ts-expect-error — no segment after $.
+      // @ts-expect-error: no segment after $.
       '$.' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects bare descendant anchor', () => {
-      // @ts-expect-error — no segment after $..
+      // @ts-expect-error: no segment after $..
       '$..' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects root alone', () => {
-      // @ts-expect-error — no segment after $
+      // @ts-expect-error: no segment after $
       '$' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects empty string', () => {
-      // @ts-expect-error — must start with $. or $..
+      // @ts-expect-error: must start with $. or $..
       '' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects field name in scope', () => {
-      // @ts-expect-error — fields are not types
+      // @ts-expect-error: fields are not types
       '$..callout.content' satisfies ContainerScope<CalloutSchema>
     })
 
     test('rejects unknown type', () => {
-      // @ts-expect-error — foo is not in the schema
+      // @ts-expect-error: foo is not in the schema
       '$..foo' satisfies ContainerScope<CalloutSchema>
     })
   })
 })
-
-// ============================================================================
-// LeafScope
-// ============================================================================
 
 describe('LeafScope', () => {
   describe('minimal schema (just spans)', () => {
@@ -288,12 +276,12 @@ describe('LeafScope', () => {
     })
 
     test('rejects span without block. parent', () => {
-      // @ts-expect-error — span must have block. parent
+      // @ts-expect-error: span must have block. parent
       '$..span' satisfies LeafScope<MinimalSchema>
     })
 
     test('rejects span at root without block. parent', () => {
-      // @ts-expect-error — span must have block. parent
+      // @ts-expect-error: span must have block. parent
       '$.span' satisfies LeafScope<MinimalSchema>
     })
   })
@@ -340,22 +328,22 @@ describe('LeafScope', () => {
     })
 
     test('rejects inline object without block. parent', () => {
-      // @ts-expect-error — stock-ticker must have block. parent
+      // @ts-expect-error: stock-ticker must have block. parent
       '$..stock-ticker' satisfies LeafScope<CalloutSchema>
     })
 
     test('rejects inline object with callout parent (no block.)', () => {
-      // @ts-expect-error — must be $..callout.block.stock-ticker
+      // @ts-expect-error: must be $..callout.block.stock-ticker
       '$..callout.stock-ticker' satisfies LeafScope<CalloutSchema>
     })
 
     test('rejects container as leaf', () => {
-      // @ts-expect-error — callout is a container
+      // @ts-expect-error: callout is a container
       '$..callout' satisfies LeafScope<CalloutSchema>
     })
 
     test('rejects block as leaf', () => {
-      // @ts-expect-error — block is a container
+      // @ts-expect-error: block is a container
       '$..block' satisfies LeafScope<CalloutSchema>
     })
 
@@ -379,7 +367,7 @@ describe('LeafScope', () => {
     })
 
     test('rejects gallery as leaf', () => {
-      // @ts-expect-error — gallery is a container
+      // @ts-expect-error: gallery is a container
       '$..gallery' satisfies LeafScope<GallerySchema>
     })
   })
@@ -398,7 +386,7 @@ describe('LeafScope', () => {
     })
 
     test('rejects middle-`..` before span (not a block parent)', () => {
-      // @ts-expect-error — span must have block. immediate parent
+      // @ts-expect-error: span must have block. immediate parent
       '$..table..span' satisfies LeafScope<TableSchema>
     })
   })

--- a/packages/editor/src/scope/scope.types.ts
+++ b/packages/editor/src/scope/scope.types.ts
@@ -1,0 +1,324 @@
+import type {SchemaDefinition} from '@portabletext/schema'
+
+/**
+ * @internal
+ *
+ * Scope grammar types for expressing positions in the schema tree.
+ *
+ * Scopes use a JSONPath-inspired grammar:
+ * - `$.` = root anchor. Terminal type must be at the editor's root.
+ * - `$..` = descendant. Matches at any depth.
+ * - Middle `..` (e.g., `$..table..span`) skips over intermediate types.
+ * - Segments are type names only. Field names never appear in scope.
+ *
+ * See `/specs/scope-grammar.md` for the full spec.
+ */
+
+// ============================================================================
+// Schema walking helpers
+// ============================================================================
+
+/**
+ * @internal
+ *
+ * Extracts the names of array-typed fields from a field list.
+ * Array fields are the ones that can hold editable children (containers).
+ */
+type ExtractArrayFields<TFields> = TFields extends readonly [
+  infer TField,
+  ...infer TRest,
+]
+  ? TField extends {name: infer TName extends string; type: 'array'}
+    ? TName | ExtractArrayFields<TRest>
+    : ExtractArrayFields<TRest>
+  : never
+
+/**
+ * @internal
+ *
+ * Walks the `of` members of array fields, extracting member types with their
+ * own field lists (so we can recurse into nested containers).
+ */
+type ExtractOfMembers<TOfMembers> = TOfMembers extends readonly [
+  infer TMember,
+  ...infer TRest,
+]
+  ? TMember extends {
+      type: infer TTypeName extends string
+      fields?: infer TFields
+    }
+    ? {type: TTypeName; fields: TFields} | ExtractOfMembers<TRest>
+    : ExtractOfMembers<TRest>
+  : never
+
+/**
+ * @internal
+ *
+ * Walks fields and returns the `of` members of their array fields.
+ */
+type WalkFields<TFields> = TFields extends readonly [
+  infer TField,
+  ...infer TRest,
+]
+  ? TField extends {type: 'array'; of?: infer TOf}
+    ? ExtractOfMembers<TOf> | WalkFields<TRest>
+    : WalkFields<TRest>
+  : never
+
+// ============================================================================
+// Container and leaf type discovery
+// ============================================================================
+
+/**
+ * @internal
+ *
+ * Discovers container types nested inside a field list.
+ * Each entry records the type's chain (dot-separated) and its array fields.
+ */
+type DiscoverContainers<TFields, TChain extends string> =
+  WalkFields<TFields> extends infer TMembers
+    ? TMembers extends {
+        type: infer TTypeName extends string
+        fields: infer TNestedFields
+      }
+      ? TTypeName extends 'block'
+        ? {chain: `${TChain}.block`; arrayFields: 'children'}
+        : ExtractArrayFields<TNestedFields> extends never
+          ? DiscoverContainers<TNestedFields, `${TChain}.${TTypeName}`>
+          :
+              | {
+                  chain: `${TChain}.${TTypeName}`
+                  arrayFields: ExtractArrayFields<TNestedFields>
+                }
+              | DiscoverContainers<TNestedFields, `${TChain}.${TTypeName}`>
+      : never
+    : never
+
+/**
+ * @internal
+ *
+ * Discovers leaf types nested inside a field list. A leaf is a type that
+ * appears as a member of an array but has no array fields of its own
+ * (void block objects). Spans and inline objects are handled separately
+ * at the top level via `AllLeaves`.
+ */
+type DiscoverLeaves<TFields, TChain extends string> =
+  WalkFields<TFields> extends infer TMembers
+    ? TMembers extends {
+        type: infer TTypeName extends string
+        fields: infer TNestedFields
+      }
+      ? TTypeName extends 'block'
+        ? never
+        : ExtractArrayFields<TNestedFields> extends never
+          ? {type: TTypeName; chain: TChain; parent: 'container'}
+          : DiscoverLeaves<TNestedFields, `${TChain}.${TTypeName}`>
+      : never
+    : never
+
+// ============================================================================
+// Schema entry points
+// ============================================================================
+
+/**
+ * @internal
+ *
+ * All containers discoverable from a schema.
+ *
+ * Always includes `{chain: 'block', arrayFields: 'children'}` for root text
+ * blocks. Additionally includes every top-level block object that has array
+ * fields, plus every nested container type recursively.
+ */
+type AllContainers<TSchema extends SchemaDefinition> =
+  | {chain: 'block'; arrayFields: 'children'}
+  | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
+      ? TBlockObject extends {
+          name: infer TName extends string
+          fields?: infer TFields
+        }
+        ? ExtractArrayFields<TFields> extends never
+          ? DiscoverContainers<TFields, TName>
+          :
+              | {chain: TName; arrayFields: ExtractArrayFields<TFields>}
+              | DiscoverContainers<TFields, TName>
+        : never
+      : never)
+
+/**
+ * @internal
+ *
+ * All leaves discoverable from a schema.
+ *
+ * Leaves come from three sources:
+ * - Spans: always available, sit inside text blocks.
+ * - Inline objects: from `schema.inlineObjects`, sit inside text blocks.
+ * - Void block objects: top-level block objects with no array fields, plus
+ *   any nested block objects without array fields inside containers.
+ */
+type AllLeaves<TSchema extends SchemaDefinition> =
+  | {type: 'span'; chain: ''; parent: 'block'}
+  | (TSchema['inlineObjects'] extends ReadonlyArray<infer TInlineObject>
+      ? TInlineObject extends {name: infer TName extends string}
+        ? {type: TName; chain: ''; parent: 'block'}
+        : never
+      : never)
+  | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
+      ? TBlockObject extends {
+          name: infer TName extends string
+          fields?: infer TFields
+        }
+        ? ExtractArrayFields<TFields> extends never
+          ? {type: TName; chain: ''; parent: 'container'}
+          : DiscoverLeaves<TFields, TName>
+        : never
+      : never)
+
+// ============================================================================
+// Chain composition
+// ============================================================================
+
+/**
+ * @internal
+ *
+ * Every container chain as an exact dotted string.
+ */
+type ContainerTerminal<TSchema extends SchemaDefinition> =
+  AllContainers<TSchema> extends {chain: infer TChain extends string}
+    ? TChain
+    : never
+
+/**
+ * @internal
+ *
+ * Build middle-`..` chain variants from a head and rest.
+ *
+ * For head="table", rest="row.cell", produces:
+ *   "table..row.cell" | "table..cell"
+ * Recurses with the next head ("row") for additional pairs.
+ */
+type BuildMiddleChains<THead extends string, TRest extends string> =
+  | `${THead}..${TRest}`
+  | (TRest extends `${string}.${infer TTail}`
+      ? BuildMiddleChains<THead, TTail>
+      : never)
+  | (TRest extends `${infer TInner}.${infer TTail}`
+      ? BuildMiddleChains<TInner, TTail>
+      : never)
+
+/**
+ * @internal
+ *
+ * All middle-`..` chain variants for the schema. For every (ancestor,
+ * descendant) pair in a discovered container chain, emits `ancestor..descendant`.
+ */
+type MiddleChains<TSchema extends SchemaDefinition> =
+  ContainerTerminal<TSchema> extends infer TChain extends string
+    ? TChain extends `${infer THead}.${infer TRest}`
+      ? BuildMiddleChains<THead, TRest>
+      : never
+    : never
+
+/**
+ * @internal
+ *
+ * All valid container chains: exact dotted chains plus middle-`..` variants.
+ */
+type ContainerChain<TSchema extends SchemaDefinition> =
+  | ContainerTerminal<TSchema>
+  | MiddleChains<TSchema>
+
+// ============================================================================
+// Public scope types
+// ============================================================================
+
+/**
+ * @internal
+ *
+ * Valid scopes for `defineContainer` (and, in the future, `defineBehavior`).
+ * Terminal type must be a container (text block or editable container type).
+ *
+ * Examples for a schema with `callout.content` containing blocks:
+ * ```
+ * '$.block' | '$..block'
+ * '$.callout' | '$..callout'
+ * '$.callout.block' | '$..callout.block'
+ * '$.callout..block' | '$..callout..block'
+ * ```
+ */
+export type ContainerScope<TSchema extends SchemaDefinition> =
+  | `$.${ContainerChain<TSchema>}`
+  | `$..${ContainerChain<TSchema>}`
+
+/**
+ * @internal
+ *
+ * Valid scopes for `defineLeaf`. Terminal type must be a leaf.
+ *
+ * Leaf terminals:
+ * - Span (`span`) and inline objects require `block.` as immediate parent.
+ * - Void block objects can appear at root or inside any container chain.
+ */
+export type LeafScope<TSchema extends SchemaDefinition> =
+  | VoidBlockLeafScope<TSchema>
+  | TextBlockLeafScope<TSchema>
+
+/**
+ * @internal
+ *
+ * Scopes whose terminal is a void block object.
+ * Can appear at root or inside any container chain.
+ */
+type VoidBlockLeafScope<TSchema extends SchemaDefinition> =
+  AllLeaves<TSchema> extends infer TLeaf
+    ? TLeaf extends {
+        type: infer TType extends string
+        chain: infer TChain extends string
+        parent: 'container'
+      }
+      ? TChain extends ''
+        ? `$.${TType}` | `$..${TType}`
+        :
+            | `$.${TChain}.${TType}`
+            | `$..${TChain}.${TType}`
+            | `$.${TChain}..${TType}`
+            | `$..${TChain}..${TType}`
+      : never
+    : never
+
+/**
+ * @internal
+ *
+ * All container chains that end in `.block` (or are exactly `block`).
+ * These are the valid "parent" chains for spans and inline objects.
+ */
+type TextBlockContainerChain<TSchema extends SchemaDefinition> =
+  ContainerChain<TSchema> extends infer TChain extends string
+    ? TChain extends 'block'
+      ? TChain
+      : TChain extends `${string}.block`
+        ? TChain
+        : TChain extends `${string}..block`
+          ? TChain
+          : never
+    : never
+
+/**
+ * @internal
+ *
+ * Scopes whose terminal is a span or inline object.
+ * Must have `block.` as immediate parent segment.
+ * Text block can be at root or inside any container chain.
+ */
+type TextBlockLeafScope<TSchema extends SchemaDefinition> =
+  AllLeaves<TSchema> extends infer TLeaf
+    ? TLeaf extends {
+        type: infer TType extends string
+        parent: 'block'
+      }
+      ? TextBlockContainerChain<TSchema> extends infer TChain extends string
+        ? TChain extends TChain
+          ? `$.${TChain}.${TType}` | `$..${TChain}.${TType}`
+          : never
+        : never
+      : never
+    : never

--- a/packages/editor/src/scope/scope.types.ts
+++ b/packages/editor/src/scope/scope.types.ts
@@ -14,10 +14,6 @@ import type {SchemaDefinition} from '@portabletext/schema'
  * See `/specs/scope-grammar.md` for the full spec.
  */
 
-// ============================================================================
-// Schema walking helpers
-// ============================================================================
-
 /**
  * @internal
  *
@@ -64,10 +60,6 @@ type WalkFields<TFields> = TFields extends readonly [
     ? ExtractOfMembers<TOf> | WalkFields<TRest>
     : WalkFields<TRest>
   : never
-
-// ============================================================================
-// Container and leaf type discovery
-// ============================================================================
 
 /**
  * @internal
@@ -116,10 +108,6 @@ type DiscoverLeaves<TFields, TChain extends string> =
       : never
     : never
 
-// ============================================================================
-// Schema entry points
-// ============================================================================
-
 /**
  * @internal
  *
@@ -129,7 +117,7 @@ type DiscoverLeaves<TFields, TChain extends string> =
  * blocks. Additionally includes every top-level block object that has array
  * fields, plus every nested container type recursively.
  */
-type AllContainers<TSchema extends SchemaDefinition> =
+export type AllContainers<TSchema extends SchemaDefinition> =
   | {chain: 'block'; arrayFields: 'children'}
   | (TSchema['blockObjects'] extends ReadonlyArray<infer TBlockObject>
       ? TBlockObject extends {
@@ -172,10 +160,6 @@ type AllLeaves<TSchema extends SchemaDefinition> =
           : DiscoverLeaves<TFields, TName>
         : never
       : never)
-
-// ============================================================================
-// Chain composition
-// ============================================================================
 
 /**
  * @internal
@@ -226,10 +210,6 @@ type MiddleChains<TSchema extends SchemaDefinition> =
 type ContainerChain<TSchema extends SchemaDefinition> =
   | ContainerTerminal<TSchema>
   | MiddleChains<TSchema>
-
-// ============================================================================
-// Public scope types
-// ============================================================================
 
 /**
  * @internal

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -416,7 +416,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Container normalization: ensure the child array field exists.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.containers.get(scopedName)
+    const arrayField = editor.containers.get(scopedName)?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -431,7 +431,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Container normalization: ensure non-empty child array.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.containers.get(scopedName)
+    const arrayField = editor.containers.get(scopedName)?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]

--- a/packages/editor/src/slate/node/is-void-node.test.ts
+++ b/packages/editor/src/slate/node/is-void-node.test.ts
@@ -1,8 +1,18 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import {createNodeTraversalTestbed} from '../../node-traversal/node-traversal-testbed'
+import type {ContainerConfig} from '../../renderers/renderer.types'
 import type {ChildArrayField} from '../../schema/resolve-containers'
+import {parseScope} from '../../scope/parse-scope'
 import {isVoidNode} from './is-void-node'
+
+function containerConfigFor(field: ChildArrayField): ContainerConfig {
+  return {
+    container: {scope: '$..dummy', field: field.name},
+    parsedScope: parseScope('$..dummy')!,
+    field,
+  }
+}
 
 describe(isVoidNode.name, () => {
   const testbed = createNodeTraversalTestbed()
@@ -179,30 +189,30 @@ describe(isVoidNode.name, () => {
       }),
     )
 
-    const containers = new Map<string, ChildArrayField>([
+    const containers = new Map<string, ContainerConfig>([
       [
         'table',
-        {
+        containerConfigFor({
           name: 'rows',
           type: 'array',
           of: [{type: 'row'}],
-        },
+        }),
       ],
       [
         'table.row',
-        {
+        containerConfigFor({
           name: 'cells',
           type: 'array',
           of: [{type: 'cell'}],
-        },
+        }),
       ],
       [
         'table.row.cell',
-        {
+        containerConfigFor({
           name: 'content',
           type: 'array',
           of: [{type: 'block'}, {type: 'image'}],
-        },
+        }),
       ],
     ])
 
@@ -264,14 +274,14 @@ describe(isVoidNode.name, () => {
       }),
     )
 
-    const containers = new Map<string, ChildArrayField>([
+    const containers = new Map<string, ContainerConfig>([
       [
         'gallery',
-        {
+        containerConfigFor({
           name: 'images',
           type: 'array',
           of: [{type: 'image'}],
-        },
+        }),
       ],
     ])
 

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -76,13 +76,15 @@ const useChildren = (props: {
       ? `${containerScope}.${node._type}`
       : node._type
 
-    const containerField = editor.containers.get(scopedKey)
+    const containerConfig = editor.containers.get(scopedKey)
 
-    if (containerField) {
-      const fieldValue = (node as Record<string, unknown>)[containerField.name]
+    if (containerConfig) {
+      const fieldValue = (node as Record<string, unknown>)[
+        containerConfig.field.name
+      ]
       if (Array.isArray(fieldValue)) {
         children = fieldValue as Array<Node>
-        childFieldName = containerField.name
+        childFieldName = containerConfig.field.name
       }
 
       childScope = scopedKey

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -1,7 +1,11 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
-import type {Containers} from '../src/schema/resolve-containers'
+import {makeContainerConfig} from '../src/schema/make-container-config'
+import {
+  resolveContainers,
+  type Containers,
+} from '../src/schema/resolve-containers'
 import {fromTextspec} from './from-textspec'
 import {toTextspec} from './to-textspec'
 
@@ -62,24 +66,32 @@ const schemaDefinition = defineSchema({
 
 const schema = compileSchema(schemaDefinition)
 
-const tableContainers: Containers = new Map([
-  [
-    'table',
-    {name: 'rows', type: 'array', of: [{type: 'tableRow', name: 'tableRow'}]},
-  ],
-  [
-    'table.tableRow',
-    {
-      name: 'cells',
-      type: 'array',
-      of: [{type: 'tableCell', name: 'tableCell'}],
-    },
-  ],
-  [
-    'table.tableRow.tableCell',
-    {name: 'content', type: 'array', of: [{type: 'block'}]},
-  ],
-])
+const tableContainers: Containers = resolveContainers(
+  schema,
+  new Map([
+    [
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+      }),
+    ],
+    [
+      '$..table.tableRow',
+      makeContainerConfig(schema, {
+        scope: '$..table.tableRow',
+        field: 'cells',
+      }),
+    ],
+    [
+      '$..table.tableRow.tableCell',
+      makeContainerConfig(schema, {
+        scope: '$..table.tableRow.tableCell',
+        field: 'content',
+      }),
+    ],
+  ]),
+)
 
 describe(fromTextspec.name, () => {
   test('simple paragraph', () => {

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -365,7 +365,7 @@ function resolveContainerScopePath(
   }
 
   // Nested: look through parent container's `of` array
-  const parentField = containers.get(parentScopePath)
+  const parentField = containers.get(parentScopePath)?.field
 
   if (!parentField) {
     return undefined
@@ -391,7 +391,7 @@ function convertContainerToPTE(
   keyGenerator: () => string,
   scopePath: string,
 ): PortableTextObject {
-  const containerField = containers.get(scopePath)
+  const containerField = containers.get(scopePath)?.field
 
   if (!containerField) {
     return {
@@ -707,9 +707,9 @@ function resolveContainerPoint(
     if (isTextBlock(schemaContext, currentNode as PortableTextBlock)) {
       childFieldName = 'children'
     } else if (typeof currentNode['_type'] === 'string') {
-      for (const [, containerField] of containers) {
-        if (currentNode[containerField.name] !== undefined) {
-          childFieldName = containerField.name
+      for (const [, containerConfig] of containers) {
+        if (currentNode[containerConfig.field.name] !== undefined) {
+          childFieldName = containerConfig.field.name
           break
         }
       }
@@ -820,9 +820,9 @@ function indexedPathToKeyedPath(
       childFieldName = 'children'
     } else if (typeof node['_type'] === 'string') {
       // Look up the field name from the containers map
-      for (const [, containerField] of containers) {
-        if (node[containerField.name] !== undefined) {
-          childFieldName = containerField.name
+      for (const [, containerConfig] of containers) {
+        if (node[containerConfig.field.name] !== undefined) {
+          childFieldName = containerConfig.field.name
           break
         }
       }

--- a/packages/editor/test-utils/to-textspec.test.ts
+++ b/packages/editor/test-utils/to-textspec.test.ts
@@ -4,7 +4,11 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {Containers} from '../src/schema/resolve-containers'
+import {makeContainerConfig} from '../src/schema/make-container-config'
+import {
+  resolveContainers,
+  type Containers,
+} from '../src/schema/resolve-containers'
 import {toTextspec} from './to-textspec'
 
 const schemaDefinition = defineSchema({
@@ -64,24 +68,32 @@ const schemaDefinition = defineSchema({
 
 const schema = compileSchema(schemaDefinition)
 
-const tableContainers: Containers = new Map([
-  [
-    'table',
-    {name: 'rows', type: 'array', of: [{type: 'tableRow', name: 'tableRow'}]},
-  ],
-  [
-    'table.tableRow',
-    {
-      name: 'cells',
-      type: 'array',
-      of: [{type: 'tableCell', name: 'tableCell'}],
-    },
-  ],
-  [
-    'table.tableRow.tableCell',
-    {name: 'content', type: 'array', of: [{type: 'block'}]},
-  ],
-])
+const tableContainers: Containers = resolveContainers(
+  schema,
+  new Map([
+    [
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+      }),
+    ],
+    [
+      '$..table.tableRow',
+      makeContainerConfig(schema, {
+        scope: '$..table.tableRow',
+        field: 'cells',
+      }),
+    ],
+    [
+      '$..table.tableRow.tableCell',
+      makeContainerConfig(schema, {
+        scope: '$..table.tableRow.tableCell',
+        field: 'content',
+      }),
+    ],
+  ]),
+)
 
 function block(
   props: Partial<PortableTextTextBlock> & {

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -355,7 +355,7 @@ function convertContainerBlock(
   block: Record<string, unknown>,
   scopePath: string,
 ): ContainerBlock {
-  const containerField = containers.get(scopePath)
+  const containerField = containers.get(scopePath)?.field
 
   if (!containerField) {
     return {

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -58,22 +58,22 @@ const schemaDefinition = defineSchema({
 
 const tableContainers = [
   {
-    container: defineContainer({
-      scope: 'table',
+    container: defineContainer<typeof schemaDefinition>({
+      scope: '$..table',
       field: 'rows',
       render: ({children}) => <>{children}</>,
     }),
   },
   {
-    container: defineContainer({
-      scope: 'table.row',
+    container: defineContainer<typeof schemaDefinition>({
+      scope: '$..table.row',
       field: 'cells',
       render: ({children}) => <>{children}</>,
     }),
   },
   {
-    container: defineContainer({
-      scope: 'table.row.cell',
+    container: defineContainer<typeof schemaDefinition>({
+      scope: '$..table.row.cell',
       field: 'content',
       render: ({children}) => <>{children}</>,
     }),
@@ -82,8 +82,8 @@ const tableContainers = [
 
 const calloutContainers = [
   {
-    container: defineContainer({
-      scope: 'callout',
+    container: defineContainer<typeof schemaDefinition>({
+      scope: '$..callout',
       field: 'content',
       render: ({children}) => <>{children}</>,
     }),
@@ -1354,12 +1354,9 @@ describe('container normalization', () => {
     // Late-register a container for callout
     ;(editor as unknown as InternalEditor)._internal.editorActor.send({
       type: 'register container',
-      containerConfig: {
-        container: {
-          scope: 'callout',
-          field: 'content',
-          render: ({children}) => children,
-        },
+      container: {
+        scope: '$..callout',
+        field: 'content',
       },
     })
 
@@ -1532,8 +1529,8 @@ describe('container normalization', () => {
         <ContainerPlugin
           containers={[
             {
-              container: defineContainer({
-                scope: 'card',
+              container: defineContainer<typeof cardSchemaDefinition>({
+                scope: '$..card',
                 field: 'tags',
                 render: ({children}) => <>{children}</>,
               }),
@@ -1665,35 +1662,35 @@ describe('container normalization', () => {
           containers={[
             {
               container: {
-                scope: 'callout',
+                scope: '$..callout',
                 field: 'content',
                 render: ({children}) => <>{children}</>,
               },
             },
             {
               container: {
-                scope: 'table',
+                scope: '$..table',
                 field: 'rows',
                 render: ({children}) => <>{children}</>,
               },
             },
             {
               container: {
-                scope: 'table.row',
+                scope: '$..table.row',
                 field: 'cells',
                 render: ({children}) => <>{children}</>,
               },
             },
             {
               container: {
-                scope: 'table.row.cell',
+                scope: '$..table.row.cell',
                 field: 'content',
                 render: ({children}) => <>{children}</>,
               },
             },
             {
               container: {
-                scope: 'figure',
+                scope: '$..figure',
                 field: 'caption',
                 render: ({children}) => <>{children}</>,
               },
@@ -1808,22 +1805,22 @@ describe('container normalization', () => {
         <ContainerPlugin
           containers={[
             {
-              container: defineContainer({
-                scope: 'table',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table',
                 field: 'rows',
                 render: ({children}) => <>{children}</>,
               }),
             },
             {
-              container: defineContainer({
-                scope: 'table.row',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table.row',
                 field: 'cells',
                 render: ({children}) => <>{children}</>,
               }),
             },
             {
-              container: defineContainer({
-                scope: 'table.row.cell',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table.row.cell',
                 field: 'content',
                 render: ({children}) => <>{children}</>,
               }),
@@ -1894,22 +1891,22 @@ describe('container normalization', () => {
         <ContainerPlugin
           containers={[
             {
-              container: defineContainer({
-                scope: 'table',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table',
                 field: 'rows',
                 render: ({children}) => <>{children}</>,
               }),
             },
             {
-              container: defineContainer({
-                scope: 'table.row',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table.row',
                 field: 'cells',
                 render: ({children}) => <>{children}</>,
               }),
             },
             {
-              container: defineContainer({
-                scope: 'table.row.cell',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..table.row.cell',
                 field: 'content',
                 render: ({children}) => <>{children}</>,
               }),
@@ -2027,12 +2024,9 @@ describe('container normalization', () => {
     // Unregister the container via the internal editor actor
     ;(editor as unknown as InternalEditor)._internal.editorActor.send({
       type: 'unregister container',
-      containerConfig: {
-        container: {
-          scope: 'callout',
-          field: 'content',
-          render: ({children}) => children,
-        },
+      container: {
+        scope: '$..callout',
+        field: 'content',
       },
     })
 
@@ -2052,6 +2046,186 @@ describe('container normalization', () => {
 
     // The empty content array should NOT be normalized because the type
     // is no longer editable
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [],
+        },
+      ])
+    })
+  })
+
+  test('calling the unregister function returned from editor.registerContainer reverts container to void', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+        },
+      ],
+    })
+
+    const unregister = (editor as unknown as InternalEditor).registerContainer({
+      container: {
+        scope: '$..callout',
+        field: 'content',
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    unregister()
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: calloutKey}, 'content'],
+          value: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [],
+        },
+      ])
+    })
+  })
+
+  test('unmounting ContainerPlugin reverts container to void', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block' as const,
+        _key: blockKey,
+        children: [
+          {_type: 'span' as const, _key: spanKey, text: 'hello', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'callout',
+        _key: calloutKey,
+      },
+    ]
+
+    const {editor, rerender} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue,
+      children: <ContainerPlugin containers={calloutContainers} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: 'k5',
+              children: [{_type: 'span', _key: 'k6', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    await rerender({
+      keyGenerator,
+      schemaDefinition,
+      initialValue,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: calloutKey}, 'content'],
+          value: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([
         {

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -30,8 +30,8 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-const calloutContainer = defineContainer({
-  scope: 'callout',
+const calloutContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..callout',
   field: 'content',
   render: ({attributes, children}) => (
     <div data-testid="callout" {...attributes}>
@@ -166,8 +166,8 @@ describe('container rendering', () => {
 
     const receivedNodes: Array<{_type: string; _key: string}> = []
 
-    const trackingContainer = defineContainer({
-      scope: 'callout',
+    const trackingContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..callout',
       field: 'content',
       render: ({attributes, children, node}) => {
         receivedNodes.push({_type: node._type, _key: node._key})
@@ -263,8 +263,8 @@ describe('table with nested rows and cells', () => {
     ],
   })
 
-  const tableContainer = defineContainer({
-    scope: 'table',
+  const tableContainer = defineContainer<typeof tableSchemaDefinition>({
+    scope: '$..table',
     field: 'rows',
     render: ({attributes, children}) => (
       <table data-testid="table" {...attributes}>
@@ -273,8 +273,8 @@ describe('table with nested rows and cells', () => {
     ),
   })
 
-  const rowContainer = defineContainer({
-    scope: 'table.row',
+  const rowContainer = defineContainer<typeof tableSchemaDefinition>({
+    scope: '$..table.row',
     field: 'cells',
     render: ({attributes, children}) => (
       <tr data-testid="row" {...attributes}>
@@ -283,8 +283,8 @@ describe('table with nested rows and cells', () => {
     ),
   })
 
-  const cellContainer = defineContainer({
-    scope: 'table.row.cell',
+  const cellContainer = defineContainer<typeof tableSchemaDefinition>({
+    scope: '$..table.row.cell',
     field: 'content',
     render: ({attributes, children}) => (
       <td data-testid="cell" {...attributes}>
@@ -429,8 +429,8 @@ describe('container with non-editable fields', () => {
     ],
   })
 
-  const cardContainer = defineContainer({
-    scope: 'card',
+  const cardContainer = defineContainer<typeof cardSchemaDefinition>({
+    scope: '$..card',
     field: 'body',
     render: ({attributes, children}) => (
       <div data-testid="card" {...attributes}>
@@ -541,8 +541,8 @@ describe('block scope and specificity', () => {
         <ContainerPlugin
           containers={[
             {
-              container: defineContainer({
-                scope: 'block',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..block',
                 field: 'children',
                 render: ({attributes, children}) => (
                   <p data-testid="custom-block" {...attributes}>
@@ -615,8 +615,8 @@ describe('block scope and specificity', () => {
           containers={[
             {container: calloutContainer},
             {
-              container: defineContainer({
-                scope: 'block',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..block',
                 field: 'children',
                 render: ({attributes, children}) => (
                   <p data-testid="universal-block" {...attributes}>
@@ -626,8 +626,8 @@ describe('block scope and specificity', () => {
               }),
             },
             {
-              container: defineContainer({
-                scope: 'callout.block',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..callout.block',
                 field: 'children',
                 render: ({attributes, children}) => (
                   <p data-testid="callout-block" {...attributes}>
@@ -707,8 +707,8 @@ describe('block scope and specificity', () => {
           containers={[
             {container: calloutContainer},
             {
-              container: defineContainer({
-                scope: 'block',
+              container: defineContainer<typeof schemaDefinition>({
+                scope: '$..block',
                 field: 'children',
                 render: ({attributes, children}) => (
                   <p data-testid="universal-block" {...attributes}>
@@ -897,8 +897,8 @@ describe('code block container', () => {
     ],
   })
 
-  const codeBlockContainer = defineContainer({
-    scope: 'code-block',
+  const codeBlockContainer = defineContainer<typeof codeBlockSchemaDefinition>({
+    scope: '$..code-block',
     field: 'code',
     render: ({attributes, children}) => (
       <pre data-testid="code-block" {...attributes}>
@@ -1038,8 +1038,8 @@ describe('gallery with void block objects', () => {
     ],
   })
 
-  const galleryContainer = defineContainer({
-    scope: 'gallery',
+  const galleryContainer = defineContainer<typeof gallerySchemaDefinition>({
+    scope: '$..gallery',
     field: 'items',
     render: ({attributes, children}) => (
       <div data-testid="gallery" {...attributes}>
@@ -1186,8 +1186,8 @@ describe('cell with mixed content', () => {
     ],
   })
 
-  const tableContainer = defineContainer({
-    scope: 'table',
+  const tableContainer = defineContainer<typeof mixedSchemaDefinition>({
+    scope: '$..table',
     field: 'rows',
     render: ({attributes, children}) => (
       <table data-testid="table" {...attributes}>
@@ -1196,8 +1196,8 @@ describe('cell with mixed content', () => {
     ),
   })
 
-  const rowContainer = defineContainer({
-    scope: 'table.row',
+  const rowContainer = defineContainer<typeof mixedSchemaDefinition>({
+    scope: '$..table.row',
     field: 'cells',
     render: ({attributes, children}) => (
       <tr data-testid="row" {...attributes}>
@@ -1206,8 +1206,8 @@ describe('cell with mixed content', () => {
     ),
   })
 
-  const cellContainer = defineContainer({
-    scope: 'table.row.cell',
+  const cellContainer = defineContainer<typeof mixedSchemaDefinition>({
+    scope: '$..table.row.cell',
     field: 'content',
     render: ({attributes, children}) => (
       <td data-testid="cell" {...attributes}>

--- a/packages/editor/tests/container-typing.test.tsx
+++ b/packages/editor/tests/container-typing.test.tsx
@@ -21,8 +21,8 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-const calloutContainer = defineContainer({
-  scope: 'callout',
+const calloutContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..callout',
   field: 'content',
   render: ({attributes, children}) => (
     <div data-testid="callout" {...attributes}>

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -215,8 +215,17 @@ describe('DOM structure', () => {
   })
 
   test('4. gallery container with void leaf children', async () => {
-    const galleryContainer = defineContainer({
-      scope: 'gallery',
+    const gallerySchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'gallery',
+          fields: [{name: 'items', type: 'array', of: [{type: 'image'}]}],
+        },
+        {name: 'image'},
+      ],
+    })
+    const galleryContainer = defineContainer<typeof gallerySchemaDefinition>({
+      scope: '$..gallery',
       field: 'items',
       render: ({attributes, children}) => (
         <div {...attributes} className="gallery">
@@ -225,15 +234,7 @@ describe('DOM structure', () => {
       ),
     })
     await createTestEditor({
-      schemaDefinition: defineSchema({
-        blockObjects: [
-          {
-            name: 'gallery',
-            fields: [{name: 'items', type: 'array', of: [{type: 'image'}]}],
-          },
-          {name: 'image'},
-        ],
-      }),
+      schemaDefinition: gallerySchemaDefinition,
       initialValue: [
         {
           _key: 'g0',
@@ -308,8 +309,47 @@ describe('DOM structure', () => {
   })
 
   test('5. deep nesting: table > row > cell > text block > inline', async () => {
-    const tableContainer = defineContainer({
-      scope: 'table',
+    const tableSchemaDefinition = defineSchema({
+      inlineObjects: [{name: 'stock-ticker'}],
+      blockObjects: [
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'row',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'cell',
+                          fields: [
+                            {
+                              name: 'content',
+                              type: 'array',
+                              of: [
+                                {type: 'block', of: [{type: 'stock-ticker'}]},
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const tableContainer = defineContainer<typeof tableSchemaDefinition>({
+      scope: '$..table',
       field: 'rows',
       render: ({attributes, children}) => (
         <table {...attributes}>
@@ -317,56 +357,18 @@ describe('DOM structure', () => {
         </table>
       ),
     })
-    const rowContainer = defineContainer({
-      scope: 'table.row',
+    const rowContainer = defineContainer<typeof tableSchemaDefinition>({
+      scope: '$..table.row',
       field: 'cells',
       render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
     })
-    const cellContainer = defineContainer({
-      scope: 'table.row.cell',
+    const cellContainer = defineContainer<typeof tableSchemaDefinition>({
+      scope: '$..table.row.cell',
       field: 'content',
       render: ({attributes, children}) => <td {...attributes}>{children}</td>,
     })
     await createTestEditor({
-      schemaDefinition: defineSchema({
-        inlineObjects: [{name: 'stock-ticker'}],
-        blockObjects: [
-          {
-            name: 'table',
-            fields: [
-              {
-                name: 'rows',
-                type: 'array',
-                of: [
-                  {
-                    type: 'row',
-                    fields: [
-                      {
-                        name: 'cells',
-                        type: 'array',
-                        of: [
-                          {
-                            type: 'cell',
-                            fields: [
-                              {
-                                name: 'content',
-                                type: 'array',
-                                of: [
-                                  {type: 'block', of: [{type: 'stock-ticker'}]},
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }),
+      schemaDefinition: tableSchemaDefinition,
       initialValue: [
         {
           _key: 't0',
@@ -488,8 +490,16 @@ describe('DOM structure', () => {
   })
 
   test('6. code block container with text blocks', async () => {
-    const codeContainer = defineContainer({
-      scope: 'code',
+    const codeSchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'code',
+          fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+    const codeContainer = defineContainer<typeof codeSchemaDefinition>({
+      scope: '$..code',
       field: 'lines',
       render: ({attributes, children}) => (
         <pre {...attributes}>
@@ -498,14 +508,7 @@ describe('DOM structure', () => {
       ),
     })
     await createTestEditor({
-      schemaDefinition: defineSchema({
-        blockObjects: [
-          {
-            name: 'code',
-            fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
-          },
-        ],
-      }),
+      schemaDefinition: codeSchemaDefinition,
       initialValue: [
         {
           _key: 'c0',

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -2458,22 +2458,24 @@ describe('event.patches', () => {
       const editorText = 'Hello'
       const incomingText = 'Hello there'
 
+      const calloutSchemaDefinition = defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      })
+
       const {editor} = await createTestEditor({
         keyGenerator,
-        schemaDefinition: defineSchema({
-          blockObjects: [
-            {
-              name: 'callout',
-              fields: [
-                {
-                  name: 'content',
-                  type: 'array',
-                  of: [{type: 'block'}],
-                },
-              ],
-            },
-          ],
-        }),
+        schemaDefinition: calloutSchemaDefinition,
         initialValue: [
           {
             _type: 'callout',
@@ -2495,8 +2497,8 @@ describe('event.patches', () => {
           <ContainerPlugin
             containers={[
               {
-                container: defineContainer({
-                  scope: 'callout',
+                container: defineContainer<typeof calloutSchemaDefinition>({
+                  scope: '$..callout',
                   field: 'content',
                   render: ({children}) => <>{children}</>,
                 }),
@@ -4641,8 +4643,8 @@ describe('event.patches', () => {
 
     const calloutContainers = [
       {
-        container: defineContainer({
-          scope: 'callout',
+        container: defineContainer<typeof containerSchema>({
+          scope: '$..callout',
           field: 'content',
           render: ({children}) => <>{children}</>,
         }),
@@ -4651,22 +4653,22 @@ describe('event.patches', () => {
 
     const tableContainers = [
       {
-        container: defineContainer({
-          scope: 'table',
+        container: defineContainer<typeof containerSchema>({
+          scope: '$..table',
           field: 'rows',
           render: ({children}) => <>{children}</>,
         }),
       },
       {
-        container: defineContainer({
-          scope: 'table.row',
+        container: defineContainer<typeof containerSchema>({
+          scope: '$..table.row',
           field: 'cells',
           render: ({children}) => <>{children}</>,
         }),
       },
       {
-        container: defineContainer({
-          scope: 'table.row.cell',
+        container: defineContainer<typeof containerSchema>({
+          scope: '$..table.row.cell',
           field: 'content',
           render: ({children}) => <>{children}</>,
         }),

--- a/packages/editor/tests/render-child.test.tsx
+++ b/packages/editor/tests/render-child.test.tsx
@@ -389,8 +389,8 @@ describe('renderChild', () => {
       inlineObjects: [{name: 'image'}],
     })
 
-    const tableContainer = defineContainer({
-      scope: 'table',
+    const tableContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..table',
       field: 'rows',
       render: ({attributes, children}) => (
         <table {...attributes}>
@@ -399,14 +399,14 @@ describe('renderChild', () => {
       ),
     })
 
-    const rowContainer = defineContainer({
-      scope: 'table.row',
+    const rowContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..table.row',
       field: 'cells',
       render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
     })
 
-    const cellContainer = defineContainer({
-      scope: 'table.row.cell',
+    const cellContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..table.row.cell',
       field: 'content',
       render: ({attributes, children}) => (
         <td data-testid="cell" {...attributes}>

--- a/packages/editor/tests/tables.test.tsx
+++ b/packages/editor/tests/tables.test.tsx
@@ -1,10 +1,13 @@
 import {set, unset} from '@portabletext/patches'
-import {defineSchema} from '@portabletext/schema'
+import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {InternalSlateEditorRefPlugin} from '../src/plugins/plugin.internal.slate-editor-ref'
+import type {Container} from '../src/renderers/renderer.types'
+import {makeContainerConfig} from '../src/schema/make-container-config'
 import type {Containers} from '../src/schema/resolve-containers'
+import {resolveContainers} from '../src/schema/resolve-containers'
 import {withoutPatching} from '../src/slate-plugins/slate-plugin.without-patching'
 import {normalize} from '../src/slate/editor/normalize'
 import {createTestEditor} from '../src/test/vitest'
@@ -52,58 +55,37 @@ const schemaDefinition = defineSchema({
 })
 
 function tableContainers(): Containers {
-  return new Map([
-    [
-      'table',
-      {
-        name: 'rows',
-        type: 'array',
-        of: [
-          {
-            type: 'row',
-            fields: [
-              {
-                name: 'cells',
-                type: 'array',
-                of: [
-                  {
-                    type: 'cell',
-                    fields: [
-                      {
-                        name: 'content',
-                        type: 'array',
-                        of: [{type: 'block'}],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    [
-      'table.row',
-      {
-        name: 'cells',
-        type: 'array',
-        of: [
-          {
-            type: 'cell',
-            fields: [
-              {
-                name: 'content',
-                type: 'array',
-                of: [{type: 'block'}],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    ['table.row.cell', {name: 'content', type: 'array', of: [{type: 'block'}]}],
-  ])
+  const render: Container['render'] = ({children}) => children
+  const schema = compileSchema(schemaDefinition)
+  return resolveContainers(
+    schema,
+    new Map([
+      [
+        '$..table',
+        makeContainerConfig(schema, {
+          scope: '$..table',
+          field: 'rows',
+          render,
+        }),
+      ],
+      [
+        '$..table.row',
+        makeContainerConfig(schema, {
+          scope: '$..table.row',
+          field: 'cells',
+          render,
+        }),
+      ],
+      [
+        '$..table.row.cell',
+        makeContainerConfig(schema, {
+          scope: '$..table.row.cell',
+          field: 'content',
+          render,
+        }),
+      ],
+    ]),
+  )
 }
 
 async function createTableTestEditor() {


### PR DESCRIPTION
## The scope language

Scope is how consumers tell the editor "apply this container here." Today it's a terse suffix-match string: `'callout.block'` means "a block in a callout, anywhere." It works, but two things have been bothering us.

There's no way to say "only at the root." `defineContainer({scope: 'block'})` overrides every text block in the document, including blocks nested deep inside callouts and table cells. Consumers who want to override only root text blocks don't have a way to express it.

The matching rule is implicit. Suffix-match, where longer wins and bare matches anywhere, is a convention you learn by reading the source. Nothing on the page signals what the rules are.

This PR redesigns the language around JSONPath, which Sanity developers already see in `@sanity/mutate` and migration tooling. Every scope starts with an anchor: `$.` for root-only, `$..` for any-descendant. Exact chains and middle `..` (as in `$..table..span`) both work.

```ts
defineContainer({
  scope: '$..callout',       // callout at any depth
  field: 'content',
  render: ...,
})

defineContainer({
  scope: '$.block',          // root text blocks only
  field: 'children',
  render: ...,
})

defineContainer({
  scope: '$..table.row',     // rows in any table
  field: 'cells',
  render: ...,
})
```

## What changes for consumers

`defineContainer<TSchema>` now accepts `ContainerScope<TSchema>`, a union of every valid scope string derivable from the schema. Autocomplete shows what's available. Typos fail at compile time. Scopes that target a type that isn't a container, or that reference a type not in the schema, fail at compile time. Bare scopes (missing `$.` or `$..`) fail at compile time.

At runtime, scopes are parsed once at registration. Invalid scopes that slip past the type checker (via `as any`, or from a dynamic source) produce a `console.warn` and the container isn't registered.

## What changes inside the editor

The suffix-match algorithm in `findByScope` is gone. On every container registration, the editor walks the schema once, enumerates every candidate type chain, matches each candidate against every registered scope with the JSONPath rules, and picks the most specific match per candidate. The result is a `Map<scopedTypeName, {field, config}>` stored on the editor.

Render, traversal, and normalization look the container up with a single `Map.get`. No matching logic at hot path.

Specificity follows the three rules from the scope grammar spec: root-anchored beats descendant, then longer chain beats shorter, then more exact segments beat fewer. `$.callout.block` beats `$..callout.block` for root callouts; `$..callout.block.span` beats `$..block.span` for spans inside callouts; `$..callout.block.span` beats `$..callout..span` when both match.

## What this PR doesn't touch

`defineLeaf` still uses the current suffix-match grammar. `LeafScope<TSchema>` is shipped as a type utility but not wired into the `defineLeaf` signature yet. That migration is a follow-up.

Everything is `@internal`. Nothing is re-exported from `src/index.ts`.

## Commit structure

1. `ContainerScope` and `LeafScope` type utilities plus colocated type-level tests.
2. `parseScope`, `matchScope`, and `compareSpecificity` runtime utilities plus unit tests.
3. `defineContainer` wired to `ContainerScope`, `resolveContainers` rewritten around the new grammar, precomputed `Map` lookup, internal call sites migrated.

Three commits, all `fix:`, no changesets (everything internal).