### PR TITLE
feat: expose `defineContainer` and `ContainerPlugin`

### DIFF
--- a/apps/playground/src/editor-settings-popover.tsx
+++ b/apps/playground/src/editor-settings-popover.tsx
@@ -72,6 +72,11 @@ export function EditorSettingsPopover(props: {editorRef: EditorActorRef}) {
               onChange={() => toggleFlag('codeEditorPlugin')}
             />
             <FeatureSwitch
+              label="Code block"
+              isSelected={featureFlags.codeBlockPlugin}
+              onChange={() => toggleFlag('codeBlockPlugin')}
+            />
+            <FeatureSwitch
               label="Typography"
               isSelected={featureFlags.typographyPlugin}
               onChange={() => toggleFlag('typographyPlugin')}

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -60,6 +60,7 @@ import {
   playgroundSchemaDefinition,
   StockTickerSchema,
 } from './playground-schema-definition'
+import {CodeBlockPlugin} from './plugins/plugin.code-block'
 import {CodeEditorPlugin} from './plugins/plugin.code-editor'
 import {HtmlDeserializerPlugin} from './plugins/plugin.html-deserializer'
 import {ImageDeserializerPlugin} from './plugins/plugin.image-deserializer'
@@ -150,6 +151,7 @@ export function Editor(props: {
             </div>
           ) : null}
           <Container className="flex flex-col overflow-clip">
+            {featureFlags.codeBlockPlugin ? <CodeBlockPlugin /> : null}
             {featureFlags.emojiPickerPlugin ? <EmojiPickerPlugin /> : null}
             {featureFlags.mentionPickerPlugin ? <MentionPickerPlugin /> : null}
             {featureFlags.slashCommandPlugin ? (

--- a/apps/playground/src/feature-flags.ts
+++ b/apps/playground/src/feature-flags.ts
@@ -20,6 +20,7 @@ export type EditorFeatureFlags = {
   mentionPickerPlugin: boolean
   slashCommandPlugin: boolean
   codeEditorPlugin: boolean
+  codeBlockPlugin: boolean
   linkPlugin: boolean
   oneLinePlugin: boolean
   markdownPlugin: boolean
@@ -35,6 +36,7 @@ export const defaultEditorFeatureFlags: EditorFeatureFlags = {
   mentionPickerPlugin: true,
   slashCommandPlugin: true,
   codeEditorPlugin: false,
+  codeBlockPlugin: true,
   linkPlugin: true,
   oneLinePlugin: false,
   markdownPlugin: true,

--- a/apps/playground/src/playground-schema-definition.tsx
+++ b/apps/playground/src/playground-schema-definition.tsx
@@ -101,6 +101,18 @@ export const playgroundSchemaDefinition = defineSchema({
         {name: 'alt', title: 'Alt text', type: 'string'},
       ],
     },
+    {
+      title: 'Code block',
+      name: 'code-block',
+      fields: [
+        {
+          name: 'lines',
+          title: 'Lines',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
   ],
   inlineObjects: [
     {

--- a/apps/playground/src/plugins/plugin.code-block.tsx
+++ b/apps/playground/src/plugins/plugin.code-block.tsx
@@ -1,0 +1,21 @@
+import {defineContainer} from '@portabletext/editor'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import type {JSX} from 'react'
+import type {playgroundSchemaDefinition} from '../playground-schema-definition'
+
+const codeBlockContainer = defineContainer<typeof playgroundSchemaDefinition>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre
+      {...attributes}
+      className="my-2 rounded bg-slate-900 p-3 font-mono text-sm text-slate-100"
+    >
+      {children}
+    </pre>
+  ),
+})
+
+export function CodeBlockPlugin(): JSX.Element {
+  return <ContainerPlugin containers={[codeBlockContainer]} />
+}

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -20,7 +20,7 @@ import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export type InternalEditor = Editor & {
-  registerContainer: (config: {container: Container}) => () => void
+  registerContainer: (container: Container) => () => void
   _internal: {
     editable: EditableAPI
     editorActor: EditorActor
@@ -90,15 +90,15 @@ export function createInternalEditor(config: EditorConfig): {
         })
       }
     },
-    registerContainer: (config) => {
+    registerContainer: (container) => {
       editorActor.send({
         type: 'register container',
-        container: config.container,
+        container,
       })
       return () => {
         editorActor.send({
           type: 'unregister container',
-          container: config.container,
+          container,
         })
       }
     },

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -43,6 +43,7 @@ export {defaultKeyGenerator as keyGenerator} from './utils/key-generator'
 export {PortableTextEditor} from './editor/PortableTextEditor'
 export type {EditorEmittedEvent, MutationEvent} from './editor/relay-machine'
 export {useEditor} from './editor/use-editor'
+export {defineContainer, type Container} from './renderers/renderer.types'
 export type {AddedAnnotationPaths} from './types/editor'
 export type {BlockOffset} from './types/block-offset'
 export type {

--- a/packages/editor/src/plugins/index.ts
+++ b/packages/editor/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export {BehaviorPlugin} from './plugin.behavior'
+export {ContainerPlugin} from './plugin.container'
 export {EditorRefPlugin} from './plugin.editor-ref'
 export {EventListenerPlugin} from './plugin.event-listener'

--- a/packages/editor/src/plugins/plugin.container.tsx
+++ b/packages/editor/src/plugins/plugin.container.tsx
@@ -4,22 +4,20 @@ import {useEditor} from '../editor/use-editor'
 import type {Container} from '../renderers/renderer.types'
 
 /**
- * @internal
+ * @alpha
  */
-export function ContainerPlugin(props: {
-  containers: Array<{container: Container}>
-}) {
+export function ContainerPlugin(props: {containers: Array<Container>}) {
   const editor = useEditor() as InternalEditor
 
   useEffect(() => {
-    const unregisters = props.containers.map((config) =>
-      editor.registerContainer(config),
+    const unregisterContainers = props.containers.map((container) =>
+      editor.registerContainer(container),
     )
 
     return () => {
-      for (const unregister of unregisters) {
+      unregisterContainers.forEach((unregister) => {
         unregister()
-      }
+      })
     }
   }, [editor, props.containers])
 

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -5,7 +5,7 @@ import type {ParsedScope} from '../scope/parse-scope'
 import type {AllContainers, ContainerScope} from '../scope/scope.types'
 
 /**
- * @internal
+ * @alpha
  */
 export type Container = {
   scope: string
@@ -82,7 +82,7 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
       : never
 
 /**
- * @internal
+ * @alpha
  *
  * Define a container.
  *
@@ -103,6 +103,9 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
 export function defineContainer<TSchema extends SchemaDefinition>(
   config: SchemaContainerConfig<TSchema>,
 ): Container
+/**
+ * @alpha
+ */
 export function defineContainer(config: Container): Container
 export function defineContainer(config: Container): Container {
   return config

--- a/packages/editor/tests/code-block.test.tsx
+++ b/packages/editor/tests/code-block.test.tsx
@@ -70,7 +70,7 @@ describe('code block', () => {
       ],
       children: (
         <>
-          <ContainerPlugin containers={[{container: codeBlockContainer}]} />
+          <ContainerPlugin containers={[codeBlockContainer]} />
           <EventListenerPlugin
             on={(event) => {
               if (event.type === 'mutation') {

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -57,37 +57,29 @@ const schemaDefinition = defineSchema({
 })
 
 const tableContainers = [
-  {
-    container: defineContainer<typeof schemaDefinition>({
-      scope: '$..table',
-      field: 'rows',
-      render: ({children}) => <>{children}</>,
-    }),
-  },
-  {
-    container: defineContainer<typeof schemaDefinition>({
-      scope: '$..table.row',
-      field: 'cells',
-      render: ({children}) => <>{children}</>,
-    }),
-  },
-  {
-    container: defineContainer<typeof schemaDefinition>({
-      scope: '$..table.row.cell',
-      field: 'content',
-      render: ({children}) => <>{children}</>,
-    }),
-  },
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table',
+    field: 'rows',
+    render: ({children}) => <>{children}</>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table.row',
+    field: 'cells',
+    render: ({children}) => <>{children}</>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table.row.cell',
+    field: 'content',
+    render: ({children}) => <>{children}</>,
+  }),
 ]
 
 const calloutContainers = [
-  {
-    container: defineContainer<typeof schemaDefinition>({
-      scope: '$..callout',
-      field: 'content',
-      render: ({children}) => <>{children}</>,
-    }),
-  },
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..callout',
+    field: 'content',
+    render: ({children}) => <>{children}</>,
+  }),
 ]
 
 describe('container normalization', () => {
@@ -1528,13 +1520,11 @@ describe('container normalization', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {
-              container: defineContainer<typeof cardSchemaDefinition>({
-                scope: '$..card',
-                field: 'tags',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
+            defineContainer<typeof cardSchemaDefinition>({
+              scope: '$..card',
+              field: 'tags',
+              render: ({children}) => <>{children}</>,
+            }),
           ]}
         />
       ),
@@ -1661,39 +1651,29 @@ describe('container normalization', () => {
         <ContainerPlugin
           containers={[
             {
-              container: {
-                scope: '$..callout',
-                field: 'content',
-                render: ({children}) => <>{children}</>,
-              },
+              scope: '$..callout',
+              field: 'content',
+              render: ({children}) => <>{children}</>,
             },
             {
-              container: {
-                scope: '$..table',
-                field: 'rows',
-                render: ({children}) => <>{children}</>,
-              },
+              scope: '$..table',
+              field: 'rows',
+              render: ({children}) => <>{children}</>,
             },
             {
-              container: {
-                scope: '$..table.row',
-                field: 'cells',
-                render: ({children}) => <>{children}</>,
-              },
+              scope: '$..table.row',
+              field: 'cells',
+              render: ({children}) => <>{children}</>,
             },
             {
-              container: {
-                scope: '$..table.row.cell',
-                field: 'content',
-                render: ({children}) => <>{children}</>,
-              },
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: ({children}) => <>{children}</>,
             },
             {
-              container: {
-                scope: '$..figure',
-                field: 'caption',
-                render: ({children}) => <>{children}</>,
-              },
+              scope: '$..figure',
+              field: 'caption',
+              render: ({children}) => <>{children}</>,
             },
           ]}
         />
@@ -1804,27 +1784,21 @@ describe('container normalization', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table',
-                field: 'rows',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table.row',
-                field: 'cells',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table.row.cell',
-                field: 'content',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table',
+              field: 'rows',
+              render: ({children}) => <>{children}</>,
+            }),
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table.row',
+              field: 'cells',
+              render: ({children}) => <>{children}</>,
+            }),
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: ({children}) => <>{children}</>,
+            }),
           ]}
         />
       ),
@@ -1890,27 +1864,21 @@ describe('container normalization', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table',
-                field: 'rows',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table.row',
-                field: 'cells',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..table.row.cell',
-                field: 'content',
-                render: ({children}) => <>{children}</>,
-              }),
-            },
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table',
+              field: 'rows',
+              render: ({children}) => <>{children}</>,
+            }),
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table.row',
+              field: 'cells',
+              render: ({children}) => <>{children}</>,
+            }),
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: ({children}) => <>{children}</>,
+            }),
           ]}
         />
       ),
@@ -2089,10 +2057,8 @@ describe('container normalization', () => {
     })
 
     const unregister = (editor as unknown as InternalEditor).registerContainer({
-      container: {
-        scope: '$..callout',
-        field: 'content',
-      },
+      scope: '$..callout',
+      field: 'content',
     })
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -79,9 +79,7 @@ describe('container rendering', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: calloutContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[calloutContainer]} />,
     })
 
     await vi.waitFor(() => {
@@ -211,9 +209,7 @@ describe('container rendering', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: trackingContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[trackingContainer]} />,
     })
 
     await vi.waitFor(() => {
@@ -336,11 +332,7 @@ describe('table with nested rows and cells', () => {
       ],
       children: (
         <ContainerPlugin
-          containers={[
-            {container: tableContainer},
-            {container: rowContainer},
-            {container: cellContainer},
-          ]}
+          containers={[tableContainer, rowContainer, cellContainer]}
         />
       ),
     })
@@ -469,7 +461,7 @@ describe('container with non-editable fields', () => {
           tags: ['tag1', 'tag2'],
         },
       ],
-      children: <ContainerPlugin containers={[{container: cardContainer}]} />,
+      children: <ContainerPlugin containers={[cardContainer]} />,
     })
 
     await vi.waitFor(() => {
@@ -540,17 +532,15 @@ describe('block scope and specificity', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..block',
-                field: 'children',
-                render: ({attributes, children}) => (
-                  <p data-testid="custom-block" {...attributes}>
-                    {children}
-                  </p>
-                ),
-              }),
-            },
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..block',
+              field: 'children',
+              render: ({attributes, children}) => (
+                <p data-testid="custom-block" {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
           ]}
         />
       ),
@@ -613,29 +603,25 @@ describe('block scope and specificity', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {container: calloutContainer},
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..block',
-                field: 'children',
-                render: ({attributes, children}) => (
-                  <p data-testid="universal-block" {...attributes}>
-                    {children}
-                  </p>
-                ),
-              }),
-            },
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..callout.block',
-                field: 'children',
-                render: ({attributes, children}) => (
-                  <p data-testid="callout-block" {...attributes}>
-                    {children}
-                  </p>
-                ),
-              }),
-            },
+            calloutContainer,
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..block',
+              field: 'children',
+              render: ({attributes, children}) => (
+                <p data-testid="universal-block" {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout.block',
+              field: 'children',
+              render: ({attributes, children}) => (
+                <p data-testid="callout-block" {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
           ]}
         />
       ),
@@ -705,18 +691,16 @@ describe('block scope and specificity', () => {
       children: (
         <ContainerPlugin
           containers={[
-            {container: calloutContainer},
-            {
-              container: defineContainer<typeof schemaDefinition>({
-                scope: '$..block',
-                field: 'children',
-                render: ({attributes, children}) => (
-                  <p data-testid="universal-block" {...attributes}>
-                    {children}
-                  </p>
-                ),
-              }),
-            },
+            calloutContainer,
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..block',
+              field: 'children',
+              render: ({attributes, children}) => (
+                <p data-testid="universal-block" {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
           ]}
         />
       ),
@@ -770,12 +754,10 @@ describe('container and renderer independence', () => {
         <ContainerPlugin
           containers={[
             {
-              container: {
-                ...calloutContainer,
-                render: ({attributes, children}) => (
-                  <div {...attributes}>{children}</div>
-                ),
-              },
+              ...calloutContainer,
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
             },
           ]}
         />
@@ -950,9 +932,7 @@ describe('code block container', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: codeBlockContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[codeBlockContainer]} />,
     })
 
     await vi.waitFor(() => {
@@ -1073,9 +1053,7 @@ describe('gallery with void block objects', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: galleryContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[galleryContainer]} />,
     })
 
     await vi.waitFor(() => {
@@ -1278,11 +1256,7 @@ describe('cell with mixed content', () => {
       ],
       children: (
         <ContainerPlugin
-          containers={[
-            {container: tableContainer},
-            {container: rowContainer},
-            {container: cellContainer},
-          ]}
+          containers={[tableContainer, rowContainer, cellContainer]}
         />
       ),
     })

--- a/packages/editor/tests/container-typing.test.tsx
+++ b/packages/editor/tests/container-typing.test.tsx
@@ -63,9 +63,7 @@ describe('typing inside containers', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: calloutContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[calloutContainer]} />,
     })
 
     const calloutElement = await vi.waitFor(() => {

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -245,9 +245,7 @@ describe('DOM structure', () => {
           ],
         },
       ],
-      children: (
-        <ContainerPlugin containers={[{container: galleryContainer}]} />
-      ),
+      children: <ContainerPlugin containers={[galleryContainer]} />,
     })
     await vi.waitFor(() => {
       const el = document.querySelector('[data-slate-editor]')
@@ -402,11 +400,7 @@ describe('DOM structure', () => {
       ],
       children: (
         <ContainerPlugin
-          containers={[
-            {container: tableContainer},
-            {container: rowContainer},
-            {container: cellContainer},
-          ]}
+          containers={[tableContainer, rowContainer, cellContainer]}
         />
       ),
     })
@@ -535,7 +529,7 @@ describe('DOM structure', () => {
           ],
         },
       ],
-      children: <ContainerPlugin containers={[{container: codeContainer}]} />,
+      children: <ContainerPlugin containers={[codeContainer]} />,
     })
     await vi.waitFor(() => {
       const el = document.querySelector('[data-slate-editor]')

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -2496,13 +2496,11 @@ describe('event.patches', () => {
         children: (
           <ContainerPlugin
             containers={[
-              {
-                container: defineContainer<typeof calloutSchemaDefinition>({
-                  scope: '$..callout',
-                  field: 'content',
-                  render: ({children}) => <>{children}</>,
-                }),
-              },
+              defineContainer<typeof calloutSchemaDefinition>({
+                scope: '$..callout',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              }),
             ]}
           />
         ),
@@ -4642,37 +4640,29 @@ describe('event.patches', () => {
     })
 
     const calloutContainers = [
-      {
-        container: defineContainer<typeof containerSchema>({
-          scope: '$..callout',
-          field: 'content',
-          render: ({children}) => <>{children}</>,
-        }),
-      },
+      defineContainer<typeof containerSchema>({
+        scope: '$..callout',
+        field: 'content',
+        render: ({children}) => <>{children}</>,
+      }),
     ]
 
     const tableContainers = [
-      {
-        container: defineContainer<typeof containerSchema>({
-          scope: '$..table',
-          field: 'rows',
-          render: ({children}) => <>{children}</>,
-        }),
-      },
-      {
-        container: defineContainer<typeof containerSchema>({
-          scope: '$..table.row',
-          field: 'cells',
-          render: ({children}) => <>{children}</>,
-        }),
-      },
-      {
-        container: defineContainer<typeof containerSchema>({
-          scope: '$..table.row.cell',
-          field: 'content',
-          render: ({children}) => <>{children}</>,
-        }),
-      },
+      defineContainer<typeof containerSchema>({
+        scope: '$..table',
+        field: 'rows',
+        render: ({children}) => <>{children}</>,
+      }),
+      defineContainer<typeof containerSchema>({
+        scope: '$..table.row',
+        field: 'cells',
+        render: ({children}) => <>{children}</>,
+      }),
+      defineContainer<typeof containerSchema>({
+        scope: '$..table.row.cell',
+        field: 'content',
+        render: ({children}) => <>{children}</>,
+      }),
     ]
 
     test('insert a block into a callout content field', async () => {

--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -165,11 +165,7 @@ describe('Performance', () => {
         schemaDefinition,
         children: (
           <ContainerPlugin
-            containers={[
-              {container: tableContainer},
-              {container: rowContainer},
-              {container: cellContainer},
-            ]}
+            containers={[tableContainer, rowContainer, cellContainer]}
           />
         ),
       })
@@ -201,11 +197,7 @@ describe('Performance', () => {
         schemaDefinition,
         children: (
           <ContainerPlugin
-            containers={[
-              {container: tableContainer},
-              {container: rowContainer},
-              {container: cellContainer},
-            ]}
+            containers={[tableContainer, rowContainer, cellContainer]}
           />
         ),
       })
@@ -243,11 +235,7 @@ describe('Performance', () => {
         schemaDefinition,
         children: (
           <ContainerPlugin
-            containers={[
-              {container: tableContainer},
-              {container: rowContainer},
-              {container: cellContainer},
-            ]}
+            containers={[tableContainer, rowContainer, cellContainer]}
           />
         ),
       })

--- a/packages/editor/tests/render-child.test.tsx
+++ b/packages/editor/tests/render-child.test.tsx
@@ -451,11 +451,7 @@ describe('renderChild', () => {
       ],
       children: (
         <ContainerPlugin
-          containers={[
-            {container: tableContainer},
-            {container: rowContainer},
-            {container: cellContainer},
-          ]}
+          containers={[tableContainer, rowContainer, cellContainer]}
         />
       ),
       editableProps: {renderChild},


### PR DESCRIPTION
Exposes `defineContainer`, `Container`, and `ContainerPlugin` as `@alpha` so we can exercise the container system end-to-end in the playground.

**Commit 1** flips the release tag on `defineContainer`, `Container`, and `ContainerPlugin` from `@internal` to `@alpha`, and re-exports them from `@portabletext/editor` and `@portabletext/editor/plugins` respectively. The generic `defineContainer<TSchema>` overload stays type-only internal plumbing; the exported runtime signature is the plain `(config: Container) => Container` shape. The schema-aware overload still fires for callers that pass `<typeof schemaDefinition>`.

**Commit 2** wires a `CodeBlockPlugin` into the playground. It adds a `code-block` block object to the playground schema with an editable `lines` array of text blocks, and registers a `defineContainer({scope: '$..code-block', field: 'lines'})` that renders to `<pre>`. Gated behind a `codeBlockPlugin` feature flag, enabled by default so the container pipeline runs on every playground session.

No changeset — `@alpha` only.