### PR TITLE
fix: emit `diffMatchPatch` patches when typing inside a container

### DIFF
--- a/.changeset/code-block-typing-patches.md
+++ b/.changeset/code-block-typing-patches.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: emit `diffMatchPatch` patches when typing inside a container

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -208,6 +208,7 @@ describe('operationToPatches', () => {
     expect(
       textPatch(
         editorActor.getSnapshot().context.schema,
+        editorActor.getSnapshot().context.containers,
         editor.children,
         {
           type: 'insert_text',
@@ -258,6 +259,7 @@ describe('operationToPatches', () => {
     expect(
       textPatch(
         blockObjectSchema,
+        new Map(),
         blockObjectChildren,
         {
           type: 'insert_text',
@@ -276,6 +278,7 @@ describe('operationToPatches', () => {
     expect(
       textPatch(
         editorActor.getSnapshot().context.schema,
+        editorActor.getSnapshot().context.containers,
         editor.children,
         {
           type: 'remove_text',

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -17,27 +17,32 @@ import type {
 
 function spanContext(
   schema: EditorSchema,
+  containers: Containers,
   value: Array<Node>,
 ): {
   schema: EditorSchema
   containers: Containers
   value: Array<Node>
 } {
-  return {schema, containers: new Map(), value}
+  return {schema, containers, value}
 }
 
 export function textPatch(
   schema: EditorSchema,
+  containers: Containers,
   children: Node[],
   operation: InsertTextOperation | RemoveTextOperation,
   beforeValue: Array<PortableTextBlock>,
 ): Array<Patch> {
-  const span = getSpanNode(spanContext(schema, children), operation.path)
+  const span = getSpanNode(
+    spanContext(schema, containers, children),
+    operation.path,
+  )
   if (!span) {
     return []
   }
   const prevSpan = getSpanNode(
-    spanContext(schema, beforeValue as Array<Node>),
+    spanContext(schema, containers, beforeValue as Array<Node>),
     operation.path,
   )
   const patch = diffMatchPatch(prevSpan?.node.text ?? '', span.node.text, [

--- a/packages/editor/src/slate-plugins/slate-plugin.patches.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.patches.ts
@@ -112,7 +112,7 @@ export function createPatchesPlugin({
       previousValue = editor.children
 
       const snapshot = editorActor.getSnapshot()
-      const {initialValue, schema} = snapshot.context
+      const {containers, initialValue, schema} = snapshot.context
 
       const editorWasEmpty =
         previousValue.length === 1 &&
@@ -142,13 +142,25 @@ export function createPatchesPlugin({
         case 'insert_text':
           patches = [
             ...patches,
-            ...textPatch(schema, editor.children, operation, previousValue),
+            ...textPatch(
+              schema,
+              containers,
+              editor.children,
+              operation,
+              previousValue,
+            ),
           ]
           break
         case 'remove_text':
           patches = [
             ...patches,
-            ...textPatch(schema, editor.children, operation, previousValue),
+            ...textPatch(
+              schema,
+              containers,
+              editor.children,
+              operation,
+              previousValue,
+            ),
           ]
           break
         case 'insert':

--- a/packages/editor/tests/code-block.test.tsx
+++ b/packages/editor/tests/code-block.test.tsx
@@ -1,0 +1,133 @@
+import {diffMatchPatch} from '@portabletext/patches'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import type {Patch} from '../src'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [
+        {
+          name: 'lines',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const codeBlockContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre data-testid="code-block" {...attributes}>
+      {children}
+    </pre>
+  ),
+})
+
+describe('code block', () => {
+  test('clicking into a code block and typing a character', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: spanKey,
+                  text: '',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <>
+          <ContainerPlugin containers={[{container: codeBlockContainer}]} />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'mutation') {
+                for (const patch of event.patches) {
+                  const {origin: _, ...rawPatch} = patch
+                  patches.push(rawPatch)
+                }
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    const codeBlockElement = await vi.waitFor(() => {
+      const element = document.querySelector('[data-testid="code-block"]')
+      expect(element).not.toEqual(null)
+      return element!
+    })
+
+    await userEvent.click(codeBlockElement)
+    await userEvent.keyboard('a')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: spanKey,
+                  text: 'a',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+
+      expect(patches).toEqual([
+        diffMatchPatch('', 'a', [
+          {_key: codeBlockKey},
+          'lines',
+          {_key: lineKey},
+          'children',
+          {_key: spanKey},
+          'text',
+        ]),
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Typing inside a container (a code block, a callout, a table cell) updates the editor's local value but never emits a `diffMatchPatch`. The text appears in the editor, but nothing goes out to the backend. To a consumer relaying patches to Sanity, the character vanishes on reload.

The culprit is `operation-to-patches.ts`, which resolves the span under the `insert_text`/`remove_text` operation path via `getSpanNode`. That traversal walks the tree using a `Containers` map — which fields are editable on which types — but the function was constructing its context with an empty `new Map()` every time. At root level this didn't matter because the traversal hits `block.children` directly. One level deep (code-block's `lines`, callout's `content`, table cell's `content`) the empty map has no entry for the container's editable field, `getNode` returns undefined, `getSpanNode` returns undefined, and the patch is silently dropped.

The fix threads the editor's live `containers` map — already resolved from `defineContainer` registrations and sitting on the machine snapshot — through the patches slate-plugin into `textPatch`. Tree traversal can now reach spans inside registered containers at any depth.

Added `tests/code-block.test.tsx` with a regression test: pre-existing code block with one empty line, click in, type `'a'`, assert the full outgoing `diffMatchPatch` by deep equality (keyed path includes `lines` and `children`).