### PR TITLE
perf: optimize container normalization for bulk insertion

### DIFF
--- a/.changeset/optimize-container-normalization.md
+++ b/.changeset/optimize-container-normalization.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: optimize container normalization for bulk insertion

--- a/packages/editor/src/slate-plugins/slate-plugin.patches.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.patches.ts
@@ -193,6 +193,7 @@ export function createPatchesPlugin({
           })
         }
       }
+
       return editor
     }
     return editor

--- a/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
@@ -31,16 +31,23 @@ export function updateValuePlugin(
 
     apply(operation)
 
-    buildIndexMaps(
-      {
-        schema: context.schema,
-        value: editor.children,
-      },
-      {
-        blockIndexMap: editor.blockIndexMap,
-        listIndexMap: editor.listIndexMap,
-      },
-    )
+    // Operations deep inside blocks (path length > 2) only modify nested
+    // structure and cannot affect root-level blockIndexMap or listIndexMap.
+    // Root-level inserts/removes are already handled incrementally by
+    // applyOperation, so we only need a full rebuild for operations at or
+    // near the root level.
+    if (operation.path.length <= 2) {
+      buildIndexMaps(
+        {
+          schema: context.schema,
+          value: editor.children,
+        },
+        {
+          blockIndexMap: editor.blockIndexMap,
+          listIndexMap: editor.listIndexMap,
+        },
+      )
+    }
   }
 
   return editor

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -15,6 +15,7 @@ import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
 import {getContainerScopedName} from '../../schema/get-container-scoped-name'
+import type {ChildArrayField, Containers} from '../../schema/resolve-containers'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import {isEditor} from '../editor/is-editor'
@@ -413,53 +414,37 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     return
   }
 
-  // Container normalization: ensure the child array field exists.
+  // Container normalization: ensure the child array field exists and is
+  // non-empty.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
     const arrayField = editor.containers.get(scopedName)?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+      const needsField = !Array.isArray(fieldValue)
+      const needsChild = needsField || fieldValue.length === 0
 
-      if (!Array.isArray(fieldValue)) {
-        setNodeProperties(editor, {[arrayField.name]: []}, path)
-        return
-      }
-    }
-  }
+      if (needsChild) {
+        const childNode = buildContainerChild(editor, scopedName, arrayField)
 
-  // Container normalization: ensure non-empty child array.
-  if (isObjectNode({schema: editor.schema}, node)) {
-    const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.containers.get(scopedName)?.field
-
-    if (arrayField) {
-      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
-
-      if (Array.isArray(fieldValue) && fieldValue.length === 0) {
-        const acceptsBlocks = arrayField.of.some(
-          (definition) => definition.type === 'block',
-        )
-
-        if (acceptsBlocks) {
-          editor.apply({
-            type: 'insert',
-            path: [...path, arrayField.name, 0],
-            node: createPlaceholderBlock(editor),
-            position: 'before',
-          })
+        if (needsField && childNode) {
+          // Set the field with its initial child in a single operation
+          // instead of two (set empty array + insert child).
+          setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
           return
         }
 
-        const firstChildType = arrayField.of.at(0)
-        if (firstChildType && firstChildType.type !== 'block') {
+        if (needsField) {
+          setNodeProperties(editor, {[arrayField.name]: []}, path)
+          return
+        }
+
+        if (childNode) {
           editor.apply({
             type: 'insert',
             path: [...path, arrayField.name, 0],
-            node: {
-              _type: firstChildType.type,
-              _key: editor.keyGenerator(),
-            },
+            node: childNode,
             position: 'before',
           })
           return
@@ -616,4 +601,59 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     return
   }
+}
+
+/**
+ * Build a child node for a container field, recursively populating any
+ * nested container fields so that the entire structure is created in a
+ * single operation instead of cascading through multiple normalization
+ * passes.
+ */
+function buildContainerChild(
+  editor: {
+    keyGenerator: () => string
+    schema: Parameters<typeof createPlaceholderBlock>[0]['schema']
+    containers: Containers
+  },
+  parentScopedName: string,
+  arrayField: ChildArrayField,
+): Node | undefined {
+  const acceptsBlocks = arrayField.of.some(
+    (definition) => definition.type === 'block',
+  )
+
+  if (acceptsBlocks) {
+    return createPlaceholderBlock(editor)
+  }
+
+  const firstChildType = arrayField.of.at(0)
+
+  if (!firstChildType || firstChildType.type === 'block') {
+    return undefined
+  }
+
+  const childNode: Record<string, unknown> = {
+    _type: firstChildType.type,
+    _key: editor.keyGenerator(),
+  }
+
+  // Recursively populate nested container fields so the full structure
+  // is built in one pass.
+  const childScopedName = `${parentScopedName}.${firstChildType.type}`
+  const childContainerConfig = editor.containers.get(childScopedName)
+  const childArrayField = childContainerConfig?.field
+
+  if (childArrayField) {
+    const grandchild = buildContainerChild(
+      editor,
+      childScopedName,
+      childArrayField,
+    )
+
+    if (grandchild) {
+      childNode[childArrayField.name] = [grandchild]
+    }
+  }
+
+  return childNode as Node
 }

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -228,73 +228,30 @@ describe('container normalization', () => {
 
     await vi.waitFor(() => {
       expect(patches).toEqual([
-        {type: 'set', path: [{_key: tableKey}, 'rows'], value: []},
-        {type: 'setIfMissing', path: [{_key: tableKey}, 'rows'], value: []},
-        {
-          type: 'insert',
-          path: [{_key: tableKey}, 'rows', 0],
-          position: 'before',
-          items: [{_type: 'row', _key: 'k5'}],
-        },
         {
           type: 'set',
-          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
-          value: [],
-        },
-        {
-          type: 'setIfMissing',
-          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells', 0],
-          position: 'before',
-          items: [{_type: 'cell', _key: 'k6'}],
-        },
-        {
-          type: 'set',
-          path: [
-            {_key: tableKey},
-            'rows',
-            {_key: 'k5'},
-            'cells',
-            {_key: 'k6'},
-            'content',
-          ],
-          value: [],
-        },
-        {
-          type: 'setIfMissing',
-          path: [
-            {_key: tableKey},
-            'rows',
-            {_key: 'k5'},
-            'cells',
-            {_key: 'k6'},
-            'content',
-          ],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [
-            {_key: tableKey},
-            'rows',
-            {_key: 'k5'},
-            'cells',
-            {_key: 'k6'},
-            'content',
-            0,
-          ],
-          position: 'before',
-          items: [
+          path: [{_key: tableKey}, 'rows'],
+          value: [
             {
-              _type: 'block',
-              _key: 'k7',
-              style: 'normal',
-              markDefs: [],
-              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+              _key: 'k5',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'k6',
+                  _type: 'cell',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k7',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 'k8', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },
@@ -388,17 +345,10 @@ describe('container normalization', () => {
 
     await vi.waitFor(() => {
       expect(patches).toEqual([
-        {type: 'set', path: [{_key: calloutKey}, 'content'], value: []},
         {
-          type: 'setIfMissing',
+          type: 'set',
           path: [{_key: calloutKey}, 'content'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: calloutKey}, 'content', 0],
-          position: 'before',
-          items: [
+          value: [
             {
               _type: 'block',
               _key: 'k5',


### PR DESCRIPTION
## Summary

Optimizes bulk insertion of container blocks (e.g. tables with nested rows → cells → content) by reducing the number of `editor.apply` calls from **~7× the block count to ~2×**.

For 1000 tables (each with 3 container levels), total `editor.apply` calls drop from **7002 → 2002**.

## Problem

When inserting a container block like a table, normalization needs to populate its nested structure: the table needs a `rows` array with a row, the row needs a `cells` array with a cell, and the cell needs a `content` array with a placeholder block. Previously, this happened through a cascade of small operations:

1. **Two-pass normalization per level**: Ensuring the field existed (`set rows = []`) and ensuring it was non-empty (`insert row`) were two separate normalization checks. Each returned early and re-normalized, so every container level required 2 `editor.apply` calls.

2. **Level-by-level cascade**: Each level was handled independently. Setting `rows: [{_type: 'row'}]` dirtied the row, which then normalized to add `cells: [{_type: 'cell'}]`, which dirtied the cell, which normalized to add `content: [{block}]`. For a 3-level table, that's 6 normalization operations per table.

3. **Redundant index map rebuilds**: Every `editor.apply` call triggered a full `buildIndexMaps` rebuild — an O(n) iteration of all root-level blocks. But normalization operations inside a container (e.g. setting `rows` on a table) only modify nested structure and can never affect root-level indices.

With 1000 tables: 1000 inserts + 6000 normalization ops + 2 initial = **7002 total `editor.apply` calls**, each going through the full plugin chain (history → patches → update-value → core apply).

## Changes

### 1. Skip `buildIndexMaps` for deeply nested operations

**`slate-plugin.update-value.ts`**

Added a path length check: if `operation.path.length > 2`, skip the `buildIndexMaps` rebuild. The index maps (`blockIndexMap`, `listIndexMap`) only track root-level blocks. Operations inside a block (like setting a container's child array field at path `[{_key: 't1'}, 'rows']`) cannot affect them. Root-level inserts are already handled incrementally by `applyOperation`.

### 2. Merge two-pass container normalization into one

**`normalize-node.ts`**

Combined the "ensure field exists" and "ensure non-empty" checks into a single normalization pass. When both conditions are true (field missing AND child needed), the field is set with its initial child in a single `setNodeProperties` call instead of two separate operations:

```typescript
// Before: 2 operations
setNodeProperties(editor, {rows: []}, path)     // pass 1
editor.apply({type: 'insert', node: row, ...})  // pass 2

// After: 1 operation
setNodeProperties(editor, {rows: [row]}, path)  // single pass
```

This cut normalization from 2 ops per container level to 1 op per level.

### 3. Recursive pre-population of nested container structure

**`normalize-node.ts`** — new `buildContainerChild` function

Instead of creating a bare child node (e.g. `{_type: 'row', _key: 'r1'}`) and letting normalization cascade through each level independently, the new function walks the `editor.containers` map using scoped type names (`'table'` → `'table.row'` → `'table.row.cell'`) and builds the full nested structure recursively:

```typescript
// Before: bare child, triggers 2 more normalization rounds
{_type: 'row', _key: 'r1'}

// After: complete structure, no further normalization needed
{
  _type: 'row', _key: 'r1',
  cells: [{
    _type: 'cell', _key: 'c1',
    content: [{
      _type: 'block', _key: 'b1',
      children: [{_type: 'span', _key: 's1', text: '', marks: []}],
      markDefs: [], style: 'normal'
    }]
  }]
}
```

When this full structure is set via a single `setNodeProperties` call, `getDirtyPaths` still walks the descendants and marks them dirty. Normalization visits each one — but since all fields are already populated, `normalizeNode` returns without issuing any additional operations.

### Patch format change

Container normalization now produces a single `set` patch with the full nested structure instead of a sequence of `set`/`setIfMissing`/`insert` patches per level. The end result is identical — remote editors receive the complete structure atomically. Test expectations in `container-normalization.test.tsx` are updated accordingly.