### PR TITLE
fix: let arrow keys and character delete navigate inside editable containers

### DIFF
--- a/.changeset/code-block-navigation.md
+++ b/.changeset/code-block-navigation.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: let arrow keys and character delete navigate inside editable containers

--- a/packages/editor/src/slate/editor/positions.ts
+++ b/packages/editor/src/slate/editor/positions.ts
@@ -1,5 +1,6 @@
 import {isSpan} from '@portabletext/schema'
 import {getNodes} from '../../node-traversal/get-nodes'
+import {isEditableContainer} from '../../schema/is-editable-container'
 import type {Editor} from '../interfaces/editor'
 import type {Location} from '../interfaces/location'
 import type {Point} from '../interfaces/point'
@@ -125,6 +126,10 @@ export function* positions(
       !isTextBlockNode({schema: editor.schema}, node) &&
       !isSpan({schema: editor.schema}, node)
     ) {
+      // Editable containers aren't leaf positions — descend into them.
+      if (isEditableContainer(editor, node, nodePath)) {
+        continue
+      }
       yield {path: nodePath, offset: 0}
       continue
     }

--- a/packages/editor/tests/code-block.navigation.test.tsx
+++ b/packages/editor/tests/code-block.navigation.test.tsx
@@ -1,0 +1,158 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [
+        {
+          name: 'lines',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const codeBlockContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre data-testid="code-block" {...attributes}>
+      {children}
+    </pre>
+  ),
+})
+
+describe('code block navigation', () => {
+  test('ArrowRight moves the caret forward inside a code block line', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[codeBlockContainer]} />,
+    })
+
+    const codeBlockElement = await vi.waitFor(() => {
+      const element = document.querySelector('[data-testid="code-block"]')
+      expect(element).not.toEqual(null)
+      return element!
+    })
+
+    await userEvent.click(codeBlockElement)
+    await userEvent.keyboard('{ArrowRight}')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: spanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: spanKey},
+          ],
+          offset: 1,
+        },
+        backward: false,
+      })
+    })
+  })
+
+  test('Backspace deletes one character inside a code block line', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[codeBlockContainer]} />,
+    })
+
+    const codeBlockElement = await vi.waitFor(() => {
+      const element = document.querySelector('[data-testid="code-block"]')
+      expect(element).not.toEqual(null)
+      return element!
+    })
+
+    await userEvent.click(codeBlockElement)
+    // click lands at offset 0; advance to offset 1 then delete back to offset 0.
+    await userEvent.keyboard('{ArrowRight}')
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [{_type: 'span', _key: spanKey, text: 'oo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Arrow keys and character delete do nothing when the caret is inside a registered editable container. Typing into a code block updates the value (since PR #2520) but the user can't navigate inside the line or fix a typo. In practice the editor feels stuck.

Slate intercepts `ArrowLeft`/`ArrowRight` in `editable.tsx` and calls its own `move(editor, {reverse})` — which walks the tree via `Editor.before` / `Editor.after` / `positions`, yielding one point per step. Delete and other cursor-aware operations share the same iterator.

The iterator had a catch-all branch for anything that wasn't a text block or a span: yield `{path, offset: 0}` and continue. That branch predates containers and was meant for void objects (which have their own earlier `isVoidNode` guard). The fallback still fires for editable containers — an ancestor on the way down, not a leaf position. One spurious yield eats the step count: the call `after(point, {distance: 1})` hits the container yield at d=0, the real span position at d=1, the next span position at d=2 → `break`, so the computed target equals the starting point. Selection and delete become no-ops.

The fix is one extra guard in the fallback branch: if the node is a registered editable container, `continue` without yielding. Void objects still get their yield from the earlier branch. Root-level navigation is unchanged — root text blocks and spans never hit this branch in the first place.

New `tests/code-block.navigation.test.tsx` asserts `ArrowRight` advances the caret by one and `Backspace` deletes one character inside a code block's line, both with full `toEqual` on `selection` / `value`.