### PR TITLE
fix: emit well-formed patches when undoing a merge

### DIFF
--- a/.changeset/undo-merge-malformed-patches.md
+++ b/.changeset/undo-merge-malformed-patches.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: emit well-formed patches when undoing a merge

--- a/packages/editor/src/slate/core/apply-operation.ts
+++ b/packages/editor/src/slate/core/apply-operation.ts
@@ -380,14 +380,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
             if (previousSibling?._key) {
               op.inverse = {
                 type: 'insert',
-                path: [...parentPath(path), {_key: previousSibling._key}],
+                path: [...path.slice(0, -1), {_key: previousSibling._key}],
                 node: children[index]!,
                 position: 'after',
               }
             } else {
               op.inverse = {
                 type: 'insert',
-                path: [...parentPath(path), 0],
+                path: [...path.slice(0, -1), 0],
                 node: children[index]!,
                 position: 'before',
               }

--- a/packages/editor/tests/undo-merge-blocks.test.tsx
+++ b/packages/editor/tests/undo-merge-blocks.test.tsx
@@ -1,0 +1,226 @@
+import {applyAll} from '@portabletext/patches'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import type {Patch} from '../src'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('merge blocks + undo emits well-formed patches', () => {
+  test('Backspace merge at root + undo does not emit malformed patches', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const block1Key = keyGenerator()
+    const span1Key = keyGenerator()
+    const block2Key = keyGenerator()
+    const span2Key = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: block1Key,
+        children: [{_type: 'span', _key: span1Key, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: block2Key,
+        children: [{_type: 'span', _key: span2Key, text: 'bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const patches: Array<Patch> = []
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: block2Key}, 'children', {_key: span2Key}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: block2Key}, 'children', {_key: span2Key}],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    const expectedPostMerge = [
+      {
+        _type: 'block',
+        _key: block1Key,
+        children: [{_type: 'span', _key: span1Key, text: 'foobar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(expectedPostMerge)
+    })
+
+    // Capture patches emitted from undo only.
+    patches.length = 0
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+
+    // Replaying the emitted undo patches on the post-merge value must not
+    // throw and must reproduce the pre-merge state.
+    expect(() => applyAll(expectedPostMerge, patches)).not.toThrow()
+  })
+
+  test('Backspace merge inside a container + undo does not emit malformed patches', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const block1Key = keyGenerator()
+    const span1Key = keyGenerator()
+    const block2Key = keyGenerator()
+    const span2Key = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'callout',
+        _key: calloutKey,
+        content: [
+          {
+            _type: 'block',
+            _key: block1Key,
+            children: [{_type: 'span', _key: span1Key, text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+          {
+            _type: 'block',
+            _key: block2Key,
+            children: [{_type: 'span', _key: span2Key, text: 'bar', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ]
+
+    const patches: Array<Patch> = []
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue,
+      children: (
+        <>
+          <ContainerPlugin
+            containers={[
+              defineContainer({
+                scope: '$..callout',
+                field: 'content',
+                render: ({children}) => <>{children}</>,
+              }),
+            ]}
+          />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                patches.push(event.patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: block2Key},
+            'children',
+            {_key: span2Key},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: block2Key},
+            'children',
+            {_key: span2Key},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    const expectedPostMerge = [
+      {
+        _type: 'callout',
+        _key: calloutKey,
+        content: [
+          {
+            _type: 'block',
+            _key: block1Key,
+            children: [
+              {_type: 'span', _key: span1Key, text: 'foobar', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(expectedPostMerge)
+    })
+
+    patches.length = 0
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+
+    expect(() => applyAll(expectedPostMerge, patches)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Merging two blocks and hitting undo crashed the Sanity patch applier with `Cannot setIfMissing value of an object to a non-object`. The reproducer is tiny: two text blocks, caret at the start of block two, Backspace, then Undo.

The unset op's inverse `insert` was being constructed with `parentPath(path)`, which strips both the trailing node segment AND the field name that precedes it. For a path like `[{block}, 'children', {span}]`, that yields `[{block}]` instead of `[{block}, 'children']`. When `@portabletext/patches` received the resulting insert patch it tried to `setIfMissing` an array on the block object itself, which the applier (correctly) rejects.

`path.slice(0, -1)` is the right slice for inverse-op construction: it strips only the last node segment, keeping the field name so the insert targets the correct children array.

The fix is two lines in `apply-operation.ts`. The test subscribes to `patch` events, captures the undo patches, and replays them through `applyAll` from `@portabletext/patches` — reproduces the crash deterministically and asserts the post-undo value matches the pre-merge state. Two scenarios: root-level merge and merge inside a container (the container case is why this bug became visible now — more paths go through the field-name-preserving code path with containers).