### PR TITLE
perf: cheap container normalization

### DIFF
--- a/.changeset/merge-container-normalization-pass.md
+++ b/.changeset/merge-container-normalization-pass.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: merge container field normalization into a single pass

--- a/.changeset/skip-index-maps-deep-ops.md
+++ b/.changeset/skip-index-maps-deep-ops.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: skip rebuilding index maps for nested operations

--- a/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
@@ -31,16 +31,23 @@ export function updateValuePlugin(
 
     apply(operation)
 
-    buildIndexMaps(
-      {
-        schema: context.schema,
-        value: editor.children,
-      },
-      {
-        blockIndexMap: editor.blockIndexMap,
-        listIndexMap: editor.listIndexMap,
-      },
-    )
+    // Operations deep inside blocks (path length > 2) only modify nested
+    // structure and cannot affect root-level blockIndexMap or listIndexMap.
+    // Root-level inserts/removes are already handled incrementally by
+    // applyOperation, so we only need a full rebuild for operations at or
+    // near the root level.
+    if (operation.path.length <= 2) {
+      buildIndexMaps(
+        {
+          schema: context.schema,
+          value: editor.children,
+        },
+        {
+          blockIndexMap: editor.blockIndexMap,
+          listIndexMap: editor.listIndexMap,
+        },
+      )
+    }
   }
 
   return editor

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -413,53 +413,50 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     return
   }
 
-  // Container normalization: ensure the child array field exists.
+  // Container normalization: ensure the child array field exists and is
+  // non-empty.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
     const arrayField = editor.containers.get(scopedName)?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+      const needsField = !Array.isArray(fieldValue)
+      const needsChild = needsField || fieldValue.length === 0
 
-      if (!Array.isArray(fieldValue)) {
-        setNodeProperties(editor, {[arrayField.name]: []}, path)
-        return
-      }
-    }
-  }
-
-  // Container normalization: ensure non-empty child array.
-  if (isObjectNode({schema: editor.schema}, node)) {
-    const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.containers.get(scopedName)?.field
-
-    if (arrayField) {
-      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
-
-      if (Array.isArray(fieldValue) && fieldValue.length === 0) {
+      if (needsChild) {
         const acceptsBlocks = arrayField.of.some(
           (definition) => definition.type === 'block',
         )
+        const firstChildType = arrayField.of.at(0)
 
+        let childNode: Node | undefined
         if (acceptsBlocks) {
-          editor.apply({
-            type: 'insert',
-            path: [...path, arrayField.name, 0],
-            node: createPlaceholderBlock(editor),
-            position: 'before',
-          })
+          childNode = createPlaceholderBlock(editor)
+        } else if (firstChildType && firstChildType.type !== 'block') {
+          childNode = {
+            _type: firstChildType.type,
+            _key: editor.keyGenerator(),
+          } as Node
+        }
+
+        if (needsField && childNode) {
+          // Set the field with its initial child in a single operation
+          // instead of two (set empty array + insert child).
+          setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
           return
         }
 
-        const firstChildType = arrayField.of.at(0)
-        if (firstChildType && firstChildType.type !== 'block') {
+        if (needsField) {
+          setNodeProperties(editor, {[arrayField.name]: []}, path)
+          return
+        }
+
+        if (childNode) {
           editor.apply({
             type: 'insert',
             path: [...path, arrayField.name, 0],
-            node: {
-              _type: firstChildType.type,
-              _key: editor.keyGenerator(),
-            },
+            node: childNode,
             position: 'before',
           })
           return

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -220,29 +220,15 @@ describe('container normalization', () => {
 
     await vi.waitFor(() => {
       expect(patches).toEqual([
-        {type: 'set', path: [{_key: tableKey}, 'rows'], value: []},
-        {type: 'setIfMissing', path: [{_key: tableKey}, 'rows'], value: []},
         {
-          type: 'insert',
-          path: [{_key: tableKey}, 'rows', 0],
-          position: 'before',
-          items: [{_type: 'row', _key: 'k5'}],
+          type: 'set',
+          path: [{_key: tableKey}, 'rows'],
+          value: [{_type: 'row', _key: 'k5'}],
         },
         {
           type: 'set',
           path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
-          value: [],
-        },
-        {
-          type: 'setIfMissing',
-          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: tableKey}, 'rows', {_key: 'k5'}, 'cells', 0],
-          position: 'before',
-          items: [{_type: 'cell', _key: 'k6'}],
+          value: [{_type: 'cell', _key: 'k6'}],
         },
         {
           type: 'set',
@@ -254,33 +240,7 @@ describe('container normalization', () => {
             {_key: 'k6'},
             'content',
           ],
-          value: [],
-        },
-        {
-          type: 'setIfMissing',
-          path: [
-            {_key: tableKey},
-            'rows',
-            {_key: 'k5'},
-            'cells',
-            {_key: 'k6'},
-            'content',
-          ],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [
-            {_key: tableKey},
-            'rows',
-            {_key: 'k5'},
-            'cells',
-            {_key: 'k6'},
-            'content',
-            0,
-          ],
-          position: 'before',
-          items: [
+          value: [
             {
               _type: 'block',
               _key: 'k7',
@@ -380,17 +340,10 @@ describe('container normalization', () => {
 
     await vi.waitFor(() => {
       expect(patches).toEqual([
-        {type: 'set', path: [{_key: calloutKey}, 'content'], value: []},
         {
-          type: 'setIfMissing',
+          type: 'set',
           path: [{_key: calloutKey}, 'content'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: calloutKey}, 'content', 0],
-          position: 'before',
-          items: [
+          value: [
             {
               _type: 'block',
               _key: 'k5',


### PR DESCRIPTION
Container normalization takes several round-trips through the editor pipeline for each container level. For a table with rows, cells, and a content array, a fresh insert produces three patches per level (`set field=[]`, `setIfMissing field=[]`, `insert field[0]=child`), and each `editor.apply` call triggers a full rebuild of the root-level index maps. Both are unnecessary for work that happens deep inside a container.

Two surgical changes cherry-picked from #2521:

### Skip rebuilding index maps for nested operations

`blockIndexMap` and `listIndexMap` only track root-level blocks. Operations at `path.length > 2` mutate nested structure and cannot affect root-level indices. Root-level inserts and removes are already handled incrementally inside `applyOperation`, so the post-apply rebuild is only needed when the operation touches the root.

### Merge container field normalization into a single pass

Normalizing a container previously took two passes: one to set the child array field to `[]` and a second to insert the placeholder child. When both are needed (the common case after inserting a fresh container), they now happen in one `setNodeProperties` call that sets the field directly to `[child]`.

The end state is identical. Consumers see a single `set` patch with the populated field instead of `set` + `setIfMissing` + `insert`.

### Not included

#2521 also adds recursive schema-driven subtree synthesis in normalization. That piece belongs in the operation that knows it is inserting a complex container, not in normalization. It is deferred to a separate change in the insert path.