### PR TITLE
feat: resolve nested block sub-schemas at compile time

### DIFF
--- a/.changeset/nested-block-sub-schema-resolution.md
+++ b/.changeset/nested-block-sub-schema-resolution.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/schema': minor
+---
+
+feat: resolve nested block sub-schemas at compile time

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -28,6 +28,21 @@ function fields(containers: Containers): Map<string, ChildArrayField> {
   return out
 }
 
+/**
+ * What `{type: 'block'}` compiles to when the root schema has no decorators,
+ * annotations, lists or inline objects declared. Compile resolves inheritance
+ * and fills in the defaults (the auto-prepended `normal` style and empty
+ * arrays for everything else).
+ */
+const resolvedEmptyBlock = {
+  type: 'block',
+  styles: [{name: 'normal', value: 'normal', title: 'Normal'}],
+  decorators: [],
+  annotations: [],
+  lists: [],
+  inlineObjects: [],
+}
+
 describe(resolveContainers.name, () => {
   test('resolves a single-level container', () => {
     const schema = compileSchema(
@@ -138,7 +153,7 @@ describe(resolveContainers.name, () => {
                           {
                             name: 'content',
                             type: 'array',
-                            of: [{type: 'block'}],
+                            of: [resolvedEmptyBlock],
                           },
                         ],
                       },
@@ -161,7 +176,7 @@ describe(resolveContainers.name, () => {
                   {
                     name: 'content',
                     type: 'array',
-                    of: [{type: 'block'}],
+                    of: [resolvedEmptyBlock],
                   },
                 ],
               },
@@ -170,7 +185,7 @@ describe(resolveContainers.name, () => {
         ],
         [
           'table.row.cell',
-          {name: 'content', type: 'array', of: [{type: 'block'}]},
+          {name: 'content', type: 'array', of: [resolvedEmptyBlock]},
         ],
       ]),
     )
@@ -212,7 +227,7 @@ describe(resolveContainers.name, () => {
     ).toEqual(
       new Map([
         ['code', {name: 'content', type: 'array', of: [{type: 'codeLine'}]}],
-        ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
+        ['callout', {name: 'content', type: 'array', of: [resolvedEmptyBlock]}],
       ]),
     )
   })
@@ -314,7 +329,7 @@ describe(resolveContainers.name, () => {
       ),
     ).toEqual(
       new Map([
-        ['callout', {name: 'content', type: 'array', of: [{type: 'block'}]}],
+        ['callout', {name: 'content', type: 'array', of: [resolvedEmptyBlock]}],
         [
           'callout.block',
           {name: 'children', type: 'array', of: [{type: 'span'}]},
@@ -371,7 +386,7 @@ describe(resolveContainers.name, () => {
       ),
     ).toEqual(
       new Map([
-        ['figure', {name: 'caption', type: 'array', of: [{type: 'block'}]}],
+        ['figure', {name: 'caption', type: 'array', of: [resolvedEmptyBlock]}],
       ]),
     )
   })

--- a/packages/schema/src/compile-schema.test.ts
+++ b/packages/schema/src/compile-schema.test.ts
@@ -87,7 +87,7 @@ describe(compileSchema.name, () => {
       ])
     })
 
-    test('of with block type preserves PTE sub-schema', () => {
+    test('of with block type resolves PTE sub-schema with inheritance', () => {
       expect(
         compileSchema({
           blockObjects: [
@@ -119,8 +119,14 @@ describe(compileSchema.name, () => {
               of: [
                 {
                   type: 'block',
-                  styles: [{name: 'normal'}, {name: 'h1'}],
-                  decorators: [{name: 'strong'}],
+                  styles: [
+                    {name: 'normal', value: 'normal'},
+                    {name: 'h1', value: 'h1'},
+                  ],
+                  decorators: [{name: 'strong', value: 'strong'}],
+                  annotations: [],
+                  lists: [],
+                  inlineObjects: [],
                 },
               ],
             },
@@ -173,6 +179,305 @@ describe(compileSchema.name, () => {
                       name: 'cells',
                       type: 'array',
                       of: [{type: 'tableCell', name: 'tableCell'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('nested block inheritance', () => {
+    test('nested block with no overrides inherits all root fields', () => {
+      expect(
+        compileSchema({
+          styles: [{name: 'h1'}, {name: 'h2'}],
+          decorators: [{name: 'strong'}, {name: 'em'}],
+          annotations: [{name: 'link'}],
+          lists: [{name: 'bullet'}],
+          inlineObjects: [{name: 'mention'}],
+          blockObjects: [
+            {
+              name: 'tableCell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [
+                    {name: 'normal', value: 'normal', title: 'Normal'},
+                    {name: 'h1', value: 'h1'},
+                    {name: 'h2', value: 'h2'},
+                  ],
+                  decorators: [
+                    {name: 'strong', value: 'strong'},
+                    {name: 'em', value: 'em'},
+                  ],
+                  annotations: [{name: 'link', fields: []}],
+                  lists: [{name: 'bullet', value: 'bullet'}],
+                  inlineObjects: [{name: 'mention', fields: []}],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('nested block overrides decorators and inherits the rest', () => {
+      expect(
+        compileSchema({
+          styles: [{name: 'h1'}],
+          decorators: [{name: 'strong'}, {name: 'em'}],
+          annotations: [{name: 'link'}],
+          blockObjects: [
+            {
+              name: 'tableCell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      decorators: [{name: 'strong'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [
+                    {name: 'normal', value: 'normal', title: 'Normal'},
+                    {name: 'h1', value: 'h1'},
+                  ],
+                  decorators: [{name: 'strong', value: 'strong'}],
+                  annotations: [{name: 'link', fields: []}],
+                  lists: [],
+                  inlineObjects: [],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('nested block declares its own inline objects', () => {
+      expect(
+        compileSchema({
+          inlineObjects: [{name: 'rootMention'}],
+          blockObjects: [
+            {
+              name: 'tableCell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      inlineObjects: [
+                        {
+                          name: 'cellMention',
+                          fields: [{name: 'id', type: 'string'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'normal', value: 'normal', title: 'Normal'}],
+                  decorators: [],
+                  annotations: [],
+                  lists: [],
+                  inlineObjects: [
+                    {
+                      name: 'cellMention',
+                      fields: [{name: 'id', type: 'string'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('nested block with empty overrides replaces root values', () => {
+      expect(
+        compileSchema({
+          decorators: [{name: 'strong'}],
+          blockObjects: [
+            {
+              name: 'tableCell',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      decorators: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'tableCell',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'normal', value: 'normal', title: 'Normal'}],
+                  decorators: [],
+                  annotations: [],
+                  lists: [],
+                  inlineObjects: [],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('deeply nested blocks inherit from root, not from intermediate containers', () => {
+      expect(
+        compileSchema({
+          decorators: [{name: 'strong'}],
+          blockObjects: [
+            {
+              name: 'table',
+              fields: [
+                {
+                  name: 'rows',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'row',
+                      name: 'row',
+                      fields: [
+                        {
+                          name: 'cells',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'cell',
+                              name: 'cell',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  type: 'array',
+                                  of: [{type: 'block'}],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'row',
+                  name: 'row',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'cell',
+                          name: 'cell',
+                          fields: [
+                            {
+                              name: 'content',
+                              type: 'array',
+                              of: [
+                                {
+                                  type: 'block',
+                                  styles: [
+                                    {
+                                      name: 'normal',
+                                      value: 'normal',
+                                      title: 'Normal',
+                                    },
+                                  ],
+                                  decorators: [
+                                    {name: 'strong', value: 'strong'},
+                                  ],
+                                  annotations: [],
+                                  lists: [],
+                                  inlineObjects: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
                     },
                   ],
                 },

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -1,43 +1,162 @@
 import type {SchemaDefinition} from './define-schema'
 import type {
+  AnnotationSchemaType,
+  BaseDefinition,
+  BlockOfDefinition,
+  DecoratorSchemaType,
   FieldDefinition,
+  InlineObjectSchemaType,
+  ListSchemaType,
   ObjectOfDefinition,
   OfDefinition,
   Schema,
+  StyleSchemaType,
 } from './schema'
 
-function compileOfMember(member: OfDefinition): OfDefinition {
-  if (member.type === 'block') {
-    return member
-  }
-  return compileObjectOfMember(member)
+/**
+ * Resolved root schema fields used to fill in unspecified fields on nested
+ * `BlockOfDefinition` entries. This is a view into the root schema captured
+ * before the `of` tree is walked, so nested blocks inherit the final
+ * post-compile values (e.g. `styles` with `normal` prepended).
+ */
+type BlockInheritance = {
+  styles: ReadonlyArray<StyleSchemaType>
+  decorators: ReadonlyArray<DecoratorSchemaType>
+  annotations: ReadonlyArray<AnnotationSchemaType>
+  lists: ReadonlyArray<ListSchemaType>
+  inlineObjects: ReadonlyArray<InlineObjectSchemaType>
 }
 
-function compileObjectOfMember(member: ObjectOfDefinition): ObjectOfDefinition {
+function isBlockOfMember(member: OfDefinition): member is BlockOfDefinition {
+  return member.type === 'block'
+}
+
+function compileOfMember(
+  member: OfDefinition,
+  inheritance: BlockInheritance,
+): OfDefinition {
+  if (isBlockOfMember(member)) {
+    return compileBlockOfMember(member, inheritance)
+  }
+  return compileObjectOfMember(member, inheritance)
+}
+
+function compileBlockOfMember(
+  member: BlockOfDefinition,
+  inheritance: BlockInheritance,
+): BlockOfDefinition {
+  return {
+    ...member,
+    styles: member.styles
+      ? member.styles.map((style) => ({...style, value: style.name}))
+      : inheritance.styles,
+    decorators: member.decorators
+      ? member.decorators.map((decorator) => ({
+          ...decorator,
+          value: decorator.name,
+        }))
+      : inheritance.decorators,
+    annotations: member.annotations
+      ? member.annotations.map((annotation) => ({
+          ...annotation,
+          fields:
+            annotation.fields?.map((field) =>
+              compileField(field, inheritance),
+            ) ?? [],
+        }))
+      : inheritance.annotations,
+    lists: member.lists
+      ? member.lists.map((list) => ({...list, value: list.name}))
+      : inheritance.lists,
+    inlineObjects: member.inlineObjects
+      ? member.inlineObjects.map((inlineObject) => ({
+          ...inlineObject,
+          fields:
+            inlineObject.fields?.map((field) =>
+              compileField(field, inheritance),
+            ) ?? [],
+        }))
+      : inheritance.inlineObjects,
+  }
+}
+
+function compileObjectOfMember(
+  member: ObjectOfDefinition,
+  inheritance: BlockInheritance,
+): ObjectOfDefinition {
   if (member.fields) {
-    return {...member, fields: member.fields.map(compileField)}
+    return {
+      ...member,
+      fields: member.fields.map((field) => compileField(field, inheritance)),
+    }
   }
   return member
 }
 
-function compileField(field: FieldDefinition): FieldDefinition {
+function compileField(
+  field: FieldDefinition,
+  inheritance: BlockInheritance,
+): FieldDefinition {
   if (field.type === 'array' && field.of) {
     return {
       ...field,
-      of: field.of.map(compileOfMember),
+      of: field.of.map((member) => compileOfMember(member, inheritance)),
     }
   }
   return field
+}
+
+function compileBaseDefinitionWithValue<T extends BaseDefinition>(
+  definition: T,
+): T & {value: string} {
+  return {...definition, value: definition.name}
 }
 
 /**
  * @public
  */
 export function compileSchema(definition: SchemaDefinition): Schema {
-  const styles = (definition.styles ?? []).map((style) => ({
-    ...style,
-    value: style.name,
-  }))
+  const userStyles = (definition.styles ?? []).map(
+    compileBaseDefinitionWithValue,
+  )
+  const styles = !userStyles.some((style) => style.value === 'normal')
+    ? [
+        {value: 'normal', name: 'normal', title: 'Normal'} as StyleSchemaType,
+        ...userStyles,
+      ]
+    : userStyles
+
+  const lists = (definition.lists ?? []).map(compileBaseDefinitionWithValue)
+  const decorators = (definition.decorators ?? []).map(
+    compileBaseDefinitionWithValue,
+  )
+
+  // Annotations and inline objects may contain array fields whose `of`
+  // includes `{type: 'block'}`. Those nested blocks must inherit from the
+  // fully-resolved root. So we build `inheritance` first using the shallow
+  // (not-yet-resolved) annotations/inlineObjects — nested blocks inherit from
+  // the top-level schema, not from a sibling annotation's schema. Then we
+  // resolve annotations, block objects, and inline objects using that view.
+  const annotationsShallow = (definition.annotations ?? []).map(
+    (annotation) => ({
+      ...annotation,
+      fields: (annotation.fields ?? []) as ReadonlyArray<FieldDefinition>,
+    }),
+  )
+  const inlineObjectsShallow = (definition.inlineObjects ?? []).map(
+    (inlineObject) => ({
+      ...inlineObject,
+      fields: (inlineObject.fields ?? []) as ReadonlyArray<FieldDefinition>,
+    }),
+  )
+
+  const inheritance: BlockInheritance = {
+    styles,
+    decorators,
+    annotations: annotationsShallow,
+    lists,
+    inlineObjects: inlineObjectsShallow,
+  }
 
   const blockFields: Array<FieldDefinition> = []
 
@@ -58,7 +177,7 @@ export function compileSchema(definition: SchemaDefinition): Schema {
         continue
       }
 
-      blockFields.push(field)
+      blockFields.push(compileField(field, inheritance))
     }
   }
 
@@ -70,28 +189,26 @@ export function compileSchema(definition: SchemaDefinition): Schema {
     span: {
       name: 'span',
     },
-    styles: !styles.some((style) => style.value === 'normal')
-      ? [{value: 'normal', name: 'normal', title: 'Normal'}, ...styles]
-      : styles,
-    lists: (definition.lists ?? []).map((list) => ({
-      ...list,
-      value: list.name,
-    })),
-    decorators: (definition.decorators ?? []).map((decorator) => ({
-      ...decorator,
-      value: decorator.name,
-    })),
+    styles,
+    lists,
+    decorators,
     annotations: (definition.annotations ?? []).map((annotation) => ({
       ...annotation,
-      fields: annotation.fields?.map(compileField) ?? [],
+      fields:
+        annotation.fields?.map((field) => compileField(field, inheritance)) ??
+        [],
     })),
     blockObjects: (definition.blockObjects ?? []).map((blockObject) => ({
       ...blockObject,
-      fields: blockObject.fields?.map(compileField) ?? [],
+      fields:
+        blockObject.fields?.map((field) => compileField(field, inheritance)) ??
+        [],
     })),
     inlineObjects: (definition.inlineObjects ?? []).map((inlineObject) => ({
       ...inlineObject,
-      fields: inlineObject.fields?.map(compileField) ?? [],
+      fields:
+        inlineObject.fields?.map((field) => compileField(field, inheritance)) ??
+        [],
     })),
   }
 }

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -75,13 +75,21 @@ export type InlineObjectSchemaType = BaseDefinition & {
  * @public
  * Describes a member type within an array field's `of`.
  * When `type` is `'block'`, PTE sub-schema properties (styles, decorators,
- * annotations, lists) are available for configuring the nested block editor.
+ * annotations, lists, inlineObjects) are available for configuring the
+ * nested text block. Unspecified fields are inherited from the root schema
+ * at `compileSchema` time.
  */
 export type OfDefinition = BlockOfDefinition | ObjectOfDefinition
 
 /**
  * @public
  * An `of` member with `type: 'block'` -- supports nested PTE sub-schema.
+ *
+ * When this entry appears in a container field's `of`, it declares a nested
+ * text block. Each sub-schema field is inherited from the root schema when
+ * absent, or fully overrides root when defined. Resolution happens at
+ * `compileSchema` time; after compilation, all fields are populated and can
+ * be read directly without merging.
  */
 export type BlockOfDefinition = {
   type: 'block'
@@ -93,6 +101,9 @@ export type BlockOfDefinition = {
     BaseDefinition & {fields?: ReadonlyArray<FieldDefinition>}
   >
   lists?: ReadonlyArray<BaseDefinition>
+  inlineObjects?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<FieldDefinition>}
+  >
 }
 
 /**


### PR DESCRIPTION
# Resolve nested block sub-schemas at compile time

A `{type: 'block'}` entry inside a container field's `of` array can now declare
its own `styles`, `decorators`, `annotations`, `lists`, and `inlineObjects`. Each
field that is defined replaces root's; each field that is absent is inherited
from root. Resolution happens once at `compileSchema`, so downstream consumers
read nested block configuration the same way they read root's — without any
merging.

## Motivation

PTE containers (table cells, code-blocks, callouts) hold nested text blocks.
Those nested blocks can need different rules than root: a cell might allow only
`strong`, or declare an inline object that doesn't exist at root. The schema
grammar already had the shape for this (`BlockOfDefinition.styles`/`decorators`
etc. were declarable at nested positions), but the compiler ignored them, and
every downstream consumer that wanted to know what the nested block supported
had to walk the `of` tree and merge by hand.

With this change, the grammar is delivered: after `compileSchema`, every nested
`{type: 'block'}` in the compiled output has its sub-schema fully resolved.

## Inheritance rule

Per-field override. Defined = replaces root. Absent = inherits root.

```ts
defineSchema({
  decorators: [{name: 'strong'}, {name: 'em'}],
  annotations: [{name: 'link'}],
  blockObjects: [{
    name: 'tableCell',
    fields: [{
      name: 'content',
      type: 'array',
      of: [{
        type: 'block',
        decorators: [{name: 'strong'}],      // overrides root
        inlineObjects: [{name: 'mention'}],  // no root inline objects
      }],
    }],
  }],
})
```

After compilation the nested block has:

- `decorators`: only `strong` (override)
- `annotations`: root's `link` (inherited)
- `styles`/`lists`: root's values (inherited)
- `inlineObjects`: own `mention`

`BlockOfDefinition` gains an `inlineObjects?` field so nested blocks can
declare their own inline object list, mirroring how root declares them via
`Schema.inlineObjects`.

## Non-goals

Editor consumers (parser, normalize, render) still read from the flat
`Schema.blockObjects`/`.inlineObjects` convenience fields today. Migrating them
to read the resolved nested sub-schemas at the correct depth is the follow-up
PR. This one is strictly the schema compiler change and does not alter any
existing editor behavior.
