### PR TITLE
fix: add `siblingPath` util and use it in `insert.block` operation

### DIFF
--- a/.changeset/sibling-path-util.md
+++ b/.changeset/sibling-path-util.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: add `siblingPath` util and use it in `insert.block` operation

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -24,6 +24,7 @@ import type {Point} from '../slate/interfaces/point'
 import type {Range} from '../slate/interfaces/range'
 import {parentPath} from '../slate/path/parent-path'
 import {pathEquals} from '../slate/path/path-equals'
+import {siblingPath} from '../slate/path/sibling-path'
 import {pointEquals} from '../slate/point/point-equals'
 import {isExpandedRange} from '../slate/range/is-expanded-range'
 import {rangeEdges} from '../slate/range/range-edges'
@@ -327,24 +328,22 @@ function insertBlockIntoEmptyEditor(
 function insertSiblingBlock(
   editor: PortableTextSlateEditor,
   block: Node,
-  siblingPath: Path,
+  siblingNodePath: Path,
   position: 'before' | 'after',
 ): Path {
-  const containerFieldPath = parentPath(siblingPath)
-  const containerFieldPathRef = pathRef(editor, containerFieldPath)
+  const siblingPathRef = pathRef(editor, siblingNodePath)
 
   const operation: InsertOperation = {
     type: 'insert',
-    path: siblingPath,
+    path: siblingNodePath,
     node: block,
     position,
   }
   editor.apply(operation)
 
-  const resolvedContainerFieldPath =
-    containerFieldPathRef.unref() ?? containerFieldPath
+  const resolvedSiblingPath = siblingPathRef.unref() ?? siblingNodePath
 
-  return [...resolvedContainerFieldPath, {_key: operation.node._key}]
+  return siblingPath(resolvedSiblingPath, operation.node._key)
 }
 
 /**

--- a/packages/editor/src/slate/path/sibling-path.test.ts
+++ b/packages/editor/src/slate/path/sibling-path.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from 'vitest'
+import {siblingPath} from './sibling-path'
+
+describe(siblingPath.name, () => {
+  test('root-level sibling', () => {
+    expect(siblingPath([{_key: 'b1'}], 'b2')).toEqual([{_key: 'b2'}])
+  })
+
+  test('span-level sibling inside text block', () => {
+    expect(siblingPath([{_key: 'b1'}, 'children', {_key: 's1'}], 's2')).toEqual(
+      [{_key: 'b1'}, 'children', {_key: 's2'}],
+    )
+  })
+
+  test('line sibling inside code-block', () => {
+    expect(siblingPath([{_key: 'cb'}, 'lines', {_key: 'l1'}], 'l2')).toEqual([
+      {_key: 'cb'},
+      'lines',
+      {_key: 'l2'},
+    ])
+  })
+
+  test('cell sibling inside nested table', () => {
+    expect(
+      siblingPath(
+        [{_key: 't'}, 'rows', {_key: 'r'}, 'cells', {_key: 'c1'}],
+        'c2',
+      ),
+    ).toEqual([{_key: 't'}, 'rows', {_key: 'r'}, 'cells', {_key: 'c2'}])
+  })
+
+  test('throws on root path', () => {
+    expect(() => siblingPath([], 'x')).toThrow(
+      /Cannot compute sibling path of the root path/,
+    )
+  })
+
+  test('throws when last segment is not keyed', () => {
+    expect(() => siblingPath([{_key: 'b'}, 'children'], 'x')).toThrow(
+      /Expected last segment of sibling path to be a keyed segment/,
+    )
+  })
+
+  test('throws when last segment is numeric', () => {
+    expect(() => siblingPath([{_key: 'b'}, 'children', 0], 'x')).toThrow(
+      /Expected last segment of sibling path to be a keyed segment/,
+    )
+  })
+})

--- a/packages/editor/src/slate/path/sibling-path.ts
+++ b/packages/editor/src/slate/path/sibling-path.ts
@@ -1,0 +1,34 @@
+import {safeStringify} from '../../internal-utils/safe-json'
+import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
+import type {Path} from '../interfaces/path'
+
+/**
+ * Compute the canonical path that a new node will have when inserted as a
+ * sibling of an existing node.
+ *
+ * Preserves the array-field segment that `existingPath` carries. Works at any
+ * depth — the caller does not need to know which array field the sibling
+ * lives in.
+ *
+ * [{_key:'b1'}]                                       + 'b2' → [{_key:'b2'}]
+ * [{_key:'b1'}, 'children', {_key:'s1'}]              + 's2' → [{_key:'b1'}, 'children', {_key:'s2'}]
+ * [{_key:'cb'}, 'lines', {_key:'l1'}]                 + 'l2' → [{_key:'cb'}, 'lines', {_key:'l2'}]
+ * [{_key:'t'}, 'rows', {_key:'r'}, 'cells', {_key:'c'}] + 'c2' → [{_key:'t'}, 'rows', {_key:'r'}, 'cells', {_key:'c2'}]
+ */
+export function siblingPath(existingPath: Path, newKey: string): Path {
+  if (existingPath.length === 0) {
+    throw new Error(
+      `Cannot compute sibling path of the root path [${existingPath}].`,
+    )
+  }
+
+  const lastSegment = existingPath.at(-1)
+
+  if (!isKeyedSegment(lastSegment)) {
+    throw new Error(
+      `Expected last segment of sibling path to be a keyed segment, got ${safeStringify(lastSegment)}.`,
+    )
+  }
+
+  return [...existingPath.slice(0, -1), {_key: newKey}]
+}


### PR DESCRIPTION
Introduces a small path primitive — `siblingPath(existingPath, newKey)` — that computes the canonical path a new node will occupy when inserted as a sibling of an existing node. The returned path preserves the array-field segment carried by the existing path, so the result is correct at any depth (root level, inside a text block, inside a container field like `lines`, or deeper).

### Background

`insertSiblingBlock` in `operation.insert.block.ts` used to compute `parentPath(siblingPath)` and concatenate the new key:

```ts
const containerFieldPath = parentPath(siblingPath)
// ...
return [...resolvedContainerFieldPath, {_key: operation.node._key}]
```

`parentPath` drops both the last keyed segment **and** the preceding field segment. So for a sibling path `[{_key:'cb'}, 'lines', {_key:'l1'}]` the result was `[{_key:'cb'}, {_key:'newKey'}]` — missing the `'lines'` field name. The emitted insert patch itself is canonical (it uses the incoming `siblingPath` directly), but the returned path flows into `editorEnd`/`editorStart` and selection updates, where a missing field segment can misroute selection when the sibling lives inside a non-root container.

### The util

```ts
siblingPath([{_key: 'b1'}], 'b2')
// → [{_key: 'b2'}]

siblingPath([{_key: 'b1'}, 'children', {_key: 's1'}], 's2')
// → [{_key: 'b1'}, 'children', {_key: 's2'}]

siblingPath([{_key: 'cb'}, 'lines', {_key: 'l1'}], 'l2')
// → [{_key: 'cb'}, 'lines', {_key: 'l2'}]
```

It throws when applied to the root path or when the last segment is not keyed, so future callers cannot accidentally build a malformed path.

### Scope

Internal, no public API change. One call site updated (`insertSiblingBlock`). Other sibling-concat sites (six in `behavior.abstract.insert.ts` and one hardcoded `'children'` rebuild in `operation.insert.block.ts`) are on a separate container-aware branch and will migrate to this util in a follow-up.