### PR TITLE
fix: emit post-normalize snapshot in mutation events

### DIFF
--- a/.changeset/mutation-snapshot-post-normalize.md
+++ b/.changeset/mutation-snapshot-post-normalize.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: emit post-normalize snapshot in mutation events

--- a/packages/editor/src/editor/mutation-machine.ts
+++ b/packages/editor/src/editor/mutation-machine.ts
@@ -83,11 +83,17 @@ export const mutationMachine = setup({
       context.slateEditor.isDeferringMutations = true
     },
     'emit mutations': enqueueActions(({context, enqueue}) => {
-      for (const bulk of context.pendingMutations) {
+      // The final bulk may have captured `value` before normalization ran.
+      // Normalization can mutate `editor.children` without emitting a patch,
+      // so the final bulk's snapshot must be read live. Earlier bulks keep
+      // their in-sequence snapshots.
+      const lastIndex = context.pendingMutations.length - 1
+      for (let i = 0; i < context.pendingMutations.length; i++) {
+        const bulk = context.pendingMutations[i]!
         enqueue.emit({
           type: 'mutation',
           patches: bulk.patches,
-          snapshot: bulk.value,
+          snapshot: i === lastIndex ? context.slateEditor.children : bulk.value,
         })
       }
       context.slateEditor.isDeferringMutations = false

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {getFirstBlock, getFocusBlock} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
 import type {EditorSelection} from '../src/types/editor'
@@ -927,6 +928,50 @@ describe('event.history.undo', () => {
     editor.send({type: 'history.undo'})
 
     // After undo: back to original value
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: Undoing removal of the only block after value broadcast restores it', async () => {
+    const initialValue = [
+      {
+        _key: 'k0',
+        _type: 'block',
+        children: [{_key: 'k1', _type: 'span', text: 'hello', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    let latestValue: typeof initialValue | undefined
+
+    const {editor, locator} = await createTestEditor({
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              latestValue = event.value as typeof initialValue
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({type: 'delete.block', at: [{_key: 'k0'}]})
+
+    await vi.waitFor(() => {
+      expect(latestValue).not.toEqual(undefined)
+      expect(latestValue?.[0]?._key).not.toEqual('k0')
+    })
+
+    editor.send({type: 'update value', value: structuredClone(latestValue)})
+
+    editor.send({type: 'history.undo'})
+
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -256,4 +256,43 @@ describe('event.mutation', () => {
       expect(mutationEvents.length).toBe(2)
     })
   })
+
+  test('Scenario: Deleting the only block emits a mutation whose value contains the normalized placeholder', async () => {
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({type: 'delete.block', at: [{_key: 'k0'}]})
+
+    await vi.waitFor(() => {
+      expect(mutationEvents.at(-1)?.value).toEqual([
+        {
+          _key: 'k2',
+          _type: 'block',
+          children: [{_key: 'k3', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
When the editor became empty (for example by deleting the only block), normalization synthesized a fresh placeholder block to preserve the empty-tree invariant. The synth runs under `withoutPatching`, so it does not emit a patch. Meanwhile mutation bulks captured their `value` snapshot per-patch at emit time, so the final bulk recorded `editor.children` as `[]` from the last user unset and never saw the synthesized placeholder.

Consumers receiving that mutation event saw `value: []`, would call `clearEditor` or broadcast the empty value back to the editor, and subsequent undo attempts failed because the history was wiped or the round-trip inserted a differently-keyed placeholder that did not match the inverse of the original delete.

The fix is to capture the final bulk's snapshot from live `editor.children` at flush time rather than per-patch at emit time. By the time the mutation-machine flushes, any in-flight `withoutNormalizing` transaction has unwound and normalization has settled, so the live children accurately reflect the post-normalize state. Earlier pending bulks keep their in-sequence snapshots; only the final bulk is updated, because that is where a patch-less synth lands.

Regression tests exercise the scenario end-to-end: delete the only block, wait for the mutation debounce, assert the emitted mutation carries a post-normalize value, feed that value back in as an `update value`, undo, and expect the original content back.
