### PR TITLE
fix: remove dead mark placeholder machinery

### DIFF
--- a/.changeset/remove-mark-placeholder.md
+++ b/.changeset/remove-mark-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: remove dead mark placeholder machinery

--- a/packages/editor/src/slate/core/apply.ts
+++ b/packages/editor/src/slate/core/apply.ts
@@ -41,8 +41,6 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
 
   // Clear any formats applied to the cursor if the selection changes.
   if (op.type === 'set_selection') {
-    editor.marks = null
-
     if (
       op.properties &&
       op.newProperties &&

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -8,7 +8,7 @@ import {hasNode} from '../../../node-traversal/has-node'
 import {path as editorPath} from '../../editor/path'
 import {start as editorStart} from '../../editor/start'
 import {unhangRange} from '../../editor/unhang-range'
-import type {BaseEditor, Editor, EditorMarks} from '../../interfaces/editor'
+import type {BaseEditor, Editor} from '../../interfaces/editor'
 import type {Operation} from '../../interfaces/operation'
 import type {Point} from '../../interfaces/point'
 import type {Range} from '../../interfaces/range'
@@ -22,7 +22,6 @@ import type {TextDiff} from '../utils/diff-text'
 import {
   closestShadowAware,
   containsShadowAware,
-  DOMText,
   getSelection,
   hasShadowRoot,
   isAfter,
@@ -69,8 +68,6 @@ export interface DOMEditor extends BaseEditor {
   userSelection: RangeRef | null
   onContextChange: ((options?: {operation?: Operation}) => void) | null
   scheduleFlush: (() => void) | null
-  pendingInsertionMarks: EditorMarks | null
-  userMarks: EditorMarks | null
   pendingDiffs: TextDiff[]
   pendingAction: Action | null
   pendingSelection: Range | null
@@ -416,27 +413,6 @@ export const DOMEditor: DOMEditorInterface = {
       const attr = text.getAttribute('data-slate-length')
       const trueLength = attr == null ? length : parseInt(attr, 10)
       const end = start + trueLength
-
-      // Prefer putting the selection inside the mark placeholder to ensure
-      // composed text is displayed with the correct marks.
-      const nextText = texts[i + 1]
-      if (
-        point.offset === end &&
-        nextText?.hasAttribute('data-slate-mark-placeholder')
-      ) {
-        const domText = nextText.childNodes[0]
-
-        domPoint = [
-          // COMPAT: If we don't explicity set the dom point to be on the actual
-          // dom text element, chrome will put the selection behind the actual dom
-          // text element, causing domRange.getBoundingClientRect() calls on a collapsed
-          // selection to return incorrect zero values (https://bugs.chromium.org/p/chromium/issues/detail?id=435438)
-          // which will cause issues when scrolling to it.
-          domText instanceof DOMText ? domText : nextText,
-          nextText.textContent?.startsWith('\uFEFF') ? 1 : 0,
-        ]
-        break
-      }
 
       if (point.offset <= end) {
         const offset = Math.min(length, Math.max(0, point.offset - start))

--- a/packages/editor/src/slate/dom/plugin/with-dom.ts
+++ b/packages/editor/src/slate/dom/plugin/with-dom.ts
@@ -28,8 +28,6 @@ export const withDOM = <T extends Editor>(editor: T): T & DOMEditor => {
   e.userSelection = null
   e.onContextChange = null
   e.scheduleFlush = null
-  e.pendingInsertionMarks = null
-  e.userMarks = null
   e.pendingDiffs = []
   e.pendingAction = null
   e.pendingSelection = null

--- a/packages/editor/src/slate/dom/utils/symbols.ts
+++ b/packages/editor/src/slate/dom/utils/symbols.ts
@@ -1,7 +1,0 @@
-/**
- * Symbols.
- */
-
-export const MARK_PLACEHOLDER_SYMBOL = Symbol(
-  'mark-placeholder',
-) as unknown as string

--- a/packages/editor/src/slate/interfaces/editor.ts
+++ b/packages/editor/src/slate/interfaces/editor.ts
@@ -1,4 +1,4 @@
-import type {PortableTextBlock, PortableTextSpan} from '@portabletext/schema'
+import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelection} from '../../types/editor'
 import type {PortableTextSlateEditor} from '../../types/slate-editor'
 import type {DOMEditor} from '../dom/plugin/dom-editor'
@@ -22,7 +22,6 @@ export interface BaseEditor {
   readonly value: PortableTextBlock[]
   selection: EditorSelection
   operations: Operation[]
-  marks: EditorMarks | null
   dirtyPaths: Path[]
   dirtyPathKeys: Set<string>
   flushing: boolean
@@ -59,5 +58,3 @@ export interface BaseEditor {
 }
 
 export type Editor = BaseEditor & DOMEditor & PortableTextSlateEditor
-
-export type EditorMarks = Omit<PortableTextSpan, 'text'>

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -3,7 +3,6 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import {isSpan} from '@portabletext/schema'
 import React, {
   forwardRef,
   useCallback,
@@ -52,7 +51,6 @@ import {
   IS_WECHATBROWSER,
 } from '../../dom/utils/environment'
 import Hotkeys from '../../dom/utils/hotkeys'
-import {MARK_PLACEHOLDER_SYMBOL} from '../../dom/utils/symbols'
 import {end as editorEnd} from '../../editor/end'
 import {range as editorRange} from '../../editor/range'
 import {rangeRef} from '../../editor/range-ref'
@@ -68,7 +66,6 @@ import {isBackwardRange} from '../../range/is-backward-range'
 import {isCollapsedRange} from '../../range/is-collapsed-range'
 import {isExpandedRange} from '../../range/is-expanded-range'
 import {rangeEquals} from '../../range/range-equals'
-import {textEquals} from '../../text/text-equals'
 import type {AndroidInputManager} from '../hooks/android-input-manager/android-input-manager'
 import {useAndroidInputManager} from '../hooks/android-input-manager/use-android-input-manager'
 import useChildren from '../hooks/use-children'
@@ -196,7 +193,6 @@ export const Editable = forwardRef(
       () => ({
         isUpdatingSelection: false,
         latestElement: null as DOMElement | null,
-        hasMarkPlaceholder: false,
       }),
       [],
     )
@@ -414,18 +410,7 @@ export const Editable = forwardRef(
           })
 
           if (slateRange && rangeEquals(slateRange, selection)) {
-            if (!state.hasMarkPlaceholder) {
-              return
-            }
-
-            // Ensure selection is inside the mark placeholder
-            if (
-              anchorNode?.parentElement?.hasAttribute(
-                'data-slate-mark-placeholder',
-              )
-            ) {
-              return
-            }
+            return
           }
         }
 
@@ -626,12 +611,6 @@ export const Editable = forwardRef(
             selection.anchor.offset !== 0
           ) {
             native = true
-
-            // Skip native if there are marks, as
-            // `insertText` will insert a node, not just text.
-            if (editor.marks) {
-              native = false
-            }
 
             // If the NODE_MAP is dirty, we can't trust the selection anchor (eg DOMEditor.toDOMPoint)
             if (!editor.isNodeMapDirty) {
@@ -1003,60 +982,6 @@ export const Editable = forwardRef(
     const decorations = decorate([editor as any, []])
     const decorateContext = useDecorateContext(decorate)
 
-    const {marks} = editor
-    state.hasMarkPlaceholder = false
-
-    if (editor.selection && isCollapsedRange(editor.selection) && marks) {
-      const {anchor} = editor.selection
-      const leafEntry = getNode(editor, anchor.path)
-      const leaf = leafEntry ? leafEntry.node : undefined
-
-      if (leaf && isSpan({schema: editor.schema}, leaf)) {
-        const {text: _text, ...rest} = leaf
-
-        if (!textEquals(leaf, marks, {loose: true})) {
-          state.hasMarkPlaceholder = true
-
-          const unset = Object.fromEntries(
-            Object.keys(rest).map((mark) => [mark, null]),
-          )
-
-          decorations.push({
-            [MARK_PLACEHOLDER_SYMBOL]: true,
-            ...unset,
-            ...marks,
-
-            anchor,
-            focus: anchor,
-          })
-        }
-      }
-    }
-
-    // Update EDITOR_TO_MARK_PLACEHOLDER_MARKS in setTimeout useEffect to ensure we don't set it
-    // before we receive the composition end event.
-    useEffect(() => {
-      setTimeout(() => {
-        const {selection} = editor
-        if (selection) {
-          const {anchor} = selection
-          const textEntry = getNode(editor, anchor.path)
-
-          if (!textEntry || !isSpan({schema: editor.schema}, textEntry.node)) {
-            return
-          }
-
-          const text = textEntry.node
-          if (marks && !textEquals(text, marks, {loose: true})) {
-            editor.pendingInsertionMarks = marks
-            return
-          }
-        }
-
-        editor.pendingInsertionMarks = null
-      })
-    })
-
     useFlushDeferredSelectorsOnRender()
 
     return (
@@ -1362,15 +1287,6 @@ export const Editable = forwardRef(
                       !IS_UC_MOBILE &&
                       event.data
                     ) {
-                      const placeholderMarks = editor.pendingInsertionMarks
-                      editor.pendingInsertionMarks = null
-
-                      // Ensure we insert text with the marks the user was actually seeing
-                      if (placeholderMarks !== undefined) {
-                        editor.userMarks = editor.marks
-                        editor.marks = placeholderMarks
-                      }
-
                       editorActor.send({
                         type: 'behavior event',
                         behaviorEvent: {
@@ -1379,12 +1295,6 @@ export const Editable = forwardRef(
                         },
                         editor,
                       })
-
-                      const userMarks = editor.userMarks
-                      editor.userMarks = null
-                      if (userMarks !== undefined) {
-                        editor.marks = userMarks
-                      }
                     }
                   }
                 },

--- a/packages/editor/src/slate/react/components/string.tsx
+++ b/packages/editor/src/slate/react/components/string.tsx
@@ -8,7 +8,6 @@ import {
 import {forwardRef, memo, useRef, useState} from 'react'
 import {getNodes} from '../../../node-traversal/get-nodes'
 import {IS_ANDROID} from '../../dom/utils/environment'
-import {MARK_PLACEHOLDER_SYMBOL} from '../../dom/utils/symbols'
 import {end as editorEnd} from '../../editor/end'
 import {start as editorStart} from '../../editor/start'
 import type {Editor} from '../../interfaces/editor'
@@ -58,7 +57,6 @@ const SlateString = (props: {
   const {isLast, leaf, parent, path, text} = props
   const editor = useSlateStatic()
   const parentPath = getParentPath(path)
-  const isMarkPlaceholder = Boolean((leaf as any)[MARK_PLACEHOLDER_SYMBOL])
   const leafText = leaf.text ?? ''
 
   // COMPAT: If this is the last text node in an empty block, render a zero-
@@ -70,14 +68,14 @@ const SlateString = (props: {
     parent.children[parent.children.length - 1] === text &&
     getTextContent(editor, parentPath) === ''
   ) {
-    return <ZeroWidthString isLineBreak isMarkPlaceholder={isMarkPlaceholder} />
+    return <ZeroWidthString isLineBreak />
   }
 
   // COMPAT: If the text is empty, it's because it's on the edge of an inline
   // node, so we render a zero-width space so that the selection can be
   // inserted next to it still.
   if (leafText === '') {
-    return <ZeroWidthString isMarkPlaceholder={isMarkPlaceholder} />
+    return <ZeroWidthString />
   }
 
   // COMPAT: Browsers will collapse trailing new lines at the end of blocks,
@@ -140,24 +138,15 @@ const MemoizedText = memo(
  * Leaf strings without text, render as zero-width strings.
  */
 
-const ZeroWidthString = (props: {
-  length?: number
-  isLineBreak?: boolean
-  isMarkPlaceholder?: boolean
-}) => {
-  const {length = 0, isLineBreak = false, isMarkPlaceholder = false} = props
+const ZeroWidthString = (props: {length?: number; isLineBreak?: boolean}) => {
+  const {length = 0, isLineBreak = false} = props
 
   const attributes: {
     'data-slate-zero-width': string
     'data-slate-length': number
-    'data-slate-mark-placeholder'?: boolean
   } = {
     'data-slate-zero-width': isLineBreak ? 'n' : 'z',
     'data-slate-length': length,
-  }
-
-  if (isMarkPlaceholder) {
-    attributes['data-slate-mark-placeholder'] = true
   }
 
   // FIXME: Inserting the \uFEFF on iOS breaks capitalization at the start of an

--- a/packages/editor/src/slate/react/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/editor/src/slate/react/hooks/android-input-manager/android-input-manager.ts
@@ -159,7 +159,6 @@ export function createAndroidInputManager({
     const selectionRef =
       editor.selection &&
       rangeRef(editor, editor.selection, {affinity: 'forward'})
-    editor.userMarks = editor.marks
 
     debug('flush', editor.pendingAction, editor.pendingDiffs)
 
@@ -168,18 +167,6 @@ export function createAndroidInputManager({
     let diff: TextDiff | undefined
     // biome-ignore lint/suspicious/noAssignInExpressions: Slate upstream pattern
     while ((diff = editor.pendingDiffs?.[0])) {
-      const pendingMarks = editor.pendingInsertionMarks
-
-      if (pendingMarks !== undefined) {
-        editor.pendingInsertionMarks = null
-        editor.marks = pendingMarks
-      }
-
-      if (pendingMarks && insertPositionHint === false) {
-        insertPositionHint = null
-        debug('insert after mark placeholder')
-      }
-
       const range = targetRange(diff)
       if (!editor.selection || !rangeEquals(editor.selection, range)) {
         editor.select(range)
@@ -210,7 +197,6 @@ export function createAndroidInputManager({
         debug('invalid diff state')
         scheduleSelectionChange = false
         editor.pendingAction = null
-        editor.userMarks = null
         flushing = 'action'
 
         // Ensure we don't restore the pending user (dom) selection
@@ -248,13 +234,6 @@ export function createAndroidInputManager({
     onDOMSelectionChange.flush()
 
     applyPendingSelection()
-
-    const userMarks = editor.userMarks
-    editor.userMarks = null
-    if (userMarks !== undefined) {
-      editor.marks = userMarks
-      editor.onChange()
-    }
   }
 
   const handleCompositionEnd = (
@@ -734,12 +713,6 @@ export function createAndroidInputManager({
         }
 
         let text = data ?? ''
-
-        // COMPAT: If we are writing inside a placeholder, the ime inserts the text inside
-        // the placeholder itself and thus includes the zero-width space inside edit events.
-        if (editor.pendingInsertionMarks) {
-          text = text.replace('\uFEFF', '')
-        }
 
         // Pastes from the Android clipboard will generate `insertText` events.
         // If the copied text contains any newlines, Android will append an


### PR DESCRIPTION
Slate ships a "mark placeholder" feature to keep IME composition in sync with pending inline marks toggled via `editor.marks`. In PTE, `editor.marks` is never populated — decorators flow through the behavior pipeline (`decorator.toggle` / `decorator.add` / `decorator.remove`), which rewrites span children directly without ever touching the `editor.marks` staging area. The `editor.marks` field and its IME machinery form a circular dependency that has no entry point.

This removes:

- `MARK_PLACEHOLDER_SYMBOL` and the `dom/utils/symbols.ts` file that housed it
- The `data-slate-mark-placeholder` attribute and its emission in `string.tsx`
- The `hasMarkPlaceholder` state field and its read in the DOM selection change handler
- The `pendingInsertionMarks` / `userMarks` fields on `DOMEditor` and their initializers
- The `useEffect` that computed `pendingInsertionMarks` from `editor.marks` each render
- The compositionEnd dance that saved/restored `editor.marks` around `insert.text`
- The Android input manager's `pendingMarks` / `userMarks` preservation and zero-width text stripping
- The `editor.marks` field itself on the base editor interface, the `EditorMarks` type, and the dead `editor.marks = null` in `apply.ts` and the dead `if (editor.marks)` guard in `editable.tsx`
- The mark-placeholder preference branch in `toSlatePoint` (dom-editor.ts)
