### PR TITLE
fix!: widen `BlockPath`, `ChildPath`, and `AnnotationPath` to `Path`

### DIFF
--- a/.changeset/containers-editor-context.md
+++ b/.changeset/containers-editor-context.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+feat: add `containers` to editor context
+
+Adds the `@alpha` `EditorContext.containers` field and container-aware node-traversal and schema helpers. Internal groundwork for depth-agnostic selectors, behaviors, operations, and rendering. No consumer-visible change.

--- a/.changeset/plugin-adapt-widened-paths.md
+++ b/.changeset/plugin-adapt-widened-paths.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/plugin-emoji-picker': patch
+'@portabletext/plugin-input-rule': patch
+'@portabletext/plugin-typeahead-picker': patch
+---
+
+fix: adapt plugins to widened path types
+
+Adjust path construction in the emoji and typeahead pickers to derive the target block prefix via `path.slice(0, -2)` instead of `path[0]._key`, so the plugins produce correct sibling paths regardless of how deep the focus span sits. Input rule block-offset comparisons use `isKeyedSegment` guards before reading the block key.

--- a/.changeset/widen-path-types.md
+++ b/.changeset/widen-path-types.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': major
+---
+
+fix!: widen `BlockPath`, `ChildPath`, and `AnnotationPath` to `Path`
+
+These three types are now aliases for `Path`, the general recursive path type, so blocks, children, and annotations can live inside editable containers at any depth. The widening cascades into every event whose `at` field accepted one of the narrow aliases (`block.set`, `block.unset`, `child.set`, `child.unset`, `delete.block`, `delete.child`, `annotation.set`, `move.block`, `move.block up`, `move.block down`, `select.block`). Consumers that destructured positional segments (e.g. `path[0]._key`) must use `path.at(-1)` for a `BlockPath` (the block key sits at the end) or `path.at(-3)` for an `AnnotationPath`, each with a `KeyedSegment` guard, or reach for traversal utilities.

--- a/packages/editor/src/behaviors/behavior.abstract.annotation.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.annotation.ts
@@ -1,5 +1,6 @@
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -7,8 +8,15 @@ export const abstractAnnotationBehaviors = [
   defineBehavior({
     on: 'annotation.set',
     guard: ({snapshot, event}) => {
-      const blockKey = event.at[0]._key
-      const markDefKey = event.at[2]._key
+      const blockSegment = event.at.at(-3)
+      const markDefSegment = event.at.at(-1)
+
+      if (!isKeyedSegment(blockSegment) || !isKeyedSegment(markDefSegment)) {
+        return false
+      }
+
+      const blockKey = blockSegment._key
+      const markDefKey = markDefSegment._key
 
       const block = getFocusTextBlock({
         ...snapshot,

--- a/packages/editor/src/behaviors/behavior.core.annotations.ts
+++ b/packages/editor/src/behaviors/behavior.core.annotations.ts
@@ -10,6 +10,7 @@ import {getSelectionStartPoint} from '../selectors/selector.get-selection-start-
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -128,11 +129,18 @@ const stripAnnotationsOnFullSpanDeletion = defineBehavior({
       return false
     }
 
-    if (startChild.path[2]._key !== endChild.path[2]._key) {
+    if (!isSpan(snapshot.context, startChild.node)) {
       return false
     }
 
-    if (!isSpan(snapshot.context, startChild.node)) {
+    const startSpanSegment = startChild.path.at(-1)
+    const endSpanSegment = endChild.path.at(-1)
+
+    if (!isKeyedSegment(startSpanSegment) || !isKeyedSegment(endSpanSegment)) {
+      return false
+    }
+
+    if (startSpanSegment._key !== endSpanSegment._key) {
       return false
     }
 

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -5,7 +5,7 @@ import type {Editor, EditorConfig} from '../editor'
 import {debug} from '../internal-utils/debug'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
-import type {Container} from '../renderers/renderer.types'
+import type {ContainerDefinition} from '../renderers/renderer.types'
 import type {EditableAPI} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {defaultKeyGenerator} from '../utils/key-generator'
@@ -20,7 +20,7 @@ import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export type InternalEditor = Editor & {
-  registerContainer: (container: Container) => () => void
+  registerContainer: (container: ContainerDefinition) => () => void
   _internal: {
     editable: EditableAPI
     editorActor: EditorActor

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -19,11 +19,14 @@ import type {Converter} from '../converters/converter.types'
 import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
-import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
 import {
   resolveContainerField,
   resolveContainers,
-  type Containers,
+  type ResolvedContainers,
 } from '../schema/resolve-containers'
 import {parseScope} from '../scope/parse-scope'
 import {DOMEditor} from '../slate/dom/plugin/dom-editor'
@@ -48,7 +51,7 @@ export * from 'xstate/guards'
  * per distinct scope string.
  */
 function collectRegisteredConfigs(
-  containers: Containers,
+  containers: ResolvedContainers,
 ): Map<string, ContainerConfig> {
   const configs = new Map<string, ContainerConfig>()
   for (const config of containers.values()) {
@@ -138,11 +141,11 @@ type InternalEditorEvent =
   | {type: 'drop'}
   | {
       type: 'register container'
-      container: Container
+      container: ContainerDefinition
     }
   | {
       type: 'unregister container'
-      container: Container
+      container: ContainerDefinition
     }
   | {type: 'add slate editor'; editor: PortableTextSlateEditor}
 
@@ -205,7 +208,7 @@ export const editorMachine = setup({
     context: {} as {
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
-      containers: Containers
+      containers: ResolvedContainers
       converters: Set<Converter>
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -71,6 +71,7 @@ export function getEditorSnapshot({
   return {
     blockIndexMap: slateEditorInstance.blockIndexMap,
     context: {
+      containers: slateEditorInstance.containers,
       converters: [...editorActorSnapshot.context.converters],
       keyGenerator: editorActorSnapshot.context.keyGenerator,
       readOnly: editorActorSnapshot.matches({'edit mode': 'read only'}),

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -1,5 +1,6 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {Converter} from '../converters/converter.types'
+import type {Containers} from '../schema/resolve-containers'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import type {EditorSchema} from './editor-schema'
@@ -14,6 +15,17 @@ export type EditorContext = {
   schema: EditorSchema
   selection: EditorSelection
   value: Array<PortableTextBlock>
+  /**
+   * Map of registered editable containers keyed by their scoped type name
+   * (the '.'-joined type chain from root, e.g. `'code-block'`,
+   * `'callout.code-block'`, `'callout.code-block.block'`).
+   *
+   * Used by container-aware selectors and traversal utilities to resolve
+   * which array field on a container node holds its editable children.
+   *
+   * @alpha
+   */
+  containers: Containers
 }
 
 /**
@@ -45,6 +57,7 @@ export function createEditorSnapshot({
   const selection = editor.selection
 
   const context = {
+    containers: editor.containers,
     converters,
     keyGenerator,
     readOnly,

--- a/packages/editor/src/editor/get-selection-state.ts
+++ b/packages/editor/src/editor/get-selection-state.ts
@@ -4,7 +4,7 @@ import {getAncestors} from '../node-traversal/get-ancestors'
 import {getNodes} from '../node-traversal/get-nodes'
 import {serializePath} from '../paths/serialize-path'
 import {isEditableContainer} from '../schema/is-editable-container'
-import type {Containers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 
@@ -53,7 +53,7 @@ const emptyState: SelectionState = {
 export function getSelectionState(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: ResolvedContainers
     value: Array<Node>
     blockIndexMap: Map<string, number>
   },

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -43,7 +43,11 @@ export {defaultKeyGenerator as keyGenerator} from './utils/key-generator'
 export {PortableTextEditor} from './editor/PortableTextEditor'
 export type {EditorEmittedEvent, MutationEvent} from './editor/relay-machine'
 export {useEditor} from './editor/use-editor'
-export {defineContainer, type Container} from './renderers/renderer.types'
+export {
+  defineContainer,
+  type ContainerDefinition,
+} from './renderers/renderer.types'
+export type {Container, Containers} from './schema/resolve-containers'
 export type {AddedAnnotationPaths} from './types/editor'
 export type {BlockOffset} from './types/block-offset'
 export type {

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -7,7 +7,7 @@ import {
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import {getSpanNode} from '../node-traversal/get-span-node'
-import type {Containers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {
   InsertOperation,
@@ -17,11 +17,11 @@ import type {
 
 function spanContext(
   schema: EditorSchema,
-  containers: Containers,
+  containers: ResolvedContainers,
   value: Array<Node>,
 ): {
   schema: EditorSchema
-  containers: Containers
+  containers: ResolvedContainers
   value: Array<Node>
 } {
   return {schema, containers, value}
@@ -29,7 +29,7 @@ function spanContext(
 
 export function textPatch(
   schema: EditorSchema,
-  containers: Containers,
+  containers: ResolvedContainers,
   children: Node[],
   operation: InsertTextOperation | RemoveTextOperation,
   beforeValue: Array<PortableTextBlock>,

--- a/packages/editor/src/node-traversal/get-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-ancestor.ts
@@ -7,7 +7,27 @@ import {getAncestors} from './get-ancestors'
 /**
  * Find the first ancestor of the node at a given path that matches a predicate.
  * Does not check the node at the path itself, only its ancestors.
+ *
+ * When `match` is a type predicate, the returned `node` narrows to that type.
  */
+export function getAncestor<TMatch extends Node>(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+  match: (node: Node, path: Path) => node is TMatch,
+): {node: TMatch; path: Path} | undefined
+export function getAncestor(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+  match: (node: Node, path: Path) => boolean,
+): {node: Node; path: Path} | undefined
 export function getAncestor(
   context: {
     schema: EditorSchema

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -1,7 +1,10 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
 import {makeContainerConfig} from '../schema/make-container-config'
 import {resolveContainers} from '../schema/resolve-containers'
 
@@ -9,7 +12,7 @@ import {resolveContainers} from '../schema/resolve-containers'
  * Container definitions for the testbed's table structure
  * (`table` → `rows`, `row` → `cells`, `cell` → `content`).
  */
-export const tableContainers: ReadonlyArray<Container> = [
+export const tableContainers: ReadonlyArray<ContainerDefinition> = [
   {scope: '$..table', field: 'rows'},
   {scope: '$..table.row', field: 'cells'},
   {scope: '$..table.row.cell', field: 'content'},
@@ -19,7 +22,7 @@ export const tableContainers: ReadonlyArray<Container> = [
  * Container definition for the testbed's code block
  * (`code-block` → `code`).
  */
-export const codeBlockContainer: Container = {
+export const codeBlockContainer: ContainerDefinition = {
   scope: '$..code-block',
   field: 'code',
 }
@@ -30,7 +33,7 @@ export const codeBlockContainer: Container = {
  */
 export function resolveTestbedContainers(
   schema: EditorSchema,
-  containers: ReadonlyArray<Container>,
+  containers: ReadonlyArray<ContainerDefinition>,
 ) {
   const configs = new Map<string, ContainerConfig>()
   for (const container of containers) {

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -3,12 +3,21 @@ import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {parseMarkDefs} from '../utils/parse-blocks'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
 > = ({context, operation}) => {
-  const blockIndex = operation.editor.blockIndexMap.get(operation.at[0]._key)
+  const blockSegment = operation.at.at(-1)
+
+  if (!isKeyedSegment(blockSegment)) {
+    throw new Error(
+      `Unable to extract block key from ${safeStringify(operation.at)}`,
+    )
+  }
+
+  const blockIndex = operation.editor.blockIndexMap.get(blockSegment._key)
 
   if (blockIndex === undefined) {
     throw new Error(

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -1,12 +1,21 @@
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
 > = ({context, operation}) => {
-  const blockKey = operation.at[0]._key
+  const blockSegment = operation.at.at(-1)
+
+  if (!isKeyedSegment(blockSegment)) {
+    throw new Error(
+      `Unable to extract block key from ${safeStringify(operation.at)}`,
+    )
+  }
+
+  const blockKey = blockSegment._key
   const blockIndex = operation.editor.blockIndexMap.get(blockKey)
 
   if (blockIndex === undefined) {

--- a/packages/editor/src/paths/get-child-field-name.ts
+++ b/packages/editor/src/paths/get-child-field-name.ts
@@ -1,6 +1,6 @@
 import type {EditorSchema} from '../editor/editor-schema'
 import {getNodeChildren} from '../node-traversal/get-children'
-import type {Containers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -15,7 +15,7 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 export function getChildFieldName(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: ResolvedContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -1,7 +1,10 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import {makeContainerConfig} from '../schema/make-container-config'
-import {resolveContainers, type Containers} from '../schema/resolve-containers'
+import {
+  resolveContainers,
+  type ResolvedContainers,
+} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import {getDirtyPaths} from './get-dirty-paths'
 
@@ -51,9 +54,9 @@ const schemaDefinition = defineSchema({
 
 const schema = compileSchema(schemaDefinition)
 
-const emptyContainers: Containers = new Map()
+const emptyContainers: ResolvedContainers = new Map()
 
-const containerContainers: Containers = resolveContainers(
+const containerContainers: ResolvedContainers = resolveContainers(
   schema,
   new Map([
     [
@@ -66,7 +69,7 @@ const containerContainers: Containers = resolveContainers(
   ]),
 )
 
-const tableContainers: Containers = resolveContainers(
+const tableContainers: ResolvedContainers = resolveContainers(
   schema,
   new Map([
     [

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
 import type {Path} from '../slate/interfaces/path'
@@ -19,7 +19,7 @@ import {getChildFieldName} from './get-child-field-name'
 function collectDescendantPaths(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: ResolvedContainers
   },
   node: Node,
   parentPath: Path,
@@ -107,7 +107,7 @@ function buildScopedName(value: Array<Node>, path: Path): string {
 export function getDirtyPaths(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: ResolvedContainers
     value: Array<Node>
   },
   op: Operation,

--- a/packages/editor/src/plugins/plugin.container.tsx
+++ b/packages/editor/src/plugins/plugin.container.tsx
@@ -1,12 +1,14 @@
 import {useEffect} from 'react'
 import type {InternalEditor} from '../editor/create-editor'
 import {useEditor} from '../editor/use-editor'
-import type {Container} from '../renderers/renderer.types'
+import type {ContainerDefinition} from '../renderers/renderer.types'
 
 /**
  * @alpha
  */
-export function ContainerPlugin(props: {containers: Array<Container>}) {
+export function ContainerPlugin(props: {
+  containers: Array<ContainerDefinition>
+}) {
   const editor = useEditor() as InternalEditor
 
   useEffect(() => {

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -7,7 +7,7 @@ import type {AllContainers, ContainerScope} from '../scope/scope.types'
 /**
  * @alpha
  */
-export type Container = {
+export type ContainerDefinition = {
   scope: string
   field: string
   render?: (props: {
@@ -64,7 +64,7 @@ type ScopedArrayFields<
 type SchemaContainerConfig<TSchema extends SchemaDefinition> =
   // Only activate the narrowed shape when the caller provides a concrete
   // schema. With the default `SchemaDefinition`, collapse to never so the
-  // overload falls through to the plain `Container` signature.
+  // overload falls through to the plain `ContainerDefinition` signature.
   SchemaDefinition extends TSchema
     ? never
     : ContainerScope<TSchema> extends infer TScope
@@ -102,12 +102,16 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
  */
 export function defineContainer<TSchema extends SchemaDefinition>(
   config: SchemaContainerConfig<TSchema>,
-): Container
+): ContainerDefinition
 /**
  * @alpha
  */
-export function defineContainer(config: Container): Container
-export function defineContainer(config: Container): Container {
+export function defineContainer(
+  config: ContainerDefinition,
+): ContainerDefinition
+export function defineContainer(
+  config: ContainerDefinition,
+): ContainerDefinition {
   return config
 }
 
@@ -115,7 +119,7 @@ export function defineContainer(config: Container): Container {
  * @internal
  */
 export type ContainerConfig = {
-  container: Container
+  container: ContainerDefinition
   parsedScope: ParsedScope
   field: ChildArrayField
 }

--- a/packages/editor/src/schema/get-block-object-schema.test.ts
+++ b/packages/editor/src/schema/get-block-object-schema.test.ts
@@ -1,0 +1,194 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
+import {getBlockObjectSchema} from './get-block-object-schema'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers} from './resolve-containers'
+
+const testRender: ContainerDefinition['render'] = ({children}) => children
+
+describe(getBlockObjectSchema.name, () => {
+  test('returns a root-level block-object definition when block is at the document root', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'image',
+            fields: [{name: 'src', type: 'string'}],
+          },
+        ],
+      }),
+    )
+    const context = {schema, containers: new Map(), value: []}
+    const node = {_type: 'image', _key: 'i0', src: 'foo.png'}
+
+    expect(getBlockObjectSchema(context, node, [{_key: 'i0'}])).toEqual({
+      name: 'image',
+      fields: [{name: 'src', type: 'string'}],
+    })
+  })
+
+  test('returns an inline-declared type definition when block is inside a container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..table.row',
+      makeContainerConfig(schema, {
+        scope: '$..table.row',
+        field: 'cells',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    // Look up the `row` block-object schema (inline-declared under table.rows.of)
+    const rowNode = {_type: 'row', _key: 'r0', cells: []}
+    expect(
+      getBlockObjectSchema(context, rowNode, [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+      ])?.name,
+    ).toBe('row')
+
+    // Look up the `cell` block-object schema (inline-declared under row.cells.of)
+    const cellNode = {_type: 'cell', _key: 'c0', content: []}
+    expect(
+      getBlockObjectSchema(context, cellNode, [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+      ])?.name,
+    ).toBe('cell')
+  })
+
+  test('falls back to root-level blockObjects when no inline match is found', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'image',
+            fields: [{name: 'src', type: 'string'}],
+          },
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const context = {schema, containers, value: []}
+    // `image` is in root `blockObjects` but not inline-declared inside callout.
+    // Looking it up at a callout-internal position falls back to root.
+    const imageNode = {_type: 'image', _key: 'i0', src: 'foo.png'}
+
+    expect(
+      getBlockObjectSchema(context, imageNode, [
+        {_key: 'co0'},
+        'content',
+        {_key: 'i0'},
+      ])?.name,
+    ).toBe('image')
+  })
+
+  test('returns undefined when the type is unknown at the effective scope', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [{name: 'image'}],
+      }),
+    )
+    const context = {schema, containers: new Map(), value: []}
+    const node = {_type: 'unknown', _key: 'u0'}
+
+    expect(getBlockObjectSchema(context, node, [{_key: 'u0'}])).toBeUndefined()
+  })
+})

--- a/packages/editor/src/schema/get-block-object-schema.ts
+++ b/packages/editor/src/schema/get-block-object-schema.ts
@@ -1,0 +1,62 @@
+import type {BaseDefinition, FieldDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getEnclosingContainer} from './get-enclosing-container'
+import type {Containers} from './resolve-containers'
+
+/**
+ * Minimal view of a block-object schema definition: its name and its
+ * declared fields (if any). Matches both root-level `blockObjects` entries
+ * and inline-declared types inside a container's `field.of`.
+ */
+export type BlockObjectSchema = BaseDefinition & {
+  fields?: ReadonlyArray<FieldDefinition>
+}
+
+/**
+ * Return the schema definition for a block-object at `path`.
+ *
+ * Walks to the nearest registered container ancestor and searches its
+ * `field.of` for an inline-declared type whose `name` matches the block's
+ * `_type`. Falls back to `schema.blockObjects` when no inline match is
+ * found (or when the block is at the root of the document).
+ *
+ * Returns `undefined` when the type is not declared at the effective scope.
+ */
+export function getBlockObjectSchema(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): BlockObjectSchema | undefined {
+  const typeName = node._type
+
+  const enclosing = getEnclosingContainer(context, path)
+
+  if (enclosing) {
+    const inline = enclosing.of.find(
+      (member) => member.type !== 'block' && member.type === typeName,
+    )
+
+    if (inline && inline.type !== 'block') {
+      // Project to BlockObjectSchema shape: `name` comes from `type`
+      // when the inline definition doesn't specify one.
+      return {
+        ...inline,
+        name: 'name' in inline && inline.name ? inline.name : inline.type,
+        fields:
+          'fields' in inline && inline.fields
+            ? (inline.fields as ReadonlyArray<FieldDefinition>)
+            : undefined,
+      }
+    }
+  }
+
+  return context.schema.blockObjects.find(
+    (definition) => definition.name === typeName,
+  )
+}

--- a/packages/editor/src/schema/get-block-sub-schema.test.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.test.ts
@@ -1,0 +1,253 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
+import {getBlockSubSchema} from './get-block-sub-schema'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers} from './resolve-containers'
+
+const testRender: ContainerDefinition['render'] = ({children}) => children
+
+describe(getBlockSubSchema.name, () => {
+  test('returns root sub-schema when path is at root', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        annotations: [{name: 'link'}],
+        styles: [{name: 'h1'}],
+      }),
+    )
+
+    const context = {
+      schema,
+      containers: new Map(),
+      value: [{_type: 'block', _key: 'b0', children: []}],
+    }
+
+    const subSchema = getBlockSubSchema(context, [{_key: 'b0'}])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong', 'em'])
+    expect(subSchema.styles.map((s) => s.name)).toEqual(['normal', 'h1'])
+    expect(subSchema.annotations.map((a) => a.name)).toEqual(['link'])
+  })
+
+  test('returns nested sub-schema inside a registered container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        styles: [{name: 'h1'}],
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'block',
+                    decorators: [{name: 'strong'}],
+                    styles: [{name: 'monospace'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'cell',
+        _key: 'c0',
+        content: [{_type: 'block', _key: 'b0', children: []}],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    // Verify-by-breaking: if the helper fell back to root, decorators would be ['strong', 'em'].
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+    expect(subSchema.styles.map((s) => s.name)).toEqual(['monospace'])
+  })
+
+  test('inherits root fields when nested block does not override', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}],
+        annotations: [{name: 'link'}],
+        inlineObjects: [{name: 'mention'}],
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'cell',
+        _key: 'c0',
+        content: [{_type: 'block', _key: 'b0', children: []}],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+    expect(subSchema.annotations.map((a) => a.name)).toEqual(['link'])
+    expect(subSchema.inlineObjects.map((i) => i.name)).toEqual(['mention'])
+  })
+
+  test('walks multiple ancestor levels to find the enclosing container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {
+                                    type: 'block',
+                                    decorators: [{name: 'strong'}],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..row',
+      makeContainerConfig(schema, {
+        scope: '$..row',
+        field: 'cells',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [{_type: 'block', _key: 'b0', children: []}],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 't0'},
+      'rows',
+      {_key: 'r0'},
+      'cells',
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+  })
+})

--- a/packages/editor/src/schema/get-block-sub-schema.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.ts
@@ -1,0 +1,145 @@
+import type {
+  AnnotationSchemaType,
+  BaseDefinition,
+  DecoratorSchemaType,
+  InlineObjectSchemaType,
+  ListSchemaType,
+  OfDefinition,
+  StyleSchemaType,
+} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getEnclosingContainer} from './get-enclosing-container'
+import type {Containers} from './resolve-containers'
+import {asFieldedTypes, asNamedTypes} from './schema-type-projections'
+
+/**
+ * The resolved validation view for a text block at a given path. At the
+ * root of the document it equals the top-level schema view. Inside a
+ * container it is the sub-schema of the nearest enclosing `{type: 'block'}`
+ * entry (resolved by `compileSchema`), with any fields the nested block
+ * doesn't override falling back to root.
+ */
+export type BlockSubSchema = {
+  styles: ReadonlyArray<StyleSchemaType>
+  decorators: ReadonlyArray<DecoratorSchemaType>
+  annotations: ReadonlyArray<AnnotationSchemaType>
+  lists: ReadonlyArray<ListSchemaType>
+  inlineObjects: ReadonlyArray<InlineObjectSchemaType>
+}
+
+type ResolvedBlockOfDefinition = {
+  type: 'block'
+  styles?: ReadonlyArray<BaseDefinition>
+  decorators?: ReadonlyArray<BaseDefinition>
+  annotations?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<unknown>}
+  >
+  lists?: ReadonlyArray<BaseDefinition>
+  inlineObjects?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<unknown>}
+  >
+}
+
+/**
+ * Return the sub-schema that applies at a given path.
+ *
+ * For paths at the root of the document, or for paths where no ancestor is
+ * a registered container, returns the top-level schema view. For paths
+ * inside a container, walks ancestors to find the nearest container and
+ * returns the sub-schema from its `{type: 'block'}` entry.
+ */
+export function getBlockSubSchema(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): BlockSubSchema {
+  const nestedBlock = findEnclosingNestedBlock(context, path)
+
+  if (!nestedBlock) {
+    return rootSubSchema(context.schema)
+  }
+
+  return {
+    styles:
+      asNamedTypes<StyleSchemaType>(nestedBlock.styles) ??
+      context.schema.styles,
+    decorators:
+      asNamedTypes<DecoratorSchemaType>(nestedBlock.decorators) ??
+      context.schema.decorators,
+    annotations:
+      asFieldedTypes<AnnotationSchemaType>(nestedBlock.annotations) ??
+      context.schema.annotations,
+    lists:
+      asNamedTypes<ListSchemaType>(nestedBlock.lists) ?? context.schema.lists,
+    inlineObjects:
+      asFieldedTypes<InlineObjectSchemaType>(nestedBlock.inlineObjects) ??
+      context.schema.inlineObjects,
+  }
+}
+
+/**
+ * Return `true` when the given path is inside a registered editable
+ * container -- i.e. when the block sub-schema at that path is resolved
+ * from a nested `{type: 'block'}` definition rather than the top-level
+ * schema.
+ *
+ * Use this to gate narrowing checks (e.g. "skip this decorator if the
+ * sub-schema doesn't declare it"). At root we want to preserve the
+ * permissive top-level behaviour where operations accept unknown
+ * decorators/annotations/styles and track them optimistically; inside a
+ * container the sub-schema is authoritative and those operations should
+ * be filtered.
+ */
+/**
+ * Return `true` when the given path is inside a registered editable
+ * container -- i.e. when the block sub-schema at that path is resolved
+ * from a nested `{type: 'block'}` definition rather than the top-level
+ * schema.
+ *
+ * Use this to gate narrowing checks (e.g. "skip this decorator if the
+ * sub-schema doesn't declare it"). At root we want to preserve the
+ * permissive top-level behaviour where operations accept unknown
+ * decorators/annotations/styles and track them optimistically; inside a
+ * container the sub-schema is authoritative and those operations should
+ * be filtered.
+ */
+function rootSubSchema(schema: EditorSchema): BlockSubSchema {
+  return {
+    styles: schema.styles,
+    decorators: schema.decorators,
+    annotations: schema.annotations,
+    lists: schema.lists,
+    inlineObjects: schema.inlineObjects,
+  }
+}
+
+function findEnclosingNestedBlock(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): ResolvedBlockOfDefinition | undefined {
+  const enclosing = getEnclosingContainer(context, path)
+
+  if (!enclosing) {
+    return undefined
+  }
+
+  const blockMember = enclosing.of.find(
+    (member): member is OfDefinition & {type: 'block'} =>
+      member.type === 'block',
+  )
+
+  if (!blockMember) {
+    return undefined
+  }
+
+  return blockMember as ResolvedBlockOfDefinition
+}

--- a/packages/editor/src/schema/get-enclosing-container.ts
+++ b/packages/editor/src/schema/get-enclosing-container.ts
@@ -1,0 +1,54 @@
+import type {OfDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isObjectNode} from '../slate/node/is-object-node'
+import {getContainerScopedName} from './get-container-scoped-name'
+import type {Containers} from './resolve-containers'
+
+/**
+ * Walk ancestors from `path` and return the nearest registered editable
+ * container — its resolved field definition, the raw `of` array, and the
+ * path at which it lives.
+ *
+ * Returns `undefined` when no ancestor is a registered container (the
+ * caller falls back to root-level schema views).
+ */
+export function getEnclosingContainer(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+):
+  | {
+      of: ReadonlyArray<OfDefinition>
+      path: Path
+    }
+  | undefined {
+  for (const ancestor of getAncestors(context, path)) {
+    if (!isObjectNode({schema: context.schema}, ancestor.node)) {
+      continue
+    }
+
+    const scopedName = getContainerScopedName(
+      context,
+      ancestor.node,
+      ancestor.path,
+    )
+    const container = context.containers.get(scopedName)
+
+    if (!container) {
+      continue
+    }
+
+    return {
+      of: container.field.of,
+      path: ancestor.path,
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/schema/get-type-chain.test.ts
+++ b/packages/editor/src/schema/get-type-chain.test.ts
@@ -1,0 +1,91 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {getNode} from '../node-traversal/get-node'
+import {defineContainer} from '../renderers/renderer.types'
+import type {Node} from '../slate/interfaces/node'
+import {getTypeChain} from './get-type-chain'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers, type Containers} from './resolve-containers'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const schema = compileSchema(schemaDefinition)
+
+const calloutContainer = defineContainer({
+  scope: '$..callout',
+  field: 'content',
+})
+
+const containers: Containers = resolveContainers(
+  schema,
+  new Map([
+    [calloutContainer.scope, makeContainerConfig(schema, calloutContainer)],
+  ]),
+)
+
+describe(getTypeChain.name, () => {
+  test('root span: ["block", "span"]', () => {
+    const value: Array<Node> = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: 'hello', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      } as unknown as Node,
+    ]
+    const context = {schema, containers, value}
+    const path = [{_key: 'b1'}, 'children', {_key: 's1'}]
+    const entry = getNode(context, path)!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual([
+      'block',
+      'span',
+    ])
+  })
+
+  test('callout-nested span: ["callout", "block", "span"]', () => {
+    const value: Array<Node> = [
+      {
+        _type: 'callout',
+        _key: 'c1',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b1',
+            children: [{_type: 'span', _key: 's1', text: 'hi', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      } as unknown as Node,
+    ]
+    const context = {schema, containers, value}
+    const path = [
+      {_key: 'c1'},
+      'content',
+      {_key: 'b1'},
+      'children',
+      {_key: 's1'},
+    ]
+    const entry = getNode(context, path)!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual([
+      'callout',
+      'block',
+      'span',
+    ])
+  })
+
+  test('root void block object: ["image"]', () => {
+    const value: Array<Node> = [{_type: 'image', _key: 'i1'} as unknown as Node]
+    const context = {schema, containers, value}
+    const entry = getNode(context, [{_key: 'i1'}])!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual(['image'])
+  })
+})

--- a/packages/editor/src/schema/get-type-chain.ts
+++ b/packages/editor/src/schema/get-type-chain.ts
@@ -1,0 +1,36 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import type {Containers} from './resolve-containers'
+
+/**
+ * Build the full type chain for a node at a given path, from root to the
+ * node itself. Unlike `getContainerScopedName`, this includes text blocks
+ * (`block`) so span and inline-object scopes that include `block.` as an
+ * intermediate segment can match.
+ *
+ * For a span at
+ * `[{_key:t1},'rows',{_key:r1},'cells',{_key:c1},'content',{_key:b1},'children',{_key:s1}]`
+ * the chain is `['table', 'row', 'cell', 'block', 'span']`.
+ */
+export function getTypeChain(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): Array<string> {
+  const chain: Array<string> = []
+  const ancestors = getAncestors(context, path)
+
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    chain.push(ancestors[i]!.node._type)
+  }
+
+  chain.push(node._type)
+
+  return chain
+}

--- a/packages/editor/src/schema/make-container-config.ts
+++ b/packages/editor/src/schema/make-container-config.ts
@@ -1,10 +1,13 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
 import {parseScope} from '../scope/parse-scope'
 import {resolveContainerField} from './resolve-containers'
 
 /**
- * Build a `ContainerConfig` from a `Container` definition, parsing the scope
+ * Build a `ContainerConfig` from a `ContainerDefinition`, parsing the scope
  * and resolving the field against the schema.
  *
  * Intended for unit tests that drive `resolveContainers` directly without
@@ -12,7 +15,7 @@ import {resolveContainerField} from './resolve-containers'
  */
 export function makeContainerConfig(
   schema: EditorSchema,
-  container: Container,
+  container: ContainerDefinition,
 ): ContainerConfig {
   const parsedScope = parseScope(container.scope)
   if (!parsedScope) {

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -1,16 +1,19 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
 import {makeContainerConfig} from './make-container-config'
-import type {ChildArrayField, Containers} from './resolve-containers'
+import type {ChildArrayField, ResolvedContainers} from './resolve-containers'
 import {resolveContainers} from './resolve-containers'
 
-const testRender: Container['render'] = ({children}) => children
+const testRender: ContainerDefinition['render'] = ({children}) => children
 
 function makeConfigs(
   schema: EditorSchema,
-  containers: Array<Container>,
+  containers: Array<ContainerDefinition>,
 ): Map<string, ContainerConfig> {
   const map = new Map<string, ContainerConfig>()
   for (const container of containers) {
@@ -20,7 +23,7 @@ function makeConfigs(
 }
 
 /** Extract the `field` shape from a resolved containers map for easier testing. */
-function fields(containers: Containers): Map<string, ChildArrayField> {
+function fields(containers: ResolvedContainers): Map<string, ChildArrayField> {
   const out = new Map<string, ChildArrayField>()
   for (const [key, config] of containers) {
     out.set(key, config.field)

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -10,12 +10,33 @@ export type ChildArrayField = FieldDefinition & {
 }
 
 /**
+ * Value shape held in the {@link Containers} map.
+ *
+ * Carries only what traversal and selectors need: the array field on the
+ * container node that holds its editable children.
+ *
+ * @alpha
+ */
+export type Container = {field: ChildArrayField}
+
+/**
+ * Map of registered editable containers carried on `EditorContext`.
+ *
+ * Keyed by scoped type name (type chain joined by '.', e.g. `'callout.block'`,
+ * `'table.row.cell'`). The internal `ResolvedContainers` map carries the full
+ * `ContainerConfig` and is a subtype of this.
+ *
+ * @alpha
+ */
+export type Containers = ReadonlyMap<string, Container>
+
+/**
  * Maps scoped type names (type chain joined by '.') to registered container
  * configs.
  *
  * Key: scoped type name (e.g., 'block', 'callout.block', 'table.row.cell').
  */
-export type Containers = Map<string, ContainerConfig>
+export type ResolvedContainers = Map<string, ContainerConfig>
 
 /**
  * Candidate type chain discoverable from the schema with an editable array
@@ -36,8 +57,8 @@ type Candidate = {
 export function resolveContainers(
   schema: EditorSchema,
   containerConfigs: Map<string, ContainerConfig>,
-): Containers {
-  const containers: Containers = new Map()
+): ResolvedContainers {
+  const containers: ResolvedContainers = new Map()
 
   if (containerConfigs.size === 0) {
     return containers

--- a/packages/editor/src/schema/schema-type-projections.ts
+++ b/packages/editor/src/schema/schema-type-projections.ts
@@ -1,0 +1,48 @@
+import type {
+  AnnotationSchemaType,
+  BaseDefinition,
+  DecoratorSchemaType,
+  InlineObjectSchemaType,
+  ListSchemaType,
+  StyleSchemaType,
+} from '@portabletext/schema'
+
+/**
+ * Project a compiled `{type: 'block'}` entry's named-array resolved shape
+ * (`styles`, `decorators`, `lists`) into the equivalent schema-type shape
+ * used throughout the editor (`{name, value}`). Returns `undefined` when
+ * the entry doesn't override the array — the caller falls back to root.
+ */
+export function asNamedTypes<
+  T extends StyleSchemaType | DecoratorSchemaType | ListSchemaType,
+>(resolved: ReadonlyArray<BaseDefinition> | undefined): Array<T> | undefined {
+  if (!resolved) {
+    return undefined
+  }
+  return resolved.map((entry) => ({...entry, value: entry.name}) as T)
+}
+
+/**
+ * Project a compiled `{type: 'block'}` entry's field-bearing resolved shape
+ * (`annotations`, `inlineObjects`) into the schema-type shape used
+ * throughout the editor. Returns `undefined` when the entry doesn't
+ * override the array.
+ *
+ * The `fields` projection is unsafe at the type level (resolved fields are
+ * typed as `ReadonlyArray<unknown>` in the schema package) but matches the
+ * runtime shape emitted by `compileSchema`.
+ */
+export function asFieldedTypes<
+  T extends AnnotationSchemaType | InlineObjectSchemaType,
+>(
+  resolved:
+    | ReadonlyArray<BaseDefinition & {fields?: ReadonlyArray<unknown>}>
+    | undefined,
+): Array<T> | undefined {
+  if (!resolved) {
+    return undefined
+  }
+  return resolved.map(
+    (entry) => ({...entry, fields: entry.fields ?? []}) as unknown as T,
+  )
+}

--- a/packages/editor/src/selectors/selector.get-next-span.ts
+++ b/packages/editor/src/selectors/selector.get-next-span.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {KeyedSegment} from '../types/paths'
+import type {Path} from '../slate/interfaces/path'
 import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
 import {getSelectionEndBlock} from './selector.get-selection-end-block'
 import {getSelectionEndPoint} from './selector.get-selection-end-point'
@@ -11,7 +11,7 @@ import {getSelectionEndPoint} from './selector.get-selection-end-point'
 export const getNextSpan: EditorSelector<
   | {
       node: PortableTextSpan
-      path: [KeyedSegment, 'children', KeyedSegment]
+      path: Path
     }
   | undefined
 > = (snapshot) => {
@@ -33,7 +33,7 @@ export const getNextSpan: EditorSelector<
   let nextSpan:
     | {
         node: PortableTextSpan
-        path: [KeyedSegment, 'children', KeyedSegment]
+        path: Path
       }
     | undefined
 

--- a/packages/editor/src/selectors/selector.get-previous-span.ts
+++ b/packages/editor/src/selectors/selector.get-previous-span.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {KeyedSegment} from '../types/paths'
+import type {Path} from '../slate/interfaces/path'
 import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
 import {getSelectionStartBlock} from './selector.get-selection-start-block'
 import {getSelectionStartPoint} from './selector.get-selection-start-point'
@@ -11,7 +11,7 @@ import {getSelectionStartPoint} from './selector.get-selection-start-point'
 export const getPreviousSpan: EditorSelector<
   | {
       node: PortableTextSpan
-      path: [KeyedSegment, 'children', KeyedSegment]
+      path: Path
     }
   | undefined
 > = (snapshot) => {
@@ -32,7 +32,7 @@ export const getPreviousSpan: EditorSelector<
   let previousSpan:
     | {
         node: PortableTextSpan
-        path: [KeyedSegment, 'children', KeyedSegment]
+        path: Path
       }
     | undefined
 

--- a/packages/editor/src/types/paths.ts
+++ b/packages/editor/src/types/paths.ts
@@ -29,9 +29,11 @@ export type PathSegment = string | number | KeyedSegment | IndexTuple
 export type Path = PathSegment[]
 
 /**
+ * A path to a block in the value.
+ *
  * @public
  */
-export type BlockPath = [{_key: string}]
+export type BlockPath = Path
 
 /**
  * @public
@@ -53,11 +55,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * A path to an annotation markDef on a block.
+ *
  * @public
  */
-export type AnnotationPath = [{_key: string}, 'markDefs', {_key: string}]
+export type AnnotationPath = Path
 
 /**
+ * A path to a child of a text block.
+ *
  * @public
  */
-export type ChildPath = [{_key: string}, 'children', {_key: string}]
+export type ChildPath = Path

--- a/packages/editor/src/types/slate-editor.ts
+++ b/packages/editor/src/types/slate-editor.ts
@@ -2,7 +2,7 @@ import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
-import type {Containers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {DOMEditor} from '../slate/dom/plugin/dom-editor'
 import type {Operation as SlateOperation} from '../slate/interfaces/operation'
 
@@ -29,7 +29,7 @@ export interface PortableTextSlateEditor extends DOMEditor {
 
   schema: EditorSchema
   keyGenerator: () => string
-  containers: Containers
+  containers: ResolvedContainers
 
   decoratedRanges: Array<DecoratedRange>
   decoratorState: Record<string, boolean | undefined>

--- a/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
+++ b/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
@@ -1,6 +1,7 @@
 import type {EditorContext} from '../editor/editor-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
+import {isKeyedSegment} from './util.is-keyed-segment'
 
 /**
  * @public
@@ -12,10 +13,16 @@ export function blockOffsetToBlockSelectionPoint({
   context: Pick<EditorContext, 'value'>
   blockOffset: BlockOffset
 }): EditorSelectionPoint | undefined {
+  const blockSegment = blockOffset.path.at(-1)
+
+  if (!isKeyedSegment(blockSegment)) {
+    return undefined
+  }
+
   let selectionPoint: EditorSelectionPoint | undefined
 
   for (const block of context.value) {
-    if (block._key === blockOffset.path[0]._key) {
+    if (block._key === blockSegment._key) {
       selectionPoint = {
         path: [{_key: block._key}],
         offset: blockOffset.offset,

--- a/packages/editor/src/utils/util.block-offset.ts
+++ b/packages/editor/src/utils/util.block-offset.ts
@@ -3,6 +3,7 @@ import type {EditorContext} from '../editor/editor-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 import type {ChildPath} from '../types/paths'
+import {isKeyedSegment} from './util.is-keyed-segment'
 import {
   getBlockKeyFromSelectionPoint,
   getChildKeyFromSelectionPoint,
@@ -20,12 +21,18 @@ export function blockOffsetToSpanSelectionPoint({
   blockOffset: BlockOffset
   direction: 'forward' | 'backward'
 }) {
+  const blockOffsetSegment = blockOffset.path.at(-1)
+
+  if (!isKeyedSegment(blockOffsetSegment)) {
+    return undefined
+  }
+
   let offsetLeft = blockOffset.offset
   let selectionPoint: {path: ChildPath; offset: number} | undefined
   let skippedInlineObject = false
 
   for (const block of context.value) {
-    if (block._key !== blockOffset.path[0]._key) {
+    if (block._key !== blockOffsetSegment._key) {
       continue
     }
 

--- a/packages/editor/test-utils/create-test-snapshot.ts
+++ b/packages/editor/test-utils/create-test-snapshot.ts
@@ -7,6 +7,7 @@ export function createTestSnapshot(snapshot: {
   decoratorState?: Partial<EditorSnapshot['decoratorState']>
 }): EditorSnapshot {
   const context = {
+    containers: snapshot.context?.containers ?? new Map(),
     converters: snapshot.context?.converters ?? [],
     schema: snapshot.context?.schema ?? compileSchema(defineSchema({})),
     keyGenerator: snapshot.context?.keyGenerator ?? createTestKeyGenerator(),

--- a/packages/editor/tests/tables.test.tsx
+++ b/packages/editor/tests/tables.test.tsx
@@ -4,9 +4,9 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {InternalSlateEditorRefPlugin} from '../src/plugins/plugin.internal.slate-editor-ref'
-import type {Container} from '../src/renderers/renderer.types'
+import type {ContainerDefinition} from '../src/renderers/renderer.types'
 import {makeContainerConfig} from '../src/schema/make-container-config'
-import type {Containers} from '../src/schema/resolve-containers'
+import type {ResolvedContainers} from '../src/schema/resolve-containers'
 import {resolveContainers} from '../src/schema/resolve-containers'
 import {withoutPatching} from '../src/slate-plugins/slate-plugin.without-patching'
 import {normalize} from '../src/slate/editor/normalize'
@@ -54,8 +54,8 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-function tableContainers(): Containers {
-  const render: Container['render'] = ({children}) => children
+function tableContainers(): ResolvedContainers {
+  const render: ContainerDefinition['render'] = ({children}) => children
   const schema = compileSchema(schemaDefinition)
   return resolveContainers(
     schema,

--- a/packages/plugin-emoji-picker/src/emoji-picker-machine.tsx
+++ b/packages/plugin-emoji-picker/src/emoji-picker-machine.tsx
@@ -161,7 +161,12 @@ function createTriggerActions({
     marks: payload.markState.marks,
   }
 
-  let focusSpan = {
+  let focusSpan: {
+    node: PortableTextSpan
+    path: ChildPath
+    textBefore: string
+    textAfter: string
+  } = {
     node: {
       _key: newSpan._key,
       _type: newSpan._type,
@@ -169,7 +174,7 @@ function createTriggerActions({
       marks: payload.markState.marks,
     },
     path: [
-      {_key: payload.focusSpan.path[0]._key},
+      ...payload.focusSpan.path.slice(0, -2),
       'children',
       {_key: newSpan._key},
     ] satisfies ChildPath,

--- a/packages/plugin-input-rule/src/plugin.input-rule.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.tsx
@@ -18,6 +18,7 @@ import {
 } from '@portabletext/editor/selectors'
 import {
   isEqualSelections,
+  isKeyedSegment,
   isSelectionCollapsed,
 } from '@portabletext/editor/utils'
 import {useActorRef} from '@xstate/react'
@@ -377,13 +378,25 @@ const inputRuleSetup = setup({
       // span-level differences (e.g. cursor at the same position but in a
       // different span after normalization).
       if (event.blockOffsets && context.endOffsets) {
+        const contextStartBlock = context.endOffsets.start.path.at(-1)
+        const eventStartBlock = event.blockOffsets.start.path.at(-1)
+        const contextEndBlock = context.endOffsets.end.path.at(-1)
+        const eventEndBlock = event.blockOffsets.end.path.at(-1)
+
+        if (
+          !isKeyedSegment(contextStartBlock) ||
+          !isKeyedSegment(eventStartBlock) ||
+          !isKeyedSegment(contextEndBlock) ||
+          !isKeyedSegment(eventEndBlock)
+        ) {
+          return false
+        }
+
         const startChanged =
-          context.endOffsets.start.path[0]._key !==
-            event.blockOffsets.start.path[0]._key ||
+          contextStartBlock._key !== eventStartBlock._key ||
           context.endOffsets.start.offset !== event.blockOffsets.start.offset
         const endChanged =
-          context.endOffsets.end.path[0]._key !==
-            event.blockOffsets.end.path[0]._key ||
+          contextEndBlock._key !== eventEndBlock._key ||
           context.endOffsets.end.offset !== event.blockOffsets.end.offset
 
         return startChanged || endChanged

--- a/packages/plugin-typeahead-picker/src/typeahead-picker-machine.tsx
+++ b/packages/plugin-typeahead-picker/src/typeahead-picker-machine.tsx
@@ -221,7 +221,7 @@ function createTriggerActions({
       marks: payload.markState.marks,
     },
     path: [
-      {_key: payload.focusSpan.path[0]._key},
+      ...payload.focusSpan.path.slice(0, -2),
       'children',
       {_key: newSpan._key},
     ] satisfies ChildPath,


### PR DESCRIPTION
The editor can't put blocks, children, or annotations inside editable containers (a code block's `lines`, a table cell's `content`) because `BlockPath`, `ChildPath`, and `AnnotationPath` encode a root-only shape. Operations, behaviors, and selectors that consume these types break down the moment a path goes deeper than one level.

This PR widens the three public path types to aliases of the recursive `Path` and adds the runtime surface the depth-agnostic follow-ups need: a `containers` field on `EditorContext`, container-aware traversal primitives (`getNode`, `getAncestor`, `getChildren`, `getSibling`, `isBlock` / `getBlock`, `isInline`, `isLeaf`, `getLeaf`, `hasNode`, `isVoidNode`, `isEditableContainer`, `getNodes`), and scope-aware schema helpers (`getBlockSubSchema`, `getBlockObjectSchema`, `getEnclosingContainer`).

No consumer-visible behavior change. Selectors, behaviors, operations, parsers, and renderers remain root-only; they move to depth-agnostic in subsequent PRs that build on this foundation.

## Breaking changes

The widening cascades into every event whose `at` accepted one of the narrow aliases: `block.set`, `block.unset`, `child.set`, `child.unset`, `delete.block`, `delete.child`, `annotation.set`, `move.block`, `move.block up`, `move.block down`, `select.block`.

Consumers that destructured positional segments (e.g. `path[0]._key`) must use `path.at(-1)` for a `BlockPath` (the block key sits at the end) or `path.at(-3)` for an `AnnotationPath` (the block key sits three segments from the end), each with a `KeyedSegment` guard, or reach for `getBlock` / `getSpan` / `getAncestor`.