### PR TITLE
feat: add containers to editor context and expand traversal primitives

### DIFF
--- a/.changeset/containers-editor-context.md
+++ b/.changeset/containers-editor-context.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+feat: add containers to editor context and expand traversal primitives

--- a/.changeset/widen-path-types.md
+++ b/.changeset/widen-path-types.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': major
+---
+
+fix!: widen `BlockPath`, `ChildPath`, and `AnnotationPath` to `Path`
+
+These types are now aliases for `Path`, the general recursive path type. This cascades into every event whose `at` field accepted one of the narrow aliases (`block.set`, `block.unset`, `child.set`, `child.unset`, `delete.block`, `delete.child`, `annotation.set`, `move.block`, `move.block up`, `move.block down`, `select.block`).
+
+Several `@public` utility functions that take a `Pick<EditorContext, ...>` context argument now require `containers`: `blockOffsetToBlockSelectionPoint`, `blockOffsetToSpanSelectionPoint`, `blockOffsetToSelectionPoint`, `blockOffsetsToSelection`, `childSelectionPointToBlockOffset`, `selectionPointToBlockOffset`, `sliceBlocks`. Consumers that pass `snapshot.context` (or spread it) are unaffected; callers that build the context object themselves need to add `containers`.

--- a/packages/editor/src/behaviors/behavior.abstract.annotation.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.annotation.ts
@@ -1,5 +1,6 @@
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -7,8 +8,15 @@ export const abstractAnnotationBehaviors = [
   defineBehavior({
     on: 'annotation.set',
     guard: ({snapshot, event}) => {
-      const blockKey = event.at[0]._key
-      const markDefKey = event.at[2]._key
+      const blockSegment = event.at.at(0)
+      const markDefSegment = event.at.at(-1)
+
+      if (!isKeyedSegment(blockSegment) || !isKeyedSegment(markDefSegment)) {
+        return false
+      }
+
+      const blockKey = blockSegment._key
+      const markDefKey = markDefSegment._key
 
       const block = getFocusTextBlock({
         ...snapshot,

--- a/packages/editor/src/behaviors/behavior.core.annotations.ts
+++ b/packages/editor/src/behaviors/behavior.core.annotations.ts
@@ -10,6 +10,7 @@ import {getSelectionStartPoint} from '../selectors/selector.get-selection-start-
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -128,11 +129,18 @@ const stripAnnotationsOnFullSpanDeletion = defineBehavior({
       return false
     }
 
-    if (startChild.path[2]._key !== endChild.path[2]._key) {
+    if (!isSpan(snapshot.context, startChild.node)) {
       return false
     }
 
-    if (!isSpan(snapshot.context, startChild.node)) {
+    const startSpanSegment = startChild.path.at(-1)
+    const endSpanSegment = endChild.path.at(-1)
+
+    if (!isKeyedSegment(startSpanSegment) || !isKeyedSegment(endSpanSegment)) {
+      return false
+    }
+
+    if (startSpanSegment._key !== endSpanSegment._key) {
       return false
     }
 

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -58,6 +58,7 @@ export function createSlateEditor(
   buildIndexMaps(
     {
       schema: context.schema,
+      containers: slateEditor.containers,
       value: slateEditor.children,
     },
     {

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -71,6 +71,7 @@ export function getEditorSnapshot({
   return {
     blockIndexMap: slateEditorInstance.blockIndexMap,
     context: {
+      containers: slateEditorInstance.containers,
       converters: [...editorActorSnapshot.context.converters],
       keyGenerator: editorActorSnapshot.context.keyGenerator,
       readOnly: editorActorSnapshot.matches({'edit mode': 'read only'}),

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -1,4 +1,8 @@
-import type {PortableTextBlock} from '@portabletext/schema'
+import type {
+  FieldDefinition,
+  OfDefinition,
+  PortableTextBlock,
+} from '@portabletext/schema'
 import type {Converter} from '../converters/converter.types'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
@@ -14,6 +18,25 @@ export type EditorContext = {
   schema: EditorSchema
   selection: EditorSelection
   value: Array<PortableTextBlock>
+  /**
+   * Map of registered editable containers keyed by their scoped type name
+   * (the '.'-joined type chain from root, e.g. `'code-block'`,
+   * `'callout.code-block'`, `'callout.code-block.block'`).
+   *
+   * Used by container-aware selectors and traversal utilities to resolve
+   * which array field on a container node holds its editable children.
+   *
+   * @alpha
+   */
+  containers: ReadonlyMap<
+    string,
+    {
+      field: FieldDefinition & {
+        type: 'array'
+        of: ReadonlyArray<OfDefinition>
+      }
+    }
+  >
 }
 
 /**
@@ -45,6 +68,7 @@ export function createEditorSnapshot({
   const selection = editor.selection
 
   const context = {
+    containers: editor.containers,
     converters,
     keyGenerator,
     readOnly,

--- a/packages/editor/src/internal-utils/build-index-maps.test.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.test.ts
@@ -4,6 +4,7 @@ import {
   type PortableTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import {defaultKeyGenerator} from '../utils/key-generator'
 import {buildIndexMaps} from './build-index-maps'
 
@@ -46,12 +47,30 @@ const schema = compileSchema(
   }),
 )
 
+function calloutContainers(): TraversalContainers {
+  return new Map([
+    [
+      'callout',
+      {
+        field: {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      },
+    ],
+  ])
+}
+
 describe(buildIndexMaps.name, () => {
   const blockIndexMap = new Map<string, number>()
   const listIndexMap = new Map<string, number>()
 
   test('empty', () => {
-    buildIndexMaps({schema, value: []}, {blockIndexMap, listIndexMap})
+    buildIndexMaps(
+      {schema, containers: new Map(), value: []},
+      {blockIndexMap, listIndexMap},
+    )
     expect(blockIndexMap).toEqual(new Map())
     expect(listIndexMap).toEqual(new Map())
   })
@@ -61,7 +80,11 @@ describe(buildIndexMaps.name, () => {
    */
   test('single list item', () => {
     buildIndexMaps(
-      {schema, value: [textBlock('k0', {listItem: 'number', level: 1})]},
+      {
+        schema,
+        containers: new Map(),
+        value: [textBlock('k0', {listItem: 'number', level: 1})],
+      },
       {blockIndexMap, listIndexMap},
     )
     expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
@@ -73,7 +96,11 @@ describe(buildIndexMaps.name, () => {
    */
   test('single indented list item', () => {
     buildIndexMaps(
-      {schema, value: [textBlock('k0', {listItem: 'number', level: 2})]},
+      {
+        schema,
+        containers: new Map(),
+        value: [textBlock('k0', {listItem: 'number', level: 2})],
+      },
       {blockIndexMap, listIndexMap},
     )
     expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
@@ -91,6 +118,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -131,6 +160,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -169,6 +200,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'bullet', level: 1}),
@@ -202,6 +235,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'bullet', level: 2}),
@@ -230,6 +265,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -263,6 +300,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -296,6 +335,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 2}),
@@ -332,6 +373,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 2}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -371,6 +414,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 3}),
@@ -422,6 +467,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'bullet', level: 1}),
           textBlock('k1', {listItem: 'number', level: 2}),
@@ -448,6 +495,8 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
+
         value: [
           textBlock('k0', {listItem: 'number', level: 2}),
           textBlock('k1', {listItem: 'bullet', level: 1}),
@@ -461,6 +510,88 @@ describe(buildIndexMaps.name, () => {
         ['k0', 1],
         ['k1', 1],
         ['k3', 1],
+      ]),
+    )
+  })
+
+  /**
+   * Callout container wraps a single numbered list of two items. Root has an
+   * earlier list that should not interfere with the container's list run.
+   *
+   * # (root)
+   * [callout:
+   *   # (inside)
+   *   # (inside)
+   * ]
+   */
+  test('list inside an editable container starts its own counter', () => {
+    buildIndexMaps(
+      {
+        schema,
+        containers: calloutContainers(),
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          {
+            _key: 'c0',
+            _type: 'callout',
+            content: [
+              textBlock('c1', {listItem: 'number', level: 1}),
+              textBlock('c2', {listItem: 'number', level: 1}),
+            ],
+          },
+        ],
+      },
+      {blockIndexMap, listIndexMap},
+    )
+    expect(listIndexMap).toEqual(
+      new Map([
+        ['k0', 1],
+        ['c1', 1],
+        ['c2', 2],
+      ]),
+    )
+  })
+
+  /**
+   * Two back-to-back callouts. Each container is its own counter scope;
+   * the second callout's list starts at 1.
+   *
+   * [callout:
+   *   #
+   *   #
+   * ]
+   * [callout:
+   *   #
+   * ]
+   */
+  test('two sibling containers each have their own list scope', () => {
+    buildIndexMaps(
+      {
+        schema,
+        containers: calloutContainers(),
+        value: [
+          {
+            _key: 'a',
+            _type: 'callout',
+            content: [
+              textBlock('a0', {listItem: 'number', level: 1}),
+              textBlock('a1', {listItem: 'number', level: 1}),
+            ],
+          },
+          {
+            _key: 'b',
+            _type: 'callout',
+            content: [textBlock('b0', {listItem: 'number', level: 1})],
+          },
+        ],
+      },
+      {blockIndexMap, listIndexMap},
+    )
+    expect(listIndexMap).toEqual(
+      new Map([
+        ['a0', 1],
+        ['a1', 2],
+        ['b0', 1],
       ]),
     )
   })

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -1,15 +1,160 @@
+import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorContext} from '../editor/editor-snapshot'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 
-// Maps for each list type, keeping track of the current list count for each
-// level.
-const levelIndexMaps = new Map<string, Map<number, number>>()
+type ListState = {
+  previousListItem:
+    | {
+        listItem: string
+        level: number
+      }
+    | undefined
+  levelIndexMaps: Map<string, Map<number, number>>
+}
+
+function createListState(): ListState {
+  return {
+    previousListItem: undefined,
+    levelIndexMaps: new Map(),
+  }
+}
+
+function walkBlock(
+  context: Pick<EditorContext, 'schema' | 'containers'>,
+  block: unknown,
+  scopeChain: string,
+  listIndexMap: Map<string, number>,
+  state: ListState,
+): void {
+  if (!isTextBlockNode(context, block)) {
+    state.levelIndexMaps.clear()
+    state.previousListItem = undefined
+
+    maybeRecurseIntoContainer(context, block, scopeChain, listIndexMap)
+    return
+  }
+
+  if (block.listItem === undefined || block.level === undefined) {
+    state.levelIndexMaps.clear()
+    state.previousListItem = undefined
+
+    maybeRecurseIntoContainer(context, block, scopeChain, listIndexMap)
+    return
+  }
+
+  if (!state.previousListItem) {
+    const listIndex = 1
+    const levelIndexMap =
+      state.levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+    levelIndexMap.set(block.level, listIndex)
+    state.levelIndexMaps.set(block.listItem, levelIndexMap)
+
+    listIndexMap.set(block._key, listIndex)
+
+    state.previousListItem = {
+      listItem: block.listItem,
+      level: block.level,
+    }
+
+    maybeRecurseIntoContainer(context, block, scopeChain, listIndexMap)
+    return
+  }
+
+  if (
+    state.previousListItem.listItem === block.listItem &&
+    state.previousListItem.level < block.level
+  ) {
+    const listIndex = 1
+    const levelIndexMap =
+      state.levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+    levelIndexMap.set(block.level, listIndex)
+    state.levelIndexMaps.set(block.listItem, levelIndexMap)
+
+    listIndexMap.set(block._key, listIndex)
+
+    state.previousListItem = {
+      listItem: block.listItem,
+      level: block.level,
+    }
+
+    maybeRecurseIntoContainer(context, block, scopeChain, listIndexMap)
+    return
+  }
+
+  state.levelIndexMaps.forEach((levelIndexMap, listItem) => {
+    if (listItem === block.listItem) {
+      return
+    }
+
+    const levelsToDelete: number[] = []
+
+    levelIndexMap.forEach((_, level) => {
+      if (level >= block.level!) {
+        levelsToDelete.push(level)
+      }
+    })
+
+    levelsToDelete.forEach((level) => {
+      levelIndexMap.delete(level)
+    })
+  })
+
+  const levelIndexMap =
+    state.levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+  const levelCounter = levelIndexMap.get(block.level) ?? 0
+  levelIndexMap.set(block.level, levelCounter + 1)
+  state.levelIndexMaps.set(block.listItem, levelIndexMap)
+
+  listIndexMap.set(block._key, levelCounter + 1)
+
+  state.previousListItem = {
+    listItem: block.listItem,
+    level: block.level,
+  }
+
+  maybeRecurseIntoContainer(context, block, scopeChain, listIndexMap)
+}
+
+function maybeRecurseIntoContainer(
+  context: Pick<EditorContext, 'schema' | 'containers'>,
+  block: unknown,
+  scopeChain: string,
+  listIndexMap: Map<string, number>,
+): void {
+  if (typeof block !== 'object' || block === null) {
+    return
+  }
+  const typed = block as {_type?: unknown}
+  if (typeof typed._type !== 'string') {
+    return
+  }
+
+  const nextScope = scopeChain ? `${scopeChain}.${typed._type}` : typed._type
+  const containerConfig = context.containers.get(nextScope)
+  if (!containerConfig) {
+    return
+  }
+
+  const children = (block as Record<string, unknown>)[
+    containerConfig.field.name
+  ]
+  if (!Array.isArray(children)) {
+    return
+  }
+
+  // Each container field is its own list-counter scope.
+  const innerState = createListState()
+
+  for (const child of children) {
+    walkBlock(context, child, nextScope, listIndexMap, innerState)
+  }
+}
 
 /**
  * Mutates the maps in place.
  */
 export function buildIndexMaps(
-  context: Pick<EditorContext, 'schema' | 'value'>,
+  context: Pick<EditorContext, 'schema' | 'containers' | 'value'>,
   {
     blockIndexMap,
     listIndexMap,
@@ -20,14 +165,8 @@ export function buildIndexMaps(
 ): void {
   blockIndexMap.clear()
   listIndexMap.clear()
-  levelIndexMaps.clear()
 
-  let previousListItem:
-    | {
-        listItem: string
-        level: number
-      }
-    | undefined
+  const rootState = createListState()
 
   for (let blockIndex = 0; blockIndex < context.value.length; blockIndex++) {
     const block = context.value.at(blockIndex)
@@ -38,94 +177,6 @@ export function buildIndexMaps(
 
     blockIndexMap.set(block._key, blockIndex)
 
-    // Clear the state if we encounter a non-text block
-    if (!isTextBlockNode(context, block)) {
-      levelIndexMaps.clear()
-      previousListItem = undefined
-
-      continue
-    }
-
-    // Clear the state if we encounter a non-list text block
-    if (block.listItem === undefined || block.level === undefined) {
-      levelIndexMaps.clear()
-      previousListItem = undefined
-
-      continue
-    }
-
-    // If we encounter a new list item, we set the initial index to 1 for the
-    // list type on that level.
-    if (!previousListItem) {
-      const listIndex = 1
-      const levelIndexMap =
-        levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-      levelIndexMap.set(block.level, listIndex)
-      levelIndexMaps.set(block.listItem, levelIndexMap)
-
-      listIndexMap.set(block._key, listIndex)
-
-      previousListItem = {
-        listItem: block.listItem,
-        level: block.level,
-      }
-
-      continue
-    }
-
-    // If the previous list item is of the same type but on a lower level, we
-    // need to reset the level index map for that type.
-    if (
-      previousListItem.listItem === block.listItem &&
-      previousListItem.level < block.level
-    ) {
-      const listIndex = 1
-      const levelIndexMap =
-        levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-      levelIndexMap.set(block.level, listIndex)
-      levelIndexMaps.set(block.listItem, levelIndexMap)
-
-      listIndexMap.set(block._key, listIndex)
-
-      previousListItem = {
-        listItem: block.listItem,
-        level: block.level,
-      }
-
-      continue
-    }
-
-    // Reset other list types at current level and deeper
-    levelIndexMaps.forEach((levelIndexMap, listItem) => {
-      if (listItem === block.listItem) {
-        return
-      }
-
-      // Reset all levels that are >= current level
-      const levelsToDelete: number[] = []
-
-      levelIndexMap.forEach((_, level) => {
-        if (level >= block.level!) {
-          levelsToDelete.push(level)
-        }
-      })
-
-      levelsToDelete.forEach((level) => {
-        levelIndexMap.delete(level)
-      })
-    })
-
-    const levelIndexMap =
-      levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-    const levelCounter = levelIndexMap.get(block.level) ?? 0
-    levelIndexMap.set(block.level, levelCounter + 1)
-    levelIndexMaps.set(block.listItem, levelIndexMap)
-
-    listIndexMap.set(block._key, levelCounter + 1)
-
-    previousListItem = {
-      listItem: block.listItem,
-      level: block.level,
-    }
+    walkBlock(context, block as PortableTextBlock, '', listIndexMap, rootState)
   }
 }

--- a/packages/editor/src/node-traversal/get-ancestor-text-block.ts
+++ b/packages/editor/src/node-traversal/get-ancestor-text-block.ts
@@ -1,7 +1,7 @@
 import type {PortableTextTextBlock} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestor} from './get-ancestor'
@@ -9,7 +9,7 @@ import {getAncestor} from './get-ancestor'
 export function getAncestorTextBlock(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-ancestor.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestors} from './get-ancestors'
@@ -7,11 +7,31 @@ import {getAncestors} from './get-ancestors'
 /**
  * Find the first ancestor of the node at a given path that matches a predicate.
  * Does not check the node at the path itself, only its ancestors.
+ *
+ * When `match` is a type predicate, the returned `node` narrows to that type.
  */
+export function getAncestor<TMatch extends Node>(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+  match: (node: Node, path: Path) => node is TMatch,
+): {node: TMatch; path: Path} | undefined
 export function getAncestor(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+  match: (node: Node, path: Path) => boolean,
+): {node: Node; path: Path} | undefined
+export function getAncestor(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-ancestors.ts
+++ b/packages/editor/src/node-traversal/get-ancestors.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -16,7 +16,7 @@ import {getNode} from './get-node'
 export function getAncestors(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -1,7 +1,7 @@
 import type {OfDefinition} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
@@ -13,7 +13,7 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 export function getChildren(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,
@@ -28,7 +28,7 @@ export function getChildren(
 export function getChildrenInternal(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -93,7 +93,7 @@ export function getChildrenInternal(
 export function getNodeChildren(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
   },
   node: Node | {value: Array<Node>},
   scopePath: string,

--- a/packages/editor/src/node-traversal/get-enclosing-block.ts
+++ b/packages/editor/src/node-traversal/get-enclosing-block.ts
@@ -1,0 +1,41 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {TraversalContainers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getAncestors} from './get-ancestors'
+import {getBlock, isBlock} from './is-block'
+
+/**
+ * Walk up from a path to find the nearest enclosing block.
+ *
+ * Returns the node at the path if it is a block, otherwise the first ancestor
+ * that is a block. Works at any depth — inside a container this returns the
+ * container-internal block, not the outer container.
+ */
+export function getEnclosingBlock(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+): {node: PortableTextBlock; path: Path} | undefined {
+  const direct = getBlock(context, path)
+
+  if (direct) {
+    return direct
+  }
+
+  for (const ancestor of getAncestors(context, path)) {
+    if (isBlock(context, ancestor.path)) {
+      const block = getBlock(context, ancestor.path)
+
+      if (block) {
+        return block
+      }
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/node-traversal/get-first-child.ts
+++ b/packages/editor/src/node-traversal/get-first-child.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -10,7 +10,7 @@ import {getChildren} from './get-children'
 export function getFirstChild(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-highest-object-node.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.ts
@@ -1,6 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isVoidNode} from '../slate/node/is-void-node'
@@ -16,7 +16,7 @@ import {getNode} from './get-node'
 export function getHighestObjectNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-last-child.ts
+++ b/packages/editor/src/node-traversal/get-last-child.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -10,7 +10,7 @@ import {getChildren} from './get-children'
 export function getLastChild(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-leaf.ts
+++ b/packages/editor/src/node-traversal/get-leaf.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
@@ -13,7 +13,7 @@ import {getNode} from './get-node'
 export function getLeaf(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-node.ts
+++ b/packages/editor/src/node-traversal/get-node.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -19,7 +19,7 @@ import {getNodeChildren} from './get-children'
 export function getNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
     blockIndexMap?: Map<string, number>
   },

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
@@ -24,7 +24,7 @@ import {getChildrenInternal} from './get-children'
 export function* getNodes(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
     blockIndexMap: Map<string, number>
   },
@@ -65,7 +65,7 @@ export function* getNodes(
 export function* getNodeDescendants(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
   },
   node: Node | {value: Array<Node>},
 ): Generator<{node: Node; path: Path}, void, undefined> {
@@ -79,7 +79,7 @@ export function* getNodeDescendants(
 function* getNodesSimple(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
   },
   root: Node | {value: Array<Node>},
   path: Path,
@@ -112,7 +112,7 @@ function* getNodesSimple(
 function comparePathsInTree(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
@@ -207,7 +207,7 @@ function comparePathsInTree(
 function* getNodesInRange(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
@@ -251,7 +251,7 @@ function* getNodesInRange(
 function isInRange(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
@@ -287,7 +287,7 @@ function isInRange(
 function couldContainInRangeNodes(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},
@@ -316,7 +316,7 @@ function couldContainInRangeNodes(
 function canStopTraversal(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     blockIndexMap: Map<string, number>
   },
   root: Node | {value: Array<Node>},

--- a/packages/editor/src/node-traversal/get-parent.ts
+++ b/packages/editor/src/node-traversal/get-parent.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getParent(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-sibling.ts
+++ b/packages/editor/src/node-traversal/get-sibling.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
@@ -12,7 +12,7 @@ import {getChildren} from './get-children'
 export function getSibling(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-span-node.ts
+++ b/packages/editor/src/node-traversal/get-span-node.ts
@@ -1,6 +1,6 @@
 import {isSpan, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getSpanNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-text-block-node.ts
+++ b/packages/editor/src/node-traversal/get-text-block-node.ts
@@ -1,6 +1,6 @@
 import {isTextBlock, type PortableTextTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -11,7 +11,7 @@ import {getNode} from './get-node'
 export function getTextBlockNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/get-text.ts
+++ b/packages/editor/src/node-traversal/get-text.ts
@@ -1,6 +1,6 @@
 import {isSpan} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -12,7 +12,7 @@ import {getNodes} from './get-nodes'
 export function getText(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
     blockIndexMap: Map<string, number>
   },

--- a/packages/editor/src/node-traversal/get-void-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-void-ancestor.ts
@@ -3,10 +3,17 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
-import {isObjectNode} from '../slate/node/is-object-node'
+import {isVoidNode} from '../slate/node/is-void-node'
 import {getAncestor} from './get-ancestor'
 
-export function getAncestorObjectNode(
+/**
+ * Find the nearest ancestor that is a void (non-editable) object node.
+ *
+ * Unlike `getAncestorObjectNode`, editable containers are skipped — they are
+ * object nodes but contain editable content, so callers that want "this
+ * subtree is a single selectable void" should use this instead.
+ */
+export function getVoidAncestor(
   context: {
     schema: EditorSchema
     containers: TraversalContainers
@@ -14,14 +21,7 @@ export function getAncestorObjectNode(
   },
   path: Path,
 ): {node: PortableTextObject; path: Path} | undefined {
-  const result = getAncestor(context, path, (node) =>
-    isObjectNode({schema: context.schema}, node),
+  return getAncestor(context, path, (node, ancestorPath) =>
+    isVoidNode(context, node, ancestorPath),
   )
-  if (!result) {
-    return undefined
-  }
-  if (!isObjectNode({schema: context.schema}, result.node)) {
-    return undefined
-  }
-  return {node: result.node, path: result.path}
 }

--- a/packages/editor/src/node-traversal/has-node.ts
+++ b/packages/editor/src/node-traversal/has-node.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
@@ -10,7 +10,7 @@ import {getNode} from './get-node'
 export function hasNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
     blockIndexMap?: Map<string, number>
   },

--- a/packages/editor/src/node-traversal/is-block.ts
+++ b/packages/editor/src/node-traversal/is-block.ts
@@ -1,6 +1,6 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isSpanNode} from '../slate/node/is-span-node'
@@ -19,7 +19,7 @@ import {getParent} from './get-parent'
 export function isBlock(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,
@@ -42,7 +42,7 @@ export function isBlock(
 export function getBlock(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/is-inline.ts
+++ b/packages/editor/src/node-traversal/is-inline.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isBlock} from './is-block'
@@ -13,7 +13,7 @@ import {isBlock} from './is-block'
 export function isInline(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/node-traversal/is-leaf.ts
+++ b/packages/editor/src/node-traversal/is-leaf.ts
@@ -1,5 +1,5 @@
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
+import type {TraversalContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -14,7 +14,7 @@ import {getNodeChildren} from './get-children'
 export function isLeaf(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -3,12 +3,21 @@ import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {parseMarkDefs} from '../utils/parse-blocks'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
 > = ({context, operation}) => {
-  const blockIndex = operation.editor.blockIndexMap.get(operation.at[0]._key)
+  const blockSegment = operation.at.at(0)
+
+  if (!isKeyedSegment(blockSegment)) {
+    throw new Error(
+      `Unable to extract block key from ${safeStringify(operation.at)}`,
+    )
+  }
+
+  const blockIndex = operation.editor.blockIndexMap.get(blockSegment._key)
 
   if (blockIndex === undefined) {
     throw new Error(

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -1,12 +1,21 @@
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
 > = ({context, operation}) => {
-  const blockKey = operation.at[0]._key
+  const blockSegment = operation.at.at(0)
+
+  if (!isKeyedSegment(blockSegment)) {
+    throw new Error(
+      `Unable to extract block key from ${safeStringify(operation.at)}`,
+    )
+  }
+
+  const blockKey = blockSegment._key
   const blockIndex = operation.editor.blockIndexMap.get(blockKey)
 
   if (blockIndex === undefined) {

--- a/packages/editor/src/schema/get-block-object-schema.test.ts
+++ b/packages/editor/src/schema/get-block-object-schema.test.ts
@@ -1,0 +1,191 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {getBlockObjectSchema} from './get-block-object-schema'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers} from './resolve-containers'
+
+const testRender: Container['render'] = ({children}) => children
+
+describe(getBlockObjectSchema.name, () => {
+  test('returns a root-level block-object definition when block is at the document root', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'image',
+            fields: [{name: 'src', type: 'string'}],
+          },
+        ],
+      }),
+    )
+    const context = {schema, containers: new Map(), value: []}
+    const node = {_type: 'image', _key: 'i0', src: 'foo.png'}
+
+    expect(getBlockObjectSchema(context, node, [{_key: 'i0'}])).toEqual({
+      name: 'image',
+      fields: [{name: 'src', type: 'string'}],
+    })
+  })
+
+  test('returns an inline-declared type definition when block is inside a container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..table.row',
+      makeContainerConfig(schema, {
+        scope: '$..table.row',
+        field: 'cells',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    // Look up the `row` block-object schema (inline-declared under table.rows.of)
+    const rowNode = {_type: 'row', _key: 'r0', cells: []}
+    expect(
+      getBlockObjectSchema(context, rowNode, [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+      ])?.name,
+    ).toBe('row')
+
+    // Look up the `cell` block-object schema (inline-declared under row.cells.of)
+    const cellNode = {_type: 'cell', _key: 'c0', content: []}
+    expect(
+      getBlockObjectSchema(context, cellNode, [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+      ])?.name,
+    ).toBe('cell')
+  })
+
+  test('falls back to root-level blockObjects when no inline match is found', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'image',
+            fields: [{name: 'src', type: 'string'}],
+          },
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const context = {schema, containers, value: []}
+    // `image` is in root `blockObjects` but not inline-declared inside callout.
+    // Looking it up at a callout-internal position falls back to root.
+    const imageNode = {_type: 'image', _key: 'i0', src: 'foo.png'}
+
+    expect(
+      getBlockObjectSchema(context, imageNode, [
+        {_key: 'co0'},
+        'content',
+        {_key: 'i0'},
+      ])?.name,
+    ).toBe('image')
+  })
+
+  test('returns undefined when the type is unknown at the effective scope', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [{name: 'image'}],
+      }),
+    )
+    const context = {schema, containers: new Map(), value: []}
+    const node = {_type: 'unknown', _key: 'u0'}
+
+    expect(getBlockObjectSchema(context, node, [{_key: 'u0'}])).toBeUndefined()
+  })
+})

--- a/packages/editor/src/schema/get-block-object-schema.ts
+++ b/packages/editor/src/schema/get-block-object-schema.ts
@@ -1,0 +1,62 @@
+import type {BaseDefinition, FieldDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getEnclosingContainer} from './get-enclosing-container'
+import type {TraversalContainers} from './resolve-containers'
+
+/**
+ * Minimal view of a block-object schema definition: its name and its
+ * declared fields (if any). Matches both root-level `blockObjects` entries
+ * and inline-declared types inside a container's `field.of`.
+ */
+export type BlockObjectSchema = BaseDefinition & {
+  fields?: ReadonlyArray<FieldDefinition>
+}
+
+/**
+ * Return the schema definition for a block-object at `path`.
+ *
+ * Walks to the nearest registered container ancestor and searches its
+ * `field.of` for an inline-declared type whose `name` matches the block's
+ * `_type`. Falls back to `schema.blockObjects` when no inline match is
+ * found (or when the block is at the root of the document).
+ *
+ * Returns `undefined` when the type is not declared at the effective scope.
+ */
+export function getBlockObjectSchema(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): BlockObjectSchema | undefined {
+  const typeName = node._type
+
+  const enclosing = getEnclosingContainer(context, path)
+
+  if (enclosing) {
+    const inline = enclosing.of.find(
+      (member) => member.type !== 'block' && member.type === typeName,
+    )
+
+    if (inline && inline.type !== 'block') {
+      // Project to BlockObjectSchema shape: `name` comes from `type`
+      // when the inline definition doesn't specify one.
+      return {
+        ...inline,
+        name: 'name' in inline && inline.name ? inline.name : inline.type,
+        fields:
+          'fields' in inline && inline.fields
+            ? (inline.fields as ReadonlyArray<FieldDefinition>)
+            : undefined,
+      }
+    }
+  }
+
+  return context.schema.blockObjects.find(
+    (definition) => definition.name === typeName,
+  )
+}

--- a/packages/editor/src/schema/get-block-sub-schema.test.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.test.ts
@@ -1,0 +1,250 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {Container, ContainerConfig} from '../renderers/renderer.types'
+import {getBlockSubSchema} from './get-block-sub-schema'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers} from './resolve-containers'
+
+const testRender: Container['render'] = ({children}) => children
+
+describe(getBlockSubSchema.name, () => {
+  test('returns root sub-schema when path is at root', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        annotations: [{name: 'link'}],
+        styles: [{name: 'h1'}],
+      }),
+    )
+
+    const context = {
+      schema,
+      containers: new Map(),
+      value: [{_type: 'block', _key: 'b0', children: []}],
+    }
+
+    const subSchema = getBlockSubSchema(context, [{_key: 'b0'}])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong', 'em'])
+    expect(subSchema.styles.map((s) => s.name)).toEqual(['normal', 'h1'])
+    expect(subSchema.annotations.map((a) => a.name)).toEqual(['link'])
+  })
+
+  test('returns nested sub-schema inside a registered container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        styles: [{name: 'h1'}],
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'block',
+                    decorators: [{name: 'strong'}],
+                    styles: [{name: 'monospace'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'cell',
+        _key: 'c0',
+        content: [{_type: 'block', _key: 'b0', children: []}],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    // Verify-by-breaking: if the helper fell back to root, decorators would be ['strong', 'em'].
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+    expect(subSchema.styles.map((s) => s.name)).toEqual(['monospace'])
+  })
+
+  test('inherits root fields when nested block does not override', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}],
+        annotations: [{name: 'link'}],
+        inlineObjects: [{name: 'mention'}],
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'cell',
+        _key: 'c0',
+        content: [{_type: 'block', _key: 'b0', children: []}],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+    expect(subSchema.annotations.map((a) => a.name)).toEqual(['link'])
+    expect(subSchema.inlineObjects.map((i) => i.name)).toEqual(['mention'])
+  })
+
+  test('walks multiple ancestor levels to find the enclosing container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {
+                                    type: 'block',
+                                    decorators: [{name: 'strong'}],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const containerConfigs: Map<string, ContainerConfig> = new Map()
+    containerConfigs.set(
+      '$..table',
+      makeContainerConfig(schema, {
+        scope: '$..table',
+        field: 'rows',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..row',
+      makeContainerConfig(schema, {
+        scope: '$..row',
+        field: 'cells',
+        render: testRender,
+      }),
+    )
+    containerConfigs.set(
+      '$..cell',
+      makeContainerConfig(schema, {
+        scope: '$..cell',
+        field: 'content',
+        render: testRender,
+      }),
+    )
+    const containers = resolveContainers(schema, containerConfigs)
+
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [{_type: 'block', _key: 'b0', children: []}],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const context = {schema, containers, value}
+
+    const subSchema = getBlockSubSchema(context, [
+      {_key: 't0'},
+      'rows',
+      {_key: 'r0'},
+      'cells',
+      {_key: 'c0'},
+      'content',
+      {_key: 'b0'},
+    ])
+
+    expect(subSchema.decorators.map((d) => d.name)).toEqual(['strong'])
+  })
+})

--- a/packages/editor/src/schema/get-block-sub-schema.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.ts
@@ -1,0 +1,143 @@
+import type {
+  AnnotationSchemaType,
+  BaseDefinition,
+  DecoratorSchemaType,
+  InlineObjectSchemaType,
+  ListSchemaType,
+  OfDefinition,
+  StyleSchemaType,
+} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getEnclosingContainer} from './get-enclosing-container'
+import type {TraversalContainers} from './resolve-containers'
+import {asFieldedTypes, asNamedTypes} from './schema-type-projections'
+
+/**
+ * The resolved validation view for a text block at a given path. At the
+ * root of the document it equals the top-level schema view. Inside a
+ * container it is the sub-schema of the nearest enclosing `{type: 'block'}`
+ * entry (resolved by `compileSchema`), with any fields the nested block
+ * doesn't override falling back to root.
+ */
+export type BlockSubSchema = {
+  styles: ReadonlyArray<StyleSchemaType>
+  decorators: ReadonlyArray<DecoratorSchemaType>
+  annotations: ReadonlyArray<AnnotationSchemaType>
+  lists: ReadonlyArray<ListSchemaType>
+  inlineObjects: ReadonlyArray<InlineObjectSchemaType>
+}
+
+type ResolvedBlockOfDefinition = {
+  type: 'block'
+  styles?: ReadonlyArray<BaseDefinition>
+  decorators?: ReadonlyArray<BaseDefinition>
+  annotations?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<unknown>}
+  >
+  lists?: ReadonlyArray<BaseDefinition>
+  inlineObjects?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<unknown>}
+  >
+}
+
+/**
+ * Return the sub-schema that applies at a given path.
+ *
+ * For paths at the root of the document, or for paths where no ancestor is
+ * a registered container, returns the top-level schema view. For paths
+ * inside a container, walks ancestors to find the nearest container and
+ * returns the sub-schema from its `{type: 'block'}` entry.
+ */
+export function getBlockSubSchema(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+): BlockSubSchema {
+  const nestedBlock = findEnclosingNestedBlock(context, path)
+
+  if (!nestedBlock) {
+    return rootSubSchema(context.schema)
+  }
+
+  return {
+    styles:
+      asNamedTypes<StyleSchemaType>(nestedBlock.styles) ??
+      context.schema.styles,
+    decorators:
+      asNamedTypes<DecoratorSchemaType>(nestedBlock.decorators) ??
+      context.schema.decorators,
+    annotations:
+      asFieldedTypes<AnnotationSchemaType>(nestedBlock.annotations) ??
+      context.schema.annotations,
+    lists:
+      asNamedTypes<ListSchemaType>(nestedBlock.lists) ?? context.schema.lists,
+    inlineObjects:
+      asFieldedTypes<InlineObjectSchemaType>(nestedBlock.inlineObjects) ??
+      context.schema.inlineObjects,
+  }
+}
+
+/**
+ * Return `true` when the given path is inside a registered editable
+ * container -- i.e. when the block sub-schema at that path is resolved
+ * from a nested `{type: 'block'}` definition rather than the top-level
+ * schema.
+ *
+ * Use this to gate narrowing checks (e.g. "skip this decorator if the
+ * sub-schema doesn't declare it"). At root we want to preserve the
+ * permissive top-level behaviour where operations accept unknown
+ * decorators/annotations/styles and track them optimistically; inside a
+ * container the sub-schema is authoritative and those operations should
+ * be filtered.
+ */
+export function isInsideEditableContainer(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+): boolean {
+  return findEnclosingNestedBlock(context, path) !== undefined
+}
+
+function rootSubSchema(schema: EditorSchema): BlockSubSchema {
+  return {
+    styles: schema.styles,
+    decorators: schema.decorators,
+    annotations: schema.annotations,
+    lists: schema.lists,
+    inlineObjects: schema.inlineObjects,
+  }
+}
+
+function findEnclosingNestedBlock(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+): ResolvedBlockOfDefinition | undefined {
+  const enclosing = getEnclosingContainer(context, path)
+
+  if (!enclosing) {
+    return undefined
+  }
+
+  const blockMember = enclosing.of.find(
+    (member): member is OfDefinition & {type: 'block'} =>
+      member.type === 'block',
+  )
+
+  if (!blockMember) {
+    return undefined
+  }
+
+  return blockMember as ResolvedBlockOfDefinition
+}

--- a/packages/editor/src/schema/get-container-scoped-name.ts
+++ b/packages/editor/src/schema/get-container-scoped-name.ts
@@ -3,7 +3,7 @@ import {getAncestors} from '../node-traversal/get-ancestors'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
-import type {Containers} from './resolve-containers'
+import type {TraversalContainers} from './resolve-containers'
 
 /**
  * Build the scoped type name for a node at a given path.
@@ -15,7 +15,7 @@ import type {Containers} from './resolve-containers'
 export function getContainerScopedName(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   node: Node,

--- a/packages/editor/src/schema/get-enclosing-container.ts
+++ b/packages/editor/src/schema/get-enclosing-container.ts
@@ -1,0 +1,54 @@
+import type {OfDefinition} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isObjectNode} from '../slate/node/is-object-node'
+import {getContainerScopedName} from './get-container-scoped-name'
+import type {TraversalContainers} from './resolve-containers'
+
+/**
+ * Walk ancestors from `path` and return the nearest registered editable
+ * container — its resolved field definition, the raw `of` array, and the
+ * path at which it lives.
+ *
+ * Returns `undefined` when no ancestor is a registered container (the
+ * caller falls back to root-level schema views).
+ */
+export function getEnclosingContainer(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  path: Path,
+):
+  | {
+      of: ReadonlyArray<OfDefinition>
+      path: Path
+    }
+  | undefined {
+  for (const ancestor of getAncestors(context, path)) {
+    if (!isObjectNode({schema: context.schema}, ancestor.node)) {
+      continue
+    }
+
+    const scopedName = getContainerScopedName(
+      context,
+      ancestor.node,
+      ancestor.path,
+    )
+    const container = context.containers.get(scopedName)
+
+    if (!container) {
+      continue
+    }
+
+    return {
+      of: container.field.of,
+      path: ancestor.path,
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/schema/get-type-chain.test.ts
+++ b/packages/editor/src/schema/get-type-chain.test.ts
@@ -1,0 +1,91 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {getNode} from '../node-traversal/get-node'
+import {defineContainer} from '../renderers/renderer.types'
+import type {Node} from '../slate/interfaces/node'
+import {getTypeChain} from './get-type-chain'
+import {makeContainerConfig} from './make-container-config'
+import {resolveContainers, type TraversalContainers} from './resolve-containers'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const schema = compileSchema(schemaDefinition)
+
+const calloutContainer = defineContainer({
+  scope: '$..callout',
+  field: 'content',
+})
+
+const containers: TraversalContainers = resolveContainers(
+  schema,
+  new Map([
+    [calloutContainer.scope, makeContainerConfig(schema, calloutContainer)],
+  ]),
+)
+
+describe(getTypeChain.name, () => {
+  test('root span: ["block", "span"]', () => {
+    const value: Array<Node> = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: 'hello', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      } as unknown as Node,
+    ]
+    const context = {schema, containers, value}
+    const path = [{_key: 'b1'}, 'children', {_key: 's1'}]
+    const entry = getNode(context, path)!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual([
+      'block',
+      'span',
+    ])
+  })
+
+  test('callout-nested span: ["callout", "block", "span"]', () => {
+    const value: Array<Node> = [
+      {
+        _type: 'callout',
+        _key: 'c1',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b1',
+            children: [{_type: 'span', _key: 's1', text: 'hi', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      } as unknown as Node,
+    ]
+    const context = {schema, containers, value}
+    const path = [
+      {_key: 'c1'},
+      'content',
+      {_key: 'b1'},
+      'children',
+      {_key: 's1'},
+    ]
+    const entry = getNode(context, path)!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual([
+      'callout',
+      'block',
+      'span',
+    ])
+  })
+
+  test('root void block object: ["image"]', () => {
+    const value: Array<Node> = [{_type: 'image', _key: 'i1'} as unknown as Node]
+    const context = {schema, containers, value}
+    const entry = getNode(context, [{_key: 'i1'}])!
+    expect(getTypeChain(context, entry.node, entry.path)).toEqual(['image'])
+  })
+})

--- a/packages/editor/src/schema/get-type-chain.ts
+++ b/packages/editor/src/schema/get-type-chain.ts
@@ -1,0 +1,36 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import {getAncestors} from '../node-traversal/get-ancestors'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import type {TraversalContainers} from './resolve-containers'
+
+/**
+ * Build the full type chain for a node at a given path, from root to the
+ * node itself. Unlike `getContainerScopedName`, this includes text blocks
+ * (`block`) so span and inline-object scopes that include `block.` as an
+ * intermediate segment can match.
+ *
+ * For a span at
+ * `[{_key:t1},'rows',{_key:r1},'cells',{_key:c1},'content',{_key:b1},'children',{_key:s1}]`
+ * the chain is `['table', 'row', 'cell', 'block', 'span']`.
+ */
+export function getTypeChain(
+  context: {
+    schema: EditorSchema
+    containers: TraversalContainers
+    value: Array<Node>
+  },
+  node: Node,
+  path: Path,
+): Array<string> {
+  const chain: Array<string> = []
+  const ancestors = getAncestors(context, path)
+
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    chain.push(ancestors[i]!.node._type)
+  }
+
+  chain.push(node._type)
+
+  return chain
+}

--- a/packages/editor/src/schema/is-editable-container.ts
+++ b/packages/editor/src/schema/is-editable-container.ts
@@ -2,7 +2,7 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getContainerScopedName} from './get-container-scoped-name'
-import type {Containers} from './resolve-containers'
+import type {TraversalContainers} from './resolve-containers'
 
 /**
  * Check if a node at the given path is a registered editable container.
@@ -10,7 +10,7 @@ import type {Containers} from './resolve-containers'
 export function isEditableContainer(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   node: Node,

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -10,6 +10,15 @@ export type ChildArrayField = FieldDefinition & {
 }
 
 /**
+ * Public shape of the container map carried on `EditorContext`.
+ *
+ * Values carry only what traversal and selectors need (the array field
+ * holding editable children). The internal `Containers` map carries the
+ * full `ContainerConfig` and is a subtype of this.
+ */
+export type TraversalContainers = ReadonlyMap<string, {field: ChildArrayField}>
+
+/**
  * Maps scoped type names (type chain joined by '.') to registered container
  * configs.
  *

--- a/packages/editor/src/schema/schema-type-projections.ts
+++ b/packages/editor/src/schema/schema-type-projections.ts
@@ -1,0 +1,48 @@
+import type {
+  AnnotationSchemaType,
+  BaseDefinition,
+  DecoratorSchemaType,
+  InlineObjectSchemaType,
+  ListSchemaType,
+  StyleSchemaType,
+} from '@portabletext/schema'
+
+/**
+ * Project a compiled `{type: 'block'}` entry's named-array resolved shape
+ * (`styles`, `decorators`, `lists`) into the equivalent schema-type shape
+ * used throughout the editor (`{name, value}`). Returns `undefined` when
+ * the entry doesn't override the array — the caller falls back to root.
+ */
+export function asNamedTypes<
+  T extends StyleSchemaType | DecoratorSchemaType | ListSchemaType,
+>(resolved: ReadonlyArray<BaseDefinition> | undefined): Array<T> | undefined {
+  if (!resolved) {
+    return undefined
+  }
+  return resolved.map((entry) => ({...entry, value: entry.name}) as T)
+}
+
+/**
+ * Project a compiled `{type: 'block'}` entry's field-bearing resolved shape
+ * (`annotations`, `inlineObjects`) into the schema-type shape used
+ * throughout the editor. Returns `undefined` when the entry doesn't
+ * override the array.
+ *
+ * The `fields` projection is unsafe at the type level (resolved fields are
+ * typed as `ReadonlyArray<unknown>` in the schema package) but matches the
+ * runtime shape emitted by `compileSchema`.
+ */
+export function asFieldedTypes<
+  T extends AnnotationSchemaType | InlineObjectSchemaType,
+>(
+  resolved:
+    | ReadonlyArray<BaseDefinition & {fields?: ReadonlyArray<unknown>}>
+    | undefined,
+): Array<T> | undefined {
+  if (!resolved) {
+    return undefined
+  }
+  return resolved.map(
+    (entry) => ({...entry, fields: entry.fields ?? []}) as unknown as T,
+  )
+}

--- a/packages/editor/src/selectors/selector.get-next-span.ts
+++ b/packages/editor/src/selectors/selector.get-next-span.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {KeyedSegment} from '../types/paths'
+import type {Path} from '../slate/interfaces/path'
 import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
 import {getSelectionEndBlock} from './selector.get-selection-end-block'
 import {getSelectionEndPoint} from './selector.get-selection-end-point'
@@ -11,7 +11,7 @@ import {getSelectionEndPoint} from './selector.get-selection-end-point'
 export const getNextSpan: EditorSelector<
   | {
       node: PortableTextSpan
-      path: [KeyedSegment, 'children', KeyedSegment]
+      path: Path
     }
   | undefined
 > = (snapshot) => {
@@ -33,7 +33,7 @@ export const getNextSpan: EditorSelector<
   let nextSpan:
     | {
         node: PortableTextSpan
-        path: [KeyedSegment, 'children', KeyedSegment]
+        path: Path
       }
     | undefined
 

--- a/packages/editor/src/selectors/selector.get-previous-span.ts
+++ b/packages/editor/src/selectors/selector.get-previous-span.ts
@@ -1,6 +1,6 @@
 import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {KeyedSegment} from '../types/paths'
+import type {Path} from '../slate/interfaces/path'
 import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
 import {getSelectionStartBlock} from './selector.get-selection-start-block'
 import {getSelectionStartPoint} from './selector.get-selection-start-point'
@@ -11,7 +11,7 @@ import {getSelectionStartPoint} from './selector.get-selection-start-point'
 export const getPreviousSpan: EditorSelector<
   | {
       node: PortableTextSpan
-      path: [KeyedSegment, 'children', KeyedSegment]
+      path: Path
     }
   | undefined
 > = (snapshot) => {
@@ -32,7 +32,7 @@ export const getPreviousSpan: EditorSelector<
   let previousSpan:
     | {
         node: PortableTextSpan
-        path: [KeyedSegment, 'children', KeyedSegment]
+        path: Path
       }
     | undefined
 

--- a/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.update-value.ts
@@ -31,23 +31,21 @@ export function updateValuePlugin(
 
     apply(operation)
 
-    // Operations deep inside blocks (path length > 2) only modify nested
-    // structure and cannot affect root-level blockIndexMap or listIndexMap.
-    // Root-level inserts/removes are already handled incrementally by
-    // applyOperation, so we only need a full rebuild for operations at or
-    // near the root level.
-    if (operation.path.length <= 2) {
-      buildIndexMaps(
-        {
-          schema: context.schema,
-          value: editor.children,
-        },
-        {
-          blockIndexMap: editor.blockIndexMap,
-          listIndexMap: editor.listIndexMap,
-        },
-      )
-    }
+    // Any non-text structural op can affect list counters anywhere in the
+    // tree (including inside editable containers). Root-level `blockIndexMap`
+    // updates are already incremental in `applyOperation`; `listIndexMap` is
+    // positional and rebuilt in full here.
+    buildIndexMaps(
+      {
+        schema: context.schema,
+        containers: editor.containers,
+        value: editor.children,
+      },
+      {
+        blockIndexMap: editor.blockIndexMap,
+        listIndexMap: editor.listIndexMap,
+      },
+    )
   }
 
   return editor

--- a/packages/editor/src/slate/node/is-void-node.ts
+++ b/packages/editor/src/slate/node/is-void-node.ts
@@ -1,7 +1,7 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSchema} from '../../editor/editor-schema'
 import {isEditableContainer} from '../../schema/is-editable-container'
-import type {Containers} from '../../schema/resolve-containers'
+import type {TraversalContainers} from '../../schema/resolve-containers'
 import type {Node} from '../interfaces/node'
 import type {Path} from '../interfaces/path'
 import {isObjectNode} from './is-object-node'
@@ -14,7 +14,7 @@ import {isObjectNode} from './is-object-node'
 export function isVoidNode(
   context: {
     schema: EditorSchema
-    containers: Containers
+    containers: TraversalContainers
     value: Array<Node>
   },
   node: unknown,

--- a/packages/editor/src/types/paths.ts
+++ b/packages/editor/src/types/paths.ts
@@ -29,9 +29,12 @@ export type PathSegment = string | number | KeyedSegment | IndexTuple
 export type Path = PathSegment[]
 
 /**
+ * A path that points at a block. Previously encoded a root-only constraint
+ * (`[{_key}]`); now an alias for `Path` to allow blocks at any depth
+ * (including inside editable containers).
  * @public
  */
-export type BlockPath = [{_key: string}]
+export type BlockPath = Path
 
 /**
  * @public
@@ -53,11 +56,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * A path that points at an annotation markDef on a block. Previously encoded
+ * a root-only constraint (`[{_key}, 'markDefs', {_key}]`); now an alias for
+ * `Path` to allow annotations on text blocks at any depth.
  * @public
  */
-export type AnnotationPath = [{_key: string}, 'markDefs', {_key: string}]
+export type AnnotationPath = Path
 
 /**
+ * A path that points at a child of a text block. Previously encoded a
+ * root-only constraint (`[{_key}, 'children', {_key}]`); now an alias for
+ * `Path` to allow children of text blocks at any depth.
  * @public
  */
-export type ChildPath = [{_key: string}, 'children', {_key: string}]
+export type ChildPath = Path

--- a/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
+++ b/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
@@ -1,6 +1,7 @@
 import type {EditorContext} from '../editor/editor-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
+import {isKeyedSegment} from './util.is-keyed-segment'
 
 /**
  * @public
@@ -12,10 +13,16 @@ export function blockOffsetToBlockSelectionPoint({
   context: Pick<EditorContext, 'value'>
   blockOffset: BlockOffset
 }): EditorSelectionPoint | undefined {
+  const blockSegment = blockOffset.path.at(0)
+
+  if (!isKeyedSegment(blockSegment)) {
+    return undefined
+  }
+
   let selectionPoint: EditorSelectionPoint | undefined
 
   for (const block of context.value) {
-    if (block._key === blockOffset.path[0]._key) {
+    if (block._key === blockSegment._key) {
       selectionPoint = {
         path: [{_key: block._key}],
         offset: blockOffset.offset,

--- a/packages/editor/src/utils/util.block-offset.ts
+++ b/packages/editor/src/utils/util.block-offset.ts
@@ -3,6 +3,7 @@ import type {EditorContext} from '../editor/editor-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 import type {ChildPath} from '../types/paths'
+import {isKeyedSegment} from './util.is-keyed-segment'
 import {
   getBlockKeyFromSelectionPoint,
   getChildKeyFromSelectionPoint,
@@ -20,12 +21,18 @@ export function blockOffsetToSpanSelectionPoint({
   blockOffset: BlockOffset
   direction: 'forward' | 'backward'
 }) {
+  const blockOffsetSegment = blockOffset.path.at(0)
+
+  if (!isKeyedSegment(blockOffsetSegment)) {
+    return undefined
+  }
+
   let offsetLeft = blockOffset.offset
   let selectionPoint: {path: ChildPath; offset: number} | undefined
   let skippedInlineObject = false
 
   for (const block of context.value) {
-    if (block._key !== blockOffset.path[0]._key) {
+    if (block._key !== blockOffsetSegment._key) {
       continue
     }
 

--- a/packages/editor/test-utils/create-test-snapshot.ts
+++ b/packages/editor/test-utils/create-test-snapshot.ts
@@ -7,6 +7,7 @@ export function createTestSnapshot(snapshot: {
   decoratorState?: Partial<EditorSnapshot['decoratorState']>
 }): EditorSnapshot {
   const context = {
+    containers: snapshot.context?.containers ?? new Map(),
     converters: snapshot.context?.converters ?? [],
     schema: snapshot.context?.schema ?? compileSchema(defineSchema({})),
     keyGenerator: snapshot.context?.keyGenerator ?? createTestKeyGenerator(),

--- a/packages/plugin-emoji-picker/src/emoji-picker-machine.tsx
+++ b/packages/plugin-emoji-picker/src/emoji-picker-machine.tsx
@@ -169,7 +169,7 @@ function createTriggerActions({
       marks: payload.markState.marks,
     },
     path: [
-      {_key: payload.focusSpan.path[0]._key},
+      ...payload.focusSpan.path.slice(0, -2),
       'children',
       {_key: newSpan._key},
     ] satisfies ChildPath,

--- a/packages/plugin-input-rule/src/plugin.input-rule.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.tsx
@@ -18,6 +18,7 @@ import {
 } from '@portabletext/editor/selectors'
 import {
   isEqualSelections,
+  isKeyedSegment,
   isSelectionCollapsed,
 } from '@portabletext/editor/utils'
 import {useActorRef} from '@xstate/react'
@@ -29,6 +30,15 @@ import {
 } from 'xstate'
 import type {InputRule, InputRuleMatch} from './input-rule'
 import {getInputRuleMatchLocation} from './input-rule-match-location'
+
+/**
+ * Extract the `_key` of the block a `BlockOffset` path points at. A block
+ * path's root segment is always a `KeyedSegment`.
+ */
+function blockKey(path: BlockOffset['path']): string | undefined {
+  const firstSegment = path.at(0)
+  return isKeyedSegment(firstSegment) ? firstSegment._key : undefined
+}
 
 /**
  * @alpha
@@ -378,12 +388,12 @@ const inputRuleSetup = setup({
       // different span after normalization).
       if (event.blockOffsets && context.endOffsets) {
         const startChanged =
-          context.endOffsets.start.path[0]._key !==
-            event.blockOffsets.start.path[0]._key ||
+          blockKey(context.endOffsets.start.path) !==
+            blockKey(event.blockOffsets.start.path) ||
           context.endOffsets.start.offset !== event.blockOffsets.start.offset
         const endChanged =
-          context.endOffsets.end.path[0]._key !==
-            event.blockOffsets.end.path[0]._key ||
+          blockKey(context.endOffsets.end.path) !==
+            blockKey(event.blockOffsets.end.path) ||
           context.endOffsets.end.offset !== event.blockOffsets.end.offset
 
         return startChanged || endChanged

--- a/packages/plugin-typeahead-picker/src/typeahead-picker-machine.tsx
+++ b/packages/plugin-typeahead-picker/src/typeahead-picker-machine.tsx
@@ -221,7 +221,7 @@ function createTriggerActions({
       marks: payload.markState.marks,
     },
     path: [
-      {_key: payload.focusSpan.path[0]._key},
+      ...payload.focusSpan.path.slice(0, -2),
       'children',
       {_key: newSpan._key},
     ] satisfies ChildPath,


### PR DESCRIPTION
Foundation for all container-aware work. Introduces the runtime surface for traversing, matching, and resolving sub-schemas inside editable containers at any depth.

This is purely internal plumbing — selectors, behaviors, operations, parsers, and renderers remain root-only and stay on their current shape until subsequent PRs make them container-aware.

## Editor context

`EditorContext.containers` is a new `@alpha` field — `ReadonlyMap<string, {field}>` keyed by scoped type name. Populated in `createEditorSnapshot` and `getEditorSnapshot` from the underlying `PortableTextSlateEditor.containers` map. A new `TraversalContainers` alias in `src/schema/resolve-containers.ts` captures the narrow shape traversal needs; the internal `Containers` map is a structural subtype.

## Traversal utilities

`getNode`, `getAncestor`, `getAncestors`, `getParent`, `getChildren`, `hasNode`, `isVoidNode`, `isEditableContainer`, `getContainerScopedName` now accept the narrower `TraversalContainers`.

New primitives: `getEnclosingBlock`, `getNodes`, `getSibling`, `isBlock` (+ paired `getBlock` narrowing helper), `isInline`, `isLeaf`, `getLeaf`, `getFirstChild`, `getLastChild`, `getAncestorObjectNode`, `getAncestorTextBlock`, `getHighestObjectNode`, `getSpanNode`, `getTextBlockNode`, `getText`, `getVoidAncestor`.

## Schema helpers

`getBlockSubSchema(context, path)` walks ancestors to find the enclosing container and returns the resolved sub-schema for that scope (styles / decorators / annotations / lists / inlineObjects).

`getBlockObjectSchema(context, path)` resolves void block object schema at any depth.

`getEnclosingContainer` extracts the ancestor-walk. `getTypeChain` collects the type chain for scope matching. `schema-type-projections` consolidates the `asNamedTypes` / `asFieldedTypes` helpers.

## Test helpers

`createTestSnapshot` falls back to an empty `Map` when `context.containers` is not provided so existing tests keep working unchanged.

---

Based on #2536 — please merge that first. Once this lands, subsequent PRs will make selectors, behaviors, operations, parsing, normalization, and rendering container-aware one concern at a time.