### PR TITLE
fix: clean up selection-content selectors

### DIFF
--- a/.changeset/container-aware-selected-value.md
+++ b/.changeset/container-aware-selected-value.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: make `getSelectedValue` and `getSelectedTextBlocks` container-aware

--- a/.changeset/selected-children-compose.md
+++ b/.changeset/selected-children-compose.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: make `getSelectedChildren` and `getSelectedSpans` container-aware

--- a/packages/editor/src/behaviors/behavior.core.lists.ts
+++ b/packages/editor/src/behaviors/behavior.core.lists.ts
@@ -4,7 +4,7 @@ import {getFocusSpan} from '../selectors/selector.get-focus-span'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getNextBlock} from '../selectors/selector.get-next-block'
 import {getPreviousBlock} from '../selectors/selector.get-previous-block'
-import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
+import {getSelectedTextBlocks} from '../selectors/selector.get-selected-text-blocks'
 import {getSelectionEndPoint} from '../selectors/selector.get-selection-end-point'
 import {getSelectionStartPoint} from '../selectors/selector.get-selection-start-point'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
@@ -210,7 +210,7 @@ const deletingListFromStart = defineBehavior({
       return false
     }
 
-    const blocksToDelete = getSelectedBlocks({
+    const blocksToDelete = getSelectedTextBlocks({
       ...snapshot,
       context: {
         ...snapshot.context,
@@ -386,15 +386,10 @@ const indentListOnTab = defineBehavior({
       return false
     }
 
-    const selectedBlocks = getSelectedBlocks(snapshot)
+    const selectedBlocks = getSelectedTextBlocks(snapshot)
     const selectedListBlocks = selectedBlocks.flatMap((block) =>
       isListBlock(snapshot.context, block.node)
-        ? [
-            {
-              node: block.node,
-              path: block.path,
-            },
-          ]
+        ? [{node: block.node, path: block.path}]
         : [],
     )
 
@@ -435,15 +430,10 @@ const unindentListOnShiftTab = defineBehavior({
       return false
     }
 
-    const selectedBlocks = getSelectedBlocks(snapshot)
+    const selectedBlocks = getSelectedTextBlocks(snapshot)
     const selectedListBlocks = selectedBlocks.flatMap((block) =>
       isListBlock(snapshot.context, block.node)
-        ? [
-            {
-              node: block.node,
-              path: block.path,
-            },
-          ]
+        ? [{node: block.node, path: block.path}]
         : [],
     )
 

--- a/packages/editor/src/selectors/selector.get-active-annotations.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotations.ts
@@ -1,7 +1,7 @@
-import {isTextBlock, type PortableTextObject} from '@portabletext/schema'
+import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getMarkState} from './selector.get-mark-state'
-import {getSelectedBlocks} from './selector.get-selected-blocks'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 
 /**
  * @public
@@ -13,7 +13,7 @@ export const getActiveAnnotations: EditorSelector<Array<PortableTextObject>> = (
     return []
   }
 
-  const selectedBlocks = getSelectedBlocks(snapshot)
+  const selectedBlocks = getSelectedTextBlocks(snapshot)
   const markState = getMarkState(snapshot)
 
   const activeAnnotations = (markState?.marks ?? []).filter(
@@ -23,10 +23,8 @@ export const getActiveAnnotations: EditorSelector<Array<PortableTextObject>> = (
         .includes(mark),
   )
 
-  const selectionMarkDefs = selectedBlocks.flatMap((block) =>
-    isTextBlock(snapshot.context, block.node)
-      ? (block.node.markDefs ?? [])
-      : [],
+  const selectionMarkDefs = selectedBlocks.flatMap(
+    (block) => block.node.markDefs ?? [],
   )
 
   return selectionMarkDefs.filter((markDef) =>

--- a/packages/editor/src/selectors/selector.get-active-list-item.ts
+++ b/packages/editor/src/selectors/selector.get-active-list-item.ts
@@ -1,7 +1,6 @@
 import type {PortableTextListBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isTextBlockNode} from '../slate/node/is-text-block-node'
-import {getSelectedBlocks} from './selector.get-selected-blocks'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 
 /**
  * @public
@@ -13,11 +12,9 @@ export const getActiveListItem: EditorSelector<
     return undefined
   }
 
-  const selectedBlocks = getSelectedBlocks(snapshot).map((block) => block.node)
-  const selectedTextBlocks = selectedBlocks.filter((block) =>
-    isTextBlockNode(snapshot.context, block),
+  const selectedTextBlocks = getSelectedTextBlocks(snapshot).map(
+    (block) => block.node,
   )
-
   const firstTextBlock = selectedTextBlocks.at(0)
 
   if (!firstTextBlock) {

--- a/packages/editor/src/selectors/selector.get-active-style.ts
+++ b/packages/editor/src/selectors/selector.get-active-style.ts
@@ -1,7 +1,6 @@
 import type {PortableTextTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isTextBlockNode} from '../slate/node/is-text-block-node'
-import {getSelectedBlocks} from './selector.get-selected-blocks'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 
 /**
  * @public
@@ -13,11 +12,9 @@ export const getActiveStyle: EditorSelector<PortableTextTextBlock['style']> = (
     return undefined
   }
 
-  const selectedBlocks = getSelectedBlocks(snapshot).map((block) => block.node)
-  const selectedTextBlocks = selectedBlocks.filter((block) =>
-    isTextBlockNode(snapshot.context, block),
+  const selectedTextBlocks = getSelectedTextBlocks(snapshot).map(
+    (block) => block.node,
   )
-
   const firstTextBlock = selectedTextBlocks.at(0)
 
   if (!firstTextBlock) {

--- a/packages/editor/src/selectors/selector.get-selected-blocks.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-blocks.test.ts
@@ -1,0 +1,122 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+  type PortableTextTextBlock,
+} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
+import {getSelectedBlocks} from './selector.get-selected-blocks'
+
+describe(getSelectedBlocks.name, () => {
+  test('returns root-level blocks the selection covers', () => {
+    const schema = compileSchema(defineSchema({}))
+    const b1: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'foo', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const b2: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b2',
+      children: [{_type: 'span', _key: 'b2c1', text: 'bar', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const value: Array<PortableTextBlock> = [b1, b2]
+    const selection = {
+      anchor: {
+        path: [{_key: 'b1'}, 'children', {_key: 'b1c1'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'b2'}, 'children', {_key: 'b2c1'}],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedBlocks(
+        createTestSnapshot({context: {schema, value, selection}}),
+      ),
+    ).toEqual([
+      {node: b1, path: [{_key: 'b1'}]},
+      {node: b2, path: [{_key: 'b2'}]},
+    ])
+  })
+
+  test('returns the enclosing container when the selection is inside one', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs = new Map()
+    configs.set(
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+      }),
+    )
+    const containers = resolveContainers(schema, configs)
+
+    const innerBlock: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'ib1',
+      children: [{_type: 'span', _key: 'ib1c1', text: 'inside', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const callout = {
+      _type: 'callout',
+      _key: 'cal1',
+      content: [innerBlock],
+    }
+    const value: Array<PortableTextBlock> = [callout]
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedBlocks(
+        createTestSnapshot({context: {schema, value, selection, containers}}),
+      ),
+    ).toEqual([{node: callout, path: [{_key: 'cal1'}]}])
+  })
+})

--- a/packages/editor/src/selectors/selector.get-selected-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-blocks.ts
@@ -1,61 +1,58 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getNodes} from '../node-traversal/get-nodes'
+import {getBlock} from '../node-traversal/is-block'
 import type {BlockPath} from '../types/paths'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 /**
+ * Returns the root-level blocks the selection covers.
+ *
+ * Only looks at direct children of the editor. If the selection is inside
+ * an editable container, the container itself is returned — not its inner
+ * blocks. Containers are preserved whole.
+ *
+ * Use for block-level operations like `move.block up/down` and
+ * drag-and-drop. For "selection as portable text" use `getSelectedValue`;
+ * for "text blocks at any depth" use `getSelectedTextBlocks`.
+ *
  * @public
  */
 export const getSelectedBlocks: EditorSelector<
   Array<{node: PortableTextBlock; path: BlockPath}>
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return []
   }
 
-  const selectedBlocks: Array<{node: PortableTextBlock; path: BlockPath}> = []
-  const startPoint = getSelectionStartPoint(snapshot.context.selection)
-  const endPoint = getSelectionEndPoint(snapshot.context.selection)
-  const startKey = getBlockKeyFromSelectionPoint(startPoint)
-  const endKey = getBlockKeyFromSelectionPoint(endPoint)
+  const startPoint = getSelectionStartPoint(selection)
+  const endPoint = getSelectionEndPoint(selection)
 
-  if (!startKey || !endKey) {
-    return selectedBlocks
+  if (!startPoint || !endPoint) {
+    return []
   }
 
-  const startBlockIndex = snapshot.blockIndexMap.get(startKey)
-  const endBlockIndex = snapshot.blockIndexMap.get(endKey)
+  const result: Array<{node: PortableTextBlock; path: BlockPath}> = []
 
-  if (startBlockIndex === undefined || endBlockIndex === undefined) {
-    return selectedBlocks
-  }
-
-  const slicedValue = snapshot.context.value.slice(
-    startBlockIndex,
-    endBlockIndex + 1,
-  )
-
-  for (const block of slicedValue) {
-    if (block._key === startKey) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
-
-      if (startKey === endKey) {
-        break
-      }
-      continue
-    }
-
-    if (block._key === endKey) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
-      break
-    }
-
-    if (selectedBlocks.length > 0) {
-      selectedBlocks.push({node: block, path: [{_key: block._key}]})
+  for (const entry of getNodes(
+    {
+      ...snapshot.context,
+      blockIndexMap: snapshot.blockIndexMap,
+    },
+    {
+      from: startPoint.path,
+      to: endPoint.path,
+      match: (_, path) => path.length === 1,
+    },
+  )) {
+    const block = getBlock(snapshot.context, entry.path)
+    if (block) {
+      result.push({node: block.node, path: block.path})
     }
   }
 
-  return selectedBlocks
+  return result
 }

--- a/packages/editor/src/selectors/selector.get-selected-children.ts
+++ b/packages/editor/src/selectors/selector.get-selected-children.ts
@@ -1,17 +1,15 @@
-import {isSpan, isTextBlock} from '@portabletext/schema'
-import type {PortableTextChild} from '@portabletext/schema'
+import {isSpan, type PortableTextChild} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {ChildPath} from '../types/paths'
-import {
-  getBlockKeyFromSelectionPoint,
-  getChildKeyFromSelectionPoint,
-} from '../utils/util.selection-point'
-import {getSelectionEndPoint} from './selector.get-selection-end-point'
-import {getSelectionStartPoint} from './selector.get-selection-start-point'
+import {getNodes} from '../node-traversal/get-nodes'
+import {isInline} from '../node-traversal/is-inline'
+import type {Path} from '../slate/interfaces/path'
+import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
+import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
 type SelectedChild<TChild extends PortableTextChild = PortableTextChild> = {
   node: TChild
-  path: ChildPath
+  path: Path
 }
 
 type GetSelectedChildrenOptions<
@@ -20,6 +18,12 @@ type GetSelectedChildrenOptions<
   filter?: (child: PortableTextChild) => child is TChild
 }
 
+/**
+ * Returns the inline children (spans and inline objects) touched by the
+ * selection, resolved at any depth.
+ *
+ * @public
+ */
 export function getSelectedChildren<
   TChild extends PortableTextChild = PortableTextChild,
 >(
@@ -28,107 +32,62 @@ export function getSelectedChildren<
   const filter = options?.filter
 
   return (snapshot) => {
-    const startPoint = getSelectionStartPoint(snapshot)
-    const endPoint = getSelectionEndPoint(snapshot)
+    const startPoint = getSelectionStartPoint(snapshot.context.selection)
+    const endPoint = getSelectionEndPoint(snapshot.context.selection)
 
     if (!startPoint || !endPoint) {
       return []
     }
 
-    const startBlockKey = getBlockKeyFromSelectionPoint(startPoint)
-    const endBlockKey = getBlockKeyFromSelectionPoint(endPoint)
-    const startChildKey = getChildKeyFromSelectionPoint(startPoint)
-    const endChildKey = getChildKeyFromSelectionPoint(endPoint)
+    const startChildKey = lastKeyedKey(startPoint.path)
+    const endChildKey = lastKeyedKey(endPoint.path)
 
-    if (!startBlockKey || !endBlockKey) {
-      return []
-    }
+    const result: Array<SelectedChild<TChild>> = []
 
-    const startBlockIndex = snapshot.blockIndexMap.get(startBlockKey)
-    const endBlockIndex = snapshot.blockIndexMap.get(endBlockKey)
+    for (const entry of getNodes(
+      {
+        ...snapshot.context,
+        blockIndexMap: snapshot.blockIndexMap,
+      },
+      {
+        from: startPoint.path,
+        to: endPoint.path,
+        match: (_, path) => isInline(snapshot.context, path),
+      },
+    )) {
+      const child = entry.node as PortableTextChild
 
-    if (startBlockIndex === undefined || endBlockIndex === undefined) {
-      return []
-    }
+      // Skip the start child when the selection begins exactly at its end
+      // and skip the end child when the selection ends exactly at its start.
+      if (child._key === startChildKey && isSpan(snapshot.context, child)) {
+        if (startPoint.offset >= child.text.length) {
+          continue
+        }
+      }
 
-    const selectedChildren: Array<SelectedChild<TChild>> = []
-    const minBlockIndex = Math.min(startBlockIndex, endBlockIndex)
-    const maxBlockIndex = Math.max(startBlockIndex, endBlockIndex)
-    const blocks = snapshot.context.value.slice(
-      minBlockIndex,
-      maxBlockIndex + 1,
-    )
+      if (child._key === endChildKey && isSpan(snapshot.context, child)) {
+        if (endPoint.offset <= 0) {
+          continue
+        }
+      }
 
-    let startChildFound = false
-
-    for (const block of blocks) {
-      if (!isTextBlock(snapshot.context, block)) {
+      if (filter && !filter(child)) {
         continue
       }
 
-      const isStartBlock = block._key === startBlockKey
-      const isEndBlock = block._key === endBlockKey
-      const isMiddleBlock = !isStartBlock && !isEndBlock
-
-      for (const child of block.children) {
-        const isStartChild = child._key === startChildKey
-        const isEndChild = child._key === endChildKey
-
-        const addChild = () => {
-          if (!filter || filter(child)) {
-            selectedChildren.push({
-              node: child as TChild,
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-            })
-          }
-        }
-
-        if (isMiddleBlock) {
-          addChild()
-          continue
-        }
-
-        if (isStartChild) {
-          startChildFound = true
-          if (isSpan(snapshot.context, child)) {
-            if (startPoint.offset < child.text.length) {
-              addChild()
-            }
-          } else {
-            addChild()
-          }
-
-          if (startChildKey === endChildKey) {
-            break
-          }
-          continue
-        }
-
-        if (isEndChild) {
-          if (isSpan(snapshot.context, child)) {
-            if (endPoint.offset > 0) {
-              addChild()
-            }
-          } else {
-            addChild()
-          }
-          break
-        }
-
-        if (startChildFound) {
-          addChild()
-        }
-      }
-
-      if (isStartBlock && startBlockKey === endBlockKey) {
-        break
-      }
-
-      if (isStartBlock) {
-        startChildFound = true
-      }
+      result.push({node: child as TChild, path: entry.path})
     }
 
-    return selectedChildren
+    return result
   }
+}
+
+function lastKeyedKey(path: Path): string | undefined {
+  for (let i = path.length - 1; i >= 0; i--) {
+    const segment = path[i]
+    if (isKeyedSegment(segment)) {
+      return segment._key
+    }
+  }
+  return undefined
 }

--- a/packages/editor/src/selectors/selector.get-selected-text-blocks.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-text-blocks.test.ts
@@ -1,0 +1,131 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+  type PortableTextTextBlock,
+} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
+
+describe(getSelectedTextBlocks.name, () => {
+  test('returns text blocks at the root when the selection is at the root', () => {
+    const schema = compileSchema(defineSchema({}))
+    const b1: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'foo', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const b2: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b2',
+      children: [{_type: 'span', _key: 'b2c1', text: 'bar', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const value: Array<PortableTextBlock> = [b1, b2]
+    const selection = {
+      anchor: {
+        path: [{_key: 'b1'}, 'children', {_key: 'b1c1'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'b2'}, 'children', {_key: 'b2c1'}],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedTextBlocks(
+        createTestSnapshot({context: {schema, value, selection}}),
+      ),
+    ).toEqual([
+      {node: b1, path: [{_key: 'b1'}]},
+      {node: b2, path: [{_key: 'b2'}]},
+    ])
+  })
+
+  test('returns text blocks from inside a container when the selection crosses a container boundary', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs = new Map()
+    configs.set(
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+      }),
+    )
+    const containers = resolveContainers(schema, configs)
+
+    const rootBlock: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'foo', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const innerBlock: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'ib1',
+      children: [{_type: 'span', _key: 'ib1c1', text: 'bar', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const callout = {
+      _type: 'callout',
+      _key: 'cal1',
+      content: [innerBlock],
+    }
+    const trailing: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b3',
+      children: [{_type: 'span', _key: 'b3c1', text: 'baz', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const value: Array<PortableTextBlock> = [rootBlock, callout, trailing]
+
+    const selection = {
+      anchor: {
+        path: [{_key: 'b1'}, 'children', {_key: 'b1c1'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'b3'}, 'children', {_key: 'b3c1'}],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedTextBlocks(
+        createTestSnapshot({context: {schema, value, selection, containers}}),
+      ),
+    ).toEqual([
+      {node: rootBlock, path: [{_key: 'b1'}]},
+      {
+        node: innerBlock,
+        path: [{_key: 'cal1'}, 'content', {_key: 'ib1'}],
+      },
+      {node: trailing, path: [{_key: 'b3'}]},
+    ])
+  })
+})

--- a/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
@@ -1,72 +1,52 @@
 import {isTextBlock, type PortableTextTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import type {BlockPath} from '../types/paths'
+import {getNodes} from '../node-traversal/get-nodes'
+import type {Path} from '../slate/interfaces/path'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 /**
+ * Returns the text blocks touched by the selection, resolved at any depth.
+ *
+ * Walks the tree between the selection endpoints and returns every text
+ * block found, regardless of container nesting. For toolbar state and
+ * anywhere that needs "text blocks with text in the selection".
+ *
  * @public
  */
 export const getSelectedTextBlocks: EditorSelector<
-  Array<{node: PortableTextTextBlock; path: BlockPath}>
+  Array<{node: PortableTextTextBlock; path: Path}>
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return []
   }
 
-  const selectedTextBlocks: Array<{
-    node: PortableTextTextBlock
-    path: BlockPath
-  }> = []
+  const startPoint = getSelectionStartPoint(selection)
+  const endPoint = getSelectionEndPoint(selection)
 
-  const startPoint = getSelectionStartPoint(snapshot.context.selection)
-  const endPoint = getSelectionEndPoint(snapshot.context.selection)
-  const startBlockKey = getBlockKeyFromSelectionPoint(startPoint)
-  const endBlockKey = getBlockKeyFromSelectionPoint(endPoint)
-
-  if (!startBlockKey || !endBlockKey) {
-    return selectedTextBlocks
+  if (!startPoint || !endPoint) {
+    return []
   }
 
-  const startBlockIndex = snapshot.blockIndexMap.get(startBlockKey)
-  const endBlockIndex = snapshot.blockIndexMap.get(endBlockKey)
+  const result: Array<{node: PortableTextTextBlock; path: Path}> = []
 
-  if (startBlockIndex === undefined || endBlockIndex === undefined) {
-    return selectedTextBlocks
-  }
-
-  const slicedValue = snapshot.context.value.slice(
-    startBlockIndex,
-    endBlockIndex + 1,
-  )
-
-  for (const block of slicedValue) {
-    if (block._key === startBlockKey) {
-      if (isTextBlock(snapshot.context, block)) {
-        selectedTextBlocks.push({node: block, path: [{_key: block._key}]})
-      }
-
-      if (startBlockKey === endBlockKey) {
-        break
-      }
-      continue
-    }
-
-    if (block._key === endBlockKey) {
-      if (isTextBlock(snapshot.context, block)) {
-        selectedTextBlocks.push({node: block, path: [{_key: block._key}]})
-      }
-
-      break
-    }
-
-    if (selectedTextBlocks.length > 0) {
-      if (isTextBlock(snapshot.context, block)) {
-        selectedTextBlocks.push({node: block, path: [{_key: block._key}]})
-      }
+  for (const entry of getNodes(
+    {
+      ...snapshot.context,
+      blockIndexMap: snapshot.blockIndexMap,
+    },
+    {
+      from: startPoint.path,
+      to: endPoint.path,
+      match: (node) => isTextBlock(snapshot.context, node),
+    },
+  )) {
+    if (isTextBlock(snapshot.context, entry.node)) {
+      result.push({node: entry.node, path: entry.path})
     }
   }
 
-  return selectedTextBlocks
+  return result
 }

--- a/packages/editor/src/selectors/selector.get-selected-value.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.test.ts
@@ -7,6 +7,8 @@ import {
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
 import {getSelectedValue} from './selector.get-selected-value'
 
 const b1: PortableTextTextBlock = {
@@ -834,5 +836,517 @@ describe(getSelectedValue.name, () => {
         }),
       ),
     ).toEqual(value)
+  })
+})
+
+describe(`${getSelectedValue.name} with containers`, () => {
+  const calloutSchema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+  const calloutContainer = {
+    scope: '$..callout' as const,
+    field: 'content' as const,
+  }
+
+  function createSnapshot(
+    value: Array<PortableTextBlock>,
+    selection: NonNullable<
+      Parameters<typeof createTestSnapshot>[0]['context']
+    >['selection'],
+    schema = calloutSchema,
+    containerDefs: ReadonlyArray<{
+      scope: `$..${string}`
+      field: string
+    }> = [calloutContainer],
+  ) {
+    const configs = new Map()
+    for (const c of containerDefs) {
+      configs.set(c.scope, makeContainerConfig(schema, c))
+    }
+    const containers = resolveContainers(schema, configs)
+    return createTestSnapshot({
+      context: {schema, value, selection, containers},
+    })
+  }
+
+  const rootBlock1: PortableTextTextBlock = {
+    _type: 'block',
+    _key: 'b1',
+    children: [{_type: 'span', _key: 'b1c1', text: 'foo', marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+  const innerBlock: PortableTextTextBlock = {
+    _type: 'block',
+    _key: 'ib1',
+    children: [{_type: 'span', _key: 'ib1c1', text: 'bar', marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+  const callout = {
+    _type: 'callout',
+    _key: 'cal1',
+    content: [innerBlock],
+  }
+  const rootBlock3: PortableTextTextBlock = {
+    _type: 'block',
+    _key: 'b3',
+    children: [{_type: 'span', _key: 'b3c1', text: 'baz', marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+
+  test('select-all across [text, callout{text}, text] preserves the callout whole', () => {
+    const value: Array<PortableTextBlock> = [rootBlock1, callout, rootBlock3]
+    const selection = {
+      anchor: {
+        path: [{_key: 'b1'}, 'children', {_key: 'b1c1'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'b3'}, 'children', {_key: 'b3c1'}],
+        offset: 3,
+      },
+    }
+
+    expect(getSelectedValue(createSnapshot(value, selection))).toEqual([
+      rootBlock1,
+      callout,
+      rootBlock3,
+    ])
+  })
+
+  test('selection starts inside callout, ends in trailing text block', () => {
+    const value: Array<PortableTextBlock> = [rootBlock1, callout, rootBlock3]
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [{_key: 'b3'}, 'children', {_key: 'b3c1'}],
+        offset: 3,
+      },
+    }
+
+    expect(getSelectedValue(createSnapshot(value, selection))).toEqual([
+      {
+        _type: 'callout',
+        _key: 'cal1',
+        content: [
+          {
+            ...innerBlock,
+            children: [{_type: 'span', _key: 'ib1c1', text: 'ar', marks: []}],
+          },
+        ],
+      },
+      rootBlock3,
+    ])
+  })
+
+  test('selection starts in leading text block, ends inside callout', () => {
+    const value: Array<PortableTextBlock> = [rootBlock1, callout, rootBlock3]
+    const selection = {
+      anchor: {
+        path: [{_key: 'b1'}, 'children', {_key: 'b1c1'}],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 2,
+      },
+    }
+
+    expect(getSelectedValue(createSnapshot(value, selection))).toEqual([
+      {
+        ...rootBlock1,
+        children: [{_type: 'span', _key: 'b1c1', text: 'oo', marks: []}],
+      },
+      {
+        _type: 'callout',
+        _key: 'cal1',
+        content: [
+          {
+            ...innerBlock,
+            children: [{_type: 'span', _key: 'ib1c1', text: 'ba', marks: []}],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('selection wholly inside a callout slices inner blocks only', () => {
+    const value: Array<PortableTextBlock> = [rootBlock1, callout, rootBlock3]
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'cal1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 3,
+      },
+    }
+
+    expect(getSelectedValue(createSnapshot(value, selection))).toEqual([
+      {
+        _type: 'callout',
+        _key: 'cal1',
+        content: [innerBlock],
+      },
+    ])
+  })
+
+  test('infinite nesting: callout inside table cell', () => {
+    const nestedSchema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {type: 'block'},
+                                  {
+                                    type: 'callout',
+                                    fields: [
+                                      {
+                                        name: 'content',
+                                        type: 'array',
+                                        of: [{type: 'block'}],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      {scope: '$..table' as const, field: 'rows' as const},
+      {scope: '$..table.row' as const, field: 'cells' as const},
+      {scope: '$..table.row.cell' as const, field: 'content' as const},
+      {
+        scope: '$..table.row.cell.callout' as const,
+        field: 'content' as const,
+      },
+    ]
+
+    const deepInnerBlock: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'dib1',
+      children: [{_type: 'span', _key: 'dib1c1', text: 'deep', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const deepCallout = {
+      _type: 'callout',
+      _key: 'dcal1',
+      content: [deepInnerBlock],
+    }
+    const deepCell = {
+      _type: 'cell',
+      _key: 'dcell1',
+      content: [deepCallout],
+    }
+    const deepRow = {_type: 'row', _key: 'drow1', cells: [deepCell]}
+    const deepTable = {_type: 'table', _key: 'dtable1', rows: [deepRow]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'dtable1'},
+          'rows',
+          {_key: 'drow1'},
+          'cells',
+          {_key: 'dcell1'},
+          'content',
+          {_key: 'dcal1'},
+          'content',
+          {_key: 'dib1'},
+          'children',
+          {_key: 'dib1c1'},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: 'dtable1'},
+          'rows',
+          {_key: 'drow1'},
+          'cells',
+          {_key: 'dcell1'},
+          'content',
+          {_key: 'dcal1'},
+          'content',
+          {_key: 'dib1'},
+          'children',
+          {_key: 'dib1c1'},
+        ],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedValue(
+        createSnapshot([deepTable], selection, nestedSchema, defs),
+      ),
+    ).toEqual([
+      {
+        _type: 'table',
+        _key: 'dtable1',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'drow1',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'dcell1',
+                content: [
+                  {
+                    _type: 'callout',
+                    _key: 'dcal1',
+                    content: [
+                      {
+                        ...deepInnerBlock,
+                        children: [
+                          {
+                            _type: 'span',
+                            _key: 'dib1c1',
+                            text: 'ee',
+                            marks: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('deep selection ending mid-annotation preserves the link and its markDefs', () => {
+    const nestedSchema = compileSchema(
+      defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      {scope: '$..table' as const, field: 'rows' as const},
+      {scope: '$..table.row' as const, field: 'cells' as const},
+      {scope: '$..table.row.cell' as const, field: 'content' as const},
+    ]
+
+    const linkKey = 'link1'
+    const unusedLinkKey = 'link2'
+
+    const innerBlock: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'ib1',
+      children: [
+        {_type: 'span', _key: 'ib1c1', text: 'foo ', marks: []},
+        {_type: 'span', _key: 'ib1c2', text: 'linked text', marks: [linkKey]},
+        {_type: 'span', _key: 'ib1c3', text: ' baz', marks: []},
+      ],
+      markDefs: [
+        {_type: 'link', _key: linkKey, href: 'https://example.com'},
+        {_type: 'link', _key: unusedLinkKey, href: 'https://unused.com'},
+      ],
+      style: 'normal',
+    }
+    const cell = {
+      _type: 'cell',
+      _key: 'cell1',
+      content: [innerBlock],
+    }
+    const row = {_type: 'row', _key: 'row1', cells: [cell]}
+    const table = {_type: 'table', _key: 'table1', rows: [row]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'ib1'},
+          'children',
+          {_key: 'ib1c2'},
+        ],
+        offset: 6,
+      },
+    }
+
+    expect(
+      getSelectedValue(createSnapshot([table], selection, nestedSchema, defs)),
+    ).toEqual([
+      {
+        _type: 'table',
+        _key: 'table1',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'row1',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'cell1',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'ib1',
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: 'ib1c1',
+                        text: 'foo ',
+                        marks: [],
+                      },
+                      {
+                        _type: 'span',
+                        _key: 'ib1c2',
+                        text: 'linked',
+                        marks: [linkKey],
+                      },
+                    ],
+                    markDefs: [
+                      {
+                        _type: 'link',
+                        _key: linkKey,
+                        href: 'https://example.com',
+                      },
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
   })
 })

--- a/packages/editor/src/selectors/selector.get-selected-value.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.ts
@@ -1,11 +1,34 @@
-import type {PortableTextBlock} from '@portabletext/schema'
+import {
+  isSpan,
+  isTextBlock,
+  type PortableTextBlock,
+  type PortableTextChild,
+} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import type {EditorContext} from '../editor/editor-snapshot'
+import {getNodeChildren} from '../node-traversal/get-children'
+import type {Path} from '../slate/interfaces/path'
+import type {EditorSelectionPoint} from '../types/editor'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {sliceBlocks} from '../utils/util.slice-blocks'
 
+type Edge = EditorSelectionPoint | 'array-start' | 'array-end'
+
+type SliceContext = Pick<
+  EditorContext,
+  'schema' | 'selection' | 'value' | 'containers'
+> & {keyGenerator?: () => string}
+
 /**
+ * Returns the portion of the document's value covered by the selection,
+ * resolved at any depth.
+ *
+ * Containers fully inside the selection are preserved verbatim. Containers
+ * on the selection boundary are recursed into so only the selected portion
+ * of their content is kept. Text blocks on the boundary are span-sliced.
+ *
  * @public
  */
 export const getSelectedValue: EditorSelector<Array<PortableTextBlock>> = (
@@ -19,48 +42,255 @@ export const getSelectedValue: EditorSelector<Array<PortableTextBlock>> = (
 
   const startPoint = getSelectionStartPoint(selection)
   const endPoint = getSelectionEndPoint(selection)
-  const startBlockKey = getBlockKeyFromSelectionPoint(startPoint)
-  const endBlockKey = getBlockKeyFromSelectionPoint(endPoint)
 
-  if (!startBlockKey || !endBlockKey) {
+  if (!startPoint || !endPoint) {
     return []
   }
 
-  const startBlockIndex = snapshot.blockIndexMap.get(startBlockKey)
-  const endBlockIndex = snapshot.blockIndexMap.get(endBlockKey)
+  return sliceArray({
+    context: snapshot.context,
+    blocks: snapshot.context.value,
+    scopePath: '',
+    pathPrefix: [],
+    fieldNameInPrefix: undefined,
+    startEdge: startPoint,
+    endEdge: endPoint,
+  })
+}
 
-  if (startBlockIndex === undefined || endBlockIndex === undefined) {
+function sliceArray({
+  context,
+  blocks,
+  scopePath,
+  pathPrefix,
+  fieldNameInPrefix,
+  startEdge,
+  endEdge,
+}: {
+  context: SliceContext
+  blocks: ReadonlyArray<PortableTextBlock>
+  scopePath: string
+  pathPrefix: Path
+  fieldNameInPrefix: string | undefined
+  startEdge: Edge
+  endEdge: Edge
+}): Array<PortableTextBlock> {
+  if (blocks.length === 0) {
     return []
   }
 
-  const startBlock = snapshot.context.value.at(startBlockIndex)
-  const slicedStartBlock = startBlock
-    ? sliceBlocks({
-        context: snapshot.context,
-        blocks: [startBlock],
-      }).at(0)
-    : undefined
+  const startIdx = resolveIndex(blocks, pathPrefix, startEdge)
+  const endIdx = resolveIndex(blocks, pathPrefix, endEdge)
 
-  if (startBlockIndex === endBlockIndex) {
-    return slicedStartBlock ? [slicedStartBlock] : []
+  if (startIdx === -1 || endIdx === -1) {
+    return []
   }
 
-  const endBlock = snapshot.context.value.at(endBlockIndex)
-  const slicedEndBlock = endBlock
-    ? sliceBlocks({
-        context: snapshot.context,
-        blocks: [endBlock],
-      }).at(0)
-    : undefined
+  const [lo, hi, loEdge, hiEdge] =
+    startIdx <= endIdx
+      ? [startIdx, endIdx, startEdge, endEdge]
+      : [endIdx, startIdx, endEdge, startEdge]
 
-  const middleBlocks = snapshot.context.value.slice(
-    startBlockIndex + 1,
-    endBlockIndex,
-  )
+  const result: Array<PortableTextBlock> = []
 
-  return [
-    ...(slicedStartBlock ? [slicedStartBlock] : []),
-    ...middleBlocks,
-    ...(slicedEndBlock ? [slicedEndBlock] : []),
-  ]
+  for (let i = lo; i <= hi; i++) {
+    const block = blocks[i]!
+    const blockPath: Path = [
+      ...pathPrefix,
+      ...(fieldNameInPrefix ? [fieldNameInPrefix] : []),
+      {_key: block._key},
+    ]
+
+    const startPointForBlock: Edge = i === lo ? loEdge : 'array-start'
+    const endPointForBlock: Edge = i === hi ? hiEdge : 'array-end'
+
+    const startInside = edgeIsInside(startPointForBlock, blockPath)
+    const endInside = edgeIsInside(endPointForBlock, blockPath)
+
+    if (!startInside && !endInside) {
+      result.push(block)
+      continue
+    }
+
+    if (isTextBlock({schema: context.schema}, block)) {
+      const sliced = sliceBoundaryTextBlock({
+        context,
+        block,
+        blockPath,
+        startEdge: startPointForBlock,
+        endEdge: endPointForBlock,
+      })
+      if (sliced) {
+        result.push(sliced)
+      }
+      continue
+    }
+
+    const childInfo = getNodeChildren(
+      {schema: context.schema, containers: context.containers},
+      block,
+      scopePath,
+    )
+
+    if (!childInfo) {
+      result.push(block)
+      continue
+    }
+
+    const innerSliced = sliceArray({
+      context,
+      blocks: childInfo.children as Array<PortableTextBlock>,
+      scopePath: childInfo.scopePath,
+      pathPrefix: blockPath,
+      fieldNameInPrefix: childInfo.fieldName,
+      startEdge: startPointForBlock,
+      endEdge: endPointForBlock,
+    })
+
+    const updatedBlock: PortableTextBlock = {...block}
+    ;(updatedBlock as Record<string, unknown>)[childInfo.fieldName] =
+      innerSliced
+
+    result.push(updatedBlock)
+  }
+
+  return result
+}
+
+function resolveIndex(
+  blocks: ReadonlyArray<PortableTextBlock>,
+  pathPrefix: Path,
+  edge: Edge,
+): number {
+  if (edge === 'array-start') {
+    return 0
+  }
+  if (edge === 'array-end') {
+    return blocks.length - 1
+  }
+  return findBlockIndexForPoint(blocks, pathPrefix, edge)
+}
+
+function findBlockIndexForPoint(
+  blocks: ReadonlyArray<PortableTextBlock>,
+  pathPrefix: Path,
+  point: EditorSelectionPoint,
+): number {
+  let nodeSegmentIndex = pathPrefix.length
+
+  if (
+    nodeSegmentIndex < point.path.length &&
+    typeof point.path[nodeSegmentIndex] === 'string'
+  ) {
+    nodeSegmentIndex++
+  }
+
+  const segment = point.path[nodeSegmentIndex]
+
+  if (segment === undefined) {
+    return -1
+  }
+
+  if (isKeyedSegment(segment)) {
+    return blocks.findIndex((block) => block._key === segment._key)
+  }
+
+  if (typeof segment === 'number') {
+    return segment >= 0 && segment < blocks.length ? segment : -1
+  }
+
+  return -1
+}
+
+function edgeIsInside(edge: Edge, blockPath: Path): boolean {
+  if (edge === 'array-start' || edge === 'array-end') {
+    return false
+  }
+  return edge.path.length > blockPath.length
+}
+
+function sliceBoundaryTextBlock({
+  context,
+  block,
+  blockPath,
+  startEdge,
+  endEdge,
+}: {
+  context: SliceContext
+  block: PortableTextBlock
+  blockPath: Path
+  startEdge: Edge
+  endEdge: Edge
+}): PortableTextBlock | undefined {
+  if (!isTextBlock({schema: context.schema}, block)) {
+    return block
+  }
+
+  const firstChild = block.children[0]
+  const lastChild = block.children[block.children.length - 1]
+
+  // Build block-relative selection points. `sliceBlocks` assumes paths start
+  // at the block level (e.g. `[{block}, 'children', {child}]`), so we strip
+  // any ancestor container prefix from the path.
+  const blockRelativeStart = stripPrefix(startEdge, blockPath, block, {
+    fallback: 'block-start',
+    firstChild,
+  })
+  const blockRelativeEnd = stripPrefix(endEdge, blockPath, block, {
+    fallback: 'block-end',
+    lastChild,
+    context,
+  })
+
+  const sliced = sliceBlocks({
+    context: {
+      ...context,
+      selection: {anchor: blockRelativeStart, focus: blockRelativeEnd},
+    },
+    blocks: [block],
+  })
+
+  return sliced[0]
+}
+
+function stripPrefix(
+  edge: Edge,
+  blockPath: Path,
+  block: PortableTextBlock,
+  opts: {
+    fallback: 'block-start' | 'block-end'
+    firstChild?: PortableTextChild
+    lastChild?: PortableTextChild
+    context?: SliceContext
+  },
+): EditorSelectionPoint {
+  if (edge !== 'array-start' && edge !== 'array-end') {
+    // Is the point inside this block? If yes, strip the prefix.
+    if (edge.path.length > blockPath.length) {
+      return {
+        path: edge.path.slice(blockPath.length - 1),
+        offset: edge.offset,
+      }
+    }
+  }
+  // Fall back to block start or end.
+  if (opts.fallback === 'block-start') {
+    return {
+      path: [
+        {_key: block._key},
+        'children',
+        {_key: opts.firstChild?._key ?? ''},
+      ],
+      offset: 0,
+    }
+  }
+  return {
+    path: [{_key: block._key}, 'children', {_key: opts.lastChild?._key ?? ''}],
+    offset:
+      opts.lastChild &&
+      opts.context &&
+      isSpan({schema: opts.context.schema}, opts.lastChild)
+        ? opts.lastChild.text.length
+        : 0,
+  }
 }

--- a/packages/editor/src/selectors/selector.is-active-annotation.ts
+++ b/packages/editor/src/selectors/selector.is-active-annotation.ts
@@ -1,7 +1,7 @@
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getActiveAnnotationsMarks} from './selector.get-active-annotation-marks'
-import {getSelectedBlocks} from './selector.get-selected-blocks'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 import {getSelectedValue} from './selector.get-selected-value'
 
 /**
@@ -34,11 +34,9 @@ export function isActiveAnnotation(
       return selectionMarkDefs.some((markDef) => markDef._type === annotation)
     }
 
-    const selectedBlocks = getSelectedBlocks(snapshot)
-    const selectionMarkDefs = selectedBlocks.flatMap((block) =>
-      isTextBlock(snapshot.context, block.node)
-        ? (block.node.markDefs ?? [])
-        : [],
+    const selectedBlocks = getSelectedTextBlocks(snapshot)
+    const selectionMarkDefs = selectedBlocks.flatMap(
+      (block) => block.node.markDefs ?? [],
     )
     const activeAnnotations = getActiveAnnotationsMarks(snapshot)
     const activeMarkDefs = selectionMarkDefs.filter(


### PR DESCRIPTION
Three overlapping selectors for "what's in the selection" today:

- `getSelectedValue` uses `getSelectedBlocks` as its primitive, so copying a selection that spans a callout flattens the callout into its inner text blocks instead of preserving it whole.
- `getSelectedTextBlocks` filters through `getSelectedBlocks` too, so text blocks inside containers are missed.
- `getSelectedChildren` does its own `blockIndexMap` walk with offset-aware trimming, not composed from existing traversal utilities.

This PR gives each selector a clear purpose, composes them from shared traversal utilities, and fixes the flattening bug:

1. **`getSelectedValue`** — selection as portable text. Walks structurally, recurses into containers on the boundary, span-slices text blocks on the boundary, preserves fully-selected containers verbatim.
2. **`getSelectedBlocks`** — root-level blocks the selection covers. Unchanged semantics, rewritten to compose `getNodes({from, to, match: (_, path) => path.length === 1})` and narrow through `getBlock`.
3. **`getSelectedTextBlocks`** — text blocks at any depth. Walks independently via `getNodes({from, to, match: isTextBlock})`.
4. **`getSelectedChildren`** and **`getSelectedSpans`** — inline children / spans at any depth. Compose `getNodes({from, to, match: isInline})` with offset-aware boundary trim.

Internal consumers migrated where the new semantics fit better:
- **Text-block consumers** move to `getSelectedTextBlocks`: `behavior.core.lists`, `behavior.core.insert-break`, `selector.get-active-style`, `get-active-annotations`, `get-active-list-item`, `is-active-annotation`.
- **Root-level consumers** stay on `getSelectedBlocks`: `behavior.core.dnd`, `behavior.core.drop-position`, `drag-selection`, playground `behavior.code-editor`.

No breaking changes to the public selector shapes.