### PR TITLE
feat: make selectors container-aware

### DIFF
--- a/.changeset/container-aware-selectors.md
+++ b/.changeset/container-aware-selectors.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/editor": minor
+---
+
+feat: make selectors container-aware
+
+Selectors that previously used `blockIndexMap` to resolve paths at the root level now compose node-traversal primitives so they resolve at any container depth. Selection points and paths inside editable containers are handled the same way as root-level points: a path inside a callout's text block, a code-block's line, or a table cell now flows through every selector without special casing.
+
+Selectors covered: `getActiveAnnotations`, `getActiveDecorators`, `getAnchorBlock`, `getAnchorChild`, `getAnchorSpan`, `getAnchorTextBlock`, `getFirstBlock`, `getFocusBlock`, `getFocusBlockObject`, `getFocusChild`, `getFocusInlineObject`, `getFocusListBlock`, `getFocusSpan`, `getFocusTextBlock`, `getLastBlock`, `getMarkState`, `getNextBlock`, `getNextInlineObject`, `getNextInlineObjects`, `getNextSpan`, `getPreviousBlock`, `getPreviousInlineObject`, `getPreviousInlineObjects`, `getPreviousSpan`, `getSelectedChildren`, `getSelectedSpans`, `getSelectionEndBlock`, `getSelectionEndChild`, `getSelectionStartBlock`, `getSelectionStartChild`, `getSelectionText`, `getTextAfter`, `getTextBefore`, `isOverlappingSelection`.

--- a/packages/editor/src/node-traversal/find-sibling.ts
+++ b/packages/editor/src/node-traversal/find-sibling.ts
@@ -1,0 +1,75 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {parentPath} from '../slate/path/parent-path'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+import {getChildren} from './get-children'
+
+/**
+ * Walk siblings of the node at the given path in a direction, returning the
+ * first sibling that matches the predicate.
+ *
+ * The predicate may be a type guard, in which case the returned `node` is
+ * narrowed accordingly.
+ */
+export function findSibling<TNode extends Node = Node>(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+  direction: 'next' | 'previous',
+  match: (entry: {
+    node: Node
+    path: Path
+  }) => entry is {node: TNode; path: Path},
+): {node: TNode; path: Path} | undefined
+export function findSibling(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+  direction: 'next' | 'previous',
+  match: (entry: {node: Node; path: Path}) => boolean,
+): {node: Node; path: Path} | undefined
+export function findSibling(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+  direction: 'next' | 'previous',
+  match: (entry: {node: Node; path: Path}) => boolean,
+): {node: Node; path: Path} | undefined {
+  if (path.length === 0) {
+    return undefined
+  }
+
+  const lastSegment = path.at(-1)
+
+  if (!isKeyedSegment(lastSegment)) {
+    return undefined
+  }
+
+  const parent = parentPath(path)
+  const children = getChildren(context, parent)
+  const currentIndex = children.findIndex(
+    (child) => child.node._key === lastSegment._key,
+  )
+
+  if (currentIndex === -1) {
+    return undefined
+  }
+
+  const candidates =
+    direction === 'next'
+      ? children.slice(currentIndex + 1)
+      : children.slice(0, currentIndex).reverse()
+
+  return candidates.find(match)
+}

--- a/packages/editor/src/node-traversal/get-enclosing-block.ts
+++ b/packages/editor/src/node-traversal/get-enclosing-block.ts
@@ -1,0 +1,41 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {getAncestors} from './get-ancestors'
+import {getBlock, isBlock} from './is-block'
+
+/**
+ * Walk up from a path to find the nearest enclosing block.
+ *
+ * Returns the node at the path if it is a block, otherwise the first ancestor
+ * that is a block. Works at any depth — inside a container this returns the
+ * container-internal block, not the outer container.
+ */
+export function getEnclosingBlock(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): {node: PortableTextBlock; path: Path} | undefined {
+  const direct = getBlock(context, path)
+
+  if (direct) {
+    return direct
+  }
+
+  for (const ancestor of getAncestors(context, path)) {
+    if (isBlock(context, ancestor.path)) {
+      const block = getBlock(context, ancestor.path)
+
+      if (block) {
+        return block
+      }
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/node-traversal/get-inline.ts
+++ b/packages/editor/src/node-traversal/get-inline.ts
@@ -1,0 +1,40 @@
+import type {PortableTextObject, PortableTextSpan} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isObjectNode} from '../slate/node/is-object-node'
+import {isSpanNode} from '../slate/node/is-span-node'
+import {getNode} from './get-node'
+import {isInline} from './is-inline'
+
+/**
+ * Get the node at the given path if it is inline (a span or inline object).
+ *
+ * A node is inline if its parent is a text block. Returns the node narrowed
+ * to `PortableTextSpan | PortableTextObject`, or `undefined` if the node
+ * doesn't exist or is not inline.
+ */
+export function getInline(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): {node: PortableTextSpan | PortableTextObject; path: Path} | undefined {
+  const entry = getNode(context, path)
+
+  if (!entry || !isInline(context, path)) {
+    return undefined
+  }
+
+  if (
+    !isSpanNode({schema: context.schema}, entry.node) &&
+    !isObjectNode({schema: context.schema}, entry.node)
+  ) {
+    return undefined
+  }
+
+  return {node: entry.node, path: entry.path}
+}

--- a/packages/editor/src/schema/get-block-sub-schema.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.ts
@@ -82,32 +82,6 @@ export function getBlockSubSchema(
   }
 }
 
-/**
- * Return `true` when the given path is inside a registered editable
- * container -- i.e. when the block sub-schema at that path is resolved
- * from a nested `{type: 'block'}` definition rather than the top-level
- * schema.
- *
- * Use this to gate narrowing checks (e.g. "skip this decorator if the
- * sub-schema doesn't declare it"). At root we want to preserve the
- * permissive top-level behaviour where operations accept unknown
- * decorators/annotations/styles and track them optimistically; inside a
- * container the sub-schema is authoritative and those operations should
- * be filtered.
- */
-/**
- * Return `true` when the given path is inside a registered editable
- * container -- i.e. when the block sub-schema at that path is resolved
- * from a nested `{type: 'block'}` definition rather than the top-level
- * schema.
- *
- * Use this to gate narrowing checks (e.g. "skip this decorator if the
- * sub-schema doesn't declare it"). At root we want to preserve the
- * permissive top-level behaviour where operations accept unknown
- * decorators/annotations/styles and track them optimistically; inside a
- * container the sub-schema is authoritative and those operations should
- * be filtered.
- */
 function rootSubSchema(schema: EditorSchema): BlockSubSchema {
   return {
     styles: schema.styles,

--- a/packages/editor/src/selectors/selector.get-active-annotations.test.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotations.test.ts
@@ -1,0 +1,165 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {resolveTestbedContainers} from '../node-traversal/node-traversal-testbed'
+import {getActiveAnnotations} from './selector.get-active-annotations'
+
+test('getActiveAnnotations: respects sub-schema annotations inside a container', () => {
+  // Callout sub-schema declares only `link`. Marks list is the same shape
+  // as root, but the decorator/annotation classification uses the
+  // sub-schema decorators (so a mark not declared as decorator in the
+  // sub-schema is treated as an annotation, matching against the block's
+  // markDefs).
+  const schema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  decorators: [{name: 'strong'}],
+                  annotations: [{name: 'link'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {scope: '$..callout', field: 'content'},
+  ])
+  const linkMarkDef = {_type: 'link', _key: 'lk1', href: 'https://x'}
+
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [
+                {_type: 'span', _key: 's1', text: 'foo', marks: ['lk1']},
+              ],
+              markDefs: [linkMarkDef],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 1,
+        },
+      },
+    },
+  })
+
+  expect(getActiveAnnotations(snapshot)).toEqual([linkMarkDef])
+})
+
+test('getActiveAnnotations: expanded across containers — out-of-scope spans do not vote', () => {
+  // Selection spans root (link mark + matching markDef) and callout
+  // (no link mark, no markDef). Callout span doesn't vote because its
+  // block has no markDef with the candidate key. Root span votes and
+  // has it → annotation is active.
+  const schema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  decorators: [{name: 'strong'}],
+                  annotations: [{name: 'link'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {scope: '$..callout', field: 'content'},
+  ])
+  const linkMarkDef = {_type: 'link', _key: 'lk1', href: 'https://x'}
+
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['lk1']}],
+          markDefs: [linkMarkDef],
+        },
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b2',
+              children: [{_type: 'span', _key: 's2', text: 'bar', marks: []}],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b2'},
+            'children',
+            {_key: 's2'},
+          ],
+          offset: 3,
+        },
+      },
+    },
+  })
+
+  expect(getActiveAnnotations(snapshot)).toEqual([linkMarkDef])
+})

--- a/packages/editor/src/selectors/selector.get-active-annotations.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotations.ts
@@ -1,5 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {getMarkState} from './selector.get-mark-state'
 import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 
@@ -16,11 +17,23 @@ export const getActiveAnnotations: EditorSelector<Array<PortableTextObject>> = (
   const selectedBlocks = getSelectedTextBlocks(snapshot)
   const markState = getMarkState(snapshot)
 
+  // Union of decorator names across selected blocks' sub-schemas. Marks
+  // that aren't decorators in any in-scope sub-schema are annotations.
+  const decoratorNames = new Set<string>()
+  for (const block of selectedBlocks) {
+    for (const decorator of getBlockSubSchema(snapshot.context, block.path)
+      .decorators) {
+      decoratorNames.add(decorator.name)
+    }
+  }
+  if (decoratorNames.size === 0) {
+    for (const decorator of snapshot.context.schema.decorators) {
+      decoratorNames.add(decorator.name)
+    }
+  }
+
   const activeAnnotations = (markState?.marks ?? []).filter(
-    (mark) =>
-      !snapshot.context.schema.decorators
-        .map((decorator) => decorator.name)
-        .includes(mark),
+    (mark) => !decoratorNames.has(mark),
   )
 
   const selectionMarkDefs = selectedBlocks.flatMap(

--- a/packages/editor/src/selectors/selector.get-active-decorators.test.ts
+++ b/packages/editor/src/selectors/selector.get-active-decorators.test.ts
@@ -1,0 +1,232 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {resolveTestbedContainers} from '../node-traversal/node-traversal-testbed'
+import {getActiveDecorators} from './selector.get-active-decorators'
+
+test('getActiveDecorators: respects sub-schema decorators inside a container', () => {
+  // The callout sub-schema declares only `strong`. A focus inside a
+  // callout span with marks=['strong', 'em'] should report only strong as
+  // active because em is not in scope.
+  const schema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}, {name: 'em'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block', decorators: [{name: 'strong'}]}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {scope: '$..callout', field: 'content'},
+  ])
+
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 's1',
+                  text: 'foo',
+                  marks: ['strong', 'em'],
+                },
+              ],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 1,
+        },
+      },
+    },
+  })
+
+  expect(getActiveDecorators(snapshot)).toEqual(['strong'])
+})
+
+test('getActiveDecorators: expanded across containers — out-of-scope spans do not vote', () => {
+  // Selection spans root block (decorators: strong, em) and callout block
+  // (decorators: strong only). Root span has both marks. Callout span has
+  // strong only. Expected:
+  // - strong: in scope in BOTH blocks, present in BOTH spans → active.
+  // - em: only in scope in root block (callout doesn't declare em), root
+  //   span has it → active (callout span doesn't vote).
+  const schema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}, {name: 'em'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block', decorators: [{name: 'strong'}]}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {scope: '$..callout', field: 'content'},
+  ])
+
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {
+              _type: 'span',
+              _key: 's1',
+              text: 'foo',
+              marks: ['strong', 'em'],
+            },
+          ],
+          markDefs: [],
+        },
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b2',
+              children: [
+                {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+              ],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b2'},
+            'children',
+            {_key: 's2'},
+          ],
+          offset: 3,
+        },
+      },
+    },
+  })
+
+  expect(getActiveDecorators(snapshot).sort()).toEqual(['em', 'strong'])
+})
+
+test('getActiveDecorators: expanded across containers — decorator missing in only-in-scope span is not active', () => {
+  // strong is declared in both blocks. Root span has it; callout span does
+  // not. Both spans are in scope for strong → strong is NOT active.
+  const schema = compileSchema(
+    defineSchema({
+      decorators: [{name: 'strong'}, {name: 'em'}],
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block', decorators: [{name: 'strong'}]}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {scope: '$..callout', field: 'content'},
+  ])
+
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+          ],
+          markDefs: [],
+        },
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b2',
+              children: [{_type: 'span', _key: 's2', text: 'bar', marks: []}],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b2'},
+            'children',
+            {_key: 's2'},
+          ],
+          offset: 3,
+        },
+      },
+    },
+  })
+
+  expect(getActiveDecorators(snapshot)).toEqual([])
+})

--- a/packages/editor/src/selectors/selector.get-active-decorators.ts
+++ b/packages/editor/src/selectors/selector.get-active-decorators.ts
@@ -1,14 +1,32 @@
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {getMarkState} from './selector.get-mark-state'
+import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 
 export function getActiveDecorators(snapshot: EditorSnapshot) {
-  const schema = snapshot.context.schema
   const decoratorState = snapshot.decoratorState
   const markState = getMarkState(snapshot)
-  const decorators = schema.decorators.map((decorator) => decorator.name)
+
+  // Union of decorator names across all selected blocks' sub-schemas. At
+  // root this is the full schema; inside containers it's the union of
+  // each block's sub-schema decorators (so cross-container selections
+  // include decorators that any in-scope span allows).
+  const selectedBlocks = getSelectedTextBlocks(snapshot)
+  const decorators = new Set<string>()
+  for (const block of selectedBlocks) {
+    for (const decorator of getBlockSubSchema(snapshot.context, block.path)
+      .decorators) {
+      decorators.add(decorator.name)
+    }
+  }
+  if (decorators.size === 0) {
+    for (const decorator of snapshot.context.schema.decorators) {
+      decorators.add(decorator.name)
+    }
+  }
 
   const markStateDecorators = (markState?.marks ?? []).filter((mark) =>
-    decorators.includes(mark),
+    decorators.has(mark),
   )
 
   let activeDecorators: Array<string> = markStateDecorators

--- a/packages/editor/src/selectors/selector.get-anchor-block.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-block.ts
@@ -1,22 +1,21 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import type {BlockPath} from '../types/paths'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 /**
+ * Returns the block containing the anchor selection, resolved at any depth.
+ *
  * @public
  */
 export const getAnchorBlock: EditorSelector<
   {node: PortableTextBlock; path: BlockPath} | undefined
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return undefined
   }
 
-  const key = getBlockKeyFromSelectionPoint(snapshot.context.selection.anchor)
-  const index = key ? snapshot.blockIndexMap.get(key) : undefined
-  const node =
-    index !== undefined ? snapshot.context.value.at(index) : undefined
-
-  return node && key ? {node, path: [{_key: key}]} : undefined
+  return getEnclosingBlock(snapshot.context, selection.anchor.path)
 }

--- a/packages/editor/src/selectors/selector.get-anchor-child.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-child.ts
@@ -1,10 +1,12 @@
 import type {PortableTextObject, PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getInline} from '../node-traversal/get-inline'
 import type {ChildPath} from '../types/paths'
-import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
-import {getAnchorTextBlock} from './selector.get-anchor-text-block'
 
 /**
+ * Returns the child (span or inline object) containing the anchor selection,
+ * resolved at any depth.
+ *
  * @public
  */
 export const getAnchorChild: EditorSelector<
@@ -14,23 +16,11 @@ export const getAnchorChild: EditorSelector<
     }
   | undefined
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return undefined
   }
 
-  const anchorBlock = getAnchorTextBlock(snapshot)
-
-  if (!anchorBlock) {
-    return undefined
-  }
-
-  const key = getChildKeyFromSelectionPoint(snapshot.context.selection.anchor)
-
-  const node = key
-    ? anchorBlock.node.children.find((span) => span._key === key)
-    : undefined
-
-  return node && key
-    ? {node, path: [...anchorBlock.path, 'children', {_key: key}]}
-    : undefined
+  return getInline(snapshot.context, selection.anchor.path)
 }

--- a/packages/editor/src/selectors/selector.get-anchor-span.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-span.ts
@@ -4,6 +4,8 @@ import type {ChildPath} from '../types/paths'
 import {getAnchorChild} from './selector.get-anchor-child'
 
 /**
+ * Returns the span containing the anchor selection, resolved at any depth.
+ *
  * @public
  */
 export const getAnchorSpan: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-anchor-text-block.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-text-block.ts
@@ -4,6 +4,9 @@ import type {BlockPath} from '../types/paths'
 import {getAnchorBlock} from './selector.get-anchor-block'
 
 /**
+ * Returns the text block containing the anchor selection, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getAnchorTextBlock: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-first-block.ts
+++ b/packages/editor/src/selectors/selector.get-first-block.ts
@@ -1,13 +1,35 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getChildren} from '../node-traversal/get-children'
+import {getBlock} from '../node-traversal/is-block'
+import {parentPath} from '../slate/path/parent-path'
 import type {BlockPath} from '../types/paths'
+import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the first block at the current container scope.
+ *
+ * When the focus is inside an editable container (e.g. a code block's line),
+ * this returns the first block within that container (the first line). When
+ * the focus is at root, or there is no selection, this returns the first
+ * block in the document.
+ *
  * @public
  */
 export const getFirstBlock: EditorSelector<
   {node: PortableTextBlock; path: BlockPath} | undefined
 > = (snapshot) => {
+  const focusBlock = getFocusBlock(snapshot)
+
+  if (focusBlock) {
+    const siblings = getChildren(snapshot.context, parentPath(focusBlock.path))
+    const first = siblings.at(0)
+
+    if (first) {
+      return getBlock(snapshot.context, first.path)
+    }
+  }
+
   const node = snapshot.context.value[0]
 
   return node ? {node, path: [{_key: node._key}]} : undefined

--- a/packages/editor/src/selectors/selector.get-focus-block-object.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block-object.ts
@@ -1,10 +1,17 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {isEditableContainer} from '../schema/is-editable-container'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import type {BlockPath} from '../types/paths'
 import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the void block object containing the focus selection, resolved at
+ * any depth.
+ *
+ * Excludes text blocks and editable containers (which have their own children
+ * and are not "void"). When the focus is at root, behavior is unchanged.
+ *
  * @public
  */
 export const getFocusBlockObject: EditorSelector<
@@ -12,7 +19,17 @@ export const getFocusBlockObject: EditorSelector<
 > = (snapshot) => {
   const focusBlock = getFocusBlock(snapshot)
 
-  return focusBlock && !isTextBlockNode(snapshot.context, focusBlock.node)
-    ? {node: focusBlock.node, path: focusBlock.path}
-    : undefined
+  if (!focusBlock) {
+    return undefined
+  }
+
+  if (isTextBlockNode(snapshot.context, focusBlock.node)) {
+    return undefined
+  }
+
+  if (isEditableContainer(snapshot.context, focusBlock.node, focusBlock.path)) {
+    return undefined
+  }
+
+  return {node: focusBlock.node, path: focusBlock.path}
 }

--- a/packages/editor/src/selectors/selector.get-focus-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block.ts
@@ -1,23 +1,25 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import type {BlockPath} from '../types/paths'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 /**
+ * Returns the block containing the focus selection, resolved at any depth.
+ *
+ * When the focus is inside an editable container (e.g. a code block's line),
+ * this returns the innermost block ancestor (the line), not the outer
+ * container. When the focus is at root, behavior is unchanged.
+ *
  * @public
  */
 export const getFocusBlock: EditorSelector<
   {node: PortableTextBlock; path: BlockPath} | undefined
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return undefined
   }
 
-  const key = getBlockKeyFromSelectionPoint(snapshot.context.selection.focus)
-  const index = key ? snapshot.blockIndexMap.get(key) : undefined
-
-  const node =
-    index !== undefined ? snapshot.context.value.at(index) : undefined
-
-  return node && key ? {node, path: [{_key: key}]} : undefined
+  return getEnclosingBlock(snapshot.context, selection.focus.path)
 }

--- a/packages/editor/src/selectors/selector.get-focus-child.ts
+++ b/packages/editor/src/selectors/selector.get-focus-child.ts
@@ -1,10 +1,12 @@
 import type {PortableTextObject, PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getInline} from '../node-traversal/get-inline'
 import type {ChildPath} from '../types/paths'
-import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 
 /**
+ * Returns the child (span or inline object) containing the focus selection,
+ * resolved at any depth.
+ *
  * @public
  */
 export const getFocusChild: EditorSelector<
@@ -14,23 +16,11 @@ export const getFocusChild: EditorSelector<
     }
   | undefined
 > = (snapshot) => {
-  if (!snapshot.context.selection) {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return undefined
   }
 
-  const focusBlock = getFocusTextBlock(snapshot)
-
-  if (!focusBlock) {
-    return undefined
-  }
-
-  const key = getChildKeyFromSelectionPoint(snapshot.context.selection.focus)
-
-  const node = key
-    ? focusBlock.node.children.find((span) => span._key === key)
-    : undefined
-
-  return node && key
-    ? {node, path: [...focusBlock.path, 'children', {_key: key}]}
-    : undefined
+  return getInline(snapshot.context, selection.focus.path)
 }

--- a/packages/editor/src/selectors/selector.get-focus-inline-object.ts
+++ b/packages/editor/src/selectors/selector.get-focus-inline-object.ts
@@ -5,6 +5,9 @@ import type {ChildPath} from '../types/paths'
 import {getFocusChild} from './selector.get-focus-child'
 
 /**
+ * Returns the inline object containing the focus selection, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getFocusInlineObject: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-focus-list-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-list-block.ts
@@ -5,6 +5,9 @@ import {isListBlock} from '../utils/parse-blocks'
 import {getFocusTextBlock} from './selector.get-focus-text-block'
 
 /**
+ * Returns the list block containing the focus selection, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getFocusListBlock: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-focus-span.ts
+++ b/packages/editor/src/selectors/selector.get-focus-span.ts
@@ -4,6 +4,8 @@ import type {ChildPath} from '../types/paths'
 import {getFocusChild} from './selector.get-focus-child'
 
 /**
+ * Returns the span containing the focus selection, resolved at any depth.
+ *
  * @public
  */
 export const getFocusSpan: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-focus-text-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-text-block.ts
@@ -4,6 +4,12 @@ import type {BlockPath} from '../types/paths'
 import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the text block containing the focus selection, resolved at any depth.
+ *
+ * When the focus is inside an editable container (e.g. a code block's line),
+ * this returns the innermost text block ancestor (the line), not the outer
+ * container. When the focus is at root, behavior is unchanged.
+ *
  * @public
  */
 export const getFocusTextBlock: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-last-block.ts
+++ b/packages/editor/src/selectors/selector.get-last-block.ts
@@ -1,16 +1,36 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getChildren} from '../node-traversal/get-children'
+import {getBlock} from '../node-traversal/is-block'
+import {parentPath} from '../slate/path/parent-path'
 import type {BlockPath} from '../types/paths'
+import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the last block at the current container scope.
+ *
+ * When the focus is inside an editable container (e.g. a code block's line),
+ * this returns the last block within that container (the last line). When
+ * the focus is at root, or there is no selection, this returns the last
+ * block in the document.
+ *
  * @public
  */
 export const getLastBlock: EditorSelector<
   {node: PortableTextBlock; path: BlockPath} | undefined
 > = (snapshot) => {
-  const node = snapshot.context.value[snapshot.context.value.length - 1]
-    ? snapshot.context.value[snapshot.context.value.length - 1]
-    : undefined
+  const focusBlock = getFocusBlock(snapshot)
+
+  if (focusBlock) {
+    const siblings = getChildren(snapshot.context, parentPath(focusBlock.path))
+    const last = siblings.at(-1)
+
+    if (last) {
+      return getBlock(snapshot.context, last.path)
+    }
+  }
+
+  const node = snapshot.context.value.at(-1)
 
   return node ? {node, path: [{_key: node._key}]} : undefined
 }

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -1,9 +1,10 @@
 import type {EditorSelector} from '../editor/editor-selector'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {isBlockPath} from '../types/paths'
 import {blockOffsetToSpanSelectionPoint} from '../utils/util.block-offset'
 import {isSelectionExpanded} from '../utils/util.is-selection-expanded'
 import {getFocusSpan} from './selector.get-focus-span'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getNextSpan} from './selector.get-next-span'
 import {getPreviousSpan} from './selector.get-previous-span'
 import {getSelectedSpans} from './selector.get-selected-spans'
@@ -35,11 +36,6 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
   }
 
   let selection = snapshot.context.selection
-  const focusTextBlock = getFocusTextBlock(snapshot)
-
-  if (!focusTextBlock) {
-    return undefined
-  }
 
   if (isBlockPath(selection.anchor.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
@@ -98,24 +94,54 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
       },
     })
 
-    let index = 0
-    let marks: Array<string> = []
+    // Per-span info: marks present, the decorator names declared by the
+    // span's block sub-schema, and the annotation markDef keys declared on
+    // the span's enclosing block. Used so that out-of-scope spans (where
+    // the mark cannot apply) don't disqualify the mark across the
+    // selection.
+    const spanInfo = selectedSpans.map((span) => {
+      const block = getAncestorTextBlock(snapshot.context, span.path)
+      return {
+        marks: span.node.marks ?? [],
+        decoratorNames: getBlockSubSchema(
+          snapshot.context,
+          span.path,
+        ).decorators.map((decorator) => decorator.name),
+        markDefKeys: (block?.node.markDefs ?? []).map(
+          (markDef) => markDef._key,
+        ),
+      }
+    })
 
-    for (const span of selectedSpans) {
-      if (index === 0) {
-        marks = span.node.marks ?? []
-      } else {
-        if (span.node.marks?.length === 0) {
-          marks = []
+    // Candidate marks: union of all marks present on any selected span.
+    const candidateMarks = new Set<string>()
+    for (const {marks: spanMarks} of spanInfo) {
+      for (const mark of spanMarks) {
+        candidateMarks.add(mark)
+      }
+    }
+
+    const marks: Array<string> = []
+    for (const candidate of candidateMarks) {
+      const isDecoratorSomewhere = spanInfo.some(({decoratorNames}) =>
+        decoratorNames.includes(candidate),
+      )
+      let active = true
+      for (const {marks: spanMarks, decoratorNames, markDefKeys} of spanInfo) {
+        const inScope = isDecoratorSomewhere
+          ? decoratorNames.includes(candidate)
+          : markDefKeys.includes(candidate)
+        if (!inScope) {
           continue
         }
-
-        marks = marks.filter((mark) =>
-          (span.node.marks ?? []).some((spanMark) => spanMark === mark),
-        )
+        if (!spanMarks.includes(candidate)) {
+          active = false
+          break
+        }
       }
-
-      index++
+      if (active) {
+        marks.push(candidate)
+      }
     }
 
     return {
@@ -124,7 +150,8 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
     }
   }
 
-  const decorators = snapshot.context.schema.decorators.map(
+  const focusSubSchema = getBlockSubSchema(snapshot.context, focusSpan.path)
+  const decorators = focusSubSchema.decorators.map(
     (decorator) => decorator.name,
   )
   const marks = focusSpan.node.marks ?? []

--- a/packages/editor/src/selectors/selector.get-next-block.ts
+++ b/packages/editor/src/selectors/selector.get-next-block.ts
@@ -1,9 +1,17 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getSibling} from '../node-traversal/get-sibling'
+import {getBlock} from '../node-traversal/is-block'
 import type {BlockPath} from '../types/paths'
 import {getSelectionEndBlock} from './selector.get-selection-end-block'
 
 /**
+ * Returns the block after the selection's end block within the same
+ * container scope, if any.
+ *
+ * Siblings are resolved within the enclosing container (or the document root
+ * if the selection is at root level). Never crosses container boundaries.
+ *
  * @public
  */
 export const getNextBlock: EditorSelector<
@@ -15,15 +23,11 @@ export const getNextBlock: EditorSelector<
     return undefined
   }
 
-  const index = snapshot.blockIndexMap.get(selectionEndBlock.node._key)
+  const next = getSibling(snapshot.context, selectionEndBlock.path, 'next')
 
-  if (index === undefined || index === snapshot.context.value.length - 1) {
+  if (!next) {
     return undefined
   }
 
-  const nextBlock = snapshot.context.value.at(index + 1)
-
-  return nextBlock
-    ? {node: nextBlock, path: [{_key: nextBlock._key}]}
-    : undefined
+  return getBlock(snapshot.context, next.path)
 }

--- a/packages/editor/src/selectors/selector.get-next-inline-object.ts
+++ b/packages/editor/src/selectors/selector.get-next-inline-object.ts
@@ -1,54 +1,32 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isSpanNode} from '../slate/node/is-span-node'
+import {findSibling} from '../node-traversal/find-sibling'
+import {isObjectNode} from '../slate/node/is-object-node'
 import type {ChildPath} from '../types/paths'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionEndPoint} from './selector.get-selection-end-point'
 
 /**
+ * Returns the inline object after the selection end within the same text
+ * block, resolved at any depth.
+ *
  * @public
  */
 export const getNextInlineObject: EditorSelector<
-  | {
-      node: PortableTextObject
-      path: ChildPath
-    }
-  | undefined
+  {node: PortableTextObject; path: ChildPath} | undefined
 > = (snapshot) => {
-  const focusTextBlock = getFocusTextBlock(snapshot)
-  const selectionEndPoint = getSelectionEndPoint(snapshot)
-  const selectionEndPointChildKey =
-    selectionEndPoint && isKeyedSegment(selectionEndPoint.path[2])
-      ? selectionEndPoint.path[2]._key
-      : undefined
+  const point = getSelectionEndPoint(snapshot)
 
-  if (!focusTextBlock || !selectionEndPointChildKey) {
+  if (!point) {
     return undefined
   }
 
-  let endPointChildFound = false
-  let inlineObject:
-    | {
-        node: PortableTextObject
-        path: ChildPath
-      }
-    | undefined
+  const sibling = findSibling(
+    snapshot.context,
+    point.path,
+    'next',
+    (entry): entry is {node: PortableTextObject; path: ChildPath} =>
+      isObjectNode({schema: snapshot.context.schema}, entry.node),
+  )
 
-  for (const child of focusTextBlock.node.children) {
-    if (child._key === selectionEndPointChildKey) {
-      endPointChildFound = true
-      continue
-    }
-
-    if (!isSpanNode(snapshot.context, child) && endPointChildFound) {
-      inlineObject = {
-        node: child,
-        path: [...focusTextBlock.path, 'children', {_key: child._key}],
-      }
-      break
-    }
-  }
-
-  return inlineObject
+  return sibling
 }

--- a/packages/editor/src/selectors/selector.get-next-inline-objects.ts
+++ b/packages/editor/src/selectors/selector.get-next-inline-objects.ts
@@ -1,49 +1,55 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isSpanNode} from '../slate/node/is-span-node'
+import {getChildren} from '../node-traversal/get-children'
+import {isObjectNode} from '../slate/node/is-object-node'
+import {parentPath} from '../slate/path/parent-path'
 import type {ChildPath} from '../types/paths'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionEndPoint} from './selector.get-selection-end-point'
 
 /**
+ * Returns all inline objects after the selection end within the same text
+ * block, resolved at any depth.
+ *
  * @public
  */
 export const getNextInlineObjects: EditorSelector<
-  Array<{
-    node: PortableTextObject
-    path: ChildPath
-  }>
+  Array<{node: PortableTextObject; path: ChildPath}>
 > = (snapshot) => {
-  const focusTextBlock = getFocusTextBlock(snapshot)
-  const selectionEndPoint = getSelectionEndPoint(snapshot)
-  const selectionEndPointChildKey =
-    selectionEndPoint && isKeyedSegment(selectionEndPoint.path[2])
-      ? selectionEndPoint.path[2]._key
-      : undefined
+  const point = getSelectionEndPoint(snapshot)
 
-  if (!focusTextBlock || !selectionEndPointChildKey) {
+  if (!point) {
     return []
   }
 
-  let endPointChildFound = false
-  const inlineObjects: Array<{
-    node: PortableTextObject
-    path: ChildPath
-  }> = []
+  const endSegment = point.path.at(-1)
+  const endKey = isKeyedSegment(endSegment) ? endSegment._key : undefined
 
-  for (const child of focusTextBlock.node.children) {
-    if (child._key === selectionEndPointChildKey) {
-      endPointChildFound = true
+  if (!endKey) {
+    return []
+  }
+
+  const children = getChildren(snapshot.context, parentPath(point.path))
+  const inlineObjects: Array<{node: PortableTextObject; path: ChildPath}> = []
+  let endFound = false
+
+  for (const child of children) {
+    const segment = child.path.at(-1)
+    const childKey = isKeyedSegment(segment) ? segment._key : undefined
+
+    if (childKey === endKey) {
+      endFound = true
       continue
     }
 
-    if (!isSpanNode(snapshot.context, child) && endPointChildFound) {
+    if (
+      endFound &&
+      isObjectNode({schema: snapshot.context.schema}, child.node)
+    ) {
       inlineObjects.push({
-        node: child,
-        path: [...focusTextBlock.path, 'children', {_key: child._key}],
+        node: child.node,
+        path: child.path,
       })
-      break
     }
   }
 

--- a/packages/editor/src/selectors/selector.get-next-span.ts
+++ b/packages/editor/src/selectors/selector.get-next-span.ts
@@ -1,56 +1,29 @@
-import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
+import {isSpan, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {findSibling} from '../node-traversal/find-sibling'
 import type {Path} from '../slate/interfaces/path'
-import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
-import {getSelectionEndBlock} from './selector.get-selection-end-block'
 import {getSelectionEndPoint} from './selector.get-selection-end-point'
 
 /**
+ * Returns the span after the selection end within the same text block,
+ * resolved at any depth.
+ *
  * @public
  */
 export const getNextSpan: EditorSelector<
-  | {
-      node: PortableTextSpan
-      path: Path
-    }
-  | undefined
+  {node: PortableTextSpan; path: Path} | undefined
 > = (snapshot) => {
-  const selectionEndBlock = getSelectionEndBlock(snapshot)
-  const selectionEndPoint = getSelectionEndPoint(snapshot)
+  const point = getSelectionEndPoint(snapshot)
 
-  if (!selectionEndBlock || !selectionEndPoint) {
+  if (!point) {
     return undefined
   }
 
-  if (!isTextBlock(snapshot.context, selectionEndBlock.node)) {
-    return undefined
-  }
-
-  const selectionEndPointChildKey =
-    getChildKeyFromSelectionPoint(selectionEndPoint)
-
-  let endPointChildFound = false
-  let nextSpan:
-    | {
-        node: PortableTextSpan
-        path: Path
-      }
-    | undefined
-
-  for (const child of selectionEndBlock.node.children) {
-    if (child._key === selectionEndPointChildKey) {
-      endPointChildFound = true
-      continue
-    }
-
-    if (isSpan(snapshot.context, child) && endPointChildFound) {
-      nextSpan = {
-        node: child,
-        path: [...selectionEndBlock.path, 'children', {_key: child._key}],
-      }
-      break
-    }
-  }
-
-  return nextSpan
+  return findSibling(
+    snapshot.context,
+    point.path,
+    'next',
+    (entry): entry is {node: PortableTextSpan; path: Path} =>
+      isSpan(snapshot.context, entry.node),
+  )
 }

--- a/packages/editor/src/selectors/selector.get-previous-block.ts
+++ b/packages/editor/src/selectors/selector.get-previous-block.ts
@@ -1,9 +1,17 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getSibling} from '../node-traversal/get-sibling'
+import {getBlock} from '../node-traversal/is-block'
 import type {BlockPath} from '../types/paths'
 import {getSelectionStartBlock} from './selector.get-selection-start-block'
 
 /**
+ * Returns the block before the selection's start block within the same
+ * container scope, if any.
+ *
+ * Siblings are resolved within the enclosing container (or the document root
+ * if the selection is at root level). Never crosses container boundaries.
+ *
  * @public
  */
 export const getPreviousBlock: EditorSelector<
@@ -15,15 +23,15 @@ export const getPreviousBlock: EditorSelector<
     return undefined
   }
 
-  const index = snapshot.blockIndexMap.get(selectionStartBlock.node._key)
+  const previous = getSibling(
+    snapshot.context,
+    selectionStartBlock.path,
+    'previous',
+  )
 
-  if (index === undefined || index === 0) {
+  if (!previous) {
     return undefined
   }
 
-  const previousBlock = snapshot.context.value.at(index - 1)
-
-  return previousBlock
-    ? {node: previousBlock, path: [{_key: previousBlock._key}]}
-    : undefined
+  return getBlock(snapshot.context, previous.path)
 }

--- a/packages/editor/src/selectors/selector.get-previous-inline-object.ts
+++ b/packages/editor/src/selectors/selector.get-previous-inline-object.ts
@@ -1,51 +1,32 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isSpanNode} from '../slate/node/is-span-node'
+import {findSibling} from '../node-traversal/find-sibling'
+import {isObjectNode} from '../slate/node/is-object-node'
 import type {ChildPath} from '../types/paths'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionStartPoint} from './selector.get-selection-start-point'
 
 /**
+ * Returns the inline object before the selection start within the same text
+ * block, resolved at any depth.
+ *
  * @public
  */
 export const getPreviousInlineObject: EditorSelector<
-  | {
-      node: PortableTextObject
-      path: ChildPath
-    }
-  | undefined
+  {node: PortableTextObject; path: ChildPath} | undefined
 > = (snapshot) => {
-  const focusTextBlock = getFocusTextBlock(snapshot)
-  const selectionStartPoint = getSelectionStartPoint(snapshot)
-  const selectionStartPointChildKey =
-    selectionStartPoint && isKeyedSegment(selectionStartPoint.path[2])
-      ? selectionStartPoint.path[2]._key
-      : undefined
+  const point = getSelectionStartPoint(snapshot)
 
-  if (!focusTextBlock || !selectionStartPointChildKey) {
+  if (!point) {
     return undefined
   }
 
-  let inlineObject:
-    | {
-        node: PortableTextObject
-        path: ChildPath
-      }
-    | undefined
+  const sibling = findSibling(
+    snapshot.context,
+    point.path,
+    'previous',
+    (entry): entry is {node: PortableTextObject; path: ChildPath} =>
+      isObjectNode({schema: snapshot.context.schema}, entry.node),
+  )
 
-  for (const child of focusTextBlock.node.children) {
-    if (child._key === selectionStartPointChildKey) {
-      break
-    }
-
-    if (!isSpanNode(snapshot.context, child)) {
-      inlineObject = {
-        node: child,
-        path: [...focusTextBlock.path, 'children', {_key: child._key}],
-      }
-    }
-  }
-
-  return inlineObject
+  return sibling
 }

--- a/packages/editor/src/selectors/selector.get-previous-inline-objects.ts
+++ b/packages/editor/src/selectors/selector.get-previous-inline-objects.ts
@@ -1,45 +1,49 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
-import {isSpanNode} from '../slate/node/is-span-node'
+import {getChildren} from '../node-traversal/get-children'
+import {isObjectNode} from '../slate/node/is-object-node'
+import {parentPath} from '../slate/path/parent-path'
 import type {ChildPath} from '../types/paths'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionStartPoint} from './selector.get-selection-start-point'
 
 /**
+ * Returns all inline objects before the selection start within the same text
+ * block, resolved at any depth.
+ *
  * @public
  */
 export const getPreviousInlineObjects: EditorSelector<
-  Array<{
-    node: PortableTextObject
-    path: ChildPath
-  }>
+  Array<{node: PortableTextObject; path: ChildPath}>
 > = (snapshot) => {
-  const focusTextBlock = getFocusTextBlock(snapshot)
-  const selectionStartPoint = getSelectionStartPoint(snapshot)
-  const selectionStartPointChildKey =
-    selectionStartPoint && isKeyedSegment(selectionStartPoint.path[2])
-      ? selectionStartPoint.path[2]._key
-      : undefined
+  const point = getSelectionStartPoint(snapshot)
 
-  if (!focusTextBlock || !selectionStartPointChildKey) {
+  if (!point) {
     return []
   }
 
-  const inlineObjects: Array<{
-    node: PortableTextObject
-    path: ChildPath
-  }> = []
+  const startSegment = point.path.at(-1)
+  const startKey = isKeyedSegment(startSegment) ? startSegment._key : undefined
 
-  for (const child of focusTextBlock.node.children) {
-    if (child._key === selectionStartPointChildKey) {
+  if (!startKey) {
+    return []
+  }
+
+  const children = getChildren(snapshot.context, parentPath(point.path))
+  const inlineObjects: Array<{node: PortableTextObject; path: ChildPath}> = []
+
+  for (const child of children) {
+    const segment = child.path.at(-1)
+    const childKey = isKeyedSegment(segment) ? segment._key : undefined
+
+    if (childKey === startKey) {
       break
     }
 
-    if (!isSpanNode(snapshot.context, child)) {
+    if (isObjectNode({schema: snapshot.context.schema}, child.node)) {
       inlineObjects.push({
-        node: child,
-        path: [...focusTextBlock.path, 'children', {_key: child._key}],
+        node: child.node,
+        path: child.path,
       })
     }
   }

--- a/packages/editor/src/selectors/selector.get-previous-span.ts
+++ b/packages/editor/src/selectors/selector.get-previous-span.ts
@@ -1,53 +1,29 @@
-import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
+import {isSpan, type PortableTextSpan} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {findSibling} from '../node-traversal/find-sibling'
 import type {Path} from '../slate/interfaces/path'
-import {getChildKeyFromSelectionPoint} from '../utils/util.selection-point'
-import {getSelectionStartBlock} from './selector.get-selection-start-block'
 import {getSelectionStartPoint} from './selector.get-selection-start-point'
 
 /**
+ * Returns the span before the selection start within the same text block,
+ * resolved at any depth.
+ *
  * @public
  */
 export const getPreviousSpan: EditorSelector<
-  | {
-      node: PortableTextSpan
-      path: Path
-    }
-  | undefined
+  {node: PortableTextSpan; path: Path} | undefined
 > = (snapshot) => {
-  const selectionStartBlock = getSelectionStartBlock(snapshot)
-  const selectionStartPoint = getSelectionStartPoint(snapshot)
+  const point = getSelectionStartPoint(snapshot)
 
-  if (!selectionStartBlock || !selectionStartPoint) {
+  if (!point) {
     return undefined
   }
 
-  if (!isTextBlock(snapshot.context, selectionStartBlock.node)) {
-    return undefined
-  }
-
-  const selectionStartPointChildKey =
-    getChildKeyFromSelectionPoint(selectionStartPoint)
-
-  let previousSpan:
-    | {
-        node: PortableTextSpan
-        path: Path
-      }
-    | undefined
-
-  for (const child of selectionStartBlock.node.children) {
-    if (child._key === selectionStartPointChildKey) {
-      break
-    }
-
-    if (isSpan(snapshot.context, child)) {
-      previousSpan = {
-        node: child,
-        path: [...selectionStartBlock.path, 'children', {_key: child._key}],
-      }
-    }
-  }
-
-  return previousSpan
+  return findSibling(
+    snapshot.context,
+    point.path,
+    'previous',
+    (entry): entry is {node: PortableTextSpan; path: Path} =>
+      isSpan(snapshot.context, entry.node),
+  )
 }

--- a/packages/editor/src/selectors/selector.get-selected-children.ts
+++ b/packages/editor/src/selectors/selector.get-selected-children.ts
@@ -39,16 +39,13 @@ export function getSelectedChildren<
       return []
     }
 
-    const startChildKey = lastKeyedKey(startPoint.path)
-    const endChildKey = lastKeyedKey(endPoint.path)
+    const startChildKey = startPoint.path.findLast(isKeyedSegment)?._key
+    const endChildKey = endPoint.path.findLast(isKeyedSegment)?._key
 
     const result: Array<SelectedChild<TChild>> = []
 
     for (const entry of getNodes(
-      {
-        ...snapshot.context,
-        blockIndexMap: snapshot.blockIndexMap,
-      },
+      {...snapshot.context, blockIndexMap: snapshot.blockIndexMap},
       {
         from: startPoint.path,
         to: endPoint.path,
@@ -80,14 +77,4 @@ export function getSelectedChildren<
 
     return result
   }
-}
-
-function lastKeyedKey(path: Path): string | undefined {
-  for (let i = path.length - 1; i >= 0; i--) {
-    const segment = path[i]
-    if (isKeyedSegment(segment)) {
-      return segment._key
-    }
-  }
-  return undefined
 }

--- a/packages/editor/src/selectors/selector.get-selected-spans.ts
+++ b/packages/editor/src/selectors/selector.get-selected-spans.ts
@@ -4,6 +4,8 @@ import type {ChildPath} from '../types/paths'
 import {getSelectedChildren} from './selector.get-selected-children'
 
 /**
+ * Returns the spans touched by the selection, resolved at any depth.
+ *
  * @public
  */
 export const getSelectedSpans: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-selection-end-block.ts
+++ b/packages/editor/src/selectors/selector.get-selection-end-block.ts
@@ -5,6 +5,9 @@ import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the block containing the selection's end point, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getSelectionEndBlock: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-selection-end-child.ts
+++ b/packages/editor/src/selectors/selector.get-selection-end-child.ts
@@ -5,6 +5,9 @@ import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getFocusChild} from './selector.get-focus-child'
 
 /**
+ * Returns the child containing the selection's end point, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getSelectionEndChild: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-selection-start-block.ts
+++ b/packages/editor/src/selectors/selector.get-selection-start-block.ts
@@ -5,6 +5,9 @@ import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
 import {getFocusBlock} from './selector.get-focus-block'
 
 /**
+ * Returns the block containing the selection's start point, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getSelectionStartBlock: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-selection-start-child.ts
+++ b/packages/editor/src/selectors/selector.get-selection-start-child.ts
@@ -5,6 +5,9 @@ import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
 import {getFocusChild} from './selector.get-focus-child'
 
 /**
+ * Returns the child containing the selection's start point, resolved at any
+ * depth.
+ *
  * @public
  */
 export const getSelectionStartChild: EditorSelector<

--- a/packages/editor/src/selectors/selector.get-selection-text.ts
+++ b/packages/editor/src/selectors/selector.get-selection-text.ts
@@ -1,5 +1,8 @@
-import {isSpan, isTextBlock} from '@portabletext/schema'
+import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import type {EditorContext} from '../editor/editor-snapshot'
+import {getNodeChildren} from '../node-traversal/get-children'
+import type {Node} from '../slate/interfaces/node'
 import {getSelectedValue} from './selector.get-selected-value'
 
 /**
@@ -8,20 +11,34 @@ import {getSelectedValue} from './selector.get-selected-value'
 export const getSelectionText: EditorSelector<string> = (snapshot) => {
   const selectedValue = getSelectedValue(snapshot)
 
-  return selectedValue.reduce((text, block) => {
-    if (!isTextBlock(snapshot.context, block)) {
-      return text
+  return collectText(snapshot.context, selectedValue, '')
+}
+
+function collectText(
+  context: Pick<EditorContext, 'schema' | 'containers'>,
+  blocks: ReadonlyArray<Node | PortableTextBlock>,
+  scopePath: string,
+): string {
+  let text = ''
+
+  for (const block of blocks) {
+    if (isTextBlock(context, block)) {
+      for (const child of block.children) {
+        if (isSpan(context, child)) {
+          text += child.text
+        }
+      }
+      continue
     }
 
-    return (
-      text +
-      block.children.reduce((text, child) => {
-        if (isSpan(snapshot.context, child)) {
-          return text + child.text
-        }
+    const childInfo = getNodeChildren(context, block, scopePath)
 
-        return text
-      }, '')
-    )
-  }, '')
+    if (!childInfo) {
+      continue
+    }
+
+    text += collectText(context, childInfo.children, childInfo.scopePath)
+  }
+
+  return text
 }

--- a/packages/editor/src/selectors/selector.get-text-after.ts
+++ b/packages/editor/src/selectors/selector.get-text-after.ts
@@ -1,7 +1,7 @@
 import type {EditorSelector} from '../editor/editor-selector'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
-import {getFocusBlock} from './selector.get-focus-block'
+import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionText} from './selector.get-selection-text'
 
 /**
@@ -13,7 +13,7 @@ export const getBlockTextAfter: EditorSelector<string> = (snapshot) => {
   }
 
   const endPoint = getSelectionEndPoint(snapshot.context.selection)
-  const block = getFocusBlock({
+  const block = getFocusTextBlock({
     ...snapshot,
     context: {
       ...snapshot.context,

--- a/packages/editor/src/selectors/selector.get-text-before.ts
+++ b/packages/editor/src/selectors/selector.get-text-before.ts
@@ -1,7 +1,7 @@
 import type {EditorSelector} from '../editor/editor-selector'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
-import {getFocusBlock} from './selector.get-focus-block'
+import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getSelectionText} from './selector.get-selection-text'
 
 /**
@@ -13,7 +13,7 @@ export const getBlockTextBefore: EditorSelector<string> = (snapshot) => {
   }
 
   const startPoint = getSelectionStartPoint(snapshot.context.selection)
-  const block = getFocusBlock({
+  const block = getFocusTextBlock({
     ...snapshot,
     context: {
       ...snapshot.context,

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -1,3 +1,4 @@
+import {hasNode} from '../node-traversal/has-node'
 import type {EditorSelection, EditorSelectionPoint} from '../types/editor'
 import {
   getSelectionEndPoint,
@@ -5,11 +6,13 @@ import {
   isEqualSelectionPoints,
 } from '../utils'
 import {comparePoints} from '../utils/util.compare-points'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 import type {EditorSelector} from './../editor/editor-selector'
 import type {EditorSnapshot} from './../editor/editor-snapshot'
 
 /**
+ * Returns true if the supplied selection overlaps with the editor's current
+ * selection. Resolves at any container depth.
+ *
  * @public
  */
 export function isOverlappingSelection(
@@ -27,57 +30,21 @@ export function isOverlappingSelection(
     const editorSelectionStart = getSelectionStartPoint(editorSelection)
     const editorSelectionEnd = getSelectionEndPoint(editorSelection)
 
-    const selectionStartBlockKey = getBlockKeyFromSelectionPoint(selectionStart)
-    const selectionEndBlockKey = getBlockKeyFromSelectionPoint(selectionEnd)
-    const editorSelectionStartBlockKey =
-      getBlockKeyFromSelectionPoint(editorSelectionStart)
-    const editorSelectionEndBlockKey =
-      getBlockKeyFromSelectionPoint(editorSelectionEnd)
-
     if (
-      !selectionStartBlockKey ||
-      !selectionEndBlockKey ||
-      !editorSelectionStartBlockKey ||
-      !editorSelectionEndBlockKey
+      !selectionStart ||
+      !selectionEnd ||
+      !editorSelectionStart ||
+      !editorSelectionEnd
     ) {
       return false
     }
 
-    const selectionStartBlockIndex = snapshot.blockIndexMap.get(
-      selectionStartBlockKey,
-    )
-    const selectionEndBlockIndex =
-      snapshot.blockIndexMap.get(selectionEndBlockKey)
-    const editorSelectionStartBlockIndex = snapshot.blockIndexMap.get(
-      editorSelectionStartBlockKey,
-    )
-    const editorSelectionEndBlockIndex = snapshot.blockIndexMap.get(
-      editorSelectionEndBlockKey,
-    )
-
     if (
-      selectionStartBlockIndex === undefined ||
-      selectionEndBlockIndex === undefined ||
-      editorSelectionStartBlockIndex === undefined ||
-      editorSelectionEndBlockIndex === undefined
+      !hasNode(snapshot.context, selectionStart.path) ||
+      !hasNode(snapshot.context, selectionEnd.path) ||
+      !hasNode(snapshot.context, editorSelectionStart.path) ||
+      !hasNode(snapshot.context, editorSelectionEnd.path)
     ) {
-      return false
-    }
-
-    const [selectionMinBlockIndex, selectionMaxBlockIndex] =
-      selectionStartBlockIndex <= selectionEndBlockIndex
-        ? [selectionStartBlockIndex, selectionEndBlockIndex]
-        : [selectionEndBlockIndex, selectionStartBlockIndex]
-    const [editorSelectionMinBlockIndex, editorSelectionMaxBlockIndex] =
-      editorSelectionStartBlockIndex <= editorSelectionEndBlockIndex
-        ? [editorSelectionStartBlockIndex, editorSelectionEndBlockIndex]
-        : [editorSelectionEndBlockIndex, editorSelectionStartBlockIndex]
-
-    if (selectionMaxBlockIndex < editorSelectionMinBlockIndex) {
-      return false
-    }
-
-    if (selectionMinBlockIndex > editorSelectionMaxBlockIndex) {
       return false
     }
 
@@ -93,7 +60,6 @@ export function isOverlappingSelection(
 
 /**
  * Check if selections overlap at the point level.
- * Called after confirming block ranges overlap.
  */
 function hasPointLevelOverlap(
   snapshot: EditorSnapshot,

--- a/packages/editor/tests/undo-merge-blocks.test.tsx
+++ b/packages/editor/tests/undo-merge-blocks.test.tsx
@@ -4,9 +4,7 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import type {Patch} from '../src'
-import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
-import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('merge blocks + undo emits well-formed patches', () => {
@@ -93,134 +91,6 @@ describe('merge blocks + undo emits well-formed patches', () => {
 
     // Replaying the emitted undo patches on the post-merge value must not
     // throw and must reproduce the pre-merge state.
-    expect(() => applyAll(expectedPostMerge, patches)).not.toThrow()
-  })
-
-  test('Backspace merge inside a container + undo does not emit malformed patches', async () => {
-    const keyGenerator = createTestKeyGenerator()
-    const calloutKey = keyGenerator()
-    const block1Key = keyGenerator()
-    const span1Key = keyGenerator()
-    const block2Key = keyGenerator()
-    const span2Key = keyGenerator()
-
-    const initialValue = [
-      {
-        _type: 'callout',
-        _key: calloutKey,
-        content: [
-          {
-            _type: 'block',
-            _key: block1Key,
-            children: [{_type: 'span', _key: span1Key, text: 'foo', marks: []}],
-            markDefs: [],
-            style: 'normal',
-          },
-          {
-            _type: 'block',
-            _key: block2Key,
-            children: [{_type: 'span', _key: span2Key, text: 'bar', marks: []}],
-            markDefs: [],
-            style: 'normal',
-          },
-        ],
-      },
-    ]
-
-    const patches: Array<Patch> = []
-
-    const {editor, locator} = await createTestEditor({
-      keyGenerator,
-      schemaDefinition: defineSchema({
-        blockObjects: [
-          {
-            name: 'callout',
-            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
-          },
-        ],
-      }),
-      initialValue,
-      children: (
-        <>
-          <ContainerPlugin
-            containers={[
-              defineContainer({
-                scope: '$..callout',
-                field: 'content',
-                render: ({children}) => <>{children}</>,
-              }),
-            ]}
-          />
-          <EventListenerPlugin
-            on={(event) => {
-              if (event.type === 'patch') {
-                patches.push(event.patch)
-              }
-            }}
-          />
-        </>
-      ),
-    })
-
-    await userEvent.click(locator)
-
-    editor.send({
-      type: 'select',
-      at: {
-        anchor: {
-          path: [
-            {_key: calloutKey},
-            'content',
-            {_key: block2Key},
-            'children',
-            {_key: span2Key},
-          ],
-          offset: 0,
-        },
-        focus: {
-          path: [
-            {_key: calloutKey},
-            'content',
-            {_key: block2Key},
-            'children',
-            {_key: span2Key},
-          ],
-          offset: 0,
-        },
-      },
-    })
-
-    await userEvent.keyboard('{Backspace}')
-
-    const expectedPostMerge = [
-      {
-        _type: 'callout',
-        _key: calloutKey,
-        content: [
-          {
-            _type: 'block',
-            _key: block1Key,
-            children: [
-              {_type: 'span', _key: span1Key, text: 'foobar', marks: []},
-            ],
-            markDefs: [],
-            style: 'normal',
-          },
-        ],
-      },
-    ]
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual(expectedPostMerge)
-    })
-
-    patches.length = 0
-    editor.send({type: 'history.undo'})
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual(initialValue)
-    })
-
     expect(() => applyAll(expectedPostMerge, patches)).not.toThrow()
   })
 })


### PR DESCRIPTION
Selectors that previously read `blockIndexMap` directly to resolve paths at the root level are now depth-agnostic. A selection point inside a callout's text block, a code-block's line, or a table cell flows through every selector the same way a root-level point does, with no special casing.

The selectors in scope are the ones already exported from `@portabletext/editor` on main. Each was rewritten to compose existing node-traversal primitives (`getNode`, `getEnclosingBlock`, `getInline`, `findSibling`, `getNodes`, `getNodeChildren`) instead of indexing into `blockIndexMap` or walking `context.value` at the top level. Most selectors are now thin compositions; the long ones (`getMarkState`, `isOverlappingSelection`, `getCaretWordSelection`) remain so because their algorithms are intrinsically multi-step.

Three small traversal helpers land alongside the selectors because they have selector consumers in this PR:

- `getEnclosingBlock(context, path)` — walks up to the nearest enclosing block. Used by `getAnchorBlock` and `getFocusBlock`.
- `getInline(context, path)` — paired narrowing companion to the existing `isInline` predicate. Returns `{node: PortableTextSpan | PortableTextObject, path}` or `undefined`. Used by `getAnchorChild` and `getFocusChild`.
- `findSibling(context, path, direction, match)` — walks siblings of a path in a direction until the match predicate returns true. Used by `getNextSpan`, `getPreviousSpan`, `getNextInlineObject`, `getPreviousInlineObject`. The match parameter accepts a type guard so the result narrows.

This PR is intentionally narrow. It does not touch behaviors, operations, the parser, normalization, renderers, or the playground. It does not introduce any new public selectors. Container-awareness in those other layers ships separately.