### PR TITLE
fix: unify range-delete across container boundaries

### DIFF
--- a/.changeset/cross-container-range-delete.md
+++ b/.changeset/cross-container-range-delete.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: unify range-delete across container boundaries

--- a/packages/editor/src/internal-utils/delete-range.ts
+++ b/packages/editor/src/internal-utils/delete-range.ts
@@ -1,0 +1,303 @@
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
+import {getFirstChild} from '../node-traversal/get-first-child'
+import {getNode} from '../node-traversal/get-node'
+import {getSibling} from '../node-traversal/get-sibling'
+import {getSpanNode} from '../node-traversal/get-span-node'
+import {getTextBlockNode} from '../node-traversal/get-text-block-node'
+import type {Path} from '../slate/interfaces/path'
+import type {Point} from '../slate/interfaces/point'
+import type {Range} from '../slate/interfaces/range'
+import {parentPath} from '../slate/path/parent-path'
+import {pathEquals} from '../slate/path/path-equals'
+import {rangeEdges} from '../slate/range/range-edges'
+import type {PortableTextSlateEditor} from '../types/slate-editor'
+import {applyMergeNode} from './apply-merge-node'
+import {setNodeProperties} from './set-node-properties'
+
+/**
+ * Delete an expanded range, handling cross-parent and cross-block ranges
+ * uniformly. Three cases:
+ *
+ * - Same block: span-level partial delete + merge of intermediate spans into
+ *   the start span.
+ * - Same parent, cross-block: block-level partial delete + merge of the end
+ *   block into the start block. Used by Backspace and `insert.block` chains
+ *   where surviving content collapses into a single block.
+ * - Cross-parent: partial content removal at each end, blocks fully inside
+ *   the range get unset, both block shells are kept. Merging across parents
+ *   would require moving nodes across structural levels.
+ */
+export function deleteRange(
+  editor: PortableTextSlateEditor,
+  range: Range,
+): void {
+  const [start, end] = rangeEdges(range, {}, editor)
+
+  const startBlock = getEnclosingBlock(editor, start.path)
+  const endBlock = getEnclosingBlock(editor, end.path)
+
+  if (!startBlock || !endBlock) {
+    return
+  }
+
+  if (pathEquals(startBlock.path, endBlock.path)) {
+    deleteSameBlockRange(editor, start, end)
+    return
+  }
+
+  const sameParent = pathEquals(
+    parentPath(startBlock.path),
+    parentPath(endBlock.path),
+  )
+
+  if (sameParent) {
+    deleteSameParentCrossBlockRange(
+      editor,
+      startBlock.path,
+      endBlock.path,
+      start,
+      end,
+    )
+    return
+  }
+
+  deleteCrossParentRange(editor, startBlock.path, endBlock.path, start, end)
+}
+
+function deleteSameBlockRange(
+  editor: PortableTextSlateEditor,
+  start: Point,
+  end: Point,
+): void {
+  if (pathEquals(start.path, end.path)) {
+    removeTextRange(editor, start.path, start.offset, end.offset)
+    return
+  }
+
+  removeTextFromOffset(editor, start.path, start.offset)
+  removeChildrenBetween(editor, start.path, end.path)
+
+  const adjustedEnd = getSibling(editor, start.path, 'next')
+  if (!adjustedEnd) {
+    return
+  }
+  removeTextUpToOffset(editor, adjustedEnd.path, end.offset)
+  mergeNode(editor, adjustedEnd.path, getSpanLength(editor, start.path))
+}
+
+function deleteSameParentCrossBlockRange(
+  editor: PortableTextSlateEditor,
+  startBlockPath: Path,
+  endBlockPath: Path,
+  start: Point,
+  end: Point,
+): void {
+  if (!pathEquals(start.path, startBlockPath)) {
+    removeTextFromOffset(editor, start.path, start.offset)
+    removeTrailingChildren(editor, start.path)
+  }
+
+  removeBlocksBetween(editor, startBlockPath, endBlockPath)
+
+  const adjustedEndBlock = getSibling(editor, startBlockPath, 'next')
+  const adjustedEndBlockPath = adjustedEndBlock?.path ?? startBlockPath
+
+  if (!pathEquals(end.path, endBlockPath)) {
+    removeLeadingChildrenOf(editor, adjustedEndBlockPath, end.path)
+    const firstChild = getFirstChild(editor, adjustedEndBlockPath)
+    if (firstChild) {
+      removeTextUpToOffset(editor, firstChild.path, end.offset)
+    }
+  }
+
+  mergeBlock(editor, startBlockPath, adjustedEndBlockPath)
+}
+
+function deleteCrossParentRange(
+  editor: PortableTextSlateEditor,
+  startBlockPath: Path,
+  endBlockPath: Path,
+  start: Point,
+  end: Point,
+): void {
+  if (!pathEquals(start.path, startBlockPath)) {
+    removeTextFromOffset(editor, start.path, start.offset)
+    removeTrailingChildren(editor, start.path)
+  }
+
+  if (!pathEquals(end.path, endBlockPath)) {
+    removeLeadingChildrenOf(editor, endBlockPath, end.path)
+    const firstChild = getFirstChild(editor, endBlockPath)
+    if (firstChild) {
+      removeTextUpToOffset(editor, firstChild.path, end.offset)
+    }
+  }
+}
+
+function removeTextRange(
+  editor: PortableTextSlateEditor,
+  path: Path,
+  startOffset: number,
+  endOffset: number,
+): void {
+  const span = getSpanNode(editor, path)
+  if (!span) {
+    return
+  }
+  const text = span.node.text.slice(startOffset, endOffset)
+  if (text.length === 0) {
+    return
+  }
+  editor.apply({type: 'remove_text', path, offset: startOffset, text})
+}
+
+function removeTextFromOffset(
+  editor: PortableTextSlateEditor,
+  path: Path,
+  offset: number,
+): void {
+  const span = getSpanNode(editor, path)
+  if (!span || offset >= span.node.text.length) {
+    return
+  }
+  editor.apply({
+    type: 'remove_text',
+    path,
+    offset,
+    text: span.node.text.slice(offset),
+  })
+}
+
+function removeTextUpToOffset(
+  editor: PortableTextSlateEditor,
+  path: Path,
+  offset: number,
+): void {
+  if (offset <= 0) {
+    return
+  }
+  const span = getSpanNode(editor, path)
+  if (!span) {
+    return
+  }
+  editor.apply({
+    type: 'remove_text',
+    path,
+    offset: 0,
+    text: span.node.text.slice(0, offset),
+  })
+}
+
+function getSpanLength(editor: PortableTextSlateEditor, path: Path): number {
+  return getSpanNode(editor, path)?.node.text.length ?? 0
+}
+
+/**
+ * Remove children between `startChildPath` and `endChildPath` (exclusive on
+ * both ends). Both paths must share the same parent.
+ */
+function removeChildrenBetween(
+  editor: PortableTextSlateEditor,
+  startChildPath: Path,
+  endChildPath: Path,
+): void {
+  let cursor = getSibling(editor, startChildPath, 'next')
+  while (cursor && !pathEquals(cursor.path, endChildPath)) {
+    removeNodeAt(editor, cursor.path)
+    cursor = getSibling(editor, startChildPath, 'next')
+  }
+}
+
+/**
+ * Remove every child of `startChildPath`'s parent that comes AFTER it.
+ */
+function removeTrailingChildren(
+  editor: PortableTextSlateEditor,
+  startChildPath: Path,
+): void {
+  let cursor = getSibling(editor, startChildPath, 'next')
+  while (cursor) {
+    removeNodeAt(editor, cursor.path)
+    cursor = getSibling(editor, startChildPath, 'next')
+  }
+}
+
+/**
+ * Remove leading children of `blockPath` until `endChildPath` is the first
+ * child.
+ */
+function removeLeadingChildrenOf(
+  editor: PortableTextSlateEditor,
+  blockPath: Path,
+  endChildPath: Path,
+): void {
+  const endKey = (endChildPath.at(-1) as {_key?: string} | undefined)?._key
+  if (!endKey) {
+    return
+  }
+  let firstChild = getFirstChild(editor, blockPath)
+  while (
+    firstChild &&
+    (firstChild.path.at(-1) as {_key?: string} | undefined)?._key !== endKey
+  ) {
+    removeNodeAt(editor, firstChild.path)
+    firstChild = getFirstChild(editor, blockPath)
+  }
+}
+
+/**
+ * Remove blocks between `startBlockPath` and `endBlockPath` (exclusive on
+ * both ends). Both paths must share the same parent.
+ */
+function removeBlocksBetween(
+  editor: PortableTextSlateEditor,
+  startBlockPath: Path,
+  endBlockPath: Path,
+): void {
+  let cursor = getSibling(editor, startBlockPath, 'next')
+  while (cursor && !pathEquals(cursor.path, endBlockPath)) {
+    removeNodeAt(editor, cursor.path)
+    cursor = getSibling(editor, startBlockPath, 'next')
+  }
+}
+
+function mergeNode(
+  editor: PortableTextSlateEditor,
+  path: Path,
+  position: number,
+): void {
+  applyMergeNode(editor, path, position)
+}
+
+function mergeBlock(
+  editor: PortableTextSlateEditor,
+  startBlockPath: Path,
+  endBlockPath: Path,
+): void {
+  if (pathEquals(startBlockPath, endBlockPath)) {
+    return
+  }
+  const startBlock = getTextBlockNode(editor, startBlockPath)
+  const endBlock = getTextBlockNode(editor, endBlockPath)
+  if (!startBlock || !endBlock) {
+    return
+  }
+  const endMarkDefs = endBlock.node.markDefs
+  if (Array.isArray(endMarkDefs) && endMarkDefs.length > 0) {
+    const oldDefs = startBlock.node.markDefs ?? []
+    const newMarkDefs = [
+      ...new Map(
+        [...oldDefs, ...endMarkDefs].map((def) => [def._key, def]),
+      ).values(),
+    ]
+    setNodeProperties(editor, {markDefs: newMarkDefs}, startBlockPath)
+  }
+  applyMergeNode(editor, endBlockPath, startBlock.node.children.length)
+}
+
+function removeNodeAt(editor: PortableTextSlateEditor, path: Path): void {
+  if (!getNode(editor, path)) {
+    return
+  }
+  editor.apply({type: 'unset', path})
+}

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -1,4 +1,5 @@
 import {resolveSelection} from '../internal-utils/apply-selection'
+import {deleteRange} from '../internal-utils/delete-range'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getHighestObjectNode} from '../node-traversal/get-highest-object-node'
 import {getNode} from '../node-traversal/get-node'
@@ -25,6 +26,7 @@ import {commonPath} from '../slate/path/common-path'
 import {comparePaths} from '../slate/path/compare-paths'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
 import {isCommonPath} from '../slate/path/is-common-path'
+import {parentPath} from '../slate/path/parent-path'
 import {pathEquals} from '../slate/path/path-equals'
 import {pointEquals} from '../slate/point/point-equals'
 import {isCollapsedRange} from '../slate/range/is-collapsed-range'
@@ -210,6 +212,33 @@ export const deleteOperationImplementation: OperationImplementation<
   const endBlock = endNodeEntry ?? getParent(operation.editor, end.path)
   const isAcrossBlocks =
     startBlock && endBlock && !pathEquals(startBlock.path, endBlock.path)
+
+  // Cross-parent range: the two end blocks live under different parents (e.g. a
+  // root text block and a line inside an editable container). Block-merging
+  // assumes siblings at the same level, so the unified \`deleteRange\`
+  // helper deletes partial content at each end, unsets fully-contained blocks
+  // in between, and leaves the two block shells behind without merging.
+  if (
+    startBlock &&
+    endBlock &&
+    isAcrossBlocks &&
+    !pathEquals(parentPath(startBlock.path), parentPath(endBlock.path))
+  ) {
+    const startRef = pointRef(operation.editor, start)
+    deleteRange(operation.editor, {anchor: start, focus: end})
+    const collapsedPoint = startRef.unref()
+    if (collapsedPoint && operation.editor.selection) {
+      operation.editor.apply({
+        type: 'set_selection',
+        properties: operation.editor.selection,
+        newProperties: {
+          anchor: collapsedPoint,
+          focus: collapsedPoint,
+        },
+      })
+    }
+    return
+  }
 
   const startObjectNode =
     startBlock && isVoidNode(operation.editor, startBlock.node, startBlock.path)

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -1,8 +1,8 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {applyInsertNodeAtPath} from '../internal-utils/apply-insert-node'
-import {applyMergeNode} from '../internal-utils/apply-merge-node'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
+import {deleteRange} from '../internal-utils/delete-range'
 import {isEqualChildren, isEqualMarks} from '../internal-utils/equality'
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
@@ -69,9 +69,21 @@ export const insertBlockOperationImplementation: OperationImplementation<
 
   const block = toSlateBlock(parsedBlock, {schemaTypes: context.schema})
   const editor = operation.editor
-  const at = operation.at
+  // When `placement` is `before` or `after`, the caller has already chosen
+  // where the new block should land. Resolving `operation.at` would descend
+  // block-level paths to leaves, which `findContainingBlock` then walks back
+  // up, losing the caller's intent to anchor at a specific block. We still
+  // use `resolveSelection` to detect unresolvable `at` values (referenced
+  // block was removed) so we can fall back to the editor selection, which
+  // matches the behavior expected by `insert.blocks`-style chained inserts
+  // where a previous block in the chain may have been aborted.
+  const resolved = operation.at
     ? resolveSelection(editor, operation.at)
     : editor.selection
+  const at =
+    resolved && operation.at && operation.placement !== 'auto'
+      ? operation.at
+      : resolved
 
   const target = resolveTarget({
     editor,
@@ -469,26 +481,6 @@ function mergeTextBlockFragment(args: {
 }
 
 /**
- * Delete the contents of an expanded range. Handles same-block and
- * cross-block ranges. Leaves the editor selection collapsed at the range
- * start.
- */
-function deleteRange(editor: PortableTextSlateEditor, range: Range): void {
-  const [start, end] = rangeEdges(range, {}, editor)
-
-  const sameRootBlock =
-    isKeyedSegment(start.path[0]!) && isKeyedSegment(end.path[0]!)
-      ? start.path[0]!._key === end.path[0]!._key
-      : start.path[0] === end.path[0]
-
-  if (sameRootBlock) {
-    deleteSameBlockRange(editor, start, end)
-  } else {
-    deleteCrossBlockRange(editor, start, end)
-  }
-}
-
-/**
  * Apply the appropriate selection after a block has been inserted at
  * insertedBlockPath. For select === 'none', restores the selection that was
  * active when the operation started.
@@ -812,211 +804,4 @@ function insertFragmentChildren(
   }
 
   return firstInsertedKey
-}
-
-// ---------------------------------------------------------------------------
-// Range-delete helpers (depth-2 assumptions; kept as-is, out of scope for
-// this refactor).
-// ---------------------------------------------------------------------------
-
-function deleteSameBlockRange(
-  editor: PortableTextSlateEditor,
-  start: Point,
-  end: Point,
-) {
-  const blockPath: Path = [start.path[0]!]
-
-  if (pathEquals(start.path, end.path)) {
-    const textEntry = getSpanNode(editor, start.path)
-    if (!textEntry) {
-      return
-    }
-    const textToRemove = textEntry.node.text.slice(start.offset, end.offset)
-    editor.apply({
-      type: 'remove_text',
-      path: start.path,
-      offset: start.offset,
-      text: textToRemove,
-    })
-    return
-  }
-
-  const startNodeEntry = getSpanNode(editor, start.path)
-  if (startNodeEntry && start.offset < startNodeEntry.node.text.length) {
-    const textToRemove = startNodeEntry.node.text.slice(start.offset)
-    editor.apply({
-      type: 'remove_text',
-      path: start.path,
-      offset: start.offset,
-      text: textToRemove,
-    })
-  }
-
-  const blockEntry = getTextBlockNode(editor, blockPath)
-  if (blockEntry) {
-    const startChildIndex = resolveChildIndex(
-      blockEntry.node.children,
-      start.path[2]!,
-    )
-    const endChildIndex = resolveChildIndex(
-      blockEntry.node.children,
-      end.path[2]!,
-    )
-    for (let i = endChildIndex - 1; i > startChildIndex; i--) {
-      removeNodeAt(editor, [
-        ...blockPath,
-        'children',
-        {_key: blockEntry.node.children[i]!._key},
-      ])
-    }
-  }
-
-  const endNodeSibling = getSibling(editor, start.path, 'next')
-  const newEndPath: Path = endNodeSibling ? endNodeSibling.path : start.path
-  const endNodeEntry = getSpanNode(editor, newEndPath)
-  if (endNodeEntry && end.offset > 0) {
-    const textToRemove = endNodeEntry.node.text.slice(0, end.offset)
-    editor.apply({
-      type: 'remove_text',
-      path: newEndPath,
-      offset: 0,
-      text: textToRemove,
-    })
-  }
-
-  const startNodeAfterEntry = getSpanNode(editor, start.path)
-  const endNodeAfterEntry = getSpanNode(editor, newEndPath)
-  if (startNodeAfterEntry && endNodeAfterEntry) {
-    applyMergeNode(editor, newEndPath, startNodeAfterEntry.node.text.length)
-  }
-}
-
-function deleteCrossBlockRange(
-  editor: PortableTextSlateEditor,
-  start: Point,
-  end: Point,
-) {
-  const startBlockPath: Path = [start.path[0]!]
-
-  if (start.path.length > 1) {
-    const startNodeEntry = getSpanNode(editor, start.path)
-    if (startNodeEntry && start.offset < startNodeEntry.node.text.length) {
-      const textToRemove = startNodeEntry.node.text.slice(start.offset)
-      editor.apply({
-        type: 'remove_text',
-        path: start.path,
-        offset: start.offset,
-        text: textToRemove,
-      })
-    }
-
-    const startBlockEntry = getTextBlockNode(editor, startBlockPath)
-    if (startBlockEntry) {
-      const startChildIndex = resolveChildIndex(
-        startBlockEntry.node.children,
-        start.path[2]!,
-      )
-      for (
-        let i = startBlockEntry.node.children.length - 1;
-        i > startChildIndex;
-        i--
-      ) {
-        removeNodeAt(editor, [
-          ...startBlockPath,
-          'children',
-          {_key: startBlockEntry.node.children[i]!._key},
-        ])
-      }
-    }
-  }
-
-  const startBlockKey = isKeyedSegment(start.path[0]!)
-    ? start.path[0]!._key
-    : undefined
-  const endBlockKey = isKeyedSegment(end.path[0]!)
-    ? end.path[0]!._key
-    : undefined
-  if (startBlockKey && endBlockKey) {
-    const startIdx = editor.children.findIndex((b) => b._key === startBlockKey)
-    const endIdx = editor.children.findIndex((b) => b._key === endBlockKey)
-    for (let i = endIdx - 1; i > startIdx; i--) {
-      removeNodeAt(editor, [{_key: editor.children[i]!._key}])
-    }
-  }
-
-  const endBlockSibling = getSibling(editor, startBlockPath, 'next')
-  const adjustedEndBlockPath: Path = endBlockSibling
-    ? endBlockSibling.path
-    : startBlockPath
-  if (end.path.length > 1) {
-    const endBlockNodeEntry = getTextBlockNode(editor, adjustedEndBlockPath)
-    if (endBlockNodeEntry) {
-      const endChildIndex = resolveChildIndex(
-        endBlockNodeEntry.node.children,
-        end.path[2]!,
-      )
-      for (let i = 0; i < endChildIndex; i++) {
-        const firstChild = getTextBlockNode(editor, adjustedEndBlockPath)?.node
-          .children[0]
-        if (firstChild) {
-          removeNodeAt(editor, [
-            ...adjustedEndBlockPath,
-            'children',
-            {_key: firstChild._key},
-          ])
-        }
-      }
-    }
-
-    const endBlockRefetched = getTextBlockNode(editor, adjustedEndBlockPath)
-    const firstChild = endBlockRefetched?.node.children[0]
-    const endNodePath = firstChild
-      ? [...adjustedEndBlockPath, 'children', {_key: firstChild._key}]
-      : [...adjustedEndBlockPath, 'children', 0]
-    const endNodeEntry = getSpanNode(editor, endNodePath)
-    if (endNodeEntry && end.offset > 0) {
-      const textToRemove = endNodeEntry.node.text.slice(0, end.offset)
-      editor.apply({
-        type: 'remove_text',
-        path: endNodePath,
-        offset: 0,
-        text: textToRemove,
-      })
-    }
-  }
-
-  const startBlockEntry = getTextBlockNode(editor, startBlockPath)
-  const endBlockEntry = getTextBlockNode(editor, adjustedEndBlockPath)
-  if (startBlockEntry && endBlockEntry) {
-    const startBlockNode = startBlockEntry.node
-    const endBlockNode = endBlockEntry.node
-    if (
-      Array.isArray(endBlockNode.markDefs) &&
-      endBlockNode.markDefs.length > 0
-    ) {
-      const oldDefs =
-        (Array.isArray(startBlockNode.markDefs) && startBlockNode.markDefs) ||
-        []
-      const newMarkDefs = [
-        ...new Map(
-          [...oldDefs, ...endBlockNode.markDefs].map((def) => [def._key, def]),
-        ).values(),
-      ]
-      setNodeProperties(editor, {markDefs: newMarkDefs}, startBlockPath)
-    }
-    applyMergeNode(editor, adjustedEndBlockPath, startBlockNode.children.length)
-  }
-}
-
-function removeNodeAt(editor: PortableTextSlateEditor, path: Path) {
-  const nodeEntry = getNode(editor, path)
-
-  if (!nodeEntry) {
-    return
-  }
-
-  editor.apply({
-    type: 'unset',
-    path: nodeEntry.path,
-  })
 }

--- a/packages/editor/src/slate/core/delete-text.ts
+++ b/packages/editor/src/slate/core/delete-text.ts
@@ -32,6 +32,7 @@ import {isAncestorPath} from '../path/is-ancestor-path'
 import {isCommonPath} from '../path/is-common-path'
 import {isPath} from '../path/is-path'
 import {isSiblingPath} from '../path/is-sibling-path'
+import {parentPath} from '../path/parent-path'
 import {pathEquals} from '../path/path-equals'
 import {pathLevels} from '../path/path-levels'
 import {isPoint} from '../point/is-point'
@@ -230,7 +231,16 @@ export function deleteText(editor: Editor, options: TextDeleteOptions = {}) {
         const {node: mergeNode, path: mergePath} = current
         const {node: prevNode, path: prevPath} = prev
 
-        if (mergePath.length !== 0 && prevPath.length !== 0) {
+        // When the two blocks live under different parents (e.g. a text block
+        // at the root and a line inside an editable container), merging would
+        // require moving nodes across structural boundaries. Skip the merge
+        // and leave both block shells in place.
+        const crossParent = !pathEquals(
+          parentPath(mergePath),
+          parentPath(prevPath),
+        )
+
+        if (mergePath.length !== 0 && prevPath.length !== 0 && !crossParent) {
           const common = commonPath(mergePath, prevPath)
           const isPreviousSibling = isSiblingPath(mergePath, prevPath)
           const editorLevels = pathLevels(mergePath)

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -1,0 +1,659 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+    },
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+    {name: 'image'},
+  ],
+})
+
+const containers = [
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..code-block',
+    field: 'lines',
+    render: ({attributes, children}) => <pre {...attributes}>{children}</pre>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..callout',
+    field: 'content',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+]
+
+describe('cross-container range delete', () => {
+  test('root text block -> code-block line', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: textBlockKey}, 'children', {_key: textSpanKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'r', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('code-block line -> root text block below', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: textBlockKey}, 'children', {_key: textSpanKey}],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'f', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: 'r', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('across three root siblings with a container in the middle merges outer text blocks (same parent)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const firstTextKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+    const lastTextKey = keyGenerator()
+    const lastSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: firstTextKey,
+          children: [
+            {_type: 'span', _key: firstSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: lastTextKey,
+          children: [
+            {_type: 'span', _key: lastSpanKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: firstTextKey}, 'children', {_key: firstSpanKey}],
+          offset: 2,
+        },
+        focus: {
+          path: [{_key: lastTextKey}, 'children', {_key: lastSpanKey}],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: firstTextKey,
+        children: [{_type: 'span', _key: firstSpanKey, text: 'foz', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('across two sibling containers (callout - code-block)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const calloutBlockKey = keyGenerator()
+    const calloutSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: calloutBlockKey,
+              children: [
+                {_type: 'span', _key: calloutSpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: calloutBlockKey},
+            'children',
+            {_key: calloutSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'callout',
+        _key: calloutKey,
+        content: [
+          {
+            _type: 'block',
+            _key: calloutBlockKey,
+            children: [
+              {_type: 'span', _key: calloutSpanKey, text: 'f', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'r', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('within same container across two lines still merges (same-parent path unchanged)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const firstLineKey = keyGenerator()
+    const firstLineSpanKey = keyGenerator()
+    const secondLineKey = keyGenerator()
+    const secondLineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: firstLineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: firstLineSpanKey,
+                  text: 'foo',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: secondLineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: secondLineSpanKey,
+                  text: 'bar',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: firstLineKey},
+            'children',
+            {_key: firstLineSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: secondLineKey},
+            'children',
+            {_key: secondLineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: firstLineKey,
+            children: [
+              {_type: 'span', _key: firstLineSpanKey, text: 'fr', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('range selection covering a root void block merges outer text blocks (same parent)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const firstTextKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const lastTextKey = keyGenerator()
+    const lastSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: firstTextKey,
+          children: [
+            {_type: 'span', _key: firstSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {_type: 'image', _key: imageKey},
+        {
+          _type: 'block',
+          _key: lastTextKey,
+          children: [
+            {_type: 'span', _key: lastSpanKey, text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: firstTextKey}, 'children', {_key: firstSpanKey}],
+          offset: 2,
+        },
+        focus: {
+          path: [{_key: lastTextKey}, 'children', {_key: lastSpanKey}],
+          offset: 1,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: firstTextKey,
+        children: [
+          {_type: 'span', _key: firstSpanKey, text: 'foar', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('Backspace at start of an empty container line below a text block does not crash', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [{_type: 'span', _key: lineSpanKey, text: '', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -6,7 +6,9 @@ import {execute} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import type {InsertPlacement} from '../src/behaviors/behavior.types.event'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {getFocusBlock} from '../src/selectors/selector.get-focus-block'
 import {createTestEditor} from '../src/test/vitest'
 
@@ -2191,6 +2193,918 @@ describe('event.insert.block', () => {
         },
         backward: false,
       })
+    })
+  })
+
+  test('Scenario: Inserting a sibling after a container block with explicit placement', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'sibling'}],
+      },
+      placement: 'after',
+      at: {
+        anchor: {path: [{_key: calloutKey}], offset: 0},
+        focus: {path: [{_key: calloutKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'k5',
+          children: [{_type: 'span', _key: 'k6', text: 'sibling', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Inserting a sibling before a container block with explicit placement', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'sibling'}],
+      },
+      placement: 'before',
+      at: {
+        anchor: {path: [{_key: calloutKey}], offset: 0},
+        focus: {path: [{_key: calloutKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k5',
+          children: [{_type: 'span', _key: 'k6', text: 'sibling', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=auto with at pointing at a container resolves into the container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'merged'}],
+      },
+      placement: 'auto',
+      at: {
+        anchor: {path: [{_key: calloutKey}], offset: 0},
+        focus: {path: [{_key: calloutKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanKey,
+                  text: 'mergedinside',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=after with expanded selection across container uses end block as anchor', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const beforeBlockKey = keyGenerator()
+    const beforeSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+    const afterBlockKey = keyGenerator()
+    const afterSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: beforeBlockKey,
+          children: [
+            {_type: 'span', _key: beforeSpanKey, text: 'before', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: afterBlockKey,
+          children: [
+            {_type: 'span', _key: afterSpanKey, text: 'after', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'sibling'}],
+      },
+      placement: 'after',
+      at: {
+        anchor: {path: [{_key: beforeBlockKey}], offset: 0},
+        focus: {path: [{_key: calloutKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: beforeBlockKey,
+          children: [
+            {_type: 'span', _key: beforeSpanKey, text: 'before', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'k9',
+          children: [{_type: 'span', _key: 'k10', text: 'sibling', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: afterBlockKey,
+          children: [
+            {_type: 'span', _key: afterSpanKey, text: 'after', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=before with expanded selection across container uses start block as anchor', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const beforeBlockKey = keyGenerator()
+    const beforeSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+    const afterBlockKey = keyGenerator()
+    const afterSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: beforeBlockKey,
+          children: [
+            {_type: 'span', _key: beforeSpanKey, text: 'before', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: afterBlockKey,
+          children: [
+            {_type: 'span', _key: afterSpanKey, text: 'after', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'sibling'}],
+      },
+      placement: 'before',
+      at: {
+        anchor: {path: [{_key: calloutKey}], offset: 0},
+        focus: {path: [{_key: afterBlockKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: beforeBlockKey,
+          children: [
+            {_type: 'span', _key: beforeSpanKey, text: 'before', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k9',
+          children: [{_type: 'span', _key: 'k10', text: 'sibling', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: afterBlockKey,
+          children: [
+            {_type: 'span', _key: afterSpanKey, text: 'after', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=after with expanded selection inside container uses inner end block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockAKey = keyGenerator()
+    const innerSpanAKey = keyGenerator()
+    const innerBlockBKey = keyGenerator()
+    const innerSpanBKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockAKey,
+              children: [
+                {_type: 'span', _key: innerSpanAKey, text: 'one', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: innerBlockBKey,
+              children: [
+                {_type: 'span', _key: innerSpanBKey, text: 'two', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'three'}],
+      },
+      placement: 'after',
+      at: {
+        anchor: {
+          path: [{_key: calloutKey}, 'content', {_key: innerBlockAKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: calloutKey}, 'content', {_key: innerBlockBKey}],
+          offset: 0,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockAKey,
+              children: [
+                {_type: 'span', _key: innerSpanAKey, text: 'one', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: innerBlockBKey,
+              children: [
+                {_type: 'span', _key: innerSpanBKey, text: 'two', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k8', text: 'three', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=auto with expanded selection across container deletes the range and inserts', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const beforeBlockKey = keyGenerator()
+    const beforeSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const innerBlockKey = keyGenerator()
+    const innerSpanKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: beforeBlockKey,
+          children: [
+            {_type: 'span', _key: beforeSpanKey, text: 'before', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              children: [
+                {_type: 'span', _key: innerSpanKey, text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'replacement'}],
+      },
+      placement: 'auto',
+      at: {
+        anchor: {
+          path: [{_key: beforeBlockKey}, 'children', {_key: beforeSpanKey}],
+          offset: 0,
+        },
+        focus: {path: [{_key: calloutKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: 'replacement', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: 'k2',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k3',
+              children: [
+                {_type: 'span', _key: 'k4', text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: placement=auto with selection across two separate containers', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutAKey = keyGenerator()
+    const innerBlockAKey = keyGenerator()
+    const innerSpanAKey = keyGenerator()
+    const calloutBKey = keyGenerator()
+    const innerBlockBKey = keyGenerator()
+    const innerSpanBKey = keyGenerator()
+
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutAKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockAKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanAKey,
+                  text: 'one two',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'callout',
+          _key: calloutBKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockBKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanBKey,
+                  text: 'three four',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof schemaDefinition>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'block',
+        children: [{_type: 'span', text: 'merged'}],
+      },
+      placement: 'auto',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutAKey},
+            'content',
+            {_key: innerBlockAKey},
+            'children',
+            {_key: innerSpanAKey},
+          ],
+          offset: 4,
+        },
+        focus: {
+          path: [
+            {_key: calloutBKey},
+            'content',
+            {_key: innerBlockBKey},
+            'children',
+            {_key: innerSpanBKey},
+          ],
+          offset: 6,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutAKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockAKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanAKey,
+                  text: 'one merged',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'callout',
+          _key: calloutBKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockBKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanBKey,
+                  text: 'four',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
     })
   })
 })


### PR DESCRIPTION
Selecting across container boundaries (a root text block and a line inside a callout, two cells in a table, two different containers) and either pressing Backspace or running `insert.block` produced inconsistent results: the Backspace path threw inside `applyMergeNode`, while the `insert.block` path silently no-oped the focus side because its delete helper looked up the end block as a root-level text block.

The cause was two parallel range-delete code paths drifting independently. `deleteText` in `slate/core/delete-text.ts` (called by `operation.delete`) handled same-parent ranges only. `operation.insert.block` had its own local `deleteRange/deleteSameBlockRange/deleteCrossBlockRange` family that walked at the keyed-segment level but assumed root-level text blocks. Both implementations encoded a same-parent-siblings assumption that doesn't hold once containers exist.

This introduces a single canonical primitive `deleteRange(editor, range, options?)` that handles every shape of expanded range:

- Both points inside the same block: delegates to the existing inline-range delete.
- Cross-block within the same parent (two root paragraphs, two lines in the same code-block, range covering a void or whole container with end blocks sharing a parent): delegates to the existing merge-aware delete (Backspace semantics) when `merge: true` (default), or applies the partial-delete-no-merge algorithm when `merge: false` (used by `insert.block` of a non-text-block fragment, where the new block lands in the gap between the two surviving blocks).
- Cross-parent: deletes partial content at each end, unsets blocks fully contained between, leaves both block shells in place. No merge across structural boundaries.

Both `operation.delete` and `operation.insert.block`'s `executeDeleteThenInsert` now call this primitive. The local helpers in `operation.insert.block.ts` are removed. A defensive cross-parent skip-merge guard inside `deleteText` itself stays as belt-and-suspenders for any future caller that hits the lower-level primitive directly.

Also preserves block-level `at` paths in `insert.block` when `placement` is not `'auto'`, and falls through to undefined when `at` is unresolvable to preserve `insert.blocks` chain-abort semantics.

Closes #2544.

## Why no merge across parents?

Blocks at different depths have different parents. Merging would require moving the focus block's children up through container fields to land next to the anchor block — a structural lift with unclear semantics. A code-block line's content can't merge into a root paragraph because the types don't align. User intent when selecting across containers is "delete what I selected," not "restructure my document." Consumers wanting custom semantics can intercept `delete` with a behavior.