### PR TITLE
fix: support range delete across different container parents

### DIFF
--- a/.changeset/cross-container-range-delete.md
+++ b/.changeset/cross-container-range-delete.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: support range delete across different container parents

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -25,6 +25,7 @@ import {commonPath} from '../slate/path/common-path'
 import {comparePaths} from '../slate/path/compare-paths'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
 import {isCommonPath} from '../slate/path/is-common-path'
+import {parentPath} from '../slate/path/parent-path'
 import {pathEquals} from '../slate/path/path-equals'
 import {pointEquals} from '../slate/point/point-equals'
 import {isCollapsedRange} from '../slate/range/is-collapsed-range'
@@ -210,6 +211,75 @@ export const deleteOperationImplementation: OperationImplementation<
   const endBlock = endNodeEntry ?? getParent(operation.editor, end.path)
   const isAcrossBlocks =
     startBlock && endBlock && !pathEquals(startBlock.path, endBlock.path)
+
+  // Cross-parent range: the two end blocks live under different parents (e.g. a
+  // root text block and a line inside an editable container). Slate's merge
+  // logic assumes siblings at the same level, so we delete partial content at
+  // each end, unset any fully-contained blocks in between, and leave the two
+  // block shells behind without merging.
+  if (
+    startBlock &&
+    endBlock &&
+    isAcrossBlocks &&
+    !pathEquals(parentPath(startBlock.path), parentPath(endBlock.path))
+  ) {
+    const startBlockEndPoint = editorEnd(operation.editor, startBlock.path)
+    const endBlockStartPoint = editorStart(operation.editor, endBlock.path)
+
+    const intermediateBlockRefs: Array<ReturnType<typeof pathRef>> = []
+    for (const entry of getNodes(operation.editor, {
+      from: startBlockEndPoint.path,
+      to: endBlockStartPoint.path,
+      match: (_node, path) => isBlock(operation.editor, path),
+    })) {
+      if (
+        isAncestorPath(entry.path, startBlock.path) ||
+        isAncestorPath(entry.path, endBlock.path) ||
+        pathEquals(entry.path, startBlock.path) ||
+        pathEquals(entry.path, endBlock.path)
+      ) {
+        continue
+      }
+      intermediateBlockRefs.push(pathRef(operation.editor, entry.path))
+    }
+
+    const startRef = pointRef(operation.editor, start)
+
+    if (!pointEquals(end, endBlockStartPoint)) {
+      deleteText(operation.editor, {
+        at: {anchor: endBlockStartPoint, focus: end},
+        hanging: true,
+      })
+    }
+
+    for (const ref of intermediateBlockRefs.reverse()) {
+      const path = ref.unref()
+      if (path) {
+        operation.editor.apply({type: 'unset', path})
+      }
+    }
+
+    if (!pointEquals(start, startBlockEndPoint)) {
+      deleteText(operation.editor, {
+        at: {anchor: start, focus: startBlockEndPoint},
+        hanging: true,
+      })
+    }
+
+    const collapsedPoint = startRef.unref()
+    if (collapsedPoint && operation.editor.selection) {
+      operation.editor.apply({
+        type: 'set_selection',
+        properties: operation.editor.selection,
+        newProperties: {
+          anchor: collapsedPoint,
+          focus: collapsedPoint,
+        },
+      })
+    }
+
+    return
+  }
 
   const startObjectNode =
     startBlock && isVoidNode(operation.editor, startBlock.node, startBlock.path)

--- a/packages/editor/src/slate/core/delete-text.ts
+++ b/packages/editor/src/slate/core/delete-text.ts
@@ -32,6 +32,7 @@ import {isAncestorPath} from '../path/is-ancestor-path'
 import {isCommonPath} from '../path/is-common-path'
 import {isPath} from '../path/is-path'
 import {isSiblingPath} from '../path/is-sibling-path'
+import {parentPath} from '../path/parent-path'
 import {pathEquals} from '../path/path-equals'
 import {pathLevels} from '../path/path-levels'
 import {isPoint} from '../point/is-point'
@@ -230,7 +231,16 @@ export function deleteText(editor: Editor, options: TextDeleteOptions = {}) {
         const {node: mergeNode, path: mergePath} = current
         const {node: prevNode, path: prevPath} = prev
 
-        if (mergePath.length !== 0 && prevPath.length !== 0) {
+        // When the two blocks live under different parents (e.g. a text block
+        // at the root and a line inside an editable container), merging would
+        // require moving nodes across structural boundaries. Skip the merge
+        // and leave both block shells in place.
+        const crossParent = !pathEquals(
+          parentPath(mergePath),
+          parentPath(prevPath),
+        )
+
+        if (mergePath.length !== 0 && prevPath.length !== 0 && !crossParent) {
           const common = commonPath(mergePath, prevPath)
           const isPreviousSibling = isSiblingPath(mergePath, prevPath)
           const editorLevels = pathLevels(mergePath)

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -1,0 +1,659 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+    },
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+    {name: 'image'},
+  ],
+})
+
+const containers = [
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..code-block',
+    field: 'lines',
+    render: ({attributes, children}) => <pre {...attributes}>{children}</pre>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..callout',
+    field: 'content',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+]
+
+describe('cross-container range delete', () => {
+  test('root text block -> code-block line', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: textBlockKey}, 'children', {_key: textSpanKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'r', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('code-block line -> root text block below', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: textBlockKey}, 'children', {_key: textSpanKey}],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'f', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: 'r', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('across three root siblings with a container in the middle merges outer text blocks (same parent)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const firstTextKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+    const lastTextKey = keyGenerator()
+    const lastSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: firstTextKey,
+          children: [
+            {_type: 'span', _key: firstSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: lastTextKey,
+          children: [
+            {_type: 'span', _key: lastSpanKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: firstTextKey}, 'children', {_key: firstSpanKey}],
+          offset: 2,
+        },
+        focus: {
+          path: [{_key: lastTextKey}, 'children', {_key: lastSpanKey}],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: firstTextKey,
+        children: [{_type: 'span', _key: firstSpanKey, text: 'foz', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('across two sibling containers (callout - code-block)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const calloutBlockKey = keyGenerator()
+    const calloutSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: calloutBlockKey,
+              children: [
+                {_type: 'span', _key: calloutSpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: 'bar', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: calloutBlockKey},
+            'children',
+            {_key: calloutSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'callout',
+        _key: calloutKey,
+        content: [
+          {
+            _type: 'block',
+            _key: calloutBlockKey,
+            children: [
+              {_type: 'span', _key: calloutSpanKey, text: 'f', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [
+              {_type: 'span', _key: lineSpanKey, text: 'r', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('within same container across two lines still merges (same-parent path unchanged)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const firstLineKey = keyGenerator()
+    const firstLineSpanKey = keyGenerator()
+    const secondLineKey = keyGenerator()
+    const secondLineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: firstLineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: firstLineSpanKey,
+                  text: 'foo',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: secondLineKey,
+              children: [
+                {
+                  _type: 'span',
+                  _key: secondLineSpanKey,
+                  text: 'bar',
+                  marks: [],
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: firstLineKey},
+            'children',
+            {_key: firstLineSpanKey},
+          ],
+          offset: 1,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: secondLineKey},
+            'children',
+            {_key: secondLineSpanKey},
+          ],
+          offset: 2,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: firstLineKey,
+            children: [
+              {_type: 'span', _key: firstLineSpanKey, text: 'fr', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('range selection covering a root void block merges outer text blocks (same parent)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const firstTextKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const lastTextKey = keyGenerator()
+    const lastSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: firstTextKey,
+          children: [
+            {_type: 'span', _key: firstSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {_type: 'image', _key: imageKey},
+        {
+          _type: 'block',
+          _key: lastTextKey,
+          children: [
+            {_type: 'span', _key: lastSpanKey, text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: firstTextKey}, 'children', {_key: firstSpanKey}],
+          offset: 2,
+        },
+        focus: {
+          path: [{_key: lastTextKey}, 'children', {_key: lastSpanKey}],
+          offset: 1,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: firstTextKey,
+        children: [
+          {_type: 'span', _key: firstSpanKey, text: 'foar', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('Backspace at start of an empty container line below a text block does not crash', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const textBlockKey = keyGenerator()
+    const textSpanKey = keyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: textBlockKey,
+          children: [
+            {_type: 'span', _key: textSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: lineKey,
+              children: [
+                {_type: 'span', _key: lineSpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: lineKey},
+            'children',
+            {_key: lineSpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Backspace}')
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [{_type: 'span', _key: textSpanKey, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'code-block',
+        _key: codeBlockKey,
+        lines: [
+          {
+            _type: 'block',
+            _key: lineKey,
+            children: [{_type: 'span', _key: lineSpanKey, text: '', marks: []}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Selecting text from inside an editable container (a code-block line, a callout's text block, a table cell) out to a sibling block and pressing Backspace would throw, because Slate's range-delete assumes the two end blocks are siblings at the same level.

The engine now detects when the selection crosses a structural boundary and applies a sensible default: the partial content at each end is removed, blocks fully contained between the two ends are removed, and the remaining shells are left in place without merging. Same-parent range-deletes still merge as before.

Cherry-picked out of the larger container-awareness branch so it can land independently.