### PR TITLE
feat: container-aware engine internals (parser, operations, behaviors)

### DIFF
--- a/.changeset/engine-internals-container-aware.md
+++ b/.changeset/engine-internals-container-aware.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: make engine internals container-aware

--- a/packages/editor/src/behaviors/behavior.abstract.annotation.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.annotation.ts
@@ -1,4 +1,5 @@
-import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
+import {isTextBlock} from '@portabletext/schema'
+import {getNode} from '../node-traversal/get-node'
 import {isActiveAnnotation} from '../selectors/selector.is-active-annotation'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {raise} from './behavior.types.action'
@@ -8,38 +9,27 @@ export const abstractAnnotationBehaviors = [
   defineBehavior({
     on: 'annotation.set',
     guard: ({snapshot, event}) => {
-      const blockSegment = event.at.at(-3)
       const markDefSegment = event.at.at(-1)
 
-      if (!isKeyedSegment(blockSegment) || !isKeyedSegment(markDefSegment)) {
+      if (!isKeyedSegment(markDefSegment)) {
         return false
       }
 
-      const blockKey = blockSegment._key
       const markDefKey = markDefSegment._key
 
-      const block = getFocusTextBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: {
-            anchor: {
-              path: [{_key: blockKey}],
-              offset: 0,
-            },
-            focus: {
-              path: [{_key: blockKey}],
-              offset: 0,
-            },
-          },
-        },
-      })
+      // The annotation's path ends in `..., 'markDefs', {_key}`. Strip the
+      // two trailing segments to get the enclosing text block's path,
+      // which works at any container depth.
+      const blockPath = event.at.slice(0, -2)
+      const blockEntry = getNode(snapshot.context, blockPath)
 
-      if (!block) {
+      if (!blockEntry || !isTextBlock(snapshot.context, blockEntry.node)) {
         return false
       }
 
-      const updatedMarkDefs = block.node.markDefs?.map((markDef) => {
+      const block = blockEntry.node
+
+      const updatedMarkDefs = block.markDefs?.map((markDef) => {
         if (markDef._key === markDefKey) {
           return {
             ...markDef,
@@ -50,13 +40,13 @@ export const abstractAnnotationBehaviors = [
         return markDef
       })
 
-      return {blockKey, updatedMarkDefs}
+      return {blockPath: blockEntry.path, updatedMarkDefs}
     },
     actions: [
-      (_, {blockKey, updatedMarkDefs}) => [
+      (_, {blockPath, updatedMarkDefs}) => [
         raise({
           type: 'block.set',
-          at: [{_key: blockKey}],
+          at: blockPath,
           props: {markDefs: updatedMarkDefs},
         }),
       ],

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -1,8 +1,7 @@
-import {isSpan} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
+import {getSibling} from '../node-traversal/get-sibling'
 import {getFocusChild} from '../selectors/selector.get-focus-child'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
-import {getNextBlock} from '../selectors/selector.get-next-block'
-import {getPreviousBlock} from '../selectors/selector.get-previous-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
 import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
@@ -49,10 +48,19 @@ export const abstractDeleteBehaviors = [
         },
       }
 
-      const previousBlock = getPreviousBlock(adjustedSnapshot)
       const focusTextBlock = getFocusTextBlock(adjustedSnapshot)
 
-      if (!previousBlock || !focusTextBlock) {
+      if (!focusTextBlock) {
+        return false
+      }
+
+      const previousSibling = getSibling(
+        adjustedSnapshot.context,
+        focusTextBlock.path,
+        'previous',
+      )
+
+      if (!previousSibling) {
         return false
       }
 
@@ -60,14 +68,19 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
+      if (!isTextBlock(snapshot.context, previousSibling.node)) {
+        return false
+      }
+
+      const previousBlock = {
+        node: previousSibling.node,
+        path: previousSibling.path,
+      }
+
       const previousBlockEndPoint = getBlockEndPoint({
         context: snapshot.context,
         block: previousBlock,
       })
-
-      if (!isTextBlockNode(snapshot.context, previousBlock.node)) {
-        return false
-      }
 
       return {previousBlockEndPoint, focusTextBlock}
     },
@@ -121,22 +134,27 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
-      const nextBlock = getNextBlock({
+      const adjustedSnapshot = {
         ...snapshot,
         context: {
           ...snapshot.context,
           selection: at,
         },
-      })
-      const focusTextBlock = getFocusTextBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: at,
-        },
-      })
+      }
 
-      if (!nextBlock || !focusTextBlock) {
+      const focusTextBlock = getFocusTextBlock(adjustedSnapshot)
+
+      if (!focusTextBlock) {
+        return false
+      }
+
+      const nextSibling = getSibling(
+        adjustedSnapshot.context,
+        focusTextBlock.path,
+        'next',
+      )
+
+      if (!nextSibling) {
         return false
       }
 
@@ -144,9 +162,13 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
+      if (!isTextBlock(snapshot.context, nextSibling.node)) {
+        return false
+      }
+
       const nextBlockStartPoint = getBlockStartPoint({
         context: snapshot.context,
-        block: nextBlock,
+        block: {node: nextSibling.node, path: nextSibling.path},
       })
 
       return {focusTextBlock, nextBlockStartPoint}
@@ -188,10 +210,19 @@ export const abstractDeleteBehaviors = [
         },
       }
 
-      const nextBlock = getNextBlock(adjustedSnapshot)
       const focusTextBlock = getFocusTextBlock(adjustedSnapshot)
 
-      if (!nextBlock || !focusTextBlock) {
+      if (!focusTextBlock) {
+        return false
+      }
+
+      const nextSibling = getSibling(
+        adjustedSnapshot.context,
+        focusTextBlock.path,
+        'next',
+      )
+
+      if (!nextSibling) {
         return false
       }
 
@@ -199,11 +230,11 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
-      if (!isTextBlockNode(snapshot.context, nextBlock.node)) {
+      if (!isTextBlockNode(snapshot.context, nextSibling.node)) {
         return false
       }
 
-      return {nextBlock}
+      return {nextBlock: {node: nextSibling.node, path: nextSibling.path}}
     },
     actions: [
       (_, {nextBlock}) => [

--- a/packages/editor/src/behaviors/behavior.abstract.insert.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.insert.ts
@@ -1,10 +1,13 @@
 import type {EditorSelector} from '../editor/editor-selector'
 import {isSelectionExpanded} from '../selectors'
+import {getFocusBlock} from '../selectors/selector.get-focus-block'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getLastBlock} from '../selectors/selector.get-last-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
+import type {Path} from '../slate/interfaces/path'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
+import {siblingPath} from '../slate/path/sibling-path'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
@@ -27,6 +30,30 @@ function getUniqueBlockKey(
 
     return blockKey
   }
+}
+
+/**
+ * Build a collapsed selection on the start of the block at `path`. Used to
+ * anchor subsequent `insert.block` raises when chaining multiple inserts.
+ */
+function selectionAt(path: Path): {
+  anchor: {path: Path; offset: number}
+  focus: {path: Path; offset: number}
+} {
+  return {
+    anchor: {path, offset: 0},
+    focus: {path, offset: 0},
+  }
+}
+
+/**
+ * Build the canonical path for a new block about to be inserted as a sibling
+ * of `referencePath`, or as a root-level block when `referencePath` is empty.
+ */
+function newBlockPath(referencePath: Path, key: string): Path {
+  return referencePath.length === 0
+    ? [{_key: key}]
+    : siblingPath(referencePath, key)
 }
 
 export const abstractInsertBehaviors = [
@@ -57,26 +84,43 @@ export const abstractInsertBehaviors = [
 
   defineBehavior({
     on: 'insert.blocks',
-    guard: ({event}) =>
-      event.placement === 'before' || event.placement === 'after',
+    guard: ({snapshot, event}) => {
+      if (event.placement !== 'before' && event.placement !== 'after') {
+        return false
+      }
+
+      const referenceSelection = event.at ?? snapshot.context.selection
+
+      const referenceBlock = referenceSelection
+        ? getFocusBlock({
+            ...snapshot,
+            context: {...snapshot.context, selection: referenceSelection},
+          })
+        : undefined
+
+      const referenceBlockPath: Path = referenceBlock ? referenceBlock.path : []
+
+      return {referenceBlockPath}
+    },
     actions: [
-      ({snapshot, event}) => {
-        let firstBlockKey: string | undefined
-        let lastBlockKey: string | undefined
-        let previousBlockKey: string | undefined
+      ({snapshot, event}, {referenceBlockPath}) => {
+        let firstBlockPath: Path | undefined
+        let lastBlockPath: Path | undefined
+        let previousBlockPath: Path | undefined
         const actions: Array<BehaviorAction> = []
 
         let index = -1
         for (const block of event.blocks) {
           index++
           const key = getUniqueBlockKey(block._key)(snapshot)
+          const blockPath: Path = newBlockPath(referenceBlockPath, key)
 
           if (index === 0) {
-            firstBlockKey = key
+            firstBlockPath = blockPath
           }
 
           if (index === event.blocks.length - 1) {
-            lastBlockKey = key
+            lastBlockPath = blockPath
           }
 
           actions.push(
@@ -90,39 +134,34 @@ export const abstractInsertBehaviors = [
                     ? 'before'
                     : 'after',
               select: 'none',
-              ...(previousBlockKey
-                ? {
-                    at: {
-                      anchor: {path: [{_key: previousBlockKey}], offset: 0},
-                      focus: {path: [{_key: previousBlockKey}], offset: 0},
-                    },
-                  }
+              ...(previousBlockPath
+                ? {at: selectionAt(previousBlockPath)}
                 : event.at
                   ? {at: event.at}
                   : {}),
             }),
           )
 
-          previousBlockKey = key
+          previousBlockPath = blockPath
         }
 
         const select = event.select ?? 'end'
 
-        if (select === 'start' && firstBlockKey) {
+        if (select === 'start' && firstBlockPath) {
           actions.push(
             raise({
               type: 'select.block',
-              at: [{_key: firstBlockKey}],
+              at: firstBlockPath,
               select: 'start',
             }),
           )
         }
 
-        if (select === 'end' && lastBlockKey) {
+        if (select === 'end' && lastBlockPath) {
           actions.push(
             raise({
               type: 'select.block',
-              at: [{_key: lastBlockKey}],
+              at: lastBlockPath,
               select: 'end',
             }),
           )
@@ -172,14 +211,10 @@ export const abstractInsertBehaviors = [
         block: focusTextBlock,
       })
       const focusTextBlockAfter = sliceTextBlock({
-        context: {
-          schema: snapshot.context.schema,
-          selection: {
-            anchor: at.focus,
-            focus: focusBlockEndPoint,
-          },
-        },
+        context: snapshot.context,
         block: focusTextBlock.node,
+        startPoint: at.focus,
+        endPoint: focusBlockEndPoint,
       })
 
       const isFirstBlockTextBlock = isTextBlockNode(
@@ -210,8 +245,9 @@ export const abstractInsertBehaviors = [
           originalSelection,
         },
       ) => {
-        let previousBlockKey: string | undefined
-        let firstBlockKey: string | undefined
+        const referenceBlockPath = focusTextBlock.path
+        let previousBlockPath: Path | undefined
+        let firstBlockPath: Path | undefined
         const actions: Array<BehaviorAction> = []
 
         let index = -1
@@ -239,11 +275,11 @@ export const abstractInsertBehaviors = [
             )
 
             if (isTextBlockNode(snapshot.context, block) && !deletingEndToEnd) {
-              firstBlockKey = focusTextBlock.node._key
-              previousBlockKey = focusTextBlock.node._key
+              firstBlockPath = focusTextBlock.path
+              previousBlockPath = focusTextBlock.path
             } else {
-              firstBlockKey = key
-              previousBlockKey = key
+              firstBlockPath = newBlockPath(referenceBlockPath, key)
+              previousBlockPath = firstBlockPath
             }
 
             actions.push(
@@ -260,20 +296,22 @@ export const abstractInsertBehaviors = [
           }
 
           if (index === event.blocks.length - 1) {
+            const lastKey = getUniqueBlockKey(block._key)(snapshot)
+
             actions.push(
               raise({
                 type: 'insert.block',
-                block,
+                block:
+                  lastKey !== block._key ? {...block, _key: lastKey} : block,
                 placement: 'after',
                 select: 'end',
-                at: previousBlockKey
-                  ? {
-                      anchor: {path: [{_key: previousBlockKey}], offset: 0},
-                      focus: {path: [{_key: previousBlockKey}], offset: 0},
-                    }
+                at: previousBlockPath
+                  ? selectionAt(previousBlockPath)
                   : undefined,
               }),
             )
+
+            previousBlockPath = newBlockPath(referenceBlockPath, lastKey)
 
             continue
           }
@@ -285,17 +323,14 @@ export const abstractInsertBehaviors = [
               type: 'insert.block',
               block: key !== block._key ? {...block, _key: key} : block,
               placement: 'after',
-              select: previousBlockKey ? 'none' : 'end',
-              at: previousBlockKey
-                ? {
-                    anchor: {path: [{_key: previousBlockKey}], offset: 0},
-                    focus: {path: [{_key: previousBlockKey}], offset: 0},
-                  }
+              select: previousBlockPath ? 'none' : 'end',
+              at: previousBlockPath
+                ? selectionAt(previousBlockPath)
                 : undefined,
             }),
           )
 
-          previousBlockKey = key
+          previousBlockPath = newBlockPath(referenceBlockPath, key)
         }
 
         if (!isEmptyTextBlock(snapshot.context, focusTextBlockAfter)) {
@@ -322,12 +357,12 @@ export const abstractInsertBehaviors = [
           if (
             (isEqualSelectionPoints(at.focus, focusBlockStartPoint) ||
               !isFirstBlockTextBlock) &&
-            firstBlockKey
+            firstBlockPath
           ) {
             actions.push(
               raise({
                 type: 'select.block',
-                at: [{_key: firstBlockKey}],
+                at: firstBlockPath,
                 select: 'start',
               }),
             )
@@ -356,26 +391,41 @@ export const abstractInsertBehaviors = [
         return false
       }
 
-      return {originalSelection: snapshot.context.selection}
+      const referenceSelection = event.at ?? snapshot.context.selection
+
+      const referenceBlock = referenceSelection
+        ? getFocusBlock({
+            ...snapshot,
+            context: {...snapshot.context, selection: referenceSelection},
+          })
+        : undefined
+
+      const referenceBlockPath: Path = referenceBlock ? referenceBlock.path : []
+
+      return {
+        referenceBlockPath,
+        originalSelection: snapshot.context.selection,
+      }
     },
     actions: [
-      ({snapshot, event}, {originalSelection}) => {
-        let firstBlockKey: string | undefined
-        let lastBlockKey: string | undefined
-        let previousBlockKey: string | undefined
+      ({snapshot, event}, {referenceBlockPath, originalSelection}) => {
+        let firstBlockPath: Path | undefined
+        let lastBlockPath: Path | undefined
+        let previousBlockPath: Path | undefined
         const actions: Array<BehaviorAction> = []
 
         let index = -1
         for (const block of event.blocks) {
           index++
           const key = getUniqueBlockKey(block._key)(snapshot)
+          const blockPath: Path = newBlockPath(referenceBlockPath, key)
 
           if (index === 0) {
-            firstBlockKey = key
+            firstBlockPath = blockPath
           }
 
           if (index === event.blocks.length - 1) {
-            lastBlockKey = key
+            lastBlockPath = blockPath
           }
 
           actions.push(
@@ -384,20 +434,15 @@ export const abstractInsertBehaviors = [
               block: key !== block._key ? {...block, _key: key} : block,
               placement: index === 0 ? 'auto' : 'after',
               select: 'none',
-              ...(previousBlockKey
-                ? {
-                    at: {
-                      anchor: {path: [{_key: previousBlockKey}], offset: 0},
-                      focus: {path: [{_key: previousBlockKey}], offset: 0},
-                    },
-                  }
+              ...(previousBlockPath
+                ? {at: selectionAt(previousBlockPath)}
                 : event.at
                   ? {at: event.at}
                   : {}),
             }),
           )
 
-          previousBlockKey = key
+          previousBlockPath = blockPath
         }
 
         const select = event.select ?? 'end'
@@ -409,19 +454,19 @@ export const abstractInsertBehaviors = [
               at: originalSelection,
             }),
           )
-        } else if (select === 'start' && firstBlockKey) {
+        } else if (select === 'start' && firstBlockPath) {
           actions.push(
             raise({
               type: 'select.block',
-              at: [{_key: firstBlockKey}],
+              at: firstBlockPath,
               select: 'start',
             }),
           )
-        } else if (lastBlockKey) {
+        } else if (lastBlockPath) {
           actions.push(
             raise({
               type: 'select.block',
-              at: [{_key: lastBlockKey}],
+              at: lastBlockPath,
               select: 'end',
             }),
           )

--- a/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
@@ -1,11 +1,11 @@
 import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
-import {getFocusBlock} from '../selectors/selector.get-focus-block'
+import {getSibling} from '../node-traversal/get-sibling'
+import {getBlock} from '../node-traversal/is-block'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
-import {getPreviousBlock} from '../selectors/selector.get-previous-block'
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
-import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {raise} from './behavior.types.action'
@@ -134,39 +134,35 @@ export const abstractKeyboardBehaviors = [
         return false
       }
 
-      const focusBlock = getFocusBlock(snapshot)
+      const focusTextBlock = getFocusTextBlock(snapshot)
 
-      if (!focusBlock) {
+      if (!focusTextBlock) {
         return false
       }
 
-      const previousBlock = getPreviousBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: {
-            anchor: {
-              path: focusBlock.path,
-              offset: 0,
-            },
-            focus: {
-              path: focusBlock.path,
-              offset: 0,
-            },
-          },
-        },
-      })
+      const previousSibling = getSibling(
+        snapshot.context,
+        focusTextBlock.path,
+        'previous',
+      )
+
+      if (!previousSibling) {
+        return false
+      }
+
+      const previousBlock = getBlock(snapshot.context, previousSibling.path)
 
       if (!previousBlock) {
         return false
       }
 
-      const hanging =
-        isTextBlockNode(snapshot.context, focusBlock.node) &&
-        snapshot.context.selection.focus.offset === 0
+      const hanging = snapshot.context.selection.focus.offset === 0
 
-      if (hanging && isEmptyTextBlock(snapshot.context, focusBlock.node)) {
-        return {previousBlock, selection: snapshot.context.selection}
+      if (hanging && isEmptyTextBlock(snapshot.context, focusTextBlock.node)) {
+        return {
+          previousBlock,
+          selection: snapshot.context.selection,
+        }
       }
 
       return false

--- a/packages/editor/src/behaviors/behavior.abstract.move.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.move.ts
@@ -1,5 +1,4 @@
-import {getNextBlock} from '../selectors/selector.get-next-block'
-import {getPreviousBlock} from '../selectors/selector.get-previous-block'
+import {getSibling} from '../node-traversal/get-sibling'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -7,35 +6,20 @@ export const abstractMoveBehaviors = [
   defineBehavior({
     on: 'move.block up',
     guard: ({snapshot, event}) => {
-      const previousBlock = getPreviousBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: {
-            anchor: {
-              path: event.at,
-              offset: 0,
-            },
-            focus: {
-              path: event.at,
-              offset: 0,
-            },
-          },
-        },
-      })
+      const previousSibling = getSibling(snapshot.context, event.at, 'previous')
 
-      if (previousBlock) {
-        return {previousBlock}
+      if (previousSibling) {
+        return {previousSibling}
       }
 
       return false
     },
     actions: [
-      ({event}, {previousBlock}) => [
+      ({event}, {previousSibling}) => [
         raise({
           type: 'move.block',
           at: event.at,
-          to: previousBlock.path,
+          to: previousSibling.path,
         }),
       ],
     ],
@@ -43,35 +27,20 @@ export const abstractMoveBehaviors = [
   defineBehavior({
     on: 'move.block down',
     guard: ({snapshot, event}) => {
-      const nextBlock = getNextBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: {
-            anchor: {
-              path: event.at,
-              offset: 0,
-            },
-            focus: {
-              path: event.at,
-              offset: 0,
-            },
-          },
-        },
-      })
+      const nextSibling = getSibling(snapshot.context, event.at, 'next')
 
-      if (nextBlock) {
-        return {nextBlock}
+      if (nextSibling) {
+        return {nextSibling}
       }
 
       return false
     },
     actions: [
-      ({event}, {nextBlock}) => [
+      ({event}, {nextSibling}) => [
         raise({
           type: 'move.block',
           at: event.at,
-          to: nextBlock.path,
+          to: nextSibling.path,
         }),
       ],
     ],

--- a/packages/editor/src/behaviors/behavior.abstract.select.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.select.ts
@@ -1,6 +1,6 @@
+import {getSibling} from '../node-traversal/get-sibling'
+import {getBlock} from '../node-traversal/is-block'
 import {getFocusBlock} from '../selectors/selector.get-focus-block'
-import {getNextBlock} from '../selectors/selector.get-next-block'
-import {getPreviousBlock} from '../selectors/selector.get-previous-block'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
@@ -13,22 +13,7 @@ export const abstractSelectBehaviors = [
         return false
       }
 
-      const block = getFocusBlock({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: {
-            anchor: {
-              path: event.at,
-              offset: 0,
-            },
-            focus: {
-              path: event.at,
-              offset: 0,
-            },
-          },
-        },
-      })
+      const block = getBlock(snapshot.context, event.at)
 
       if (!block) {
         return false
@@ -76,13 +61,23 @@ export const abstractSelectBehaviors = [
   defineBehavior({
     on: 'select.previous block',
     guard: ({snapshot}) => {
-      const previousBlock = getPreviousBlock(snapshot)
+      const focusBlockPath = getFocusBlock(snapshot)?.path
 
-      if (!previousBlock) {
+      if (!focusBlockPath) {
         return false
       }
 
-      return {previousBlock}
+      const previousSibling = getSibling(
+        snapshot.context,
+        focusBlockPath,
+        'previous',
+      )
+
+      if (!previousSibling) {
+        return false
+      }
+
+      return {previousBlock: previousSibling}
     },
     actions: [
       ({event}, {previousBlock}) => [
@@ -97,13 +92,19 @@ export const abstractSelectBehaviors = [
   defineBehavior({
     on: 'select.next block',
     guard: ({snapshot}) => {
-      const nextBlock = getNextBlock(snapshot)
+      const focusBlockPath = getFocusBlock(snapshot)?.path
 
-      if (!nextBlock) {
+      if (!focusBlockPath) {
         return false
       }
 
-      return {nextBlock}
+      const nextSibling = getSibling(snapshot.context, focusBlockPath, 'next')
+
+      if (!nextSibling) {
+        return false
+      }
+
+      return {nextBlock: nextSibling}
     },
     actions: [
       ({event}, {nextBlock}) => [

--- a/packages/editor/src/behaviors/behavior.abstract.split.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.split.ts
@@ -1,9 +1,8 @@
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {isSelectionExpanded} from '../selectors'
 import {getFocusBlockObject} from '../selectors/selector.get-focus-block-object'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
-import {getSelectionEndBlock} from '../selectors/selector.get-selection-end-block'
-import {getSelectionStartBlock} from '../selectors/selector.get-selection-start-block'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {isEqualSelectionPoints} from '../utils'
 import {parseBlock} from '../utils/parse-blocks'
@@ -55,8 +54,8 @@ export const abstractSplitBehaviors = [
         return false
       }
 
-      const startBlock = getSelectionStartBlock(snapshot)
-      const endBlock = getSelectionEndBlock(snapshot)
+      const startBlock = getAncestorTextBlock(snapshot.context, startPoint.path)
+      const endBlock = getAncestorTextBlock(snapshot.context, endPoint.path)
 
       if (!startBlock || !endBlock) {
         return false
@@ -122,11 +121,10 @@ export const abstractSplitBehaviors = [
 
       const newTextBlock = parseBlock({
         block: sliceTextBlock({
-          context: {
-            ...snapshot.context,
-            selection: newTextBlockSelection,
-          },
+          context: snapshot.context,
           block: focusTextBlock.node,
+          startPoint: selectionStartPoint,
+          endPoint: blockEndPoint,
         }),
         context: snapshot.context,
         options: {

--- a/packages/editor/src/behaviors/behavior.core.block-objects.ts
+++ b/packages/editor/src/behaviors/behavior.core.block-objects.ts
@@ -1,8 +1,7 @@
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
+import {getSibling} from '../node-traversal/get-sibling'
 import {getFocusBlockObject} from '../selectors/selector.get-focus-block-object'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
-import {getNextBlock} from '../selectors/selector.get-next-block'
-import {getPreviousBlock} from '../selectors/selector.get-previous-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {isListBlock} from '../utils/parse-blocks'
@@ -27,10 +26,19 @@ const arrowDownOnLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const focusBlockObject = getFocusBlockObject(snapshot)
-    const nextBlock = getNextBlock(snapshot)
+    const focusedBlockObject = getFocusBlockObject(snapshot)
 
-    return focusBlockObject && !nextBlock
+    if (!focusedBlockObject) {
+      return false
+    }
+
+    const nextBlock = getSibling(
+      snapshot.context,
+      focusedBlockObject.path,
+      'next',
+    )
+
+    return !nextBlock
   },
   actions: [
     ({snapshot}) => [
@@ -60,10 +68,19 @@ const arrowUpOnLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const focusBlockObject = getFocusBlockObject(snapshot)
-    const previousBlock = getPreviousBlock(snapshot)
+    const focusedBlockObject = getFocusBlockObject(snapshot)
 
-    return focusBlockObject && !previousBlock
+    if (!focusedBlockObject) {
+      return false
+    }
+
+    const previousBlock = getSibling(
+      snapshot.context,
+      focusedBlockObject.path,
+      'previous',
+    )
+
+    return !previousBlock
   },
   actions: [
     ({snapshot}) => [
@@ -81,10 +98,10 @@ const arrowUpOnLonelyBlockObject = defineBehavior({
 const breakingBlockObject = defineBehavior({
   on: 'insert.break',
   guard: ({snapshot}) => {
-    const focusBlockObject = getFocusBlockObject(snapshot)
+    const focusedBlockObject = getFocusBlockObject(snapshot)
     const collapsedSelection = isSelectionCollapsed(snapshot)
 
-    return collapsedSelection && focusBlockObject !== undefined
+    return collapsedSelection && focusedBlockObject !== undefined
   },
   actions: [
     ({snapshot}) => [
@@ -110,26 +127,29 @@ const clickingAboveLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const focusBlockObject = getFocusBlockObject({
+    const positionSnapshot = {
       ...snapshot,
       context: {
         ...snapshot.context,
         selection: event.position.selection,
       },
-    })
-    const previousBlock = getPreviousBlock({
-      ...snapshot,
-      context: {
-        ...snapshot.context,
-        selection: event.position.selection,
-      },
-    })
+    }
+    const focusedBlockObject = getFocusBlockObject(positionSnapshot)
+
+    if (!focusedBlockObject) {
+      return false
+    }
+
+    const previousSibling = getSibling(
+      snapshot.context,
+      focusedBlockObject.path,
+      'previous',
+    )
 
     return (
-      event.position.isEditor &&
+      (event.position.isEditor || event.position.isContainer) &&
       event.position.block === 'start' &&
-      focusBlockObject &&
-      !previousBlock
+      !previousSibling
     )
   },
   actions: [
@@ -161,26 +181,29 @@ const clickingBelowLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const focusBlockObject = getFocusBlockObject({
+    const positionSnapshot = {
       ...snapshot,
       context: {
         ...snapshot.context,
         selection: event.position.selection,
       },
-    })
-    const nextBlock = getNextBlock({
-      ...snapshot,
-      context: {
-        ...snapshot.context,
-        selection: event.position.selection,
-      },
-    })
+    }
+    const focusedBlockObject = getFocusBlockObject(positionSnapshot)
+
+    if (!focusedBlockObject) {
+      return false
+    }
+
+    const nextSibling = getSibling(
+      snapshot.context,
+      focusedBlockObject.path,
+      'next',
+    )
 
     return (
-      event.position.isEditor &&
+      (event.position.isEditor || event.position.isContainer) &&
       event.position.block === 'end' &&
-      focusBlockObject &&
-      !nextBlock
+      !nextSibling
     )
   },
   actions: [
@@ -204,38 +227,47 @@ const clickingBelowLonelyBlockObject = defineBehavior({
 const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
   on: 'delete.backward',
   guard: ({snapshot}) => {
-    const focusTextBlock = getFocusTextBlock(snapshot)
+    const focusedTextBlock = getFocusTextBlock(snapshot)
     const selectionCollapsed = isSelectionCollapsed(snapshot)
-    const previousBlock = getPreviousBlock(snapshot)
 
-    if (!focusTextBlock || !selectionCollapsed || !previousBlock) {
+    if (!focusedTextBlock || !selectionCollapsed) {
       return false
     }
 
-    if (isListBlock(snapshot.context, focusTextBlock.node)) {
+    const previousSibling = getSibling(
+      snapshot.context,
+      focusedTextBlock.path,
+      'previous',
+    )
+
+    if (!previousSibling) {
+      return false
+    }
+
+    if (isListBlock(snapshot.context, focusedTextBlock.node)) {
       return false
     }
 
     if (
-      isEmptyTextBlock(snapshot.context, focusTextBlock.node) &&
-      !isTextBlockNode(snapshot.context, previousBlock.node)
+      isEmptyTextBlock(snapshot.context, focusedTextBlock.node) &&
+      !isTextBlockNode(snapshot.context, previousSibling.node)
     ) {
-      return {focusTextBlock, previousBlock}
+      return {focusedTextBlock, previousSibling}
     }
 
     return false
   },
   actions: [
-    (_, {focusTextBlock, previousBlock}) => [
+    (_, {focusedTextBlock, previousSibling}) => [
       raise({
         type: 'delete.block',
-        at: focusTextBlock.path,
+        at: focusedTextBlock.path,
       }),
       raise({
         type: 'select',
         at: {
-          anchor: {path: previousBlock.path, offset: 0},
-          focus: {path: previousBlock.path, offset: 0},
+          anchor: {path: previousSibling.path, offset: 0},
+          focus: {path: previousSibling.path, offset: 0},
         },
       }),
     ],
@@ -245,34 +277,43 @@ const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
 const deletingEmptyTextBlockBeforeBlockObject = defineBehavior({
   on: 'delete.forward',
   guard: ({snapshot}) => {
-    const focusTextBlock = getFocusTextBlock(snapshot)
+    const focusedTextBlock = getFocusTextBlock(snapshot)
     const selectionCollapsed = isSelectionCollapsed(snapshot)
-    const nextBlock = getNextBlock(snapshot)
 
-    if (!focusTextBlock || !selectionCollapsed || !nextBlock) {
+    if (!focusedTextBlock || !selectionCollapsed) {
+      return false
+    }
+
+    const nextSibling = getSibling(
+      snapshot.context,
+      focusedTextBlock.path,
+      'next',
+    )
+
+    if (!nextSibling) {
       return false
     }
 
     if (
-      isEmptyTextBlock(snapshot.context, focusTextBlock.node) &&
-      !isTextBlockNode(snapshot.context, nextBlock.node)
+      isEmptyTextBlock(snapshot.context, focusedTextBlock.node) &&
+      !isTextBlockNode(snapshot.context, nextSibling.node)
     ) {
-      return {focusTextBlock, nextBlock}
+      return {focusedTextBlock, nextSibling}
     }
 
     return false
   },
   actions: [
-    (_, {focusTextBlock, nextBlock}) => [
+    (_, {focusedTextBlock, nextSibling}) => [
       raise({
         type: 'delete.block',
-        at: focusTextBlock.path,
+        at: focusedTextBlock.path,
       }),
       raise({
         type: 'select',
         at: {
-          anchor: {path: nextBlock.path, offset: 0},
-          focus: {path: nextBlock.path, offset: 0},
+          anchor: {path: nextSibling.path, offset: 0},
+          focus: {path: nextSibling.path, offset: 0},
         },
       }),
     ],

--- a/packages/editor/src/behaviors/behavior.core.containers.ts
+++ b/packages/editor/src/behaviors/behavior.core.containers.ts
@@ -1,0 +1,98 @@
+import {getAncestor} from '../node-traversal/get-ancestor'
+import {getSibling} from '../node-traversal/get-sibling'
+import {isEditableContainer} from '../schema/is-editable-container'
+import {getFirstBlock} from '../selectors/selector.get-first-block'
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
+import {getLastBlock} from '../selectors/selector.get-last-block'
+import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
+import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
+import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
+import {pathEquals} from '../slate/path/path-equals'
+import {defineBehavior} from './behavior.types.behavior'
+
+/**
+ * Prevent the browser from escaping the caret out of an editable container
+ * when there is nowhere to go.
+ *
+ * At the start of the first block inside a container (ArrowUp) or the end
+ * of the last block (ArrowDown), browsers rendering `<table>`-based
+ * containers move the DOM caret outside the container element. When the
+ * container has a sibling at its parent level, the browser's native
+ * navigation lands correctly in that sibling and Slate picks it up. But
+ * when no sibling exists, the caret escapes into a DOM position that
+ * doesn't map back to the model, and the next keystroke produces orphan
+ * text nodes.
+ *
+ * This behavior only fires in that dead-end case and suppresses the
+ * native event to keep the caret in place. All other caret movement
+ * inside containers is left to the browser.
+ */
+const arrowDownOutOfContainer = defineBehavior({
+  on: 'keyboard.keydown',
+  guard: ({snapshot, event}) =>
+    event.originEvent.key === 'ArrowDown' &&
+    isAtContainerDeadEnd(snapshot, 'end'),
+  actions: [],
+})
+
+const arrowUpOutOfContainer = defineBehavior({
+  on: 'keyboard.keydown',
+  guard: ({snapshot, event}) =>
+    event.originEvent.key === 'ArrowUp' &&
+    isAtContainerDeadEnd(snapshot, 'start'),
+  actions: [],
+})
+
+function isAtContainerDeadEnd(
+  snapshot: Parameters<typeof getFocusTextBlock>[0],
+  edge: 'start' | 'end',
+): boolean {
+  if (!isSelectionCollapsed(snapshot)) {
+    return false
+  }
+
+  const focusTextBlock = getFocusTextBlock(snapshot)
+
+  if (!focusTextBlock) {
+    return false
+  }
+
+  const container = getAncestor(
+    snapshot.context,
+    focusTextBlock.path,
+    (node, path) => isEditableContainer(snapshot.context, node, path),
+  )
+
+  if (!container) {
+    return false
+  }
+
+  const edgeBlock =
+    edge === 'end' ? getLastBlock(snapshot) : getFirstBlock(snapshot)
+
+  if (!edgeBlock || !pathEquals(edgeBlock.path, focusTextBlock.path)) {
+    return false
+  }
+
+  const caretAtEdge =
+    edge === 'end'
+      ? isAtTheEndOfBlock(focusTextBlock)(snapshot)
+      : isAtTheStartOfBlock(focusTextBlock)(snapshot)
+
+  if (!caretAtEdge) {
+    return false
+  }
+
+  const sibling = getSibling(
+    snapshot.context,
+    container.path,
+    edge === 'end' ? 'next' : 'previous',
+  )
+
+  return sibling === undefined
+}
+
+export const coreContainerBehaviors = {
+  arrowDownOutOfContainer,
+  arrowUpOutOfContainer,
+}

--- a/packages/editor/src/behaviors/behavior.core.insert-break.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert-break.ts
@@ -1,13 +1,16 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
+import {getNodes} from '../node-traversal/get-nodes'
+import {getBlock, isBlock} from '../node-traversal/is-block'
+import {getDefaultStyle} from '../selectors/selector.get-default-style'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
 import {getFocusSpan} from '../selectors/selector.get-focus-span'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
-import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
-import {getSelectionEndBlock} from '../selectors/selector.get-selection-end-block'
-import {getSelectionStartBlock} from '../selectors/selector.get-selection-start-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
 import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
+import type {Path} from '../slate/interfaces/path'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
@@ -53,7 +56,7 @@ const breakingAtTheEndOfTextBlock = defineBehavior({
           markDefs: [],
           listItem: focusListItem,
           level: focusLevel,
-          style: snapshot.context.schema.styles[0]?.name,
+          style: getDefaultStyle(snapshot),
         },
         placement: 'after',
       }),
@@ -115,7 +118,7 @@ const breakingAtTheStartOfTextBlock = defineBehavior({
           ],
           listItem: focusListItem,
           level: focusLevel,
-          style: snapshot.context.schema.styles[0]?.name,
+          style: getDefaultStyle(snapshot),
         },
         placement: 'before',
         select: 'none',
@@ -135,9 +138,23 @@ const breakingEntireBlocks = defineBehavior({
       return false
     }
 
-    const selectedBlocks = getSelectedBlocks(snapshot)
-    const selectionStartBlock = getSelectionStartBlock(snapshot)
-    const selectionEndBlock = getSelectionEndBlock(snapshot)
+    const selectionStartPoint = getSelectionStartPoint(
+      snapshot.context.selection,
+    )
+    const selectionEndPoint = getSelectionEndPoint(snapshot.context.selection)
+
+    if (!selectionStartPoint || !selectionEndPoint) {
+      return false
+    }
+
+    const selectionStartBlock = getEnclosingBlock(
+      snapshot.context,
+      selectionStartPoint.path,
+    )
+    const selectionEndBlock = getEnclosingBlock(
+      snapshot.context,
+      selectionEndPoint.path,
+    )
 
     if (!selectionStartBlock || !selectionEndBlock) {
       return false
@@ -147,19 +164,29 @@ const breakingEntireBlocks = defineBehavior({
       context: snapshot.context,
       block: selectionStartBlock,
     })
-    const selectionStartPoint = getSelectionStartPoint(
-      snapshot.context.selection,
-    )
     const endBlockEndPoint = getBlockEndPoint({
       context: snapshot.context,
       block: selectionEndBlock,
     })
-    const selectionEndPoint = getSelectionEndPoint(snapshot.context.selection)
 
     if (
       isEqualSelectionPoints(selectionStartPoint, startBlockStartPoint) &&
       isEqualSelectionPoints(selectionEndPoint, endBlockEndPoint)
     ) {
+      const selectedBlocks: Array<{node: PortableTextBlock; path: Path}> = []
+      for (const entry of getNodes(
+        {...snapshot.context, blockIndexMap: snapshot.blockIndexMap},
+        {
+          from: selectionStartBlock.path,
+          to: selectionEndBlock.path,
+          match: (_node, path) => isBlock(snapshot.context, path),
+        },
+      )) {
+        const block = getBlock(snapshot.context, entry.path)
+        if (block) {
+          selectedBlocks.push(block)
+        }
+      }
       return {selectedBlocks}
     }
 

--- a/packages/editor/src/behaviors/behavior.core.lists.ts
+++ b/packages/editor/src/behaviors/behavior.core.lists.ts
@@ -283,14 +283,10 @@ const deletingListFromStart = defineBehavior({
       },
     })
     const slicedEndBlock = sliceTextBlock({
-      context: {
-        schema: snapshot.context.schema,
-        selection: {
-          anchor: deleteEndPoint,
-          focus: endBlockEndPoint,
-        },
-      },
+      context: snapshot.context,
       block: endBlock,
+      startPoint: deleteEndPoint,
+      endPoint: endBlockEndPoint,
     })
 
     return {

--- a/packages/editor/src/behaviors/behavior.core.ts
+++ b/packages/editor/src/behaviors/behavior.core.ts
@@ -2,6 +2,7 @@ import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
 import {coreAnnotationBehaviors} from './behavior.core.annotations'
 import {coreBlockObjectBehaviors} from './behavior.core.block-objects'
+import {coreContainerBehaviors} from './behavior.core.containers'
 import {coreDecoratorBehaviors} from './behavior.core.decorators'
 import {coreDndBehaviors} from './behavior.core.dnd'
 import {coreInsertBehaviors} from './behavior.core.insert'
@@ -19,6 +20,8 @@ const coreBehaviors = [
   coreBlockObjectBehaviors.clickingBelowLonelyBlockObject,
   coreBlockObjectBehaviors.arrowDownOnLonelyBlockObject,
   coreBlockObjectBehaviors.arrowUpOnLonelyBlockObject,
+  coreContainerBehaviors.arrowDownOutOfContainer,
+  coreContainerBehaviors.arrowUpOutOfContainer,
   coreBlockObjectBehaviors.breakingBlockObject,
   coreBlockObjectBehaviors.deletingEmptyTextBlockAfterBlockObject,
   coreBlockObjectBehaviors.deletingEmptyTextBlockBeforeBlockObject,

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -129,6 +129,8 @@ export function performEvent({
         context: {
           keyGenerator,
           schema,
+          containers: editor.containers,
+          value: editor.children,
         },
         operation: {
           ...event,
@@ -370,7 +372,12 @@ export function performEvent({
       }
 
       performOperation({
-        context: {keyGenerator, schema},
+        context: {
+          keyGenerator,
+          schema,
+          containers: editor.containers,
+          value: editor.children,
+        },
         operation: {
           ...event,
           editor,

--- a/packages/editor/src/internal-utils/create-placeholder-block.ts
+++ b/packages/editor/src/internal-utils/create-placeholder-block.ts
@@ -1,13 +1,30 @@
 import type {PortableTextSpan} from '@portabletext/schema'
 import type {EditorContext} from '../editor/editor-snapshot'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
 
+/**
+ * Create a placeholder text block -- the empty initial block used when the
+ * editor value is empty or when a container needs a default child.
+ *
+ * When `path` is provided and points into a container, the placeholder
+ * uses the container's default style. Without `path`, or at root depth,
+ * falls back to the root schema's first style.
+ */
 export function createPlaceholderBlock(
-  context: Pick<EditorContext, 'keyGenerator' | 'schema'>,
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'> & {
+    containers?: Containers
+    value?: Array<Node>
+  },
+  path?: Path,
 ) {
+  const style = resolveDefaultStyle(context, path)
   return {
     _type: context.schema.block.name,
     _key: context.keyGenerator(),
-    style: context.schema.styles[0]?.name ?? 'normal',
+    style,
     markDefs: [],
     children: [
       {
@@ -18,4 +35,26 @@ export function createPlaceholderBlock(
       } as PortableTextSpan,
     ],
   }
+}
+
+function resolveDefaultStyle(
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'> & {
+    containers?: Containers
+    value?: Array<Node>
+  },
+  path?: Path,
+): string {
+  const rootFallback = context.schema.styles[0]?.name ?? 'normal'
+  if (!path || !context.containers || !context.value) {
+    return rootFallback
+  }
+  const subSchema = getBlockSubSchema(
+    {
+      schema: context.schema,
+      containers: context.containers,
+      value: context.value,
+    },
+    path,
+  )
+  return subSchema.styles[0]?.name ?? rootFallback
 }

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -3,9 +3,11 @@ import {getDomNodePath} from '../dom-traversal/get-dom-node-path'
 import type {EditorActor} from '../editor/editor-machine'
 import {getNode} from '../node-traversal/get-node'
 import {getBlock} from '../node-traversal/is-block'
+import {isEditableContainer} from '../schema/is-editable-container'
 import {DOMEditor} from '../slate/dom/plugin/dom-editor'
 import {isDOMNode} from '../slate/dom/utils/dom'
 import {isEditor} from '../slate/editor/is-editor'
+import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
@@ -17,9 +19,16 @@ import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 export type EventPosition = {
   block: 'start' | 'end'
   /**
-   * Did the event origin from the editor DOM node itself or from a child node?
+   * Did the event originate from the editor root DOM node itself, rather than
+   * from a block inside the editor?
    */
   isEditor: boolean
+  /**
+   * Did the event originate from an editable container's DOM node itself (for
+   * example a code block or a table cell), rather than from a block inside the
+   * container?
+   */
+  isContainer: boolean
   selection: NonNullable<EditorSelection>
 }
 export type EventPositionBlock = EventPosition['block']
@@ -58,13 +67,14 @@ export function getEventPosition({
     eventBlock &&
     eventPositionBlock &&
     !eventSelection &&
-    !isEditor(eventNode)
+    !isEventContainer(slateEditor, eventNode, eventPath)
   ) {
     // If we for some reason can't find the event selection, then we default to
     // selecting the entire block that the event originates from.
     return {
       block: eventPositionBlock,
       isEditor: false,
+      isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
           context: editorActor.getSnapshot().context,
@@ -106,6 +116,7 @@ export function getEventPosition({
     return {
       block: eventPositionBlock,
       isEditor: false,
+      isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
           context: editorActor.getSnapshot().context,
@@ -128,6 +139,9 @@ export function getEventPosition({
   return {
     block: eventPositionBlock,
     isEditor: isEditor(eventNode),
+    isContainer: isEditor(eventNode)
+      ? false
+      : isEditableContainer(slateEditor, eventNode, eventPath),
     selection: eventSelection,
   }
 }
@@ -279,4 +293,15 @@ function getSelectionFromEvent(
   } catch {
     return undefined
   }
+}
+
+function isEventContainer(
+  slateEditor: PortableTextSlateEditor,
+  eventNode: Node | PortableTextSlateEditor,
+  eventPath: Path,
+): boolean {
+  if (isEditor(eventNode)) {
+    return true
+  }
+  return isEditableContainer(slateEditor, eventNode, eventPath)
 }

--- a/packages/editor/src/internal-utils/transform-operation.test.ts
+++ b/packages/editor/src/internal-utils/transform-operation.test.ts
@@ -1,12 +1,16 @@
 import type {Patch} from '@portabletext/patches'
+import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import type {Operation} from '../slate/interfaces/operation'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {transformOperation} from './transform-operation'
 
+const testSchema = compileSchema(defineSchema({}))
+
 /**
- * Minimal editor mock. transformOperation only reads editor.children
- * and editor.selection (for set_selection target resolution).
+ * Minimal editor mock. transformOperation only reads editor.children,
+ * editor.schema, editor.containers (for block resolution), and
+ * editor.selection (for set_selection target resolution).
  */
 function createMockEditor(
   children: Array<{_key: string; _type: string; [key: string]: unknown}>,
@@ -18,6 +22,8 @@ function createMockEditor(
   return {
     children,
     selection: selection ?? null,
+    schema: testSchema,
+    containers: new Map(),
   } as unknown as PortableTextSlateEditor
 }
 

--- a/packages/editor/src/internal-utils/transform-operation.ts
+++ b/packages/editor/src/internal-utils/transform-operation.ts
@@ -5,10 +5,13 @@ import {
   DIFF_INSERT,
   parsePatch,
 } from '@sanity/diff-match-patch'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
+import type {Path} from '../slate/interfaces/path'
+import {isAncestorPath} from '../slate/path/is-ancestor-path'
+import {pathEquals} from '../slate/path/path-equals'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
-import {isKeyedSegment} from '../utils'
 import {debug} from './debug'
 
 /**
@@ -24,9 +27,14 @@ export function transformOperation(
   patch: Patch,
   operation: Operation,
 ): Operation[] {
+  const context = {
+    schema: editor.schema,
+    containers: editor.containers,
+    value: editor.children,
+  }
   const transformedOperation = {...operation}
 
-  if (patch.type === 'insert' && patch.path.length === 1) {
+  if (patch.type === 'insert') {
     // With keyed paths, block insertions don't affect other operations' paths.
     // Keys are stable - no path adjustment needed.
     debug.history(
@@ -35,27 +43,22 @@ export function transformOperation(
     return [transformedOperation]
   }
 
-  if (patch.type === 'unset' && patch.path.length === 1) {
-    const pathSegment = patch.path[0]
-    // If this operation targets the same block that got removed, drop it
+  if (patch.type === 'unset' && patch.path.length > 0) {
+    // If this operation targets anything inside the subtree that got
+    // removed, drop it. With keyed paths, other operations' paths don't
+    // need adjustment. Compare path prefixes rather than resolving
+    // against the tree — `editor.children` reflects the post-patch state
+    // where the removed subtree is already gone.
     if (
       'path' in transformedOperation &&
-      Array.isArray(transformedOperation.path)
+      Array.isArray(transformedOperation.path) &&
+      pathStartsWith(transformedOperation.path, patch.path)
     ) {
-      const operationBlockSegment = transformedOperation.path[0]
-      if (
-        isKeyedSegment(pathSegment) &&
-        isKeyedSegment(operationBlockSegment) &&
-        operationBlockSegment._key === pathSegment._key
-      ) {
-        debug.history('Skipping transformation that targeted removed block')
-        return []
-      }
+      debug.history('Skipping transformation that targeted removed block')
+      return []
     }
-    // With keyed paths, block removals don't affect other operations' paths.
     return [transformedOperation]
   }
-
   // Someone reset the whole value
   if (patch.type === 'unset' && patch.path.length === 0) {
     debug.history(
@@ -66,14 +69,15 @@ export function transformOperation(
 
   if (patch.type === 'diffMatchPatch') {
     const operationTargetBlock = findOperationTargetBlock(
+      context,
       editor,
       transformedOperation,
     )
-    const pathSegment = patch.path[0]
+    const patchTargetBlock = getEnclosingBlock(context, patch.path)
     if (
       !operationTargetBlock ||
-      !isKeyedSegment(pathSegment) ||
-      operationTargetBlock._key !== pathSegment._key
+      !patchTargetBlock ||
+      operationTargetBlock._key !== patchTargetBlock.node._key
     ) {
       return [transformedOperation]
     }
@@ -154,21 +158,30 @@ export function transformOperation(
 }
 
 function findOperationTargetBlock(
+  context: {
+    schema: PortableTextSlateEditor['schema']
+    containers: PortableTextSlateEditor['containers']
+    value: Array<Node>
+  },
   editor: PortableTextSlateEditor,
   operation: Operation,
 ): Node | undefined {
   if (operation.type === 'set_selection' && editor.selection) {
-    const focusSegment = editor.selection.focus.path[0]
-    if (isKeyedSegment(focusSegment)) {
-      return editor.children.find((child) => child._key === focusSegment._key)
-    }
-    return undefined
+    const block = getEnclosingBlock(context, editor.selection.focus.path)
+    return block?.node
   }
   if ('path' in operation) {
-    const blockSegment = operation.path[0]
-    if (isKeyedSegment(blockSegment)) {
-      return editor.children.find((child) => child._key === blockSegment._key)
-    }
+    const block = getEnclosingBlock(context, operation.path)
+    return block?.node
   }
   return undefined
+}
+
+/**
+ * Return true when `path` equals `prefix` or is a descendant of `prefix`.
+ * Used to decide whether an operation falls inside a subtree that was
+ * removed by an `unset` patch.
+ */
+function pathStartsWith(path: Path, prefix: Path): boolean {
+  return pathEquals(path, prefix) || isAncestorPath(prefix, path)
 }

--- a/packages/editor/src/node-traversal/get-void-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-void-ancestor.ts
@@ -1,0 +1,27 @@
+import type {PortableTextObject} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isVoidNode} from '../slate/node/is-void-node'
+import {getAncestor} from './get-ancestor'
+
+/**
+ * Find the nearest ancestor that is a void (non-editable) object node.
+ *
+ * Unlike `getAncestorObjectNode`, editable containers are skipped — they are
+ * object nodes but contain editable content, so callers that want "this
+ * subtree is a single selectable void" should use this instead.
+ */
+export function getVoidAncestor(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): {node: PortableTextObject; path: Path} | undefined {
+  return getAncestor(context, path, (node, ancestorPath) =>
+    isVoidNode(context, node, ancestorPath),
+  )
+}

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -7,6 +7,10 @@ import {getChildren} from '../node-traversal/get-children'
 import {getNode} from '../node-traversal/get-node'
 import {getNodes} from '../node-traversal/get-nodes'
 import {isLeaf} from '../node-traversal/is-leaf'
+import {
+  getBlockSubSchema,
+  isInsideEditableContainer,
+} from '../schema/get-block-sub-schema'
 import {isEdge} from '../slate/editor/is-edge'
 import {isEnd} from '../slate/editor/is-end'
 import {isStart} from '../slate/editor/is-start'
@@ -79,6 +83,20 @@ export const addAnnotationOperationImplementation: OperationImplementation<
 
       if (block.children.length === 1 && block.children[0]?.text === '') {
         continue
+      }
+
+      // Inside an editable container the sub-schema is authoritative:
+      // skip blocks whose sub-schema doesn't declare this annotation type.
+      // At root we remain permissive so unknown annotations pass through.
+      if (isInsideEditableContainer(context, blockPath)) {
+        const subSchema = getBlockSubSchema(context, blockPath)
+        if (
+          !subSchema.annotations.some(
+            (annotation) => annotation.name === parsedAnnotation._type,
+          )
+        ) {
+          continue
+        }
       }
 
       const annotationKey =

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -3,6 +3,7 @@ import {isSpan, isTextBlock} from '@portabletext/schema'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getChildren} from '../node-traversal/get-children'
 import {getNode} from '../node-traversal/get-node'
 import {getNodes} from '../node-traversal/get-nodes'
@@ -10,7 +11,6 @@ import {isLeaf} from '../node-traversal/is-leaf'
 import {isEdge} from '../slate/editor/is-edge'
 import {isEnd} from '../slate/editor/is-end'
 import {isStart} from '../slate/editor/is-start'
-import {path as editorPath} from '../slate/editor/path'
 import {rangeRef} from '../slate/editor/range-ref'
 import {withoutNormalizing} from '../slate/editor/without-normalizing'
 import type {Path} from '../slate/interfaces/path'
@@ -26,7 +26,7 @@ import type {OperationImplementation} from './operation.types'
 
 export const removeAnnotationOperationImplementation: OperationImplementation<
   'annotation.remove'
-> = ({operation}) => {
+> = ({context, operation}) => {
   const editor = operation.editor
 
   const at = operation.at
@@ -40,9 +40,9 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
   }
 
   if (isCollapsedRange(effectiveSelection)) {
-    const blockEntry = getNode(
-      editor,
-      editorPath(editor, effectiveSelection, {depth: 1}),
+    const blockEntry = getAncestorTextBlock(
+      context,
+      effectiveSelection.focus.path,
     )
 
     if (!blockEntry) {
@@ -51,19 +51,12 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
 
     const {node: block, path: blockPath} = blockEntry
 
-    if (!isTextBlock({schema: editor.schema}, block)) {
-      return
-    }
-
     const markDefs = block.markDefs ?? []
     const potentialAnnotations = markDefs.filter(
       (markDef) => markDef._type === operation.annotation.name,
     )
 
-    const selectedChildEntry = getNode(
-      editor,
-      editorPath(editor, effectiveSelection, {depth: 2}),
-    )
+    const selectedChildEntry = getNode(editor, effectiveSelection.focus.path)
 
     if (!selectedChildEntry) {
       return

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -1,37 +1,26 @@
 import {applyAll, set} from '@portabletext/patches'
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
+import {getNode} from '../node-traversal/get-node'
+import {getBlockObjectSchema} from '../schema/get-block-object-schema'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {parseMarkDefs} from '../utils/parse-blocks'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
 > = ({context, operation}) => {
-  const blockSegment = operation.at.at(-1)
+  const blockEntry = getNode(operation.editor, operation.at)
 
-  if (!isKeyedSegment(blockSegment)) {
-    throw new Error(
-      `Unable to extract block key from ${safeStringify(operation.at)}`,
-    )
-  }
-
-  const blockIndex = operation.editor.blockIndexMap.get(blockSegment._key)
-
-  if (blockIndex === undefined) {
-    throw new Error(
-      `Unable to find block index for block at ${safeStringify(operation.at)}`,
-    )
-  }
-
-  const slateBlock = operation.editor.children.at(blockIndex)
-
-  if (!slateBlock) {
+  if (!blockEntry) {
     throw new Error(`Unable to find block at ${safeStringify(operation.at)}`)
   }
 
+  const slateBlock = blockEntry.node
+
   if (isTextBlockNode(context, slateBlock)) {
+    const subSchema = getBlockSubSchema(context, blockEntry.path)
     const filteredProps: Record<string, unknown> = {}
 
     for (const key of Object.keys(operation.props)) {
@@ -46,9 +35,7 @@ export const blockSetOperationImplementation: OperationImplementation<
 
       if (key === 'style') {
         if (
-          context.schema.styles.some(
-            (style) => style.name === operation.props[key],
-          )
+          subSchema.styles.some((style) => style.name === operation.props[key])
         ) {
           filteredProps[key] = operation.props[key]
         }
@@ -57,9 +44,7 @@ export const blockSetOperationImplementation: OperationImplementation<
 
       if (key === 'listItem') {
         if (
-          context.schema.lists.some(
-            (list) => list.name === operation.props[key],
-          )
+          subSchema.lists.some((list) => list.name === operation.props[key])
         ) {
           filteredProps[key] = operation.props[key]
         }
@@ -86,12 +71,12 @@ export const blockSetOperationImplementation: OperationImplementation<
       }
     }
 
-    setNodeProperties(operation.editor, filteredProps, [
-      {_key: slateBlock._key},
-    ])
+    setNodeProperties(operation.editor, filteredProps, blockEntry.path)
   } else {
-    const schemaDefinition = context.schema.blockObjects.find(
-      (definition) => definition.name === slateBlock._type,
+    const schemaDefinition = getBlockObjectSchema(
+      context,
+      slateBlock,
+      blockEntry.path,
     )
     const filteredProps: Record<string, unknown> = {}
 
@@ -105,7 +90,7 @@ export const blockSetOperationImplementation: OperationImplementation<
         continue
       }
 
-      if (schemaDefinition?.fields.some((field) => field.name === key)) {
+      if (schemaDefinition?.fields?.some((field) => field.name === key)) {
         filteredProps[key] = operation.props[key]
       }
     }
@@ -116,8 +101,6 @@ export const blockSetOperationImplementation: OperationImplementation<
 
     const updatedSlateBlock = applyAll(slateBlock, patches)
 
-    setNodeProperties(operation.editor, updatedSlateBlock, [
-      {_key: slateBlock._key},
-    ])
+    setNodeProperties(operation.editor, updatedSlateBlock, blockEntry.path)
   }
 }

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -1,35 +1,19 @@
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
+import {getNode} from '../node-traversal/get-node'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
 > = ({context, operation}) => {
-  const blockSegment = operation.at.at(-1)
+  const blockEntry = getNode(operation.editor, operation.at)
 
-  if (!isKeyedSegment(blockSegment)) {
-    throw new Error(
-      `Unable to extract block key from ${safeStringify(operation.at)}`,
-    )
-  }
-
-  const blockKey = blockSegment._key
-  const blockIndex = operation.editor.blockIndexMap.get(blockKey)
-
-  if (blockIndex === undefined) {
-    throw new Error(`Unable to find block index for block key ${blockKey}`)
-  }
-
-  const slateBlock =
-    blockIndex !== undefined
-      ? operation.editor.children.at(blockIndex)
-      : undefined
-
-  if (!slateBlock) {
+  if (!blockEntry) {
     throw new Error(`Unable to find block at ${safeStringify(operation.at)}`)
   }
+
+  const slateBlock = blockEntry.node
 
   if (isTextBlockNode(context, slateBlock)) {
     const propsToRemove = operation.props.filter(
@@ -40,12 +24,14 @@ export const blockUnsetOperationImplementation: OperationImplementation<
     for (const prop of propsToRemove) {
       unsetProps[prop] = null
     }
-    setNodeProperties(operation.editor, unsetProps, [{_key: blockKey}])
+    setNodeProperties(operation.editor, unsetProps, blockEntry.path)
 
     if (operation.props.includes('_key')) {
-      setNodeProperties(operation.editor, {_key: context.keyGenerator()}, [
-        {_key: blockKey},
-      ])
+      setNodeProperties(
+        operation.editor,
+        {_key: context.keyGenerator()},
+        blockEntry.path,
+      )
     }
 
     return
@@ -62,5 +48,5 @@ export const blockUnsetOperationImplementation: OperationImplementation<
       unsetProps[key] = null
     }
   }
-  setNodeProperties(operation.editor, unsetProps, [{_key: blockKey}])
+  setNodeProperties(operation.editor, unsetProps, blockEntry.path)
 }

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -2,7 +2,9 @@ import {isSpan} from '@portabletext/schema'
 import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNode} from '../node-traversal/get-node'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {isObjectNode} from '../slate/node/is-object-node'
+import {parentPath} from '../slate/path/parent-path'
 import type {OperationImplementation} from './operation.types'
 
 export const childSetOperationImplementation: OperationImplementation<
@@ -56,7 +58,9 @@ export const childSetOperationImplementation: OperationImplementation<
   }
 
   if (isObjectNode({schema: operation.editor.schema}, child)) {
-    const definition = context.schema.inlineObjects.find(
+    const blockPath = parentPath(childPath)
+    const {inlineObjects} = getBlockSubSchema(context, blockPath)
+    const definition = inlineObjects.find(
       (definition) => definition.name === child._type,
     )
 

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -1,15 +1,19 @@
-import {isSpan, isTextBlock} from '@portabletext/schema'
+import {isSpan} from '@portabletext/schema'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
-import {getNode} from '../node-traversal/get-node'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNodes} from '../node-traversal/get-nodes'
+import {
+  getBlockSubSchema,
+  isInsideEditableContainer,
+} from '../schema/get-block-sub-schema'
 import {isEdge} from '../slate/editor/is-edge'
 import {isEnd} from '../slate/editor/is-end'
 import {isStart} from '../slate/editor/is-start'
-import {path as editorPath} from '../slate/editor/path'
 import {rangeRef} from '../slate/editor/range-ref'
 import {withoutNormalizing} from '../slate/editor/without-normalizing'
+import {parentPath} from '../slate/path/parent-path'
 import {isExpandedRange} from '../slate/range/is-expanded-range'
 import {rangeEdges} from '../slate/range/range-edges'
 import {rangeEnd} from '../slate/range/range-end'
@@ -18,7 +22,7 @@ import type {OperationImplementation} from './operation.types'
 
 export const decoratorAddOperationImplementation: OperationImplementation<
   'decorator.add'
-> = ({operation}) => {
+> = ({context, operation}) => {
   const editor = operation.editor
   const mark = operation.decorator
 
@@ -82,6 +86,20 @@ export const decoratorAddOperationImplementation: OperationImplementation<
           continue
         }
 
+        // Inside an editable container the sub-schema is authoritative:
+        // skip spans whose block's sub-schema doesn't declare this
+        // decorator. At root we remain permissive and allow unknown
+        // decorators to be tracked optimistically.
+        const blockPath = parentPath(spanPath)
+        if (isInsideEditableContainer(context, blockPath)) {
+          const subSchema = getBlockSubSchema(context, blockPath)
+          if (
+            !subSchema.decorators.some((decorator) => decorator.name === mark)
+          ) {
+            continue
+          }
+        }
+
         const marks = [
           ...(Array.isArray(node.marks) ? node.marks : []).filter(
             (eMark: string) => eMark !== mark,
@@ -104,13 +122,24 @@ export const decoratorAddOperationImplementation: OperationImplementation<
       return
     }
 
-    const blockEntry = getNode(editor, editorPath(editor, at, {depth: 1}))
+    const blockEntry = getAncestorTextBlock(context, at.focus.path)
     if (!blockEntry) {
       return
     }
     const {node: block, path: blockPath} = blockEntry
+
+    // Inside an editable container the sub-schema is authoritative: bail
+    // when the block's sub-schema doesn't declare this decorator. At root
+    // we remain permissive so unknown decorators are tracked in
+    // `decoratorState` (the existing root-level behaviour).
+    if (isInsideEditableContainer(context, blockPath)) {
+      const subSchema = getBlockSubSchema(context, blockPath)
+      if (!subSchema.decorators.some((decorator) => decorator.name === mark)) {
+        return
+      }
+    }
+
     const lonelyEmptySpan =
-      isTextBlock({schema: editor.schema}, block) &&
       block.children.length === 1 &&
       isSpan({schema: editor.schema}, block.children[0]) &&
       block.children[0].text === ''

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -2,21 +2,21 @@ import {isSpan, isTextBlock} from '@portabletext/schema'
 import {resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNode} from '../node-traversal/get-node'
 import {getNodes} from '../node-traversal/get-nodes'
 import {isLeaf} from '../node-traversal/is-leaf'
 import {isEdge} from '../slate/editor/is-edge'
 import {isEnd} from '../slate/editor/is-end'
 import {isStart} from '../slate/editor/is-start'
-import {path as editorPath} from '../slate/editor/path'
 import {rangeRef} from '../slate/editor/range-ref'
 import {withoutNormalizing} from '../slate/editor/without-normalizing'
+import {parentPath} from '../slate/path/parent-path'
 import {isCollapsedRange} from '../slate/range/is-collapsed-range'
 import {isExpandedRange} from '../slate/range/is-expanded-range'
 import {rangeEdges} from '../slate/range/range-edges'
 import {rangeEnd} from '../slate/range/range-end'
 import {rangeStart} from '../slate/range/range-start'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const decoratorRemoveOperationImplementation: OperationImplementation<
@@ -77,12 +77,9 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
             continue
           }
 
-          const blockSegment = nodePath[0]!
-          const block = isKeyedSegment(blockSegment)
-            ? editor.children.find((b) => b._key === blockSegment._key)
-            : editor.children.at(
-                typeof blockSegment === 'number' ? blockSegment : -1,
-              )
+          const blockPath = parentPath(nodePath)
+          const blockEntry = getNode(editor, blockPath)
+          const block = blockEntry?.node
           if (
             isTextBlock({schema: editor.schema}, block) &&
             block.children.includes(node)
@@ -102,13 +99,12 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
       }
     }) // end withoutNormalizing
   } else {
-    const blockEntry = getNode(editor, editorPath(editor, at, {depth: 1}))
-    if (!blockEntry) {
+    const textBlockEntry = getAncestorTextBlock(context, at.focus.path)
+    if (!textBlockEntry) {
       return
     }
-    const {node: block, path: blockPath} = blockEntry
+    const {node: block, path: blockPath} = textBlockEntry
     const lonelyEmptySpan =
-      isTextBlock({schema: editor.schema}, block) &&
       block.children.length === 1 &&
       isSpan({schema: editor.schema}, block.children[0]) &&
       block.children[0].text === ''

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -50,36 +50,27 @@ export const deleteOperationImplementation: OperationImplementation<
   const [start, end] = rangeEdges(at, {}, operation.editor)
 
   if (operation.unit === 'block') {
-    const startBlockSegment = start.path.at(0)
-    const endBlockSegment = end.path.at(0)
-
-    if (startBlockSegment === undefined || endBlockSegment === undefined) {
-      throw new Error('Failed to get start or end block segment')
-    }
-
-    const removeRange = {
-      anchor: {path: [startBlockSegment], offset: 0},
-      focus: {path: [endBlockSegment], offset: 0},
-    }
-    const removeRangeEdges = rangeEdges(removeRange, {}, operation.editor)
-    const blockMatches: Array<{node: Node; path: Path}> = []
-    let lastHighestPath: Path | undefined
+    const removeRangeEdges = rangeEdges(at, {}, operation.editor)
+    const candidateEntries: Array<{node: Node; path: Path}> = []
 
     for (const entry of getNodes(operation.editor, {
       from: removeRangeEdges[0].path,
       to: removeRangeEdges[1].path,
     })) {
-      const {path: entryPath} = entry
-
-      if (lastHighestPath && isAncestorPath(lastHighestPath, entryPath)) {
-        continue
-      }
-
-      if (isBlock(operation.editor, entryPath)) {
-        lastHighestPath = entryPath
-        blockMatches.push(entry)
+      if (isBlock(operation.editor, entry.path)) {
+        candidateEntries.push(entry)
       }
     }
+
+    // Keep only the deepest matching block along each branch. A candidate
+    // whose path is an ancestor of any later candidate is dropped.
+    const blockMatches = candidateEntries.filter(
+      (candidate, index) =>
+        !candidateEntries.some(
+          (other, otherIndex) =>
+            otherIndex > index && isAncestorPath(candidate.path, other.path),
+        ),
+    )
     const blockPathRefs = Array.from(blockMatches, (entry) =>
       pathRef(operation.editor, entry.path),
     )

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -8,11 +8,10 @@ import {safeStringify} from '../internal-utils/safe-json'
 import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {toSlateBlock} from '../internal-utils/values'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
-import {getNode} from '../node-traversal/get-node'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import {getSibling} from '../node-traversal/get-sibling'
 import {getSpanNode} from '../node-traversal/get-span-node'
 import {getTextBlockNode} from '../node-traversal/get-text-block-node'
-import {isBlock} from '../node-traversal/is-block'
 import {end as editorEnd} from '../slate/editor/end'
 import {pathRef} from '../slate/editor/path-ref'
 import {rangeRef} from '../slate/editor/range-ref'
@@ -130,8 +129,8 @@ function resolveTarget(args: {
     ? rangeEdges(at, {}, editor)
     : [editorStart(editor, []), editorEnd(editor, [])]
 
-  const startBlockEntry = findContainingBlock(editor, startPoint.path)
-  const endBlockEntry = findContainingBlock(editor, endPoint.path)
+  const startBlockEntry = getEnclosingBlock(editor, startPoint.path)
+  const endBlockEntry = getEnclosingBlock(editor, endPoint.path)
 
   if (!startBlockEntry || !endBlockEntry) {
     return undefined
@@ -197,27 +196,6 @@ function resolveTarget(args: {
     blockPath: endBlockPath,
     splitAt: collapsedPoint,
   }
-}
-
-/**
- * Find the closest ancestor block that contains the given point path. Walks
- * up prefix-by-prefix (deepest first) so it works at any depth.
- */
-function findContainingBlock(
-  editor: PortableTextSlateEditor,
-  pointPath: Path,
-): {node: Node; path: Path} | undefined {
-  for (let length = pointPath.length; length >= 1; length--) {
-    const candidatePath = pointPath.slice(0, length)
-    if (typeof candidatePath[candidatePath.length - 1] === 'string') {
-      continue
-    }
-    const entry = getNode(editor, candidatePath)
-    if (entry && isBlock(editor, candidatePath)) {
-      return entry
-    }
-  }
-  return undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -470,11 +448,10 @@ function mergeTextBlockFragment(args: {
   }
 
   if (select === 'start' && firstInsertedKey && resolvedAtPath) {
-    const firstInsertedPath: Path = [
-      ...parentPath(resolvedAtPath),
-      'children',
-      {_key: firstInsertedKey},
-    ]
+    const firstInsertedPath: Path = siblingPath(
+      resolvedAtPath,
+      firstInsertedKey,
+    )
     const startPoint = editorStart(editor, firstInsertedPath)
     applySelect(editor, startPoint)
   }
@@ -538,8 +515,8 @@ function executeDeleteThenInsert(args: {
   const rangeStartPoint = rangeStart(range, editor)
   const rangeEndPoint = rangeEnd(range, editor)
 
-  const startBlockEntry = findContainingBlock(editor, rangeStartPoint.path)
-  const endBlockEntry = findContainingBlock(editor, rangeEndPoint.path)
+  const startBlockEntry = getEnclosingBlock(editor, rangeStartPoint.path)
+  const endBlockEntry = getEnclosingBlock(editor, rangeEndPoint.path)
   const wasCrossBlock =
     startBlockEntry !== undefined &&
     endBlockEntry !== undefined &&
@@ -609,7 +586,7 @@ function executeDeleteThenInsert(args: {
   }
 
   const containingBlockEntry =
-    resolvedBlock ?? findContainingBlock(editor, collapsedPoint.path)
+    resolvedBlock ?? getEnclosingBlock(editor, collapsedPoint.path)
 
   if (!containingBlockEntry) {
     return

--- a/packages/editor/src/operations/operation.insert.child.ts
+++ b/packages/editor/src/operations/operation.insert.child.ts
@@ -3,36 +3,46 @@ import {
   applyInsertNodeAtPath,
   applyInsertNodeAtPoint,
 } from '../internal-utils/apply-insert-node'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNode} from '../node-traversal/get-node'
 import {getSibling} from '../node-traversal/get-sibling'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {parseInlineObject, parseSpan} from '../utils/parse-blocks'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {OperationImplementation} from './operation.types'
 
 export const insertChildOperationImplementation: OperationImplementation<
   'insert.child'
 > = ({context, operation}) => {
   const focus = operation.editor.selection?.focus
-  const focusBlockIndex = focus?.path.at(0)
-  const focusChildIndex = focus?.path.at(2)
 
-  if (focusBlockIndex === undefined || focusChildIndex === undefined) {
+  if (!focus) {
     throw new Error('Unable to insert child without a focus')
   }
 
-  const focusBlockEntry = focus
-    ? getNode(operation.editor, focus.path.slice(0, 1))
-    : undefined
-  const focusBlock = focusBlockEntry?.node
-  const focusBlockPath = focusBlockEntry?.path
+  const focusBlockEntry = getAncestorTextBlock(operation.editor, focus.path)
 
-  if (!focus || !focusBlock || !focusBlockPath) {
+  if (!focusBlockEntry) {
     throw new Error('Unable to insert child without a focus block')
   }
+
+  const focusBlock = focusBlockEntry.node
 
   if (!isTextBlockNode(context, focusBlock)) {
     throw new Error('Unable to insert child into a non-text block')
   }
+
+  const focusChildSegment = focus.path.at(-1)
+
+  if (!isKeyedSegment(focusChildSegment)) {
+    throw new Error('Unable to insert child without a focus child')
+  }
+
+  const focusChildPath = [
+    ...focusBlockEntry.path,
+    'children',
+    focusChildSegment,
+  ]
 
   const markDefs = focusBlock.markDefs ?? []
   const markDefKeyMap = new Map<string, string>()
@@ -48,7 +58,7 @@ export const insertChildOperationImplementation: OperationImplementation<
   })
 
   if (span) {
-    const focusSpanEntry = getNode(operation.editor, focus.path.slice(0, 3))
+    const focusSpanEntry = getNode(operation.editor, focusChildPath)
     const focusSpan =
       focusSpanEntry &&
       isSpan({schema: operation.editor.schema}, focusSpanEntry.node)
@@ -58,7 +68,6 @@ export const insertChildOperationImplementation: OperationImplementation<
     if (focusSpan) {
       applyInsertNodeAtPoint(operation.editor, span, focus)
     } else {
-      const focusChildPath = focus.path.slice(0, 3)
       const nextSibling = getSibling(operation.editor, focusChildPath, 'next')
       if (nextSibling) {
         applyInsertNodeAtPath(operation.editor, span, nextSibling.path)
@@ -94,7 +103,7 @@ export const insertChildOperationImplementation: OperationImplementation<
       ...rest,
     }
 
-    const focusSpanEntry = getNode(operation.editor, focus.path.slice(0, 3))
+    const focusSpanEntry = getNode(operation.editor, focusChildPath)
     const focusSpan =
       focusSpanEntry &&
       isSpan({schema: operation.editor.schema}, focusSpanEntry.node)
@@ -104,7 +113,6 @@ export const insertChildOperationImplementation: OperationImplementation<
     if (focusSpan) {
       applyInsertNodeAtPoint(operation.editor, inlineNode, focus)
     } else {
-      const focusChildPath = focus.path.slice(0, 3)
       const nextSibling = getSibling(operation.editor, focusChildPath, 'next')
       if (nextSibling) {
         applyInsertNodeAtPath(operation.editor, inlineNode, nextSibling.path)

--- a/packages/editor/src/operations/operation.move.block.ts
+++ b/packages/editor/src/operations/operation.move.block.ts
@@ -1,63 +1,57 @@
+import {safeStringify} from '../internal-utils/safe-json'
+import {getChildren} from '../node-traversal/get-children'
 import {getNode} from '../node-traversal/get-node'
 import {withoutNormalizing} from '../slate/editor/without-normalizing'
-import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
+import {parentPath} from '../slate/path/parent-path'
 import type {OperationImplementation} from './operation.types'
 
 export const moveBlockOperationImplementation: OperationImplementation<
   'move.block'
 > = ({operation}) => {
-  const originKey = getBlockKeyFromSelectionPoint({
-    path: operation.at,
-    offset: 0,
-  })
-
-  if (!originKey) {
-    throw new Error('Failed to get block key from selection point')
-  }
-
-  const originBlockIndex = operation.editor.blockIndexMap.get(originKey)
-
-  if (originBlockIndex === undefined) {
-    throw new Error('Failed to get block index from block key')
-  }
-
-  const destinationKey = getBlockKeyFromSelectionPoint({
-    path: operation.to,
-    offset: 0,
-  })
-
-  if (!destinationKey) {
-    throw new Error('Failed to get block key from selection point')
-  }
-
-  const destinationBlockIndex =
-    operation.editor.blockIndexMap.get(destinationKey)
-
-  if (destinationBlockIndex === undefined) {
-    throw new Error('Failed to get block index from block key')
-  }
-
   const editor = operation.editor
-  const nodeEntry = getNode(editor, [{_key: originKey}])
+  const originEntry = getNode(editor, operation.at)
 
-  if (!nodeEntry) {
-    return
+  if (!originEntry) {
+    throw new Error(
+      `Failed to resolve origin block at ${safeStringify(operation.at)}`,
+    )
   }
 
-  const node = nodeEntry.node
+  const destinationEntry = getNode(editor, operation.to)
 
+  if (!destinationEntry) {
+    throw new Error(
+      `Failed to resolve destination block at ${safeStringify(operation.to)}`,
+    )
+  }
+
+  // Determine movement direction within the shared sibling array. Only
+  // supports moves at the same level today (root → root or within the
+  // same container field). Cross-level moves would need the behavior to
+  // split the move into remove + insert with explicit parent resolution.
+  const siblings = getChildren(editor, parentPath(originEntry.path))
+  const originIndex = siblings.findIndex(
+    (sibling) => sibling.node._key === originEntry.node._key,
+  )
+  const destinationIndex = siblings.findIndex(
+    (sibling) => sibling.node._key === destinationEntry.node._key,
+  )
+  const movingDown =
+    originIndex !== -1 &&
+    destinationIndex !== -1 &&
+    originIndex < destinationIndex
+
+  const node = originEntry.node
   const savedSelection = editor.selection
-
-  const movingDown = originBlockIndex < destinationBlockIndex
 
   withoutNormalizing(editor, () => {
     editor.apply({
       type: 'unset',
-      path: [{_key: node._key}],
+      path: originEntry.path,
     })
     editor.apply({
       type: 'insert',
-      path: [{_key: destinationKey}],
+      path: destinationEntry.path,
       node,
       position: movingDown ? 'after' : 'before',
     })

--- a/packages/editor/src/operations/operation.types.ts
+++ b/packages/editor/src/operations/operation.types.ts
@@ -6,7 +6,10 @@ import type {EditorContext} from '../editor/editor-snapshot'
 import type {OmitFromUnion, PickFromUnion} from '../type-utils'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 
-export type OperationContext = Pick<EditorContext, 'keyGenerator' | 'schema'>
+export type OperationContext = Pick<
+  EditorContext,
+  'keyGenerator' | 'schema' | 'containers' | 'value'
+>
 
 export type OperationImplementation<TOperationType extends Operation['type']> =
   ({

--- a/packages/editor/src/schema/get-block-sub-schema.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.ts
@@ -82,6 +82,24 @@ export function getBlockSubSchema(
   }
 }
 
+/**
+ * Returns true when the given path is inside an editable container.
+ *
+ * Used by operations to know when sub-schema validation applies. At the root
+ * the editor's permissive contract is preserved; inside a container the
+ * sub-schema is authoritative and those operations should be filtered.
+ */
+export function isInsideEditableContainer(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): boolean {
+  return findEnclosingNestedBlock(context, path) !== undefined
+}
+
 function rootSubSchema(schema: EditorSchema): BlockSubSchema {
   return {
     styles: schema.styles,

--- a/packages/editor/src/selectors/selector.get-default-style.ts
+++ b/packages/editor/src/selectors/selector.get-default-style.ts
@@ -1,0 +1,24 @@
+import type {EditorSelector} from '../editor/editor-selector'
+import {getBlockSubSchema} from '../schema/get-block-sub-schema'
+import {getFocusTextBlock} from './selector.get-focus-text-block'
+
+/**
+ * Returns the default style name for a new block at the current focus.
+ *
+ * This is the first entry of the focus text block's sub-schema styles, or
+ * the first entry of the root styles when there is no focus text block
+ * (e.g. focus in a void block object). Used by `insert.break` when
+ * creating a sibling block.
+ *
+ * Returns `undefined` when the applicable sub-schema declares no styles.
+ */
+export const getDefaultStyle: EditorSelector<string | undefined> = (
+  snapshot,
+) => {
+  const focusTextBlock = getFocusTextBlock(snapshot)
+  if (focusTextBlock) {
+    return getBlockSubSchema(snapshot.context, focusTextBlock.path).styles[0]
+      ?.name
+  }
+  return snapshot.context.schema.styles[0]?.name
+}

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -14,6 +14,7 @@ import {getNode} from '../../node-traversal/get-node'
 import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {getBlockSubSchema} from '../../schema/get-block-sub-schema'
 import {getContainerScopedName} from '../../schema/get-container-scoped-name'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
@@ -222,13 +223,12 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Add missing .style to text block nodes
    */
-  {
-    const defaultStyle = editor.schema.styles.at(0)?.name
-    if (
-      defaultStyle &&
-      isTextBlockNode({schema: editor.schema}, node) &&
-      typeof node.style === 'undefined'
-    ) {
+  if (
+    isTextBlockNode({schema: editor.schema}, node) &&
+    typeof node.style === 'undefined'
+  ) {
+    const defaultStyle = getBlockSubSchema(editor, path).styles.at(0)?.name
+    if (defaultStyle) {
       debug.normalization('adding .style to block node')
       setNodeProperties(editor, {style: defaultStyle}, path)
       return
@@ -267,7 +267,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     if (!blockEntry) {
       return
     }
-    const decorators = editor.schema.decorators.map(
+    const decorators = getBlockSubSchema(editor, path).decorators.map(
       (decorator) => decorator.name,
     )
     const annotations = node.marks?.filter((mark) => !decorators.includes(mark))
@@ -287,7 +287,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Remove orphaned annotations from child spans of block nodes
    */
   if (isTextBlock({schema: editor.schema}, node)) {
-    const decorators = editor.schema.decorators.map(
+    const decorators = getBlockSubSchema(editor, path).decorators.map(
       (decorator) => decorator.name,
     )
 
@@ -327,7 +327,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     if (blockEntry2) {
       const block = blockEntry2.node
-      const decorators = editor.schema.decorators.map(
+      const decorators = getBlockSubSchema(editor, path).decorators.map(
         (decorator) => decorator.name,
       )
       const marks = node.marks ?? []
@@ -432,7 +432,11 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
         let childNode: Node | undefined
         if (acceptsBlocks) {
-          childNode = createPlaceholderBlock(editor)
+          childNode = createPlaceholderBlock(editor, [
+            ...path,
+            arrayField.name,
+            0,
+          ])
         } else if (firstChildType && firstChildType.type !== 'block') {
           childNode = {
             _type: firstChildType.type,

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -17,10 +17,10 @@ import scrollIntoView from 'scroll-into-view-if-needed'
 import {getDomNode} from '../../../dom-traversal/get-dom-node'
 import {getDomNodePath} from '../../../dom-traversal/get-dom-node-path'
 import type {EditorActor} from '../../../editor/editor-machine'
-import {getAncestorObjectNode} from '../../../node-traversal/get-ancestor-object-node'
 import {getAncestorTextBlock} from '../../../node-traversal/get-ancestor-text-block'
 import {getNode} from '../../../node-traversal/get-node'
 import {getText} from '../../../node-traversal/get-text'
+import {getVoidAncestor} from '../../../node-traversal/get-void-ancestor'
 import {collapse} from '../../core/collapse'
 import {deselect} from '../../core/deselect'
 import {move} from '../../core/move'
@@ -1231,24 +1231,25 @@ export const Editable = forwardRef(
                     const start = editorStart(editor, path)
                     const end = editorEnd(editor, path)
                     const startEntry = getNode(editor, start.path)
-                    const startObjectNode =
+                    const startVoidNode =
                       startEntry &&
                       isVoidNode(editor, startEntry.node, start.path)
                         ? startEntry
-                        : getAncestorObjectNode(editor, start.path)
+                        : getVoidAncestor(editor, start.path)
                     const endEntry = getNode(editor, end.path)
-                    const endObjectNode =
+                    const endVoidNode =
                       endEntry && isVoidNode(editor, endEntry.node, end.path)
                         ? endEntry
-                        : getAncestorObjectNode(editor, end.path)
+                        : getVoidAncestor(editor, end.path)
 
                     if (
-                      startObjectNode &&
-                      endObjectNode &&
-                      pathEquals(startObjectNode.path, endObjectNode.path)
+                      startVoidNode &&
+                      endVoidNode &&
+                      pathEquals(startVoidNode.path, endVoidNode.path)
                     ) {
                       const range = editorRange(editor, start)
                       editor.select(range)
+                      return
                     }
                   }
                 },

--- a/packages/editor/src/utils/parse-blocks.test.ts
+++ b/packages/editor/src/utils/parse-blocks.test.ts
@@ -834,3 +834,172 @@ describe(parseChild.name, () => {
     })
   })
 })
+
+describe('container-aware parsing', () => {
+  const containerSchema = defineSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    inlineObjects: [{name: 'rootMention'}],
+    blockObjects: [
+      {
+        name: 'tableCell',
+        fields: [
+          {
+            name: 'content',
+            type: 'array',
+            of: [
+              {
+                type: 'block',
+                decorators: [{name: 'strong'}],
+                inlineObjects: [
+                  {name: 'cellMention', fields: [{name: 'id', type: 'string'}]},
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  test('nested span strips decorators not allowed by the container sub-schema', () => {
+    const schema = compileSchema(containerSchema)
+    const parsed = parseBlock({
+      block: {
+        _type: 'tableCell',
+        _key: 'cell0',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b0',
+            children: [
+              {
+                _type: 'span',
+                _key: 's0',
+                text: 'hi',
+                marks: ['strong', 'em'],
+              },
+            ],
+          },
+        ],
+      },
+      context: {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      },
+      options: {
+        normalize: false,
+        removeUnusedMarkDefs: false,
+        validateFields: true,
+      },
+    })
+
+    expect(parsed).toEqual({
+      _type: 'tableCell',
+      _key: 'cell0',
+      content: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {
+              _type: 'span',
+              _key: 's0',
+              text: 'hi',
+              marks: ['strong'],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test('nested inline object from root is rejected when the container declares its own list', () => {
+    const schema = compileSchema(containerSchema)
+    const parsed = parseBlock({
+      block: {
+        _type: 'tableCell',
+        _key: 'cell0',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b0',
+            children: [
+              {_type: 'span', _key: 's0', text: 'before', marks: []},
+              {_type: 'rootMention', _key: 'x0'},
+              {_type: 'cellMention', _key: 'x1', id: 'alice'},
+              {_type: 'span', _key: 's1', text: 'after', marks: []},
+            ],
+          },
+        ],
+      },
+      context: {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      },
+      options: {
+        normalize: false,
+        removeUnusedMarkDefs: false,
+        validateFields: true,
+      },
+    })
+
+    expect(parsed).toEqual({
+      _type: 'tableCell',
+      _key: 'cell0',
+      content: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 's0', text: 'before', marks: []},
+            {_type: 'cellMention', _key: 'x1', id: 'alice'},
+            {_type: 'span', _key: 's1', text: 'after', marks: []},
+          ],
+        },
+      ],
+    })
+  })
+
+  test('nested blocks inherit annotations and lists from root when not overridden', () => {
+    const schema = compileSchema(containerSchema)
+    const parsed = parseBlock({
+      block: {
+        _type: 'tableCell',
+        _key: 'cell0',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b0',
+            markDefs: [{_type: 'link', _key: 'L', href: 'https://example.com'}],
+            children: [
+              {_type: 'span', _key: 's0', text: 'linked', marks: ['L']},
+            ],
+          },
+        ],
+      },
+      context: {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      },
+      options: {
+        normalize: false,
+        removeUnusedMarkDefs: false,
+        validateFields: true,
+      },
+    })
+
+    expect(parsed).toEqual({
+      _type: 'tableCell',
+      _key: 'cell0',
+      content: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          markDefs: [{_type: 'link', _key: 'L', href: 'https://example.com'}],
+          children: [{_type: 'span', _key: 's0', text: 'linked', marks: ['L']}],
+        },
+      ],
+    })
+  })
+})

--- a/packages/editor/src/utils/parse-blocks.ts
+++ b/packages/editor/src/utils/parse-blocks.ts
@@ -1,16 +1,164 @@
 import {
   isSpan,
   isTextBlock,
+  type AnnotationSchemaType,
+  type BaseDefinition,
+  type BlockObjectSchemaType,
+  type DecoratorSchemaType,
+  type InlineObjectSchemaType,
+  type ListSchemaType,
+  type OfDefinition,
   type PortableTextBlock,
   type PortableTextListBlock,
   type PortableTextObject,
   type PortableTextSpan,
   type PortableTextTextBlock,
+  type StyleSchemaType,
   type TypedObject,
 } from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
 import type {EditorContext} from '../editor/editor-snapshot'
+import {asFieldedTypes, asNamedTypes} from '../schema/schema-type-projections'
 import {isRecord, isTypedObject} from './asserters'
+
+type AnyField = {
+  name: string
+  type: string
+  of?: ReadonlyArray<OfDefinition>
+}
+
+/**
+ * Shape of a compiled `{type: 'block'}` entry inside a container field's
+ * `of`. `compileSchema` resolves every sub-schema field, so after
+ * compilation these are always populated (though the input type declares
+ * them optional).
+ */
+type BlockOfDefinitionResolved = {
+  type: 'block'
+  name?: string
+  title?: string
+  styles?: ReadonlyArray<BaseDefinition>
+  decorators?: ReadonlyArray<BaseDefinition>
+  annotations?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<AnyField>}
+  >
+  lists?: ReadonlyArray<BaseDefinition>
+  inlineObjects?: ReadonlyArray<
+    BaseDefinition & {fields?: ReadonlyArray<AnyField>}
+  >
+}
+
+/**
+ * The resolved view used to validate a text block and its children at a given
+ * depth. At the root of the document it is built from the schema. Inside a
+ * container field it is built from the field's `of` -- the `{type: 'block'}`
+ * entry (with its sub-schema fully resolved by `compileSchema`) plus any
+ * non-block siblings acting as block-object members at that scope.
+ */
+type BlockScope = {
+  block: {name: string}
+  blockCustomFields: ReadonlyArray<string>
+  span: {name: string}
+  styles: ReadonlyArray<StyleSchemaType>
+  decorators: ReadonlyArray<DecoratorSchemaType>
+  annotations: ReadonlyArray<AnnotationSchemaType>
+  lists: ReadonlyArray<ListSchemaType>
+  inlineObjects: ReadonlyArray<InlineObjectSchemaType>
+  blockObjects: ReadonlyArray<BlockObjectSchemaType>
+}
+
+function rootBlockScope(schema: EditorContext['schema']): BlockScope {
+  return {
+    block: {name: schema.block.name},
+    blockCustomFields: (schema.block.fields ?? []).map((field) => field.name),
+    span: {name: schema.span.name},
+    styles: schema.styles,
+    decorators: schema.decorators,
+    annotations: schema.annotations,
+    lists: schema.lists,
+    inlineObjects: schema.inlineObjects,
+    blockObjects: schema.blockObjects,
+  }
+}
+
+/**
+ * Build a child `BlockScope` from a container field's `of` members. The
+ * `{type: 'block'}` entry (if present) supplies the resolved sub-schema; the
+ * non-block members become the scope's block objects. When there is no
+ * `{type: 'block'}` entry the returned scope still carries root's `block`
+ * and `span` names for fallback, but every validation list is empty.
+ */
+function childBlockScope(
+  schema: EditorContext['schema'],
+  of: ReadonlyArray<OfDefinition>,
+): BlockScope {
+  const blockMember = of.find(
+    (member): member is BlockOfDefinitionResolved => member.type === 'block',
+  )
+  const objectMembers: Array<{
+    type: string
+    name?: string
+    title?: string
+    fields: ReadonlyArray<AnyField>
+  }> = []
+
+  for (const member of of) {
+    if (member.type === 'block') {
+      continue
+    }
+    const objectMember = member as {
+      type: string
+      name?: string
+      title?: string
+      fields?: ReadonlyArray<AnyField>
+    }
+    objectMembers.push({
+      type: objectMember.type,
+      name: objectMember.name,
+      title: objectMember.title,
+      fields: objectMember.fields ?? [],
+    })
+  }
+
+  const blockObjects: ReadonlyArray<BlockObjectSchemaType> = objectMembers.map(
+    (member) => ({
+      name: member.name ?? member.type,
+      title: member.title,
+      fields: member.fields as BlockObjectSchemaType['fields'],
+    }),
+  )
+
+  if (!blockMember) {
+    return {
+      block: {name: schema.block.name},
+      blockCustomFields: [],
+      span: {name: schema.span.name},
+      styles: [],
+      decorators: [],
+      annotations: [],
+      lists: [],
+      inlineObjects: [],
+      blockObjects,
+    }
+  }
+
+  return {
+    block: {name: blockMember.name ?? schema.block.name},
+    blockCustomFields: [],
+    span: {name: schema.span.name},
+    styles: asNamedTypes<StyleSchemaType>(blockMember.styles) ?? schema.styles,
+    decorators:
+      asNamedTypes<DecoratorSchemaType>(blockMember.decorators) ??
+      schema.decorators,
+    annotations:
+      asFieldedTypes<AnnotationSchemaType>(blockMember.annotations) ??
+      schema.annotations,
+    lists: asNamedTypes<ListSchemaType>(blockMember.lists) ?? schema.lists,
+    inlineObjects:
+      asFieldedTypes<InlineObjectSchemaType>(blockMember.inlineObjects) ??
+      schema.inlineObjects,
+    blockObjects,
+  }
+}
 
 export function parseBlocks({
   context,
@@ -29,8 +177,10 @@ export function parseBlocks({
     return []
   }
 
+  const scope = rootBlockScope(context.schema)
+
   return blocks.flatMap((block) => {
-    const parsedBlock = parseBlock({context, block, options})
+    const parsedBlock = parseBlockInScope({context, scope, block, options})
 
     return parsedBlock ? [parsedBlock] : []
   })
@@ -49,26 +199,128 @@ export function parseBlock({
     validateFields: boolean
   }
 }): PortableTextBlock | undefined {
+  return parseBlockInScope({
+    context,
+    scope: rootBlockScope(context.schema),
+    block,
+    options,
+  })
+}
+
+export function parseSpan({
+  span,
+  context,
+  markDefKeyMap,
+  options,
+}: {
+  span: unknown
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  markDefKeyMap: Map<string, string>
+  options: {validateFields: boolean}
+}): PortableTextSpan | undefined {
+  return parseSpanInScope({
+    span,
+    context,
+    scope: rootBlockScope(context.schema),
+    markDefKeyMap,
+    options,
+  })
+}
+
+export function parseInlineObject({
+  inlineObject,
+  context,
+  options,
+}: {
+  inlineObject: unknown
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  options: {validateFields: boolean}
+}): PortableTextObject | undefined {
+  return parseInlineObjectInScope({
+    inlineObject,
+    context,
+    scope: rootBlockScope(context.schema),
+    options,
+  })
+}
+
+export function parseChild({
+  child,
+  context,
+  markDefKeyMap,
+  options,
+}: {
+  child: unknown
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  markDefKeyMap: Map<string, string>
+  options: {validateFields: boolean}
+}): PortableTextSpan | PortableTextObject | undefined {
+  return parseChildInScope({
+    child,
+    context,
+    scope: rootBlockScope(context.schema),
+    markDefKeyMap,
+    options,
+  })
+}
+
+export function parseMarkDefs({
+  context,
+  markDefs,
+  options,
+}: {
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  markDefs: unknown
+  options: {validateFields: boolean}
+}): {
+  markDefs: Array<PortableTextObject>
+  markDefKeyMap: Map<string, string>
+} {
+  return parseMarkDefsInScope({
+    context,
+    scope: rootBlockScope(context.schema),
+    markDefs,
+    options,
+  })
+}
+
+function parseBlockInScope({
+  context,
+  scope,
+  block,
+  options,
+}: {
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
+  block: unknown
+  options: {
+    normalize: boolean
+    removeUnusedMarkDefs: boolean
+    validateFields: boolean
+  }
+}): PortableTextBlock | undefined {
   return (
-    parseTextBlock({block, context, options}) ??
-    parseBlockObject({blockObject: block, context, options})
+    parseTextBlock({block, context, scope, options}) ??
+    parseBlockObject({blockObject: block, context, scope, options})
   )
 }
 
 function parseBlockObject({
   blockObject,
   context,
+  scope,
   options,
 }: {
   blockObject: unknown
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   options: {validateFields: boolean}
 }): PortableTextObject | undefined {
   if (!isTypedObject(blockObject)) {
     return undefined
   }
 
-  const schemaType = context.schema.blockObjects.find(
+  const schemaType = scope.blockObjects.find(
     ({name}) => name === blockObject._type,
   )
 
@@ -78,10 +330,8 @@ function parseBlockObject({
 
   return parseObject({
     object: blockObject,
-    context: {
-      keyGenerator: context.keyGenerator,
-      schemaType,
-    },
+    context,
+    schemaType,
     options,
   })
 }
@@ -100,10 +350,12 @@ export function isListBlock(
 function parseTextBlock({
   block,
   context,
+  scope,
   options,
 }: {
   block: unknown
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   options: {
     normalize: boolean
     removeUnusedMarkDefs: boolean
@@ -111,6 +363,10 @@ function parseTextBlock({
   }
 }): PortableTextTextBlock | undefined {
   if (!isTypedObject(block)) {
+    return undefined
+  }
+
+  if (block._type !== scope.block.name) {
     return undefined
   }
 
@@ -130,7 +386,7 @@ function parseTextBlock({
     }
 
     if (options.validateFields) {
-      if (context.schema.block.fields?.some((field) => field.name === key)) {
+      if (scope.blockCustomFields.includes(key)) {
         customFields[key] = block[key]
       }
     } else {
@@ -138,15 +394,12 @@ function parseTextBlock({
     }
   }
 
-  if (block._type !== context.schema.block.name) {
-    return undefined
-  }
-
   const _key =
     typeof block['_key'] === 'string' ? block['_key'] : context.keyGenerator()
 
-  const {markDefs, markDefKeyMap} = parseMarkDefs({
+  const {markDefs, markDefKeyMap} = parseMarkDefsInScope({
     context,
+    scope,
     markDefs: block['markDefs'],
     options,
   })
@@ -156,7 +409,9 @@ function parseTextBlock({
     : []
 
   const parsedChildren = unparsedChildren
-    .map((child) => parseChild({child, context, markDefKeyMap, options}))
+    .map((child) =>
+      parseChildInScope({child, context, scope, markDefKeyMap, options}),
+    )
     .filter((child) => child !== undefined)
   const marks = parsedChildren.flatMap((child) => child.marks ?? [])
 
@@ -166,7 +421,7 @@ function parseTextBlock({
       : [
           {
             _key: context.keyGenerator(),
-            _type: context.schema.span.name,
+            _type: scope.span.name,
             text: '',
             marks: [],
           },
@@ -187,7 +442,7 @@ function parseTextBlock({
               ...normalizedChildren,
               {
                 _key: context.keyGenerator(),
-                _type: context.schema.span.name,
+                _type: scope.span.name,
                 text: '',
                 marks: [],
               },
@@ -196,7 +451,7 @@ function parseTextBlock({
                 ? [
                     {
                       _key: context.keyGenerator(),
-                      _type: context.schema.span.name,
+                      _type: scope.span.name,
                       text: '',
                       marks: [],
                     },
@@ -212,7 +467,7 @@ function parseTextBlock({
     : children
 
   const parsedBlock: PortableTextTextBlock = {
-    _type: context.schema.block.name,
+    _type: scope.block.name,
     _key,
     children: normalizedChildren,
     ...customFields,
@@ -226,14 +481,14 @@ function parseTextBlock({
 
   if (
     typeof block['style'] === 'string' &&
-    context.schema.styles.find((style) => style.name === block['style'])
+    scope.styles.find((style) => style.name === block['style'])
   ) {
     parsedBlock.style = block['style']
   }
 
   if (
     typeof block['listItem'] === 'string' &&
-    context.schema.lists.find((list) => list.name === block['listItem'])
+    scope.lists.find((list) => list.name === block['listItem'])
   ) {
     parsedBlock.listItem = block['listItem']
   }
@@ -245,12 +500,14 @@ function parseTextBlock({
   return parsedBlock
 }
 
-export function parseMarkDefs({
+function parseMarkDefsInScope({
   context,
+  scope,
   markDefs,
   options,
 }: {
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   markDefs: unknown
   options: {validateFields: boolean}
 }): {
@@ -267,7 +524,7 @@ export function parseMarkDefs({
       return []
     }
 
-    const schemaType = context.schema.annotations.find(
+    const schemaType = scope.annotations.find(
       ({name}) => name === markDef._type,
     )
 
@@ -283,10 +540,8 @@ export function parseMarkDefs({
 
     const parsedAnnotation = parseObject({
       object: markDef,
-      context: {
-        schemaType,
-        keyGenerator: context.keyGenerator,
-      },
+      context,
+      schemaType,
       options,
     })
 
@@ -305,31 +560,40 @@ export function parseMarkDefs({
   }
 }
 
-export function parseChild({
+function parseChildInScope({
   child,
   context,
+  scope,
   markDefKeyMap,
   options,
 }: {
   child: unknown
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   markDefKeyMap: Map<string, string>
   options: {validateFields: boolean}
 }): PortableTextSpan | PortableTextObject | undefined {
   return (
-    parseSpan({span: child, context, markDefKeyMap, options}) ??
-    parseInlineObject({inlineObject: child, context, options})
+    parseSpanInScope({span: child, context, scope, markDefKeyMap, options}) ??
+    parseInlineObjectInScope({
+      inlineObject: child,
+      context,
+      scope,
+      options,
+    })
   )
 }
 
-export function parseSpan({
+function parseSpanInScope({
   span,
   context,
+  scope,
   markDefKeyMap,
   options,
 }: {
   span: unknown
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   markDefKeyMap: Map<string, string>
   options: {validateFields: boolean}
 }): PortableTextSpan | undefined {
@@ -364,26 +628,21 @@ export function parseSpan({
       return [markDefKey]
     }
 
-    if (
-      context.schema.decorators.some((decorator) => decorator.name === mark)
-    ) {
+    if (scope.decorators.some((decorator) => decorator.name === mark)) {
       return [mark]
     }
 
     return []
   })
 
-  if (
-    typeof span['_type'] === 'string' &&
-    span['_type'] !== context.schema.span.name
-  ) {
+  if (typeof span['_type'] === 'string' && span['_type'] !== scope.span.name) {
     return undefined
   }
 
   if (typeof span['_type'] !== 'string') {
     if (typeof span['text'] === 'string') {
       return {
-        _type: context.schema.span.name as 'span',
+        _type: scope.span.name as 'span',
         _key:
           typeof span['_key'] === 'string'
             ? span['_key']
@@ -398,7 +657,7 @@ export function parseSpan({
   }
 
   return {
-    _type: context.schema.span.name as 'span',
+    _type: scope.span.name as 'span',
     _key:
       typeof span['_key'] === 'string' ? span['_key'] : context.keyGenerator(),
     text: typeof span['text'] === 'string' ? span['text'] : '',
@@ -407,20 +666,22 @@ export function parseSpan({
   }
 }
 
-export function parseInlineObject({
+function parseInlineObjectInScope({
   inlineObject,
   context,
+  scope,
   options,
 }: {
   inlineObject: unknown
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  scope: BlockScope
   options: {validateFields: boolean}
 }): PortableTextObject | undefined {
   if (!isTypedObject(inlineObject)) {
     return undefined
   }
 
-  const schemaType = context.schema.inlineObjects.find(
+  const schemaType = scope.inlineObjects.find(
     ({name}) => name === inlineObject._type,
   )
 
@@ -430,10 +691,8 @@ export function parseInlineObject({
 
   return parseObject({
     object: inlineObject,
-    context: {
-      keyGenerator: context.keyGenerator,
-      schemaType,
-    },
+    context,
+    schemaType,
     options,
   })
 }
@@ -461,50 +720,140 @@ export function parseAnnotation({
 
   return parseObject({
     object: annotation,
-    context: {
-      keyGenerator: context.keyGenerator,
-      schemaType,
-    },
+    context,
+    schemaType,
     options,
   })
 }
 
+/**
+ * Parse an object against a `{name, fields}` schema type. Validates top-level
+ * fields and recurses into any array field whose `of` contains a block-like
+ * member -- parsing the nested blocks against a child `BlockScope` built from
+ * that `of`.
+ */
 function parseObject({
   object,
   context,
+  schemaType,
   options,
 }: {
   object: TypedObject
-  context: Pick<EditorContext, 'keyGenerator'> & {
-    schemaType: EditorSchema['blockObjects'][0]
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  schemaType: {
+    name: string
+    fields: ReadonlyArray<{
+      name: string
+      type: string
+      of?: ReadonlyArray<OfDefinition>
+    }>
   }
   options: {validateFields: boolean}
 }): PortableTextObject {
-  const {_type, _key, ...customFields} = object
+  const {_key, ...customFields} = object
 
-  // Validates all props on the object and only takes those that match
-  // the name of a field
-  const values = options.validateFields
-    ? context.schemaType.fields.reduce<Record<string, unknown>>(
-        (fieldValues, field) => {
-          const fieldValue = object[field.name]
+  const fieldsByName = new Map(
+    schemaType.fields.map((field) => [field.name, field]),
+  )
 
-          if (fieldValue !== undefined) {
-            fieldValues[field.name] = fieldValue
-          }
+  const values: Record<string, unknown> = {}
 
-          return fieldValues
-        },
-        {},
-      )
-    : customFields
+  for (const [key, value] of Object.entries(customFields)) {
+    if (key === '_type') {
+      continue
+    }
+
+    const field = fieldsByName.get(key)
+
+    if (options.validateFields && !field) {
+      continue
+    }
+
+    if (field && field.type === 'array' && field.of && Array.isArray(value)) {
+      values[key] = parseContainerFieldValue({
+        context,
+        of: field.of,
+        value,
+        options,
+      })
+      continue
+    }
+
+    values[key] = value
+  }
 
   return {
-    _type: context.schemaType.name,
-    _key:
-      typeof object['_key'] === 'string'
-        ? object['_key']
-        : context.keyGenerator(),
+    _type: schemaType.name,
+    _key: typeof _key === 'string' ? _key : context.keyGenerator(),
     ...values,
   }
+}
+
+/**
+ * Parse the value of an array field whose `of` declares what's allowed at
+ * that position. If any member is `{type: 'block'}`, the field is a PTE
+ * container: recurse via `parseBlocks` in a child `BlockScope`. Otherwise it
+ * is an opaque array of non-PTE members (rows, cells, scalars, objects that
+ * happen to sit between containers and the actual text blocks) -- recurse
+ * into each member object so nested PTE arrays further down are still
+ * reached.
+ */
+function parseContainerFieldValue({
+  context,
+  of,
+  value,
+  options,
+}: {
+  context: Pick<EditorContext, 'keyGenerator' | 'schema'>
+  of: ReadonlyArray<OfDefinition>
+  value: ReadonlyArray<unknown>
+  options: {validateFields: boolean; normalize?: boolean}
+}): Array<unknown> {
+  const hasBlockMember = of.some((member) => member.type === 'block')
+
+  if (hasBlockMember) {
+    const scope = childBlockScope(context.schema, of)
+    return value.flatMap((block) => {
+      const parsed = parseBlockInScope({
+        context,
+        scope,
+        block,
+        options: {
+          normalize: false,
+          removeUnusedMarkDefs: false,
+          validateFields: options.validateFields,
+        },
+      })
+      return parsed ? [parsed] : []
+    })
+  }
+
+  // Non-PTE array: recurse into object members so any deeper PTE arrays
+  // (e.g. `table.rows[].cells[].content`) still get parsed.
+  return value.flatMap((item) => {
+    if (!isTypedObject(item)) {
+      return [item]
+    }
+    const member = of.find(
+      (entry) => entry.type !== 'block' && entry.type === item._type,
+    )
+    if (!member || member.type === 'block' || !('fields' in member)) {
+      return [item]
+    }
+    return [
+      parseObject({
+        object: item,
+        context,
+        schemaType: {
+          name: member.type,
+          fields: (member.fields ?? []) as ReadonlyArray<{
+            name: string
+            type: string
+            of?: ReadonlyArray<OfDefinition>
+          }>,
+        },
+        options,
+      }),
+    ]
+  })
 }

--- a/packages/editor/src/utils/util.slice-text-block.test.ts
+++ b/packages/editor/src/utils/util.slice-text-block.test.ts
@@ -56,20 +56,16 @@ describe(sliceTextBlock.name, () => {
 
     expect(
       sliceTextBlock({
-        context: {
-          schema,
-          selection: {
-            anchor: {
-              path: [{_key: block._key}, 'children', {_key: span._key}],
-              offset: 0,
-            },
-            focus: {
-              path: [{_key: block._key}, 'children', {_key: span._key}],
-              offset: 0,
-            },
-          },
-        },
+        context: {schema},
         block,
+        startPoint: {
+          path: [{_key: block._key}, 'children', {_key: span._key}],
+          offset: 0,
+        },
+        endPoint: {
+          path: [{_key: block._key}, 'children', {_key: span._key}],
+          offset: 0,
+        },
       }),
     ).toEqual(block)
   })
@@ -84,20 +80,16 @@ describe(sliceTextBlock.name, () => {
 
     expect(
       sliceTextBlock({
-        context: {
-          schema,
-          selection: {
-            anchor: {
-              path: [{_key: block._key}, 'children', {_key: span._key}],
-              offset: 4,
-            },
-            focus: {
-              path: [{_key: block._key}, 'children', {_key: span._key}],
-              offset: 7,
-            },
-          },
-        },
+        context: {schema},
         block,
+        startPoint: {
+          path: [{_key: block._key}, 'children', {_key: span._key}],
+          offset: 4,
+        },
+        endPoint: {
+          path: [{_key: block._key}, 'children', {_key: span._key}],
+          offset: 7,
+        },
       }),
     ).toEqual({
       ...block,
@@ -133,20 +125,16 @@ describe(sliceTextBlock.name, () => {
     test('mid-span', () => {
       expect(
         sliceTextBlock({
-          context: {
-            schema,
-            selection: {
-              anchor: {
-                path: [{_key: block._key}, 'children', {_key: barSpan._key}],
-                offset: 1,
-              },
-              focus: {
-                path: [{_key: block._key}, 'children', {_key: bazSpan._key}],
-                offset: 1,
-              },
-            },
-          },
+          context: {schema},
           block,
+          startPoint: {
+            path: [{_key: block._key}, 'children', {_key: barSpan._key}],
+            offset: 1,
+          },
+          endPoint: {
+            path: [{_key: block._key}, 'children', {_key: bazSpan._key}],
+            offset: 1,
+          },
         }),
       ).toEqual({
         ...block,
@@ -167,20 +155,16 @@ describe(sliceTextBlock.name, () => {
     test('from end of span to end of block', () => {
       expect(
         sliceTextBlock({
-          context: {
-            schema,
-            selection: {
-              anchor: {
-                path: [{_key: block._key}, 'children', {_key: fooSpan._key}],
-                offset: 3,
-              },
-              focus: {
-                path: [{_key: block._key}, 'children', {_key: bazSpan._key}],
-                offset: 3,
-              },
-            },
-          },
+          context: {schema},
           block,
+          startPoint: {
+            path: [{_key: block._key}, 'children', {_key: fooSpan._key}],
+            offset: 3,
+          },
+          endPoint: {
+            path: [{_key: block._key}, 'children', {_key: bazSpan._key}],
+            offset: 3,
+          },
         }),
       ).toEqual({
         ...block,

--- a/packages/editor/src/utils/util.slice-text-block.ts
+++ b/packages/editor/src/utils/util.slice-text-block.ts
@@ -4,36 +4,34 @@ import {
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import type {EditorContext} from '../editor/editor-snapshot'
-import {getSelectionEndPoint} from './util.get-selection-end-point'
-import {getSelectionStartPoint} from './util.get-selection-start-point'
-import {
-  getBlockKeyFromSelectionPoint,
-  getChildKeyFromSelectionPoint,
-} from './util.selection-point'
+import type {EditorSelectionPoint} from '../types/editor'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
+/**
+ * Return a shallow copy of `block` that contains the content between
+ * `startPoint` and `endPoint`. Depth-agnostic: resolves child keys from the
+ * last segment of each point's path, so it works for blocks at any depth
+ * (including inside editable containers).
+ */
 export function sliceTextBlock({
   context,
   block,
+  startPoint,
+  endPoint,
 }: {
-  context: Pick<EditorContext, 'schema' | 'selection'>
+  context: Pick<EditorContext, 'schema'>
   block: PortableTextTextBlock
+  startPoint: EditorSelectionPoint
+  endPoint: EditorSelectionPoint
 }): PortableTextTextBlock {
-  const startPoint = getSelectionStartPoint(context.selection)
-  const endPoint = getSelectionEndPoint(context.selection)
-
-  if (!startPoint || !endPoint) {
-    return block
-  }
-
-  const startBlockKey = getBlockKeyFromSelectionPoint(startPoint)
-  const endBlockKey = getBlockKeyFromSelectionPoint(endPoint)
-
-  if (startBlockKey !== endBlockKey || startBlockKey !== block._key) {
-    return block
-  }
-
-  const startChildKey = getChildKeyFromSelectionPoint(startPoint)
-  const endChildKey = getChildKeyFromSelectionPoint(endPoint)
+  const startChildSegment = startPoint.path.at(-1)
+  const endChildSegment = endPoint.path.at(-1)
+  const startChildKey = isKeyedSegment(startChildSegment)
+    ? startChildSegment._key
+    : undefined
+  const endChildKey = isKeyedSegment(endChildSegment)
+    ? endChildSegment._key
+    : undefined
 
   if (!startChildKey || !endChildKey) {
     return block

--- a/packages/editor/src/utils/util.split-text-block.ts
+++ b/packages/editor/src/utils/util.split-text-block.ts
@@ -22,31 +22,26 @@ export function splitTextBlock({
     return undefined
   }
 
+  const blockStartPoint: EditorSelectionPoint = {
+    path: [{_key: block._key}, 'children', {_key: firstChild._key}],
+    offset: 0,
+  }
+  const blockEndPoint: EditorSelectionPoint = {
+    path: [{_key: block._key}, 'children', {_key: lastChild._key}],
+    offset: isSpan(context, lastChild) ? lastChild.text.length : 0,
+  }
+
   const before = sliceTextBlock({
-    context: {
-      schema: context.schema,
-      selection: {
-        anchor: {
-          path: [{_key: block._key}, 'children', {_key: firstChild._key}],
-          offset: 0,
-        },
-        focus: point,
-      },
-    },
+    context,
     block,
+    startPoint: blockStartPoint,
+    endPoint: point,
   })
   const after = sliceTextBlock({
-    context: {
-      schema: context.schema,
-      selection: {
-        anchor: point,
-        focus: {
-          path: [{_key: block._key}, 'children', {_key: lastChild._key}],
-          offset: isSpan(context, lastChild) ? lastChild.text.length : 0,
-        },
-      },
-    },
+    context,
     block,
+    startPoint: point,
+    endPoint: blockEndPoint,
   })
 
   return {before, after}

--- a/packages/editor/tests/click-lonely-block-object-container.test.tsx
+++ b/packages/editor/tests/click-lonely-block-object-container.test.tsx
@@ -1,0 +1,189 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineContainer, defineSchema} from '../src'
+import {ContainerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {name: 'image', fields: [{name: 'src', type: 'string'}]},
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}, {type: 'image'}],
+        },
+      ],
+    },
+  ],
+})
+
+const calloutContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..callout',
+  field: 'content',
+})
+
+describe('click above/below lonely block object in containers', () => {
+  test('Scenario: clicking below a lonely block object inside a container inserts a text block after it', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: imageKey,
+              _type: 'image',
+              src: 'https://example.com/pic.png',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[calloutContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const imageSelection = {
+      anchor: {
+        path: [{_key: calloutKey}, 'content', {_key: imageKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: calloutKey}, 'content', {_key: imageKey}],
+        offset: 0,
+      },
+    }
+
+    editor.send({type: 'select', at: imageSelection})
+
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: true,
+        selection: imageSelection,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: imageKey,
+              _type: 'image',
+              src: 'https://example.com/pic.png',
+            },
+            {
+              _key: 'k4',
+              _type: 'block',
+              children: [
+                {
+                  _key: 'k5',
+                  _type: 'span',
+                  marks: [],
+                  text: '',
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: clicking above a lonely block object inside a container inserts a text block before it', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: imageKey,
+              _type: 'image',
+              src: 'https://example.com/pic.png',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[calloutContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const imageSelection = {
+      anchor: {
+        path: [{_key: calloutKey}, 'content', {_key: imageKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: calloutKey}, 'content', {_key: imageKey}],
+        offset: 0,
+      },
+    }
+
+    editor.send({type: 'select', at: imageSelection})
+
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: true,
+        selection: imageSelection,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: 'k4',
+              _type: 'block',
+              children: [
+                {
+                  _key: 'k5',
+                  _type: 'span',
+                  marks: [],
+                  text: '',
+                },
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _key: imageKey,
+              _type: 'image',
+              src: 'https://example.com/pic.png',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/code-block.navigation.test.tsx
+++ b/packages/editor/tests/code-block.navigation.test.tsx
@@ -61,37 +61,33 @@ describe('code block navigation', () => {
       children: <ContainerPlugin containers={[codeBlockContainer]} />,
     })
 
-    const codeBlockElement = await vi.waitFor(() => {
-      const element = document.querySelector('[data-testid="code-block"]')
+    const editable = await vi.waitFor(() => {
+      const element = document.querySelector('[role="textbox"]')
       expect(element).not.toEqual(null)
       return element!
     })
 
-    await userEvent.click(codeBlockElement)
+    await userEvent.click(editable)
+    const spanPath = [
+      {_key: codeBlockKey},
+      'lines',
+      {_key: lineKey},
+      'children',
+      {_key: spanKey},
+    ]
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: spanPath, offset: 0},
+        focus: {path: spanPath, offset: 0},
+      },
+    })
     await userEvent.keyboard('{ArrowRight}')
 
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {
-          path: [
-            {_key: codeBlockKey},
-            'lines',
-            {_key: lineKey},
-            'children',
-            {_key: spanKey},
-          ],
-          offset: 1,
-        },
-        focus: {
-          path: [
-            {_key: codeBlockKey},
-            'lines',
-            {_key: lineKey},
-            'children',
-            {_key: spanKey},
-          ],
-          offset: 1,
-        },
+        anchor: {path: spanPath, offset: 1},
+        focus: {path: spanPath, offset: 1},
         backward: false,
       })
     })
@@ -126,15 +122,27 @@ describe('code block navigation', () => {
       children: <ContainerPlugin containers={[codeBlockContainer]} />,
     })
 
-    const codeBlockElement = await vi.waitFor(() => {
-      const element = document.querySelector('[data-testid="code-block"]')
+    const editable = await vi.waitFor(() => {
+      const element = document.querySelector('[role="textbox"]')
       expect(element).not.toEqual(null)
       return element!
     })
 
-    await userEvent.click(codeBlockElement)
-    // click lands at offset 0; advance to offset 1 then delete back to offset 0.
-    await userEvent.keyboard('{ArrowRight}')
+    await userEvent.click(editable)
+    const spanPath = [
+      {_key: codeBlockKey},
+      'lines',
+      {_key: lineKey},
+      'children',
+      {_key: spanKey},
+    ]
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: spanPath, offset: 1},
+        focus: {path: spanPath, offset: 1},
+      },
+    })
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -95,6 +95,7 @@ describe('event.drag.drop', () => {
       position: {
         block: 'end',
         isEditor: false,
+        isContainer: false,
         selection: {
           anchor: {
             path: [{_key: blockKey}, 'children', {_key: barKey}],
@@ -198,6 +199,7 @@ describe('event.drag.drop', () => {
       position: {
         block: 'start',
         isEditor: false,
+        isContainer: false,
         selection: {
           anchor: {
             path: [{_key: blockKey}, 'children', {_key: spanKey}],


### PR DESCRIPTION
The parser, operations, and core behaviors walk into editable containers instead of assuming root-level blocks.

**Parser and normalization.** `parseObject` threads `allowedTypes` through nested resolution so inline-declared types (table rows/cells) parse correctly. Normalization uses `getBlockSubSchema` to validate against the applicable sub-schema rather than the root.

**Operations.** `block.set`/`block.unset`, `child.set`, `annotation.add`/`remove`, `decorator.add`/`remove`, `delete`, `insert.block`, `split.block`, and the inverse-operation transformer all resolve targets via `getNode` instead of `path[0]`/`path[2]` indexing. Sub-schema gating preserves the root-level permissive contract: new validation only applies when `isInsideEditableContainer` is true.

**Core behaviors.** Block-object guards (arrow-up/down on lonely, click-above/below, delete-empty-text-block-after/before) walk ancestors. `insert.break` uses the focus block's sub-schema for the default style. New `behavior.core.containers.ts` intercepts ArrowUp at the start of a container's first block and ArrowDown at the end of the last block to prevent native `<table>` caret escape. Click handling lets the DOM place the caret natively inside containers (`getVoidAncestor` excludes editable containers from snap-to-start).

The text-block placeholder behavior, parsing of inline-declared schema types, and operations like inserting an image into a code-block line all work at any depth.
