### PR TITLE
test: migrate plugin gherkin tests from terse-pt to textspec

### DIFF
--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -3,6 +3,7 @@ import {getTersePt, parseTersePt} from '@portabletext/test'
 import {Given, Then, When} from 'racejar'
 import {assert, expect, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
+import {boundaryEquivalentSelections} from '../../../test-utils/boundary-equivalent'
 import {getEditorSelection} from '../../../test-utils/editor-selection'
 import {
   fromTextspec,
@@ -96,6 +97,14 @@ async function assertEditorState(
     // names (e.g. `l2`, `c3`) to any markDef keys the editor produced that
     // aren't in the user-defined keyMap. This lets assertions express
     // "annotation with a different key" structurally.
+    // For each markDef the editor produced, decide what symbolic name
+    // to render in textspec output:
+    //   1. If keyMap pre-registered the key (via `a "link" "l1" around`),
+    //      use the symbolic name from keyMap.
+    //   2. If the expected string asks for the actual key by name
+    //      (e.g. `_key="k4"`), identity-map it.
+    //   3. Otherwise, auto-assign the next symbolic name in the type's
+    //      prefix sequence (e.g. `l2`, `c3`).
     if (keys.size > 0) {
       const counters = new Map<string, number>()
       for (const symbolic of annotationKeys.values()) {
@@ -119,6 +128,10 @@ async function assertEditorState(
           if (annotationKeys.has(md._key)) {
             continue
           }
+          if (keys.has(md._key)) {
+            annotationKeys.set(md._key, md._key)
+            continue
+          }
           const prefix = (md._type ?? 'k').charAt(0)
           const next = (counters.get(prefix) ?? 0) + 1
           counters.set(prefix, next)
@@ -127,21 +140,44 @@ async function assertEditorState(
       }
     }
 
-    expect(
+    const toTextspecOptions = options.singleLine
+      ? {singleLine: true as const, keys: keys.size > 0 ? keys : undefined}
+      : {keys: keys.size > 0 ? keys : undefined}
+
+    const renderActual = (effectiveSelection: typeof selection): string =>
       toTextspec(
         {
           schema,
           value,
-          selection: assertsSelection ? selection : null,
+          selection: assertsSelection ? effectiveSelection : null,
           containers,
           annotationKeys,
         },
-        options.singleLine
-          ? {singleLine: true, keys: keys.size > 0 ? keys : undefined}
-          : {keys: keys.size > 0 ? keys : undefined},
-      ),
-      'Unexpected editor state',
-    ).toBe(expected)
+        toTextspecOptions,
+      )
+
+    const strict = renderActual(selection)
+
+    if (strict === expected || !assertsSelection) {
+      expect(strict, 'Unexpected editor state').toBe(expected)
+      return
+    }
+
+    // Span boundaries: `{span-A, end}` and `{span-B, 0}` describe the same
+    // caret position but the editor model picks one form, and that pick
+    // can vary by browser when native beforeinput insertion is involved.
+    // Accept any boundary-equivalent selection that produces the expected
+    // textspec.
+    for (const variant of boundaryEquivalentSelections(
+      {schema, containers, value},
+      selection,
+    )) {
+      if (renderActual(variant) === expected) {
+        return
+      }
+    }
+
+    expect(strict, 'Unexpected editor state').toBe(expected)
   })
 }
 

--- a/packages/editor/test-utils/boundary-equivalent.test.ts
+++ b/packages/editor/test-utils/boundary-equivalent.test.ts
@@ -1,0 +1,187 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {boundaryEquivalentSelections} from './boundary-equivalent'
+
+const schema = compileSchema(defineSchema({}))
+const containers = new Map()
+
+describe(boundaryEquivalentSelections.name, () => {
+  test('returns no variants when selection is null', () => {
+    expect(
+      boundaryEquivalentSelections({schema, value: [], containers}, null),
+    ).toEqual([])
+  })
+
+  test('returns no variants when point is in middle of span', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 's2', _type: 'span', text: 'bar'},
+      ],
+    }
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 1,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: point, focus: point, backward: false},
+      ),
+    ).toEqual([])
+  })
+
+  test('returns no variants when point is at boundary but no sibling span', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [{_key: 's1', _type: 'span', text: 'foo'}],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: endOfS1, focus: endOfS1, backward: false},
+      ),
+    ).toEqual([])
+  })
+
+  test('returns next-span variant for collapsed selection at end of span', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 's2', _type: 'span', text: 'bar'},
+      ],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    const startOfS2 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 0,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: endOfS1, focus: endOfS1, backward: false},
+      ),
+    ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: false}])
+  })
+
+  test('returns previous-span variant for collapsed selection at start of span', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 's2', _type: 'span', text: 'bar'},
+      ],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    const startOfS2 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 0,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: startOfS2, focus: startOfS2, backward: false},
+      ),
+    ).toEqual([{anchor: endOfS1, focus: endOfS1, backward: false}])
+  })
+
+  test('returns no variant when sibling is an inline object, not a span', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 'i1', _type: 'stock-ticker'},
+      ],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: endOfS1, focus: endOfS1, backward: false},
+      ),
+    ).toEqual([])
+  })
+
+  test('returns cartesian product for expanded selection with both endpoints at boundaries', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 's2', _type: 'span', text: 'bar'},
+        {_key: 's3', _type: 'span', text: 'baz'},
+      ],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    const startOfS2 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 0,
+    }
+    const endOfS2 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 3,
+    }
+    const startOfS3 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's3'}],
+      offset: 0,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: endOfS1, focus: endOfS2, backward: false},
+      ),
+    ).toEqual([
+      {anchor: endOfS1, focus: startOfS3, backward: false},
+      {anchor: startOfS2, focus: endOfS2, backward: false},
+      {anchor: startOfS2, focus: startOfS3, backward: false},
+    ])
+  })
+
+  test('preserves backward flag in variants', () => {
+    const block = {
+      _key: 'b1',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'foo'},
+        {_key: 's2', _type: 'span', text: 'bar'},
+      ],
+    }
+    const endOfS1 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    const startOfS2 = {
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 0,
+    }
+    expect(
+      boundaryEquivalentSelections(
+        {schema, value: [block], containers},
+        {anchor: endOfS1, focus: endOfS1, backward: true},
+      ),
+    ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: true}])
+  })
+})

--- a/packages/editor/test-utils/boundary-equivalent.ts
+++ b/packages/editor/test-utils/boundary-equivalent.ts
@@ -1,0 +1,93 @@
+import {isSpan} from '@portabletext/schema'
+import type {EditorSchema} from '../src/editor/editor-schema'
+import {getSibling} from '../src/node-traversal/get-sibling'
+import {getSpanNode} from '../src/node-traversal/get-span-node'
+import type {Containers} from '../src/schema/resolve-containers'
+import type {Node} from '../src/slate/interfaces/node'
+import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
+import {isEqualSelectionPoints} from '../src/utils/util.is-equal-selection-points'
+
+type Context = {
+  schema: EditorSchema
+  containers: Containers
+  value: Array<Node>
+}
+
+/**
+ * Two selection points are visually equivalent at a span boundary:
+ * `{span-A, offset: span-A.text.length}` and `{span-B, offset: 0}`
+ * where span-B is the next sibling span. They render to the same caret
+ * position but the editor model picks one. `userEvent.type` can leave
+ * the editor at either form depending on the browser, particularly when
+ * native beforeinput insertion is used at a span boundary.
+ *
+ * Given a selection, return any boundary-equivalent selections. The
+ * original selection is not included.
+ *
+ * Container-aware via the traversal utilities.
+ */
+export function boundaryEquivalentSelections(
+  context: Context,
+  selection: EditorSelection,
+): Array<NonNullable<EditorSelection>> {
+  if (!selection) {
+    return []
+  }
+
+  const anchorVariants = pointVariants(context, selection.anchor)
+  const collapsed = isEqualSelectionPoints(selection.anchor, selection.focus)
+  const focusVariants = collapsed
+    ? null
+    : pointVariants(context, selection.focus)
+
+  const variants: Array<NonNullable<EditorSelection>> = []
+
+  if (focusVariants === null) {
+    for (const anchor of anchorVariants) {
+      variants.push({anchor, focus: anchor, backward: selection.backward})
+    }
+  } else {
+    for (const anchor of anchorVariants) {
+      for (const focus of focusVariants) {
+        variants.push({anchor, focus, backward: selection.backward})
+      }
+    }
+  }
+
+  return variants.filter(
+    (variant) =>
+      !(
+        isEqualSelectionPoints(variant.anchor, selection.anchor) &&
+        isEqualSelectionPoints(variant.focus, selection.focus)
+      ),
+  )
+}
+
+function pointVariants(
+  context: Context,
+  point: EditorSelectionPoint,
+): Array<EditorSelectionPoint> {
+  const span = getSpanNode(context, point.path)
+
+  if (!span) {
+    return [point]
+  }
+
+  const variants: Array<EditorSelectionPoint> = [point]
+
+  if (point.offset === 0) {
+    const previous = getSibling(context, span.path, 'previous')
+    if (previous && isSpan({schema: context.schema}, previous.node)) {
+      variants.push({path: previous.path, offset: previous.node.text.length})
+    }
+  }
+
+  if (point.offset === span.node.text.length) {
+    const next = getSibling(context, span.path, 'next')
+    if (next && isSpan({schema: context.schema}, next.node)) {
+      variants.push({path: next.path, offset: 0})
+    }
+  }
+
+  return variants
+}

--- a/packages/plugin-emoji-picker/src/emoji-picker.feature
+++ b/packages/plugin-emoji-picker/src/emoji-picker.feature
@@ -1,23 +1,26 @@
 Feature: Emoji Picker
 
+  Background:
+    Given a global keymap
+
   Scenario Outline: Picking a direct hit
     When the editor is focused
     And <initial text> is inserted
     And <inserted text> is inserted
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | initial text | inserted text | final text |
-      | ""           | ":joy:"       | "😂"       |
-      | ":jo"        | "y:"          | "😂"       |
-      | ":joy"       | ":"           | "😂"       |
+      | initial text | inserted text | final state |
+      | ""           | ":joy:"       | "B: 😂\|"   |
+      | ":jo"        | "y:"          | "B: 😂\|"   |
+      | ":joy"       | ":"           | "B: 😂\|"   |
 
   Scenario: Picking direct hit with multiple exact matches
     When the editor is focused
     And ":dog" is typed
     Then the matches are "🐕,🐩"
     When ":" is typed
-    Then the text is "🐕"
+    Then the editor state is "B: 🐕|"
 
   Scenario: Triggering after a trigger character
     When the editor is focused
@@ -36,7 +39,7 @@ Feature: Emoji Picker
     And "foo" is typed
     And "{ArrowRight}" is pressed
     And ":dog:" is inserted
-    Then the text is "foo:🐕"
+    Then the editor state is "B: foo:🐕|"
     And the keyword is ""
 
   Scenario: Toggling trigger, deleting it and toggling it again
@@ -44,32 +47,32 @@ Feature: Emoji Picker
     And ":d" is typed
     And "{Backspace}{Backspace}" is pressed
     And ":d" is typed
-    Then the text is ":d"
+    Then the editor state is "B: :d|"
     And the keyword is "d"
     And the matches are "🐕,🐩"
 
   Scenario Outline: Is only triggered when an initial colon is typed
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <inserted text> is inserted
-    Then the text is <final text>
+    Then the editor state is <final state>
     And the keyword is <keyword>
 
     Examples:
-      | text   | position     | inserted text | final text | keyword |
-      | ""     | after ""     | ":j"          | ":j"       | "j"     |
-      | ":"    | after ":"    | "j"           | ":j"       | ""      |
-      | ":j"   | after ":j"   | "o"           | ":jo"      | ""      |
-      | ":jo"  | after ":jo"  | ":"           | ":jo:"     | ""      |
-      | ":joy" | after ":joy" | ":"           | ":joy:"    | ""      |
+      | state      | position     | inserted text | final state  | keyword |
+      | "B: "      | after ""     | ":j"          | "B: :j\|"    | "j"     |
+      | "B: :"     | after ":"    | "j"           | "B: :j\|"    | ""      |
+      | "B: :j\|"  | after ":j"   | "o"           | "B: :jo\|"   | ""      |
+      | "B: :jo\|" | after ":jo"  | ":"           | "B: :jo:\|"  | ""      |
+      | "B: :joy"  | after ":joy" | ":"           | "B: :joy:\|" | ""      |
 
   Scenario: Undo after direct hit
     When the editor is focused
     And ":joy:" is typed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
     When undo is performed
-    Then the text is ":joy:"
+    Then the editor state is "B: :joy:|"
 
   Scenario: Picking direct hit after undo
     When the editor is focused
@@ -77,14 +80,14 @@ Feature: Emoji Picker
     And undo is performed
     And "{Backspace}" is pressed
     And ":" is typed
-    Then the text is ":joy:"
+    Then the editor state is "B: :joy:|"
     And the keyword is ""
     And the matches are ""
 
   Scenario: Picking wrong direct hit
     When the editor is focused
     And ":jo:" is typed
-    Then the text is ":jo:"
+    Then the editor state is "B: :jo:|"
     And the keyword is "jo"
     And the matches are "😂,😹,🕹️"
 
@@ -92,7 +95,7 @@ Feature: Emoji Picker
     When the editor is focused
     And ":jo:" is typed
     And ":" is typed
-    Then the text is ":jo::"
+    Then the editor state is "B: :jo::|"
     And the keyword is "jo:"
     And the matches are ""
 
@@ -102,53 +105,53 @@ Feature: Emoji Picker
     And undo is performed
     And "{Backspace}{Backspace}" is pressed
     And ":" is typed
-    Then the text is ":jo:"
+    Then the editor state is "B: :jo:|"
     And the keyword is ""
     And the matches are ""
 
   Scenario: Two consecutive direct hits
     When the editor is focused
     And ":joy:" is typed
-    And ":joy_cat:" is typed
-    Then the text is "😂😹"
+    And ":joy_cat:" is inserted
+    Then the editor state is "B: 😂😹|"
 
   Scenario: Picking the closest hit with Enter
     When the editor is focused
     And ":joy" is typed
     And "{Enter}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario: Picking the closest hit with Tab
     When the editor is focused
     And ":joy" is typed
     And "{Tab}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario: Navigating down the list
     When the editor is focused
     And ":joy" is typed
     And "{ArrowDown}" is pressed
     And "{Enter}" is pressed
-    Then the text is "😹"
+    Then the editor state is "B: 😹|"
 
   Scenario: Aborting on Escape
     When the editor is focused
     And ":joy" is typed
     And "{Escape}" is pressed
     And "{Enter}" is pressed
-    Then the text is ":joy|"
+    Then the editor state is "B: :joy;;B: |"
 
   Scenario: Aborting and forwarding Enter if there is no keyword
     When the editor is focused
     And ":" is typed
     And "{Enter}" is pressed
-    Then the text is ":|"
+    Then the editor state is "B: :;;B: |"
 
   Scenario: Aborting Enter if there are no matches
     When the editor is focused
     And ":asdf" is typed
     And "{Enter}" is pressed
-    Then the text is ":asdf"
+    Then the editor state is "B: :asdf|"
     And the keyword is ""
 
   Scenario: Backspacing to narrow search
@@ -156,37 +159,37 @@ Feature: Emoji Picker
     And ":joy" is typed
     And "{Backspace}" is pressed
     And "{Enter}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario Outline: Inserting longer trigger text
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And <new text> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text | inserted text | new text | final text |
-      | ""   | ":"           | "joy:"   | "😂"       |
-      | ""   | ":j"          | "oy:"    | "😂"       |
-      | ""   | ":joy"        | ":"      | "😂"       |
-      | ""   | ":joy:"       | ":"      | "😂:"      |
+      | state | inserted text | new text | final state |
+      | "B: " | ":"           | "joy:"   | "B: 😂\|"   |
+      | "B: " | ":j"          | "oy:"    | "B: 😂\|"   |
+      | "B: " | ":joy"        | ":"      | "B: 😂\|"   |
+      | "B: " | ":joy:"       | ":"      | "B: 😂:\|"  |
 
   Scenario Outline: Matching inside decorator
-    Given the text <text>
+    Given the editor state is <state>
     And "strong" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | decorated | position        | keyword | final text        |
-      | "foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "foo ,b😂ar, baz" |
-      | "foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "foo ,ba😂r, baz" |
+      | state            | decorated | position        | keyword | final state                   |
+      | "B: foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "B: foo [strong:b😂\|ar] baz" |
+      | "B: foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "B: foo [strong:ba😂\|r] baz" |
 
   Scenario Outline: Triggering at the edge of decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
@@ -201,35 +204,35 @@ Feature: Emoji Picker
       | before " baz" |
 
   Scenario Outline: Matching at the edge of decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
     And ":joy:" is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | position      | final text        |
-      | after "foo "  | "foo 😂,bar, baz" |
-      | before "bar"  | "foo 😂,bar, baz" |
-      | after "bar"   | "foo ,bar😂, baz" |
-      | before " baz" | "foo ,bar😂, baz" |
+      | position      | final state                   |
+      | after "foo "  | "B: foo 😂\|[strong:bar] baz" |
+      | before "bar"  | "B: foo 😂[strong:\|bar] baz" |
+      | after "bar"   | "B: foo [strong:bar😂\|] baz" |
+      | before " baz" | "B: foo [strong:bar😂]\| baz" |
 
   Scenario Outline: Matching inside annotation
-    Given the text <text>
+    Given the editor state is <state>
     And a "link" "l1" around <annotated>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | annotated | position        | keyword | final text        |
-      | "foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "foo ,b😂ar, baz" |
-      | "foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "foo ,ba😂r, baz" |
+      | state            | annotated | position        | keyword | final state                            |
+      | "B: foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "B: foo [@link _key=\"l1\":b😂ar] baz" |
+      | "B: foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "B: foo [@link _key=\"l1\":ba😂r] baz" |
 
   Scenario Outline: Triggering at the edge of an annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "bar"
     When the editor is focused
     And the caret is put <position>
@@ -244,80 +247,104 @@ Feature: Emoji Picker
       | before " baz" |
 
   Scenario Outline: Matching at the edge of an annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "bar"
     When the editor is focused
     And the caret is put <position>
     And ":joy:" is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | position      | final text        |
-      | after "foo "  | "foo 😂,bar, baz" |
-      | before "bar"  | "foo 😂,bar, baz" |
-      | after "bar"   | "foo ,bar,😂 baz" |
-      | before " baz" | "foo ,bar,😂 baz" |
+      | position      | final state                            |
+      | after "foo "  | "B: foo 😂[@link _key=\"l1\":bar] baz" |
+      | before "bar"  | "B: foo 😂[@link _key=\"l1\":bar] baz" |
+      | after "bar"   | "B: foo [@link _key=\"l1\":bar]😂 baz" |
+      | before " baz" | "B: foo [@link _key=\"l1\":bar]😂 baz" |
 
   Scenario Outline: Typing before the colon dismisses the emoji picker
-    Given the text <text>
+    Given the editor state is <state>
     When <inserted text> is typed
     And <button> is pressed
     And <new text> is typed
     Then the keyword is ""
 
     Examples:
-      | text | inserted text | button                   | new text |
-      | ""   | ":j"          | "{ArrowLeft}{ArrowLeft}" | "f"      |
-      | "fo" | ":j"          | "{ArrowLeft}{ArrowLeft}" | "o"      |
-      | ""   | ":j"          | "{ArrowLeft}{ArrowLeft}" | ":"      |
+      | state   | inserted text | button                   | new text |
+      | "B: "   | ":j"          | "{ArrowLeft}{ArrowLeft}" | "f"      |
+      | "B: fo" | ":j"          | "{ArrowLeft}{ArrowLeft}" | "o"      |
+      | "B: "   | ":j"          | "{ArrowLeft}{ArrowLeft}" | ":"      |
 
   Scenario Outline: Navigating away from the keyword
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
     And <button> is pressed
     And "{Enter}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | position    | keyword | button                              | final text        |
-      | "foo bar baz" | after "foo" | ":j"    | "{ArrowRight}"                      | "foo:j \|bar baz" |
-      | "foo bar baz" | after "foo" | ":j"    | "{ArrowLeft}{ArrowLeft}{ArrowLeft}" | "fo\|o:j bar baz" |
+      | state            | position    | keyword | button                              | final state               |
+      | "B: foo bar baz" | after "foo" | ":j"    | "{ArrowRight}"                      | "B: foo:j ;;B: \|bar baz" |
+      | "B: foo bar baz" | after "foo" | ":j"    | "{ArrowLeft}{ArrowLeft}{ArrowLeft}" | "B: fo;;B: \|o:j bar baz" |
 
   Scenario: Dismissing by pressing Space
-    Given the text ""
+    Given the editor state is "B: "
     When ":joy" is typed
     Then the keyword is "joy"
     When " " is typed
     Then the keyword is ""
 
   Scenario Outline: Allow special characters
-    Given the text <text>
+    Given the editor state is <state>
     When <inserted text> is inserted
     Then the keyword is <keyword>
     And the matches are <matches>
 
     Examples:
-      | text | inserted text | keyword | matches        |
-      | ""   | ":joy!"       | "joy!"  | "🕹️"          |
-      | ""   | ":*"          | "*"     | "😘"           |
-      | ""   | ":!"          | "!"     | "🕹️,❗️,⁉️,‼️" |
-      | ""   | ":!!"         | "!!"    | "‼️"           |
-      | ""   | "::)"         | ":)"    | "😊"           |
-      | ""   | "::"          | ":"     | "😊"           |
+      | state | inserted text | keyword | matches        |
+      | "B: " | ":joy!"       | "joy!"  | "🕹️"          |
+      | "B: " | ":*"          | "*"     | "😘"           |
+      | "B: " | ":!"          | "!"     | "🕹️,❗️,⁉️,‼️" |
+      | "B: " | ":!!"         | "!!"    | "‼️"           |
+      | "B: " | "::)"         | ":)"    | "😊"           |
+      | "B: " | "::"          | ":"     | "😊"           |
 
   Scenario: Narrowing keyword by deletion
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put after "fo"
     And <inserted text> is inserted
     And "{ArrowLeft}" is pressed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
     And the keyword is <keyword>
 
     Examples:
-      | inserted text | final text | keyword |
-      | ":joy"        | "fo:jyo"   | "jy"    |
-      | ":j👻y"       | "fo:jyo"   | "jy"    |
+      | inserted text | final state | keyword |
+      | ":joy"        | "B: fo:jyo" | "jy"    |
+      | ":j👻y"       | "B: fo:jyo" | "jy"    |
+
+  Scenario: Inserting character to form exact match triggers auto-complete
+    Given the editor state is "B: "
+    When the editor is focused
+    And ":og:" is typed
+    Then the editor state is "B: :og:"
+    And the keyword is "og"
+    When "{ArrowLeft}{ArrowLeft}{ArrowLeft}" is pressed
+    And "d" is typed
+    Then the editor state is "B: 🐕|"
+    And the keyword is ""
+    And the matches are ""
+
+  Scenario: Triggering picker when complete pattern exists elsewhere in text
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And the caret is put after "foo"
+    And ":xyz:" is typed
+    Then the editor state is "B: foo:xyz:"
+    When " bar " is typed
+    And ":j" is typed
+    Then the editor state is "B: foo:xyz: bar :j|"
+    And the keyword is "j"
+    And the matches are "😂,😹,🕹️"

--- a/packages/plugin-input-rule/src/edge-cases.feature
+++ b/packages/plugin-input-rule/src/edge-cases.feature
@@ -4,97 +4,97 @@ Feature: Edge Cases
     Given a global keymap
 
   Scenario Outline: Longer Transform
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text       | inserted text | new text            |
-      | ""         | "."           | "...new"            |
-      | "foo"      | "."           | "foo...new"         |
-      | ""         | "foo."        | "foo...new"         |
-      | "foo."     | "."           | "foo....new"        |
-      | ""         | "foo.bar."    | "foo...bar...new"   |
-      | "foo.bar." | "baz."        | "foo.bar.baz...new" |
+      | state         | inserted text | new state                |
+      | "B: "         | "."           | "B: ...new\|"            |
+      | "B: foo"      | "."           | "B: foo...new\|"         |
+      | "B: "         | "foo."        | "B: foo...new\|"         |
+      | "B: foo."     | "."           | "B: foo....new\|"        |
+      | "B: "         | "foo.bar."    | "B: foo...bar...new\|"   |
+      | "B: foo.bar." | "baz."        | "B: foo.bar.baz...new\|" |
 
   Scenario Outline: End String Rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text         | inserted text | new text            |
-      | "-"          | ">"           | "→new"              |
-      | ""           | "->"          | "→new"              |
-      | "foo"        | "->"          | "foo→new"           |
-      | ""           | "foo->"       | "foo→new"           |
-      | "foo-"       | ">bar"        | "foo->barnew"       |
-      | ""           | "foo->bar->"  | "foo->bar→new"      |
-      | "foo->bar->" | "baz->"       | "foo->bar->baz→new" |
+      | state           | inserted text | new state                |
+      | "B: -\|"        | ">"           | "B: →new\|"              |
+      | "B: "           | "->"          | "B: →new\|"              |
+      | "B: foo"        | "->"          | "B: foo→new\|"           |
+      | "B: "           | "foo->"       | "B: foo→new\|"           |
+      | "B: foo-"       | ">bar"        | "B: foo->barnew\|"       |
+      | "B: "           | "foo->bar->"  | "B: foo->bar→new\|"      |
+      | "B: foo->bar->" | "baz->"       | "B: foo->bar->baz→new\|" |
 
   Scenario Outline: Non-Global Rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text           | inserted text  | new text              |
-      | "(c"           | ")"            | "©new"                |
-      | ""             | "(c)"          | "©new"                |
-      | "foo"          | "(c)"          | "foo©new"             |
-      | ""             | "foo(c)"       | "foo©new"             |
-      | "foo(c"        | ")bar"         | "foo©barnew"          |
-      | ""             | "foo(c)bar(c)" | "foo©bar©new"         |
-      | "foo(c)bar(c)" | "baz(c)"       | "foo(c)bar(c)baz©new" |
+      | state             | inserted text  | new state                  |
+      | "B: (c"           | ")"            | "B: ©new\|"                |
+      | "B: "             | "(c)"          | "B: ©new\|"                |
+      | "B: foo"          | "(c)"          | "B: foo©new\|"             |
+      | "B: "             | "foo(c)"       | "B: foo©new\|"             |
+      | "B: foo(c"        | ")bar"         | "B: foo©barnew\|"          |
+      | "B: "             | "foo(c)bar(c)" | "B: foo©bar©new\|"         |
+      | "B: foo(c)bar(c)" | "baz(c)"       | "B: foo(c)bar(c)baz©new\|" |
 
   Scenario Outline: Writing after Multiple Groups Rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text    | inserted text | new text       |
-      | ""      | "xfooy"       | "zfooznew"     |
-      | "xfoo"  | "y"           | "zfooznew"     |
-      | "xfooy" | "z"           | "xfooyznew"    |
-      | ""      | "xfyxoy"      | "zfzzoznew"    |
-      | ""      | "xfyxoyxoy"   | "zfzzozzoznew" |
+      | state      | inserted text | new state           |
+      | "B: "      | "xfooy"       | "B: zfooznew\|"     |
+      | "B: xfoo"  | "y"           | "B: zfooznew\|"     |
+      | "B: xfooy" | "z"           | "B: xfooyznew\|"    |
+      | "B: "      | "xfyxoy"      | "B: zfzzoznew\|"    |
+      | "B: "      | "xfyxoyxoy"   | "B: zfzzozzoznew\|" |
 
   Scenario Outline: Replacing 'a' and 'c'
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text | inserted text | new text |
-      | ""   | "ABC"         | "CBAnew" |
-      | "AB" | "C"           | "CBAnew" |
+      | state   | inserted text | new state     |
+      | "B: "   | "ABC"         | "B: CBAnew\|" |
+      | "B: AB" | "C"           | "B: CBAnew\|" |
 
   Scenario Outline: Undoing Multiple Groups Rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
-    Then the text is <before undo>
+    Then the editor state is <before undo>
     When undo is performed
-    Then the text is <after undo>
+    Then the editor state is <after undo>
 
     Examples:
-      | text    | inserted text | before undo | after undo  |
-      | ""      | "xfooy"       | "zfooz"     | "xfooy"     |
-      | "xfoo"  | "y"           | "zfooz"     | "xfooy"     |
-      | "xfooy" | "z"           | "xfooyz"    | "xfooy"     |
-      | ""      | "xfyxoy"      | "zfzzoz"    | "xfyxoy"    |
-      | ""      | "xfyxoyxoy"   | "zfzzozzoz" | "xfyxoyxoy" |
+      | state      | inserted text | before undo      | after undo     |
+      | "B: "      | "xfooy"       | "B: zfooz\|"     | "B: xfooy"     |
+      | "B: xfoo"  | "y"           | "B: zfooz\|"     | "B: xfooy"     |
+      | "B: xfooy" | "z"           | "B: xfooyz\|"    | "B: xfooy"     |
+      | "B: "      | "xfyxoy"      | "B: zfzzoz\|"    | "B: xfyxoy"    |
+      | "B: "      | "xfyxoyxoy"   | "B: zfzzozzoz\|" | "B: xfyxoyxoy" |
 
   Scenario Outline: Preserving inline objects
     When the editor is focused
@@ -111,120 +111,120 @@ Feature: Edge Cases
       | ",{stock-ticker},-"                 | ">"           | ",{stock-ticker},→new"                  |
 
   Scenario: Preserving adjoining inline object and placing caret correctly
-    Given the text "(c,{stock-ticker},"
+    Given the editor state is "B: (c{stock-ticker}"
     When the editor is focused
     And the caret is put after "c"
     And ")new" is typed
-    Then the text is "©new,{stock-ticker},"
+    Then the editor state is "B: ©new|{stock-ticker}"
 
   Scenario: Preserving adjoining inline object and placing caret correctly
-    Given the text "#,{stock-ticker},"
+    Given the editor state is "B: #{stock-ticker}"
     When the editor is focused
     And the caret is put after "#"
     And " new" is typed
-    Then the text is "new,{stock-ticker},"
+    Then the editor state is "B: new|{stock-ticker}"
 
   Scenario Outline: H1 rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <key> is pressed
     And "# " is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text                  | position    | key           | new text                   |
+      | state                  | position    | key           | new state                     |
       # Pressing Shift is a noop. It only exists so we can press Backspace in
       # subsequent Scenarios to position to caret at the edge of the inline
       # object.
-      | ""                    | after ""    | "{Shift}"     | "new"                      |
-      | "foo"                 | after "foo" | "{Shift}"     | "foo# new"                 |
-      | ",{stock-ticker},foo" | after "foo" | "{Shift}"     | ",{stock-ticker},foo# new" |
+      | "B: "                  | after ""    | "{Shift}"     | "B: new\|"                    |
+      | "B: foo"               | after "foo" | "{Shift}"     | "B: foo# new\|"               |
+      | "B: {stock-ticker}foo" | after "foo" | "{Shift}"     | "B: {stock-ticker}foo# new\|" |
       # This is an edge case we have to live with. There's no way of knowing
       # that the inline object before the caret should prevent the rule from
       # running.
-      | ",{stock-ticker},f"   | after "f"   | "{Backspace}" | "new,{stock-ticker},"      |
-      | "f,{stock-ticker},"   | after "f"   | "{Backspace}" | "new,{stock-ticker},"      |
+      | "B: {stock-ticker}f"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"      |
+      | "B: f{stock-ticker}"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"      |
 
   Scenario Outline: Better H2 rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <key> is pressed
     And "## " is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text                  | position    | key           | new text                    |
+      | state                  | position    | key           | new state                      |
       # Pressing Shift is a noop. It only exists so we can press Backspace in
       # subsequent Scenarios to position to caret at the edge of the inline
       # object.
-      | ""                    | after ""    | "{Shift}"     | "new"                       |
-      | "foo"                 | after "foo" | "{Shift}"     | "foo## new"                 |
-      | ",{stock-ticker},foo" | after "foo" | "{Shift}"     | ",{stock-ticker},foo## new" |
-      | ",{stock-ticker},f"   | after "f"   | "{Backspace}" | ",{stock-ticker},## new"    |
-      | "f,{stock-ticker},"   | after "f"   | "{Backspace}" | "new,{stock-ticker},"       |
+      | "B: "                  | after ""    | "{Shift}"     | "B: new\|"                     |
+      | "B: foo"               | after "foo" | "{Shift}"     | "B: foo## new\|"               |
+      | "B: {stock-ticker}foo" | after "foo" | "{Shift}"     | "B: {stock-ticker}foo## new\|" |
+      | "B: {stock-ticker}f"   | after "f"   | "{Backspace}" | "B: {stock-ticker}## new\|"    |
+      | "B: f{stock-ticker}"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"       |
 
   Scenario Outline: Unmatched Groups Rule
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text | position | inserted text | new text    |
-      | ""   | after "" | "---"         | "<hr />new" |
+      | state | position | inserted text | new state        |
+      | "B: " | after "" | "---"         | "B: <hr />new\|" |
 
   Scenario Outline: Expanded selection
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <selection> is selected
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text        | selection | inserted text | new text  |
-      | "(foo"      | "foo"     | "c)"          | "©new"    |
-      | "(foo"      | "oo"      | "c)"          | "(fc)new" |
-      | "(foo"      | "(foo"    | "c)"          | "c)new"   |
-      | "(coo\|bar" | "ooba"    | ")"           | "©newr"   |
+      | state             | selection | inserted text | new state      |
+      | "B: (foo"         | "foo"     | "c)"          | "B: ©new\|"    |
+      | "B: (foo"         | "oo"      | "c)"          | "B: (fc)new\|" |
+      | "B: (foo"         | "(foo"    | "c)"          | "B: c)new\|"   |
+      | "B: (coo;;B: bar" | "ooba"    | ")"           | "B: ©new\|r"   |
 
   Scenario Outline: Undo after transform on expanded selection
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <selection> is selected
     And <inserted text> is inserted
-    Then the text is <before undo>
+    Then the editor state is <before undo>
     When undo is performed
-    Then the text is <after undo>
+    Then the editor state is <after undo>
 
     Examples:
-      | text  | selection | inserted text | before undo | after undo |
-      | "(cf" | "f"       | ")"           | "©"         | "(c)"      |
+      | state    | selection | inserted text | before undo | after undo |
+      | "B: (cf" | "f"       | ")"           | "B: ©\|"    | "B: (c)"   |
 
   Scenario: Consecutive undo after selection change
-    Given the text ""
+    Given the editor state is "B: "
     When "->" is typed
     And undo is performed
     And "{ArrowLeft}" is pressed
     And undo is performed
-    Then the text is "-"
+    Then the editor state is "B: -|"
 
   Scenario Outline: Multiple overlapping matches in one insertion
-    Given the text ""
+    Given the editor state is "B: "
     When "1*2*3" is inserted
-    Then the text is "1×2×3"
+    Then the editor state is "B: 1×2×3|"
 
   Scenario: Backspace after typing following input rule should delete character
-    Given the text ""
+    Given the editor state is "B: "
     When "->" is typed
-    Then the text is "→"
+    Then the editor state is "B: →|"
     When "foo" is typed
-    Then the text is "→foo"
+    Then the editor state is "B: →foo"
     When "{Backspace}" is pressed
-    Then the text is "→fo"
+    Then the editor state is "B: →fo|"

--- a/packages/plugin-input-rule/src/emoji-picker-rules.feature
+++ b/packages/plugin-input-rule/src/emoji-picker-rules.feature
@@ -1,25 +1,25 @@
 Feature: Emoji Picker Rules
 
   Scenario: Trigger Rule
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And ":" is typed
     Then the keyword is ""
 
   Scenario: Partial Keyword Rule
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And ":jo" is typed
     Then the keyword is "jo"
 
   Scenario: Keyword Rule
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And ":joy:" is typed
     Then the keyword is "joy"
 
   Scenario Outline: Consecutive keywords
-    Given the text ":joy:"
+    Given the editor state is "B: :joy:"
     When the editor is focused
     And <text> is typed
     Then the keyword is <keyword>

--- a/packages/plugin-input-rule/src/rule.stock-ticker.feature
+++ b/packages/plugin-input-rule/src/rule.stock-ticker.feature
@@ -1,25 +1,25 @@
 Feature: Stock Ticker Rule
 
   Scenario Outline: Transforms plain text into stock ticker
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "{ArrowRight}" is pressed
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text | inserted text | new text              |
-      | ""   | "{AAPL}"      | ",{stock-ticker},new" |
+      | state | inserted text | new state                |
+      | "B: " | "{AAPL}"      | "B: {stock-ticker}new\|" |
 
   Scenario Outline: Smart undo with Backspace
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
-    Then the text is <before undo>
+    Then the editor state is <before undo>
     When "{Backspace}" is pressed
-    Then the text is <after undo>
+    Then the editor state is <after undo>
 
     Examples:
-      | text | inserted text | before undo        | after undo |
-      | ""   | "{APPL}"      | ",{stock-ticker}," | "{APPL}"   |
+      | state   | inserted text | before undo           | after undo      |
+      | "B: \|" | "{APPL}"      | "B: \|{stock-ticker}" | "B: \{APPL\}\|" |

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
@@ -4,91 +4,91 @@ Feature: Markdown Behaviors
     Given a global keymap
 
   Scenario: Automatic blockquote
-    Given the text ">"
+    Given the editor state is "B: >"
     When the editor is focused
     And "{Space}" is pressed
-    Then the text is "q:"
+    Then the editor state is "B style=\"blockquote\": |"
 
   Scenario: Automatic blockquote not toggled by space in the beginning
-    Given the text ">"
+    Given the editor state is "B: >"
     When the editor is focused
     And the caret is put before ">"
     When "{Space}" is pressed
-    Then the text is " >"
+    Then the editor state is "B:  |>"
 
   Scenario: Automatic blockquote in non-empty block
-    Given the text ">foo"
+    Given the editor state is "B: >foo"
     When the editor is focused
     And the caret is put before "f"
     And "{Space}" is pressed
-    Then the text is "q:foo"
+    Then the editor state is "B style=\"blockquote\": |foo"
 
   Scenario Outline: Automatic headings
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And "{Space}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text      | new text   |
-      | "#"       | "h1:"      |
-      | "##"      | "h2:"      |
-      | "###"     | "h3:"      |
-      | "####"    | "h4:"      |
-      | "#####"   | "h5:"      |
-      | "######"  | "h6:"      |
-      | "#######" | "####### " |
+      | state        | new state            |
+      | "B: #"       | "B style=\"h1\": \|" |
+      | "B: ##"      | "B style=\"h2\": \|" |
+      | "B: ###"     | "B style=\"h3\": \|" |
+      | "B: ####"    | "B style=\"h4\": \|" |
+      | "B: #####"   | "B style=\"h5\": \|" |
+      | "B: ######"  | "B style=\"h6\": \|" |
+      | "B: #######" | "B: ####### \|"      |
 
   Scenario Outline: Automatic headings not toggled by space in the beginning
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     When "{Space}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text  | position     | new text |
-      | "#"   | before "#"   | " #"     |
-      | "##"  | before "##"  | " ##"    |
-      | "###" | before "###" | " ###"   |
+      | state    | position     | new state   |
+      | "B: #"   | before "#"   | "B:  \|#"   |
+      | "B: ##"  | before "##"  | "B:  \|##"  |
+      | "B: ###" | before "###" | "B:  \|###" |
 
   Scenario Outline: Automatic headings toggled by space mid-heading
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     When "{ArrowRight}" is pressed
     When "{Space}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text  | position     | new text |
-      | "##"  | before "##"  | "h1:#"   |
-      | "###" | before "###" | "h1:##"  |
+      | state    | position     | new state              |
+      | "B: ##"  | before "##"  | "B style=\"h1\": \|#"  |
+      | "B: ###" | before "###" | "B style=\"h1\": \|##" |
 
   Scenario Outline: Automatic headings in non-empty block
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And "{Space}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text         | position     | new text      |
-      | "foo"        | before "foo" | " foo"        |
-      | "#foo"       | before "foo" | "h1:foo"      |
-      | "##foo"      | before "foo" | "h2:foo"      |
-      | "###foo"     | before "foo" | "h3:foo"      |
-      | "####foo"    | before "foo" | "h4:foo"      |
-      | "#####foo"   | before "foo" | "h5:foo"      |
-      | "######foo"  | before "foo" | "h6:foo"      |
-      | "#######foo" | before "foo" | "####### foo" |
+      | state           | position     | new state               |
+      | "B: foo"        | before "foo" | "B:  \|foo"             |
+      | "B: #foo"       | before "foo" | "B style=\"h1\": \|foo" |
+      | "B: ##foo"      | before "foo" | "B style=\"h2\": \|foo" |
+      | "B: ###foo"     | before "foo" | "B style=\"h3\": \|foo" |
+      | "B: ####foo"    | before "foo" | "B style=\"h4\": \|foo" |
+      | "B: #####foo"   | before "foo" | "B style=\"h5\": \|foo" |
+      | "B: ######foo"  | before "foo" | "B style=\"h6\": \|foo" |
+      | "B: #######foo" | before "foo" | "B: ####### \|foo"      |
 
   Scenario Outline: Clear style on Backspace
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And <style> is toggled
     And "{Backspace}" is pressed 4 times
-    Then the text is ""
+    Then the editor state is "B: |"
 
     Examples:
       | style |
@@ -100,25 +100,25 @@ Feature: Markdown Behaviors
       | "h6"  |
 
   Scenario: Unordered list clear-on-enter works on second cycle
-    Given the text "-"
+    Given the editor state is "B: -"
     When the editor is focused
     And "{Space}" is pressed
-    Then the text is ">-:"
+    Then the editor state is "B listItem=\"bullet\": |"
     When "{Enter}" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"
     When "-" is typed
     And "{Space}" is pressed
-    Then the text is ">-:"
+    Then the editor state is "B listItem=\"bullet\": |"
     When "{Enter}" is pressed
-    Then the text is ""
+    Then the editor state is "B: |"
 
   Scenario Outline: Clear style on Backspace in empty block
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And <style> is toggled
     And "{Backspace}" is pressed 4 times
     And "bar" is typed
-    Then the text is "bar"
+    Then the editor state is "B: bar|"
 
     Examples:
       | style |

--- a/packages/plugin-markdown-shortcuts/src/rule.markdown-link.feature
+++ b/packages/plugin-markdown-shortcuts/src/rule.markdown-link.feature
@@ -4,58 +4,51 @@ Feature: Markdown Link Rule
     Given a global keymap
 
   Scenario Outline: Transform markdown Link into annotation
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
-    And <annotated> has <marks>
+    Then the editor state is <new state>
 
     Examples:
-      | text          | inserted text | new text          | annotated | marks      |
-      | "[foo](bar"   | ")"           | "foo,new"         | "foo"     | marks "k4" |
-      | "[[foo](bar"  | ")"           | "[,foo,new"       | "foo"     | marks "k4" |
-      | "[f[oo](bar"  | ")"           | "[f,oo,new"       | "oo"      | marks "k4" |
-      | "[f[]oo](bar" | ")"           | "[f[]oo](bar)new" | ""        | no marks   |
+      | state                | inserted text | new state                           |
+      | "B: \[foo\](bar"     | ")"           | "B: [@link _key=\"k4\":foo]new"     |
+      | "B: \[\[foo\](bar"   | ")"           | "B: \[[@link _key=\"k4\":foo]new\|" |
+      | "B: \[f\[oo\](bar"   | ")"           | "B: \[f[@link _key=\"k4\":oo]new\|" |
+      | "B: \[f\[\]oo\](bar" | ")"           | "B: \[f\[\]oo\](bar)new\|"          |
 
   Scenario: Preserving decorator in link text
-    Given the text "[foo](bar"
+    Given the editor state is "B: \[foo\](bar"
     And "strong" around "foo"
     When the editor is focused
     And ")" is inserted
     And "new" is typed
-    Then the text is "foo,new"
-    And "foo" has marks "strong,k6"
+    Then the editor state is "B: [strong:[@link:foo]]new|"
 
   Scenario: Preserving decorators in link text
-    Given the text "[foo](bar"
+    Given the editor state is "B: \[foo\](bar"
     And "strong" around "foo"
     And "em" around "oo"
     When the editor is focused
     And ")" is inserted
     And "new" is typed
-    Then the text is "f,oo,new"
-    And "f" has marks "strong,k7"
-    And "oo" has marks "strong,em,k7"
+    Then the editor state is "B: [strong:[@link:f]][strong:[em:[@link:oo]]]new|"
 
   Scenario: Overwriting other links
-    Given the text "[foo](bar"
+    Given the editor state is "B: \[foo\](bar"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "bar"
     And ")" is inserted
     And "new" is typed
-    Then the text is "foo,new"
-    And "foo" has an annotation different than "l1"
+    Then the editor state is "B: [@link _key=\"k8\":foo]new"
 
   Scenario: Preserving other annotations
-    Given the text "[foo](bar"
+    Given the editor state is "B: \[foo\](bar"
     And a "link" "l1" around "foo"
     And a "comment" "c1" around "foo"
     When the editor is focused
     And the caret is put after "bar"
     And ")" is inserted
     And "new" is typed
-    Then the text is "foo,new"
-    And "foo" has an annotation different than "l1"
-    And "foo" has marks "c1,k9"
+    Then the editor state is "B: [@comment _key=\"c1\":[@link _key=\"k9\":foo]]new|"

--- a/packages/plugin-paste-link/src/paste-link.feature
+++ b/packages/plugin-paste-link/src/paste-link.feature
@@ -4,76 +4,69 @@ Feature: Paste Link
     Given a global keymap
 
   Scenario: Paste URL on selected text
-    Given the text "click here"
+    Given the editor state is "B: click here"
     When the editor is focused
     And "click here" is selected
     And data is pasted
       | text/plain | https://example.com |
-    Then the text is "click here"
-    And "click here" has marks "k4"
+    Then the editor state is "B: [@link _key=\"k4\" href=\"https://example.com\":^click here|]"
 
   Scenario: Paste URL on existing link replaces it
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "k1" around "oo bar ba"
     When the editor is focused
     And "bar" is selected
     And data is pasted
       | text/plain | https://newurl.com |
-    Then the text is "f,oo ,bar, ba,z"
-    And "oo " has marks "k1"
-    And "bar" has marks "k9"
-    And " ba" has marks "k1"
+    Then the editor state is "B: f[@link _key=\"k1\":oo ][@link _key=\"k9\" href=\"https://newurl.com\":^bar|][@link _key=\"k1\": ba]z"
 
   Scenario: Paste URL at collapsed selection
-    Given the text "before"
+    Given the editor state is "B: before"
     When the editor is focused
     And the caret is put after "before"
     And data is pasted
       | text/plain | https://example.com |
-    Then the text is "before,https://example.com"
-    And "https://example.com" has marks "k4"
+    Then the editor state is "B: before[@link _key=\"k4\" href=\"https://example.com\":https://example.com|]"
 
   Scenario: Paste URL preserves strong decorator
-    Given the text "text"
+    Given the editor state is "B: text"
     And "strong" around "text"
     When the editor is focused
     And the caret is put after "text"
     And data is pasted
       | text/plain | https://example.com |
-    Then the text is "text,https://example.com"
-    And "https://example.com" has marks "strong,k4"
+    Then the editor state is "B: [strong:text][strong:[@link _key=\"k4\" href=\"https://example.com\":https://example.com|]]"
 
   Scenario: Pasting non-URL inside decorator
-    Given the text "foo bar"
+    Given the editor state is "B: foo bar"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put after "foo b"
     And data is pasted
       | text/plain | new |
-    Then the text is "foo ,bnewar"
+    Then the editor state is "B: foo [strong:bnew|ar]"
 
   Scenario: Pasting non-URL inside annotation
-    Given the text "foo bar"
+    Given the editor state is "B: foo bar"
     And a "link" "k1" around "bar"
     When the editor is focused
     And the caret is put after "foo b"
     And data is pasted
       | text/plain | new |
-    Then the text is "foo ,b,new,ar"
+    Then the editor state is "B: foo [@link _key=\"k1\":b][@link _key=\"k8\":new|][@link _key=\"k1\":ar]"
 
   Scenario: Non-URL text is pasted normally
-    Given the text "before"
+    Given the editor state is "B: before"
     When the editor is focused
     And the caret is put after "before"
     And data is pasted
       | text/plain | hello world |
-    Then the text is "beforehello world"
+    Then the editor state is "B: beforehello world|"
 
   Scenario: Unsupported protocol is pasted as plain text
-    Given the text "before"
+    Given the editor state is "B: before"
     When the editor is focused
     And the caret is put after "before"
     And data is pasted
       | text/plain | ftp://example.com |
-    Then the text is "beforeftp://example.com"
-    And "ftp://example.com" has no marks
+    Then the editor state is "B: beforeftp://example.com|"

--- a/packages/plugin-typeahead-picker/src/emoji-picker.feature
+++ b/packages/plugin-typeahead-picker/src/emoji-picker.feature
@@ -1,23 +1,26 @@
 Feature: Emoji Picker
 
+  Background:
+    Given a global keymap
+
   Scenario Outline: Picking a direct hit
     When the editor is focused
     And <initial text> is inserted
     And <inserted text> is inserted
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | initial text | inserted text | final text |
-      | ""           | ":joy:"       | "😂"       |
-      | ":jo"        | "y:"          | "😂"       |
-      | ":joy"       | ":"           | "😂"       |
+      | initial text | inserted text | final state |
+      | ""           | ":joy:"       | "B: 😂\|"   |
+      | ":jo"        | "y:"          | "B: 😂\|"   |
+      | ":joy"       | ":"           | "B: 😂\|"   |
 
   Scenario: Picking direct hit with multiple exact matches
     When the editor is focused
     And ":dog" is typed
     Then the matches are "🐕,🐩"
     When ":" is typed
-    Then the text is "🐕"
+    Then the editor state is "B: 🐕|"
 
   Scenario: Triggering after a trigger character
     When the editor is focused
@@ -36,7 +39,7 @@ Feature: Emoji Picker
     And "foo" is typed
     And "{ArrowRight}" is pressed
     And ":dog:" is inserted
-    Then the text is "foo:🐕"
+    Then the editor state is "B: foo:🐕|"
     And the keyword is ""
 
   Scenario: Toggling trigger, deleting it and toggling it again
@@ -44,32 +47,32 @@ Feature: Emoji Picker
     And ":d" is typed
     And "{Backspace}{Backspace}" is pressed
     And ":d" is typed
-    Then the text is ":d"
+    Then the editor state is "B: :d|"
     And the keyword is "d"
     And the matches are "🐕,🐩"
 
   Scenario Outline: Is only triggered when an initial colon is typed
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <inserted text> is inserted
-    Then the text is <final text>
+    Then the editor state is <final state>
     And the keyword is <keyword>
 
     Examples:
-      | text   | position     | inserted text | final text | keyword |
-      | ""     | after ""     | ":j"          | ":j"       | "j"     |
-      | ":"    | after ":"    | "j"           | ":j"       | ""      |
-      | ":j"   | after ":j"   | "o"           | ":jo"      | ""      |
-      | ":jo"  | after ":jo"  | ":"           | ":jo:"     | ""      |
-      | ":joy" | after ":joy" | ":"           | ":joy:"    | ""      |
+      | state      | position     | inserted text | final state  | keyword |
+      | "B: "      | after ""     | ":j"          | "B: :j\|"    | "j"     |
+      | "B: :"     | after ":"    | "j"           | "B: :j\|"    | ""      |
+      | "B: :j\|"  | after ":j"   | "o"           | "B: :jo\|"   | ""      |
+      | "B: :jo\|" | after ":jo"  | ":"           | "B: :jo:\|"  | ""      |
+      | "B: :joy"  | after ":joy" | ":"           | "B: :joy:\|" | ""      |
 
   Scenario: Undo after direct hit
     When the editor is focused
     And ":joy:" is typed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
     When undo is performed
-    Then the text is ":joy:"
+    Then the editor state is "B: :joy:|"
 
   Scenario: Picking direct hit after undo
     When the editor is focused
@@ -77,14 +80,14 @@ Feature: Emoji Picker
     And undo is performed
     And "{Backspace}" is pressed
     And ":" is typed
-    Then the text is ":joy:"
+    Then the editor state is "B: :joy:|"
     And the keyword is ""
     And the matches are ""
 
   Scenario: Picking wrong direct hit
     When the editor is focused
     And ":jo:" is typed
-    Then the text is ":jo:"
+    Then the editor state is "B: :jo:|"
     And the keyword is "jo"
     And the matches are "😂,😹,🕹️"
 
@@ -92,7 +95,7 @@ Feature: Emoji Picker
     When the editor is focused
     And ":jo:" is typed
     And ":" is typed
-    Then the text is ":jo::"
+    Then the editor state is "B: :jo::|"
     And the keyword is "jo:"
     And the matches are ""
 
@@ -102,7 +105,7 @@ Feature: Emoji Picker
     And undo is performed
     And "{Backspace}{Backspace}" is pressed
     And ":" is typed
-    Then the text is ":jo:"
+    Then the editor state is "B: :jo:|"
     And the keyword is ""
     And the matches are ""
 
@@ -110,45 +113,45 @@ Feature: Emoji Picker
     When the editor is focused
     And ":joy:" is typed
     And ":joy_cat:" is inserted
-    Then the text is "😂😹"
+    Then the editor state is "B: 😂😹|"
 
   Scenario: Picking the closest hit with Enter
     When the editor is focused
     And ":joy" is typed
     And "{Enter}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario: Picking the closest hit with Tab
     When the editor is focused
     And ":joy" is typed
     And "{Tab}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario: Navigating down the list
     When the editor is focused
     And ":joy" is typed
     And "{ArrowDown}" is pressed
     And "{Enter}" is pressed
-    Then the text is "😹"
+    Then the editor state is "B: 😹|"
 
   Scenario: Aborting on Escape
     When the editor is focused
     And ":joy" is typed
     And "{Escape}" is pressed
     And "{Enter}" is pressed
-    Then the text is ":joy|"
+    Then the editor state is "B: :joy;;B: |"
 
   Scenario: Aborting and forwarding Enter if there is no keyword
     When the editor is focused
     And ":" is typed
     And "{Enter}" is pressed
-    Then the text is ":|"
+    Then the editor state is "B: :;;B: |"
 
   Scenario: Aborting Enter if there are no matches
     When the editor is focused
     And ":asdf" is typed
     And "{Enter}" is pressed
-    Then the text is ":asdf"
+    Then the editor state is "B: :asdf|"
     And the keyword is ""
 
   Scenario: Backspacing to narrow search
@@ -156,37 +159,37 @@ Feature: Emoji Picker
     And ":joy" is typed
     And "{Backspace}" is pressed
     And "{Enter}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
 
   Scenario Outline: Inserting longer trigger text
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And <new text> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text | inserted text | new text | final text |
-      | ""   | ":"           | "joy:"   | "😂"       |
-      | ""   | ":j"          | "oy:"    | "😂"       |
-      | ""   | ":joy"        | ":"      | "😂"       |
-      | ""   | ":joy:"       | ":"      | "😂:"      |
+      | state | inserted text | new text | final state |
+      | "B: " | ":"           | "joy:"   | "B: 😂\|"   |
+      | "B: " | ":j"          | "oy:"    | "B: 😂\|"   |
+      | "B: " | ":joy"        | ":"      | "B: 😂\|"   |
+      | "B: " | ":joy:"       | ":"      | "B: 😂:\|"  |
 
   Scenario Outline: Matching inside decorator
-    Given the text <text>
+    Given the editor state is <state>
     And "strong" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | decorated | position        | keyword | final text        |
-      | "foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "foo ,b😂ar, baz" |
-      | "foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "foo ,ba😂r, baz" |
+      | state            | decorated | position        | keyword | final state                   |
+      | "B: foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "B: foo [strong:b😂\|ar] baz" |
+      | "B: foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "B: foo [strong:ba😂\|r] baz" |
 
   Scenario Outline: Triggering at the edge of decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
@@ -201,35 +204,35 @@ Feature: Emoji Picker
       | before " baz" |
 
   Scenario Outline: Matching at the edge of decorator
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And "strong" around "bar"
     When the editor is focused
     And the caret is put <position>
     And ":joy:" is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | position      | final text        |
-      | after "foo "  | "foo 😂,bar, baz" |
-      | before "bar"  | "foo 😂,bar, baz" |
-      | after "bar"   | "foo ,bar😂, baz" |
-      | before " baz" | "foo ,bar😂, baz" |
+      | position      | final state                   |
+      | after "foo "  | "B: foo 😂\|[strong:bar] baz" |
+      | before "bar"  | "B: foo 😂[strong:\|bar] baz" |
+      | after "bar"   | "B: foo [strong:bar😂\|] baz" |
+      | before " baz" | "B: foo [strong:bar😂]\| baz" |
 
   Scenario Outline: Matching inside annotation
-    Given the text <text>
+    Given the editor state is <state>
     And a "link" "l1" around <annotated>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | annotated | position        | keyword | final text        |
-      | "foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "foo ,b😂ar, baz" |
-      | "foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "foo ,ba😂r, baz" |
+      | state            | annotated | position        | keyword | final state                              |
+      | "B: foo bar baz" | "bar"     | before "ar baz" | ":joy:" | "B: foo [@link _key=\"l1\":b😂\|ar] baz" |
+      | "B: foo bar baz" | "bar"     | before "r baz"  | ":joy:" | "B: foo [@link _key=\"l1\":ba😂\|r] baz" |
 
   Scenario Outline: Triggering at the edge of an annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "bar"
     When the editor is focused
     And the caret is put <position>
@@ -244,104 +247,104 @@ Feature: Emoji Picker
       | before " baz" |
 
   Scenario Outline: Matching at the edge of an annotation
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And a "link" "l1" around "bar"
     When the editor is focused
     And the caret is put <position>
     And ":joy:" is typed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | position      | final text        |
-      | after "foo "  | "foo 😂,bar, baz" |
-      | before "bar"  | "foo 😂,bar, baz" |
-      | after "bar"   | "foo ,bar,😂 baz" |
-      | before " baz" | "foo ,bar,😂 baz" |
+      | position      | final state                              |
+      | after "foo "  | "B: foo 😂\|[@link _key=\"l1\":bar] baz" |
+      | before "bar"  | "B: foo 😂[@link _key=\"l1\":\|bar] baz" |
+      | after "bar"   | "B: foo [@link _key=\"l1\":bar]😂\| baz" |
+      | before " baz" | "B: foo [@link _key=\"l1\":bar]😂\| baz" |
 
   Scenario Outline: Typing before the colon dismisses the emoji picker
-    Given the text <text>
+    Given the editor state is <state>
     When <inserted text> is typed
     And <button> is pressed
     And <new text> is typed
     Then the keyword is ""
 
     Examples:
-      | text | inserted text | button                   | new text |
-      | ""   | ":j"          | "{ArrowLeft}{ArrowLeft}" | "f"      |
-      | "fo" | ":j"          | "{ArrowLeft}{ArrowLeft}" | "o"      |
-      | ""   | ":j"          | "{ArrowLeft}{ArrowLeft}" | ":"      |
+      | state   | inserted text | button                   | new text |
+      | "B: "   | ":j"          | "{ArrowLeft}{ArrowLeft}" | "f"      |
+      | "B: fo" | ":j"          | "{ArrowLeft}{ArrowLeft}" | "o"      |
+      | "B: "   | ":j"          | "{ArrowLeft}{ArrowLeft}" | ":"      |
 
   Scenario Outline: Navigating away from the keyword
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And the caret is put <position>
     And <keyword> is typed
     And <button> is pressed
     And "{Enter}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text          | position    | keyword | button                              | final text        |
-      | "foo bar baz" | after "foo" | ":j"    | "{ArrowRight}"                      | "foo:j \|bar baz" |
-      | "foo bar baz" | after "foo" | ":j"    | "{ArrowLeft}{ArrowLeft}{ArrowLeft}" | "fo\|o:j bar baz" |
+      | state            | position    | keyword | button                              | final state               |
+      | "B: foo bar baz" | after "foo" | ":j"    | "{ArrowRight}"                      | "B: foo:j ;;B: \|bar baz" |
+      | "B: foo bar baz" | after "foo" | ":j"    | "{ArrowLeft}{ArrowLeft}{ArrowLeft}" | "B: fo;;B: \|o:j bar baz" |
 
   Scenario: Dismissing by pressing Space
-    Given the text ""
+    Given the editor state is "B: "
     When ":joy" is typed
     Then the keyword is "joy"
     When " " is typed
     Then the keyword is ""
 
   Scenario Outline: Allow special characters
-    Given the text <text>
+    Given the editor state is <state>
     When <inserted text> is inserted
     Then the keyword is <keyword>
     And the matches are <matches>
 
     Examples:
-      | text | inserted text | keyword | matches        |
-      | ""   | ":joy!"       | "joy!"  | "🕹️"          |
-      | ""   | ":*"          | "*"     | "😘"           |
-      | ""   | ":!"          | "!"     | "🕹️,❗️,⁉️,‼️" |
-      | ""   | ":!!"         | "!!"    | "‼️"           |
-      | ""   | "::)"         | ":)"    | "😊"           |
-      | ""   | "::"          | ":"     | "😊"           |
+      | state | inserted text | keyword | matches        |
+      | "B: " | ":joy!"       | "joy!"  | "🕹️"          |
+      | "B: " | ":*"          | "*"     | "😘"           |
+      | "B: " | ":!"          | "!"     | "🕹️,❗️,⁉️,‼️" |
+      | "B: " | ":!!"         | "!!"    | "‼️"           |
+      | "B: " | "::)"         | ":)"    | "😊"           |
+      | "B: " | "::"          | ":"     | "😊"           |
 
   Scenario: Narrowing keyword by deletion
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put after "fo"
     And <inserted text> is inserted
     And "{ArrowLeft}" is pressed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
     And the keyword is <keyword>
 
     Examples:
-      | inserted text | final text | keyword |
-      | ":joy"        | "fo:jyo"   | "jy"    |
-      | ":j👻y"       | "fo:jyo"   | "jy"    |
+      | inserted text | final state   | keyword |
+      | ":joy"        | "B: fo:j\|yo" | "jy"    |
+      | ":j👻y"       | "B: fo:j\|yo" | "jy"    |
 
   Scenario: Inserting character to form exact match triggers auto-complete
-    Given the text ""
+    Given the editor state is "B: "
     When the editor is focused
     And ":og:" is typed
-    Then the text is ":og:"
+    Then the editor state is "B: :og:|"
     And the keyword is "og"
     When "{ArrowLeft}{ArrowLeft}{ArrowLeft}" is pressed
     And "d" is typed
-    Then the text is "🐕"
+    Then the editor state is "B: 🐕|"
     And the keyword is ""
     And the matches are ""
 
   Scenario: Triggering picker when complete pattern exists elsewhere in text
-    Given the text "foo"
+    Given the editor state is "B: foo"
     When the editor is focused
     And the caret is put after "foo"
     And ":xyz:" is typed
-    Then the text is "foo:xyz:"
+    Then the editor state is "B: foo:xyz:|"
     When " bar " is typed
     And ":j" is typed
-    Then the text is "foo:xyz: bar :j"
+    Then the editor state is "B: foo:xyz: bar :j|"
     And the keyword is "j"
     And the matches are "😂,😹,🕹️"

--- a/packages/plugin-typeahead-picker/src/mention-picker.feature
+++ b/packages/plugin-typeahead-picker/src/mention-picker.feature
@@ -25,7 +25,7 @@ Feature: Mention Picker
     And "@john" is typed
     Then the matches are "John Doe"
     When "{Enter}" is pressed
-    Then the text is "John Doe"
+    Then the editor state is "B: John Doe|"
     And the picker state is "idle"
 
   Scenario: Tab selects match
@@ -33,7 +33,7 @@ Feature: Mention Picker
     And "@john" is typed
     Then the matches are "John Doe"
     When "{Tab}" is pressed
-    Then the text is "John Doe"
+    Then the editor state is "B: John Doe|"
     And the picker state is "idle"
 
   # Dismissing
@@ -41,7 +41,7 @@ Feature: Mention Picker
     When the editor is focused
     And "@john" is typed
     When "{Escape}" is pressed
-    Then the text is "@john"
+    Then the editor state is "B: @john|"
     And the picker state is "idle"
 
   Scenario: Dismissing by moving cursor left
@@ -63,7 +63,7 @@ Feature: Mention Picker
     And "@xyz" is typed
     Then the picker state is "no matches"
     When "{Enter}" is pressed
-    Then the text is "@xyz"
+    Then the editor state is "B: @xyz|"
     And the picker state is "idle"
 
   # Keyboard navigation
@@ -97,7 +97,7 @@ Feature: Mention Picker
     Then the picker state is "showing matches"
     When "{ArrowDown}" is pressed
     And "{Enter}" is pressed
-    Then the text is "Jane Smith"
+    Then the editor state is "B: Jane Smith|"
 
   # Narrowing search
   Scenario: Typing more characters narrows results

--- a/packages/plugin-typeahead-picker/src/on-dismiss.feature
+++ b/packages/plugin-typeahead-picker/src/on-dismiss.feature
@@ -21,7 +21,7 @@ Feature: onDismiss
     And "@j" is typed
     And "{Escape}" is pressed
     And "foo" is typed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Dismissing and triggering again
     When the editor is focused
@@ -31,21 +31,21 @@ Feature: onDismiss
     Then the picker state is "no matches"
     When "{Escape}" is pressed
     And "foo" is typed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Dismissing with no matches and typing again
     When the editor is focused
     And "@k" is typed
     And "{Escape}" is pressed
     And "foo" is typed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Dismissing with Enter and typing again
     When the editor is focused
     And "@k" is typed
     And "{Enter}" is pressed
     And "foo" is typed
-    Then the text is "foo"
+    Then the editor state is "B: foo|"
 
   Scenario: Programmatic dismiss triggers onDismiss
     When the editor is focused

--- a/packages/plugin-typeahead-picker/src/slash-command-picker.feature
+++ b/packages/plugin-typeahead-picker/src/slash-command-picker.feature
@@ -47,7 +47,7 @@ Feature: Slash Command Picker
     And "/h" is typed
     Then the picker state is "showing matches"
     When "{Enter}" is pressed
-    Then the text is "h1:"
+    Then the editor state is "B style=\"h1\": |"
     And the picker state is "idle"
 
   Scenario: Arrow down then Enter selects correct command
@@ -57,7 +57,7 @@ Feature: Slash Command Picker
     When "{ArrowDown}" is pressed
     Then the selected index is "1"
     When "{Enter}" is pressed
-    Then the text is "h2:"
+    Then the editor state is "B style=\"h2\": |"
     And the picker state is "idle"
 
   Scenario: Dismissing with Escape
@@ -66,4 +66,4 @@ Feature: Slash Command Picker
     Then the picker state is "showing matches"
     When "{Escape}" is pressed
     Then the picker state is "idle"
-    And the text is "/head"
+    And the editor state is "B: /head|"

--- a/packages/plugin-typeahead-picker/src/typeahead-picker.feature
+++ b/packages/plugin-typeahead-picker/src/typeahead-picker.feature
@@ -27,7 +27,7 @@ Feature: Typeahead Picker
     Then the picker state is "showing matches"
     When "{Escape}" is pressed
     Then the picker state is "idle"
-    And the text is ":joy"
+    And the editor state is "B: :joy|"
 
   Scenario: Dismissing by moving selection outside keyword
     When the editor is focused
@@ -40,7 +40,7 @@ Feature: Typeahead Picker
     When the editor is focused
     And ":xyz" is typed
     And "{Enter}" is pressed
-    Then the text is ":xyz"
+    Then the editor state is "B: :xyz|"
     And the picker state is "idle"
 
   # Tests for keyboard navigation
@@ -72,7 +72,7 @@ Feature: Typeahead Picker
     And ":joy" is typed
     Then the picker state is "showing matches"
     When "{Enter}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
     And the picker state is "idle"
 
   Scenario: Tab selects match
@@ -80,7 +80,7 @@ Feature: Typeahead Picker
     And ":joy" is typed
     Then the picker state is "showing matches"
     When "{Tab}" is pressed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
     And the picker state is "idle"
 
   Scenario: Arrow down then Enter selects correct match
@@ -90,19 +90,19 @@ Feature: Typeahead Picker
     When "{ArrowDown}" is pressed
     Then the selected index is "1"
     When "{Enter}" is pressed
-    Then the text is "😹"
+    Then the editor state is "B: 😹|"
     And the picker state is "idle"
 
   # Tests for complete trigger auto-insert
   Scenario: Complete trigger auto-inserts exact match
     When the editor is focused
     And ":joy:" is typed
-    Then the text is "😂"
+    Then the editor state is "B: 😂|"
     And the picker state is "idle"
 
   Scenario: Complete trigger with no exact match stays active
     When the editor is focused
     And ":jo:" is typed
-    Then the text is ":jo:"
+    Then the editor state is "B: :jo:|"
     And the keyword is "jo"
     And the picker state is "showing matches"

--- a/packages/plugin-typography/src/disallow-in-code.feature
+++ b/packages/plugin-typography/src/disallow-in-code.feature
@@ -1,57 +1,60 @@
 Feature: Disallow in code
 
+  Background:
+    Given a global keymap
+
   Scenario Outline: Decorated text
-    Given the text <text>
+    Given the editor state is <state>
     And "code" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And "->" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text          | decorated | position        | new text          |
-      | "foo"         | "foo"     | after "foo"     | "foo->"           |
-      | "foo bar baz" | "bar"     | after "bar"     | "foo ,bar->, baz" |
-      | "foo bar baz" | "bar"     | before "bar"    | "foo →,bar, baz"  |
-      | "foo bar baz" | "bar"     | before "ar baz" | "foo ,b->ar, baz" |
+      | state            | decorated | position        | new state                   |
+      | "B: foo"         | "foo"     | after "foo"     | "B: [code:foo->\|]"         |
+      | "B: foo bar baz" | "bar"     | after "bar"     | "B: foo [code:bar->\|] baz" |
+      | "B: foo bar baz" | "bar"     | before "bar"    | "B: foo →\|[code:bar] baz"  |
+      | "B: foo bar baz" | "bar"     | before "ar baz" | "B: foo [code:b->\|ar] baz" |
 
   Scenario Outline: Partially decorated text
-    Given the text "foo bar2x baz"
+    Given the editor state is "B: foo bar2x baz"
     And "code" around "bar2x"
     When the editor is focused
     And the caret is put after "bar2x"
     And "2" is typed
-    Then the text is "foo ,bar2x2, baz"
+    Then the editor state is "B: foo [code:bar2x2|] baz"
 
   Scenario Outline: Partially decorated text with decorator toggled off
-    Given the text <text>
+    Given the editor state is <state>
     And "code" around <decorated>
     When the editor is focused
     And the caret is put <position>
     And "code" is toggled
     And <inserted text> is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text            | decorated | position      | inserted text | new text           |
-      | "foo bar baz"   | "bar"     | after "bar"   | "2x2"         | "foo ,bar,2×2 baz" |
-      | "foo bar2 baz"  | "bar2"    | after "bar2"  | "x2"          | "foo ,bar2,x2 baz" |
-      | "foo bar2x baz" | "bar2x"   | after "bar2x" | "2"           | "foo ,bar2x,2 baz" |
+      | state              | decorated | position      | inserted text | new state                    |
+      | "B: foo bar baz"   | "bar"     | after "bar"   | "2x2"         | "B: foo [code:bar]2×2\| baz" |
+      | "B: foo bar2 baz"  | "bar2"    | after "bar2"  | "x2"          | "B: foo [code:bar2]x2\| baz" |
+      | "B: foo bar2x baz" | "bar2x"   | after "bar2x" | "2"           | "B: foo [code:bar2x]2\| baz" |
 
   Scenario Outline: Decorated and annotated text
-    Given the text "foo bar baz"
+    Given the editor state is "B: foo bar baz"
     And <decorator> around "bar"
     And a "link" "l1" around "bar"
     When the editor is focused
     And the caret is put <position>
     And "->" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | decorator | position        | new text          |
-      | "code"    | after "bar"     | "foo ,bar,→ baz"  |
-      | "strong"  | after "bar"     | "foo ,bar,→ baz"  |
-      | "code"    | before "bar"    | "foo →,bar, baz"  |
-      | "strong"  | before "bar"    | "foo →,bar, baz"  |
-      | "code"    | before "ar baz" | "foo ,b->ar, baz" |
-      | "strong"  | before "ar baz" | "foo ,b→ar, baz"  |
+      | decorator | position        | new state                                        |
+      | "code"    | after "bar"     | "B: foo [code:[@link _key=\"l1\":bar]]→\| baz"   |
+      | "strong"  | after "bar"     | "B: foo [strong:[@link _key=\"l1\":bar]]→\| baz" |
+      | "code"    | before "bar"    | "B: foo →\|[code:[@link _key=\"l1\":bar]] baz"   |
+      | "strong"  | before "bar"    | "B: foo →\|[strong:[@link _key=\"l1\":bar]] baz" |
+      | "code"    | before "ar baz" | "B: foo [code:[@link _key=\"l1\":b->\|ar]] baz"  |
+      | "strong"  | before "ar baz" | "B: foo [strong:[@link _key=\"l1\":b→\|ar]] baz" |

--- a/packages/plugin-typography/src/input-rule.ellipsis.feature
+++ b/packages/plugin-typography/src/input-rule.ellipsis.feature
@@ -4,99 +4,93 @@ Feature: Ellipsis Input Rule
     Given a global keymap
 
   Scenario Outline: Inserting ellipsis in unformatted text
-    Given the text <text>
+    Given the editor state is <state>
     # The "When {string} is inserted" step inserts all characters at once to
     # mimic how insert.text behaves on Android
     When <inserted text> is inserted
-    Then the text is <before undo>
+    Then the editor state is <before undo>
     When undo is performed
-    Then the text is <after undo>
+    Then the editor state is <after undo>
 
     Examples:
-      | text           | inserted text  | before undo        | after undo           |
-      | ".."           | "."            | "…"                | "..."                |
-      | ""             | "..."          | "…"                | "..."                |
-      | "foo"          | "..."          | "foo…"             | "foo..."             |
-      | ""             | "foo..."       | "foo…"             | "foo..."             |
-      | "foo.."        | ".bar"         | "foo…bar"          | "foo...bar"          |
-      | ""             | "foo...bar..." | "foo…bar…"         | "foo...bar..."       |
-      | "foo...bar..." | "baz..."       | "foo...bar...baz…" | "foo...bar...baz..." |
+      | state               | inserted text  | before undo             | after undo                |
+      | "B: .."             | "."            | "B: …\|"                | "B: ...\|"                |
+      | "B: "               | "..."          | "B: …\|"                | "B: ...\|"                |
+      | "B: foo"            | "..."          | "B: foo…\|"             | "B: foo...\|"             |
+      | "B: "               | "foo..."       | "B: foo…\|"             | "B: foo...\|"             |
+      | "B: foo.."          | ".bar"         | "B: foo…bar\|"          | "B: foo...bar\|"          |
+      | "B: "               | "foo...bar..." | "B: foo…bar…\|"         | "B: foo...bar...\|"       |
+      | "B: foo...bar...\|" | "baz..."       | "B: foo...bar...baz…\|" | "B: foo...bar...baz...\|" |
 
   Scenario: Inserting ellipsis inside a decorator
-    Given the text "foo.."
+    Given the editor state is "B: foo.."
     And "strong" around "foo.."
     When the editor is focused
     And the caret is put after "foo.."
     And "." is typed
-    Then the text is "foo…"
-    And "foo…" has marks "strong"
+    Then the editor state is "B: [strong:foo…|]"
 
   Scenario: Inserting ellipsis at the edge of a decorator
-    Given the text "foo.."
+    Given the editor state is "B: foo.."
     And "strong" around "foo"
     When the editor is focused
     And the caret is put after "foo.."
     And "." is typed
-    Then the text is "foo,…"
-    And "foo" has marks "strong"
-    And "…" has no marks
+    Then the editor state is "B: [strong:foo]…|"
 
   Scenario: Inserting ellipsis inside an annotation
-    Given the text "foo.."
+    Given the editor state is "B: foo.."
     And a "link" "l1" around "foo.."
     When the editor is focused
     And the caret is put after "foo.."
     And "." is typed
-    Then the text is "foo…"
-    And "foo…" has marks "l1"
+    Then the editor state is "B: [@link _key=\"l1\":foo…|]"
 
   Scenario: Inserting ellipsis at the edge of an annotation
-    Given the text "foo.."
+    Given the editor state is "B: foo.."
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "foo.."
     And "." is typed
-    Then the text is "foo,…"
-    And "foo" has marks "l1"
-    And "…" has no marks
+    Then the editor state is "B: [@link _key=\"l1\":foo]…|"
 
   Scenario Outline: Smart undo with Backspace
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "{Backspace}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text           | inserted text  | new text             |
-      | ".."           | "."            | "..."                |
-      | ""             | "..."          | "..."                |
-      | "foo"          | "..."          | "foo..."             |
-      | ""             | "foo..."       | "foo..."             |
-      | "foo.."        | ".bar"         | "foo...bar"          |
-      | ""             | "foo...bar..." | "foo...bar..."       |
-      | "foo...bar..." | "baz..."       | "foo...bar...baz..." |
+      | state               | inserted text  | new state                 |
+      | "B: ..\|"           | "."            | "B: ...\|"                |
+      | "B: \|"             | "..."          | "B: ...\|"                |
+      | "B: foo\|"          | "..."          | "B: foo...\|"             |
+      | "B: \|"             | "foo..."       | "B: foo...\|"             |
+      | "B: foo..\|"        | ".bar"         | "B: foo...bar\|"          |
+      | "B: \|"             | "foo...bar..." | "B: foo...bar...\|"       |
+      | "B: foo...bar...\|" | "baz..."       | "B: foo...bar...baz...\|" |
 
   Scenario Outline: Smart undo aborted after text changes
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And <new text> is typed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text | inserted text | new text | final text |
-      | ""   | "..."         | "n"      | "…"        |
+      | state | inserted text | new text | final state |
+      | "B: " | "..."         | "n"      | "B: …\|"    |
 
   Scenario Outline: Smart undo aborted after selection changes
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "{ArrowLeft}" is pressed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text  | inserted text | final text |
-      | "foo" | "..."         | "fo…"      |
+      | state    | inserted text | final state |
+      | "B: foo" | "..."         | "B: fo\|…"  |

--- a/packages/plugin-typography/src/input-rule.em-dash.feature
+++ b/packages/plugin-typography/src/input-rule.em-dash.feature
@@ -4,108 +4,101 @@ Feature: Em Dash Input Rule
     Given a global keymap
 
   Scenario Outline: Inserting em dash in unformatted text
-    Given the text <text>
+    Given the editor state is <state>
     # The "When {string} is inserted" step inserts all characters at once to
     # mimic how insert.text behaves on Android
     When <inserted text> is inserted
-    Then the text is <before undo>
+    Then the editor state is <before undo>
     When undo is performed
-    Then the text is <after undo>
+    Then the editor state is <after undo>
 
     Examples:
-      | text         | inserted text | before undo      | after undo        |
-      | "-"          | "-"           | "—"              | "--"              |
-      | ""           | "--"          | "—"              | "--"              |
-      | "foo"        | "--"          | "foo—"           | "foo--"           |
-      | ""           | "foo--"       | "foo—"           | "foo--"           |
-      | "foo-"       | "-bar"        | "foo—bar"        | "foo--bar"        |
-      | ""           | "foo--bar--"  | "foo—bar—"       | "foo--bar--"      |
-      | "foo--bar--" | "baz--"       | "foo--bar--baz—" | "foo--bar--baz--" |
+      | state             | inserted text | before undo           | after undo             |
+      | "B: -"            | "-"           | "B: —\|"              | "B: --\|"              |
+      | "B: "             | "--"          | "B: —\|"              | "B: --\|"              |
+      | "B: foo"          | "--"          | "B: foo—\|"           | "B: foo--\|"           |
+      | "B: "             | "foo--"       | "B: foo—\|"           | "B: foo--\|"           |
+      | "B: foo-"         | "-bar"        | "B: foo—bar\|"        | "B: foo--bar\|"        |
+      | "B: "             | "foo--bar--"  | "B: foo—bar—\|"       | "B: foo--bar--\|"      |
+      | "B: foo--bar--\|" | "baz--"       | "B: foo--bar--baz—\|" | "B: foo--bar--baz--\|" |
 
   Scenario: Inserting em dash inside a decorator
-    Given the text "foo-"
+    Given the editor state is "B: foo-"
     And "strong" around "foo-"
     When the editor is focused
     And the caret is put after "foo-"
     And "-" is typed
-    Then the text is "foo—"
-    And "foo—" has marks "strong"
+    Then the editor state is "B: [strong:foo—|]"
 
   Scenario: Inserting em dash at the edge of a decorator
-    Given the text "foo-"
+    Given the editor state is "B: foo-"
     And "strong" around "foo"
     When the editor is focused
     And the caret is put after "foo-"
     And "-" is typed
-    Then the text is "foo,—"
-    And "foo" has marks "strong"
-    And "—" has no marks
+    Then the editor state is "B: [strong:foo]—|"
 
   Scenario: Inserting em dash inside an annotation
-    Given the text "foo-"
+    Given the editor state is "B: foo-"
     And a "link" "l1" around "foo-"
     When the editor is focused
     And the caret is put after "foo-"
     And "-" is typed
-    Then the text is "foo—"
-    And "foo—" has marks "l1"
+    Then the editor state is "B: [@link _key=\"l1\":foo—|]"
 
   Scenario: Inserting em dash halfway inside an annotation
-    Given the text "foo-"
+    Given the editor state is "B: foo-"
     And a "link" "l1" around "foo-"
     When the editor is focused
     And the caret is put after "foo-"
     And "-" is typed
-    Then the text is "foo—"
-    And "foo—" has marks "l1"
+    Then the editor state is "B: [@link _key=\"l1\":foo—|]"
 
   Scenario: Inserting em dash at the edge of an annotation
-    Given the text "foo-"
+    Given the editor state is "B: foo-"
     And a "link" "l1" around "foo"
     When the editor is focused
     And the caret is put after "foo-"
     And "-" is typed
-    Then the text is "foo,—"
-    And "foo" has marks "l1"
-    And "—" has no marks
+    Then the editor state is "B: [@link _key=\"l1\":foo]—|"
 
   Scenario Outline: Smart undo with Backspace
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "{Backspace}" is pressed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text         | inserted text | new text          |
-      | "-"          | "-"           | "--"              |
-      | ""           | "--"          | "--"              |
-      | "foo"        | "--"          | "foo--"           |
-      | ""           | "foo--"       | "foo--"           |
-      | "foo-"       | "-bar"        | "foo--bar"        |
-      | ""           | "foo--bar--"  | "foo--bar--"      |
-      | "foo--bar--" | "baz--"       | "foo--bar--baz--" |
+      | state             | inserted text | new state              |
+      | "B: -\|"          | "-"           | "B: --\|"              |
+      | "B: \|"           | "--"          | "B: --\|"              |
+      | "B: foo\|"        | "--"          | "B: foo--\|"           |
+      | "B: \|"           | "foo--"       | "B: foo--\|"           |
+      | "B: foo-\|"       | "-bar"        | "B: foo--bar\|"        |
+      | "B: \|"           | "foo--bar--"  | "B: foo--bar--\|"      |
+      | "B: foo--bar--\|" | "baz--"       | "B: foo--bar--baz--\|" |
 
   Scenario Outline: Smart undo aborted after text changes
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And <new text> is typed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text | inserted text | new text | final text |
-      | ""   | "--"          | "n"      | "—"        |
+      | state | inserted text | new text | final state |
+      | "B: " | "--"          | "n"      | "B: —\|"    |
 
   Scenario Outline: Smart undo aborted after selection changes
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "{ArrowLeft}" is pressed
     And "{Backspace}" is pressed
-    Then the text is <final text>
+    Then the editor state is <final state>
 
     Examples:
-      | text  | inserted text | final text |
-      | "foo" | "--"          | "fo—"      |
+      | state    | inserted text | final state |
+      | "B: foo" | "--"          | "B: fo\|—"  |

--- a/packages/plugin-typography/src/input-rule.multiplication.feature
+++ b/packages/plugin-typography/src/input-rule.multiplication.feature
@@ -1,23 +1,23 @@
 Feature: Multiplication Input Rule
 
   Scenario Outline: Inserting multiplication sign
-    Given the text <text>
+    Given the editor state is <state>
     When <inserted text> is inserted
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text | inserted text | new text |
-      | ""   | "1*2"         | "1×2"    |
-      | ""   | "1*2*3"       | "1×2×3"  |
+      | state | inserted text | new state    |
+      | "B: " | "1*2"         | "B: 1×2\|"   |
+      | "B: " | "1*2*3"       | "B: 1×2×3\|" |
 
   Scenario Outline: Inserting multiplication sign and writing afterwards
-    Given the text <text>
+    Given the editor state is <state>
     When the editor is focused
     And <inserted text> is inserted
     And "new" is typed
-    Then the text is <new text>
+    Then the editor state is <new state>
 
     Examples:
-      | text | inserted text | new text   |
-      | ""   | "1*2"         | "1×2new"   |
-      | ""   | "1*2*3"       | "1×2×3new" |
+      | state | inserted text | new state       |
+      | "B: " | "1*2"         | "B: 1×2new\|"   |
+      | "B: " | "1*2*3"       | "B: 1×2×3new\|" |


### PR DESCRIPTION
Follows up PR #2512 by migrating the plugin packages' gherkin tests from terse-pt to textspec notation. 16 feature files across `plugin-typography`, `plugin-input-rule`, `plugin-markdown-shortcuts`, `plugin-paste-link`, `plugin-emoji-picker`, and `plugin-typeahead-picker` now express setup and assertions in textspec.

Plugin-specific step definitions stay (`the keyword is`, `the picker state is`, `the matches are`, `the editor text is`, etc.) — only `Given/Then the text is "X"` swaps to `Given/Then the editor state is "B: X"`. A handful of scenarios that depend on terse-pt's lossy serialization (`plugin-typography/input-rule.smart-quotes.feature`, `plugin-input-rule/edge-cases.feature` "Preserving inline objects") stay on terse-pt by mixing both step types in the same file.