### PR TITLE
test: bump perf timeout for container inserts and fix flaky kanji undo

### DIFF
--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -190,7 +190,7 @@ describe('Performance', () => {
       const duration = performance.now() - start
 
       console.warn(`Inserted 1000 tables in ${duration.toFixed(2)}ms`)
-    })
+    }, 30_000)
 
     test('Inserting 1000 tables before an existing block', async () => {
       const {editor, locator} = await createTestEditor({
@@ -228,7 +228,7 @@ describe('Performance', () => {
       console.warn(
         `Inserted 1000 tables before an existing block in ${duration.toFixed(2)}ms`,
       )
-    })
+    }, 30_000)
 
     test('Inserting 1000 tables after an existing block', async () => {
       const {editor, locator} = await createTestEditor({
@@ -266,7 +266,7 @@ describe('Performance', () => {
       console.warn(
         `Inserted 1000 tables after an existing block in ${duration.toFixed(2)}ms`,
       )
-    })
+    }, 30_000)
   })
 
   test('onChange is batched', async () => {

--- a/packages/editor/tests/undo-redo-collaboration.test.tsx
+++ b/packages/editor/tests/undo-redo-collaboration.test.tsx
@@ -495,7 +495,7 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
       expect(editorB.getSnapshot().context.selection).toEqual(selectionB)
     })
 
-    await userEvent.type(locatorB, newPrefix)
+    editorB.send({type: 'insert.text', text: newPrefix})
 
     await vi.waitFor(() => {
       expect(getTersePt(editorB.getSnapshot().context)).toEqual([


### PR DESCRIPTION
Two flaky tests on webkit, two different root causes.

**Container perf tests time out at 15s.** Inserting 1000 nested-container DOM trees (3 layers × 1000 rows = 3000 nested elements) takes longer on webkit than chromium/firefox. Bumping `testTimeout` to 30s for the three `Inserting 1000 tables` tests reflects the real cost on the slowest target rather than masking a regression.

**Kanji multi-line undo collaboration test has the same focus-race fingerprint already fixed in `3892471e` for the single-line emoji test.** `userEvent.type(locatorB, …)` dispatches keyboard events one at a time via Playwright, and with two editors on the page some keystrokes land on the wrong editor and corrupt state — manifesting as the collaborator prefix being missing and a stray character (the last char of the prefix) appearing at the end of the text. Apply the same fix here: replace `userEvent.type(locatorB, newPrefix)` with `editorB.send({type: 'insert.text', text: newPrefix})`. The test verifies collaborative undo behaviour, not browser keyboard input.