### PR TITLE
test: migrate unit tests from terse-pt to textspec

### DIFF
--- a/packages/editor/src/editor/validate-selection-machine.test.ts
+++ b/packages/editor/src/editor/validate-selection-machine.test.ts
@@ -1,7 +1,6 @@
-import {getTersePt} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import {getSelectionAfterText} from '../../test-utils/text-selection'
+import {toTextspec} from '../../test-utils/to-textspec'
 import {createTestEditor} from '../test/vitest'
 import {validateSelectionMachine} from './validate-selection-machine'
 
@@ -14,10 +13,7 @@ describe(validateSelectionMachine.id, () => {
     editor.send({type: 'insert.text', text: 'foo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
-      expect(editor.getSnapshot().context.selection).toEqual(
-        getSelectionAfterText(editor.getSnapshot().context, 'foo'),
-      )
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
 
     // This event is being sent in before "foo" has been inserted in the DOM
@@ -29,19 +25,13 @@ describe(validateSelectionMachine.id, () => {
     editor.send({type: 'insert.text', text: 'bar'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
-      expect(editor.getSnapshot().context.selection).toEqual(
-        getSelectionAfterText(editor.getSnapshot().context, 'foobar'),
-      )
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
     })
 
     editor.send({type: 'delete.backward', unit: 'character'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['fooba'])
-      expect(editor.getSnapshot().context.selection).toEqual(
-        getSelectionAfterText(editor.getSnapshot().context, 'fooba'),
-      )
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: fooba|')
     })
   })
 })

--- a/packages/editor/src/plugins/plugin.internal.auto-close-brackets.test.tsx
+++ b/packages/editor/src/plugins/plugin.internal.auto-close-brackets.test.tsx
@@ -1,6 +1,6 @@
-import {getTersePt} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
+import {toTextspec} from '../../test-utils/to-textspec'
 import {createTestEditor} from '../test/vitest'
 import {AutoCloseBracketsPlugin} from './plugin.internal.auto-close-brackets'
 
@@ -15,25 +15,25 @@ describe(AutoCloseBracketsPlugin.name, () => {
     editor.send({type: 'insert.text', text: '('})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['()'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (|)')
     })
 
     await userEvent.type(locator, 'foo')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(foo)'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (foo|)')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['()'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (|)')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['('])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (|')
     })
   })
 
@@ -47,25 +47,25 @@ describe(AutoCloseBracketsPlugin.name, () => {
     editor.send({type: 'insert.text', text: '(f'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(f)'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (f|)')
     })
 
     await userEvent.type(locator, 'oo')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(foo)'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (foo|)')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(f)'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (f|)')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(f'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (f|')
     })
   })
 })

--- a/packages/editor/src/test/index.ts
+++ b/packages/editor/src/test/index.ts
@@ -1,1 +1,2 @@
 export * from './gherkin-parameter-types'
+export {toTextspec} from '../../test-utils/to-textspec'

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema, type EditorEmittedEvent} from '../src'
@@ -14,6 +14,7 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Behavior API', () => {
   test('Scenario: Suppressing raised events while executing', async () => {
@@ -41,13 +42,13 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -84,13 +85,13 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -115,9 +116,9 @@ describe('Behavior API', () => {
     editor.send({type: 'custom.hello world'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'Hello, world!',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: Hello, world!|',
+      )
     })
   })
 
@@ -144,9 +145,9 @@ describe('Behavior API', () => {
     editor.send({type: 'custom.hello world'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'Hello, world!',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: Hello, world!|',
+      )
     })
   })
 
@@ -166,13 +167,13 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -194,7 +195,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     expect(sideEffect).toHaveBeenCalled()
@@ -237,7 +238,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     expect(sideEffectA).toHaveBeenCalled()
@@ -247,7 +248,7 @@ describe('Behavior API', () => {
     await userEvent.type(locator, 'c')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['ac'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ac|')
     })
 
     expect(sideEffectB).toHaveBeenCalled()
@@ -278,7 +279,7 @@ describe('Behavior API', () => {
     await userEvent.type(locator, 'b')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
   })
 
@@ -304,7 +305,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
   })
 
@@ -332,7 +333,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bb'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: bb|')
     })
   })
 
@@ -359,7 +360,7 @@ describe('Behavior API', () => {
     await userEvent.type(locator, 'a')
     await userEvent.type(locator, 'c')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['c'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: c|')
     })
   })
 
@@ -379,7 +380,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
   })
 
@@ -399,7 +400,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
   })
 
@@ -419,7 +420,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -459,7 +460,7 @@ describe('Behavior API', () => {
 
     await userEvent.type(locator, 'a')
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
     await vi.waitFor(() => {
       expect(events.includes('keyboard.keyup')).toBe(true)
@@ -606,7 +607,9 @@ describe('Behavior API', () => {
     editor.send({type: 'insert.break'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', ' bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: | bar'].join('\n'),
+      )
     })
   })
 
@@ -649,7 +652,9 @@ describe('Behavior API', () => {
     editor.send({type: 'insert.break'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', ' bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: | bar'].join('\n'),
+      )
     })
   })
 
@@ -705,7 +710,7 @@ describe('Behavior API', () => {
     await userEvent.type(locator, ')')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['(c)'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: (c)|')
     })
 
     expect(insertTextEvents).toEqual(['insert.text', 'insert.text'])
@@ -746,7 +751,7 @@ describe('Behavior API', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
       })
     })
 

--- a/packages/editor/tests/event.annotation.test.tsx
+++ b/packages/editor/tests/event.annotation.test.tsx
@@ -1,5 +1,4 @@
 import {defineSchema, type PortableTextTextBlock} from '@portabletext/schema'
-import {getTersePt} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
@@ -8,6 +7,7 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.annotation', () => {
   test('.add/.remove', async () => {
@@ -51,9 +51,9 @@ describe('event.annotation', () => {
       },
     })
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual([
-      'Hello,, ,world,!',
-    ])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      'B: [@link href="https://portabletext.org":^Hello|], [@link href="https://sanity.io":world]!',
+    )
     expect(getTextMarks(editor.getSnapshot().context, 'Hello')).toEqual(['k5'])
     expect(getTextMarks(editor.getSnapshot().context, 'world')).toEqual(['k2'])
 
@@ -69,7 +69,9 @@ describe('event.annotation', () => {
       },
     })
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello,, world!'])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      'B: [@link href="https://portabletext.org":Hello], wor|ld!',
+    )
     expect(getTextMarks(editor.getSnapshot().context, 'Hello')).toEqual(['k5'])
   })
 

--- a/packages/editor/tests/event.child.set.test.tsx
+++ b/packages/editor/tests/event.child.set.test.tsx
@@ -1,8 +1,9 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema, type Patch} from '../src'
 import {EventListenerPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.child.set', () => {
   test('Scenario: Setting properties on inline object', async () => {
@@ -54,9 +55,9 @@ describe('event.child.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{image},',
-      ])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {image url="https://www.sanity.io/logo.svg"}',
+      )
     })
 
     const newImageKey = keyGenerator()
@@ -160,9 +161,9 @@ describe('event.child.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{cell},',
-      ])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {cell alive=false}',
+      )
     })
 
     editor.send({
@@ -263,9 +264,9 @@ describe('event.child.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{cell},',
-      ])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {cell alive=false}',
+      )
     })
 
     editor.send({
@@ -334,7 +335,9 @@ describe('event.child.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: Hello',
+      )
     })
 
     const newSpanKey = keyGenerator()
@@ -413,9 +416,9 @@ describe('event.child.set', () => {
     })
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{mention},',
-      ])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {mention text="J"}',
+      )
     })
 
     editor.send({

--- a/packages/editor/tests/event.child.unset.test.tsx
+++ b/packages/editor/tests/event.child.unset.test.tsx
@@ -1,10 +1,11 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema, type Patch} from '../src'
 import {EventListenerPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.child.unset', () => {
   test('Scenario: Unsetting span marks', async () => {
@@ -46,7 +47,9 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: [strong:Hello]',
+      )
       expect(patches).toEqual([])
     })
 
@@ -57,7 +60,7 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: Hello')
       expect(patches).toEqual([
         {
           origin: 'local',
@@ -110,7 +113,7 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: Hello')
       expect(patches).toEqual([])
     })
 
@@ -168,7 +171,7 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hell'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: Hell')
       expect(patches).toEqual([])
     })
 
@@ -229,7 +232,7 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: Hello')
       expect(patches).toEqual([])
     })
 
@@ -306,7 +309,9 @@ describe('event.child.unset', () => {
     await userEvent.type(locator, 'o')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['Hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: [strong:Hello|]',
+      )
       expect(patches).toEqual([
         {
           origin: 'local',
@@ -392,7 +397,7 @@ describe('event.child.unset', () => {
     await userEvent.type(locator, 'f')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['f'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: f|')
       expect(patches.slice(8)).toEqual([
         {
           origin: 'local',
@@ -474,7 +479,9 @@ describe('event.child.unset', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([',{image},'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {image alt="Sanity Logo" url="https://www.sanity.io/logo.svg"}',
+      )
     })
 
     editor.send({

--- a/packages/editor/tests/event.delete.backward.test.tsx
+++ b/packages/editor/tests/event.delete.backward.test.tsx
@@ -6,7 +6,7 @@ import {
   unset,
   type Patch,
 } from '@portabletext/patches'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -21,6 +21,7 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.delete.backward', () => {
   test('Scenario: Deleting lonely block object', async () => {
@@ -132,7 +133,7 @@ describe('event.delete.backward', () => {
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual(['fo'])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual('B: fo|')
     })
   })
 
@@ -282,7 +283,9 @@ describe('event.delete.backward', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo  baz'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: foo | baz',
+          )
         })
       })
 
@@ -311,9 +314,9 @@ describe('event.delete.backward', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([
-            'foo b baz',
-          ])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: foo b| baz',
+          )
         })
       })
     })
@@ -341,7 +344,9 @@ describe('event.delete.backward', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo  baz'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: foo  baz',
+          )
         })
       })
 
@@ -367,9 +372,9 @@ describe('event.delete.backward', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([
-            'foo b baz',
-          ])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: foo b baz',
+          )
         })
       })
     })
@@ -410,7 +415,7 @@ describe('event.delete.backward', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar baz'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |bar baz')
       })
     })
 
@@ -442,7 +447,7 @@ describe('event.delete.backward', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar baz'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: bar baz')
       })
     })
   })

--- a/packages/editor/tests/event.delete.test.tsx
+++ b/packages/editor/tests/event.delete.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -14,6 +14,7 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.delete', () => {
   test('Scenario: Deleting collapsed selection', async () => {
@@ -56,11 +57,9 @@ describe('event.delete', () => {
     await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        'bar',
-        '{image}',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: bar', '{IMAGE}'].join('\n'),
+      )
     })
 
     editor.send({
@@ -78,10 +77,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foobar',
-        '{image}',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foobar', '{IMAGE}'].join('\n'),
+      )
     })
 
     editor.send({
@@ -99,7 +97,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar')
     })
   })
 
@@ -138,11 +136,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', '{IMAGE}', 'B: bar'].join('\n'),
+      )
     })
 
     editor.send({
@@ -160,7 +156,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ')
     })
   })
 
@@ -190,11 +186,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', '{IMAGE}', 'B: bar'].join('\n'),
+      )
     })
 
     editor.send({
@@ -212,7 +206,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: bar')
     })
   })
 
@@ -242,11 +236,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', '{IMAGE}', 'B: bar'].join('\n'),
+      )
     })
 
     editor.send({
@@ -265,7 +257,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: bar')
     })
   })
 
@@ -295,11 +287,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', '{IMAGE}', 'B: bar'].join('\n'),
+      )
     })
 
     editor.send({
@@ -317,7 +307,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo')
     })
   })
 
@@ -382,7 +372,9 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['', 'baz'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            ['B: ', 'B: baz'].join('\n'),
+          )
 
           expect(editor.getSnapshot().context.selection).toBeNull()
         })
@@ -420,7 +412,9 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['', 'baz'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            ['B: |', 'B: baz'].join('\n'),
+          )
           expect(editor.getSnapshot().context.selection).toEqual({
             anchor: {
               path: [{_key: fooBlockKey}, 'children', {_key: fooSpanKey}],
@@ -461,7 +455,7 @@ describe('event.delete', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ')
       })
     })
   })
@@ -516,10 +510,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,bar,baz',
-        'fi,z',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo[strong:bar]baz', 'B: fi[strong:z]'].join('\n'),
+      )
     })
 
     editor.send({
@@ -537,7 +530,9 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foaz', 'fi,z'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foaz', 'B: fi[strong:z]'].join('\n'),
+      )
     })
   })
 
@@ -589,7 +584,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: baz')
     })
   })
 
@@ -619,7 +614,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo baz')
       expect(editor.getSnapshot().context.selection).toBeNull()
     })
   })
@@ -657,7 +652,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo |baz')
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {
           path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
@@ -705,7 +700,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo| baz')
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {
           path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
@@ -766,7 +761,7 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ')
         })
       })
 
@@ -795,7 +790,7 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ')
         })
       })
 
@@ -824,9 +819,9 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([
-            ',{stock-ticker},bar',
-          ])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: {stock-ticker}bar',
+          )
         })
       })
 
@@ -855,7 +850,7 @@ describe('event.delete', () => {
         })
 
         await vi.waitFor(() => {
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar')
         })
       })
     })
@@ -886,7 +881,7 @@ describe('event.delete', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['{image}'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('{IMAGE}')
       })
     })
 
@@ -936,11 +931,9 @@ describe('event.delete', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual([
-          '',
-          '{image}',
-          '',
-        ])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual(
+          ['B: ', '{IMAGE}', 'B: '].join('\n'),
+        )
       })
     })
   })
@@ -983,7 +976,7 @@ describe('event.delete', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|bar')
     })
   })
 
@@ -1034,7 +1027,7 @@ describe('event.delete', () => {
 
     await vi.waitFor(() => {
       // Then a placeholder block is silently inserted
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
       expect(behaviorEvents).toEqual([
         {
           type: 'delete',

--- a/packages/editor/tests/event.focus.test.tsx
+++ b/packages/editor/tests/event.focus.test.tsx
@@ -1,10 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {page, userEvent, type Locator} from 'vitest/browser'
 import {useEditor, type Editor} from '../src'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.focus', () => {
   test('Scenario: Immediate focus after decorator toggle', async () => {
@@ -42,7 +43,9 @@ describe('event.focus', () => {
 
     // Then the text is "hello ,world"
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello ,world'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: hello [strong:^world|]',
+      )
     })
 
     // And "world" is selected
@@ -95,7 +98,9 @@ describe('event.focus', () => {
 
     // Then the text is "hello ,world"
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello ,world'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: hello [strong:^world|]',
+      )
     })
 
     // And "world" is selected

--- a/packages/editor/tests/event.history.redo.test.tsx
+++ b/packages/editor/tests/event.history.redo.test.tsx
@@ -1,8 +1,9 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.redo', () => {
   test('Scenario: Redo after remote patches', async () => {
@@ -18,13 +19,13 @@ describe('event.history.redo', () => {
     editor.send({type: 'insert.text', text: 'hello'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
 
     const snapshotAfterRemote = [
@@ -51,13 +52,13 @@ describe('event.history.redo', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['world'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: world|')
     })
 
     editor.send({type: 'history.redo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['helloworld'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|world')
     })
   })
 
@@ -74,19 +75,19 @@ describe('event.history.redo', () => {
     editor.send({type: 'insert.text', text: 'foo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
 
     editor.send({type: 'history.redo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
   })
 })

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -13,6 +13,7 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {getFirstBlock, getFocusBlock} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
 import type {EditorSelection} from '../src/types/editor'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.undo', () => {
   test('Scenario: Undoing action sets', async () => {
@@ -45,25 +46,25 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'x')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['y*z'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: y*z|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['y*'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: y*|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['x'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: x|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -88,13 +89,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bc'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: bc|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
   })
 
@@ -148,19 +149,19 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'c')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['d'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: d|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['abc'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: abc|')
     })
   })
 
@@ -196,13 +197,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['yz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: yz|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['y'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: y|')
     })
   })
 
@@ -235,13 +236,15 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['B', 'c'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: B', 'B: c|'].join('\n'),
+      )
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -273,13 +276,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['AB'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: AB|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['A'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: A|')
     })
   })
 
@@ -319,13 +322,13 @@ describe('event.history.undo', () => {
       editor.send({type: 'custom.insert block', text: 'bar'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
       })
 
       editor.send({type: 'history.undo'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
       })
     })
 
@@ -364,13 +367,13 @@ describe('event.history.undo', () => {
       editor.send({type: 'custom.insert block', text: 'bar'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
       })
 
       editor.send({type: 'history.undo'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
       })
     })
 
@@ -409,13 +412,13 @@ describe('event.history.undo', () => {
       editor.send({type: 'custom.insert block', text: 'bar'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
       })
 
       editor.send({type: 'history.undo'})
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
       })
     })
   })
@@ -444,13 +447,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
   })
 
@@ -472,13 +475,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['aa'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: aa|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -503,13 +506,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['aa'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: aa|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
   })
 
@@ -544,31 +547,31 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['ABAB'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ABAB|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['ABA'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ABA|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['AB'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: AB|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['A'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: A|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -596,13 +599,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     await userEvent.keyboard('{ArrowLeft}')
@@ -610,7 +613,7 @@ describe('event.history.undo', () => {
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -640,13 +643,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'hello')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -685,14 +688,14 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'hello')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|')
       expect(sideEffectLog).toHaveLength(5)
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -729,14 +732,14 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'hi')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['h!i!'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: h!i!|')
     })
 
     // First undo reverts the second raise ('!' after 'i')
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['h!i'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: h!i|')
     })
 
     // Second undo reverts the forwarded 'i' and the first raise ('!' after 'h')
@@ -744,7 +747,7 @@ describe('event.history.undo', () => {
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['h'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: h|')
     })
   })
 
@@ -778,13 +781,13 @@ describe('event.history.undo', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['b'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: b|')
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['a'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: a|')
     })
 
     const firstBlock = getFirstBlock(editor.getSnapshot())
@@ -805,7 +808,7 @@ describe('event.history.undo', () => {
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
 
@@ -855,7 +858,9 @@ describe('event.history.undo', () => {
 
     // After adding: "f" + "oob" (strong) + "ar" — three spans
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['f,oob,ar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: f[strong:^oob|]ar',
+      )
     })
 
     editor.send({type: 'history.undo'})
@@ -921,7 +926,9 @@ describe('event.history.undo', () => {
 
     // After adding: "f" + "oob" (link) + "ar" — three spans
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['f,oob,ar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: f[@link:^oob|]ar',
+      )
     })
 
     editor.send({type: 'history.undo'})

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -1,6 +1,6 @@
 import type {Patch} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {execute} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
@@ -11,6 +11,7 @@ import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {getFocusBlock} from '../src/selectors/selector.get-focus-block'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.block', () => {
   test('Scenario: Inserting block with custom _key', async () => {
@@ -444,9 +445,9 @@ describe('event.insert.block', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{stock-ticker},',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: |{stock-ticker symbol="AAPL"}',
+      )
     })
 
     await vi.waitFor(() => {
@@ -541,9 +542,9 @@ describe('event.insert.block', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{stock-ticker},,{stock-ticker},',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: |{stock-ticker symbol="AAPL"}{stock-ticker symbol="GOOG"}',
+      )
     })
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/event.insert.blocks.test.tsx
+++ b/packages/editor/tests/event.insert.blocks.test.tsx
@@ -1,5 +1,5 @@
 import {isTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -7,6 +7,7 @@ import {defineBehavior, type InsertPlacement} from '../src/behaviors'
 import {BehaviorPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextBlockText} from '../src/utils'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.blocks', () => {
   test('Scenario: Inserting text block with lonely inline object', async () => {
@@ -62,10 +63,12 @@ describe('event.insert.blocks', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{image},',
-        '',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        [
+          'B: {image alt="Image" src="https://example.com/image.jpg"}',
+          'B: |',
+        ].join('\n'),
+      )
     })
   })
 
@@ -2296,7 +2299,9 @@ describe('event.insert.blocks', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', 'baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: baz|'].join('\n'),
+      )
     })
   })
 })

--- a/packages/editor/tests/event.insert.child.test.tsx
+++ b/packages/editor/tests/event.insert.child.test.tsx
@@ -1,12 +1,13 @@
 import type {Patch} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineBehavior, raise} from '../src/behaviors'
 import {BehaviorPlugin, EventListenerPlugin} from '../src/plugins'
 import {getFocusSpan, getFocusTextBlock} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.child', () => {
   test('Scenario: Carrying over an annotation', async () => {
@@ -163,9 +164,9 @@ describe('event.insert.child', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},newbar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo{stock-ticker}newbar|',
+      )
     })
   })
 
@@ -225,9 +226,9 @@ describe('event.insert.child', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},,{stock-ticker}, bar baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo{stock-ticker}{stock-ticker} bar baz|',
+      )
     })
   })
 
@@ -293,9 +294,9 @@ describe('event.insert.child', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo|{stock-ticker symbol="AAPL"}',
+      )
     })
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/event.insert.inline-object.test.tsx
+++ b/packages/editor/tests/event.insert.inline-object.test.tsx
@@ -1,11 +1,12 @@
 import {defineSchema, type PortableTextTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {page, userEvent} from 'vitest/browser'
 import type {EditorEmittedEvent} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {isKeyedSegment} from '../src/utils'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.inline object', () => {
   test('Scenario: Inserting inline object without any initial fields', async () => {
@@ -264,10 +265,9 @@ describe('event.insert.inline object', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        '{image}',
-        ',{stock ticker},',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        '{IMAGE}\nB: |{stock ticker symbol="AAPL"}',
+      )
     })
   })
 })

--- a/packages/editor/tests/event.insert.span.test.tsx
+++ b/packages/editor/tests/event.insert.span.test.tsx
@@ -1,10 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {execute, forward} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.span', () => {
   test('Scenario: Unknown decorators are filtered out', async () => {
@@ -227,10 +228,9 @@ describe('event.insert.span', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        '{image}',
-        'foo',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        '{IMAGE}\nB: foo|',
+      )
     })
   })
 
@@ -303,7 +303,7 @@ describe('event.insert.span', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([',{image},foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: {image}foo|')
     })
   })
 })

--- a/packages/editor/tests/event.insert.text.test.tsx
+++ b/packages/editor/tests/event.insert.text.test.tsx
@@ -1,5 +1,5 @@
 import {isSpan} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -10,6 +10,7 @@ import {IS_MAC} from '../src/internal-utils/is-hotkey'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.text', () => {
   test('Scenario: Consecutive `insert.text` events', async () => {
@@ -21,7 +22,7 @@ describe('event.insert.text', () => {
     editor.send({type: 'insert.text', text: 'foo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
         focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
@@ -32,7 +33,7 @@ describe('event.insert.text', () => {
     editor.send({type: 'insert.text', text: 'bar'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 6},
         focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 6},
@@ -43,7 +44,7 @@ describe('event.insert.text', () => {
     editor.send({type: 'delete.backward', unit: 'character'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['fooba'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: fooba|')
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
         focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
@@ -117,9 +118,9 @@ describe('event.insert.text', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo ,bar, baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo [strong:bar] baz|',
+      )
     })
   })
 
@@ -154,7 +155,9 @@ describe('event.insert.text', () => {
     await userEvent.type(locator, ' baz')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo bar baz|',
+      )
     })
   })
 
@@ -264,7 +267,9 @@ describe('event.insert.text', () => {
     await userEvent.type(locator, ' baz')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo bar baz|',
+      )
     })
   })
 
@@ -310,7 +315,9 @@ describe('event.insert.text', () => {
     await userEvent.type(locator, ' baz')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo bar baz|',
+      )
     })
   })
 
@@ -320,7 +327,7 @@ describe('event.insert.text', () => {
     editor.send({type: 'insert.text', text: 'foo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
   })
 
@@ -405,9 +412,9 @@ describe('event.insert.text', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'before,{stock-ticker},after',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: before{stock-ticker symbol="AAPL"}after',
+      )
     })
 
     editor.send({
@@ -441,9 +448,9 @@ describe('event.insert.text', () => {
     editor.send({type: 'insert.text', text: 'hello'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'before,{stock-ticker},helloafter',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: before{stock-ticker symbol="AAPL"}hello|after',
+      )
     })
   })
 })

--- a/packages/editor/tests/event.keyboard.keydown.test.tsx
+++ b/packages/editor/tests/event.keyboard.keydown.test.tsx
@@ -1,4 +1,3 @@
-import {getTersePt} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {execute, raise} from '../src/behaviors/behavior.types.action'
@@ -7,6 +6,7 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {getNextBlock} from '../src/selectors/selector.get-next-block'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionBeforeText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.keyboard.keydown', () => {
   const initialValue = [
@@ -119,11 +119,9 @@ describe('event.keyboard.keydown', () => {
     await userEvent.type(locator, 'new')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        'newbar',
-        'baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: new|bar', 'B: baz'].join('\n'),
+      )
     })
   })
 
@@ -201,11 +199,9 @@ describe('event.keyboard.keydown', () => {
     await userEvent.type(locator, 'new')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        'newbar',
-        'baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: new|bar', 'B: baz'].join('\n'),
+      )
     })
   })
 })

--- a/packages/editor/tests/event.move.block.selection.test.tsx
+++ b/packages/editor/tests/event.move.block.selection.test.tsx
@@ -1,8 +1,9 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {whenTheCaretIsPutAfter} from '../test-utils/caret-placement'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.move.block regression', () => {
   test('Scenario: Moving a block down preserves selection on the moved block', async () => {
@@ -36,7 +37,7 @@ describe('event.move.block regression', () => {
 
     await userEvent.click(locator)
 
-    const afterFooSelection = await whenTheCaretIsPutAfter(editor, 'foo')
+    await whenTheCaretIsPutAfter(editor, 'foo')
 
     editor.send({
       type: 'move.block down',
@@ -44,15 +45,9 @@ describe('event.move.block regression', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'bar',
-        'foo',
-        'baz',
-      ])
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual(afterFooSelection)
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: bar', 'B: foo|', 'B: baz'].join('\n'),
+      )
     })
   })
 
@@ -86,7 +81,7 @@ describe('event.move.block regression', () => {
     })
 
     await userEvent.click(locator)
-    const afterBazSelection = await whenTheCaretIsPutAfter(editor, 'baz')
+    await whenTheCaretIsPutAfter(editor, 'baz')
 
     editor.send({
       type: 'move.block up',
@@ -94,15 +89,9 @@ describe('event.move.block regression', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        'baz',
-        'bar',
-      ])
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual(afterBazSelection)
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: baz|', 'B: bar'].join('\n'),
+      )
     })
   })
 
@@ -141,21 +130,17 @@ describe('event.move.block regression', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'bar',
-        'foo',
-        'baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: bar', 'B: foo', 'B: baz'].join('\n'),
+      )
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        'bar',
-        'baz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: bar', 'B: baz'].join('\n'),
+      )
     })
   })
 
@@ -190,16 +175,17 @@ describe('event.move.block regression', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar', 'foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: bar', 'B: foo|'].join('\n'),
+      )
     })
 
     await userEvent.type(locator, 'baz')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'bar',
-        'foobaz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: bar', 'B: foobaz|'].join('\n'),
+      )
     })
   })
 })

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -1,5 +1,5 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {useState} from 'react'
 import {describe, expect, test, vi} from 'vitest'
@@ -14,6 +14,7 @@ import {
 } from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.mutation', () => {
   test('Scenario: Deferring mutation events when read-only', async () => {
@@ -31,10 +32,11 @@ describe('event.mutation', () => {
             onEvent(event)
             if (
               event.type === 'mutation' &&
-              getTersePt({
+              toTextspec({
                 schema: compileSchema(defineSchema({})),
                 value: event.value ?? [],
-              }).at(0) === 'foo'
+                selection: null,
+              }) === 'B: foo'
             ) {
               resolveFooMutation()
             }

--- a/packages/editor/tests/event.paste.test.tsx
+++ b/packages/editor/tests/event.paste.test.tsx
@@ -1,12 +1,13 @@
 import {htmlToPortableText, type ObjectMatcher} from '@portabletext/html'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {raise} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.clipboard.paste', () => {
   test('Scenario: Cut/paste block object', async () => {
@@ -248,11 +249,13 @@ describe('event.clipboard.paste', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context!)).toEqual([
-          'Hello world',
-          'foo ,{image}, bar',
-          'baz',
-        ])
+        expect(toTextspec(editor.getSnapshot().context!)).toEqual(
+          [
+            'B: Hello world',
+            'B: foo {image alt="Image" src="https://example.com/image.jpg"} bar',
+            'B: baz|',
+          ].join('\n'),
+        )
       })
     })
 
@@ -296,13 +299,15 @@ describe('event.clipboard.paste', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context!)).toEqual([
-          'Hello world',
-          'foo',
-          '{image}',
-          'bar',
-          'baz',
-        ])
+        expect(toTextspec(editor.getSnapshot().context!)).toEqual(
+          [
+            'B: Hello world',
+            'B: foo',
+            '{IMAGE alt="Image" src="https://example.com/image.jpg"}',
+            'B: bar',
+            'B: baz|',
+          ].join('\n'),
+        )
       })
     })
 
@@ -323,11 +328,9 @@ describe('event.clipboard.paste', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context!)).toEqual([
-          'Hello world',
-          'foo bar',
-          'baz',
-        ])
+        expect(toTextspec(editor.getSnapshot().context!)).toEqual(
+          ['B: Hello world', 'B: foo bar', 'B: baz|'].join('\n'),
+        )
       })
     })
   })
@@ -413,12 +416,9 @@ describe('event.clipboard.paste', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context!)).toEqual([
-        'foo',
-        'bar',
-        'baz',
-        'fizz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context!)).toEqual(
+        ['B: foo', 'B: bar|', 'B: baz', 'B: fizz'].join('\n'),
+      )
     })
   })
 })

--- a/packages/editor/tests/event.patch.test.tsx
+++ b/packages/editor/tests/event.patch.test.tsx
@@ -8,11 +8,12 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.patch', () => {
   test('Scenario: Deleting empty block above non-empty text block', async () => {
@@ -70,7 +71,7 @@ describe('event.patch', () => {
     await userEvent.keyboard('{Delete}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |bar')
     })
 
     expect(patches).toEqual([
@@ -519,7 +520,7 @@ describe('event.patch', () => {
 
         await vi.waitFor(() => {
           expect(editor.getSnapshot().context.value).toEqual(remoteValue)
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|')
         })
       })
 
@@ -558,9 +559,9 @@ describe('event.patch', () => {
 
         await vi.waitFor(() => {
           expect(editor.getSnapshot().context.value).toEqual(remoteValue)
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([
-            'hello world',
-          ])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: hello world|',
+          )
         })
       })
     })
@@ -587,7 +588,7 @@ describe('event.patch', () => {
 
         await vi.waitFor(() => {
           expect(editor.getSnapshot().context.value).toEqual(remoteValue)
-          expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello'])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual('B: hello|')
         })
       })
 
@@ -626,9 +627,9 @@ describe('event.patch', () => {
 
         await vi.waitFor(() => {
           expect(editor.getSnapshot().context.value).toEqual(remoteValue)
-          expect(getTersePt(editor.getSnapshot().context)).toEqual([
-            'hello world',
-          ])
+          expect(toTextspec(editor.getSnapshot().context)).toEqual(
+            'B: hello world|',
+          )
         })
       })
     })
@@ -677,7 +678,7 @@ describe('event.patch', () => {
     await userEvent.keyboard('{Delete}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
 
     expect(patches).toEqual(

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -7,7 +7,7 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
@@ -16,6 +16,7 @@ import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor, createTestEditors} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.patches', () => {
   describe('Scenario: `set`ing the entire value', () => {
@@ -2006,7 +2007,7 @@ describe('event.patches', () => {
     await userEvent.type(locator, ' bar')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo bar|')
     })
 
     editor.send({
@@ -2033,7 +2034,7 @@ describe('event.patches', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |baz')
     })
   })
 
@@ -2681,7 +2682,7 @@ describe('event.patches', () => {
       })
 
       await vi.waitFor(() => {
-        expect(getTersePt(editor.getSnapshot().context)).toEqual(['{image}'])
+        expect(toTextspec(editor.getSnapshot().context)).toEqual('{IMAGE}')
       })
     })
 

--- a/packages/editor/tests/event.select.test.tsx
+++ b/packages/editor/tests/event.select.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -17,6 +17,7 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.select', () => {
   test('Scenario: Arrow navigation causes `select` event', async () => {
@@ -863,7 +864,7 @@ describe('event.select', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
 
       expect(selectEvents).toEqual([
         {

--- a/packages/editor/tests/event.split.test.tsx
+++ b/packages/editor/tests/event.split.test.tsx
@@ -1,10 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionText} from '../test-utils/selection-text'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.split', () => {
   test('Scenario: Splitting mid-block before inline object', async () => {
@@ -52,10 +53,9 @@ describe('event.split', () => {
       type: 'split',
     })
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual([
-      'foo',
-      ',{stock-ticker},',
-    ])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      ['B: foo', 'B: |{stock-ticker}'].join('\n'),
+    )
   })
 
   test('Scenario: Splitting text block with custom properties', async () => {
@@ -179,9 +179,9 @@ describe('event.split', () => {
 
     await userEvent.type(locator, 'bar')
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual([
-      'foo,{stock-ticker},bar',
-    ])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      'B: foo{stock-ticker value="AAPL"}bar|',
+    )
   })
 
   test('Scenario: Splitting block object is a noop', async () => {
@@ -230,10 +230,9 @@ describe('event.split', () => {
     editor.send({type: 'split'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        '^{IMAGE}|\nB: bar',
+      )
     })
   })
 
@@ -299,27 +298,31 @@ describe('event.split', () => {
     editor.send({type: 'split'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', 'ar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: |ar'].join('\n'),
+      )
     })
 
     await userEvent.type(locator, 'baz')
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', 'bazar'])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      ['B: foo', 'B: baz|ar'].join('\n'),
+    )
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', 'ar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: |ar'].join('\n'),
+      )
     })
 
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo',
-        '{image}',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', '|{IMAGE}', 'B: b^ar'].join('\n'),
+      )
     })
   })
 
@@ -385,12 +388,16 @@ describe('event.split', () => {
     editor.send({type: 'split'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['f', 'bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: f|', 'B: bar'].join('\n'),
+      )
     })
 
     await userEvent.type(locator, 'baz')
 
-    expect(getTersePt(editor.getSnapshot().context)).toEqual(['fbaz', 'bar'])
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      ['B: fbaz|', 'B: bar'].join('\n'),
+    )
   })
 
   test('Scenario: Splitting with an expanded selection from one span to another', async () => {
@@ -440,10 +447,9 @@ describe('event.split', () => {
     editor.send({type: 'split'})
 
     await vi.waitFor(() => {
-      return expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo',
-        'ar',
-      ])
+      return expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: fo', 'B: [strong:|ar]'].join('\n'),
+      )
     })
   })
 })

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1,8 +1,9 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema, type EditorEmittedEvent} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.update value', () => {
   test('Scenario: Clearing placeholder value', async () => {
@@ -539,7 +540,7 @@ describe('event.update value', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo')
     })
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/inline-objects.test.tsx
+++ b/packages/editor/tests/inline-objects.test.tsx
@@ -1,10 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineBehavior, raise} from '../src/behaviors'
 import {BehaviorPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Inline Objects', () => {
   test('Scenario: Deleting inline object with Backspace', async () => {
@@ -60,13 +61,13 @@ describe('Feature: Inline Objects', () => {
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
 
     await userEvent.type(locator, 'bar')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
     })
   })
 
@@ -123,13 +124,13 @@ describe('Feature: Inline Objects', () => {
     await userEvent.keyboard('{Delete}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo|')
     })
 
     await userEvent.type(locator, 'bar')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foobar|')
     })
   })
 
@@ -186,19 +187,17 @@ describe('Feature: Inline Objects', () => {
     await userEvent.keyboard('{Enter}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},',
-        '',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo{stock-ticker}', 'B: |'].join('\n'),
+      )
     })
 
     await userEvent.type(locator, 'bar')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},',
-        'bar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo{stock-ticker}', 'B: bar|'].join('\n'),
+      )
     })
   })
 
@@ -256,9 +255,9 @@ describe('Feature: Inline Objects', () => {
     editor.send({type: 'insert.text', text: 'hello'})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo,{stock-ticker},hellobar',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo{stock-ticker}hello|bar',
+      )
     })
   })
 
@@ -320,9 +319,9 @@ describe('Feature: Inline Objects', () => {
     await userEvent.type(locator, 'a')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{stock-ticker},',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: |{stock-ticker}',
+      )
     })
 
     await userEvent.keyboard('{ArrowRight}')
@@ -344,9 +343,9 @@ describe('Feature: Inline Objects', () => {
     await userEvent.type(locator, 'new')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        ',{stock-ticker},new',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: {stock-ticker}new|',
+      )
     })
   })
 })

--- a/packages/editor/tests/overlapping-annotations.test.tsx
+++ b/packages/editor/tests/overlapping-annotations.test.tsx
@@ -1,5 +1,5 @@
 import {isTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema} from '../src'
 import {execute, raise} from '../src/behaviors/behavior.types.action'
@@ -9,6 +9,7 @@ import {isActiveAnnotation} from '../src/selectors/selector.is-active-annotation
 import {createTestEditor} from '../src/test/vitest'
 import {getTextMarks} from '../test-utils/text-marks'
 import {getTextSelection} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * By default, annotations of the same type cannot overlap.
@@ -76,9 +77,9 @@ describe('overlapping annotations', () => {
 
     await vi.waitFor(() => {
       // Then the text is "fo,o bar b,az"
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo,o bar b,az',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: fo[@comment text="Comment B":^o bar b|]az',
+      )
 
       const block = editor.getSnapshot().context.value.at(0)
 
@@ -130,9 +131,9 @@ describe('overlapping annotations', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo,o ,bar, b,az',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: fo[@comment text="Comment B":^o ][@comment text="Comment A":[@comment text="Comment B":bar]][@comment text="Comment B": b|]az',
+      )
 
       const block = editor.getSnapshot().context.value.at(0)
 
@@ -215,9 +216,9 @@ describe('overlapping annotations', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo,o bar b,az',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: fo[@link href="https://portabletext.org":^o bar b|]az',
+      )
 
       const block = editor.getSnapshot().context.value.at(0)
 
@@ -244,9 +245,9 @@ describe('overlapping annotations', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo,o, bar b,az',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: [@link href="https://sanity.io":^fo][@link href="https://portabletext.org":[@link href="https://sanity.io":o|]][@link href="https://portabletext.org": bar b]az',
+      )
 
       const block = editor.getSnapshot().context.value.at(0)
 

--- a/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
+++ b/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
@@ -1,10 +1,11 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema, PortableTextEditor} from '../src'
 import {InternalPortableTextEditorRefPlugin} from '../src/plugins/plugin.internal.portable-text-editor-ref'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe(PortableTextEditor.addAnnotation.name, () => {
   test('Scenario: Prevents overlapping annotations of the same type', async () => {
@@ -52,9 +53,9 @@ describe(PortableTextEditor.addAnnotation.name, () => {
     )
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'fo,o bar b,az',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: fo[@link href="https://sanity.io":^o bar b|]az',
+      )
     })
   })
 

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -4,7 +4,7 @@ import {
   isTextBlock,
   type PortableTextBlock,
 } from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {createRef, useState, type ReactNode, type RefObject} from 'react'
 import {describe, expect, it, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
@@ -31,6 +31,7 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 const helloBlock: PortableTextBlock = {
   _key: '123',
@@ -216,10 +217,9 @@ describe('RangeDecorations', () => {
     await userEvent.type(locator, '123 ')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        '123 Hello there world',
-        "It's a beautiful day on planet earth",
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        "B: 123 |Hello there world\nB: It's a beautiful day on planet earth",
+      )
     })
 
     await rerender({

--- a/packages/editor/tests/selection-after-remote-patches.test.tsx
+++ b/packages/editor/tests/selection-after-remote-patches.test.tsx
@@ -1,11 +1,12 @@
 import {diffMatchPatch, insert, unset} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {whenTheCaretIsPutAfter} from '../test-utils/caret-placement'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Selection adjustment after remote patches', () => {
   test('Scenario: Remote insert block before cursor', async () => {
@@ -356,7 +357,9 @@ describe('Feature: Selection adjustment after remote patches', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['hello world'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: hello world|',
+      )
     })
 
     await vi.waitFor(() => {
@@ -416,7 +419,9 @@ describe('Feature: Selection adjustment after remote patches', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['world,hello'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: [strong:world]hello|',
+      )
     })
 
     await vi.waitFor(() => {
@@ -486,7 +491,9 @@ describe('Feature: Selection adjustment after remote patches', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo', 'bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo|', 'B: bar'].join('\n'),
+      )
     })
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/self-solving.test.tsx
+++ b/packages/editor/tests/self-solving.test.tsx
@@ -1,6 +1,6 @@
 import type {Patch} from '@portabletext/patches'
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
@@ -15,6 +15,7 @@ import {
   getSelectionAfterText,
   getTextSelection,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Self-solving', () => {
   test('Scenario: Missing .markDefs and .marks are added after the editor is made dirty', async () => {
@@ -453,7 +454,9 @@ describe('Feature: Self-solving', () => {
     await userEvent.type(locator, 'b')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo,barb'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo[strong:barb|]',
+      )
 
       expect(patches).toEqual([
         {

--- a/packages/editor/tests/serialize-deserialize.test.tsx
+++ b/packages/editor/tests/serialize-deserialize.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {execute, forward, raise} from '../src/behaviors/behavior.types.action'
@@ -8,6 +8,7 @@ import {safeStringify} from '../src/internal-utils/safe-json'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Serialize/Deserialize', () => {
   test('Scenario: Custom text/html deserializer', async () => {
@@ -133,7 +134,7 @@ describe('Serialize/Deserialize', () => {
 
     // And the text is ""
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([''])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
 
     // When a paste is performed
@@ -147,7 +148,9 @@ describe('Serialize/Deserialize', () => {
 
     // Then the text is "foo bar baz"
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo bar baz|',
+      )
     })
 
     // However, when only text/plain and text/html is pasted
@@ -164,10 +167,12 @@ describe('Serialize/Deserialize', () => {
 
     // The custom HTML deserializer takes precedence
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo bar baz',
-        '{image}',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        [
+          'B: foo bar baz',
+          '^{IMAGE src="https://example.com/image.png"}|',
+        ].join('\n'),
+      )
     })
   })
 
@@ -316,9 +321,9 @@ describe('Serialize/Deserialize', () => {
 
     // Then the text is "Overwritten HTML"
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'Overwritten HTML',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: Overwritten HTML|',
+      )
     })
   })
 
@@ -374,7 +379,9 @@ describe('Serialize/Deserialize', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo bar baz|',
+      )
     })
   })
 
@@ -429,7 +436,7 @@ describe('Serialize/Deserialize', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['fizz buzz'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: fizz buzz|')
     })
   })
 })

--- a/packages/editor/tests/setup.test.tsx
+++ b/packages/editor/tests/setup.test.tsx
@@ -1,5 +1,5 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import type {
@@ -9,6 +9,7 @@ import type {
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Setup', () => {
   test('Scenario: Unknown block object', async () => {
@@ -44,10 +45,11 @@ describe('Setup', () => {
 
             if (
               event.type === 'mutation' &&
-              getTersePt({
+              toTextspec({
                 schema: compileSchema(defineSchema({})),
                 value: event.value ?? [],
-              }).at(0) === 'foo bar'
+                selection: null,
+              }) === 'B: foo bar'
             ) {
               resolveFooBarMutation()
               mutationEvent = event
@@ -60,7 +62,7 @@ describe('Setup', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo')
     })
 
     expect(events.slice(0, 2)).toEqual([
@@ -83,7 +85,7 @@ describe('Setup', () => {
     await userEvent.type(locator, ' bar')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo bar|')
     })
 
     await fooBarMutationPromise

--- a/packages/editor/tests/text-plain-paste.test.tsx
+++ b/packages/editor/tests/text-plain-paste.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {raise} from '../src/behaviors/behavior.types.action'
@@ -6,6 +6,7 @@ import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('`text/plain` paste', () => {
   test('Scenario: Consumer behavior on `deserialize.data` can produce rich blocks from `text/plain`', async () => {
@@ -172,9 +173,9 @@ describe('`text/plain` paste', () => {
 
     // The pasted text should inherit the bold formatting
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'foo ,banewr, buz',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo [strong:banew|r] buz',
+      )
     })
   })
 })

--- a/packages/editor/tests/undo-redo-collaboration.test.tsx
+++ b/packages/editor/tests/undo-redo-collaboration.test.tsx
@@ -7,6 +7,7 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
+import {toTextspec} from '../test-utils/to-textspec'
 
 function createInitialValue(text: string): Array<PortableTextBlock> {
   return [
@@ -49,9 +50,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.type(locator, '?')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'First paragraph\n\nSecond paragraph!?',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: First paragraph', '', 'Second paragraph!?|'].join('\n'),
+      )
     })
 
     await userEvent.click(locatorB)
@@ -80,9 +81,11 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        'Welcome\n\nFirst paragraph\n\nSecond paragraph!',
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: Welcome', '', 'First paragraph', '', 'Second paragraph!|'].join(
+          '\n',
+        ),
+      )
     })
   })
 
@@ -233,9 +236,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.type(locator, 'P1>')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `P1>${firstParagraph}\n\n${secondParagraph}`,
-      ])
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: P1>${firstParagraph}\n\n${secondParagraph}`,
+      )
     })
 
     await userEvent.click(locatorB)
@@ -254,12 +257,12 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.type(locatorB, '/P1')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `P1>${firstParagraph}/P1\n\n${secondParagraph}`,
-      ])
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `P1>${firstParagraph}/P1\n\n${secondParagraph}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: P1>|${firstParagraph}/P1\n\n${secondParagraph}`,
+      )
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: P1>${firstParagraph}/P1|\n\n${secondParagraph}`,
+      )
     })
 
     await userEvent.click(locator)
@@ -279,9 +282,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.type(locator, '/P2')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `P1>${firstParagraph}/P1\n\n${secondParagraph}/P2`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: P1>${firstParagraph}/P1\n\n${secondParagraph}/P2|`,
+      )
     })
 
     editor.send({
@@ -292,9 +295,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `${firstParagraph}/P1\n\n${secondParagraph}`,
-      ])
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: ${firstParagraph}/P1|\n\n${secondParagraph}`,
+      )
     })
 
     editorB.send({
@@ -302,9 +305,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${firstParagraph}\n\n${secondParagraph}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: |${firstParagraph}\n\n${secondParagraph}`,
+      )
     })
   })
 
@@ -332,9 +335,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `${beginning}${end.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: ${beginning}${end.slice(0, -1)}`,
+      )
     })
 
     await userEvent.click(locatorB)
@@ -354,9 +357,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     editorB.send({type: 'insert.text', text: middle})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${beginning}${middle}${end.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${beginning}${middle}${end.slice(0, -1)}|`,
+      )
     })
 
     editor.send({
@@ -364,9 +367,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${beginning}${middle}${end}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${beginning}${middle}${end}|`,
+      )
     })
   })
 
@@ -388,9 +391,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: ${initialText.slice(0, -1)}`,
+      )
     })
 
     await userEvent.click(locatorB)
@@ -410,9 +413,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.type(locatorB, newPrefix)
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${newPrefix}${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}${initialText.slice(0, -1)}|`,
+      )
     })
 
     await userEvent.click(locatorB)
@@ -437,9 +440,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${newPrefix}\n\n${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}\n\n${initialText.slice(0, -1)}|`,
+      )
     })
 
     editor.send({
@@ -447,9 +450,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${newPrefix}\n\n${initialText}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}\n\n${initialText}|`,
+      )
     })
   })
 
@@ -475,9 +478,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     await userEvent.keyboard('{Backspace}')
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${initialText.slice(0, -1)}|`,
+      )
     })
 
     const newPrefix = 'new prefix'
@@ -498,9 +501,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     editorB.send({type: 'insert.text', text: newPrefix})
 
     await vi.waitFor(() => {
-      expect(getTersePt(editorB.getSnapshot().context)).toEqual([
-        `${newPrefix}${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editorB.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}|${initialText.slice(0, -1)}`,
+      )
     })
 
     const selectionC = getSelectionAfterText(
@@ -523,9 +526,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${newPrefix}\n\n${initialText.slice(0, -1)}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}\n\n${initialText.slice(0, -1)}|`,
+      )
     })
 
     editor.send({
@@ -533,9 +536,9 @@ describe('Undo/Redo Collaboration (hand-coded)', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual([
-        `${newPrefix}\n\n${initialText}`,
-      ])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        `B: ${newPrefix}\n\n${initialText}|`,
+      )
     })
   })
 })

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -1,9 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import type {EditorEmittedEvent} from '../src/editor/relay-machine'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Value validation', () => {
   test('Initial value with `null` child results in a validation error', async () => {
@@ -106,7 +107,9 @@ describe('Value validation', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo,bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo[strong:bar]',
+      )
     })
 
     await vi.waitFor(() => {
@@ -141,7 +144,9 @@ describe('Value validation', () => {
     })
 
     await vi.waitFor(() => {
-      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo,bar'])
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo[strong:bar]',
+      )
     })
   })
 

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -1,8 +1,9 @@
 import type {Editor} from '@portabletext/editor'
 import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
 import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {toTextspec} from '@portabletext/editor/test'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {createRef} from 'react'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
@@ -90,8 +91,8 @@ function makeBlock(key: string, text: string): PortableTextBlock {
   }
 }
 
-function getEditorText(editor: Editor): string[] {
-  return getTersePt(editor.getSnapshot().context)
+function getEditorText(editor: Editor): string {
+  return toTextspec(editor.getSnapshot().context)
 }
 
 // ---- Tests ----
@@ -111,7 +112,7 @@ describe('ValueSyncPlugin', () => {
       cleanup = unmount
 
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello'])
+        expect(getEditorText(editor)).toEqual('B: Hello')
       })
     })
 
@@ -121,7 +122,7 @@ describe('ValueSyncPlugin', () => {
       cleanup = unmount
 
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual([''])
+        expect(getEditorText(editor)).toEqual('B: |')
       })
     })
   })
@@ -141,11 +142,12 @@ describe('ValueSyncPlugin', () => {
 
       const pushedValue = store.pushValue.mock.lastCall?.[0] ?? []
       expect(
-        getTersePt({
+        toTextspec({
           value: pushedValue,
           schema: editor.getSnapshot().context.schema,
+          selection: null,
         }),
-      ).toEqual(['Hello'])
+      ).toEqual('B: Hello')
     })
   })
 
@@ -158,7 +160,7 @@ describe('ValueSyncPlugin', () => {
       store.setRemoteValue([makeBlock('b1', 'Hello from remote')])
 
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello from remote'])
+        expect(getEditorText(editor)).toEqual('B: Hello from remote')
       })
     })
   })
@@ -181,7 +183,7 @@ describe('ValueSyncPlugin', () => {
       // by the "pushing to remote" state. The editor should still
       // have the correct value.
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello'])
+        expect(getEditorText(editor)).toEqual('B: Hello|')
       })
     })
 
@@ -211,7 +213,7 @@ describe('ValueSyncPlugin', () => {
 
       // Editor should still have the correct value, not reverted
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello'])
+        expect(getEditorText(editor)).toEqual('B: Hello|')
       })
     })
   })
@@ -241,7 +243,7 @@ describe('ValueSyncPlugin', () => {
       // Editor should NOT revert to "Hello" — it has pending writes.
       // Wait a bit to make sure no revert happens.
       await new Promise((resolve) => setTimeout(resolve, 100))
-      expect(getEditorText(editor)).toEqual(['Hello world'])
+      expect(getEditorText(editor)).toEqual('B: Hello world|')
 
       // Wait for the second push
       await vi.waitFor(() => {
@@ -250,7 +252,7 @@ describe('ValueSyncPlugin', () => {
 
       // After mutation flush, editor should have the full text
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello world'])
+        expect(getEditorText(editor)).toEqual('B: Hello world|')
       })
     })
 
@@ -297,7 +299,9 @@ describe('ValueSyncPlugin', () => {
       // `pending sync` defers the sync until after the push. The deferred
       // sync should detect the remote block and apply it.
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello world', 'from remote'])
+        expect(getEditorText(editor)).toEqual(
+          ['B: Hello world|', 'B: from remote'].join('\n'),
+        )
       })
     })
 
@@ -309,7 +313,7 @@ describe('ValueSyncPlugin', () => {
       store.setRemoteValue([makeBlock('b1', 'Hello from remote')])
 
       await vi.waitFor(() => {
-        expect(getEditorText(editor)).toEqual(['Hello from remote'])
+        expect(getEditorText(editor)).toEqual('B: Hello from remote')
       })
     })
   })


### PR DESCRIPTION
Migrates remaining unit-test usage of `getTersePt` from `@portabletext/test` to `toTextspec` from the editor package's test-utils.

`getTersePt` returns an array of terse-pt strings (one per block); textspec returns a single string with `;;` between blocks and inline selection markers. Combining text and selection in one assertion drops paired selection assertions where they existed.

Doing this file-by-file as fixups so each migration is reviewable on its own. Tests pass on chromium per file.