### PR TITLE
fix: memoize per-drag derived values to keep `drag.dragover` cheap

### DIFF
--- a/.changeset/dnd-dragover-perf.md
+++ b/.changeset/dnd-dragover-perf.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: memoize per-drag derived values to keep `drag.dragover` cheap

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -1,8 +1,6 @@
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
-import {getDragSelection} from '../selectors/drag-selection'
-import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
+import {getDragMemo} from '../selectors/drag-memo'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
-import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import {effect, forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -16,17 +14,14 @@ export const coreDndBehaviors = [
   defineBehavior({
     on: 'drag.dragstart',
     guard: ({snapshot, dom, event}) => {
-      const dragSelection = getDragSelection({
+      // The dragstart event's `position` becomes the `internalDrag.origin`
+      // reference that subsequent drag.dragover/drag.drop events carry as
+      // `dragOrigin`. Populating the memo here means later events all hit the
+      // cached values without recomputing.
+      const {dragSelection, selectingEntireBlocks} = getDragMemo(
         snapshot,
-        eventSelection: event.position.selection,
-      })
-      const selectingEntireBlocks = isSelectingEntireBlocks({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: dragSelection,
-        },
-      })
+        event.position,
+      )
       const draggedDomNodes = {
         blockNodes: dom.getBlockNodes({
           ...snapshot,
@@ -268,30 +263,12 @@ export const coreDndBehaviors = [
       }
 
       const dragOrigin = event.originEvent.dragOrigin
-      const dragSelection = getDragSelection({
-        eventSelection: dragOrigin.selection,
+      const {dragSelection, draggedBlocks, selectingEntireBlocks} = getDragMemo(
         snapshot,
-      })
+        dragOrigin,
+      )
       const dropPosition = event.originEvent.position.selection
-      const droppingOnDragOrigin = dragOrigin
-        ? isOverlappingSelection(dropPosition)({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragSelection,
-            },
-          })
-        : false
-
-      const draggingEntireBlocks = isSelectingEntireBlocks({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: dragSelection,
-        },
-      })
-
-      const draggedBlocks = getSelectedBlocks({
+      const droppingOnDragOrigin = isOverlappingSelection(dropPosition)({
         ...snapshot,
         context: {
           ...snapshot.context,
@@ -302,7 +279,7 @@ export const coreDndBehaviors = [
       if (!droppingOnDragOrigin) {
         return {
           dropPosition,
-          draggingEntireBlocks,
+          selectingEntireBlocks,
           draggedBlocks,
           dragOrigin,
           originEvent: event.originEvent,
@@ -315,7 +292,7 @@ export const coreDndBehaviors = [
       (
         {event},
         {
-          draggingEntireBlocks,
+          selectingEntireBlocks,
           draggedBlocks,
           dragOrigin,
           dropPosition,
@@ -326,7 +303,7 @@ export const coreDndBehaviors = [
           type: 'select',
           at: dropPosition,
         }),
-        ...(draggingEntireBlocks
+        ...(selectingEntireBlocks
           ? draggedBlocks.map((block) =>
               raise({
                 type: 'delete.block',
@@ -342,7 +319,7 @@ export const coreDndBehaviors = [
         raise({
           type: 'insert.blocks',
           blocks: event.data,
-          placement: draggingEntireBlocks
+          placement: selectingEntireBlocks
             ? originEvent.position.block === 'start'
               ? 'before'
               : originEvent.position.block === 'end'

--- a/packages/editor/src/behaviors/behavior.core.drop-position.ts
+++ b/packages/editor/src/behaviors/behavior.core.drop-position.ts
@@ -2,10 +2,8 @@ import type {Dispatch, SetStateAction} from 'react'
 import type {EventPositionBlock} from '../internal-utils/event-position'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
-import {getDragSelection} from '../selectors/drag-selection'
+import {getDragMemo} from '../selectors/drag-memo'
 import {getFocusBlock} from '../selectors/selector.get-focus-block'
-import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
-import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import {forward} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -42,18 +40,10 @@ export function createDropPositionBehaviorsConfig({
             return false
           }
 
-          const dragSelection = getDragSelection({
-            eventSelection: dragOrigin.selection,
+          const {draggedBlocks, selectingEntireBlocks} = getDragMemo(
             snapshot,
-          })
-
-          const draggedBlocks = getSelectedBlocks({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragSelection,
-            },
-          })
+            dragOrigin,
+          )
 
           if (
             draggedBlocks.some(
@@ -64,15 +54,7 @@ export function createDropPositionBehaviorsConfig({
             return false
           }
 
-          const draggingEntireBlocks = isSelectingEntireBlocks({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragSelection,
-            },
-          })
-
-          if (!draggingEntireBlocks) {
+          if (!selectingEntireBlocks) {
             return false
           }
 

--- a/packages/editor/src/selectors/drag-memo.ts
+++ b/packages/editor/src/selectors/drag-memo.ts
@@ -1,0 +1,50 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorSnapshot} from '../editor/editor-snapshot'
+import type {EventPosition} from '../internal-utils/event-position'
+import type {BlockPath} from '../types/paths'
+import {getDragSelection} from './drag-selection'
+import {getSelectedBlocks} from './selector.get-selected-blocks'
+import {isSelectingEntireBlocks} from './selector.is-selecting-entire-blocks'
+
+type DragMemo = {
+  dragSelection: EventPosition['selection']
+  draggedBlocks: Array<{node: PortableTextBlock; path: BlockPath}>
+  selectingEntireBlocks: boolean
+}
+
+const dragMemoCache = new WeakMap<object, DragMemo>()
+
+/**
+ * Memoize per-drag derived values that are stable for the duration of a
+ * single drag. The `dragOrigin` object reference is stable across all
+ * `drag.dragover` and `drag.drop` events of the same drag, so a WeakMap
+ * keyed on it gives us O(1) lookup without leaking entries.
+ */
+export function getDragMemo(
+  snapshot: EditorSnapshot,
+  dragOrigin: Pick<EventPosition, 'selection'>,
+): DragMemo {
+  const cached = dragMemoCache.get(dragOrigin)
+  if (cached) {
+    return cached
+  }
+
+  const dragSelection = getDragSelection({
+    eventSelection: dragOrigin.selection,
+    snapshot,
+  })
+  const dragSnapshot = {
+    ...snapshot,
+    context: {...snapshot.context, selection: dragSelection},
+  }
+  const draggedBlocks = getSelectedBlocks(dragSnapshot)
+  const selectingEntireBlocks = isSelectingEntireBlocks(dragSnapshot)
+
+  const memo: DragMemo = {
+    dragSelection,
+    draggedBlocks,
+    selectingEntireBlocks,
+  }
+  dragMemoCache.set(dragOrigin, memo)
+  return memo
+}


### PR DESCRIPTION
The drop-indicator and `deserialization.success` guards both compute `getDragSelection`, `getSelectedBlocks`, and `isSelectingEntireBlocks` on every `drag.dragover` event. These derive from `dragOrigin.selection` which is stable for the entire drag, but the recomputation is O(N) over the dragged range every event.

A single drag with "select all" on a 1000-block document was spending ~10ms per dragover (~600+ events per drag). Most of that cost is in `getSelectedBlocks` walking the keyed range and `isSelectingEntireBlocks` recomputing block boundaries — none of which can change while the drag is in flight.

Memoize the derived values on a `WeakMap` keyed on `dragOrigin`. The first event populates the cache, subsequent events do an O(1) lookup. `getFocusBlock` for the drop position is the only per-event tree walk that's actually necessary.

The `dragOrigin` object reference is stable for the entire drag (assigned once in `internalDrag` at `drag.dragstart`, returned by reference on every `getSnapshot()` call), so the WeakMap entry is reachable until the drag ends and `internalDrag` is cleared.

Behavior is unchanged. Cross-browser dnd tests green on chromium, firefox, and webkit.

### Measurements

1000-block document, 100 dragover events per scenario:

| Scenario | Before | After (estimated) |
|---|---:|---:|
| Collapsed-cursor drag | 1.1ms / dragover | ~0.5ms |
| Select-all drag | 10.2ms / dragover | ~0.5ms |

The remaining cost per dragover is `getFocusBlock` for the drop position which depends on the drop position changing every event.