### PR TITLE
fix: refresh internalDrag.origin on every dragstart

### DIFF
--- a/.changeset/dnd-stale-internal-drag-origin.md
+++ b/.changeset/dnd-stale-internal-drag-origin.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: refresh `internalDrag.origin` on every `dragstart`
+
+When `dragend` was missed after a successful drop (which happens consistently in some browser/layout combinations), the editor machine stayed in `dragging internally` and ignored subsequent `dragstart` events. Any later drop then read the previous gesture's drag origin while `dataTransfer` carried the new gesture's content, deleting the wrong block and duplicating the new one. `dragstart` now re-assigns `internalDrag.origin` even when the machine has not returned to `idle`.

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -611,6 +611,15 @@ export const editorMachine = setup({
               ],
               tags: ['dragging internally'],
               on: {
+                dragstart: {
+                  actions: [
+                    assign({
+                      internalDrag: ({event}) => ({
+                        origin: event.origin,
+                      }),
+                    }),
+                  ],
+                },
                 dragend: {target: 'idle'},
                 drop: {target: 'idle'},
               },

--- a/packages/editor/tests/event.drag.drop.duplication.test.tsx
+++ b/packages/editor/tests/event.drag.drop.duplication.test.tsx
@@ -1,0 +1,100 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import type {InternalEditor} from '../src/editor/create-editor'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Reproduces the duplication observed in Sanity Studio when dragging block
+ * objects between each other.
+ *
+ * Mechanism: `internalDrag.origin` is set by the editor machine in response
+ * to `dragstart` events. The machine only assigns `internalDrag.origin`
+ * while in the `idle` state, and returns to `idle` only when the document
+ * sees a `drop` or `dragend`. In some browsers — and consistently in
+ * Sanity Studio under specific layouts — `dragend` does not fire on the
+ * document after a successful drop. The machine stays in
+ * `dragging internally`, the next `dragstart` is ignored by the machine,
+ * and `internalDrag.origin` keeps pointing at the PREVIOUS drag's source.
+ *
+ * On the next drop, `Editable.tsx` reads `dragOrigin` from the stale
+ * `internalDrag.origin` while `dataTransfer` carries the new drag's
+ * freshly-serialized content. The drop handler trusts both inputs and
+ * deletes the old block while inserting the new — duplicating the second
+ * block and losing the first.
+ */
+describe('event.drag.drop: stale internalDrag.origin', () => {
+  test("Scenario: a second dragstart updates internalDrag.origin even when the machine hasn't returned to idle", async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageAKey = keyGenerator()
+    const imageBKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: imageAKey,
+          _type: 'image',
+          src: 'https://example.com/image-a.jpg',
+        },
+        {
+          _key: imageBKey,
+          _type: 'image',
+          src: 'https://example.com/image-b.jpg',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    const imageAOrigin = {
+      selection: {
+        anchor: {path: [{_key: imageAKey}], offset: 0},
+        focus: {path: [{_key: imageAKey}], offset: 0},
+      },
+    }
+    const imageBOrigin = {
+      selection: {
+        anchor: {path: [{_key: imageBKey}], offset: 0},
+        focus: {path: [{_key: imageBKey}], offset: 0},
+      },
+    }
+
+    const {editorActor} = (editor as InternalEditor)._internal
+
+    // Given a first drag of image A starts (entering "dragging internally")
+    editorActor.send({type: 'dragstart', origin: imageAOrigin})
+    await vi.waitFor(() => {
+      expect(editorActor.getSnapshot().context.internalDrag?.origin).toEqual(
+        imageAOrigin,
+      )
+    })
+
+    // When a second drag of image B starts WITHOUT an intervening dragend
+    // (mirroring the browser behavior we observe in Studio: after a
+    // successful drop, dragend does not always fire on the document)
+    editorActor.send({type: 'dragstart', origin: imageBOrigin})
+
+    // Then internalDrag.origin should track the latest dragstart, not the
+    // stale first one. The bug: it stays at imageAOrigin because the
+    // machine ignores dragstart while in "dragging internally".
+    await vi.waitFor(() => {
+      expect(editorActor.getSnapshot().context.internalDrag?.origin).toEqual(
+        imageBOrigin,
+      )
+    })
+  })
+})


### PR DESCRIPTION
## The bug

In Sanity Studio, dragging block objects between each other sometimes resulted in two copies of the second block appearing in the document, with the first block deleted. The captured event log showed the failing drop carried `dragOrigin._key = imageA` while `dataTransfer` contained image B's content. The drop handler deleted the block referenced by `dragOrigin` and inserted the block carried by `dataTransfer`, so image B ended up duplicated and image A was lost.

## How `dragOrigin` and `dataTransfer` got out of sync

`dragOrigin` is read from `internalDrag.origin` in the editor machine. Before this fix, the machine only assigned `internalDrag.origin` while in the `idle` state, and only returned to `idle` when the document received a `drop` or `dragend` event.

`dataTransfer` is overwritten by the LATEST `dragstart` in the behavior pipeline, which always re-runs the dragstart serializer regardless of machine state.

In some browsers (and consistently in Studio under specific layouts), `dragend` does not fire on the document after a successful drop. The machine stayed in `dragging internally`, the next `dragstart` was ignored, and `internalDrag.origin` kept pointing at the previous gesture's source while `dataTransfer` was freshly serialized from the new gesture. On drop, the two inputs disagreed and the drop handler corrupted the document.

## The fix

`dragstart` now re-assigns `internalDrag.origin` while in `dragging internally`, in addition to the existing assignment on the `idle → dragging internally` transition. The behavior layer continues to trust its inputs unchanged.

## Regression test

`packages/editor/tests/event.drag.drop.duplication.test.tsx` drives the actor directly: it dispatches two consecutive `dragstart` events without an intervening `dragend` and asserts that `internalDrag.origin` reflects the LATEST `dragstart`'s origin, not the first.