### PR TITLE
chore: set changesets baseBranch to editor-v6.x

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "editor-v6.x",
   "updateInternalDependencies": "patch",
   "ignore": ["docs", "playground", "example-basic"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - editor-v6.x
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Wires the changesets release line for `editor-v6.x` so v6.6.x patch releases can be cut from this maintenance branch alongside the v7-alpha releases that flow from `main`.

This commit changes `.changeset/config.json` to set `baseBranch` to `editor-v6.x`. With that, `changesets/action` (invoked from the reusable `portabletext/.github/.github/workflows/changesets.yml@main` workflow) will open Version Packages PRs targeting `editor-v6.x` instead of `main`, and merging them will publish v6.6.x releases.

The companion change — updating `.github/workflows/release.yml` to trigger on push to `editor-v6.x` instead of `main` — needs to be pushed by a maintainer, since GitHub OAuth Apps cannot modify workflow files without `workflow` scope.

Once both are in place, `editor-v6.x` becomes a self-contained release line. Concurrency in the reusable workflow is keyed by `github.ref`, so the two release flows run independently with no shared state.