### PR TITLE
feat: unwrap empty editable containers on Backspace and Delete

### DIFF
--- a/.changeset/delete-empty-container.md
+++ b/.changeset/delete-empty-container.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: unwrap empty editable containers on Backspace and Delete
+
+Pressing Backspace or Delete inside an empty editable container now unwraps the container so its empty inner block becomes a sibling at the container's parent level. The cursor follows the unwrapped block, so a second keystroke merges or deletes it like any ordinary empty text block.
+
+When the container's parent doesn't accept the inner block (a callout sitting alone in a table cell, for example), the unwrap walks up through structural ancestors, dissolving each level that holds only the chain on its way out, until it finds an ancestor whose parent's field accepts the payload. If no level accepts every type in the payload, or if the chain hits a non-lonely ancestor along the way, the keystroke is a no-op.
+
+The editor doesn't need to know what the container represents: code-blocks, callouts, fact-boxes, and table cells in single-cell rows all dissolve the same way once their content is empty.

--- a/packages/editor/src/internal-utils/get-unwrap-target.test.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.test.ts
@@ -1,0 +1,926 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {
+  ContainerConfig,
+  ContainerDefinition,
+} from '../renderers/renderer.types'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
+import {getUnwrapTarget} from './get-unwrap-target'
+
+const testRender: ContainerDefinition['render'] = ({children}) => children
+
+describe(getUnwrapTarget.name, () => {
+  test('stops at the origin when its parent accepts the payload', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {type: 'block'},
+                  {
+                    type: 'callout',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..cell',
+        makeContainerConfig(schema, {
+          scope: '$..cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'c0'}, 'content', {_key: 'co0'}],
+        new Set(['block']),
+      ),
+    ).toEqual([{_key: 'c0'}, 'content', {_key: 'co0'}])
+  })
+
+  test('walks up through structural ancestors until root accepts the payload', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {
+                                    type: 'callout',
+                                    fields: [
+                                      {
+                                        name: 'content',
+                                        type: 'array',
+                                        of: [{type: 'block'}],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..table',
+        makeContainerConfig(schema, {
+          scope: '$..table',
+          field: 'rows',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..table.row',
+        makeContainerConfig(schema, {
+          scope: '$..table.row',
+          field: 'cells',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..table.row.cell',
+        makeContainerConfig(schema, {
+          scope: '$..table.row.cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..table.row.cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..table.row.cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'table',
+              _key: 't0',
+              rows: [
+                {
+                  _type: 'row',
+                  _key: 'r0',
+                  cells: [
+                    {
+                      _type: 'cell',
+                      _key: 'c0',
+                      content: [
+                        {
+                          _type: 'callout',
+                          _key: 'co0',
+                          content: [
+                            {
+                              _type: 'block',
+                              _key: 'cb0',
+                              children: [
+                                {
+                                  _type: 'span',
+                                  _key: 'cs0',
+                                  text: '',
+                                  marks: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [
+          {_key: 't0'},
+          'rows',
+          {_key: 'r0'},
+          'cells',
+          {_key: 'c0'},
+          'content',
+          {_key: 'co0'},
+        ],
+        new Set(['block']),
+      ),
+    ).toEqual([{_key: 't0'}])
+  })
+
+  test('no-ops when a non-lonely ancestor blocks the cascade', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'row',
+            fields: [
+              {
+                name: 'cells',
+                type: 'array',
+                of: [
+                  {
+                    type: 'cell',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'callout',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..row',
+        makeContainerConfig(schema, {
+          scope: '$..row',
+          field: 'cells',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..row.cell',
+        makeContainerConfig(schema, {
+          scope: '$..row.cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..row.cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..row.cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co1',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb1',
+                          children: [
+                            {
+                              _type: 'span',
+                              _key: 'cs1',
+                              text: 'bar',
+                              marks: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'r0'}, 'cells', {_key: 'c0'}, 'content', {_key: 'co0'}],
+        new Set(['block']),
+      ),
+    ).toBeUndefined()
+  })
+
+  test('returns origin when it sits at the root', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..callout',
+        makeContainerConfig(schema, {
+          scope: '$..callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'callout',
+              _key: 'co0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'co0'}],
+        new Set(['block']),
+      ),
+    ).toEqual([{_key: 'co0'}])
+  })
+
+  test('returns origin when its parent accepts a mixed payload directly', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {name: 'image'},
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {type: 'block'},
+                  {type: 'image'},
+                  {
+                    type: 'callout',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}, {type: 'image'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..cell',
+        makeContainerConfig(schema, {
+          scope: '$..cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'c0'}, 'content', {_key: 'co0'}],
+        new Set(['block', 'image']),
+      ),
+    ).toEqual([{_key: 'c0'}, 'content', {_key: 'co0'}])
+  })
+
+  test('walks up to root when a mixed payload needs to escape a rejecting parent', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {name: 'image'},
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'callout',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}, {type: 'image'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..cell',
+        makeContainerConfig(schema, {
+          scope: '$..cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'c0'}, 'content', {_key: 'co0'}],
+        new Set(['block', 'image']),
+      ),
+    ).toEqual([{_key: 'c0'}])
+  })
+
+  test('no-ops when root does not accept every payload type', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'callout',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}, {type: 'image'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..cell',
+        makeContainerConfig(schema, {
+          scope: '$..cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.callout',
+        makeContainerConfig(schema, {
+          scope: '$..cell.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'c0'}, 'content', {_key: 'co0'}],
+        new Set(['block', 'image']),
+      ),
+    ).toBeUndefined()
+  })
+
+  test('no-ops when the origin has a sibling at the same level', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'row',
+            fields: [
+              {
+                name: 'cells',
+                type: 'array',
+                of: [
+                  {
+                    type: 'cell',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..row',
+        makeContainerConfig(schema, {
+          scope: '$..row',
+          field: 'cells',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..row.cell',
+        makeContainerConfig(schema, {
+          scope: '$..row.cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      children: [
+                        {_type: 'span', _key: 's1', text: 'bar', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'r0'}, 'cells', {_key: 'c0'}],
+        new Set(['block']),
+      ),
+    ).toBeUndefined()
+  })
+
+  test('stops at an intermediate ancestor when its parent accepts the payload', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {name: 'image'},
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {type: 'block'},
+                  {type: 'image'},
+                  {
+                    type: 'section',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'callout',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}, {type: 'image'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..cell',
+        makeContainerConfig(schema, {
+          scope: '$..cell',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.section',
+        makeContainerConfig(schema, {
+          scope: '$..cell.section',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+      [
+        '$..cell.section.callout',
+        makeContainerConfig(schema, {
+          scope: '$..cell.section.callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'section',
+                  _key: 'se0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                        {_type: 'image', _key: 'im0'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        [{_key: 'c0'}, 'content', {_key: 'se0'}, 'content', {_key: 'co0'}],
+        new Set(['block', 'image']),
+      ),
+    ).toEqual([{_key: 'c0'}, 'content', {_key: 'se0'}])
+  })
+
+  test('no-ops when origin sits at the root and root rejects part of the payload', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}, {type: 'image'}],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const configs: Map<string, ContainerConfig> = new Map([
+      [
+        '$..callout',
+        makeContainerConfig(schema, {
+          scope: '$..callout',
+          field: 'content',
+          render: testRender,
+        }),
+      ],
+    ])
+    const containers = resolveContainers(schema, configs)
+
+    expect(
+      getUnwrapTarget(
+        {
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'callout',
+              _key: 'co0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+                },
+                {_type: 'image', _key: 'im0'},
+              ],
+            },
+          ],
+        },
+        [{_key: 'co0'}],
+        new Set(['block', 'image']),
+      ),
+    ).toBeUndefined()
+  })
+})

--- a/packages/editor/src/internal-utils/get-unwrap-target.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.ts
@@ -1,0 +1,59 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import {getChildren} from '../node-traversal/get-children'
+import {getEnclosingContainer} from '../schema/get-enclosing-container'
+import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+
+/**
+ * Walk up from `originPath` (an empty editable container) looking for
+ * the outermost ancestor whose parent's field accepts every type in
+ * `payloadTypes`. Every container in the chain must be the only child
+ * in its own parent's field, otherwise promoting past it would damage
+ * siblings and the function returns `undefined`.
+ *
+ * The returned path is the outermost empty container to unwrap; the
+ * caller unsets every container from `originPath` up through this
+ * path and lands the payload at the parent's sibling position.
+ *
+ * Reaching root level (no enclosing container) only succeeds if root
+ * accepts every type in `payloadTypes`. Root accepts text blocks plus
+ * the registered block-object types in `schema.blockObjects`. If the
+ * payload contains a type that root doesn't declare, the function
+ * returns `undefined`.
+ */
+export function getUnwrapTarget(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  originPath: Path,
+  payloadTypes: ReadonlySet<string>,
+): Path | undefined {
+  let current = originPath
+
+  while (true) {
+    const enclosing = getEnclosingContainer(context, current)
+
+    if (!enclosing) {
+      const rootAccepted = getRootAcceptedTypes(context.schema)
+      if ([...payloadTypes].every((type) => rootAccepted.has(type))) {
+        return current
+      }
+      return undefined
+    }
+
+    const accepted = new Set(enclosing.of.map((member) => member.type))
+    if ([...payloadTypes].every((type) => accepted.has(type))) {
+      return current
+    }
+
+    if (getChildren(context, enclosing.path).length !== 1) {
+      return undefined
+    }
+
+    current = enclosing.path
+  }
+}

--- a/packages/editor/src/internal-utils/unwrap-container.ts
+++ b/packages/editor/src/internal-utils/unwrap-container.ts
@@ -1,0 +1,85 @@
+import {getChildren} from '../node-traversal/get-children'
+import type {Path} from '../slate/interfaces/path'
+import type {Point} from '../slate/interfaces/point'
+import {isAncestorPath} from '../slate/path/is-ancestor-path'
+import type {PortableTextSlateEditor} from '../types/slate-editor'
+import {getUnwrapTarget} from './get-unwrap-target'
+
+/**
+ * Move every child of an empty editable container at `originPath` to
+ * be a sibling at the level where they're accepted, unsetting every
+ * container along the way.
+ *
+ * The unwrap target is computed by {@link getUnwrapTarget}: if the
+ * origin's parent's field accepts the children, only the origin is
+ * unset; otherwise the operation walks up until it finds an accepting
+ * level, or no-ops if the path is blocked by a non-lonely level or by
+ * a payload type that root doesn't accept.
+ *
+ * `position: 'before'` lands the children before the unwrap target at
+ * the parent level; `'after'` lands them after.
+ *
+ * Selection follows: any point that pointed inside the origin is
+ * rewritten to point at the same node at its new sibling location.
+ * Points outside the origin are left alone.
+ */
+export function unwrapContainer(
+  editor: PortableTextSlateEditor,
+  originPath: Path,
+  position: 'before' | 'after',
+): void {
+  const children = getChildren(editor, originPath)
+  if (children.length === 0) {
+    editor.apply({type: 'unset', path: originPath})
+    return
+  }
+
+  const payloadTypes = new Set(children.map((child) => child.node._type))
+  const unwrapTarget = getUnwrapTarget(editor, originPath, payloadTypes)
+  if (!unwrapTarget) {
+    return
+  }
+
+  // `children[0].path` resolves to e.g. `[...originPath, fieldName, {_key}]`,
+  // giving us the field name without re-resolving the container.
+  const innerPrefix = children[0]!.path.slice(0, originPath.length + 1)
+  const previousSelection = editor.selection
+
+  // Repeated `position: 'before'` against the same path inserts in
+  // reverse, so iterate backward; `'after'` is symmetric.
+  const order = position === 'before' ? [...children].reverse() : children
+  for (const child of order) {
+    editor.apply({
+      type: 'insert',
+      path: unwrapTarget,
+      node: child.node,
+      position,
+    })
+  }
+  editor.apply({type: 'unset', path: unwrapTarget})
+
+  if (previousSelection) {
+    const anchor = transformPoint(previousSelection.anchor, innerPrefix)
+    const focus = transformPoint(previousSelection.focus, innerPrefix)
+    editor.apply({
+      type: 'set_selection',
+      properties: editor.selection,
+      newProperties: {anchor, focus},
+    })
+  }
+}
+
+/**
+ * If `point` is inside the origin (its path starts with `innerPrefix`),
+ * strip the prefix so the point now refers to the same node at its new
+ * sibling location. Otherwise return `point` unchanged.
+ */
+function transformPoint(point: Point, innerPrefix: Path): Point {
+  if (!isAncestorPath(innerPrefix, point.path)) {
+    return point
+  }
+  return {
+    path: point.path.slice(innerPrefix.length),
+    offset: point.offset,
+  }
+}

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -7,6 +7,7 @@ import {
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
 import type {InvalidValueResolution} from '../types/editor'
 
 interface Validation {
@@ -26,10 +27,7 @@ export function validateValue(
     types.span.name,
     ...types.inlineObjects.map((t) => t.name),
   ]
-  const validBlockTypes = [
-    types.block.name,
-    ...types.blockObjects.map((t) => t.name),
-  ]
+  const validBlockTypes = getRootAcceptedTypes(types)
 
   // Undefined is allowed
   if (value === undefined) {
@@ -92,7 +90,7 @@ export function validateValue(
         return true
       }
       // Test that every block has valid _type
-      if (!blk._type || !validBlockTypes.includes(blk._type)) {
+      if (!blk._type || !validBlockTypes.has(blk._type)) {
         // Special case where block type is set to default 'block', but the block type is named something else according to the schema.
         if (blk._type === 'block') {
           const currentBlockTypeName = types.block.name

--- a/packages/editor/src/node-traversal/is-empty-container.ts
+++ b/packages/editor/src/node-traversal/is-empty-container.ts
@@ -1,0 +1,22 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+import type {Path} from '../slate/interfaces/path'
+import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
+import {getChildren} from './get-children'
+
+/**
+ * True if the node at `path` is an editable container whose only child
+ * is an empty text block.
+ */
+export function isEmptyContainer(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  },
+  path: Path,
+): boolean {
+  const children = getChildren(context, path)
+  return children.length === 1 && isEmptyTextBlock(context, children[0]!.node)
+}

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -3,10 +3,14 @@ import {deleteCollapsed} from '../internal-utils/delete-collapsed'
 import {deleteRange} from '../internal-utils/delete-range'
 import {findCurrentLineRange} from '../internal-utils/find-current-line-range'
 import {unsetMatchedNodesInRange} from '../internal-utils/unset-matched-in-range'
+import {unwrapContainer} from '../internal-utils/unwrap-container'
+import {getAncestor} from '../node-traversal/get-ancestor'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNode} from '../node-traversal/get-node'
 import {isBlock} from '../node-traversal/is-block'
+import {isEmptyContainer} from '../node-traversal/is-empty-container'
 import {isInline} from '../node-traversal/is-inline'
+import {isEditableContainer} from '../schema/is-editable-container'
 import {range as editorRange} from '../slate/editor/range'
 import {unhangRange} from '../slate/editor/unhang-range'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
@@ -89,6 +93,25 @@ export const deleteOperationImplementation: OperationImplementation<
   const selection: 'collapse-to-start' | 'preserve' = operation.at
     ? 'preserve'
     : 'collapse-to-start'
+
+  if (isCollapsedRange(at)) {
+    const enclosingContainer = getAncestor(
+      operation.editor,
+      at.anchor.path,
+      (node, path) => isEditableContainer(operation.editor, node, path),
+    )
+    if (
+      enclosingContainer &&
+      isEmptyContainer(operation.editor, enclosingContainer.path)
+    ) {
+      unwrapContainer(
+        operation.editor,
+        enclosingContainer.path,
+        operation.direction === 'backward' ? 'before' : 'after',
+      )
+      return
+    }
+  }
 
   if (operation.unit === 'word' && isCollapsedRange(at)) {
     deleteCollapsed(operation.editor, at.anchor, {

--- a/packages/editor/src/schema/get-root-accepted-types.ts
+++ b/packages/editor/src/schema/get-root-accepted-types.ts
@@ -1,0 +1,16 @@
+import type {EditorSchema} from '../editor/editor-schema'
+
+/**
+ * Set of types that are valid at the root of the editor's value: the
+ * configured text-block type plus every registered block-object type.
+ *
+ * The editor accepts these at the top level of `value` and uses them
+ * to validate input and as the implicit accept-list for any payload
+ * that escapes registered containers.
+ */
+export function getRootAcceptedTypes(schema: EditorSchema): Set<string> {
+  return new Set<string>([
+    schema.block.name,
+    ...schema.blockObjects.map((blockObject) => blockObject.name),
+  ])
+}

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -564,7 +564,7 @@ describe('cross-container range delete', () => {
     ])
   })
 
-  test('Backspace at start of an empty container line below a text block does not crash', async () => {
+  test('Backspace at start of an empty container line below a text block unwraps the line', async () => {
     const keyGenerator = createTestKeyGenerator()
     const textBlockKey = keyGenerator()
     const textSpanKey = keyGenerator()
@@ -642,17 +642,11 @@ describe('cross-container range delete', () => {
         style: 'normal',
       },
       {
-        _type: 'code-block',
-        _key: codeBlockKey,
-        lines: [
-          {
-            _type: 'block',
-            _key: lineKey,
-            children: [{_type: 'span', _key: lineSpanKey, text: '', marks: []}],
-            markDefs: [],
-            style: 'normal',
-          },
-        ],
+        _type: 'block',
+        _key: lineKey,
+        children: [{_type: 'span', _key: lineSpanKey, text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
       },
     ])
   })

--- a/packages/editor/tests/delete-empty-container.test.tsx
+++ b/packages/editor/tests/delete-empty-container.test.tsx
@@ -1,0 +1,742 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+/**
+ * Pressing Backspace or Delete inside an empty callout should remove the
+ * callout entirely. The structural-container heuristic kicks in only when the
+ * callout has *content* — empty containers don't earn preservation.
+ */
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const containers = [
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..callout',
+    field: 'content',
+  }),
+]
+
+describe('delete on empty container', () => {
+  test('Backspace in empty callout with text block before unwraps to root', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+        },
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo\nB: |')
+    })
+  })
+
+  test('Backspace in empty callout with text block after unwraps to root', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |\nB: foo')
+    })
+  })
+
+  test('Backspace in empty callout that is the only block leaves a placeholder text block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
+
+  test('Delete in empty callout with text block after unwraps to root', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |\nB: foo')
+    })
+  })
+})
+
+/**
+ * Cascade rule: a Backspace or Delete that starts inside a lonely empty
+ * editable container walks up the ancestor chain looking for the first
+ * ancestor whose parent field accepts the payload (the original empty
+ * text block). When found, every container from origin up through that
+ * ancestor is unset and the payload lands at the ancestor's sibling
+ * position. If a non-lonely ancestor is hit before an accepting parent
+ * is found, the whole cascade no-ops.
+ *
+ * In practice we only ever cascade with an empty text block as payload,
+ * so the gate is "does this level's parent's of include {type: 'block'}".
+ */
+
+const tableSchemaPermissive = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [
+                            {type: 'block'},
+                            {
+                              type: 'callout',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  type: 'array',
+                                  of: [{type: 'block'}],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const tableContainersPermissive = [
+  defineContainer<typeof tableSchemaPermissive>({
+    scope: '$..table',
+    field: 'rows',
+  }),
+  defineContainer<typeof tableSchemaPermissive>({
+    scope: '$..table.row',
+    field: 'cells',
+  }),
+  defineContainer<typeof tableSchemaPermissive>({
+    scope: '$..table.row.cell',
+    field: 'content',
+  }),
+  defineContainer<typeof tableSchemaPermissive>({
+    scope: '$..table.row.cell.callout',
+    field: 'content',
+  }),
+]
+
+const tableSchemaStructural = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'callout',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  type: 'array',
+                                  of: [{type: 'block'}],
+                                },
+                              ],
+                            },
+                            {type: 'image'},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const tableContainersStructural = [
+  defineContainer<typeof tableSchemaStructural>({
+    scope: '$..table',
+    field: 'rows',
+  }),
+  defineContainer<typeof tableSchemaStructural>({
+    scope: '$..table.row',
+    field: 'cells',
+  }),
+  defineContainer<typeof tableSchemaStructural>({
+    scope: '$..table.row.cell',
+    field: 'content',
+  }),
+  defineContainer<typeof tableSchemaStructural>({
+    scope: '$..table.row.cell.callout',
+    field: 'content',
+  }),
+]
+
+const calloutInPermissiveCellSelection = {
+  path: [
+    {_key: 't0'},
+    'rows',
+    {_key: 'r0'},
+    'cells',
+    {_key: 'c0'},
+    'content',
+    {_key: 'co0'},
+    'content',
+    {_key: 'cb0'},
+    'children',
+    {_key: 'cs0'},
+  ],
+  offset: 0,
+}
+
+describe('delete on empty container - nested cascade', () => {
+  test('Backspace in empty callout in permissive cell unwraps only the callout', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaPermissive,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainersPermissive} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: calloutInPermissiveCellSelection,
+        focus: calloutInPermissiveCellSelection,
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      // Cell accepts text blocks, so the cascade stops at the cell:
+      // only the callout is unset. The callout's empty text block
+      // takes its place inside the cell. Table and row stay intact.
+      const value = editor.getSnapshot().context.value
+      expect(value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Backspace in empty callout in lonely structural cell cascades all the way to root', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaStructural,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainersStructural} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: calloutInPermissiveCellSelection,
+        focus: calloutInPermissiveCellSelection,
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      // Cell rejects text blocks, row only accepts cell, table only
+      // accepts row. Cascade promotes all the way to root, which does
+      // accept text blocks. Table+row+cell+callout all unset, empty
+      // text block becomes the lone block at root.
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
+
+  test('Backspace in empty callout in lonely structural cell with text block before lands payload after that text block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaStructural,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+        },
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainersStructural} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: calloutInPermissiveCellSelection,
+        focus: calloutInPermissiveCellSelection,
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      // Backspace direction = before; payload lands before the table's
+      // sibling position (i.e. as the new second block, after foo).
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo\nB: |')
+    })
+  })
+
+  test('Backspace in empty callout in structural cell with sibling cells is a no-op', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaStructural,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co1',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb1',
+                          children: [
+                            {
+                              _type: 'span',
+                              _key: 'cs1',
+                              text: 'bar',
+                              marks: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainersStructural} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    const before = editor.getSnapshot().context.value
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: calloutInPermissiveCellSelection,
+        focus: calloutInPermissiveCellSelection,
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      // Cell rejects text blocks. Cascade tries to promote past cell,
+      // but the cell has a sibling (c1), so promotion would damage
+      // sibling content. Whole cascade no-ops; the table is unchanged.
+      expect(editor.getSnapshot().context.value).toEqual(before)
+    })
+  })
+})


### PR DESCRIPTION
Pressing Backspace or Delete inside an empty editable container used to be a no-op. The keystroke fell through to the cross-parent range delete, which only trims endpoints and never removes the container shell.

This change treats an editable container that holds nothing but a single empty text block the same way the editor treats an empty paragraph: the inner block is hoisted to the container's parent and the container is unset. The cursor follows the hoisted block, so a second keystroke merges or deletes it like any ordinary empty text block.

When the container's parent doesn't accept the unwrapped payload, for example an empty callout sitting alone in a table cell that only holds callouts, the unwrap walks up through structural ancestors, dissolving each level that holds only the chain on its way out, until it finds an ancestor whose parent's field accepts every type in the payload. The walk respects two stop conditions: it bails out if any level along the chain has a sibling (so unwrapping a single empty cell in a multi-cell row is a no-op), and it refuses to land at root if the editor schema doesn't declare every type in the payload as a top-level block object.

The editor doesn't need to know what the container represents: code-blocks, callouts, fact-boxes, and table cells dissolve the same way once their content is empty.
