### PR TITLE
docs: add /editor section landing page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
         {
           label: 'Editor',
           items: [
+            {slug: 'editor', label: 'Overview'},
             {slug: 'editor/getting-started'},
             {slug: 'editor/guides/custom-blocks'},
             {

--- a/apps/docs/src/content/docs/editor/index.mdx
+++ b/apps/docs/src/content/docs/editor/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Portable Text Editor
+description: A headless, schema-driven block content editor for React. Officially supported, fully customizable, and built around the Portable Text specification.
+---
+
+The Portable Text Editor (`@portabletext/editor`) is the officially supported editor for working with [Portable Text](/specification/) content. It's a headless block content editor for React: you bring the UI, the editor handles the editing.
+
+You configure the editor by declaring a [schema](/editor/concepts/portabletext/) of styles, decorators, annotations, lists, block objects, and inline objects. Rendering is yours to control through render props on `PortableTextEditable`. Interactions are extensible through the [Behavior API](/editor/concepts/behavior/) and a growing set of [plugins](/editor/reference/plugins/). The companion [`@portabletext/toolbar`](/editor/reference/toolbar/) package gives you headless hooks for building toolbar UI.
+
+### [Getting started](/editor/getting-started/)
+
+Install the editor, define a schema, and build your first toolbar.
+
+### [Concepts](/editor/concepts/)
+
+How the schema, decorators, annotations, and behaviors fit together.
+
+### [Guides](/editor/guides/)
+
+Practical walkthroughs: custom blocks and inline objects, custom rendering, building toolbars, writing behaviors, and testing.
+
+### [Reference](/editor/reference/)
+
+API documentation for the editor, behaviors, plugins, selectors, toolbar, and keyboard shortcuts.


### PR DESCRIPTION
https://www.portabletext.org/editor returned a 404 because the Editor sidebar group had no overview page, while every other top-level group (`/rendering`, `/conversion`) has one.

This adds `editor/index.mdx` that introduces the editor and links out to Getting started, Concepts, Guides, and Reference, plus a sidebar Overview entry so the page is reachable through the nav. Same shape as `/rendering`.