### PR TITLE
fix: only unwrap object-level editable containers on Backspace and Delete

### DIFF
--- a/.changeset/unwrap-object-containers-only.md
+++ b/.changeset/unwrap-object-containers-only.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: only unwrap object-level editable containers on Backspace and Delete

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -13,6 +13,7 @@ import {isInline} from '../node-traversal/is-inline'
 import {isEditableContainer} from '../schema/is-editable-container'
 import {range as editorRange} from '../slate/editor/range'
 import {unhangRange} from '../slate/editor/unhang-range'
+import {isObjectNode} from '../slate/node/is-object-node'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {commonPath} from '../slate/path/common-path'
 import {pathEquals} from '../slate/path/path-equals'
@@ -98,7 +99,9 @@ export const deleteOperationImplementation: OperationImplementation<
     const enclosingContainer = getAncestor(
       operation.editor,
       at.anchor.path,
-      (node, path) => isEditableContainer(operation.editor, node, path),
+      (node, path) =>
+        isObjectNode(operation.editor, node) &&
+        isEditableContainer(operation.editor, node, path),
     )
     if (
       enclosingContainer &&

--- a/packages/editor/tests/delete-empty-container.test.tsx
+++ b/packages/editor/tests/delete-empty-container.test.tsx
@@ -740,3 +740,174 @@ describe('delete on empty container - nested cascade', () => {
     })
   })
 })
+
+/**
+ * Editable containers can be registered both on object nodes (the
+ * structural shell, e.g. `$..fact-box`) and on the text blocks inside
+ * them (`$..fact-box.block` for custom block rendering). The unwrap-on-
+ * empty-Backspace rule should only fire for the structural object-level
+ * registration. Text-block-level container registrations are a render-
+ * customization concern and shouldn't trigger container deletion when
+ * the user hits Backspace inside an empty paragraph.
+ */
+describe('delete on empty container - nested block container', () => {
+  const schemaDefinition = defineSchema({
+    blockObjects: [
+      {
+        name: 'fact-box',
+        fields: [
+          {
+            name: 'content',
+            type: 'array',
+            of: [
+              {
+                type: 'block',
+                styles: [{name: 'normal'}, {name: 'h1'}],
+                decorators: [{name: 'strong'}],
+                annotations: [],
+                lists: [],
+                inlineObjects: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  const containers = [
+    defineContainer<typeof schemaDefinition>({
+      scope: '$..fact-box',
+      field: 'content',
+    }),
+    defineContainer<typeof schemaDefinition>({
+      scope: '$..fact-box.block',
+      field: 'children',
+    }),
+  ]
+
+  test('Backspace inside empty fact-box with nested block container unwraps the fact-box', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'fact-box',
+          _key: 'f0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'f0'},
+            'content',
+            {_key: 'b0'},
+            'children',
+            {_key: 's0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'f0'},
+            'content',
+            {_key: 'b0'},
+            'children',
+            {_key: 's0'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
+
+  test('Backspace at the start of a non-first text block inside fact-box merges with the previous block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'fact-box',
+          _key: 'f0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+            },
+            {
+              _type: 'block',
+              _key: 'b1',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's1', text: 'bar', marks: []}],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'f0'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'f0'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete', direction: 'backward'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['FACT-BOX:', '  B: foo|bar'].join('\n'),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Editable containers can be registered on object nodes (the structural shell, e.g. `$..fact-box`) and on the text blocks inside them (`$..fact-box.block` for custom block rendering). The unwrap-on-empty-Backspace path was firing for both, so Backspace inside an empty paragraph that happened to have a block-level container registration would unwrap the wrong layer (the inner block) instead of the structural shell. The result was the fact-box / callout staying intact while the inner block was replaced by a fresh empty block.

Narrows the enclosing-container search to object nodes so block-level container registrations remain a pure rendering concern. Only object-level registrations (callout, code-block, fact-box outer, table cell) trigger the unwrap path.

Two regression tests in `delete-empty-container.test.tsx`:

- empty fact-box with both `$..fact-box` and `$..fact-box.block` containers registered → Backspace unwraps to `B: |`.
- foo/bar in fact-box with both containers registered → Backspace at start of bar merges to `FACT-BOX:\n  B: foo|bar`.