### PR TITLE
fix: unset structural containers fully covered by a delete range

### DIFF
--- a/.changeset/unset-fully-covered-container.md
+++ b/.changeset/unset-fully-covered-container.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: unset structural containers fully covered by a delete range

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -342,10 +342,17 @@ function deleteCrossParentRange(
   // 2. Walk up the start branch. At every level above the start block
   //    and below the start branch root, drop all trailing siblings.
   //    Trailing siblings of the start branch root itself are handled
-  //    by `removeChildrenBetween` below.
+  //    by `removeChildrenBetween` below. When the level's parent is a
+  //    structural container (its field doesn't accept text-block), the
+  //    siblings are structural shells (e.g. table cells in a row);
+  //    clear their contents instead of removing the shells themselves.
   let startLevel = startBlockPath
   while (!pathEquals(startLevel, startBranchRoot)) {
-    removeTrailingChildren(editor, startLevel)
+    if (parentAcceptsTextBlock(editor, startLevel)) {
+      removeTrailingChildren(editor, startLevel)
+    } else {
+      clearTrailingSiblings(editor, startLevel)
+    }
     startLevel = parentPath(startLevel)
   }
 
@@ -373,10 +380,16 @@ function deleteCrossParentRange(
   // 4. Walk up the end branch. At every level above the end block and
   //    below the end branch root, drop all preceding siblings.
   //    Preceding siblings of the end branch root itself are handled
-  //    by `removeChildrenBetween` above.
+  //    by `removeChildrenBetween` above. When the level's parent is a
+  //    structural container, clear sibling contents instead of
+  //    removing the shells.
   let endLevel = endBlockPath
   while (!pathEquals(endLevel, endBranchRoot)) {
-    removePrecedingSiblings(editor, endLevel)
+    if (parentAcceptsTextBlock(editor, endLevel)) {
+      removePrecedingSiblings(editor, endLevel)
+    } else {
+      clearPrecedingSiblings(editor, endLevel)
+    }
     endLevel = parentPath(endLevel)
   }
 
@@ -530,6 +543,19 @@ function removeTrailingChildren(
   }
 }
 
+/** Clear contents of every sibling that comes after `startChildPath`. */
+function clearTrailingSiblings(
+  editor: PortableTextSlateEditor,
+  startChildPath: Path,
+): void {
+  let cursor = getSibling(editor, startChildPath, 'next')
+  while (cursor) {
+    const cursorPath = cursor.path
+    clearContainerContents(editor, cursorPath)
+    cursor = getSibling(editor, cursorPath, 'next')
+  }
+}
+
 /** Remove every sibling that comes before `startChildPath`. */
 function removePrecedingSiblings(
   editor: PortableTextSlateEditor,
@@ -540,6 +566,36 @@ function removePrecedingSiblings(
     removeNodeAt(editor, cursor.path)
     cursor = getSibling(editor, startChildPath, 'previous')
   }
+}
+
+/** Clear contents of every sibling that comes before `startChildPath`. */
+function clearPrecedingSiblings(
+  editor: PortableTextSlateEditor,
+  startChildPath: Path,
+): void {
+  let cursor = getSibling(editor, startChildPath, 'previous')
+  while (cursor) {
+    const cursorPath = cursor.path
+    clearContainerContents(editor, cursorPath)
+    cursor = getSibling(editor, cursorPath, 'previous')
+  }
+}
+
+/**
+ * True when the path's parent is a registered editable container whose
+ * field accepts text-block. False when the parent is structural (e.g. a
+ * row whose `cells` field only accepts cells) or when the path is at
+ * root level.
+ */
+function parentAcceptsTextBlock(
+  editor: PortableTextSlateEditor,
+  path: Path,
+): boolean {
+  const enclosing = getEnclosingContainer(editor, path)
+  if (!enclosing) {
+    return true
+  }
+  return enclosing.of.some((member) => member.type === editor.schema.block.name)
 }
 
 /**

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -1,0 +1,60 @@
+import {getNode} from '../node-traversal/get-node'
+import {isEditableContainer} from '../schema/is-editable-container'
+import {end as editorEnd} from '../slate/editor/end'
+import {start as editorStart} from '../slate/editor/start'
+import type {Path} from '../slate/interfaces/path'
+import type {Range} from '../slate/interfaces/range'
+import {commonPath} from '../slate/path/common-path'
+import {parentPath} from '../slate/path/parent-path'
+import {pointEquals} from '../slate/point/point-equals'
+import {rangeEdges} from '../slate/range/range-edges'
+import type {PortableTextSlateEditor} from '../types/slate-editor'
+
+/**
+ * Walk up from the lowest common ancestor of `range`'s endpoints and
+ * return the outermost editable container the range covers from its
+ * deepest first leaf to its deepest last leaf. Stops as soon as an
+ * ancestor's start/end leaf points don't match the range's. Returns
+ * `undefined` if no ancestor in the chain qualifies.
+ *
+ * Intended for callers that need to know "did the user select a whole
+ * container?" before delegating to a textual delete primitive that
+ * would unhang the range and lose the original boundary signal.
+ */
+export function getFullyCoveredContainer(
+  editor: PortableTextSlateEditor,
+  range: Range,
+): Path | undefined {
+  const [start, end] = rangeEdges(range, {}, editor)
+  const lca = commonPath(start.path, end.path)
+
+  // The lca may end in a field segment (e.g. `[{table}, 'rows']`); in
+  // that case the children at the LCA are siblings inside the keyed
+  // parent (the table). Strip a trailing field segment so the walk
+  // starts at the parent node itself.
+  let cursor: Path =
+    lca.length > 0 && typeof lca[lca.length - 1] === 'string'
+      ? lca.slice(0, -1)
+      : lca
+
+  let outermost: Path | undefined
+  while (cursor.length > 0) {
+    const entry = getNode(editor, cursor)
+    if (!entry) {
+      break
+    }
+    if (isEditableContainer(editor, entry.node, cursor)) {
+      const containerStart = editorStart(editor, cursor)
+      const containerEnd = editorEnd(editor, cursor)
+      if (
+        !pointEquals(start, containerStart) ||
+        !pointEquals(end, containerEnd)
+      ) {
+        return outermost
+      }
+      outermost = cursor
+    }
+    cursor = parentPath(cursor)
+  }
+  return outermost
+}

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -2,6 +2,7 @@ import {resolveSelection} from '../internal-utils/apply-selection'
 import {deleteCollapsed} from '../internal-utils/delete-collapsed'
 import {deleteRange} from '../internal-utils/delete-range'
 import {findCurrentLineRange} from '../internal-utils/find-current-line-range'
+import {getFullyCoveredContainer} from '../internal-utils/get-fully-covered-container'
 import {unsetMatchedNodesInRange} from '../internal-utils/unset-matched-in-range'
 import {unwrapContainer} from '../internal-utils/unwrap-container'
 import {getAncestor} from '../node-traversal/get-ancestor'
@@ -131,6 +132,17 @@ export const deleteOperationImplementation: OperationImplementation<
       direction,
       selection,
     })
+    return
+  }
+
+  // If the selection covers an enclosing structural container end-to-end
+  // (e.g. start at the first cell, end at the last cell of a table),
+  // unset that container instead of running the textual delete. The
+  // textual primitive would unhang the range and then trim each end,
+  // leaving the container's empty shell behind.
+  const fullyCovered = getFullyCoveredContainer(operation.editor, at)
+  if (fullyCovered) {
+    operation.editor.apply({type: 'unset', path: fullyCovered})
     return
   }
 

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -1043,6 +1043,8 @@ describe('cross-container range delete: deep structures', () => {
         '    CELL:',
         '      CALLOUT:',
         '        B: f|',
+        '    CELL:',
+        '      B: ',
         'B: x',
       ].join('\n'),
     )
@@ -1203,6 +1205,8 @@ describe('cross-container range delete: deep structures', () => {
         'B: f|',
         'TABLE:',
         '  ROW:',
+        '    CELL:',
+        '      B: ',
         '    CELL:',
         '      CALLOUT:',
         '        B: z',
@@ -1537,6 +1541,514 @@ describe('cross-container range delete: deep structures', () => {
         '  ROW:',
         '    CELL:',
         '      B: z',
+      ].join('\n'),
+    )
+  })
+
+  test('Selecting an entire empty table and pressing Delete unsets the table', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const row1Key = keyGenerator()
+    const cell00Key = keyGenerator()
+    const block00Key = keyGenerator()
+    const span00Key = keyGenerator()
+    const cell01Key = keyGenerator()
+    const block01Key = keyGenerator()
+    const span01Key = keyGenerator()
+    const cell02Key = keyGenerator()
+    const block02Key = keyGenerator()
+    const span02Key = keyGenerator()
+    const row2Key = keyGenerator()
+    const cell10Key = keyGenerator()
+    const block10Key = keyGenerator()
+    const span10Key = keyGenerator()
+    const cell11Key = keyGenerator()
+    const block11Key = keyGenerator()
+    const span11Key = keyGenerator()
+    const cell12Key = keyGenerator()
+    const block12Key = keyGenerator()
+    const span12Key = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: row1Key,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cell00Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block00Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span00Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell01Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block01Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span01Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell02Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block02Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span02Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: row2Key,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cell10Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block10Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span10Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell11Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block11Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span11Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell12Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block12Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span12Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: row1Key},
+            'cells',
+            {_key: cell00Key},
+            'content',
+            {_key: block00Key},
+            'children',
+            {_key: span00Key},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: row2Key},
+            'cells',
+            {_key: cell12Key},
+            'content',
+            {_key: block12Key},
+            'children',
+            {_key: span12Key},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Delete}')
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+  })
+
+  test('Selecting only the first two of three empty cells in a row is a no-op', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cell0Key = keyGenerator()
+    const block0Key = keyGenerator()
+    const span0Key = keyGenerator()
+    const cell1Key = keyGenerator()
+    const block1Key = keyGenerator()
+    const span1Key = keyGenerator()
+    const cell2Key = keyGenerator()
+    const block2Key = keyGenerator()
+    const span2Key = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: rowKey,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cell0Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block0Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span0Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell1Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block1Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span1Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell2Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block2Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span2Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: rowKey},
+            'cells',
+            {_key: cell0Key},
+            'content',
+            {_key: block0Key},
+            'children',
+            {_key: span0Key},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: rowKey},
+            'cells',
+            {_key: cell1Key},
+            'content',
+            {_key: block1Key},
+            'children',
+            {_key: span1Key},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Delete}')
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'TABLE:',
+        '  ROW:',
+        '    CELL:',
+        '      B: ^',
+        '    CELL:',
+        '      B: |',
+        '    CELL:',
+        '      B: ',
+      ].join('\n'),
+    )
+  })
+
+  test('Selecting from the first cell to a middle cell of a 2x3 table preserves the trailing cells', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const row0Key = keyGenerator()
+    const cell00Key = keyGenerator()
+    const block00Key = keyGenerator()
+    const span00Key = keyGenerator()
+    const cell01Key = keyGenerator()
+    const block01Key = keyGenerator()
+    const span01Key = keyGenerator()
+    const cell02Key = keyGenerator()
+    const block02Key = keyGenerator()
+    const span02Key = keyGenerator()
+    const row1Key = keyGenerator()
+    const cell10Key = keyGenerator()
+    const block10Key = keyGenerator()
+    const span10Key = keyGenerator()
+    const cell11Key = keyGenerator()
+    const block11Key = keyGenerator()
+    const span11Key = keyGenerator()
+    const cell12Key = keyGenerator()
+    const block12Key = keyGenerator()
+    const span12Key = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: tableSchemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: row0Key,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cell00Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block00Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span00Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell01Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block01Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span01Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell02Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block02Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span02Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: row1Key,
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: cell10Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block10Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span10Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell11Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block11Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span11Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: cell12Key,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: block12Key,
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: span12Key, text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={tableContainers} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: row0Key},
+            'cells',
+            {_key: cell00Key},
+            'content',
+            {_key: block00Key},
+            'children',
+            {_key: span00Key},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: tableKey},
+            'rows',
+            {_key: row1Key},
+            'cells',
+            {_key: cell11Key},
+            'content',
+            {_key: block11Key},
+            'children',
+            {_key: span11Key},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Delete}')
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'TABLE:',
+        '  ROW:',
+        '    CELL:',
+        '      B: |',
+        '    CELL:',
+        '      B: ',
+        '    CELL:',
+        '      B: ',
+        '  ROW:',
+        '    CELL:',
+        '      B: ',
+        '    CELL:',
+        '      B: ',
+        '    CELL:',
+        '      B: ',
       ].join('\n'),
     )
   })


### PR DESCRIPTION
When a delete range covers an entire editable container — for example, the user clicks at the start of the first cell and shift-clicks at the start of the last cell of a 2x3 table — the cross-parent delete primitive trimmed the endpoints and applied the structural-container heuristic only to siblings between the start and end branches at the LCA. The walks up each branch still removed siblings as if their parent's field accepted text-blocks. Cells inside a row got dropped instead of having their contents cleared, and a fully-covered table was left as an empty shell.

Two changes in `deleteCrossParentRange`:

The walks up the start and end branches now check whether each level's parent field accepts text-blocks. When the parent is a structural container (a row whose `cells` field only accepts cells, a table whose `rows` field only accepts rows), trailing/preceding siblings get cleared via `clearContainerContents` instead of unset. The structural shell stays; only its contents become a fresh empty placeholder block.

A pre-check at the operation entry point walks up from the lowest common ancestor of the input range. For each ancestor that's a registered editable container, it compares the container's deepest start and end leaf points against the range's start and end. The outermost container that matches end-to-end gets unset wholesale. The check runs on the pre-unhang range so a cell-aligned selection still resolves to its original boundaries.

Adds three regression tests:
- A 2x3 empty table fully selected resolves to a single empty text block.
- The first two of three empty cells in a row is a no-op (nothing to delete).
- A selection from the first cell to a middle cell of a 2x3 table preserves every cell shell with its content cleared.

Updates two existing tests whose old expectations encoded the structural-trim bug (the "callout-in-cell-in-table" pair).