### PR TITLE
refactor: consolidate range overlap and fix `isOverlappingSelection` touching semantics

### DIFF
--- a/.changeset/is-overlapping-selection-touching.md
+++ b/.changeset/is-overlapping-selection-touching.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: treat touching selections as overlapping

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -1,10 +1,62 @@
+import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
 import {getDragSelection} from '../selectors/drag-selection'
 import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
+import {comparePoints} from '../slate/point/compare-points'
+import {isCollapsedRange} from '../slate/range/is-collapsed-range'
+import {rangeEdges} from '../slate/range/range-edges'
+import type {EditorSelection} from '../types/editor'
 import {effect, forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+
+/**
+ * Self-drop suppression: returns true when the drop position lands inside the
+ * drag origin in a way that would make the drop a no-op.
+ *
+ * Two expanded selections that only touch at a single endpoint are not treated
+ * as a self-drop — the drop position covers an adjacent block (typical when
+ * dragging a block-object onto the next block via the expanded fallback in
+ * `getEventPosition`), and the user genuinely wants the drop to happen.
+ */
+function isDropTargetingDragOrigin(
+  dropSelection: NonNullable<EditorSelection>,
+  dragOriginSelection: NonNullable<EditorSelection>,
+  snapshot: EditorSnapshot,
+): boolean {
+  const overlapping = isOverlappingSelection(dropSelection)({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: dragOriginSelection,
+    },
+  })
+
+  if (!overlapping) {
+    return false
+  }
+
+  if (
+    isCollapsedRange(dropSelection) ||
+    isCollapsedRange(dragOriginSelection)
+  ) {
+    return true
+  }
+
+  const root = {children: snapshot.context.value}
+  const [startA, endA] = rangeEdges(dropSelection, root)
+  const [startB, endB] = rangeEdges(dragOriginSelection, root)
+
+  if (
+    comparePoints(endA, startB, root) === 0 ||
+    comparePoints(endB, startA, root) === 0
+  ) {
+    return false
+  }
+
+  return true
+}
 
 export const coreDndBehaviors = [
   /**
@@ -182,13 +234,11 @@ export const coreDndBehaviors = [
     guard: ({snapshot, event}) => {
       const dragOrigin = event.dragOrigin
       const draggingOverDragOrigin = dragOrigin
-        ? isOverlappingSelection(event.position.selection)({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragOrigin.selection,
-            },
-          })
+        ? isDropTargetingDragOrigin(
+            event.position.selection,
+            dragOrigin.selection,
+            snapshot,
+          )
         : false
 
       return draggingOverDragOrigin
@@ -206,13 +256,11 @@ export const coreDndBehaviors = [
       const dragOrigin = event.dragOrigin
       const dropPosition = event.position.selection
       const droppingOnDragOrigin = dragOrigin
-        ? isOverlappingSelection(dropPosition)({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragOrigin.selection,
-            },
-          })
+        ? isDropTargetingDragOrigin(
+            dropPosition,
+            dragOrigin.selection,
+            snapshot,
+          )
         : false
       return droppingOnDragOrigin
     },
@@ -274,13 +322,7 @@ export const coreDndBehaviors = [
       })
       const dropPosition = event.originEvent.position.selection
       const droppingOnDragOrigin = dragOrigin
-        ? isOverlappingSelection(dropPosition)({
-            ...snapshot,
-            context: {
-              ...snapshot.context,
-              selection: dragSelection,
-            },
-          })
+        ? isDropTargetingDragOrigin(dropPosition, dragSelection, snapshot)
         : false
 
       const draggingEntireBlocks = isSelectingEntireBlocks({

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.test.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.test.ts
@@ -86,7 +86,7 @@ describe(isOverlappingSelection.name, () => {
     ).toBe(true)
   })
 
-  test('selection right before', () => {
+  test('selection touching at start endpoint', () => {
     expect(
       isOverlappingSelection({
         anchor: {path: [{_key: 'k1'}, 'children', {_key: 'k3'}], offset: 0},
@@ -97,7 +97,7 @@ describe(isOverlappingSelection.name, () => {
           focus: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 1},
         }),
       ),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test('selection overlapping from the start', () => {
@@ -114,7 +114,7 @@ describe(isOverlappingSelection.name, () => {
     ).toBe(true)
   })
 
-  test('selection right after', () => {
+  test('selection touching at end endpoint', () => {
     expect(
       isOverlappingSelection({
         anchor: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 1},
@@ -125,7 +125,7 @@ describe(isOverlappingSelection.name, () => {
           focus: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 1},
         }),
       ),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test('selection overlapping from the end', () => {
@@ -184,7 +184,7 @@ describe(isOverlappingSelection.name, () => {
     ).toBe(true)
   })
 
-  test('expanded selection at the end edge of span', () => {
+  test('expanded selection touching at the end edge of span', () => {
     expect(
       isOverlappingSelection({
         anchor: {path: [{_key: 'k1'}, 'children', {_key: 'k3'}], offset: 0},
@@ -195,7 +195,7 @@ describe(isOverlappingSelection.name, () => {
           focus: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 1},
         }),
       ),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test('collapsed selection at the end edge of span', () => {
@@ -212,7 +212,7 @@ describe(isOverlappingSelection.name, () => {
     ).toBe(true)
   })
 
-  test('expanded selection at the start edge of span', () => {
+  test('expanded selection touching at the start edge of span', () => {
     expect(
       isOverlappingSelection({
         anchor: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 0},
@@ -223,7 +223,7 @@ describe(isOverlappingSelection.name, () => {
           focus: {path: [{_key: 'k1'}, 'children', {_key: 'k5'}], offset: 0},
         }),
       ),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test('collapsed selection at the start edge of span', () => {

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -1,17 +1,18 @@
 import {hasNode} from '../node-traversal/has-node'
-import type {EditorSelection, EditorSelectionPoint} from '../types/editor'
-import {
-  getSelectionEndPoint,
-  getSelectionStartPoint,
-  isEqualSelectionPoints,
-} from '../utils'
-import {comparePoints} from '../utils/util.compare-points'
+import {comparePoints} from '../slate/point/compare-points'
+import {isCollapsedRange} from '../slate/range/is-collapsed-range'
+import {rangeEdges} from '../slate/range/range-edges'
+import {rangesOverlap} from '../slate/range/ranges-overlap'
+import type {EditorSelection} from '../types/editor'
 import type {EditorSelector} from './../editor/editor-selector'
-import type {EditorSnapshot} from './../editor/editor-snapshot'
 
 /**
  * Returns true if the supplied selection overlaps with the editor's current
  * selection. Resolves at any container depth.
+ *
+ * Two selections that only touch at a single endpoint are considered
+ * overlapping when at least one is collapsed. Two expanded selections that
+ * only touch at a single endpoint do not overlap.
  *
  * @public
  */
@@ -25,178 +26,34 @@ export function isOverlappingSelection(
       return false
     }
 
-    const selectionStart = getSelectionStartPoint(selection)
-    const selectionEnd = getSelectionEndPoint(selection)
-    const editorSelectionStart = getSelectionStartPoint(editorSelection)
-    const editorSelectionEnd = getSelectionEndPoint(editorSelection)
-
     if (
-      !selectionStart ||
-      !selectionEnd ||
-      !editorSelectionStart ||
-      !editorSelectionEnd
+      !hasNode(snapshot.context, selection.anchor.path) ||
+      !hasNode(snapshot.context, selection.focus.path) ||
+      !hasNode(snapshot.context, editorSelection.anchor.path) ||
+      !hasNode(snapshot.context, editorSelection.focus.path)
     ) {
       return false
     }
 
+    const root = {children: snapshot.context.value}
+
+    if (!rangesOverlap(selection, editorSelection, root)) {
+      return false
+    }
+
+    if (isCollapsedRange(selection) || isCollapsedRange(editorSelection)) {
+      return true
+    }
+
+    const [startA, endA] = rangeEdges(selection, root)
+    const [startB, endB] = rangeEdges(editorSelection, root)
     if (
-      !hasNode(snapshot.context, selectionStart.path) ||
-      !hasNode(snapshot.context, selectionEnd.path) ||
-      !hasNode(snapshot.context, editorSelectionStart.path) ||
-      !hasNode(snapshot.context, editorSelectionEnd.path)
+      comparePoints(endA, startB, root) === 0 ||
+      comparePoints(endB, startA, root) === 0
     ) {
       return false
     }
 
-    return hasPointLevelOverlap(
-      snapshot,
-      selectionStart,
-      selectionEnd,
-      editorSelectionStart,
-      editorSelectionEnd,
-    )
-  }
-}
-
-/**
- * Check if selections overlap at the point level.
- */
-function hasPointLevelOverlap(
-  snapshot: EditorSnapshot,
-  selectionStart: EditorSelectionPoint,
-  selectionEnd: EditorSelectionPoint,
-  editorSelectionStart: EditorSelectionPoint,
-  editorSelectionEnd: EditorSelectionPoint,
-): boolean {
-  // Check for exact equality first
-  if (
-    isEqualSelectionPoints(selectionStart, editorSelectionStart) &&
-    isEqualSelectionPoints(selectionEnd, editorSelectionEnd)
-  ) {
     return true
   }
-
-  // Compare selection start against editor selection bounds
-  const selectionStartVsEditorSelectionStart = comparePoints(
-    snapshot,
-    selectionStart,
-    editorSelectionStart,
-  )
-  const selectionStartVsEditorSelectionEnd = comparePoints(
-    snapshot,
-    selectionStart,
-    editorSelectionEnd,
-  )
-
-  // Compare selection end against editor selection bounds
-  const selectionEndVsEditorSelectionStart = comparePoints(
-    snapshot,
-    selectionEnd,
-    editorSelectionStart,
-  )
-  const selectionEndVsEditorSelectionEnd = comparePoints(
-    snapshot,
-    selectionEnd,
-    editorSelectionEnd,
-  )
-
-  // Compare editor selection bounds against selection bounds
-  const editorSelectionStartVsSelectionStart = comparePoints(
-    snapshot,
-    editorSelectionStart,
-    selectionStart,
-  )
-  const editorSelectionEndVsSelectionEnd = comparePoints(
-    snapshot,
-    editorSelectionEnd,
-    selectionEnd,
-  )
-
-  // Derive boolean flags
-  const selectionStartBeforeEditorSelectionStart =
-    selectionStartVsEditorSelectionStart === -1
-  const selectionStartAfterEditorSelectionEnd =
-    selectionStartVsEditorSelectionEnd === 1
-  const selectionEndBeforeEditorSelectionStart =
-    selectionEndVsEditorSelectionStart === -1
-  const selectionEndAfterEditorSelectionEnd =
-    selectionEndVsEditorSelectionEnd === 1
-
-  const editorSelectionStartBeforeSelectionStart =
-    editorSelectionStartVsSelectionStart === -1
-  const editorSelectionStartAfterSelectionStart =
-    editorSelectionStartVsSelectionStart === 1
-  const editorSelectionEndBeforeSelectionEnd =
-    editorSelectionEndVsSelectionEnd === -1
-  const editorSelectionEndAfterSelectionEnd =
-    editorSelectionEndVsSelectionEnd === 1
-
-  const selectionStartEqualEditorSelectionEnd = isEqualSelectionPoints(
-    selectionStart,
-    editorSelectionEnd,
-  )
-  const selectionEndEqualEditorSelectionStart = isEqualSelectionPoints(
-    selectionEnd,
-    editorSelectionStart,
-  )
-
-  // If all relative position checks fail, selections don't overlap
-  if (
-    !selectionEndEqualEditorSelectionStart &&
-    !selectionStartEqualEditorSelectionEnd &&
-    !editorSelectionStartBeforeSelectionStart &&
-    !editorSelectionStartAfterSelectionStart &&
-    !editorSelectionEndBeforeSelectionEnd &&
-    !editorSelectionEndAfterSelectionEnd
-  ) {
-    return false
-  }
-
-  // Selection ends before editor selection starts
-  if (
-    selectionEndBeforeEditorSelectionStart &&
-    !selectionEndEqualEditorSelectionStart
-  ) {
-    return false
-  }
-
-  // Selection starts after editor selection ends
-  if (
-    selectionStartAfterEditorSelectionEnd &&
-    !selectionStartEqualEditorSelectionEnd
-  ) {
-    return false
-  }
-
-  // Editor selection is entirely after the input selection start
-  if (
-    !editorSelectionStartBeforeSelectionStart &&
-    editorSelectionStartAfterSelectionStart &&
-    !editorSelectionEndBeforeSelectionEnd &&
-    editorSelectionEndAfterSelectionEnd
-  ) {
-    return !selectionEndEqualEditorSelectionStart
-  }
-
-  // Editor selection is entirely before the input selection end
-  if (
-    editorSelectionStartBeforeSelectionStart &&
-    !editorSelectionStartAfterSelectionStart &&
-    editorSelectionEndBeforeSelectionEnd &&
-    !editorSelectionEndAfterSelectionEnd
-  ) {
-    return !selectionStartEqualEditorSelectionEnd
-  }
-
-  // If any of these conditions is false, there's overlap
-  if (
-    !selectionStartAfterEditorSelectionEnd ||
-    !selectionStartBeforeEditorSelectionStart ||
-    !selectionEndAfterEditorSelectionEnd ||
-    !selectionEndBeforeEditorSelectionStart
-  ) {
-    return true
-  }
-
-  return false
 }

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -1,18 +1,14 @@
 import {hasNode} from '../node-traversal/has-node'
-import {comparePoints} from '../slate/point/compare-points'
-import {isCollapsedRange} from '../slate/range/is-collapsed-range'
-import {rangeEdges} from '../slate/range/range-edges'
 import {rangesOverlap} from '../slate/range/ranges-overlap'
 import type {EditorSelection} from '../types/editor'
 import type {EditorSelector} from './../editor/editor-selector'
 
 /**
- * Returns true if the supplied selection overlaps with the editor's current
- * selection. Resolves at any container depth.
+ * Returns true if the supplied selection shares at least one point with the
+ * editor's current selection. Resolves at any container depth.
  *
- * Two selections that only touch at a single endpoint are considered
- * overlapping when at least one is collapsed. Two expanded selections that
- * only touch at a single endpoint do not overlap.
+ * Two selections that touch at a single endpoint share that point and are
+ * considered overlapping.
  *
  * @public
  */
@@ -35,25 +31,8 @@ export function isOverlappingSelection(
       return false
     }
 
-    const root = {children: snapshot.context.value}
-
-    if (!rangesOverlap(selection, editorSelection, root)) {
-      return false
-    }
-
-    if (isCollapsedRange(selection) || isCollapsedRange(editorSelection)) {
-      return true
-    }
-
-    const [startA, endA] = rangeEdges(selection, root)
-    const [startB, endB] = rangeEdges(editorSelection, root)
-    if (
-      comparePoints(endA, startB, root) === 0 ||
-      comparePoints(endB, startA, root) === 0
-    ) {
-      return false
-    }
-
-    return true
+    return rangesOverlap(selection, editorSelection, {
+      children: snapshot.context.value,
+    })
   }
 }

--- a/packages/editor/src/slate/range/range-intersection.ts
+++ b/packages/editor/src/slate/range/range-intersection.ts
@@ -2,21 +2,20 @@ import type {Node} from '../interfaces/node'
 import type {Range} from '../interfaces/range'
 import {isBeforePoint} from '../point/is-before-point'
 import {rangeEdges} from './range-edges'
+import {rangesOverlap} from './ranges-overlap'
 
 export function rangeIntersection(
   range: Range,
   another: Range,
   root: {children: Array<Node>},
 ): Range | null {
+  if (!rangesOverlap(range, another, root)) {
+    return null
+  }
   const {anchor: _anchor, focus: _focus, ...rest} = range
   const [s1, e1] = rangeEdges(range, root)
   const [s2, e2] = rangeEdges(another, root)
   const start = isBeforePoint(s1, s2, root) ? s2 : s1
   const end = isBeforePoint(e1, e2, root) ? e1 : e2
-
-  if (isBeforePoint(end, start, root)) {
-    return null
-  } else {
-    return {anchor: start, focus: end, ...rest}
-  }
+  return {anchor: start, focus: end, ...rest}
 }

--- a/packages/editor/src/slate/range/ranges-overlap.test.ts
+++ b/packages/editor/src/slate/range/ranges-overlap.test.ts
@@ -1,0 +1,173 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {rangesOverlap} from './ranges-overlap'
+
+const value: Array<PortableTextBlock> = [
+  {
+    _type: 'block',
+    _key: 'k0',
+    children: [
+      {_type: 'span', _key: 's0', text: 'foo'},
+      {_type: 'span', _key: 's1', text: 'bar'},
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'k1',
+    children: [{_type: 'span', _key: 's2', text: 'baz'}],
+  },
+]
+
+const root = {children: value}
+
+describe(rangesOverlap.name, () => {
+  test('disjoint ranges in same span', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        root,
+      ),
+    ).toBe(false)
+  })
+
+  test('disjoint ranges across blocks', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+        },
+        {
+          anchor: {path: [{_key: 'k1'}, 'children', {_key: 's2'}], offset: 0},
+          focus: {path: [{_key: 'k1'}, 'children', {_key: 's2'}], offset: 1},
+        },
+        root,
+      ),
+    ).toBe(false)
+  })
+
+  test('touching at one endpoint', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        root,
+      ),
+    ).toBe(true)
+  })
+
+  test('partial overlap', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        root,
+      ),
+    ).toBe(true)
+  })
+
+  test('full containment', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+        },
+        root,
+      ),
+    ).toBe(true)
+  })
+
+  test('identical ranges', () => {
+    const range = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+    }
+    expect(rangesOverlap(range, range, root)).toBe(true)
+  })
+
+  test('two collapsed ranges at the same point', () => {
+    const point = {
+      path: [{_key: 'k0'}, 'children', {_key: 's0'}],
+      offset: 1,
+    }
+    expect(
+      rangesOverlap(
+        {anchor: point, focus: point},
+        {anchor: point, focus: point},
+        root,
+      ),
+    ).toBe(true)
+  })
+
+  test('two collapsed ranges at different points', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+        },
+        root,
+      ),
+    ).toBe(false)
+  })
+
+  test('collapsed range inside expanded range', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+        },
+        root,
+      ),
+    ).toBe(true)
+  })
+
+  test('backward range overlapping forward range', () => {
+    expect(
+      rangesOverlap(
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 2},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 0},
+        },
+        {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 1},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 's0'}], offset: 3},
+        },
+        root,
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/editor/src/slate/range/ranges-overlap.ts
+++ b/packages/editor/src/slate/range/ranges-overlap.ts
@@ -1,0 +1,23 @@
+import type {Node} from '../interfaces/node'
+import type {Range} from '../interfaces/range'
+import {comparePoints} from '../point/compare-points'
+import {rangeEdges} from './range-edges'
+
+/**
+ * Returns true if the two ranges share at least one point.
+ *
+ * Two ranges overlap iff each one's start is at or before the other's end.
+ * Adjacent ranges that touch at a single point are considered overlapping.
+ */
+export function rangesOverlap(
+  rangeA: Range,
+  rangeB: Range,
+  root: {children: Array<Node>},
+): boolean {
+  const [startA, endA] = rangeEdges(rangeA, root)
+  const [startB, endB] = rangeEdges(rangeB, root)
+  return (
+    comparePoints(startA, endB, root) <= 0 &&
+    comparePoints(startB, endA, root) <= 0
+  )
+}

--- a/packages/editor/tests/event.drag.drop.self-drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.self-drop.test.tsx
@@ -1,0 +1,402 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {assert, describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {converterPortableText} from '../src/converters/converter.portable-text'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.drag.drop self-drop semantics', () => {
+  test('Scenario: collapsed drop inside expanded drag origin is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 0,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 6},
+    }
+    const dropSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 3,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 3},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    // Wait a tick to let any async drop processing complete
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+
+  test('Scenario: collapsed drop at start edge of expanded drag origin is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 0,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 6},
+    }
+    const dropSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 0,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 0},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+
+  test('Scenario: collapsed drop at end edge of expanded drag origin is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 0,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 6},
+    }
+    const dropSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 6,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 6},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+
+  test('Scenario: drop onto block-object inside drag origin is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKeyA = keyGenerator()
+    const spanKeyA = keyGenerator()
+    const imageKey = keyGenerator()
+    const blockKeyB = keyGenerator()
+    const spanKeyB = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKeyA,
+          _type: 'block',
+          children: [{_key: spanKeyA, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {_key: imageKey, _type: 'image', src: 'https://example.com/image.jpg'},
+        {
+          _key: blockKeyB,
+          _type: 'block',
+          children: [{_key: spanKeyB, _type: 'span', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKeyA}, 'children', {_key: spanKeyA}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: blockKeyB}, 'children', {_key: spanKeyB}],
+        offset: 3,
+      },
+    }
+    const dropSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+
+  test('Scenario: drop after the drag origin end is allowed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKeyA = keyGenerator()
+    const spanKeyA = keyGenerator()
+    const blockKeyB = keyGenerator()
+    const spanKeyB = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: blockKeyA,
+          _type: 'block',
+          children: [{_key: spanKeyA, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: blockKeyB,
+          _type: 'block',
+          children: [{_key: spanKeyB, _type: 'span', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKeyA}, 'children', {_key: spanKeyA}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: blockKeyA}, 'children', {_key: spanKeyA}],
+        offset: 3,
+      },
+    }
+    const dropSelection = {
+      anchor: {
+        path: [{_key: blockKeyB}, 'children', {_key: spanKeyB}],
+        offset: 3,
+      },
+      focus: {
+        path: [{_key: blockKeyB}, 'children', {_key: spanKeyB}],
+        offset: 3,
+      },
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).not.toEqual(initialValue)
+    })
+  })
+})


### PR DESCRIPTION
`isOverlappingSelection` carried 180 lines for one boolean answer: ten manual boolean variables, six `comparePoints` calls, and a conditional ladder that was hard to verify against any canonical formula. Range overlap on a totally-ordered point space is two comparisons: `startA <= endB && startB <= endA`. The bloat hid the math.

The same concern surfaces in `rangeIntersection` (returns the clipped range or null when ranges don't overlap). It was implementing its own overlap math too.

This PR factors both consumers through a shared `rangesOverlap` primitive, then narrows the public `isOverlappingSelection` semantics to match what its name claims.

### Commit 1: `refactor: consolidate range overlap into a shared primitive`

`rangesOverlap` lives at `slate/range/ranges-overlap.ts` as the canonical math: two ranges overlap when they share at least one point. Unit tests cover disjoint, touching, partial, contained, identical, collapsed-equal, collapsed-different, and backward-range cases.

`rangeIntersection` short-circuits through it. `isOverlappingSelection` delegates to it, then keeps a small clause to preserve its original "two expanded ranges touching at a single endpoint do not overlap" semantics. No behavior change.

### Commit 2: `fix: treat touching selections as overlapping in isOverlappingSelection`

The original "touching expanded ranges don't overlap" carve-out gave wrong answers. Two ranges that share an endpoint share a point; the JSDoc claim ("shares at least one point") said as much, but the implementation contradicted it.

The carve-out existed to support drag-and-drop self-drop suppression: when a user drags content from one block and drops onto an adjacent block via the expanded fallback in `getEventPosition`, the drop position's start touches the drag origin's end at the block boundary. Suppressing that drop would block a legitimate drop on the adjacent block.

That semantic is finer-grained than range overlap; it belongs in the dnd consumer. The dnd guards now do their own check via a local `isDropTargetingDragOrigin` helper that asks `isOverlappingSelection` for the math, then excludes the touch-only-between-expanded case for self-drop purposes.

`isOverlappingSelection` is now pure interval overlap with no special cases.

Five existing self-drop browser tests pass unchanged across chromium/firefox/webkit. Four unit tests covering touching cases were renamed (`'selection right before'` → `'selection touching at start endpoint'`) and flipped to assert the corrected semantic.