### PR TITLE
fix: prevent block-object duplication on internal drag-and-drop

### DIFF
--- a/.changeset/dnd-internal-drop-payload-from-origin.md
+++ b/.changeset/dnd-internal-drop-payload-from-origin.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: compute internal drop payload from drag origin selection

--- a/.changeset/dnd-pass-drop-position-directly.md
+++ b/.changeset/dnd-pass-drop-position-directly.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: pass drop position directly to insert.blocks during drag move

--- a/.changeset/dnd-prevent-default-on-missing-position.md
+++ b/.changeset/dnd-prevent-default-on-missing-position.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: prevent default drop when position cannot be resolved

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -2,6 +2,7 @@ import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
 import {getDragSelection} from '../selectors/drag-selection'
 import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
+import {getSelectedValue} from '../selectors/selector.get-selected-value'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import {comparePoints} from '../slate/point/compare-points'
@@ -341,6 +342,14 @@ export const coreDndBehaviors = [
         },
       })
 
+      const originPayload = getSelectedValue({
+        ...snapshot,
+        context: {
+          ...snapshot.context,
+          selection: dragSelection,
+        },
+      })
+
       if (!droppingOnDragOrigin) {
         return {
           dropPosition,
@@ -348,6 +357,7 @@ export const coreDndBehaviors = [
           draggedBlocks,
           dragOrigin,
           originEvent: event.originEvent,
+          originPayload,
         }
       }
 
@@ -355,13 +365,14 @@ export const coreDndBehaviors = [
     },
     actions: [
       (
-        {event},
+        _,
         {
           draggingEntireBlocks,
           draggedBlocks,
           dragOrigin,
           dropPosition,
           originEvent,
+          originPayload,
         },
       ) => [
         ...(draggingEntireBlocks
@@ -379,7 +390,7 @@ export const coreDndBehaviors = [
             ]),
         raise({
           type: 'insert.blocks',
-          blocks: event.data,
+          blocks: originPayload,
           placement: draggingEntireBlocks
             ? originEvent.position.block === 'start'
               ? 'before'

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -364,10 +364,6 @@ export const coreDndBehaviors = [
           originEvent,
         },
       ) => [
-        raise({
-          type: 'select',
-          at: dropPosition,
-        }),
         ...(draggingEntireBlocks
           ? draggedBlocks.map((block) =>
               raise({
@@ -391,6 +387,7 @@ export const coreDndBehaviors = [
                 ? 'after'
                 : 'auto'
             : 'auto',
+          at: dropPosition,
         }),
       ],
     ],

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -874,6 +874,11 @@ export const PortableTextEditable = forwardRef<
 
       if (!position) {
         console.warn('Could not find position for drop event')
+        // Prevent the browser from running its default drop handling, which
+        // would otherwise insert the dragged dataTransfer payload (text/html
+        // or text/plain) at the cursor and leave the source content in place,
+        // resulting in a duplicate.
+        event.preventDefault()
         return
       }
 

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -2,7 +2,11 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import {assert, describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
+import {raise} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {converterPortableText} from '../src/converters/converter.portable-text'
+import {safeStringify} from '../src/internal-utils/safe-json'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('event.drag.drop', () => {
@@ -320,6 +324,161 @@ describe('event.drag.drop', () => {
           ],
           markDefs: [],
           style: 'normal',
+        },
+      ])
+    })
+  })
+  test('Scenario: External drag.drop (no dragOrigin) inserts the deserialized payload', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo'}],
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    const externalPayload = safeStringify([
+      {
+        _key: 'externalImage',
+        _type: 'image',
+        src: 'https://example.com/external.jpg',
+      },
+    ])
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('application/x-portable-text', externalPayload)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 3,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: 'externalImage',
+          _type: 'image',
+          src: 'https://example.com/external.jpg',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: A consumer-overridden drag.drop reaches deserialization.success and inserts the payload', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo'}],
+        },
+      ],
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'drag.drop',
+              actions: [
+                ({event}) => [raise({type: 'deserialize', originEvent: event})],
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    const consumerPayload = safeStringify([
+      {
+        _key: 'consumerImage',
+        _type: 'image',
+        src: 'https://example.com/consumer.jpg',
+      },
+    ])
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('application/x-portable-text', consumerPayload)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 3,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: 'consumerImage',
+          _type: 'image',
+          src: 'https://example.com/consumer.jpg',
         },
       ])
     })

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -232,4 +232,96 @@ describe('event.drag.drop', () => {
       ])
     })
   })
+
+  test('Scenario: Dragging a block object when dataTransfer only carries text/plain (mobile/iOS)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo bar baz'}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: imageSelection})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...imageSelection,
+        backward: false,
+      })
+    })
+
+    // Mimic iOS Safari: dataTransfer carries ONLY text/plain. Custom mime
+    // types like `application/x-portable-text` were silently stripped by
+    // the platform during the drag. The drop handler must still complete
+    // the move because `dragOrigin` carries the source selection.
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', '[Image]')
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {
+        dataTransfer,
+      },
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 0,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: spanKey, _type: 'span', text: 'foo bar baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Reports of dragged block-objects appearing twice after an internal drag-and-drop, plus a separate report of dragged images turning into the literal `[Image]` text on iOS. Static analysis surfaced three independent code paths that each contribute to the failure modes, plus regression tests that pin the behavior of the abstract deserialize fallback for external and consumer-overridden drops.

## Three layers of defense

**1. Prevent default drop when position cannot be resolved**

`handleDrop` returned without preventing the native drop default when `getEventPosition` failed to find a Slate position for the drop coordinates. The browser then ran its own drop handling on the contenteditable and inserted the dragged `dataTransfer` payload at an unpredictable DOM location while the source content stayed in place. Calling `event.preventDefault()` on this early-return path stops the browser from filling in for us. The drop silently fails — recoverable, where a duplicate forces the user to track down and remove the unintended copy.

**2. Pass drop position directly to insert.blocks**

The move-emulation behavior raised three events on `deserialization.success`: `select(at: dropPosition)` to move the caret, then `delete.block` (or `delete`) to remove the source content, then `insert.blocks` to write the dragged data at the caret. The leading `select` existed only to pass the drop position to `insert.blocks` via `editor.selection`, since `insert.blocks` falls back to the editor's current selection when no `at` is provided.

`insert.blocks` accepts an explicit `at` parameter. Passing `dropPosition` directly removes the indirection. The intermediate selection move is no longer observable, the action set drops from three raises to two, and the chain no longer depends on the editor's selection state surviving an intervening `delete.block` operation.

**3. Compute internal drop payload from drag origin selection**

iOS Safari silently strips custom mime types like `application/x-portable-text` from `dataTransfer` during drags. When that happens, only `text/plain` survives. The dnd handler then deserializes from `text/plain` and inserts whatever literal the converter produced (the block-object's title in brackets — e.g., `[Image]`) instead of the actual block.

For internal drags, the drop payload is now computed by looking up the editor value at the drag origin's selection rather than reading it back from `event.data` (the deserialized `dataTransfer`). The browser's `dataTransfer` is still populated for external-app drops, but PTE's own dnd no longer depends on the round-trip surviving.

## Regression tests for the abstract deserialize fallback

Two new tests pin the abstract `deserialization.success` fallback in `behavior.abstract.deserialize.ts`. The fallback fires for any deserialize chain where no earlier handler claimed the event, raising `insert.blocks` with the deserialized payload. Two consumers depend on it:

- **External drops** (no `dragOrigin`) — the dnd-specific handler skips them, the abstract fallback is the only path that inserts external content.
- **Consumer-overridden `drag.drop`** — when a consumer registers a custom `drag.drop` behavior that raises `deserialize`, the chain reaches `deserialization.success` and the abstract fallback inserts the payload at the auto position.

Both scenarios are pinned in `tests/event.drag.drop.test.tsx`.