### PR TITLE
fix: render zero-width character in void spacers on Android

### DIFF
--- a/.changeset/android-void-spacer-fefff.md
+++ b/.changeset/android-void-spacer-fefff.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: render the zero-width character in void spacers on Android so DOM selection can anchor to them

--- a/packages/editor/src/slate/react/components/object-node.tsx
+++ b/packages/editor/src/slate/react/components/object-node.tsx
@@ -1,7 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import React, {type JSX} from 'react'
 import {serializePath} from '../../../paths/serialize-path'
-import {IS_ANDROID} from '../../dom/utils/environment'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
 import type {DecoratedRange} from '../../interfaces/text'
@@ -69,7 +68,7 @@ const ObjectNodeComponent = (props: {
     >
       <span data-slate-node="text">
         <span data-slate-leaf>
-          <span data-slate-zero-width="z">{!IS_ANDROID ? '\uFEFF' : null}</span>
+          <span data-slate-zero-width="z">{'\uFEFF'}</span>
         </span>
       </span>
     </Tag>


### PR DESCRIPTION
Tapping a block-object on Android moves the visual caret past the void's wrapper and into the next editable text block. Inline objects can't be selected at all. The visible symptom is that the user taps an image and the cursor lands somewhere else; with the cursor in the wrong place, every follow-up keystroke ends up acting on the wrong block.

The cause is in PTE's void-spacer rendering. Each block- or inline-object void renders a hidden zero-width spacer span as the DOM selection anchor, so the browser caret has somewhere to land inside an otherwise non-editable wrapper. PTE conditionally stripped the `\uFEFF` zero-width character from that spacer on Android, leaving it textless. Without text content, Android Chrome's tap-retargeting walks straight past the empty spacer into the nearest editable text below.

Slate has a similar Android carve-out, but only on the line-break path used for empty text blocks (where accepting an IME suggestion at the start of an empty block removes DOM elements that `toSlateRange` depends on — Slate issue #5703). Void spacers are rendered inside `contentEditable=false` wrappers and don't receive IME input directly, so that crash mode doesn't apply. Slate's `string.tsx` keeps the `\uFEFF` for non-line-break zero-width strings on Android.

Aligning PTE's void spacer with Slate's narrower carve-out: always render `\uFEFF` in the void spacer regardless of platform. Empty-text-block line-break handling in `string.tsx` is unchanged and still matches Slate's IME-safe behavior.

Verified on Android: both block-object and inline-object taps now select the void with the visual caret in the correct place. Targeted browser-test sweep (block-object, inline-object, select, delete, move, insert, drag-and-drop, render-block, placeholder-block) green on chromium.