### PR TITLE
fix: render zero-width character in void spacers on Android

### DIFF
--- a/.changeset/android-void-spacer-fefff.md
+++ b/.changeset/android-void-spacer-fefff.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: render the zero-width character in void spacers on Android so DOM selection can anchor to them

--- a/packages/editor/src/slate/react/components/object-node.tsx
+++ b/packages/editor/src/slate/react/components/object-node.tsx
@@ -1,6 +1,5 @@
 import type {PortableTextObject} from '@portabletext/schema'
 import React, {type JSX} from 'react'
-import {IS_ANDROID} from '../../dom/utils/environment'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
 import type {DecoratedRange} from '../../interfaces/text'
@@ -70,7 +69,7 @@ const ObjectNodeComponent = (props: {
       <span data-slate-node="text">
         <span data-slate-leaf>
           <span data-slate-zero-width="z" data-slate-length={0}>
-            {!IS_ANDROID ? '\uFEFF' : null}
+            {'\uFEFF'}
           </span>
         </span>
       </span>


### PR DESCRIPTION
Cherry-picks the Android void-selection fix from main (PR #2578, commit `ba1613704`) onto the v6 release line so a 6.6.x patch ships the fix to consumers still on v6.

Tapping a block-object on Android moves the visual caret past the void's wrapper and into the next editable text block. Inline objects can't be selected at all. The cause is in PTE's void-spacer rendering: the spacer renders a zero-width span as the DOM selection anchor, but PTE conditionally stripped the `\uFEFF` zero-width character on Android, leaving it textless. Without text content, Android Chrome's tap-retargeting walks straight past the empty spacer into the nearest editable text below.

Slate has a similar Android carve-out, but only on the line-break path used for empty text blocks (where accepting an IME suggestion at the start of an empty block removes DOM elements that `toSlateRange` depends on — Slate issue #5703). Void spacers are rendered inside `contentEditable=false` wrappers and don't receive IME input directly, so that crash mode doesn't apply. Slate's `string.tsx` keeps the `\uFEFF` for non-line-break zero-width strings on Android.

Aligning PTE's void spacer with Slate's narrower carve-out: always render `\uFEFF` in the void spacer regardless of platform.

The bug shipped in `@portabletext/editor@6.1.0` (commit `919c97670`, March 2026) and has been present in every release since, including the current 6.6.3.

Verified on Android via PR #2578: both block-object and inline-object taps now select the void with the visual caret in the correct place. Targeted browser-test sweep green on chromium against the v6 codebase.