### PR TITLE
feat!: remove editor._internal runtime field

### DIFF
--- a/.changeset/remove-editor-internal.md
+++ b/.changeset/remove-editor-internal.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/editor": major
+---
+
+feat!: remove `editor._internal` runtime field
+
+The `_internal` field that exposed `editorActor`, `slateEditor`, and `editable` on the runtime editor object has been removed. Consumers that reached into this field through type casts (`editor as unknown as {_internal: ...}`) will get `undefined` at runtime in v7.
+
+The supported public surface for advanced use cases is `editor.send(...)`, `editor.on(...)`, `editor.getSnapshot()`, `editor.dom`, and the selectors exported from `@portabletext/editor/selectors`. If your code depends on the underlying `slateEditor` history or actor state, please open an issue describing the use case so we can find a supported alternative.

--- a/packages/editor/src/editor/PortableTextEditor.tsx
+++ b/packages/editor/src/editor/PortableTextEditor.tsx
@@ -12,6 +12,7 @@ import type {
 } from '../types/editor'
 import type {Path} from '../types/paths'
 import type {InternalEditor} from './create-editor'
+import {getInternalState} from './internal-state'
 
 /**
  * @public
@@ -46,14 +47,15 @@ export class PortableTextEditor {
 
   constructor(config: {editor: InternalEditor}) {
     this.editor = config.editor
-    this.schemaTypes =
-      config.editor._internal.editorActor.getSnapshot().context.schema
-    this.editable = config.editor._internal.editable
+    const internalState = getInternalState(config.editor)
+    this.schemaTypes = internalState.editorActor.getSnapshot().context.schema
+    this.editable = internalState.editable
   }
 
   public setEditable = (editable: EditableAPI) => {
-    this.editor._internal.editable = {
-      ...this.editor._internal.editable,
+    const internalState = getInternalState(this.editor)
+    internalState.editable = {
+      ...internalState.editable,
       ...editable,
     }
   }

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -6,7 +6,6 @@ import {debug} from '../internal-utils/debug'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
 import type {ContainerDefinition} from '../renderers/renderer.types'
-import type {EditableAPI} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {defaultKeyGenerator} from '../utils/key-generator'
 import {createEditableAPI} from './create-editable-api'
@@ -15,17 +14,13 @@ import {createEditorDom} from './editor-dom'
 import type {EditorActor} from './editor-machine'
 import {editorMachine, rerouteExternalBehaviorEvent} from './editor-machine'
 import {getEditorSnapshot} from './editor-selector'
+import {setInternalState} from './internal-state'
 import {mutationMachine, type MutationActor} from './mutation-machine'
 import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export type InternalEditor = Editor & {
   registerContainer: (container: ContainerDefinition) => () => void
-  _internal: {
-    editable: EditableAPI
-    editorActor: EditorActor
-    slateEditor: PortableTextSlateEditor
-  }
 }
 
 export function createInternalEditor(config: EditorConfig): {
@@ -144,12 +139,9 @@ export function createInternalEditor(config: EditorConfig): {
 
       return subscription
     },
-    _internal: {
-      editable,
-      editorActor,
-      slateEditor,
-    },
   } satisfies InternalEditor
+
+  setInternalState(editor, {editable, editorActor, slateEditor})
 
   return {
     actors: {

--- a/packages/editor/src/editor/editor-provider.tsx
+++ b/packages/editor/src/editor/editor-provider.tsx
@@ -1,11 +1,12 @@
 import type React from 'react'
-import {useEffect, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import type {EditorConfig} from '../editor'
 import {stopActor} from '../internal-utils/stop-actor'
 import {Slate} from '../slate/react/components/slate'
 import {createInternalEditor} from './create-editor'
 import {EditorActorContext} from './editor-actor-context'
 import {EditorContext} from './editor-context'
+import {getInternalState} from './internal-state'
 import {PortableTextEditor} from './PortableTextEditor'
 import {RelayActorContext} from './relay-actor-context'
 import {PortableTextEditorContext} from './usePortableTextEditor'
@@ -46,6 +47,11 @@ export function EditorProvider(props: EditorProviderProps) {
     return {internalEditor, portableTextEditor}
   })
 
+  const slateEditor = useMemo(
+    () => getInternalState(internalEditor.editor).slateEditor,
+    [internalEditor],
+  )
+
   useEffect(() => {
     const unsubscribers: Array<() => void> = []
 
@@ -56,7 +62,7 @@ export function EditorProvider(props: EditorProviderProps) {
     internalEditor.actors.editorActor.start()
     internalEditor.actors.editorActor.send({
       type: 'add slate editor',
-      editor: internalEditor.editor._internal.slateEditor,
+      editor: slateEditor,
     })
     internalEditor.actors.mutationActor.start()
     internalEditor.actors.relayActor.start()
@@ -72,13 +78,13 @@ export function EditorProvider(props: EditorProviderProps) {
       stopActor(internalEditor.actors.relayActor)
       stopActor(internalEditor.actors.syncActor)
     }
-  }, [internalEditor])
+  }, [internalEditor, slateEditor])
 
   return (
     <EditorContext.Provider value={internalEditor.editor}>
       <EditorActorContext.Provider value={internalEditor.actors.editorActor}>
         <RelayActorContext.Provider value={internalEditor.actors.relayActor}>
-          <Slate editor={internalEditor.editor._internal.slateEditor}>
+          <Slate editor={slateEditor}>
             <PortableTextEditorContext.Provider value={portableTextEditor}>
               {props.children}
             </PortableTextEditorContext.Provider>

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -1,9 +1,9 @@
 import {useSelector} from '@xstate/react'
 import type {Editor} from '../editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
-import type {InternalEditor} from './create-editor'
 import type {EditorActor} from './editor-machine'
 import type {EditorSnapshot} from './editor-snapshot'
+import {getInternalState} from './internal-state'
 
 function defaultCompare<T>(a: T, b: T) {
   return a === b
@@ -43,12 +43,13 @@ export function useEditorSelector<TSelected>(
   selector: EditorSelector<TSelected>,
   compare: (a: TSelected, b: TSelected) => boolean = defaultCompare,
 ) {
+  const {editorActor, slateEditor} = getInternalState(editor)
   return useSelector(
-    (editor as InternalEditor)._internal.editorActor,
+    editorActor,
     (editorActorSnapshot) => {
       const snapshot = getEditorSnapshot({
         editorActorSnapshot,
-        slateEditorInstance: (editor as InternalEditor)._internal.slateEditor,
+        slateEditorInstance: slateEditor,
       })
 
       return selector(snapshot)

--- a/packages/editor/src/editor/internal-state.ts
+++ b/packages/editor/src/editor/internal-state.ts
@@ -1,0 +1,32 @@
+import type {Editor} from '../editor'
+import type {EditableAPI} from '../types/editor'
+import type {PortableTextSlateEditor} from '../types/slate-editor'
+import type {EditorActor} from './editor-machine'
+
+/**
+ * Internal state attached to each Editor instance. Intentionally not exposed
+ * on the Editor type; PTE-internal code retrieves it via `getInternalState`.
+ * Consumers should use the public Editor API (`editor.send`, `editor.on`,
+ * `editor.getSnapshot`, `editor.dom`) and selectors instead.
+ */
+export type InternalState = {
+  editable: EditableAPI
+  editorActor: EditorActor
+  slateEditor: PortableTextSlateEditor
+}
+
+const REGISTRY = new WeakMap<Editor, InternalState>()
+
+export function setInternalState(editor: Editor, state: InternalState): void {
+  REGISTRY.set(editor, state)
+}
+
+export function getInternalState(editor: Editor): InternalState {
+  const state = REGISTRY.get(editor)
+  if (state === undefined) {
+    throw new Error(
+      'Editor was not initialized through createInternalEditor or has been garbage collected',
+    )
+  }
+  return state
+}

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../test-utils/text-selection'
 import {toTextspec} from '../../../test-utils/to-textspec'
 import {getValueAnnotations} from '../../../test-utils/value-annotations'
-import type {InternalEditor} from '../../editor/create-editor'
+import {getInternalState} from '../../editor/internal-state'
 import {IS_MAC} from '../../internal-utils/is-hotkey'
 import {safeParse} from '../../internal-utils/safe-json'
 import {createTestEditor, createTestEditors} from '../../test/vitest'
@@ -56,7 +56,7 @@ const schemaDefinition = defineSchema({
 
 function setEditorState(context: Context, textspec: string): void {
   const {schema, keyGenerator} = context.editor.getSnapshot().context
-  const {containers} = (context.editor as InternalEditor)._internal.slateEditor
+  const {containers} = getInternalState(context.editor).slateEditor
 
   const {blocks} = fromTextspec({schema, keyGenerator, containers}, textspec)
 
@@ -75,8 +75,7 @@ async function assertEditorState(
 ): Promise<void> {
   await vi.waitFor(() => {
     const {schema, value, selection} = context.editor.getSnapshot().context
-    const {containers} = (context.editor as InternalEditor)._internal
-      .slateEditor
+    const {containers} = getInternalState(context.editor).slateEditor
 
     const expected = options.singleLine
       ? textspec.replace(/\\n/g, '\n')
@@ -186,8 +185,7 @@ async function selectionFromInput(context: Context, textspec: string) {
 
   await vi.waitFor(() => {
     const {schema, value} = context.editor.getSnapshot().context
-    const {containers} = (context.editor as InternalEditor)._internal
-      .slateEditor
+    const {containers} = getInternalState(context.editor).slateEditor
 
     const selection = selectionFromTextspec(
       {schema, containers},
@@ -273,8 +271,7 @@ export const stepDefinitions = [
 
       await vi.waitFor(() => {
         const {schema, value} = context.editor.getSnapshot().context
-        const {containers} = (context.editor as InternalEditor)._internal
-          .slateEditor
+        const {containers} = getInternalState(context.editor).slateEditor
 
         const selection = selectionFromTextspec(
           {schema, containers},

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -3,6 +3,7 @@ import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import type {InternalEditor} from '../src/editor/create-editor'
+import {getInternalState} from '../src/editor/internal-state'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {PatchesPlugin} from '../src/plugins/plugin.patches'
 import {defineContainer} from '../src/renderers/renderer.types'
@@ -1297,7 +1298,7 @@ describe('container normalization', () => {
     })
 
     // Late-register a container for callout
-    ;(editor as unknown as InternalEditor)._internal.editorActor.send({
+    getInternalState(editor).editorActor.send({
       type: 'register container',
       container: {
         scope: '$..callout',
@@ -1943,7 +1944,7 @@ describe('container normalization', () => {
     })
 
     // Unregister the container via the internal editor actor
-    ;(editor as unknown as InternalEditor)._internal.editorActor.send({
+    getInternalState(editor).editorActor.send({
       type: 'unregister container',
       container: {
         scope: '$..callout',

--- a/packages/editor/tests/event.drag.drop.duplication.test.tsx
+++ b/packages/editor/tests/event.drag.drop.duplication.test.tsx
@@ -2,7 +2,7 @@ import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import type {InternalEditor} from '../src/editor/create-editor'
+import {getInternalState} from '../src/editor/internal-state'
 import {createTestEditor} from '../src/test/vitest'
 
 /**
@@ -73,7 +73,7 @@ describe('event.drag.drop: stale internalDrag.origin', () => {
       },
     }
 
-    const {editorActor} = (editor as InternalEditor)._internal
+    const {editorActor} = getInternalState(editor)
 
     // Given a first drag of image A starts (entering "dragging internally")
     editorActor.send({type: 'dragstart', origin: imageAOrigin})


### PR DESCRIPTION
Removes the `editor._internal` runtime field and drops the `editor` parameter from `useEditorSelector`.

`useEditorSelector(selector)` now resolves the editor from React context instead of taking the editor as a parameter. Every consumer audited (PTE itself, Canvas, plugin-typeahead-picker) pairs `useEditor()` immediately above `useEditorSelector(editor, ...)` — the parameter was ceremonial.

```diff
- const value = useEditorSelector(editor, selectors.getActiveStyle)
+ const value = useEditorSelector(selectors.getActiveStyle)
```

`createInternalEditor` returns a flat `{actors, editor, slateEditor, editable, subscriptions}` instead of nesting `slateEditor` and `editable` under `_internal`. Internal modules consume these fields directly through existing React contexts (`EditorActorContext`, Slate's `useSlateStatic()`).

The internal Slate editor and editable surface previously exposed via `editor._internal` are no longer reachable from outside the editor package. If you reached into `editor._internal` to drive raw machine events or read internal state, please open an issue with your use case.