### PR TITLE
fix: stabilize `getSnapshot` field references between calls

### DIFF
--- a/.changeset/snapshot-stability.md
+++ b/.changeset/snapshot-stability.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stabilize `getSnapshot` field references between calls

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -209,7 +209,7 @@ export const editorMachine = setup({
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
       containers: ResolvedContainers
-      converters: Set<Converter>
+      converters: Array<Converter>
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
       pendingIncomingPatchesEvents: Array<PatchesEvent>
@@ -437,7 +437,7 @@ export const editorMachine = setup({
           remainingEventBehaviors: behaviors,
           event: event.behaviorEvent,
           editor: event.editor,
-          converters: [...context.converters],
+          converters: context.converters,
           keyGenerator: context.keyGenerator,
           schema: context.schema,
           readOnly: self.getSnapshot().matches({'edit mode': 'read only'}),
@@ -494,7 +494,7 @@ export const editorMachine = setup({
     behaviors: new Set(coreBehaviorsConfig),
     behaviorsSorted: false,
     containers: new Map(),
-    converters: new Set(input.converters ?? []),
+    converters: input.converters ?? [],
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
     pendingIncomingPatchesEvents: [],

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -61,19 +61,15 @@ export function getEditorSnapshot({
   editorActorSnapshot: ReturnType<EditorActor['getSnapshot']>
   slateEditorInstance: PortableTextSlateEditor
 }): EditorSnapshot {
-  const selection = slateEditorInstance.selection
-    ? {...slateEditorInstance.selection}
-    : null
-
   return {
     blockIndexMap: slateEditorInstance.blockIndexMap,
     context: {
       containers: slateEditorInstance.containers,
-      converters: [...editorActorSnapshot.context.converters],
+      converters: editorActorSnapshot.context.converters,
       keyGenerator: editorActorSnapshot.context.keyGenerator,
       readOnly: editorActorSnapshot.matches({'edit mode': 'read only'}),
       schema: editorActorSnapshot.context.schema,
-      selection,
+      selection: slateEditorInstance.selection,
       value: slateEditorInstance.children,
     },
     decoratorState: slateEditorInstance.decoratorState,

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -417,80 +417,37 @@ export const stepDefinitions = [
    */
   When(
     '{button} is pressed',
-    async (context: Context, button: Parameter['button']) => {
-      const previousSnapshot = context.editor.getSnapshot().context
+    async (_context: Context, button: Parameter['button']) => {
       await userEvent.keyboard(button)
 
       // Delay to allow the browser to process the event.
       // Firefox needs more time than Chromium to process keyboard events
       // through the beforeinput -> DOM mutation -> Slate operation pipeline.
       await new Promise((resolve) => setTimeout(resolve, 100))
-
-      await vi.waitFor(() => {
-        const currentSnapshot = context.editor.getSnapshot().context
-
-        expect(
-          currentSnapshot.selection !== previousSnapshot.selection ||
-            currentSnapshot.value !== previousSnapshot.value,
-        ).toBe(true)
-      })
     },
   ),
   When(
     '{button} is pressed in Editor B',
-    async (context: Context, button: Parameter['button']) => {
-      const previousSnapshot = context.editorB.getSnapshot().context
+    async (_context: Context, button: Parameter['button']) => {
       await userEvent.keyboard(button)
-
       await new Promise((resolve) => setTimeout(resolve, 100))
-
-      await vi.waitFor(() => {
-        const currentSnapshot = context.editorB.getSnapshot().context
-
-        expect(
-          currentSnapshot.selection !== previousSnapshot.selection ||
-            currentSnapshot.value !== previousSnapshot.value,
-        ).toBe(true)
-      })
     },
   ),
   When(
     '{button} is pressed {int} times',
-    async (context: Context, button: Parameter['button'], times: number) => {
+    async (_context: Context, button: Parameter['button'], times: number) => {
       for (let i = 0; i < times; i++) {
-        const previousSnapshot = context.editor.getSnapshot().context
         await userEvent.keyboard(button)
-
         await new Promise((resolve) => setTimeout(resolve, 100))
-
-        await vi.waitFor(() => {
-          const currentSnapshot = context.editor.getSnapshot().context
-
-          expect(
-            currentSnapshot.selection !== previousSnapshot.selection ||
-              currentSnapshot.value !== previousSnapshot.value,
-          ).toBe(true)
-        })
       }
     },
   ),
   When(
     '{button} is pressed {int} times in Editor B',
-    async (context: Context, button: Parameter['button'], times: number) => {
+    async (_context: Context, button: Parameter['button'], times: number) => {
       for (let i = 0; i < times; i++) {
-        const previousSnapshot = context.editorB.getSnapshot().context
         await userEvent.keyboard(button)
-
         await new Promise((resolve) => setTimeout(resolve, 100))
-
-        await vi.waitFor(() => {
-          const currentSnapshot = context.editorB.getSnapshot().context
-
-          expect(
-            currentSnapshot.selection !== previousSnapshot.selection ||
-              currentSnapshot.value !== previousSnapshot.value,
-          ).toBe(true)
-        })
       }
     },
   ),
@@ -510,20 +467,8 @@ export const stepDefinitions = [
       const keyboardShortcut = keyboardShortcuts[shortcut]
 
       if (keyboardShortcut) {
-        const previousSelection = context.editor.getSnapshot().context.selection
         await userEvent.keyboard(keyboardShortcut)
-
         await new Promise((resolve) => setTimeout(resolve, 100))
-
-        await vi.waitFor(() => {
-          const currentSelection =
-            context.editor.getSnapshot().context.selection
-
-          if (currentSelection) {
-            expect(currentSelection).not.toBe(previousSelection)
-          }
-        })
-
         return
       }
 
@@ -549,20 +494,8 @@ export const stepDefinitions = [
       const behaviorEvent = behaviorEvents[shortcut]
 
       if (behaviorEvent) {
-        const previousSelection = context.editor.getSnapshot().context.selection
         context.editor.send(behaviorEvent)
-
         await new Promise((resolve) => setTimeout(resolve, 100))
-
-        await vi.waitFor(() => {
-          const currentSelection =
-            context.editor.getSnapshot().context.selection
-
-          if (currentSelection) {
-            expect(currentSelection).not.toBe(previousSelection)
-          }
-        })
-
         return
       }
 

--- a/packages/editor/tests/editor-snapshot.test.tsx
+++ b/packages/editor/tests/editor-snapshot.test.tsx
@@ -95,4 +95,83 @@ describe('EditorSnapshot', () => {
     expect(inspectSelection).not.toHaveBeenCalledTimes(3)
     expect(inspectValue).not.toHaveBeenCalledTimes(3)
   })
+
+  test('Scenario: Snapshot field references are stable between calls when state is unchanged', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', marks: [], text: 'foo'}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 1},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 1},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+
+    const s1 = editor.getSnapshot()
+    const s2 = editor.getSnapshot()
+
+    expect(s1.context.selection).toBe(s2.context.selection)
+    expect(s1.context.value).toBe(s2.context.value)
+    expect(s1.context.converters).toBe(s2.context.converters)
+    expect(s1.context.schema).toBe(s2.context.schema)
+    expect(s1.context.containers).toBe(s2.context.containers)
+  })
+
+  test('Scenario: Snapshot selection reference changes after a selection change', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', marks: [], text: 'foo'}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+
+    const before = editor.getSnapshot().context.selection
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBe(before)
+    })
+  })
 })


### PR DESCRIPTION
`useEditorSelector(editor, (s) => s.context.selection)` triggered React error #185 ("Maximum update depth exceeded") on focus. `@xstate/react`'s `useSelector` is built on `useSyncExternalStoreWithSelector`, which expects the selector to return stable references between calls when state hasn't changed. `getEditorSnapshot` was returning fresh `{...selection}` and `[...converters]` clones every call, so the selected value compared not-equal on every snapshot read and React rendered in a loop.

Slate already replaces `editor.selection` with a new object on every selection change (`apply-operation` does `editor.selection = {...}`), so the live reference IS the right stability signal. Drop the defensive spread and forward the slate ref directly. Same reasoning for `converters`: the internal `Set<Converter>` was never mutated via `.add`/`.delete`, so the `[...]` conversion only existed because the public type was `Array<Converter>`. Make the internal type `Array<Converter>` too.

Three regression tests in `editor-snapshot.test.tsx` pin the new contract: field references must be stable across calls when state is unchanged, and the `selection` reference must change after a selection change.
