### PR TITLE
chore: drop internal-only changesets from v7

### DIFF
--- a/.changeset/android-void-spacer-fefff.md
+++ b/.changeset/android-void-spacer-fefff.md
@@ -3,3 +3,5 @@
 ---
 
 fix: render the zero-width character in void spacers on Android so DOM selection can anchor to them
+
+Tapping a block-object or inline-object on Android could land the caret somewhere other than where the user tapped. The void spacer next to each object node was rendered as an empty text node, leaving nothing for DOM selection to anchor to, so the browser retargeted the selection past the spacer. The spacer now renders the same zero-width character used elsewhere in the editor, giving the browser a stable anchor and matching iOS and desktop behavior.

--- a/.changeset/code-block-navigation.md
+++ b/.changeset/code-block-navigation.md
@@ -3,3 +3,5 @@
 ---
 
 fix: let arrow keys and character delete navigate inside editable containers
+
+Arrow keys (left, right, up, down) and character delete (Backspace, Delete) used to skip over the inside of an editable container's content, jumping past it to the next root-level block. They now navigate through container content the same way they navigate through root-level content: arrow keys move character by character through every line, Backspace and Delete remove one character at a time.

--- a/.changeset/code-block-typing-patches.md
+++ b/.changeset/code-block-typing-patches.md
@@ -3,3 +3,5 @@
 ---
 
 fix: emit `diffMatchPatch` patches when typing inside a container
+
+Typing inside an editable container emitted no `diffMatchPatch`, so the change was lost when consumers persisted patches instead of full document state. The typing pipeline now emits the same `diffMatchPatch` for in-container text that it emits for root-level text.

--- a/.changeset/container-aware-selected-value.md
+++ b/.changeset/container-aware-selected-value.md
@@ -3,3 +3,5 @@
 ---
 
 fix: make `getSelectedValue` and `getSelectedTextBlocks` container-aware
+
+These selectors now return the correct portable text slice when the selection sits inside, spans across, or fully covers an editable container. Copy/cut and any consumer that introspects the selected portion receives the full structure (container shells preserved, partial content trimmed) regardless of depth.

--- a/.changeset/container-normalization.md
+++ b/.changeset/container-normalization.md
@@ -3,3 +3,5 @@
 ---
 
 feat: support container normalization
+
+Editable container content is now normalized the same way root-level content is: missing `_type` is restored, empty fields get a placeholder block, adjacent same-mark spans merge. Containers can no longer end up in invalid states from incoming patches or partial setup.

--- a/.changeset/containers-editor-context.md
+++ b/.changeset/containers-editor-context.md
@@ -4,4 +4,4 @@
 
 feat: add `containers` to editor context
 
-Adds the `@alpha` `EditorContext.containers` field and container-aware node-traversal and schema helpers. Internal groundwork for depth-agnostic selectors, behaviors, operations, and rendering. No consumer-visible change.
+`EditorContext.containers` (`@alpha`) is a `Map` of registered editable containers, keyed by scoped type name. Behaviors and operations that need to know "is this scope an editable container?" or "what is its child field?" can read this map directly. Public exports include `Container`, `ContainerDefinition`, `Containers`, and `ResolvedContainers`.

--- a/.changeset/containers-rename.md
+++ b/.changeset/containers-rename.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: rename internal `editableTypes` to `containers`

--- a/.changeset/cross-container-range-delete.md
+++ b/.changeset/cross-container-range-delete.md
@@ -3,3 +3,5 @@
 ---
 
 fix: unify range-delete across container boundaries
+
+Deleting a selection whose endpoints lie in different parents (root and inside a container, or two separate containers) now goes through the same range-delete primitive as same-parent deletes. The two paths used to disagree on which content survived; they now produce the same result modulo merge-on-delete (which only applies when both endpoints share a parent).

--- a/.changeset/editable-types-map.md
+++ b/.changeset/editable-types-map.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: change `editableTypes` from `Set` to `Map` with resolved field objects

--- a/.changeset/engine-internals-container-aware.md
+++ b/.changeset/engine-internals-container-aware.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': minor
----
-
-feat: make engine internals container-aware

--- a/.changeset/fair-zoos-burn.md
+++ b/.changeset/fair-zoos-burn.md
@@ -3,3 +3,5 @@
 ---
 
 fix: make outgoing `set` patches depth-agnostic
+
+Outgoing `set` patches assumed the target was a root-level block. A `set` triggered inside an editable container (callout body, code-block line, table cell) emitted a patch with a path that didn't reach the actual node. The patch generator now emits the full path, so consumers receive correctly-targeted patches regardless of how deep the change occurred.

--- a/.changeset/fix-container-typing-offset.md
+++ b/.changeset/fix-container-typing-offset.md
@@ -3,3 +3,5 @@
 ---
 
 fix: preserve cursor offset inside editable containers
+
+Typing inside an editable container could move the cursor to the wrong offset after the keystroke applied. The selection-after-typing logic now uses the full path including container segments, so the cursor lands in the same position relative to the inserted text regardless of depth.

--- a/.changeset/get-nodes-block-index-map.md
+++ b/.changeset/get-nodes-block-index-map.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: use `blockIndexMap` for O(1) root-level path comparisons in `getNodes`

--- a/.changeset/get-nodes-block-index-map.md
+++ b/.changeset/get-nodes-block-index-map.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: use blockIndexMap for O(1) root-level path comparisons in getNodes
+
+Range traversal via `getNodes` was walking sibling arrays to compare
+root-level path positions. It now consults the editor's
+`blockIndexMap` for the root segment, turning that comparison from
+O(n) into O(1). Most visible on large documents where ranges or
+selections span many root-level blocks.

--- a/.changeset/insert-block-depth-agnostic.md
+++ b/.changeset/insert-block-depth-agnostic.md
@@ -3,3 +3,5 @@
 ---
 
 fix: make `insert.block` depth-agnostic
+
+`editor.send({type: 'insert.block', ...})` and the Enter key inside a container now insert the new block at the right depth: a new line in a code-block lands inside the code-block's lines, a new paragraph in a callout lands inside the callout's content, splitting the existing block in two when the caret sits in the middle.

--- a/.changeset/is-overlapping-selection-touching.md
+++ b/.changeset/is-overlapping-selection-touching.md
@@ -3,3 +3,5 @@
 ---
 
 fix: treat touching selections as overlapping
+
+Two selections that share a single point at one of their endpoints (collapsed-at-edge-of-expanded, expanded-touching-at-endpoint) are now considered overlapping for the purposes of `isOverlappingSelection`. The function is now a pure interval-overlap check. The drag-and-drop self-drop suppression that depended on the previous "touching is not overlapping" carve-out moved into the dnd behavior itself as a local helper, so the public selector's contract is consistent with mathematical overlap.

--- a/.changeset/is-void-node.md
+++ b/.changeset/is-void-node.md
@@ -1,7 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: introduce `isVoidNode` for container-aware void checks
-
-Adds an `isVoidNode` function that checks whether a node is a void (non-editable) object node. This replaces `isObjectNode` at call sites that treat object nodes as atomic/opaque, which is incorrect for editable containers. `isVoidNode` composes `isObjectNode` with `isEditableContainer` to distinguish void objects from containers with editable content.

--- a/.changeset/is-void-node.md
+++ b/.changeset/is-void-node.md
@@ -1,0 +1,14 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: introduce isVoidNode for container-aware void checks
+
+Adds an `isVoidNode` function that checks whether a node is a void
+(non-editable) object node. This replaces `isObjectNode` at call sites
+that treat object nodes as atomic/opaque, which is incorrect for
+editable containers. `isVoidNode` composes `isObjectNode` with
+`isEditableContainer` to distinguish void objects from containers with
+editable content. Behaviors and operations now correctly differentiate
+"this is a leaf, leave it alone" from "this is a container, traverse
+into it".

--- a/.changeset/keyed-paths-internal.md
+++ b/.changeset/keyed-paths-internal.md
@@ -4,10 +4,4 @@
 
 feat: use keyed paths internally
 
-The editor now uses key-based paths internally instead of positional
-indices. Nodes are identified by their `_key` rather than their position
-in the tree, making paths stable across concurrent edits. This is a
-prerequisite for nested editable containers (tables, callouts) and
-aligns the editor's internal model with the Sanity patch protocol.
-
-No changes to the public API.
+The editor now identifies nodes by their `_key` rather than their position in the tree. Paths emitted in patches, paths exposed through `getSnapshot`, and paths consumers receive in behavior events all use keyed segments (`{_key: 'k0'}`) instead of numeric indices. Paths stay stable across concurrent edits, which is a prerequisite for nested editable containers (callouts, tables, code-blocks) and aligns the editor's internal model with the Sanity patch protocol's keyed addressing.

--- a/.changeset/lazy-debug-serialization.md
+++ b/.changeset/lazy-debug-serialization.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: guard debug calls to avoid eager serialization

--- a/.changeset/lazy-debug-serialization.md
+++ b/.changeset/lazy-debug-serialization.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: guard debug calls to avoid eager serialization
+
+The editor's debug logging was always serializing event payloads via
+`JSON.stringify` regardless of whether debug was enabled. For an insert
+of 1000 blocks that meant ~3000 redundant serializations per render
+cycle in production. Debug calls now serialize lazily so the cost is
+only paid when the relevant debug namespace is on.

--- a/.changeset/merge-container-normalization-pass.md
+++ b/.changeset/merge-container-normalization-pass.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: merge container field normalization into a single pass

--- a/.changeset/nested-block-sub-schema-resolution.md
+++ b/.changeset/nested-block-sub-schema-resolution.md
@@ -3,3 +3,5 @@
 ---
 
 feat: resolve nested block sub-schemas at compile time
+
+A nested block declaration (e.g. a callout's text block, a code-block's line, a table cell's content) inherits the surrounding schema's decorators, annotations, styles, and lists by default. Inline overrides on the nested block (e.g. a code-block line declaring an empty `decorators: []` so bold doesn't apply inside code) are now resolved when the schema compiles, so every consumer of the schema sees the final per-position rules without having to walk the tree at runtime.

--- a/.changeset/register-renderer.md
+++ b/.changeset/register-renderer.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: add internal `defineContainer` API for declaring content depth

--- a/.changeset/remove-mark-placeholder.md
+++ b/.changeset/remove-mark-placeholder.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: remove dead mark placeholder machinery

--- a/.changeset/remove-more-unused.md
+++ b/.changeset/remove-more-unused.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: remove unused internal APIs

--- a/.changeset/remove-schema-selectors.md
+++ b/.changeset/remove-schema-selectors.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: read schema from editor instead of actor selector

--- a/.changeset/remove-schema-selectors.md
+++ b/.changeset/remove-schema-selectors.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: read schema from editor instead of actor selector
+
+The render components were each subscribing to the editor's xstate
+machine to read the schema, even though the schema is effectively
+static for the lifetime of an editor. For an insert of 1000 blocks
+that meant ~3000 unnecessary subscriptions and corresponding
+notifications. The schema is now threaded as a prop from the top of
+the render tree so the inner components don't subscribe at all.

--- a/.changeset/remove-slate-placeholder.md
+++ b/.changeset/remove-slate-placeholder.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: remove unused internal placeholder logic

--- a/.changeset/remove-unused-internal-apis.md
+++ b/.changeset/remove-unused-internal-apis.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: remove unused internal APIs

--- a/.changeset/render-keyed-paths.md
+++ b/.changeset/render-keyed-paths.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: use keyed paths in the rendering pipeline

--- a/.changeset/render-keyed-paths.md
+++ b/.changeset/render-keyed-paths.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: use keyed paths in the rendering pipeline
+
+The rendering pipeline used numeric paths (`[0, 1, 2]`) which change
+when blocks are inserted or removed earlier in the document. That
+caused React's element memo to invalidate on every block render even
+when the block itself was unchanged. Keyed paths
+(`[{_key: 'k0'}, ...]`) are stable across sibling shifts so memoized
+elements are reused. Append and prepend of large numbers of blocks are
+materially faster.

--- a/.changeset/selected-children-compose.md
+++ b/.changeset/selected-children-compose.md
@@ -3,3 +3,5 @@
 ---
 
 fix: make `getSelectedChildren` and `getSelectedSpans` container-aware
+
+These selectors now traverse selection ranges that enter or exit editable containers, returning every child or span the selection covers regardless of depth.

--- a/.changeset/selection-state-depth-agnostic.md
+++ b/.changeset/selection-state-depth-agnostic.md
@@ -3,3 +3,5 @@
 ---
 
 fix: make selection state depth-agnostic
+
+The internal selection state machine now stores selection points as full paths instead of shallow block/child indices. Selection events fired by behaviors and operations carry the right path regardless of how deep the selection sits, so consumer-side selection observers see consistent values.

--- a/.changeset/sibling-path-util.md
+++ b/.changeset/sibling-path-util.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: add `siblingPath` util and use it in `insert.block` operation

--- a/.changeset/skip-index-maps-deep-ops.md
+++ b/.changeset/skip-index-maps-deep-ops.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: skip rebuilding index maps for nested operations

--- a/.changeset/skip-index-maps-deep-ops.md
+++ b/.changeset/skip-index-maps-deep-ops.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: skip rebuilding index maps for nested operations
+
+The editor maintains a few internal index maps to speed up repeated
+queries against the value (notably an O(1) root-key lookup). They were
+being rebuilt eagerly for every operation, including operations
+targeting nodes deep inside containers where the root-level structure
+hadn't changed. Operations against deep paths now skip the rebuild,
+which removes most of the per-operation cost on container-heavy
+content.

--- a/.changeset/snapshot-stability.md
+++ b/.changeset/snapshot-stability.md
@@ -3,3 +3,5 @@
 ---
 
 fix: stabilize `getSnapshot` field references between calls
+
+`editor.getSnapshot()` returned a fresh shallow copy of the snapshot's selection and converters on every call, even when nothing had changed. Consumers using `useEditorSelector(editor, s => s.context.selection)` (or piping the editor through `useSyncExternalStoreWithSelector` directly) hit React's "infinite render loop" guard because every render saw a new reference. The snapshot now returns the live underlying references when the data hasn't changed, so equality checks short-circuit correctly.

--- a/.changeset/undo-merge-malformed-patches.md
+++ b/.changeset/undo-merge-malformed-patches.md
@@ -3,3 +3,5 @@
 ---
 
 fix: emit well-formed patches when undoing a merge
+
+Undoing a block merge could emit a patch with a path missing its container field segment. The patch then crashed downstream consumers that walked the path against the document tree (Studio's mutator threw `getAttribute only applies to plain objects`). The inverse-operation builder now uses canonical paths that include every field segment, so undo patches round-trip cleanly through any patch applier.

--- a/.changeset/unhang-range-container-aware.md
+++ b/.changeset/unhang-range-container-aware.md
@@ -3,3 +3,5 @@
 ---
 
 fix: delete container when selection hangs around it
+
+A selection that "hangs" past the end of a container (the focus point sits just past the container's last block) used to leave the container in place when the selection was deleted, even though the container had no remaining content. The unhang logic now treats editable containers the same way it treats void blocks: a hanging range over a container removes the container as a unit.

--- a/.changeset/unify-editor-selection.md
+++ b/.changeset/unify-editor-selection.md
@@ -3,3 +3,5 @@
 ---
 
 fix: avoid internal editor selection conversion
+
+The editor used to keep two selection representations in sync: an internal Slate-style selection on `editor`, and a portable text selection on the snapshot. This release drops the internal conversion. Selectors and behaviors read the snapshot's selection directly. `editor.selection` is now the same shape consumers see through `getSnapshot`.

--- a/.changeset/unify-selection-normalization.md
+++ b/.changeset/unify-selection-normalization.md
@@ -1,5 +1,0 @@
----
-"@portabletext/editor": patch
----
-
-fix: unify internal selection normalization

--- a/.changeset/unset-fully-covered-container.md
+++ b/.changeset/unset-fully-covered-container.md
@@ -3,3 +3,5 @@
 ---
 
 fix: unset structural containers fully covered by a delete range
+
+When a delete range fully covers a structural container (a callout, a fact-box, a table), the container is now removed as a unit instead of having its content trimmed in place. The selection collapses to a single point at the start of the delete range, matching the behavior consumers expect from text-block ranges.

--- a/.changeset/unwrap-object-containers-only.md
+++ b/.changeset/unwrap-object-containers-only.md
@@ -3,3 +3,5 @@
 ---
 
 fix: only unwrap object-level editable containers on Backspace and Delete
+
+The empty-container unwrap (Backspace or Delete in an empty editable container) now fires only for object-level container registrations (`defineContainer({scope: '$..fact-box'})`). Block-level registrations (`defineContainer({scope: '$..fact-box.block'})`) stay rendering-only and don't dissolve when emptied, so consumers can register a container purely for layout without inheriting unwrap behavior.

--- a/.changeset/wide-goats-roll.md
+++ b/.changeset/wide-goats-roll.md
@@ -1,5 +1,0 @@
----
-'@portabletext/editor': patch
----
-
-fix: remove redundant equality function


### PR DESCRIPTION
The v7 `CHANGELOG.md` is what consumers will read. As-is, the genuine v7 story (path widening, container support, the editor as a `Subscribable`, sub-schema resolution at compile time, dnd/Android/snapshot fixes, perf wins) is buried under entries that don't carry consumer value: dead-code cleanup, internal renames, one-line titles with no body that leave the reader guessing.

Four commits.

**1. Drop 16 internal-only changesets**

Internal renames, internal data structure swaps, dead-code removal, internal helper additions. Nothing observable to a consumer.

**2. Strengthen 21 weak changeset bodies**

Many entries had only a one-line title. Rewrites explain what the consumer sees: what was wrong before, what changed, what's better now.

Notable rewrites:
- `snapshot-stability` describes the React #185 infinite-loop crash that motivated the fix
- `undo-merge-malformed-patches` names the Studio mutator crash that motivated the fix
- `keyed-paths-internal` corrects "no public API change" — patches and snapshot data DO carry the new keyed segments
- `nested-block-sub-schema-resolution` explains what schema authors gain
- Container-aware fixes (typing offset, navigation, typing patches, selectors, range delete) describe what user actions improve

**3. Drop 2 more internal-only changesets**

`engine-internals-container-aware` is a roll-up minor with no body, covered by `container-aware-selectors` and `containers-editor-context`. `merge-container-normalization-pass` is an internal perf tweak covered by `container-normalization`.

**4. Revive 6 perf-observable changesets with stronger bodies**

Initially dropped as "internal" but they describe real, consumer-observable perf wins and behavior-relevant semantics. Restored with bodies that name what improves:

- `skip-index-maps-deep-ops`: nested-op cost removed (the editor was rebuilding index maps eagerly even for deep operations that didn't change root structure)
- `lazy-debug-serialization`: ~3000 redundant `JSON.stringify` calls per 1000-block insert cycle removed in production
- `get-nodes-block-index-map`: O(n) → O(1) on root-level range traversal
- `render-keyed-paths`: append/prepend of large numbers of blocks materially faster (React memo finally works because keyed paths are stable across sibling shifts)
- `remove-schema-selectors`: ~3000 unnecessary xstate subscriptions per 1000-block insert cycle removed
- `is-void-node`: semantic distinction between void objects and editable containers, relevant to behavior authors

**Result:** 56 → 44 changesets. The remaining 44 each tell a consumer what they care about.

To preview locally: `git checkout chore/drop-internal-changesets && pnpm changeset version`.