### PR TITLE
fix: preserve editable container shell when delete covers all of its text

### DIFF
--- a/.changeset/keep-editable-container-shell-on-full-text-delete.md
+++ b/.changeset/keep-editable-container-shell-on-full-text-delete.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: do not unset editable containers when a delete range covers all of their text
+
+Selecting all the text inside an editable container (such as a fact-box or
+callout) and pressing Delete previously removed the container itself, since
+the range fully covered it. The container is now preserved with an empty
+placeholder block inside, matching what the user expects when emptying its
+contents. Structural containers like tables continue to be removed when the
+range covers them end-to-end.

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -1,4 +1,5 @@
 import {getNode} from '../node-traversal/get-node'
+import {getContainerScopedName} from '../schema/get-container-scoped-name'
 import {isEditableContainer} from '../schema/is-editable-container'
 import {end as editorEnd} from '../slate/editor/end'
 import {start as editorStart} from '../slate/editor/start'
@@ -12,14 +13,22 @@ import type {PortableTextSlateEditor} from '../types/slate-editor'
 
 /**
  * Walk up from the lowest common ancestor of `range`'s endpoints and
- * return the outermost editable container the range covers from its
+ * return the outermost structural container the range covers from its
  * deepest first leaf to its deepest last leaf. Stops as soon as an
  * ancestor's start/end leaf points don't match the range's. Returns
  * `undefined` if no ancestor in the chain qualifies.
  *
+ * Only considers containers whose editable field does NOT accept
+ * text-block (e.g. a table whose `rows` only accept rows). Editable
+ * containers whose field accepts text-block (e.g. a fact-box) are
+ * skipped — selecting all the text inside such a container should
+ * leave the shell with an empty placeholder block, not delete the
+ * container itself.
+ *
  * Intended for callers that need to know "did the user select a whole
- * container?" before delegating to a textual delete primitive that
- * would unhang the range and lose the original boundary signal.
+ * structural container?" before delegating to a textual delete
+ * primitive that would unhang the range and lose the original
+ * boundary signal.
  */
 export function getFullyCoveredContainer(
   editor: PortableTextSlateEditor,
@@ -52,7 +61,14 @@ export function getFullyCoveredContainer(
       ) {
         return outermost
       }
-      outermost = cursor
+      const scopedName = getContainerScopedName(editor, entry.node, cursor)
+      const container = editor.containers.get(scopedName)
+      const fieldAcceptsTextBlock = container?.field.of.some(
+        (member) => member.type === editor.schema.block.name,
+      )
+      if (!fieldAcceptsTextBlock) {
+        outermost = cursor
+      }
     }
     cursor = parentPath(cursor)
   }

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -2124,4 +2124,58 @@ describe('cross-container range delete: deep structures', () => {
       ].join('\n'),
     )
   })
+
+  test('selecting all the text in an editable container preserves the shell', async () => {
+    // Slash-command flow: typing `/im` inside a callout, selecting the
+    // Image action emits `delete` of the pattern selection followed by
+    // `insert.block`. The callout shell must remain in place so the
+    // image lands inside its `content` field, not at the root.
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: blockKey,
+              children: [
+                {_type: 'span', _key: spanKey, text: '/im', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    const spanPath = [
+      {_key: calloutKey},
+      'content',
+      {_key: blockKey},
+      'children',
+      {_key: spanKey},
+    ]
+
+    editor.send({
+      type: 'delete',
+      at: {
+        anchor: {path: spanPath, offset: 0},
+        focus: {path: spanPath, offset: 3},
+      },
+    })
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      ['CALLOUT:', '  B: '].join('\n'),
+    )
+  })
 })


### PR DESCRIPTION
Selecting all the text inside an editable container (a fact-box, callout, code-block) and pressing Delete previously removed the container itself. Same with the slash-command flow: typing `/im` inside a callout, picking the Image action, ended up replacing the callout with a root-level image.

The cause is `getFullyCoveredContainer`, used by `operation.delete` to detect "did the user select an entire structural container?" before delegating to the textual delete primitive. It walked up the ancestor chain and returned the outermost editable container whose start/end leaf points matched the range — but didn't distinguish containers whose editable field accepts text-block (the user's "empty everything inside" intent should preserve the shell) from containers whose field doesn't (a table whose `rows` only accept rows — selecting all cells should delete the table).

The check now skips containers whose field accepts text-block. Editable containers fall through to the textual primitive, which trims the content and leaves an empty placeholder block inside the shell. Structural containers like tables continue to be removed end-to-end.

The new test in `cross-container-range-delete.test.tsx` exercises the slash-command flow inside a callout: deleting the entire span of text leaves the callout with an empty text block, not nothing.