### PR TITLE
fix: keep `insert.block` inside an editable container when the prior delete left it without text

### DIFF
--- a/.changeset/insert-block-stale-selection.md
+++ b/.changeset/insert-block-stale-selection.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep `insert.block` inside an editable container when the prior delete left it without text

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -12,6 +12,7 @@ import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import {getSibling} from '../node-traversal/get-sibling'
 import {getSpanNode} from '../node-traversal/get-span-node'
 import {getTextBlockNode} from '../node-traversal/get-text-block-node'
+import {getContainerScopedName} from '../schema/get-container-scoped-name'
 import {end as editorEnd} from '../slate/editor/end'
 import {pathRef} from '../slate/editor/path-ref'
 import {rangeRef} from '../slate/editor/range-ref'
@@ -45,6 +46,7 @@ type InsertTarget =
   | {kind: 'before'; blockPath: Path}
   | {kind: 'after'; blockPath: Path}
   | {kind: 'replace'; blockPath: Path}
+  | {kind: 'first-child'; insertAt: Path}
   | {kind: 'split-insert'; blockPath: Path; splitAt: Point}
   | {kind: 'fragment'; at: Point; endBlockPath: Path}
   | {kind: 'delete-then-insert'; range: Range; startBlockPath: Path}
@@ -76,9 +78,16 @@ export const insertBlockOperationImplementation: OperationImplementation<
   // block was removed) so we can fall back to the editor selection, which
   // matches the behavior expected by `insert.blocks`-style chained inserts
   // where a previous block in the chain may have been aborted.
+  // Resolve both `operation.at` and the editor's own selection through
+  // `resolveSelection` so a selection whose endpoints reference nodes that
+  // no longer exist (e.g. after a previous `delete` whose target was
+  // unset by normalization) doesn't drag `resolveTarget` up to an
+  // ancestor that's still in the tree. Treat such stale selections like
+  // "no selection at all" — `resolveTarget` then uses the editor's end,
+  // which lands the block in the right field of an empty container.
   const resolved = operation.at
     ? resolveSelection(editor, operation.at)
-    : editor.selection
+    : resolveSelection(editor, editor.selection)
   const at =
     resolved && operation.at && operation.placement !== 'auto'
       ? operation.at
@@ -154,6 +163,30 @@ function resolveTarget(args: {
     if (isEmptyTextBlock(schemaContext, endBlock)) {
       return {kind: 'replace', blockPath: endBlockPath}
     }
+
+    // When the editor's end falls on a registered editable container
+    // whose editable field is empty, descend into that field instead of
+    // placing the new block as a sibling after the container. Reachable
+    // when a behavior raises a `delete` followed by an `insert.block`:
+    // the raises run as one batch and normalization hasn't yet inserted
+    // a placeholder when the second one starts.
+    const containerField = editor.containers.get(
+      getContainerScopedName(editor, endBlock, endBlockPath),
+    )?.field
+    const fieldValue =
+      containerField &&
+      (endBlock as Record<string, unknown>)[containerField.name]
+    if (
+      containerField &&
+      Array.isArray(fieldValue) &&
+      fieldValue.length === 0
+    ) {
+      return {
+        kind: 'first-child',
+        insertAt: [...endBlockPath, containerField.name, 0],
+      }
+    }
+
     return {kind: 'after', blockPath: endBlockPath}
   }
 
@@ -252,6 +285,13 @@ function dispatchInsert(args: {
 
     case 'replace': {
       const insertedPath = replaceBlock(editor, block, target.blockPath)
+      applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
+      return
+    }
+
+    case 'first-child': {
+      applyInsertNodeAtPath(editor, block, target.insertAt)
+      const insertedPath = [...target.insertAt.slice(0, -1), {_key: block._key}]
       applyPostInsertSelection(editor, insertedPath, select, selectionAtEntry)
       return
     }

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -456,21 +456,94 @@ function convertSelection(
   // PTE represents a selected block object as a collapsed selection at
   // offset 0 of the block's path. Textspec represents it as a range from
   // offset 0 to offset 1. Translate when both points resolve to the same
-  // path of a non-text block.
+  // non-text block at any depth (root-level or inside an editable
+  // container). The parent check excludes inline nodes whose path sits
+  // inside a text block's `children`, where offset 0 means "caret before
+  // this child", not "this child is selected".
   if (
     anchor.offset === 0 &&
     focus.offset === 0 &&
-    anchor.path.length === 1 &&
-    focus.path.length === 1 &&
-    anchor.path[0] === focus.path[0]
+    isEqualIndexedPaths(anchor.path, focus.path)
   ) {
-    const blockIndex = anchor.path[0]
-    const block = blockIndex !== undefined ? blocks[blockIndex] : undefined
+    const entry = nodeAtKeyedPath(blocks, selection.anchor.path)
+    const schemaContext = {schema}
 
-    if (block && !isTextBlock({schema}, block)) {
+    if (
+      entry &&
+      !isTextBlock(schemaContext, entry.node) &&
+      (!entry.parent || !isTextBlock(schemaContext, entry.parent))
+    ) {
       return {anchor, focus: {path: focus.path, offset: 1}}
     }
   }
 
   return {anchor, focus}
+}
+
+function isEqualIndexedPaths(
+  a: ReadonlyArray<number>,
+  b: ReadonlyArray<number>,
+): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Walk a keyed path through `blocks` and the editable container fields it
+ * traverses, returning the node it points to and the node that contains
+ * it. Used to distinguish a block-object-as-block (its parent is an
+ * editable container field) from an inline node inside a text block (its
+ * parent IS a text block).
+ */
+function nodeAtKeyedPath(
+  blocks: Array<PortableTextBlock>,
+  keyedPath: EditorSelectionPoint['path'],
+):
+  | {
+      node: PortableTextBlock | PortableTextObject
+      parent: PortableTextBlock | PortableTextObject | undefined
+    }
+  | undefined {
+  let currentChildren: Array<Record<string, unknown>> = blocks as Array<
+    Record<string, unknown>
+  >
+  let currentNode: Record<string, unknown> | undefined
+  let parentNode: Record<string, unknown> | undefined
+
+  for (const segment of keyedPath) {
+    if (typeof segment === 'object' && segment !== null && '_key' in segment) {
+      const next = currentChildren.find(
+        (child) => child['_key'] === segment._key,
+      )
+      if (!next) {
+        return undefined
+      }
+      parentNode = currentNode
+      currentNode = next
+    } else if (typeof segment === 'string' && currentNode) {
+      const field = currentNode[segment]
+      if (!Array.isArray(field)) {
+        return undefined
+      }
+      currentChildren = field as Array<Record<string, unknown>>
+    } else {
+      return undefined
+    }
+  }
+
+  if (!currentNode) {
+    return undefined
+  }
+
+  return {
+    node: currentNode as PortableTextBlock | PortableTextObject,
+    parent: parentNode as PortableTextBlock | PortableTextObject | undefined,
+  }
 }

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -11,7 +11,9 @@ import {
 } from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
 import {toTextspec} from '../test-utils/to-textspec'
@@ -818,6 +820,105 @@ describe('Behavior API', () => {
             style: 'normal',
           },
         ])
+      })
+    })
+  })
+
+  describe('Chained `delete` and `insert.block` from a custom event', () => {
+    test('Scenario: Slash-command pattern inside an editable container lands the new block inside, not after', async () => {
+      const schemaDefinition = defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+          {name: 'image'},
+        ],
+      })
+
+      const calloutContainer = defineContainer<typeof schemaDefinition>({
+        scope: '$..callout',
+        field: 'content',
+        render: ({attributes, children}) => (
+          <div {...attributes}>{children}</div>
+        ),
+      })
+      const calloutBlockContainer = defineContainer<typeof schemaDefinition>({
+        scope: '$..callout.block',
+        field: 'children',
+        render: ({attributes, children}) => <p {...attributes}>{children}</p>,
+      })
+
+      const calloutKey = 'callout'
+      const blockKey = 'block'
+      const spanKey = 'span'
+      const spanPath = [
+        {_key: calloutKey},
+        'content',
+        {_key: blockKey},
+        'children',
+        {_key: spanKey},
+      ]
+
+      const {editor} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        schemaDefinition,
+        initialValue: [
+          {
+            _type: 'callout',
+            _key: calloutKey,
+            content: [
+              {
+                _type: 'block',
+                _key: blockKey,
+                children: [
+                  {_type: 'span', _key: spanKey, text: '/im', marks: []},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        children: (
+          <>
+            <ContainerPlugin
+              containers={[calloutContainer, calloutBlockContainer]}
+            />
+            <BehaviorPlugin
+              behaviors={[
+                defineBehavior({
+                  on: 'custom.slash-command',
+                  actions: [
+                    () => [
+                      raise({
+                        type: 'delete',
+                        at: {
+                          anchor: {path: spanPath, offset: 0},
+                          focus: {path: spanPath, offset: 3},
+                        },
+                      }),
+                      raise({
+                        type: 'insert.block',
+                        block: {_type: 'image'},
+                        placement: 'auto',
+                        select: 'end',
+                      }),
+                    ],
+                  ],
+                }),
+              ]}
+            />
+          </>
+        ),
+      })
+
+      editor.send({type: 'custom.slash-command'})
+
+      await vi.waitFor(() => {
+        expect(toTextspec(editor.getSnapshot().context)).toEqual(
+          ['CALLOUT:', '  ^{IMAGE}|'].join('\n'),
+        )
       })
     })
   })

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -15,7 +15,13 @@ const schemaDefinition = defineSchema({
     },
     {
       name: 'callout',
-      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}, {type: 'image'}],
+        },
+      ],
     },
     {name: 'image'},
   ],
@@ -2176,6 +2182,91 @@ describe('cross-container range delete: deep structures', () => {
 
     expect(toTextspec(editor.getSnapshot().context)).toEqual(
       ['CALLOUT:', '  B: '].join('\n'),
+    )
+  })
+
+  test('inserting a block after fully clearing the text inside a callout lands the block inside', async () => {
+    // Slash-command flow: typing '/im' inside a callout, picking the
+    // Image action raises 'delete' of the typed pattern then
+    // 'insert.block' for the image. The image must land inside the
+    // callout's 'content' field (replacing the empty placeholder
+    // text block left by the delete), not as a root sibling after
+    // the callout. Mirrors the playground's fact-box where a second
+    // container is registered at the text-block scope
+    // ('\$..callout.block') — the configuration that triggers the
+    // bug, since the inner-container registration is what causes the
+    // empty text block to be unset (leaving the editor selection
+    // stale) instead of just emptied.
+    const calloutBlockContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..callout.block',
+      field: 'children',
+      render: ({attributes, children}) => <p {...attributes}>{children}</p>,
+    })
+
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: blockKey,
+              children: [
+                {_type: 'span', _key: spanKey, text: '/im', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin containers={[...containers, calloutBlockContainer]} />
+      ),
+    })
+
+    const spanPath = [
+      {_key: calloutKey},
+      'content',
+      {_key: blockKey},
+      'children',
+      {_key: spanKey},
+    ]
+
+    // Place the caret in the span (matches state after the user types '/im').
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: spanPath, offset: 3},
+        focus: {path: spanPath, offset: 3},
+      },
+    })
+
+    editor.send({
+      type: 'delete',
+      at: {
+        anchor: {path: spanPath, offset: 0},
+        focus: {path: spanPath, offset: 3},
+      },
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {_type: 'image'},
+      placement: 'auto',
+      select: 'end',
+    })
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      ['CALLOUT:', '  ^{IMAGE}|'].join('\n'),
     )
   })
 })


### PR DESCRIPTION
A behavior chain that deletes a range and then immediately inserts a block — such as a slash-command picker that turns `/im` inside a callout into an image — used to leave the new block outside the surrounding container. Two paths through the code both produced the same wrong outcome:

When normalization had run between the two raises, the empty text block inside the container was unset and a fresh placeholder inserted, but the editor's selection still pointed at the dead block. `insert.block`'s `placement: 'auto'` walked up that stale path, found the surviving container as the enclosing block, and placed the new block as a root sibling after it.

When the chain ran without a normalization gap between, the container's editable field was already empty when `insert.block` saw it. The fallback to the editor's end landed on the container itself, again producing a sibling placement.

The first case is now handled by resolving `editor.selection` through the same path-resolution helper used for explicit `at` ranges; stale selections fall through to the no-selection branch. The second case is handled by detecting an empty editable container at the resolved end and inserting as the first child of its editable field.

The original `behavior.action.insert.block.ts` had a guard that took an explicit "no resolvable selection" branch when block lookup against `editor.children` failed. The depth-agnostic refactor of `insert.block` dropped that guard. This restores the behavior, expressed as a one-line composition of an existing helper plus an explicit empty-container case.

The deeper pattern — apply-operation's selection fixup keeping a stale ref when an ancestor of the selected span is unset — is load-bearing for remote-patch reconciliation and the documented `delete unit:'block'` selection semantics, so it stays as-is. The fix is at the operation that consumes the stale selection.