### PR TITLE
docs: refer to `racejar` by its actual package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 # Portable Text Editor Monorepo
 
-This monorepo contains the official [Portable Text](https://github.com/portabletext/portabletext) editor and related packages for building rich text editing experiences.
+[Portable Text](https://github.com/portabletext/portabletext) is an open specification for structured block content. Rich text, images, code blocks, and any custom type you define, stored as JSON and renderable anywhere.
 
-For documentation and guides, visit [portabletext.org](https://www.portabletext.org/).
+This monorepo contains [`@portabletext/editor`](./packages/editor/), the officially supported editor for working with Portable Text content. It's a headless, schema-driven block content editor for React: you bring the UI, the editor handles the editing. The other packages in this repository support editor work, including schema definition, toolbar hooks, plugins, conversion to and from HTML and Markdown, and testing utilities.
 
-Or try the editor in the [Portable Text Playground](https://playground.portabletext.org/).
+> **Looking to render Portable Text?** The renderers (`@portabletext/react`, `@portabletext/to-html`, and friends) live in separate repositories. See [Render Portable Text](https://www.portabletext.org/rendering/) for the full picture.
+
+For documentation and guides, visit [portabletext.org](https://www.portabletext.org/). To try the editor, head to the [Portable Text Playground](https://playground.portabletext.org/).
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset=".github/assets/playground-dark.png">

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Or try the editor in the [Portable Text Playground](https://playground.portablet
 | [`@portabletext/sanity-bridge`](./packages/sanity-bridge/)           | Convert between Sanity schemas and Portable Text schemas |
 | [`@portabletext/patches`](./packages/patches/)                       | Apply Sanity patches to a value                          |
 | [`@portabletext/test`](./packages/test/)                             | Testing utilities for the Portable Text Editor           |
-| [`@portabletext/racejar`](./packages/racejar/)                       | A testing framework agnostic Gherkin driver              |
+| [`racejar`](./packages/racejar/)                                     | A testing framework agnostic Gherkin driver              |


### PR DESCRIPTION
Two small README touch-ups so the entry point reads cleanly for both humans and LLMs.

**1. Refer to `racejar` by its actual package name.** The "Other Libraries" table listed it under `@portabletext/racejar`. The package is published as just `racejar`.

**2. Explain what this monorepo provides at a glance.** The previous opener said "the official Portable Text editor and related packages for building rich text editing experiences" — accurate, but assumes the reader already knows what Portable Text is and what makes this editor different. The new opener:

- One-line definition of Portable Text (mirroring the docs site landing).
- A short bulleted summary of what's inside the monorepo: the editor, plugins, supporting libraries.
- A pointer for readers who want to *render* Portable Text (those packages live in separate repositories) so they don't get lost looking for `@portabletext/react` here.

The package tables below are unchanged.
