### PR TITLE
fix: preserve a text block's shell when delete covers all of its text

### DIFF
--- a/.changeset/keep-text-block-shell-on-full-text-delete.md
+++ b/.changeset/keep-text-block-shell-on-full-text-delete.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: preserve a text block's shell when delete covers all of its text and the block is registered as an editable container

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -1,3 +1,4 @@
+import {isTextBlock} from '@portabletext/schema'
 import {getNode} from '../node-traversal/get-node'
 import {getContainerScopedName} from '../schema/get-container-scoped-name'
 import {isEditableContainer} from '../schema/is-editable-container'
@@ -66,7 +67,8 @@ export function getFullyCoveredContainer(
       const fieldAcceptsTextBlock = container?.field.of.some(
         (member) => member.type === editor.schema.block.name,
       )
-      if (!fieldAcceptsTextBlock) {
+      const isText = isTextBlock({schema: editor.schema}, entry.node)
+      if (!fieldAcceptsTextBlock && !isText) {
         outermost = cursor
       }
     }

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -921,5 +921,96 @@ describe('Behavior API', () => {
         )
       })
     })
+
+    test('Scenario: Replacing the entire span text inside an editable container in one batch lands the replacement in the surviving block', async () => {
+      const schemaDefinition = defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      })
+
+      const calloutContainer = defineContainer<typeof schemaDefinition>({
+        scope: '$..callout',
+        field: 'content',
+        render: ({attributes, children}) => (
+          <div {...attributes}>{children}</div>
+        ),
+      })
+      const calloutBlockContainer = defineContainer<typeof schemaDefinition>({
+        scope: '$..callout.block',
+        field: 'children',
+        render: ({attributes, children}) => <p {...attributes}>{children}</p>,
+      })
+
+      const calloutKey = 'callout'
+      const blockKey = 'block'
+      const spanKey = 'span'
+      const spanPath = [
+        {_key: calloutKey},
+        'content',
+        {_key: blockKey},
+        'children',
+        {_key: spanKey},
+      ]
+
+      const {editor} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        schemaDefinition,
+        initialValue: [
+          {
+            _type: 'callout',
+            _key: calloutKey,
+            content: [
+              {
+                _type: 'block',
+                _key: blockKey,
+                children: [
+                  {_type: 'span', _key: spanKey, text: ':foo', marks: []},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        children: (
+          <>
+            <ContainerPlugin
+              containers={[calloutContainer, calloutBlockContainer]}
+            />
+            <BehaviorPlugin
+              behaviors={[
+                defineBehavior({
+                  on: 'custom.replace-with-emoji',
+                  actions: [
+                    () => [
+                      raise({
+                        type: 'delete',
+                        at: {
+                          anchor: {path: spanPath, offset: 0},
+                          focus: {path: spanPath, offset: 4},
+                        },
+                      }),
+                      raise({type: 'insert.text', text: '👣'}),
+                    ],
+                  ],
+                }),
+              ]}
+            />
+          </>
+        ),
+      })
+
+      editor.send({type: 'custom.replace-with-emoji'})
+
+      await vi.waitFor(() => {
+        expect(toTextspec(editor.getSnapshot().context)).toEqual(
+          ['CALLOUT:', '  B: 👣|'].join('\n'),
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
When a consumer registers a text block as an editable container (so it can render the surrounding element with its own attributes), selecting all the inline content and deleting it currently unsets the whole block. Real-world reproduction: emoji picker inside a callout where the user types `:foo` and presses Enter — the picker raises `delete + insert.text` in one batch; the fully-covered-container detection walks up to the text block, sees a `children` field that doesn't accept text-block, and treats it as a structural shell to remove (the same path tables and rows take).

The detection now skips text blocks regardless of how their inline-only field is shaped. They behave like editable containers whose field accepts text-block: clear the content, leave the shell.

Same shape as #2587, one level deeper in the registration tree.