### PR TITLE
feat(schema): support an `options.list` on string fields to declare predefined values

### DIFF
--- a/.changeset/string-field-options-list.md
+++ b/.changeset/string-field-options-list.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/schema': minor
+---
+
+feat: support an `options.list` on string fields to declare predefined values

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ListSchemaType,
   OfDefinition,
   Schema,
+  StringOptions,
   StyleSchemaType,
 } from './schema'
 export {isSpan, isTextBlock, isTypedObject} from './types'

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -126,8 +126,23 @@ export type FieldDefinition =
       of?: ReadonlyArray<OfDefinition>
     })
   | (BaseDefinition & {
-      type: 'string' | 'number' | 'boolean' | 'object'
+      type: 'string'
+      options?: StringOptions
     })
+  | (BaseDefinition & {
+      type: 'number' | 'boolean' | 'object'
+    })
+
+/**
+ * @public
+ *
+ * Options for a string field. Mirrors the shape of Sanity Studio's
+ * `StringOptions.list` so consumers familiar with Studio can declare
+ * predefined values the same way.
+ */
+export type StringOptions = {
+  list?: ReadonlyArray<string | {value: string; title?: string}>
+}
 
 /**
  * @public


### PR DESCRIPTION
String fields don't currently have a way to declare their legal values on the schema, so consumers that want to constrain a string to a small enum end up sniffing field names or hardcoding option lists at the renderer or serializer layer.

This adds `options.list` to string `FieldDefinition`, mirroring the shape Sanity Studio uses on its `StringDefinition`. Each entry can be a bare string or a `{value, title}` object, letting consumers give human-readable labels alongside the underlying value:

```ts
defineSchema({
  blockObjects: [
    {
      name: 'callout',
      fields: [
        {
          name: 'tone',
          type: 'string',
          options: {
            list: [
              {value: 'note', title: 'Note'},
              {value: 'tip', title: 'Tip'},
              {value: 'important', title: 'Important'},
              {value: 'warning', title: 'Warning'},
              {value: 'caution', title: 'Caution'},
            ],
          },
        },
        // ...
      ],
    },
  ],
})
```

Form renderers can read the list to pick a select-style input over a free-form text input. Serializers and parsers can read it to map between portable-text values and external representations (e.g. mapping `> [!NOTE]` GFM alerts to `tone: 'note'`). Validation can read it to flag illegal values.

The new `StringOptions` type is exported alongside `FieldDefinition`. The field shape stays backwards-compatible: omitting `options` falls through to a plain string field as before.