### PR TITLE
fix: use targetRange from beforeinput to place text replacements

### DIFF
--- a/.changeset/insert-replacement-text-target-range.md
+++ b/.changeset/insert-replacement-text-target-range.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: use `targetRange` from `beforeinput` to place text replacements
+
+When an extension or IME uses `insertReplacementText` (Grammarly, browser autocorrect, macOS substitution panel, etc.), the replacement now lands at the range the browser indicates via `getTargetRanges()` instead of at the editor selection, and the caret lands right after the inserted text instead of jumping back to where the user was typing.
+
+The previous behavior bailed out when the node-map dirty flag was set from a recent edit, falling back to `editor.selection`. Reported as: typing a character and then accepting a suggestion placed the replacement at the post-typing caret instead of at the underlined word. For cross-block replacements, the caret also stayed in the original block instead of following the replacement, because the handler stashed the pre-replacement selection in `userSelection` and then restored it after the replacement was applied.

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -61,7 +61,6 @@ import {
 } from '../../dom/utils/symbols'
 import {end as editorEnd} from '../../editor/end'
 import {range as editorRange} from '../../editor/range'
-import {rangeRef} from '../../editor/range-ref'
 import {start as editorStart} from '../../editor/start'
 import type {Editor} from '../../interfaces/editor'
 import type {NodeEntry} from '../../interfaces/node'
@@ -701,32 +700,18 @@ export const Editable = forwardRef(
           // COMPAT: For the deleting forward/backward input types we don't want
           // to change the selection because it is the range that will be deleted,
           // and those commands determine that for themselves.
-          // If the NODE_MAP is dirty, we can't trust the selection anchor (eg ReactEditor.toDOMPoint via ReactEditor.toSlateRange)
-          if (
-            (!type.startsWith('delete') || type.startsWith('deleteBy')) &&
-            !editor.isNodeMapDirty
-          ) {
+          if (!type.startsWith('delete') || type.startsWith('deleteBy')) {
             const [targetRange] = (event as any).getTargetRanges()
 
             if (targetRange) {
               const range = ReactEditor.toSlateRange(editor, targetRange, {
                 exactMatch: false,
-                suppressThrow: false,
+                suppressThrow: true,
               })
 
-              if (!selection || !rangeEquals(selection, range)) {
+              if (range && (!selection || !rangeEquals(selection, range))) {
                 native = false
-
-                const selectionRef =
-                  !isCompositionChange &&
-                  editor.selection &&
-                  rangeRef(editor, editor.selection)
-
                 editor.select(range)
-
-                if (selectionRef) {
-                  editor.userSelection = selectionRef
-                }
               }
             }
           }

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -701,10 +701,22 @@ export const Editable = forwardRef(
           // to change the selection because it is the range that will be deleted,
           // and those commands determine that for themselves.
           if (!type.startsWith('delete') || type.startsWith('deleteBy')) {
-            const [targetRange] = (event as any).getTargetRanges()
+            let [domRange] = (event as any).getTargetRanges() as [Range?]
 
-            if (targetRange) {
-              const range = ReactEditor.toSlateRange(editor, targetRange, {
+            // Fallback for iframe contexts (e.g. Grammarly in Sanity Dashboard)
+            // where `getTargetRanges()` is empty even though the DOM selection
+            // is set immediately before the `beforeinput`. The comment above
+            // about IMEs and Grammarly applies here: read the DOM selection
+            // directly so the replacement still lands at the intended range.
+            if (!domRange) {
+              const domSelection = ReactEditor.getWindow(editor).getSelection()
+              if (domSelection && domSelection.rangeCount > 0) {
+                domRange = domSelection.getRangeAt(0)
+              }
+            }
+
+            if (domRange) {
+              const range = ReactEditor.toSlateRange(editor, domRange, {
                 exactMatch: false,
                 suppressThrow: true,
               })

--- a/packages/editor/tests/event.input.test.tsx
+++ b/packages/editor/tests/event.input.test.tsx
@@ -569,4 +569,86 @@ describe('event.input.*', () => {
       backward: false,
     })
   })
+
+  test('Scenario: insertReplacementText falls back to DOM selection when getTargetRanges is empty', async () => {
+    // Repro for Grammarly in iframe-hosted Studios (Sanity Dashboard). The
+    // extension sets the DOM selection to the misspelled word and then fires
+    // a `beforeinput` event whose `getTargetRanges()` is empty (the iframe
+    // context strips it). The replacement should still land at the visually
+    // selected word.
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'wat is the problem',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const editorEl = locator.element() as HTMLElement
+    editorEl.focus()
+    const textNode = editorEl.querySelector('[data-slate-string]')!
+      .childNodes[0] as Text
+
+    document.getSelection()!.setBaseAndExtent(textNode, 18, textNode, 18)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(18)
+    })
+
+    // Simulate the extension selecting "wat" (0..3) visually in the DOM but
+    // without letting Slate's selectionchange listener catch up.
+    document.getSelection()!.setBaseAndExtent(textNode, 0, textNode, 3)
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'What')
+
+    const beforeInput = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertReplacementText',
+      data: 'What',
+      dataTransfer,
+    })
+    // Empty getTargetRanges, mirroring Grammarly in iframe context.
+    Object.defineProperty(beforeInput, 'getTargetRanges', {
+      value: () => [],
+    })
+
+    editorEl.dispatchEvent(beforeInput)
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'What is the problem',
+      ])
+    })
+
+    // The caret should land right after the inserted replacement.
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 4,
+      },
+      focus: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 4,
+      },
+      backward: false,
+    })
+  })
 })

--- a/packages/editor/tests/event.input.test.tsx
+++ b/packages/editor/tests/event.input.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
@@ -368,6 +368,205 @@ describe('event.input.*', () => {
           style: 'normal',
         },
       ])
+    })
+  })
+
+  test('Scenario: insertReplacementText lands at targetRange', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'I has a problem', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const editorEl = locator.element() as HTMLElement
+    editorEl.focus()
+    const textNode = editorEl.querySelector('[data-slate-string]')!
+      .childNodes[0] as Text
+
+    document.getSelection()!.setBaseAndExtent(textNode, 15, textNode, 15)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(15)
+    })
+
+    // A fresh edit dirties the node-map and shifts the selection. The
+    // browser then fires the replacement event before the next React paint.
+    editor.send({type: 'insert.text', text: '!'})
+
+    const liveTextNode = editorEl.querySelector('[data-slate-string]')!
+      .childNodes[0] as Text
+    const targetRange = document.createRange()
+    targetRange.setStart(liveTextNode, 2)
+    targetRange.setEnd(liveTextNode, 5)
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'have')
+
+    const beforeInput = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertReplacementText',
+      data: 'have',
+      dataTransfer,
+    })
+    Object.defineProperty(beforeInput, 'getTargetRanges', {
+      value: () => [targetRange],
+    })
+
+    editorEl.dispatchEvent(beforeInput)
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'I have a problem!',
+      ])
+    })
+
+    // The caret should land right after the inserted replacement.
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 6,
+      },
+      focus: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 6,
+      },
+      backward: false,
+    })
+  })
+
+  test('Scenario: insertReplacementText with cross-block targetRange lands at targetRange', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const li1Key = keyGenerator()
+    const li1SpanKey = keyGenerator()
+    const li2Key = keyGenerator()
+    const li2SpanKey = keyGenerator()
+    const li3Key = keyGenerator()
+    const li3SpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: li1Key,
+          children: [
+            {_type: 'span', _key: li1SpanKey, text: 'first item', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+          level: 1,
+          listItem: 'bullet',
+        },
+        {
+          _type: 'block',
+          _key: li2Key,
+          children: [
+            {_type: 'span', _key: li2SpanKey, text: 'second item', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+          level: 1,
+          listItem: 'bullet',
+        },
+        {
+          _type: 'block',
+          _key: li3Key,
+          children: [
+            {
+              _type: 'span',
+              _key: li3SpanKey,
+              text: 'I has a problem',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+          level: 1,
+          listItem: 'bullet',
+        },
+      ],
+    })
+
+    const editorEl = locator.element() as HTMLElement
+    editorEl.focus()
+
+    // Place caret in middle of li2 (the user is editing here)
+    const li2TextNode = editorEl.querySelector(
+      `[data-block-key="${li2Key}"] [data-slate-string]`,
+    )!.childNodes[0] as Text
+    document.getSelection()!.setBaseAndExtent(li2TextNode, 6, li2TextNode, 6)
+    await vi.waitFor(() => {
+      const sel = editor.getSnapshot().context.selection
+      expect(sel?.focus.offset).toBe(6)
+    })
+
+    // Recent edit (matches video: user has just been typing)
+    editor.send({type: 'insert.text', text: 'X'})
+
+    // Grammarly accepts a suggestion in li3 (a different block from caret).
+    // Browser fires beforeinput with targetRange pointing into li3.
+    const li3TextNode = editorEl.querySelector(
+      `[data-block-key="${li3Key}"] [data-slate-string]`,
+    )!.childNodes[0] as Text
+    const targetRange = document.createRange()
+    targetRange.setStart(li3TextNode, 2)
+    targetRange.setEnd(li3TextNode, 5)
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'have')
+
+    const beforeInput = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertReplacementText',
+      data: 'have',
+      dataTransfer,
+    })
+    Object.defineProperty(beforeInput, 'getTargetRanges', {
+      value: () => [targetRange],
+    })
+
+    editorEl.dispatchEvent(beforeInput)
+
+    // The replacement must land in li3 (where the targetRange was), NOT in li2
+    // (where the caret was). li2's text should still have just the typed 'X'.
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        '>-:first item',
+        '>-:secondX item',
+        '>-:I have a problem',
+      ])
+    })
+
+    // The caret should land right after the inserted replacement in li3,
+    // not back in li2 where the user was typing.
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [{_key: li3Key}, 'children', {_key: li3SpanKey}],
+        offset: 6,
+      },
+      focus: {
+        path: [{_key: li3Key}, 'children', {_key: li3SpanKey}],
+        offset: 6,
+      },
+      backward: false,
     })
   })
 })


### PR DESCRIPTION
When an extension or IME (Grammarly, browser autocorrect, macOS substitution panel, etc.) fires `beforeinput` with `inputType: 'insertReplacementText'`, the browser provides a target range via `event.getTargetRanges()` indicating where the replacement should land. The editor was bailing out of that path when its node-map dirty flag was set, falling back to `editor.selection` — which is whatever the last keystroke left it at, not the replacement's target. After applying the replacement, the caret also jumped back to the user's pre-replacement position instead of following the inserted text.

Reported as: typing a character and then accepting a suggestion places the replacement at the post-typing caret position instead of at the underlined word. For cross-block replacements (caret in one list item, suggestion accepted in another), the replacement landed in the wrong block AND the caret stayed in the original block.

The dirty-flag guard was inherited from upstream Slate, where it prevents crashes when `NODE_TO_INDEX` and `NODE_TO_PARENT` WeakMaps are stale relative to the DOM. PTE doesn't use those WeakMaps; `toSlateRange` walks `data-slate-*` DOM attributes directly via `getDomNodePath`, so the original failure mode the guard was protecting against doesn't exist here. Removing the guard lets the target range take effect; switching `toSlateRange` to `suppressThrow: true` and gating the `editor.select(range)` call on a non-null result keeps things safe if a path can't be resolved for any other reason.

The caret-jumps-back issue was a separate latent bug in the same path: the targetRange handler also stashed the pre-targetRange selection in `userSelection`, which the bottom-of-handler restore would then put back. Dropping that stash leaves the caret at the targetRange (where the replacement landed) — which is what users expect.

Includes regression tests for two scenarios:

- A same-block replacement that triggers the dirty-flag bail (recent typing, then accept a suggestion in the same block). Without the fix the replacement appends to the post-typing caret instead of replacing the target word.
- A cross-block replacement (caret in one list item, suggestion accepted in a different list item). Without the fix the replacement lands in the caret's block, not the target's block. Both scenarios assert the resulting caret position.