### PR TITLE
fix: render collapsed range decorations inside editable containers

### DIFF
--- a/.changeset/range-decorations-container-aware.md
+++ b/.changeset/range-decorations-container-aware.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: render collapsed range decorations inside editable containers
+
+The collapsed-range branch in `range-decorations-machine.ts` matched a decoration's anchor block to the iterating node by reading `path.at(0)` (root-level segment) and `path.at(2)` (root-level child). When the decoration's anchor pointed inside a callout or other editable container, the comparison failed and the decoration never rendered. Resolves the enclosing block via `getEnclosingBlock` and reads the child segment from the path tail so collapsed range decorations work at any depth.

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -9,6 +9,7 @@ import {
 } from 'xstate'
 import {isDeepEqual} from '../internal-utils/equality'
 import {moveRangeByOperation} from '../internal-utils/move-range-by-operation'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import type {Node, NodeEntry} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
 import type {Range} from '../slate/interfaces/range'
@@ -358,28 +359,22 @@ function createDecorate(
       return []
     }
 
-    const blockSegment = path.at(0)
-
-    if (blockSegment === undefined) {
-      return []
-    }
-
     return slateEditor.decoratedRanges.filter((decoratedRange) => {
       // Special case in order to only return one decoration for collapsed ranges
       if (isCollapsedRange(decoratedRange)) {
         // Collapsed ranges should only be decorated if they are on a block child level.
-        const anchorBlockSegment = decoratedRange.anchor.path.at(0)
-        const anchorChildSegment = decoratedRange.anchor.path.at(2)
+        const anchorBlock = getEnclosingBlock(
+          slateEditor,
+          decoratedRange.anchor.path,
+        )
+        const anchorChildSegment = decoratedRange.anchor.path.at(-1)
 
-        if (
-          !isKeyedSegment(anchorBlockSegment) ||
-          !isKeyedSegment(anchorChildSegment)
-        ) {
+        if (!anchorBlock || !isKeyedSegment(anchorChildSegment)) {
           return false
         }
 
         return (
-          anchorBlockSegment._key === node._key &&
+          anchorBlock.node._key === node._key &&
           node.children.some(
             (child: Node) => child._key === anchorChildSegment._key,
           )

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -10,6 +10,7 @@ import {describe, expect, it, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
 import {page, userEvent} from 'vitest/browser'
 import {
+  defineContainer,
   defineSchema,
   EditorProvider,
   PortableTextEditable,
@@ -19,7 +20,7 @@ import {
   type RangeDecorationOnMovedDetails,
 } from '../src'
 import type {PortableTextEditor} from '../src/editor/PortableTextEditor'
-import {EventListenerPlugin} from '../src/plugins'
+import {ContainerPlugin, EventListenerPlugin} from '../src/plugins'
 import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
 import {InternalPortableTextEditorRefPlugin} from '../src/plugins/plugin.internal.portable-text-editor-ref'
 import {createTestEditor} from '../src/test/vitest'
@@ -608,6 +609,96 @@ describe('RangeDecorations', () => {
     // Assert that the caret is still after "f"
     expect(editorRef.current?.getSnapshot().context.selection).toEqual(
       getSelectionAfterText(editorRef.current!.getSnapshot().context, 'f'),
+    )
+  })
+})
+
+describe('RangeDecorations inside editable containers', () => {
+  test('Scenario: Drawing a collapsed Range Decoration inside a callout', async () => {
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    })
+
+    const calloutContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..callout',
+      field: 'content',
+    })
+
+    // A collapsed range decoration whose path points inside a container.
+    // `range-decorations-machine.ts` has a special branch for collapsed
+    // ranges that matches by block key. With root-only path slicing
+    // (`path.at(0)` = callout key) the inner text block iteration sees a
+    // mismatch and the decoration never renders. Container-aware lookup
+    // resolves the enclosing block at any depth.
+    const rangeDecorations: Array<RangeDecoration> = [
+      {
+        component: (props) => (
+          <span data-testid="range-decoration">{props.children}</span>
+        ),
+        selection: {
+          anchor: {
+            path: [
+              {_key: 'callout1'},
+              'content',
+              {_key: 'inner1'},
+              'children',
+              {_key: 'span1'},
+            ],
+            offset: 6,
+          },
+          focus: {
+            path: [
+              {_key: 'callout1'},
+              'content',
+              {_key: 'inner1'},
+              'children',
+              {_key: 'span1'},
+            ],
+            offset: 6,
+          },
+        },
+      },
+    ]
+
+    const {locator} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'callout1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'inner1',
+              children: [
+                {_type: 'span', _key: 'span1', text: 'Hello there world'},
+              ],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      editableProps: {
+        rangeDecorations,
+      },
+      children: <ContainerPlugin containers={[calloutContainer]} />,
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
     )
   })
 })


### PR DESCRIPTION
The collapsed-range branch in `createDecorate` matched the decoration's anchor block to the iterating leaf by reading `path.at(0)` (root segment) and `path.at(2)` (root child). When the decoration's anchor pointed inside a container (e.g. a callout's text block), `path.at(0)` gave the container's key while `node._key` was the inner text block's key, so the comparison always failed and the decoration never rendered.

Resolves the anchor's enclosing block via `getEnclosingBlock` and reads the child segment from `path.at(-1)`, so collapsed range decorations match nodes at any depth.

The expanded-range branch already worked at any depth via `rangeIntersection` / `rangeIncludes`.