### PR TITLE
fix: compare selection points at any depth

### DIFF
--- a/.changeset/compare-points-container-aware.md
+++ b/.changeset/compare-points-container-aware.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: compare selection points at any depth
+
+`isPointBeforeSelection` and `isPointAfterSelection` returned the wrong answer for points inside a container's text block, because the underlying point comparison only walked the root segment of each path. Pickers and other consumers that ask whether a point is before or after the current selection (emoji picker, typeahead picker) now resolve correctly inside containers.

--- a/packages/editor/src/selectors/selector.is-point-relative-to-selection.test.ts
+++ b/packages/editor/src/selectors/selector.is-point-relative-to-selection.test.ts
@@ -1,0 +1,394 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {makeContainerConfig} from '../schema/make-container-config'
+import {resolveContainers} from '../schema/resolve-containers'
+import {isPointAfterSelection} from './selector.is-point-after-selection'
+import {isPointBeforeSelection} from './selector.is-point-before-selection'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const schema = compileSchema(schemaDefinition)
+
+const calloutContainers = resolveContainers(
+  schema,
+  new Map([
+    [
+      '$..callout',
+      makeContainerConfig(schema, {
+        scope: '$..callout',
+        field: 'content',
+      }),
+    ],
+  ]),
+)
+
+describe(isPointBeforeSelection.name, () => {
+  test('Scenario: a point in an earlier text block in a callout is before a selection in a later text block in the same callout', () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const firstBlockKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const secondBlockKey = keyGenerator()
+    const secondSpanKey = keyGenerator()
+
+    const snapshot = createTestSnapshot({
+      context: {
+        schema,
+        containers: calloutContainers,
+        value: [
+          {
+            _key: calloutKey,
+            _type: 'callout',
+            content: [
+              {
+                _key: firstBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: firstSpanKey,
+                    _type: 'span',
+                    text: 'first',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _key: secondBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: secondSpanKey,
+                    _type: 'span',
+                    text: 'second',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        selection: {
+          anchor: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: secondBlockKey},
+              'children',
+              {_key: secondSpanKey},
+            ],
+            offset: 2,
+          },
+          focus: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: secondBlockKey},
+              'children',
+              {_key: secondSpanKey},
+            ],
+            offset: 2,
+          },
+          backward: false,
+        },
+      },
+    })
+
+    const point = {
+      path: [
+        {_key: calloutKey},
+        'content',
+        {_key: firstBlockKey},
+        'children',
+        {_key: firstSpanKey},
+      ],
+      offset: 0,
+    }
+
+    expect(isPointBeforeSelection(point)(snapshot)).toBe(true)
+  })
+
+  test('Scenario: a point in a later text block in a callout is not before a selection in an earlier text block in the same callout', () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const firstBlockKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const secondBlockKey = keyGenerator()
+    const secondSpanKey = keyGenerator()
+
+    const snapshot = createTestSnapshot({
+      context: {
+        schema,
+        containers: calloutContainers,
+        value: [
+          {
+            _key: calloutKey,
+            _type: 'callout',
+            content: [
+              {
+                _key: firstBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: firstSpanKey,
+                    _type: 'span',
+                    text: 'first',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _key: secondBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: secondSpanKey,
+                    _type: 'span',
+                    text: 'second',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        selection: {
+          anchor: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: firstBlockKey},
+              'children',
+              {_key: firstSpanKey},
+            ],
+            offset: 2,
+          },
+          focus: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: firstBlockKey},
+              'children',
+              {_key: firstSpanKey},
+            ],
+            offset: 2,
+          },
+          backward: false,
+        },
+      },
+    })
+
+    const point = {
+      path: [
+        {_key: calloutKey},
+        'content',
+        {_key: secondBlockKey},
+        'children',
+        {_key: secondSpanKey},
+      ],
+      offset: 0,
+    }
+
+    expect(isPointBeforeSelection(point)(snapshot)).toBe(false)
+  })
+})
+
+describe(isPointAfterSelection.name, () => {
+  test('Scenario: a point in a later text block in a callout is after a selection in an earlier text block in the same callout', () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const firstBlockKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const secondBlockKey = keyGenerator()
+    const secondSpanKey = keyGenerator()
+
+    const snapshot = createTestSnapshot({
+      context: {
+        schema,
+        containers: calloutContainers,
+        value: [
+          {
+            _key: calloutKey,
+            _type: 'callout',
+            content: [
+              {
+                _key: firstBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: firstSpanKey,
+                    _type: 'span',
+                    text: 'first',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _key: secondBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: secondSpanKey,
+                    _type: 'span',
+                    text: 'second',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        selection: {
+          anchor: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: firstBlockKey},
+              'children',
+              {_key: firstSpanKey},
+            ],
+            offset: 2,
+          },
+          focus: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: firstBlockKey},
+              'children',
+              {_key: firstSpanKey},
+            ],
+            offset: 2,
+          },
+          backward: false,
+        },
+      },
+    })
+
+    const point = {
+      path: [
+        {_key: calloutKey},
+        'content',
+        {_key: secondBlockKey},
+        'children',
+        {_key: secondSpanKey},
+      ],
+      offset: 0,
+    }
+
+    expect(isPointAfterSelection(point)(snapshot)).toBe(true)
+  })
+
+  test('Scenario: a point in an earlier text block in a callout is not after a selection in a later text block in the same callout', () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const firstBlockKey = keyGenerator()
+    const firstSpanKey = keyGenerator()
+    const secondBlockKey = keyGenerator()
+    const secondSpanKey = keyGenerator()
+
+    const snapshot = createTestSnapshot({
+      context: {
+        schema,
+        containers: calloutContainers,
+        value: [
+          {
+            _key: calloutKey,
+            _type: 'callout',
+            content: [
+              {
+                _key: firstBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: firstSpanKey,
+                    _type: 'span',
+                    text: 'first',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _key: secondBlockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: secondSpanKey,
+                    _type: 'span',
+                    text: 'second',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+        selection: {
+          anchor: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: secondBlockKey},
+              'children',
+              {_key: secondSpanKey},
+            ],
+            offset: 2,
+          },
+          focus: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: secondBlockKey},
+              'children',
+              {_key: secondSpanKey},
+            ],
+            offset: 2,
+          },
+          backward: false,
+        },
+      },
+    })
+
+    const point = {
+      path: [
+        {_key: calloutKey},
+        'content',
+        {_key: firstBlockKey},
+        'children',
+        {_key: firstSpanKey},
+      ],
+      offset: 0,
+    }
+
+    expect(isPointAfterSelection(point)(snapshot)).toBe(false)
+  })
+})

--- a/packages/editor/src/utils/util.compare-points.ts
+++ b/packages/editor/src/utils/util.compare-points.ts
@@ -1,10 +1,6 @@
-import {isTextBlock} from '@portabletext/schema'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {comparePaths} from '../slate/path/compare-paths'
 import type {EditorSelectionPoint} from '../types/editor'
-import {
-  getBlockKeyFromSelectionPoint,
-  getChildKeyFromSelectionPoint,
-} from './util.selection-point'
 
 /**
  * Returns:
@@ -12,114 +8,30 @@ import {
  * - `-1` if `pointA` is before `pointB`
  * - `0` if `pointA` and `pointB` are equal
  * - `1` if `pointA` is after `pointB`.
+ *
+ * Compares the two points by document order, resolved at any depth. When
+ * the paths are equal, compares offsets.
  */
 export function comparePoints(
   snapshot: EditorSnapshot,
   pointA: EditorSelectionPoint,
   pointB: EditorSelectionPoint,
 ): -1 | 0 | 1 {
-  const blockKeyA = getBlockKeyFromSelectionPoint(pointA)
-  const blockKeyB = getBlockKeyFromSelectionPoint(pointB)
+  const pathComparison = comparePaths(pointA.path, pointB.path, {
+    children: snapshot.context.value,
+  })
 
-  if (!blockKeyA) {
-    throw new Error(`Cannot compare points: no block key found for ${pointA}`)
+  if (pathComparison !== 0) {
+    return pathComparison
   }
 
-  if (!blockKeyB) {
-    throw new Error(`Cannot compare points: no block key found for ${pointB}`)
-  }
-
-  const blockIndexA = snapshot.blockIndexMap.get(blockKeyA)
-  const blockIndexB = snapshot.blockIndexMap.get(blockKeyB)
-
-  if (blockIndexA === undefined) {
-    throw new Error(`Cannot compare points: block "${blockKeyA}" not found`)
-  }
-
-  if (blockIndexB === undefined) {
-    throw new Error(`Cannot compare points: block "${blockKeyB}" not found`)
-  }
-
-  if (blockIndexA < blockIndexB) {
+  if (pointA.offset < pointB.offset) {
     return -1
   }
 
-  if (blockIndexA > blockIndexB) {
+  if (pointA.offset > pointB.offset) {
     return 1
   }
 
-  // Same block - need to compare at child level
-  const block = snapshot.context.value.at(blockIndexA)
-
-  if (!block || !isTextBlock(snapshot.context, block)) {
-    // Block objects - same block means equal position
-    return 0
-  }
-
-  const childKeyA = getChildKeyFromSelectionPoint(pointA)
-  const childKeyB = getChildKeyFromSelectionPoint(pointB)
-
-  if (!childKeyA) {
-    throw new Error(`Cannot compare points: no child key found for ${pointA}`)
-  }
-
-  if (!childKeyB) {
-    throw new Error(`Cannot compare points: no child key found for ${pointB}`)
-  }
-
-  // Find child indices
-  let childIndexA: number | undefined
-  let childIndexB: number | undefined
-
-  for (let i = 0; i < block.children.length; i++) {
-    const child = block.children.at(i)
-
-    if (!child) {
-      continue
-    }
-
-    if (child._key === childKeyA && child._key === childKeyB) {
-      // Same child - compare offsets directly
-      if (pointA.offset < pointB.offset) {
-        return -1
-      }
-
-      if (pointA.offset > pointB.offset) {
-        return 1
-      }
-
-      return 0
-    }
-
-    if (child._key === childKeyA) {
-      childIndexA = i
-    }
-
-    if (child._key === childKeyB) {
-      childIndexB = i
-    }
-
-    if (childIndexA !== undefined && childIndexB !== undefined) {
-      break
-    }
-  }
-
-  if (childIndexA === undefined) {
-    throw new Error(`Cannot compare points: child "${childKeyA}" not found`)
-  }
-
-  if (childIndexB === undefined) {
-    throw new Error(`Cannot compare points: child "${childKeyB}" not found`)
-  }
-
-  if (childIndexA < childIndexB) {
-    return -1
-  }
-
-  if (childIndexA > childIndexB) {
-    return 1
-  }
-
-  // Same child index but different keys (shouldn't happen)
   return 0
 }


### PR DESCRIPTION
`isPointBeforeSelection` and `isPointAfterSelection` returned the wrong answer for points inside a container's text block, because the underlying point comparison only walked the root segment of each path. Pickers and other consumers that ask whether a point is before or after the current selection (emoji picker, typeahead picker) now resolve correctly inside containers.