### PR TITLE
fix: detect "at the beginning of block" at any depth

### DIFF
--- a/.changeset/at-the-beginning-of-block-container-aware.md
+++ b/.changeset/at-the-beginning-of-block-container-aware.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: detect "at the beginning of block" at any depth
+
+`isAtTheBeginningOfBlock` read the focus child key from `path.at(2)` (root-only). When the selection focus pointed inside a container's text block, the lookup returned undefined and the function reported the caret was not at the start. Lists inside containers now toggle correctly when the caret is at the start of a block.

--- a/packages/editor/src/utils/util.at-the-beginning-of-block.ts
+++ b/packages/editor/src/utils/util.at-the-beginning-of-block.ts
@@ -1,7 +1,8 @@
 import {isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {EditorContext} from '../editor/editor-snapshot'
+import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
+import {isKeyedSegment} from './util.is-keyed-segment'
 import {isSelectionCollapsed} from './util.is-selection-collapsed'
-import {getChildKeyFromSelectionPoint} from './util.selection-point'
 
 export function isAtTheBeginningOfBlock({
   context,
@@ -22,10 +23,24 @@ export function isAtTheBeginningOfBlock({
     return false
   }
 
-  const focusSpanKey = getChildKeyFromSelectionPoint(context.selection.focus)
+  // Resolve the focus's enclosing text block so we know we're inside `block`
+  // and not in some unrelated structural position. Then read the child key
+  // from the last keyed segment of the focus path; the field name (`children`,
+  // or whatever the container declares) is irrelevant.
+  const focusPath = context.selection.focus.path
+  const ancestorTextBlock = getAncestorTextBlock(context, focusPath)
+
+  if (!ancestorTextBlock || ancestorTextBlock.node._key !== block._key) {
+    return false
+  }
+
+  const lastSegment = focusPath.at(-1)
+  const focusChildKey = isKeyedSegment(lastSegment)
+    ? lastSegment._key
+    : undefined
 
   return (
-    focusSpanKey === block.children[0]?._key &&
+    focusChildKey === block.children[0]?._key &&
     context.selection.focus.offset === 0
   )
 }


### PR DESCRIPTION
`isAtTheBeginningOfBlock` read the focus child key from `path.at(2)` (root-only). When the selection focus pointed inside a container's text block, the lookup returned undefined and the function reported the caret was not at the start. Lists inside containers now toggle correctly when the caret is at the start of a block.