### PR TITLE
refactor: small internal cleanups

### DIFF
--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -5,6 +5,7 @@ import {getNode} from '../node-traversal/get-node'
 import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {parentPath} from '../slate/path/parent-path'
+import {siblingPath} from '../slate/path/sibling-path'
 import type {OperationImplementation} from './operation.types'
 
 export const childSetOperationImplementation: OperationImplementation<
@@ -33,7 +34,7 @@ export const childSetOperationImplementation: OperationImplementation<
     const newKey = rest['_key']
     const textPath =
       typeof newKey === 'string' && newKey !== child._key
-        ? [...childPath.slice(0, -1), {_key: newKey}]
+        ? siblingPath(childPath, newKey)
         : childPath
 
     if (typeof text === 'string') {

--- a/packages/editor/src/utils/util.split-text-block.ts
+++ b/packages/editor/src/utils/util.split-text-block.ts
@@ -16,7 +16,7 @@ export function splitTextBlock({
   point: EditorSelectionPoint
 }): {before: PortableTextTextBlock; after: PortableTextTextBlock} | undefined {
   const firstChild = block.children.at(0)
-  const lastChild = block.children.at(block.children.length - 1)
+  const lastChild = block.children.at(-1)
 
   if (!firstChild || !lastChild) {
     return undefined


### PR DESCRIPTION
Three internal-only refactors extracted from #2594. No consumer-visible behavior change.

- Use `siblingPath` instead of `path.slice(0, -1)` arithmetic when building a child-rename text path
- Use `at(-1)` instead of `at(length - 1)` in `splitTextBlock`