### PR TITLE
feat: example markdown-editor app

### DIFF
--- a/apps/markdown-editor/.gitignore
+++ b/apps/markdown-editor/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+dist-ssr
+.turbo
+*.local
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/apps/markdown-editor/eslint.config.js
+++ b/apps/markdown-editor/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  {ignores: ['dist']},
+  reactHooks.configs.flat.recommended,
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      'react-hooks/exhaustive-deps': 'error',
+      'react-refresh/only-export-components': [
+        'warn',
+        {allowConstantExport: true},
+      ],
+    },
+  },
+)

--- a/apps/markdown-editor/index.html
+++ b/apps/markdown-editor/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown editor (PTE)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/markdown-editor/package.json
+++ b/apps/markdown-editor/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "markdown-editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "check:lint": "eslint .",
+    "check:types": "tsc --noEmit --pretty --project tsconfig.app.json",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@portabletext/editor": "workspace:*",
+    "@portabletext/markdown": "workspace:*",
+    "@portabletext/plugin-input-rule": "workspace:*",
+    "@portabletext/plugin-markdown-shortcuts": "workspace:*",
+    "@portabletext/schema": "workspace:*",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.59.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "globals": "^17.5.0",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.2"
+  }
+}

--- a/apps/markdown-editor/src/App.css
+++ b/apps/markdown-editor/src/App.css
@@ -1,0 +1,263 @@
+.shell {
+  display: flex;
+  min-height: 100vh;
+  padding: 2rem;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.25rem 0;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: #6f7785;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background: #fff;
+  border: 1px solid #d9dde3;
+  border-radius: 0.5rem;
+  align-items: center;
+}
+
+.toolbar-divider {
+  width: 1px;
+  height: 1.5rem;
+  background: #d9dde3;
+  margin: 0 0.25rem;
+}
+
+.toolbar-button {
+  font: inherit;
+  cursor: pointer;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.35rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #15171c;
+  min-width: 2rem;
+  text-align: center;
+}
+
+.toolbar-button:hover {
+  background: #eef0f3;
+}
+
+.toolbar-button[aria-pressed='true'] {
+  background: #15171c;
+  color: #fff;
+}
+
+.editor-frame {
+  background: #fff;
+  border: 1px solid #d9dde3;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  flex: 1;
+}
+
+.editor[role='textbox'] {
+  outline: none;
+  min-height: 12rem;
+  --list-padding: 1.5em;
+  counter-reset: level-1 level-2 level-3 level-4 level-5 level-6 level-7 level-8
+    level-9 level-10;
+}
+
+.editor h1 {
+  font-size: 1.6rem;
+  margin: 0.5rem 0;
+}
+.editor h2 {
+  font-size: 1.3rem;
+  margin: 0.5rem 0;
+}
+.editor h3 {
+  font-size: 1.1rem;
+  margin: 0.5rem 0;
+}
+.editor .block {
+  margin: 0.25rem 0;
+}
+
+.editor code {
+  font-family:
+    'SF Mono', ui-monospace, 'Cascadia Mono', 'Roboto Mono', Menlo, Consolas,
+    monospace;
+  background: #f0f1f4;
+  padding: 0 0.25em;
+  border-radius: 0.25em;
+  font-size: 0.95em;
+}
+
+/* PTE renders list items with data attributes */
+[data-list-item] {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+[data-list-item]::before {
+  text-align: right;
+  width: 1.5rem;
+  flex-shrink: 0;
+}
+
+[data-list-item='number']::before {
+  font-size: 0.95rem;
+  font-variant-numeric: tabular-nums;
+}
+[data-list-item='bullet']::before {
+  font-size: 0.45rem;
+  align-self: center;
+}
+[data-list-item='task']::before {
+  content: none;
+  width: 0;
+}
+
+/* Number list counter */
+[data-level='1'][data-list-index='1'] {
+  counter-set: level-1 1;
+}
+[data-level='2'][data-list-index='1'] {
+  counter-set: level-2 1;
+}
+[data-level='3'][data-list-index='1'] {
+  counter-set: level-3 1;
+}
+[data-level='1']:not([data-list-index='1']) {
+  counter-increment: level-1;
+}
+[data-level='2']:not([data-list-index='1']) {
+  counter-increment: level-2;
+}
+[data-level='3']:not([data-list-index='1']) {
+  counter-increment: level-3;
+}
+[data-list-item='number'][data-level='1']::before {
+  content: counter(level-1, decimal) '.';
+}
+[data-list-item='number'][data-level='2']::before {
+  content: counter(level-2, lower-alpha) '.';
+}
+[data-list-item='number'][data-level='3']::before {
+  content: counter(level-3, lower-roman) '.';
+}
+
+/* Bulleted markers */
+[data-list-item='bullet'][data-level='1']::before {
+  content: '●';
+}
+[data-list-item='bullet'][data-level='2']::before {
+  content: '○';
+}
+[data-list-item='bullet'][data-level='3']::before {
+  content: '■';
+}
+
+/* Indentation */
+[data-level='2'] {
+  padding-left: var(--list-padding);
+}
+[data-level='3'] {
+  padding-left: calc(var(--list-padding) * 2);
+}
+[data-level='4'] {
+  padding-left: calc(var(--list-padding) * 3);
+}
+[data-level='5'] {
+  padding-left: calc(var(--list-padding) * 4);
+}
+
+/* Task list */
+.task-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.task-checkbox {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border: 1.5px solid #6f7785;
+  border-radius: 0.25rem;
+  background: #fff;
+  cursor: pointer;
+  position: relative;
+  top: 0.15em;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.task-checkbox:hover {
+  border-color: #15171c;
+}
+
+.task-row[data-checked='true'] .task-checkbox {
+  background: #15171c;
+  border-color: #15171c;
+}
+
+.task-row[data-checked='true'] .task-checkbox::after {
+  content: '';
+  position: absolute;
+  inset: 1px 3px 3px 2px;
+  border-bottom: 2px solid #fff;
+  border-right: 2px solid #fff;
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+
+.task-row[data-checked='true'] .task-content {
+  color: #6f7785;
+  text-decoration: line-through;
+}
+
+.task-content {
+  flex: 1;
+}
+
+.statusbar {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #6f7785;
+}
+
+.active-marks {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.active-mark {
+  padding: 0 0.4rem;
+  border-radius: 0.25rem;
+  background: #15171c;
+  color: #fff;
+}

--- a/apps/markdown-editor/src/App.tsx
+++ b/apps/markdown-editor/src/App.tsx
@@ -11,9 +11,16 @@ import {
   type RenderStyleFunction,
 } from '@portabletext/editor'
 import * as selectors from '@portabletext/editor/selectors'
+import {InputRulePlugin} from '@portabletext/plugin-input-rule'
+import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import './App.css'
+import {MarkdownEditorBehaviorsPlugin} from './markdown-editor-behaviors'
+import {createTaskListRule} from './rules/task-list'
 
 export const schemaDefinition = defineSchema({
+  block: {
+    fields: [{name: 'checked', type: 'boolean'}],
+  },
   decorators: [
     {name: 'strong'},
     {name: 'em'},
@@ -89,6 +96,36 @@ function App() {
         </header>
 
         <EditorProvider initialConfig={{schemaDefinition}}>
+          <MarkdownEditorBehaviorsPlugin />
+          <MarkdownShortcutsPlugin
+            headingStyle={({context, props}) =>
+              context.schema.styles.find((s) => s.name === `h${props.level}`)
+                ?.name
+            }
+            unorderedList={({context}) =>
+              context.schema.lists.find((l) => l.name === 'bullet')?.name
+            }
+            orderedList={({context}) =>
+              context.schema.lists.find((l) => l.name === 'number')?.name
+            }
+            boldDecorator={({context}) =>
+              context.schema.decorators.find((d) => d.name === 'strong')?.name
+            }
+            italicDecorator={({context}) =>
+              context.schema.decorators.find((d) => d.name === 'em')?.name
+            }
+            codeDecorator={({context}) =>
+              context.schema.decorators.find((d) => d.name === 'code')?.name
+            }
+          />
+          <InputRulePlugin
+            rules={[
+              createTaskListRule({
+                taskList: ({context}) =>
+                  context.schema.lists.find((l) => l.name === 'task')?.name,
+              }),
+            ]}
+          />
           <Toolbar />
           <div className="editor-frame">
             <PortableTextEditable
@@ -199,7 +236,7 @@ function DecoratorButton(props: {
 function StatusBar() {
   return (
     <div className="statusbar">
-      <span>Hotkeys: Cmd/Ctrl+B, I, U, E</span>
+      <span>Hotkeys: Cmd/Ctrl+B, I, U, ' for bold/italic/underline/code</span>
       <span className="active-marks">
         {schemaDefinition.decorators.map((decorator) => (
           <ActiveMarkLabel key={decorator.name} decorator={decorator.name} />

--- a/apps/markdown-editor/src/App.tsx
+++ b/apps/markdown-editor/src/App.tsx
@@ -1,0 +1,51 @@
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type RenderDecoratorFunction,
+  type RenderStyleFunction,
+} from '@portabletext/editor'
+
+const schemaDefinition = defineSchema({
+  decorators: [
+    {name: 'strong'},
+    {name: 'em'},
+    {name: 'underline'},
+    {name: 'code'},
+  ],
+  styles: [{name: 'normal'}, {name: 'h1'}, {name: 'h2'}, {name: 'h3'}],
+  lists: [{name: 'bullet'}, {name: 'number'}, {name: 'task'}],
+})
+
+const renderDecorator: RenderDecoratorFunction = (props) => {
+  if (props.value === 'strong') return <strong>{props.children}</strong>
+  if (props.value === 'em') return <em>{props.children}</em>
+  if (props.value === 'underline') return <u>{props.children}</u>
+  if (props.value === 'code') return <code>{props.children}</code>
+  return <>{props.children}</>
+}
+
+const renderStyle: RenderStyleFunction = (props) => {
+  if (props.schemaType.value === 'h1') return <h1>{props.children}</h1>
+  if (props.schemaType.value === 'h2') return <h2>{props.children}</h2>
+  if (props.schemaType.value === 'h3') return <h3>{props.children}</h3>
+  return <>{props.children}</>
+}
+
+function App() {
+  return (
+    <main>
+      <h1>Markdown editor (PTE)</h1>
+      <EditorProvider initialConfig={{schemaDefinition}}>
+        <PortableTextEditable
+          placeholder="Write Markdown..."
+          renderDecorator={renderDecorator}
+          renderStyle={renderStyle}
+          renderListItem={(props) => <>{props.children}</>}
+        />
+      </EditorProvider>
+    </main>
+  )
+}
+
+export default App

--- a/apps/markdown-editor/src/App.tsx
+++ b/apps/markdown-editor/src/App.tsx
@@ -2,11 +2,18 @@ import {
   defineSchema,
   EditorProvider,
   PortableTextEditable,
+  useEditor,
+  useEditorSelector,
+  type BlockListItemRenderProps,
+  type RenderBlockFunction,
   type RenderDecoratorFunction,
+  type RenderListItemFunction,
   type RenderStyleFunction,
 } from '@portabletext/editor'
+import * as selectors from '@portabletext/editor/selectors'
+import './App.css'
 
-const schemaDefinition = defineSchema({
+export const schemaDefinition = defineSchema({
   decorators: [
     {name: 'strong'},
     {name: 'em'},
@@ -32,20 +39,184 @@ const renderStyle: RenderStyleFunction = (props) => {
   return <>{props.children}</>
 }
 
+const renderBlock: RenderBlockFunction = (props) => {
+  return <div className="block">{props.children}</div>
+}
+
+const renderListItem: RenderListItemFunction = (props) => {
+  if (props.value === 'task') {
+    return <TaskListItem {...props} />
+  }
+  return <>{props.children}</>
+}
+
+function TaskListItem(props: BlockListItemRenderProps) {
+  const editor = useEditor()
+  const checked = (props.block as {checked?: boolean}).checked === true
+
+  return (
+    <span className="task-row" data-checked={checked}>
+      <button
+        aria-label={checked ? 'Mark task incomplete' : 'Mark task complete'}
+        aria-pressed={checked}
+        className="task-checkbox"
+        contentEditable={false}
+        type="button"
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => {
+          editor.send({
+            type: 'block.set',
+            at: props.path,
+            props: {checked: !checked},
+          })
+          editor.send({type: 'focus'})
+        }}
+      />
+      <span className="task-content">{props.children}</span>
+    </span>
+  )
+}
+
 function App() {
   return (
-    <main>
-      <h1>Markdown editor (PTE)</h1>
-      <EditorProvider initialConfig={{schemaDefinition}}>
-        <PortableTextEditable
-          placeholder="Write Markdown..."
-          renderDecorator={renderDecorator}
-          renderStyle={renderStyle}
-          renderListItem={(props) => <>{props.children}</>}
-        />
-      </EditorProvider>
+    <main className="shell">
+      <section className="workspace" aria-label="Markdown editor">
+        <header className="topbar">
+          <div>
+            <p className="eyebrow">Portable Text prototype</p>
+            <h1>Markdown-first editor</h1>
+          </div>
+        </header>
+
+        <EditorProvider initialConfig={{schemaDefinition}}>
+          <Toolbar />
+          <div className="editor-frame">
+            <PortableTextEditable
+              className="editor"
+              placeholder="Write Markdown..."
+              renderDecorator={renderDecorator}
+              renderStyle={renderStyle}
+              renderBlock={renderBlock}
+              renderListItem={renderListItem}
+            />
+          </div>
+          <StatusBar />
+        </EditorProvider>
+      </section>
     </main>
   )
+}
+
+function Toolbar() {
+  return (
+    <div className="toolbar" aria-label="Formatting toolbar">
+      <StyleButton style="normal" label="P" title="Paragraph" />
+      <StyleButton style="h1" label="H1" title="Heading 1" />
+      <StyleButton style="h2" label="H2" title="Heading 2" />
+      <StyleButton style="h3" label="H3" title="Heading 3" />
+      <ListButton list="bullet" label="Bullet" title="Bulleted list" />
+      <ListButton list="number" label="Numbered" title="Numbered list" />
+      <ListButton list="task" label="Task" title="Task list" />
+      <span className="toolbar-divider" />
+      <DecoratorButton decorator="strong" label="B" title="Bold" />
+      <DecoratorButton decorator="em" label="I" title="Italic" />
+      <DecoratorButton decorator="underline" label="U" title="Underline" />
+      <DecoratorButton decorator="code" label="Code" title="Inline code" />
+    </div>
+  )
+}
+
+function StyleButton(props: {style: string; label: string; title: string}) {
+  const editor = useEditor()
+  const active = useEditorSelector(editor, selectors.isActiveStyle(props.style))
+  return (
+    <button
+      aria-pressed={active}
+      className="toolbar-button"
+      title={props.title}
+      type="button"
+      onMouseDown={(event) => {
+        event.preventDefault()
+        editor.send({type: 'style.toggle', style: props.style})
+        editor.send({type: 'focus'})
+      }}
+    >
+      {props.label}
+    </button>
+  )
+}
+
+function ListButton(props: {list: string; label: string; title: string}) {
+  const editor = useEditor()
+  const active = useEditorSelector(
+    editor,
+    selectors.isActiveListItem(props.list),
+  )
+  return (
+    <button
+      aria-pressed={active}
+      className="toolbar-button"
+      title={props.title}
+      type="button"
+      onMouseDown={(event) => {
+        event.preventDefault()
+        editor.send({type: 'list item.toggle', listItem: props.list})
+        editor.send({type: 'focus'})
+      }}
+    >
+      {props.label}
+    </button>
+  )
+}
+
+function DecoratorButton(props: {
+  decorator: string
+  label: string
+  title: string
+}) {
+  const editor = useEditor()
+  const active = useEditorSelector(
+    editor,
+    selectors.isActiveDecorator(props.decorator),
+  )
+  return (
+    <button
+      aria-pressed={active}
+      className="toolbar-button"
+      title={props.title}
+      type="button"
+      onMouseDown={(event) => {
+        event.preventDefault()
+        editor.send({type: 'decorator.toggle', decorator: props.decorator})
+        editor.send({type: 'focus'})
+      }}
+    >
+      {props.label}
+    </button>
+  )
+}
+
+function StatusBar() {
+  return (
+    <div className="statusbar">
+      <span>Hotkeys: Cmd/Ctrl+B, I, U, E</span>
+      <span className="active-marks">
+        {schemaDefinition.decorators.map((decorator) => (
+          <ActiveMarkLabel key={decorator.name} decorator={decorator.name} />
+        ))}
+      </span>
+    </div>
+  )
+}
+
+function ActiveMarkLabel(props: {decorator: string}) {
+  const editor = useEditor()
+  const active = useEditorSelector(
+    editor,
+    selectors.isActiveDecorator(props.decorator),
+  )
+  if (!active) return null
+  return <span className="active-mark">{props.decorator}</span>
 }
 
 export default App

--- a/apps/markdown-editor/src/index.css
+++ b/apps/markdown-editor/src/index.css
@@ -1,0 +1,31 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif;
+  color-scheme: light;
+  color: #15171c;
+  background-color: #f5f6f8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+body {
+  display: flex;
+}
+
+#root {
+  width: 100%;
+}

--- a/apps/markdown-editor/src/main.tsx
+++ b/apps/markdown-editor/src/main.tsx
@@ -1,0 +1,10 @@
+import {StrictMode} from 'react'
+import {createRoot} from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/markdown-editor/src/markdown-editor-behaviors.tsx
+++ b/apps/markdown-editor/src/markdown-editor-behaviors.tsx
@@ -1,0 +1,64 @@
+import {useEditor} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {
+  getFocusTextBlock,
+  isSelectionCollapsed,
+} from '@portabletext/editor/selectors'
+import {isEmptyTextBlock} from '@portabletext/editor/utils'
+import {useEffect} from 'react'
+
+/**
+ * Pressing Enter on an empty heading converts it to a paragraph instead of
+ * inserting a new heading line. Mirrors the "Enter exits a heading" behavior
+ * common to markdown-first editors.
+ */
+const enterOnEmptyHeadingResetsStyle = defineBehavior({
+  on: 'insert.break',
+  guard: ({snapshot}) => {
+    const focusTextBlock = getFocusTextBlock(snapshot)
+
+    if (!focusTextBlock) {
+      return false
+    }
+    if (!isSelectionCollapsed(snapshot)) {
+      return false
+    }
+    if (
+      focusTextBlock.node.style === undefined ||
+      focusTextBlock.node.style === 'normal'
+    ) {
+      return false
+    }
+    if (!isEmptyTextBlock(snapshot.context, focusTextBlock.node)) {
+      return false
+    }
+
+    return {focusTextBlock}
+  },
+  actions: [
+    (_, {focusTextBlock}) => [
+      raise({
+        type: 'block.unset',
+        props: ['style'],
+        at: focusTextBlock.path,
+      }),
+    ],
+  ],
+})
+
+/**
+ * Hosts custom behaviors specific to the markdown-editor example app.
+ *
+ * Render this as a child of `EditorProvider`.
+ */
+export function MarkdownEditorBehaviorsPlugin() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    return editor.registerBehavior({
+      behavior: enterOnEmptyHeadingResetsStyle,
+    })
+  }, [editor])
+
+  return null
+}

--- a/apps/markdown-editor/src/rules/task-list.ts
+++ b/apps/markdown-editor/src/rules/task-list.ts
@@ -1,0 +1,75 @@
+import type {EditorContext} from '@portabletext/editor'
+import {raise} from '@portabletext/editor/behaviors'
+import {getPreviousInlineObject} from '@portabletext/editor/selectors'
+import {defineInputRule} from '@portabletext/plugin-input-rule'
+
+/**
+ * Markdown shortcut for GFM-style task list items.
+ *
+ * Matches `-[] ` / `-[ ] ` / `-[x] ` / `-[X] ` at the start of a block, sets
+ * `listItem: <task list name>` and `checked: <bool>` on the block, and deletes
+ * the matched prefix.
+ *
+ * Modeled directly on the unordered-list rule from
+ * `@portabletext/plugin-markdown-shortcuts`. Lives in the example app for
+ * now because the shared plugin doesn't ship a task-list rule.
+ */
+export function createTaskListRule(config: {
+  taskList: ({
+    context,
+  }: {
+    context: Pick<EditorContext, 'schema'>
+  }) => string | undefined
+}) {
+  return defineInputRule({
+    on: /^-\[( |x|X)?\] /,
+    guard: ({snapshot, event}) => {
+      const taskList = config.taskList({
+        context: {schema: snapshot.context.schema},
+      })
+
+      if (!taskList) {
+        return false
+      }
+
+      const previousInlineObject = getPreviousInlineObject(snapshot)
+
+      if (previousInlineObject) {
+        return false
+      }
+
+      const match = event.matches.at(0)
+
+      if (!match) {
+        return false
+      }
+
+      const checkedMarker = match.groupMatches.at(0)?.text ?? ''
+      const checked = checkedMarker.toLowerCase() === 'x'
+
+      return {match, taskList, checked}
+    },
+    actions: [
+      ({event}, {match, taskList, checked}) => [
+        raise({
+          type: 'block.unset',
+          props: ['style'],
+          at: event.focusBlock.path,
+        }),
+        raise({
+          type: 'block.set',
+          props: {
+            listItem: taskList,
+            level: event.focusBlock.node.level ?? 1,
+            checked,
+          },
+          at: event.focusBlock.path,
+        }),
+        raise({
+          type: 'delete',
+          at: match.targetOffsets,
+        }),
+      ],
+    ],
+  })
+}

--- a/apps/markdown-editor/src/vite-env.d.ts
+++ b/apps/markdown-editor/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/markdown-editor/tsconfig.app.json
+++ b/apps/markdown-editor/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/markdown-editor/tsconfig.json
+++ b/apps/markdown-editor/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/apps/markdown-editor/tsconfig.node.json
+++ b/apps/markdown-editor/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/markdown-editor/vite.config.ts
+++ b/apps/markdown-editor/vite.config.ts
@@ -1,0 +1,50 @@
+import path from 'node:path'
+import react from '@vitejs/plugin-react'
+import {defineConfig} from 'vite'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [
+    react({
+      babel: (id) => {
+        const isVendoredSlate =
+          id.includes('/src/slate/') ||
+          id.includes('/src/slate-dom/') ||
+          id.includes('/src/slate-react/')
+        return {
+          plugins: isVendoredSlate
+            ? []
+            : [['babel-plugin-react-compiler', {target: '19'}]],
+        }
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@portabletext/editor': path.resolve(
+        __dirname,
+        '../../packages/editor/src',
+      ),
+      '@portabletext/markdown': path.resolve(
+        __dirname,
+        '../../packages/markdown/src',
+      ),
+      '@portabletext/plugin-input-rule': path.resolve(
+        __dirname,
+        '../../packages/plugin-input-rule/src',
+      ),
+      '@portabletext/plugin-markdown-shortcuts': path.resolve(
+        __dirname,
+        '../../packages/plugin-markdown-shortcuts/src',
+      ),
+      '@portabletext/schema': path.resolve(
+        __dirname,
+        '../../packages/schema/src',
+      ),
+      '@portabletext/patches': path.resolve(
+        __dirname,
+        '../../packages/patches/src',
+      ),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,70 @@ importers:
         specifier: ^4.8.0
         version: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
 
+  apps/markdown-editor:
+    dependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      '@portabletext/markdown':
+        specifier: workspace:*
+        version: link:../../packages/markdown
+      '@portabletext/plugin-input-rule':
+        specifier: workspace:*
+        version: link:../../packages/plugin-input-rule
+      '@portabletext/plugin-markdown-shortcuts':
+        specifier: workspace:*
+        version: link:../../packages/plugin-markdown-shortcuts
+      '@portabletext/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.1
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-refresh:
+        specifier: ^0.5.2
+        version: 0.5.2(eslint@9.39.1(jiti@2.6.1))
+      globals:
+        specifier: ^17.5.0
+        version: 17.6.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
   apps/playground:
     dependencies:
       '@floating-ui/react-dom':
@@ -1575,24 +1639,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.10':
     resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.10':
     resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.10':
     resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.10':
     resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
@@ -2496,89 +2564,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2813,48 +2897,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.120.0':
     resolution: {integrity: sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.120.0':
     resolution: {integrity: sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.120.0':
     resolution: {integrity: sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.120.0':
     resolution: {integrity: sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.120.0':
     resolution: {integrity: sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.120.0':
     resolution: {integrity: sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.120.0':
     resolution: {integrity: sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.120.0':
     resolution: {integrity: sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA==}
@@ -2933,41 +3025,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -4059,48 +4159,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.54':
     resolution: {integrity: sha512-pY8N2X5C+/ZQcy0eRdfOzOP//OFngP1TaIqDjFwfBPws2UNavKS8SpxhPEgUaYIaT0keVBd/TB+eVy9z+CIOtw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
     resolution: {integrity: sha512-ENLmSQCWqSA/+YN45V2FqTIemg7QspaiTjlm327eUAMeOLdqmSOVVyrQexJGNTQ5M8sDYCgVAig2Kk01Ggmqaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.54':
     resolution: {integrity: sha512-cgTooAFm2MUmFriB7IYaWBNyqrGlRPKG+yaK2rGFl2rcdOcO24urY4p3eyB0ogqsRLvJbIxwjjYiWiIP7Eo1Cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
     resolution: {integrity: sha512-klahlb2EIFltSUubn/VLjuc3qxp1E7th8ukayPfdkcKvvYcQ5rJztgx8JsJSuAKVzKtNTqUGOhy4On71BuyV8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.54':
     resolution: {integrity: sha512-nGyLT1Qau0W+kEL44V2jhHmvfS3wyJW08E4WEu2E6NuIy+uChKN1X0aoxzFIDi2owDsYaZYez/98/f268EupIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
     resolution: {integrity: sha512-UuA+JqQIgqtkgGN2c/AQ5wi8M6mJHrahz/wciENPTeI6zEIbbLGoth5XN+sQe2pJDejEVofN9aOAp0kaazwnVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.54':
     resolution: {integrity: sha512-KH374P0TUjDXssROT/orvzaWrzGOptD13PTrltgKwbDprJTMknoLiYsOD6Ttz92O2VuAcCtFuJ1xbyFM2Uo/Xg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
     resolution: {integrity: sha512-1BNQW8u4ro8bsN1+tgKENJiqmvc+WfuaUhXzMImOVSMw28pkBKdfZtX2qJPADV3terx+vNJtlsgSGeb3+W6Jiw==}
@@ -4336,186 +4444,223 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -4874,24 +5019,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -5899,6 +6048,11 @@ packages:
     peerDependencies:
       eslint: '>=8.40'
 
+  eslint-plugin-react-refresh@0.5.2:
+    resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
+    peerDependencies:
+      eslint: ^9 || ^10
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6205,6 +6359,10 @@ packages:
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -6688,24 +6846,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -14378,6 +14540,10 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
+  eslint-plugin-react-refresh@0.5.2(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.1(jiti@2.6.1)
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -14728,6 +14894,8 @@ snapshots:
   globals@14.0.0: {}
 
   globals@15.15.0: {}
+
+  globals@17.6.0: {}
 
   globby@11.1.0:
     dependencies:


### PR DESCRIPTION
A small example app that mirrors the functionality of a typical markdown-first editor (paragraphs, headings, three list styles, four inline marks, markdown shortcuts at start of block, markdown serialization round-trip, localStorage persistence). Useful as a feature-parity reference for "what does PTE look like as a plain markdown editor?" and as a stress test of the markdown shortcuts plugin, the input rule plugin, and the markdown package against a non-Sanity consumer surface.

Lives at `apps/markdown-editor/` alongside `apps/playground` and `apps/docs`.

## What's here so far

- Vite + React + TypeScript scaffold with the same `babel-plugin-react-compiler` config and workspace aliases as the playground.
- Schema with `strong`/`em`/`underline`/`code` decorators, `normal`/`h1`/`h2`/`h3` styles, `bullet`/`number`/`task` lists.
- Empty `EditorProvider` mounting an editable surface with placeholder.

## What's coming next (drafted in subsequent commits)

- Render functions (decorator, style, list-item, block) and CSS targeting PTE's `data-list-item` / `data-level` attributes.
- Toolbar with active-state buttons for blocks/lists/marks.
- Keyboard hotkeys (`Cmd/Ctrl+B/I/U/E`).
- `MarkdownShortcutsPlugin` wiring with a local task-list rule (the plugin doesn't ship one yet; this is a deliberate first friction point).
- Markdown round-trip via `@portabletext/markdown` with thin app-side wrappers for task syntax (`- [ ]` / `- [x]`) and `<u>...</u>` underline runs (also currently unsupported by the package; second friction point).
- localStorage persistence + a "Reset document" button.
- Initial sample document showing every supported feature.
- Playwright e2e tests covering list-item navigation and markdown shortcuts.

## Why this exists

The friction surfaced while building this app is the deliverable. Each gap (no `taskList` shortcut rule, no GFM task matcher in the markdown package, asymmetric `<u>` round-trip, no clear story for per-block extension fields like `checked`) is something a real consumer would hit. Surfacing them inside the monorepo with a runnable counter-example makes it easy to decide which to close vs keep as documented limitations.