### PR TITLE
feat!: take `snapshot` on block-offset utilities

### DIFF
--- a/.changeset/block-offset-utilities-container-aware.md
+++ b/.changeset/block-offset-utilities-container-aware.md
@@ -4,6 +4,6 @@
 
 feat!: tighten and adjust block-offset utilities
 
-`blockOffsetToSpanSelectionPoint`, `spanSelectionPointToBlockOffset`, `blockOffsetsToSelection`, and `childSelectionPointToBlockOffset` now require `containers` on their `context` argument so they resolve through container-nested text blocks at any depth. Callers passing the editor's full snapshot context keep working unchanged (`containers` is part of `EditorContext`); explicitly narrowed `Pick<EditorContext, ...>` annotations need to add `'containers'`.
+`blockOffsetToSpanSelectionPoint`, `spanSelectionPointToBlockOffset`, `blockOffsetsToSelection`, and `childSelectionPointToBlockOffset` now take a `snapshot` argument and resolve through container-nested text blocks at any depth. Pass the editor snapshot directly instead of a `context` object.
 
 `blockOffsetToBlockSelectionPoint`, `blockOffsetToSelectionPoint`, and `selectionPointToBlockOffset` are no longer part of the public API. They had no external consumers and only existed to feed the public utilities listed above.

--- a/packages/editor/src/behaviors/behavior.abstract.annotation.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.annotation.ts
@@ -21,7 +21,7 @@ export const abstractAnnotationBehaviors = [
       // two trailing segments to get the enclosing text block's path,
       // which works at any container depth.
       const blockPath = event.at.slice(0, -2)
-      const blockEntry = getNode(snapshot.context, blockPath)
+      const blockEntry = getNode(snapshot, blockPath)
 
       if (!blockEntry || !isTextBlock(snapshot.context, blockEntry.node)) {
         return false

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -55,7 +55,7 @@ export const abstractDeleteBehaviors = [
       }
 
       const previousSibling = getSibling(
-        adjustedSnapshot.context,
+        adjustedSnapshot,
         focusTextBlock.path,
         'previous',
       )
@@ -149,7 +149,7 @@ export const abstractDeleteBehaviors = [
       }
 
       const nextSibling = getSibling(
-        adjustedSnapshot.context,
+        adjustedSnapshot,
         focusTextBlock.path,
         'next',
       )
@@ -217,7 +217,7 @@ export const abstractDeleteBehaviors = [
       }
 
       const nextSibling = getSibling(
-        adjustedSnapshot.context,
+        adjustedSnapshot,
         focusTextBlock.path,
         'next',
       )

--- a/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
@@ -141,7 +141,7 @@ export const abstractKeyboardBehaviors = [
       }
 
       const previousSibling = getSibling(
-        snapshot.context,
+        snapshot,
         focusTextBlock.path,
         'previous',
       )
@@ -150,7 +150,7 @@ export const abstractKeyboardBehaviors = [
         return false
       }
 
-      const previousBlock = getBlock(snapshot.context, previousSibling.path)
+      const previousBlock = getBlock(snapshot, previousSibling.path)
 
       if (!previousBlock) {
         return false

--- a/packages/editor/src/behaviors/behavior.abstract.move.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.move.ts
@@ -6,7 +6,7 @@ export const abstractMoveBehaviors = [
   defineBehavior({
     on: 'move.block up',
     guard: ({snapshot, event}) => {
-      const previousSibling = getSibling(snapshot.context, event.at, 'previous')
+      const previousSibling = getSibling(snapshot, event.at, 'previous')
 
       if (previousSibling) {
         return {previousSibling}
@@ -27,7 +27,7 @@ export const abstractMoveBehaviors = [
   defineBehavior({
     on: 'move.block down',
     guard: ({snapshot, event}) => {
-      const nextSibling = getSibling(snapshot.context, event.at, 'next')
+      const nextSibling = getSibling(snapshot, event.at, 'next')
 
       if (nextSibling) {
         return {nextSibling}

--- a/packages/editor/src/behaviors/behavior.abstract.select.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.select.ts
@@ -13,7 +13,7 @@ export const abstractSelectBehaviors = [
         return false
       }
 
-      const block = getBlock(snapshot.context, event.at)
+      const block = getBlock(snapshot, event.at)
 
       if (!block) {
         return false
@@ -67,11 +67,7 @@ export const abstractSelectBehaviors = [
         return false
       }
 
-      const previousSibling = getSibling(
-        snapshot.context,
-        focusBlockPath,
-        'previous',
-      )
+      const previousSibling = getSibling(snapshot, focusBlockPath, 'previous')
 
       if (!previousSibling) {
         return false
@@ -98,7 +94,7 @@ export const abstractSelectBehaviors = [
         return false
       }
 
-      const nextSibling = getSibling(snapshot.context, focusBlockPath, 'next')
+      const nextSibling = getSibling(snapshot, focusBlockPath, 'next')
 
       if (!nextSibling) {
         return false

--- a/packages/editor/src/behaviors/behavior.abstract.split.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.split.ts
@@ -54,8 +54,8 @@ export const abstractSplitBehaviors = [
         return false
       }
 
-      const startBlock = getAncestorTextBlock(snapshot.context, startPoint.path)
-      const endBlock = getAncestorTextBlock(snapshot.context, endPoint.path)
+      const startBlock = getAncestorTextBlock(snapshot, startPoint.path)
+      const endBlock = getAncestorTextBlock(snapshot, endPoint.path)
 
       if (!startBlock || !endBlock) {
         return false

--- a/packages/editor/src/behaviors/behavior.core.block-objects.ts
+++ b/packages/editor/src/behaviors/behavior.core.block-objects.ts
@@ -32,11 +32,7 @@ const arrowDownOnLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const nextBlock = getSibling(
-      snapshot.context,
-      focusedBlockObject.path,
-      'next',
-    )
+    const nextBlock = getSibling(snapshot, focusedBlockObject.path, 'next')
 
     return !nextBlock
   },
@@ -75,7 +71,7 @@ const arrowUpOnLonelyBlockObject = defineBehavior({
     }
 
     const previousBlock = getSibling(
-      snapshot.context,
+      snapshot,
       focusedBlockObject.path,
       'previous',
     )
@@ -141,7 +137,7 @@ const clickingAboveLonelyBlockObject = defineBehavior({
     }
 
     const previousSibling = getSibling(
-      snapshot.context,
+      snapshot,
       focusedBlockObject.path,
       'previous',
     )
@@ -194,11 +190,7 @@ const clickingBelowLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const nextSibling = getSibling(
-      snapshot.context,
-      focusedBlockObject.path,
-      'next',
-    )
+    const nextSibling = getSibling(snapshot, focusedBlockObject.path, 'next')
 
     return (
       (event.position.isEditor || event.position.isContainer) &&
@@ -235,7 +227,7 @@ const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
     }
 
     const previousSibling = getSibling(
-      snapshot.context,
+      snapshot,
       focusedTextBlock.path,
       'previous',
     )
@@ -284,11 +276,7 @@ const deletingEmptyTextBlockBeforeBlockObject = defineBehavior({
       return false
     }
 
-    const nextSibling = getSibling(
-      snapshot.context,
-      focusedTextBlock.path,
-      'next',
-    )
+    const nextSibling = getSibling(snapshot, focusedTextBlock.path, 'next')
 
     if (!nextSibling) {
       return false

--- a/packages/editor/src/behaviors/behavior.core.containers.ts
+++ b/packages/editor/src/behaviors/behavior.core.containers.ts
@@ -57,10 +57,8 @@ function isAtContainerDeadEnd(
     return false
   }
 
-  const container = getAncestor(
-    snapshot.context,
-    focusTextBlock.path,
-    (node, path) => isEditableContainer(snapshot.context, node, path),
+  const container = getAncestor(snapshot, focusTextBlock.path, (node, path) =>
+    isEditableContainer(snapshot, node, path),
   )
 
   if (!container) {
@@ -84,7 +82,7 @@ function isAtContainerDeadEnd(
   }
 
   const sibling = getSibling(
-    snapshot.context,
+    snapshot,
     container.path,
     edge === 'end' ? 'next' : 'previous',
   )

--- a/packages/editor/src/behaviors/behavior.core.insert-break.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert-break.ts
@@ -148,11 +148,11 @@ const breakingEntireBlocks = defineBehavior({
     }
 
     const selectionStartBlock = getEnclosingBlock(
-      snapshot.context,
+      snapshot,
       selectionStartPoint.path,
     )
     const selectionEndBlock = getEnclosingBlock(
-      snapshot.context,
+      snapshot,
       selectionEndPoint.path,
     )
 
@@ -174,15 +174,12 @@ const breakingEntireBlocks = defineBehavior({
       isEqualSelectionPoints(selectionEndPoint, endBlockEndPoint)
     ) {
       const selectedBlocks: Array<{node: PortableTextBlock; path: Path}> = []
-      for (const entry of getNodes(
-        {...snapshot.context, blockIndexMap: snapshot.blockIndexMap},
-        {
-          from: selectionStartBlock.path,
-          to: selectionEndBlock.path,
-          match: (_node, path) => isBlock(snapshot.context, path),
-        },
-      )) {
-        const block = getBlock(snapshot.context, entry.path)
+      for (const entry of getNodes(snapshot, {
+        from: selectionStartBlock.path,
+        to: selectionEndBlock.path,
+        match: (_node, path) => isBlock(snapshot, path),
+      })) {
+        const block = getBlock(snapshot, entry.path)
         if (block) {
           selectedBlocks.push(block)
         }

--- a/packages/editor/src/behaviors/behavior.core.lists.ts
+++ b/packages/editor/src/behaviors/behavior.core.lists.ts
@@ -36,7 +36,7 @@ const clearListOnBackspace = defineBehavior({
 
     if (
       !isAtTheBeginningOfBlock({
-        context: snapshot.context,
+        snapshot,
         block: focusTextBlock.node,
       })
     ) {
@@ -150,7 +150,7 @@ const mergeTextIntoListOnBackspace = defineBehavior({
 
     if (
       !isAtTheBeginningOfBlock({
-        context: snapshot.context,
+        snapshot,
         block: focusTextBlock.node,
       })
     ) {

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -126,15 +126,7 @@ export function performEvent({
       }
 
       performOperation({
-        snapshot: {
-          context: {
-            keyGenerator,
-            schema,
-            containers: editor.containers,
-            value: editor.children,
-          },
-          blockIndexMap: editor.blockIndexMap,
-        },
+        snapshot: editor,
         operation: {
           ...event,
           editor,
@@ -375,15 +367,7 @@ export function performEvent({
       }
 
       performOperation({
-        snapshot: {
-          context: {
-            keyGenerator,
-            schema,
-            containers: editor.containers,
-            value: editor.children,
-          },
-          blockIndexMap: editor.blockIndexMap,
-        },
+        snapshot: editor,
         operation: {
           ...event,
           editor,

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -126,11 +126,14 @@ export function performEvent({
       }
 
       performOperation({
-        context: {
-          keyGenerator,
-          schema,
-          containers: editor.containers,
-          value: editor.children,
+        snapshot: {
+          context: {
+            keyGenerator,
+            schema,
+            containers: editor.containers,
+            value: editor.children,
+          },
+          blockIndexMap: editor.blockIndexMap,
         },
         operation: {
           ...event,
@@ -372,11 +375,14 @@ export function performEvent({
       }
 
       performOperation({
-        context: {
-          keyGenerator,
-          schema,
-          containers: editor.containers,
-          value: editor.children,
+        snapshot: {
+          context: {
+            keyGenerator,
+            schema,
+            containers: editor.containers,
+            value: editor.children,
+          },
+          blockIndexMap: editor.blockIndexMap,
         },
         operation: {
           ...event,

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -219,14 +219,7 @@ export function createEditableAPI(
       PortableTextBlock | PortableTextChild | undefined,
       Path | undefined,
     ] => {
-      const result = getNode(
-        {
-          schema: editor.schema,
-          containers: editor.containers,
-          value: editor.children,
-        },
-        path as InternalPath,
-      )
+      const result = getNode(editor, path as InternalPath)
 
       if (!result) {
         return [undefined, undefined]
@@ -240,7 +233,9 @@ export function createEditableAPI(
       let node: Node | undefined
       try {
         const entry = Array.from(
-          getNodes(editor, {match: (n) => n._key === element._key}),
+          getNodes(editor, {
+            match: (n) => n._key === element._key,
+          }),
         )[0]
         if (entry) {
           const itemPath = entry.path

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -21,7 +21,15 @@ export function createSlateEditor(
 
   const context = config.editorActor.getSnapshot().context
 
-  const placeholderBlock = createPlaceholderBlock(context)
+  const placeholderBlock = createPlaceholderBlock({
+    context: {
+      schema: context.schema,
+      containers: context.containers,
+      value: [],
+      keyGenerator: context.keyGenerator,
+    },
+    blockIndexMap: new Map(),
+  })
 
   const editor = createEditor()
 

--- a/packages/editor/src/editor/get-selection-state.test.ts
+++ b/packages/editor/src/editor/get-selection-state.test.ts
@@ -7,7 +7,7 @@ describe(getSelectionState.name, () => {
   test('returns defaults when selection is null', () => {
     const testbed = createNodeTraversalTestbed()
 
-    expect(getSelectionState(testbed.context, null)).toEqual({
+    expect(getSelectionState(testbed.snapshot, null)).toEqual({
       focusedLeafPath: undefined,
       selectedLeafPaths: new Set(),
       focusedContainerPath: undefined,
@@ -23,7 +23,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.span1._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath: focusPath,
       focusPath,
       backward: false,
@@ -57,7 +57,7 @@ describe(getSelectionState.name, () => {
     const testbed = createNodeTraversalTestbed()
     const focusPath = [{_key: testbed.image._key}]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath: focusPath,
       focusPath,
       backward: false,
@@ -91,7 +91,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.stockTicker1._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath: focusPath,
       focusPath,
       backward: false,
@@ -123,7 +123,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.cellSpan1._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath: focusPath,
       focusPath,
       backward: false,
@@ -198,7 +198,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.stockTicker2._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath: focusPath,
       focusPath,
       backward: false,
@@ -237,7 +237,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.span2._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath,
       focusPath,
       backward: false,
@@ -286,7 +286,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.span3._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath,
       focusPath,
       backward: false,
@@ -348,7 +348,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.cellSpan3._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath,
       focusPath,
       backward: false,
@@ -458,7 +458,7 @@ describe(getSelectionState.name, () => {
       {_key: testbed.span1._key},
     ]
 
-    const result = getSelectionState(testbed.context, {
+    const result = getSelectionState(testbed.snapshot, {
       anchorPath,
       focusPath,
       backward: true,

--- a/packages/editor/src/editor/get-selection-state.ts
+++ b/packages/editor/src/editor/get-selection-state.ts
@@ -1,11 +1,9 @@
 import {isTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
 import {getAncestors} from '../node-traversal/get-ancestors'
 import {getNodes} from '../node-traversal/get-nodes'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import {serializePath} from '../paths/serialize-path'
 import {isEditableContainer} from '../schema/is-editable-container'
-import type {ResolvedContainers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 
 export type SelectionState = {
@@ -51,12 +49,7 @@ const emptyState: SelectionState = {
  * - `focusedContainerPath` is the nearest ancestor container of the focus.
  */
 export function getSelectionState(
-  context: {
-    schema: EditorSchema
-    containers: ResolvedContainers
-    value: Array<Node>
-    blockIndexMap: Map<string, number>
-  },
+  snapshot: TraversalSnapshot,
   selection: {
     anchorPath: Path
     focusPath: Path
@@ -76,15 +69,15 @@ export function getSelectionState(
   const from = selection.backward ? selection.focusPath : selection.anchorPath
   const to = selection.backward ? selection.anchorPath : selection.focusPath
 
-  for (const {node, path} of getNodes(context, {
+  for (const {node, path} of getNodes(snapshot, {
     from,
     to,
   })) {
     const serialized = serializePath(path)
 
     if (
-      isTextBlock({schema: context.schema}, node) ||
-      isEditableContainer(context, node, path)
+      isTextBlock({schema: snapshot.context.schema}, node) ||
+      isEditableContainer(snapshot, node, path)
     ) {
       selectedContainerPaths.add(serialized)
     } else {
@@ -103,7 +96,7 @@ export function getSelectionState(
     }
 
     for (const {path: ancestorPath} of getAncestors(
-      context,
+      snapshot,
       selection.focusPath,
     )) {
       const serializedAncestorPath = serializePath(ancestorPath)

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -49,9 +49,11 @@ export function SelectionStateProvider({
 
       return getSelectionState(
         {
-          schema: snapshot.context.schema,
-          containers: slateEditor.containers,
-          value: snapshot.context.value,
+          context: {
+            schema: snapshot.context.schema,
+            containers: slateEditor.containers,
+            value: snapshot.context.value,
+          },
           blockIndexMap: slateEditor.blockIndexMap,
         },
         selection,

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -292,6 +292,7 @@ describe(resolveSelection.name, () => {
         schema: context.schema,
         containers: context.containers,
         children: context.value,
+        blockIndexMap: new Map(),
       },
       {
         anchor: {
@@ -338,6 +339,7 @@ describe(resolveSelection.name, () => {
         schema: context.schema,
         containers: context.containers,
         children: context.value,
+        blockIndexMap: new Map(),
       },
       {
         anchor: {

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -22,6 +22,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockKey,
@@ -73,6 +74,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockKey,
@@ -122,6 +124,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockObjectKey,
@@ -157,6 +160,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockKey,
@@ -198,6 +202,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockKey,
@@ -239,6 +244,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        blockIndexMap: new Map(),
         children: [
           {
             _key: blockKey,

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -22,7 +22,7 @@ import {
 
 type ResolveSelectionEditor = Pick<
   PortableTextSlateEditor,
-  'children' | 'schema' | 'containers'
+  'children' | 'schema' | 'containers' | 'blockIndexMap'
 >
 
 /**
@@ -90,16 +90,19 @@ function resolveSelectionPoint(
       offset: number
     }
   | undefined {
-  const context = {
-    schema: editor.schema,
-    containers: editor.containers,
-    value: editor.children,
+  const snapshot = {
+    context: {
+      schema: editor.schema,
+      containers: editor.containers,
+      value: editor.children,
+    },
+    blockIndexMap: editor.blockIndexMap,
   }
 
-  const entry = getNode(context, selectionPoint.path)
+  const entry = getNode(snapshot, selectionPoint.path)
 
   if (entry) {
-    const children = getChildren(context, entry.path)
+    const children = getChildren(snapshot, entry.path)
 
     // Leaf node (span, inline object, block object). Clamp offset.
     if (children.length === 0) {
@@ -145,7 +148,7 @@ function resolveSelectionPoint(
 
     // Non-leaf, non-text-block (container or text block without offset).
     // Descend to the nearest leaf.
-    const leaf = getLeaf(context, entry.path, {
+    const leaf = getLeaf(snapshot, entry.path, {
       edge: direction === 'forward' ? 'start' : 'end',
     })
 
@@ -160,13 +163,13 @@ function resolveSelectionPoint(
     return undefined
   }
 
-  const blockEntry = getNode(context, [{_key: blockKey}])
+  const blockEntry = getNode(snapshot, [{_key: blockKey}])
 
   if (!blockEntry) {
     return undefined
   }
 
-  const leaf = getLeaf(context, blockEntry.path, {edge: 'start'})
+  const leaf = getLeaf(snapshot, blockEntry.path, {edge: 'start'})
 
   return leaf
     ? {path: leaf.path, offset: 0}

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -15,10 +15,7 @@ import type {EditorSelection} from '../types/editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {blockOffsetToSpanSelectionPoint} from '../utils/util.block-offset'
 import {isEqualSelectionPoints} from '../utils/util.is-equal-selection-points'
-import {
-  getBlockKeyFromSelectionPoint,
-  getChildKeyFromSelectionPoint,
-} from '../utils/util.selection-point'
+import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 type ResolveSelectionEditor = Pick<
   PortableTextSlateEditor,
@@ -122,30 +119,16 @@ function resolveSelectionPoint(
 
     if (isTextBlock({schema: editor.schema}, entry.node) && isBlockLevelPath) {
       const spanPoint = blockOffsetToSpanSelectionPoint({
-        snapshot: {
-          context: {
-            schema: editor.schema,
-            value: [entry.node],
-            containers: editor.containers,
-          },
-          blockIndexMap: new Map(),
-        },
+        snapshot,
         blockOffset: {
-          path: [{_key: entry.node._key}],
+          path: entry.path,
           offset: selectionPoint.offset,
         },
         direction,
       })
 
       if (spanPoint) {
-        return {
-          path: [
-            ...entry.path,
-            'children',
-            {_key: getChildKeyFromSelectionPoint(spanPoint)!},
-          ],
-          offset: spanPoint.offset,
-        }
+        return spanPoint
       }
     }
 

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -118,14 +118,17 @@ function resolveSelectionPoint(
     // Resolve the offset to a specific span position. The `isBlock` predicate
     // answers "is this path AT a block (as opposed to inside one)" at any
     // depth, regardless of the parent field name.
-    const isBlockLevelPath = isBlock(context, selectionPoint.path)
+    const isBlockLevelPath = isBlock(snapshot, selectionPoint.path)
 
     if (isTextBlock({schema: editor.schema}, entry.node) && isBlockLevelPath) {
       const spanPoint = blockOffsetToSpanSelectionPoint({
-        context: {
-          schema: editor.schema,
-          value: [entry.node],
-          containers: editor.containers,
+        snapshot: {
+          context: {
+            schema: editor.schema,
+            value: [entry.node],
+            containers: editor.containers,
+          },
+          blockIndexMap: new Map(),
         },
         blockOffset: {
           path: [{_key: entry.node._key}],

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -64,7 +64,14 @@ export function createApplyPatch(
 function diffMatchPatch(
   editor: Pick<
     PortableTextSlateEditor,
-    'children' | 'apply' | 'selection' | 'onChange' | 'schema' | 'containers'
+    | 'children'
+    | 'apply'
+    | 'selection'
+    | 'onChange'
+    | 'schema'
+    | 'containers'
+    | 'context'
+    | 'blockIndexMap'
   >,
   patch: DiffMatchPatch,
 ): boolean {
@@ -74,14 +81,7 @@ function diffMatchPatch(
   }
 
   const spanPath = patch.path.slice(0, -1)
-  const spanEntry = getNode(
-    {
-      schema: editor.schema,
-      containers: editor.containers,
-      value: editor.children,
-    },
-    spanPath,
-  )
+  const spanEntry = getNode(editor, spanPath)
 
   if (!spanEntry || !isSpan({schema: editor.schema}, spanEntry.node)) {
     return false

--- a/packages/editor/src/internal-utils/create-placeholder-block.ts
+++ b/packages/editor/src/internal-utils/create-placeholder-block.ts
@@ -1,9 +1,18 @@
 import type {PortableTextSpan} from '@portabletext/schema'
-import type {EditorContext} from '../editor/editor-snapshot'
 import {getBlockSubSchema} from '../schema/get-block-sub-schema'
 import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
+
+type PlaceholderSnapshot = {
+  context: {
+    schema: import('../editor/editor-schema').EditorSchema
+    containers: Containers
+    value: Array<Node>
+    keyGenerator: () => string
+  }
+  blockIndexMap: Map<string, number>
+}
 
 /**
  * Create a placeholder text block -- the empty initial block used when the
@@ -14,22 +23,19 @@ import type {Path} from '../slate/interfaces/path'
  * falls back to the root schema's first style.
  */
 export function createPlaceholderBlock(
-  context: Pick<EditorContext, 'keyGenerator' | 'schema'> & {
-    containers?: Containers
-    value?: Array<Node>
-  },
+  snapshot: PlaceholderSnapshot,
   path?: Path,
 ) {
-  const style = resolveDefaultStyle(context, path)
+  const style = resolveDefaultStyle(snapshot, path)
   return {
-    _type: context.schema.block.name,
-    _key: context.keyGenerator(),
+    _type: snapshot.context.schema.block.name,
+    _key: snapshot.context.keyGenerator(),
     style,
     markDefs: [],
     children: [
       {
-        _type: context.schema.span.name,
-        _key: context.keyGenerator(),
+        _type: snapshot.context.schema.span.name,
+        _key: snapshot.context.keyGenerator(),
         text: '',
         marks: [],
       } as PortableTextSpan,
@@ -38,26 +44,13 @@ export function createPlaceholderBlock(
 }
 
 function resolveDefaultStyle(
-  context: Pick<EditorContext, 'keyGenerator' | 'schema'> & {
-    containers?: Containers
-    value?: Array<Node>
-  },
+  snapshot: PlaceholderSnapshot,
   path?: Path,
 ): string {
-  const rootFallback = context.schema.styles[0]?.name ?? 'normal'
-  if (!path || !context.containers || !context.value) {
+  const rootFallback = snapshot.context.schema.styles[0]?.name ?? 'normal'
+  if (!path) {
     return rootFallback
   }
-  const subSchema = getBlockSubSchema(
-    {
-      context: {
-        schema: context.schema,
-        containers: context.containers,
-        value: context.value,
-      },
-      blockIndexMap: new Map<string, number>(),
-    },
-    path,
-  )
+  const subSchema = getBlockSubSchema(snapshot, path)
   return subSchema.styles[0]?.name ?? rootFallback
 }

--- a/packages/editor/src/internal-utils/create-placeholder-block.ts
+++ b/packages/editor/src/internal-utils/create-placeholder-block.ts
@@ -50,9 +50,12 @@ function resolveDefaultStyle(
   }
   const subSchema = getBlockSubSchema(
     {
-      schema: context.schema,
-      containers: context.containers,
-      value: context.value,
+      context: {
+        schema: context.schema,
+        containers: context.containers,
+        value: context.value,
+      },
+      blockIndexMap: new Map<string, number>(),
     },
     path,
   )

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -79,14 +79,14 @@ export function getEventPosition({
       isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
-          context: editorActor.getSnapshot().context,
+          context: slateEditor,
           block: {
             node: eventBlock,
             path: eventBlockPath,
           },
         }),
         focus: getBlockEndPoint({
-          context: editorActor.getSnapshot().context,
+          context: slateEditor,
           block: {
             node: eventBlock,
             path: eventBlockPath,
@@ -124,14 +124,14 @@ export function getEventPosition({
       isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
-          context: editorActor.getSnapshot().context,
+          context: slateEditor,
           block: {
             node: eventBlock,
             path: eventBlockPath,
           },
         }),
         focus: getBlockEndPoint({
-          context: editorActor.getSnapshot().context,
+          context: slateEditor,
           block: {
             node: eventBlock,
             path: eventBlockPath,

--- a/packages/editor/src/internal-utils/get-unwrap-target.test.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.test.ts
@@ -63,29 +63,32 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'cell',
-              _key: 'c0',
-              content: [
-                {
-                  _type: 'callout',
-                  _key: 'co0',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'cb0',
-                      children: [
-                        {_type: 'span', _key: 'cs0', text: '', marks: []},
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'callout',
+                    _key: 'co0',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'cb0',
+                        children: [
+                          {_type: 'span', _key: 'cs0', text: '', marks: []},
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block']),
@@ -182,46 +185,49 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'table',
-              _key: 't0',
-              rows: [
-                {
-                  _type: 'row',
-                  _key: 'r0',
-                  cells: [
-                    {
-                      _type: 'cell',
-                      _key: 'c0',
-                      content: [
-                        {
-                          _type: 'callout',
-                          _key: 'co0',
-                          content: [
-                            {
-                              _type: 'block',
-                              _key: 'cb0',
-                              children: [
-                                {
-                                  _type: 'span',
-                                  _key: 'cs0',
-                                  text: '',
-                                  marks: [],
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'table',
+                _key: 't0',
+                rows: [
+                  {
+                    _type: 'row',
+                    _key: 'r0',
+                    cells: [
+                      {
+                        _type: 'cell',
+                        _key: 'c0',
+                        content: [
+                          {
+                            _type: 'callout',
+                            _key: 'co0',
+                            content: [
+                              {
+                                _type: 'block',
+                                _key: 'cb0',
+                                children: [
+                                  {
+                                    _type: 'span',
+                                    _key: 'cs0',
+                                    text: '',
+                                    marks: [],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [
           {_key: 't0'},
@@ -307,59 +313,62 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'row',
-              _key: 'r0',
-              cells: [
-                {
-                  _type: 'cell',
-                  _key: 'c0',
-                  content: [
-                    {
-                      _type: 'callout',
-                      _key: 'co0',
-                      content: [
-                        {
-                          _type: 'block',
-                          _key: 'cb0',
-                          children: [
-                            {_type: 'span', _key: 'cs0', text: '', marks: []},
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  _type: 'cell',
-                  _key: 'c1',
-                  content: [
-                    {
-                      _type: 'callout',
-                      _key: 'co1',
-                      content: [
-                        {
-                          _type: 'block',
-                          _key: 'cb1',
-                          children: [
-                            {
-                              _type: 'span',
-                              _key: 'cs1',
-                              text: 'bar',
-                              marks: [],
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'row',
+                _key: 'r0',
+                cells: [
+                  {
+                    _type: 'cell',
+                    _key: 'c0',
+                    content: [
+                      {
+                        _type: 'callout',
+                        _key: 'co0',
+                        content: [
+                          {
+                            _type: 'block',
+                            _key: 'cb0',
+                            children: [
+                              {_type: 'span', _key: 'cs0', text: '', marks: []},
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    _type: 'cell',
+                    _key: 'c1',
+                    content: [
+                      {
+                        _type: 'callout',
+                        _key: 'co1',
+                        content: [
+                          {
+                            _type: 'block',
+                            _key: 'cb1',
+                            children: [
+                              {
+                                _type: 'span',
+                                _key: 'cs1',
+                                text: 'bar',
+                                marks: [],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'r0'}, 'cells', {_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block']),
@@ -393,21 +402,26 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'callout',
-              _key: 'co0',
-              content: [
-                {
-                  _type: 'block',
-                  _key: 'cb0',
-                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'callout',
+                _key: 'co0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'cb0',
+                    children: [
+                      {_type: 'span', _key: 'cs0', text: '', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'co0'}],
         new Set(['block']),
@@ -469,30 +483,33 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'cell',
-              _key: 'c0',
-              content: [
-                {
-                  _type: 'callout',
-                  _key: 'co0',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'cb0',
-                      children: [
-                        {_type: 'span', _key: 'cs0', text: '', marks: []},
-                      ],
-                    },
-                    {_type: 'image', _key: 'im0'},
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'callout',
+                    _key: 'co0',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'cb0',
+                        children: [
+                          {_type: 'span', _key: 'cs0', text: '', marks: []},
+                        ],
+                      },
+                      {_type: 'image', _key: 'im0'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
@@ -552,30 +569,33 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'cell',
-              _key: 'c0',
-              content: [
-                {
-                  _type: 'callout',
-                  _key: 'co0',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'cb0',
-                      children: [
-                        {_type: 'span', _key: 'cs0', text: '', marks: []},
-                      ],
-                    },
-                    {_type: 'image', _key: 'im0'},
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'callout',
+                    _key: 'co0',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'cb0',
+                        children: [
+                          {_type: 'span', _key: 'cs0', text: '', marks: []},
+                        ],
+                      },
+                      {_type: 'image', _key: 'im0'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
@@ -634,30 +654,33 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'cell',
-              _key: 'c0',
-              content: [
-                {
-                  _type: 'callout',
-                  _key: 'co0',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'cb0',
-                      children: [
-                        {_type: 'span', _key: 'cs0', text: '', marks: []},
-                      ],
-                    },
-                    {_type: 'image', _key: 'im0'},
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'callout',
+                    _key: 'co0',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'cb0',
+                        children: [
+                          {_type: 'span', _key: 'cs0', text: '', marks: []},
+                        ],
+                      },
+                      {_type: 'image', _key: 'im0'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
@@ -716,42 +739,45 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'row',
-              _key: 'r0',
-              cells: [
-                {
-                  _type: 'cell',
-                  _key: 'c0',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'b0',
-                      children: [
-                        {_type: 'span', _key: 's0', text: '', marks: []},
-                      ],
-                    },
-                  ],
-                },
-                {
-                  _type: 'cell',
-                  _key: 'c1',
-                  content: [
-                    {
-                      _type: 'block',
-                      _key: 'b1',
-                      children: [
-                        {_type: 'span', _key: 's1', text: 'bar', marks: []},
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'row',
+                _key: 'r0',
+                cells: [
+                  {
+                    _type: 'cell',
+                    _key: 'c0',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'b0',
+                        children: [
+                          {_type: 'span', _key: 's0', text: '', marks: []},
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    _type: 'cell',
+                    _key: 'c1',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'b1',
+                        children: [
+                          {_type: 'span', _key: 's1', text: 'bar', marks: []},
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'r0'}, 'cells', {_key: 'c0'}],
         new Set(['block']),
@@ -832,36 +858,39 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'cell',
-              _key: 'c0',
-              content: [
-                {
-                  _type: 'section',
-                  _key: 'se0',
-                  content: [
-                    {
-                      _type: 'callout',
-                      _key: 'co0',
-                      content: [
-                        {
-                          _type: 'block',
-                          _key: 'cb0',
-                          children: [
-                            {_type: 'span', _key: 'cs0', text: '', marks: []},
-                          ],
-                        },
-                        {_type: 'image', _key: 'im0'},
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'cell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'section',
+                    _key: 'se0',
+                    content: [
+                      {
+                        _type: 'callout',
+                        _key: 'co0',
+                        content: [
+                          {
+                            _type: 'block',
+                            _key: 'cb0',
+                            children: [
+                              {_type: 'span', _key: 'cs0', text: '', marks: []},
+                            ],
+                          },
+                          {_type: 'image', _key: 'im0'},
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'c0'}, 'content', {_key: 'se0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
@@ -901,22 +930,27 @@ describe(getUnwrapTarget.name, () => {
     expect(
       getUnwrapTarget(
         {
-          schema,
-          containers,
-          value: [
-            {
-              _type: 'callout',
-              _key: 'co0',
-              content: [
-                {
-                  _type: 'block',
-                  _key: 'cb0',
-                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
-                },
-                {_type: 'image', _key: 'im0'},
-              ],
-            },
-          ],
+          context: {
+            schema,
+            containers,
+            value: [
+              {
+                _type: 'callout',
+                _key: 'co0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'cb0',
+                    children: [
+                      {_type: 'span', _key: 'cs0', text: '', marks: []},
+                    ],
+                  },
+                  {_type: 'image', _key: 'im0'},
+                ],
+              },
+            ],
+          },
+          blockIndexMap: new Map(),
         },
         [{_key: 'co0'}],
         new Set(['block', 'image']),

--- a/packages/editor/src/internal-utils/get-unwrap-target.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.ts
@@ -1,9 +1,7 @@
-import type {EditorSchema} from '../editor/editor-schema'
 import {getChildren} from '../node-traversal/get-children'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import {getEnclosingContainer} from '../schema/get-enclosing-container'
 import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 
 /**
@@ -24,21 +22,17 @@ import type {Path} from '../slate/interfaces/path'
  * returns `undefined`.
  */
 export function getUnwrapTarget(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   originPath: Path,
   payloadTypes: ReadonlySet<string>,
 ): Path | undefined {
   let current = originPath
 
   while (true) {
-    const enclosing = getEnclosingContainer(context, current)
+    const enclosing = getEnclosingContainer(snapshot, current)
 
     if (!enclosing) {
-      const rootAccepted = getRootAcceptedTypes(context.schema)
+      const rootAccepted = getRootAcceptedTypes(snapshot.context.schema)
       if ([...payloadTypes].every((type) => rootAccepted.has(type))) {
         return current
       }
@@ -50,7 +44,7 @@ export function getUnwrapTarget(
       return current
     }
 
-    if (getChildren(context, enclosing.path).length !== 1) {
+    if (getChildren(snapshot, enclosing.path).length !== 1) {
       return undefined
     }
 

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -28,6 +28,9 @@ const relayActor = createActor(relayMachine)
 
 const e = createEditor()
 e.children = [] as any
+e.schema = schema
+e.containers = new Map()
+e.blockIndexMap = new Map()
 Object.defineProperty(e, 'value', {
   get() {
     return e.children
@@ -207,9 +210,7 @@ describe('operationToPatches', () => {
     editor.onChange()
     expect(
       textPatch(
-        editorActor.getSnapshot().context.schema,
-        editorActor.getSnapshot().context.containers,
-        editor.children,
+        editor,
         {
           type: 'insert_text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
@@ -258,9 +259,14 @@ describe('operationToPatches', () => {
 
     expect(
       textPatch(
-        blockObjectSchema,
-        new Map(),
-        blockObjectChildren,
+        {
+          context: {
+            schema: blockObjectSchema,
+            containers: new Map(),
+            value: blockObjectChildren,
+          },
+          blockIndexMap: new Map(),
+        },
         {
           type: 'insert_text',
           path: [{_key: 'img1'}, 'children', {_key: 'void-child'}],
@@ -277,16 +283,13 @@ describe('operationToPatches', () => {
     ;(before[0] as PortableTextTextBlock).children[2]!.text = '1'
     expect(
       textPatch(
-        editorActor.getSnapshot().context.schema,
-        editorActor.getSnapshot().context.containers,
-        editor.children,
+        editor,
         {
           type: 'remove_text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
           text: '1',
           offset: 1,
         },
-
         before,
       ),
     ).toMatchInlineSnapshot(`

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -5,9 +5,8 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
 import {getSpanNode} from '../node-traversal/get-span-node'
-import type {ResolvedContainers} from '../schema/resolve-containers'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {
   InsertOperation,
@@ -15,35 +14,24 @@ import type {
   RemoveTextOperation,
 } from '../slate/interfaces/operation'
 
-function spanContext(
-  schema: EditorSchema,
-  containers: ResolvedContainers,
-  value: Array<Node>,
-) {
-  return {
-    context: {schema, containers, value},
-    blockIndexMap: new Map<string, number>(),
-  }
-}
-
 export function textPatch(
-  schema: EditorSchema,
-  containers: ResolvedContainers,
-  children: Node[],
+  snapshot: TraversalSnapshot,
   operation: InsertTextOperation | RemoveTextOperation,
   beforeValue: Array<PortableTextBlock>,
 ): Array<Patch> {
-  const span = getSpanNode(
-    spanContext(schema, containers, children),
-    operation.path,
-  )
+  const span = getSpanNode(snapshot, operation.path)
   if (!span) {
     return []
   }
-  const prevSpan = getSpanNode(
-    spanContext(schema, containers, beforeValue as Array<Node>),
-    operation.path,
-  )
+  const beforeSnapshot: TraversalSnapshot = {
+    context: {
+      schema: snapshot.context.schema,
+      containers: snapshot.context.containers,
+      value: beforeValue as Array<Node>,
+    },
+    blockIndexMap: new Map(),
+  }
+  const prevSpan = getSpanNode(beforeSnapshot, operation.path)
   const patch = diffMatchPatch(prevSpan?.node.text ?? '', span.node.text, [
     ...operation.path,
     'text',

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -19,12 +19,11 @@ function spanContext(
   schema: EditorSchema,
   containers: ResolvedContainers,
   value: Array<Node>,
-): {
-  schema: EditorSchema
-  containers: ResolvedContainers
-  value: Array<Node>
-} {
-  return {schema, containers, value}
+) {
+  return {
+    context: {schema, containers, value},
+    blockIndexMap: new Map<string, number>(),
+  }
 }
 
 export function textPatch(

--- a/packages/editor/src/internal-utils/transform-operation.ts
+++ b/packages/editor/src/internal-utils/transform-operation.ts
@@ -6,6 +6,7 @@ import {
   parsePatch,
 } from '@sanity/diff-match-patch'
 import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
 import type {Path} from '../slate/interfaces/path'
@@ -27,11 +28,7 @@ export function transformOperation(
   patch: Patch,
   operation: Operation,
 ): Operation[] {
-  const context = {
-    schema: editor.schema,
-    containers: editor.containers,
-    value: editor.children,
-  }
+  const snapshot: TraversalSnapshot = editor
   const transformedOperation = {...operation}
 
   if (patch.type === 'insert') {
@@ -69,11 +66,11 @@ export function transformOperation(
 
   if (patch.type === 'diffMatchPatch') {
     const operationTargetBlock = findOperationTargetBlock(
-      context,
+      snapshot,
       editor,
       transformedOperation,
     )
-    const patchTargetBlock = getEnclosingBlock(context, patch.path)
+    const patchTargetBlock = getEnclosingBlock(snapshot, patch.path)
     if (
       !operationTargetBlock ||
       !patchTargetBlock ||
@@ -158,20 +155,16 @@ export function transformOperation(
 }
 
 function findOperationTargetBlock(
-  context: {
-    schema: PortableTextSlateEditor['schema']
-    containers: PortableTextSlateEditor['containers']
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   editor: PortableTextSlateEditor,
   operation: Operation,
 ): Node | undefined {
   if (operation.type === 'set_selection' && editor.selection) {
-    const block = getEnclosingBlock(context, editor.selection.focus.path)
+    const block = getEnclosingBlock(snapshot, editor.selection.focus.path)
     return block?.node
   }
   if ('path' in operation) {
-    const block = getEnclosingBlock(context, operation.path)
+    const block = getEnclosingBlock(snapshot, operation.path)
     return block?.node
   }
   return undefined

--- a/packages/editor/src/internal-utils/unset-matched-in-range.ts
+++ b/packages/editor/src/internal-utils/unset-matched-in-range.ts
@@ -22,7 +22,11 @@ export function unsetMatchedNodesInRange(
 ): void {
   const candidates: Array<{node: Node; path: Path}> = []
 
-  for (const entry of getNodes(editor, {from, to, match: predicate})) {
+  for (const entry of getNodes(editor, {
+    from,
+    to,
+    match: predicate,
+  })) {
     candidates.push(entry)
   }
 

--- a/packages/editor/src/node-traversal/find-sibling.ts
+++ b/packages/editor/src/node-traversal/find-sibling.ts
@@ -1,10 +1,9 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Walk siblings of the node at the given path in a direction, returning the
@@ -14,11 +13,7 @@ import {getChildren} from './get-children'
  * narrowed accordingly.
  */
 export function findSibling<TNode extends Node = Node>(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   direction: 'next' | 'previous',
   match: (entry: {
@@ -27,21 +22,13 @@ export function findSibling<TNode extends Node = Node>(
   }) => entry is {node: TNode; path: Path},
 ): {node: TNode; path: Path} | undefined
 export function findSibling(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   direction: 'next' | 'previous',
   match: (entry: {node: Node; path: Path}) => boolean,
 ): {node: Node; path: Path} | undefined
 export function findSibling(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   direction: 'next' | 'previous',
   match: (entry: {node: Node; path: Path}) => boolean,
@@ -57,7 +44,7 @@ export function findSibling(
   }
 
   const parent = parentPath(path)
-  const children = getChildren(context, parent)
+  const children = getChildren(snapshot, parent)
   const currentIndex = children.findIndex(
     (child) => child.node._key === lastSegment._key,
   )

--- a/packages/editor/src/node-traversal/get-ancestor-object-node.ts
+++ b/packages/editor/src/node-traversal/get-ancestor-object-node.ts
@@ -1,26 +1,20 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {getAncestor} from './get-ancestor'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 export function getAncestorObjectNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextObject; path: Path} | undefined {
-  const result = getAncestor(context, path, (node) =>
-    isObjectNode({schema: context.schema}, node),
+  const result = getAncestor(snapshot, path, (node) =>
+    isObjectNode({schema: snapshot.context.schema}, node),
   )
   if (!result) {
     return undefined
   }
-  if (!isObjectNode({schema: context.schema}, result.node)) {
+  if (!isObjectNode({schema: snapshot.context.schema}, result.node)) {
     return undefined
   }
   return {node: result.node, path: result.path}

--- a/packages/editor/src/node-traversal/get-ancestor-text-block.ts
+++ b/packages/editor/src/node-traversal/get-ancestor-text-block.ts
@@ -1,26 +1,20 @@
 import type {PortableTextTextBlock} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestor} from './get-ancestor'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 export function getAncestorTextBlock(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextTextBlock; path: Path} | undefined {
-  const result = getAncestor(context, path, (node) =>
-    isTextBlock({schema: context.schema}, node),
+  const result = getAncestor(snapshot, path, (node) =>
+    isTextBlock({schema: snapshot.context.schema}, node),
   )
   if (!result) {
     return undefined
   }
-  if (!isTextBlock({schema: context.schema}, result.node)) {
+  if (!isTextBlock({schema: snapshot.context.schema}, result.node)) {
     return undefined
   }
   return {node: result.node, path: result.path}

--- a/packages/editor/src/node-traversal/get-ancestor.test.ts
+++ b/packages/editor/src/node-traversal/get-ancestor.test.ts
@@ -9,18 +9,18 @@ describe(getAncestor.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('empty path returns undefined', () => {
-    expect(getAncestor(testbed.context, [], () => true)).toBeUndefined()
+    expect(getAncestor(testbed.snapshot, [], () => true)).toBeUndefined()
   })
 
   test('top-level block returns undefined', () => {
     expect(
-      getAncestor(testbed.context, [{_key: 'k3'}], () => true),
+      getAncestor(testbed.snapshot, [{_key: 'k3'}], () => true),
     ).toBeUndefined()
   })
 
   test('find text block ancestor of span', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k3'}, 'children', {_key: 'k0'}],
       (node) => isTextBlock({schema: testbed.schema}, node),
     )
@@ -30,7 +30,7 @@ describe(getAncestor.name, () => {
 
   test('find text block ancestor of span in cell', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -58,7 +58,7 @@ describe(getAncestor.name, () => {
 
   test('find cell ancestor of span in cell', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -84,7 +84,7 @@ describe(getAncestor.name, () => {
 
   test('find row ancestor of span in cell', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -104,7 +104,7 @@ describe(getAncestor.name, () => {
 
   test('find table ancestor of span in cell', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -125,7 +125,7 @@ describe(getAncestor.name, () => {
   test('no matching ancestor returns undefined', () => {
     expect(
       getAncestor(
-        testbed.context,
+        testbed.snapshot,
         [{_key: 'k3'}, 'children', {_key: 'k0'}],
         (node) => node._type === 'table',
       ),
@@ -134,7 +134,7 @@ describe(getAncestor.name, () => {
 
   test('match receives path', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -159,7 +159,7 @@ describe(getAncestor.name, () => {
   test('does not check the node itself', () => {
     expect(
       getAncestor(
-        testbed.context,
+        testbed.snapshot,
         [
           {_key: 'k26'},
           'rows',
@@ -178,7 +178,7 @@ describe(getAncestor.name, () => {
 
   test('find code block ancestor of code span', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k11'}, 'code', {_key: 'k8'}, 'children', {_key: 'k7'}],
       (node) => node._type === 'code-block',
     )
@@ -188,7 +188,7 @@ describe(getAncestor.name, () => {
 
   test('returns nearest matching ancestor', () => {
     const entry = getAncestor(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',

--- a/packages/editor/src/node-traversal/get-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-ancestor.ts
@@ -1,8 +1,7 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestors} from './get-ancestors'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Find the first ancestor of the node at a given path that matches a predicate.
@@ -11,33 +10,21 @@ import {getAncestors} from './get-ancestors'
  * When `match` is a type predicate, the returned `node` narrows to that type.
  */
 export function getAncestor<TMatch extends Node>(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   match: (node: Node, path: Path) => node is TMatch,
 ): {node: TMatch; path: Path} | undefined
 export function getAncestor(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   match: (node: Node, path: Path) => boolean,
 ): {node: Node; path: Path} | undefined
 export function getAncestor(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   match: (node: Node, path: Path) => boolean,
 ): {node: Node; path: Path} | undefined {
-  const ancestors = getAncestors(context, path)
+  const ancestors = getAncestors(snapshot, path)
 
   for (const ancestor of ancestors) {
     if (match(ancestor.node, ancestor.path)) {

--- a/packages/editor/src/node-traversal/get-ancestors.test.ts
+++ b/packages/editor/src/node-traversal/get-ancestors.test.ts
@@ -6,15 +6,15 @@ describe(getAncestors.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('empty path returns empty array', () => {
-    expect(getAncestors(testbed.context, [])).toEqual([])
+    expect(getAncestors(testbed.snapshot, [])).toEqual([])
   })
 
   test('top-level block has no ancestors', () => {
-    expect(getAncestors(testbed.context, [{_key: 'k3'}])).toEqual([])
+    expect(getAncestors(testbed.snapshot, [{_key: 'k3'}])).toEqual([])
   })
 
   test('span in text block has one ancestor', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k3'},
       'children',
       {_key: 'k1'},
@@ -25,7 +25,7 @@ describe(getAncestors.name, () => {
   })
 
   test('span in cell block has four ancestors', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -66,7 +66,7 @@ describe(getAncestors.name, () => {
   })
 
   test('block in cell has three ancestors', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -95,7 +95,7 @@ describe(getAncestors.name, () => {
   })
 
   test('cell has two ancestors', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -114,7 +114,7 @@ describe(getAncestors.name, () => {
   })
 
   test('row has one ancestor', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -125,7 +125,7 @@ describe(getAncestors.name, () => {
   })
 
   test('code span has two ancestors', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k8'},
@@ -140,7 +140,7 @@ describe(getAncestors.name, () => {
   })
 
   test('code line has one ancestor', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k8'},
@@ -151,7 +151,7 @@ describe(getAncestors.name, () => {
   })
 
   test('ancestors are ordered from nearest to furthest', () => {
-    const ancestors = getAncestors(testbed.context, [
+    const ancestors = getAncestors(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},

--- a/packages/editor/src/node-traversal/get-ancestors.ts
+++ b/packages/editor/src/node-traversal/get-ancestors.ts
@@ -1,9 +1,8 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get all ancestors of the node at a given path, from nearest to furthest.
@@ -14,11 +13,7 @@ import {getNode} from './get-node'
  *   [{_key:'t1'}]
  */
 export function getAncestors(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): Array<{node: Node; path: Path}> {
   const keyedIndices: Array<number> = []
@@ -45,7 +40,7 @@ export function getAncestors(
     }
 
     const ancestorPath = path.slice(0, endIndex + 1)
-    const entry = getNode(context, ancestorPath)
+    const entry = getNode(snapshot, ancestorPath)
 
     if (entry) {
       ancestors.push(entry)

--- a/packages/editor/src/node-traversal/get-children.test.ts
+++ b/packages/editor/src/node-traversal/get-children.test.ts
@@ -11,7 +11,7 @@ describe(getChildren.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('root children', () => {
-    expect(getChildren(testbed.context, [])).toEqual([
+    expect(getChildren(testbed.snapshot, [])).toEqual([
       {node: testbed.textBlock1, path: [{_key: 'k3'}]},
       {node: testbed.image, path: [{_key: 'k4'}]},
       {node: testbed.textBlock2, path: [{_key: 'k6'}]},
@@ -21,7 +21,7 @@ describe(getChildren.name, () => {
   })
 
   test('text block children', () => {
-    expect(getChildren(testbed.context, [{_key: 'k3'}])).toEqual([
+    expect(getChildren(testbed.snapshot, [{_key: 'k3'}])).toEqual([
       {node: testbed.span1, path: [{_key: 'k3'}, 'children', {_key: 'k0'}]},
       {
         node: testbed.stockTicker1,
@@ -32,7 +32,7 @@ describe(getChildren.name, () => {
   })
 
   test('code block children (code lines)', () => {
-    expect(getChildren(testbed.context, [{_key: 'k11'}])).toEqual([
+    expect(getChildren(testbed.snapshot, [{_key: 'k11'}])).toEqual([
       {node: testbed.codeLine1, path: [{_key: 'k11'}, 'code', {_key: 'k8'}]},
       {node: testbed.codeLine2, path: [{_key: 'k11'}, 'code', {_key: 'k10'}]},
     ])
@@ -40,7 +40,7 @@ describe(getChildren.name, () => {
 
   test('code line children', () => {
     expect(
-      getChildren(testbed.context, [{_key: 'k11'}, 'code', {_key: 'k8'}]),
+      getChildren(testbed.snapshot, [{_key: 'k11'}, 'code', {_key: 'k8'}]),
     ).toEqual([
       {
         node: testbed.codeSpan1,
@@ -50,7 +50,7 @@ describe(getChildren.name, () => {
   })
 
   test('table children (rows)', () => {
-    expect(getChildren(testbed.context, [{_key: 'k26'}])).toEqual([
+    expect(getChildren(testbed.snapshot, [{_key: 'k26'}])).toEqual([
       {node: testbed.row1, path: [{_key: 'k26'}, 'rows', {_key: 'k21'}]},
       {node: testbed.row2, path: [{_key: 'k26'}, 'rows', {_key: 'k25'}]},
     ])
@@ -58,7 +58,7 @@ describe(getChildren.name, () => {
 
   test('row children (cells)', () => {
     expect(
-      getChildren(testbed.context, [{_key: 'k26'}, 'rows', {_key: 'k21'}]),
+      getChildren(testbed.snapshot, [{_key: 'k26'}, 'rows', {_key: 'k21'}]),
     ).toEqual([
       {
         node: testbed.cell1,
@@ -73,7 +73,7 @@ describe(getChildren.name, () => {
 
   test('cell with multiple blocks', () => {
     expect(
-      getChildren(testbed.context, [
+      getChildren(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -110,7 +110,7 @@ describe(getChildren.name, () => {
 
   test('block inside cell children', () => {
     expect(
-      getChildren(testbed.context, [
+      getChildren(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -153,16 +153,16 @@ describe(getChildren.name, () => {
 
   test('leaf node returns empty array', () => {
     expect(
-      getChildren(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
+      getChildren(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
     ).toEqual([])
   })
 
   test('block object without children returns empty array', () => {
-    expect(getChildren(testbed.context, [{_key: 'k4'}])).toEqual([])
+    expect(getChildren(testbed.snapshot, [{_key: 'k4'}])).toEqual([])
   })
 
   test('invalid path returns empty array', () => {
-    expect(getChildren(testbed.context, [{_key: 'nonexistent'}])).toEqual([])
+    expect(getChildren(testbed.snapshot, [{_key: 'nonexistent'}])).toEqual([])
   })
 
   test('non-editable code block returns empty array', () => {
@@ -171,7 +171,13 @@ describe(getChildren.name, () => {
       tableContainers,
     )
     expect(
-      getChildren({...testbed.context, containers: tableOnly}, [{_key: 'k11'}]),
+      getChildren(
+        {
+          ...testbed.snapshot,
+          context: {...testbed.snapshot.context, containers: tableOnly},
+        },
+        [{_key: 'k11'}],
+      ),
     ).toEqual([])
   })
 
@@ -180,7 +186,13 @@ describe(getChildren.name, () => {
       codeBlockContainer,
     ])
     expect(
-      getChildren({...testbed.context, containers: codeOnly}, [{_key: 'k26'}]),
+      getChildren(
+        {
+          ...testbed.snapshot,
+          context: {...testbed.snapshot.context, containers: codeOnly},
+        },
+        [{_key: 'k26'}],
+      ),
     ).toEqual([])
   })
 })

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -15,40 +15,11 @@ export function getChildren(
   snapshot: TraversalSnapshot,
   path: Path,
 ): Array<{node: Node; path: Path}> {
-  const traversalContext = {
-    schema: snapshot.context.schema,
-    containers: snapshot.context.containers,
-  }
-  return getChildrenInternal(
-    traversalContext,
-    {value: snapshot.context.value},
-    path,
-  )
-}
-
-export function getChildrenInternal(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-  },
-  root: Node | {value: Array<Node>},
-  path: Path,
-): Array<{node: Node; path: Path}> {
-  const rootChildren = getNodeChildren(context, root, '')
-
-  if (!rootChildren) {
-    return []
-  }
-
-  let currentChildren = rootChildren.children
-  let scopePath = rootChildren.scopePath
-  let currentFieldName = rootChildren.fieldName
+  let currentChildren: Array<Node> = snapshot.context.value
+  let scopePath = ''
+  let currentFieldName = 'value'
   let currentPath: Path = []
-  // The editor root wrapper ({value: [...]}) is not a real node, so its field
-  // name is not part of paths. Block paths start with [{_key: 'blockKey'}],
-  // not ['value', {_key: 'blockKey'}]. But for standalone nodes (e.g., a text
-  // block passed to getNodeDescendants), the field name IS part of the path.
-  let isRoot = !('_key' in root) && !('_type' in root)
+  let isRoot = true
 
   for (const segment of path) {
     if (typeof segment === 'string') {
@@ -56,7 +27,6 @@ export function getChildrenInternal(
     }
 
     let node: Node | undefined
-
     if (isKeyedSegment(segment)) {
       node = currentChildren.find((child) => child._key === segment._key)
     } else if (typeof segment === 'number') {
@@ -72,7 +42,7 @@ export function getChildrenInternal(
       : [...currentPath, currentFieldName, {_key: node._key}]
     isRoot = false
 
-    const next = getNodeChildren(context, node, scopePath)
+    const next = getNodeChildren(snapshot.context, node, scopePath)
 
     if (!next) {
       return []

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -6,23 +6,24 @@ import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the children of a node at a given path.
  */
 export function getChildren(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): Array<{node: Node; path: Path}> {
   const traversalContext = {
-    schema: context.schema,
-    containers: context.containers,
+    schema: snapshot.context.schema,
+    containers: snapshot.context.containers,
   }
-  return getChildrenInternal(traversalContext, {value: context.value}, path)
+  return getChildrenInternal(
+    traversalContext,
+    {value: snapshot.context.value},
+    path,
+  )
 }
 
 export function getChildrenInternal(

--- a/packages/editor/src/node-traversal/get-enclosing-block.ts
+++ b/packages/editor/src/node-traversal/get-enclosing-block.ts
@@ -1,10 +1,8 @@
 import type {PortableTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getAncestors} from './get-ancestors'
 import {getBlock, isBlock} from './is-block'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Walk up from a path to find the nearest enclosing block.
@@ -14,22 +12,18 @@ import {getBlock, isBlock} from './is-block'
  * container-internal block, not the outer container.
  */
 export function getEnclosingBlock(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextBlock; path: Path} | undefined {
-  const direct = getBlock(context, path)
+  const direct = getBlock(snapshot, path)
 
   if (direct) {
     return direct
   }
 
-  for (const ancestor of getAncestors(context, path)) {
-    if (isBlock(context, ancestor.path)) {
-      const block = getBlock(context, ancestor.path)
+  for (const ancestor of getAncestors(snapshot, path)) {
+    if (isBlock(snapshot, ancestor.path)) {
+      const block = getBlock(snapshot, ancestor.path)
 
       if (block) {
         return block

--- a/packages/editor/src/node-traversal/get-first-child.test.ts
+++ b/packages/editor/src/node-traversal/get-first-child.test.ts
@@ -10,28 +10,28 @@ describe(getFirstChild.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('first descendant from root', () => {
-    expect(getFirstChild(testbed.context, [])).toEqual({
+    expect(getFirstChild(testbed.snapshot, [])).toEqual({
       node: testbed.textBlock1,
       path: [{_key: 'k3'}],
     })
   })
 
   test('first descendant of text block', () => {
-    expect(getFirstChild(testbed.context, [{_key: 'k3'}])).toEqual({
+    expect(getFirstChild(testbed.snapshot, [{_key: 'k3'}])).toEqual({
       node: testbed.span1,
       path: [{_key: 'k3'}, 'children', {_key: 'k0'}],
     })
   })
 
   test('first descendant of code block', () => {
-    expect(getFirstChild(testbed.context, [{_key: 'k11'}])).toEqual({
+    expect(getFirstChild(testbed.snapshot, [{_key: 'k11'}])).toEqual({
       node: testbed.codeLine1,
       path: [{_key: 'k11'}, 'code', {_key: 'k8'}],
     })
   })
 
   test('first descendant of table', () => {
-    expect(getFirstChild(testbed.context, [{_key: 'k26'}])).toEqual({
+    expect(getFirstChild(testbed.snapshot, [{_key: 'k26'}])).toEqual({
       node: testbed.row1,
       path: [{_key: 'k26'}, 'rows', {_key: 'k21'}],
     })
@@ -39,17 +39,17 @@ describe(getFirstChild.name, () => {
 
   test('leaf node returns undefined', () => {
     expect(
-      getFirstChild(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
+      getFirstChild(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
     ).toBeUndefined()
   })
 
   test('void block object returns undefined', () => {
-    expect(getFirstChild(testbed.context, [{_key: 'k4'}])).toBeUndefined()
+    expect(getFirstChild(testbed.snapshot, [{_key: 'k4'}])).toBeUndefined()
   })
 
   test('invalid path returns undefined', () => {
     expect(
-      getFirstChild(testbed.context, [{_key: 'nonexistent'}]),
+      getFirstChild(testbed.snapshot, [{_key: 'nonexistent'}]),
     ).toBeUndefined()
   })
 
@@ -59,9 +59,13 @@ describe(getFirstChild.name, () => {
       tableContainers,
     )
     expect(
-      getFirstChild({...testbed.context, containers: tableOnly}, [
-        {_key: 'k11'},
-      ]),
+      getFirstChild(
+        {
+          ...testbed.snapshot,
+          context: {...testbed.snapshot.context, containers: tableOnly},
+        },
+        [{_key: 'k11'}],
+      ),
     ).toBeUndefined()
   })
 })

--- a/packages/editor/src/node-traversal/get-first-child.ts
+++ b/packages/editor/src/node-traversal/get-first-child.ts
@@ -1,19 +1,14 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the first child of a node at a given path.
  */
 export function getFirstChild(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: Node; path: Path} | undefined {
-  return getChildren(context, path).at(0)
+  return getChildren(snapshot, path).at(0)
 }

--- a/packages/editor/src/node-traversal/get-highest-object-node.test.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.test.ts
@@ -6,18 +6,18 @@ describe(getHighestObjectNode.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('empty path returns undefined', () => {
-    expect(getHighestObjectNode(testbed.context, [])).toBeUndefined()
+    expect(getHighestObjectNode(testbed.snapshot, [])).toBeUndefined()
   })
 
   test('text block returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [{_key: 'k3'}]),
+      getHighestObjectNode(testbed.snapshot, [{_key: 'k3'}]),
     ).toBeUndefined()
   })
 
   test('span returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k3'},
         'children',
         {_key: 'k0'},
@@ -26,13 +26,13 @@ describe(getHighestObjectNode.name, () => {
   })
 
   test('block object at path returns itself', () => {
-    const entry = getHighestObjectNode(testbed.context, [{_key: 'k4'}])
+    const entry = getHighestObjectNode(testbed.snapshot, [{_key: 'k4'}])
     expect(entry?.node).toBe(testbed.image)
     expect(entry?.path).toEqual([{_key: 'k4'}])
   })
 
   test('inline object at path returns itself', () => {
-    const entry = getHighestObjectNode(testbed.context, [
+    const entry = getHighestObjectNode(testbed.snapshot, [
       {_key: 'k3'},
       'children',
       {_key: 'k1'},
@@ -43,13 +43,13 @@ describe(getHighestObjectNode.name, () => {
 
   test('editable container at path returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [{_key: 'k26'}]),
+      getHighestObjectNode(testbed.snapshot, [{_key: 'k26'}]),
     ).toBeUndefined()
   })
 
   test('span inside cell returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -65,7 +65,7 @@ describe(getHighestObjectNode.name, () => {
 
   test('cell block returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -79,7 +79,7 @@ describe(getHighestObjectNode.name, () => {
 
   test('cell returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -91,7 +91,7 @@ describe(getHighestObjectNode.name, () => {
 
   test('row returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -101,7 +101,7 @@ describe(getHighestObjectNode.name, () => {
 
   test('code span returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [
+      getHighestObjectNode(testbed.snapshot, [
         {_key: 'k11'},
         'code',
         {_key: 'k8'},
@@ -112,7 +112,7 @@ describe(getHighestObjectNode.name, () => {
   })
 
   test('inline object in cell returns itself', () => {
-    const entry = getHighestObjectNode(testbed.context, [
+    const entry = getHighestObjectNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -139,7 +139,7 @@ describe(getHighestObjectNode.name, () => {
 
   test('invalid path returns undefined', () => {
     expect(
-      getHighestObjectNode(testbed.context, [{_key: 'nonexistent'}]),
+      getHighestObjectNode(testbed.snapshot, [{_key: 'nonexistent'}]),
     ).toBeUndefined()
   })
 })

--- a/packages/editor/src/node-traversal/get-highest-object-node.ts
+++ b/packages/editor/src/node-traversal/get-highest-object-node.ts
@@ -1,11 +1,9 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isVoidNode} from '../slate/node/is-void-node'
 import {getAncestors} from './get-ancestors'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Find the highest (closest to root) object node at or above the given path.
@@ -14,15 +12,11 @@ import {getNode} from './get-node'
  * found. If no ancestor is an object node, checks the node at the path itself.
  */
 export function getHighestObjectNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextObject; path: Path} | undefined {
   // Walk ancestors from furthest (root) to nearest, return the first object node
-  const ancestors = getAncestors(context, path)
+  const ancestors = getAncestors(snapshot, path)
 
   for (let i = ancestors.length - 1; i >= 0; i--) {
     const ancestor = ancestors[i]
@@ -31,19 +25,19 @@ export function getHighestObjectNode(
       continue
     }
 
-    if (isVoidNode(context, ancestor.node, ancestor.path)) {
+    if (isVoidNode(snapshot, ancestor.node, ancestor.path)) {
       return {node: ancestor.node, path: ancestor.path}
     }
   }
 
   // No ancestor is an object node - check the node at the path itself
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
   if (!entry) {
     return undefined
   }
 
-  if (!isVoidNode(context, entry.node, entry.path)) {
+  if (!isVoidNode(snapshot, entry.node, entry.path)) {
     return undefined
   }
 

--- a/packages/editor/src/node-traversal/get-inline.ts
+++ b/packages/editor/src/node-traversal/get-inline.ts
@@ -1,12 +1,10 @@
 import type {PortableTextObject, PortableTextSpan} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {isSpanNode} from '../slate/node/is-span-node'
 import {getNode} from './get-node'
 import {isInline} from './is-inline'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the node at the given path if it is inline (a span or inline object).
@@ -16,22 +14,18 @@ import {isInline} from './is-inline'
  * doesn't exist or is not inline.
  */
 export function getInline(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextSpan | PortableTextObject; path: Path} | undefined {
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
-  if (!entry || !isInline(context, path)) {
+  if (!entry || !isInline(snapshot, path)) {
     return undefined
   }
 
   if (
-    !isSpanNode({schema: context.schema}, entry.node) &&
-    !isObjectNode({schema: context.schema}, entry.node)
+    !isSpanNode({schema: snapshot.context.schema}, entry.node) &&
+    !isObjectNode({schema: snapshot.context.schema}, entry.node)
   ) {
     return undefined
   }

--- a/packages/editor/src/node-traversal/get-last-child.test.ts
+++ b/packages/editor/src/node-traversal/get-last-child.test.ts
@@ -10,28 +10,28 @@ describe(getLastChild.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('last descendant from root', () => {
-    expect(getLastChild(testbed.context, [])).toEqual({
+    expect(getLastChild(testbed.snapshot, [])).toEqual({
       node: testbed.table,
       path: [{_key: 'k26'}],
     })
   })
 
   test('last descendant of text block', () => {
-    expect(getLastChild(testbed.context, [{_key: 'k3'}])).toEqual({
+    expect(getLastChild(testbed.snapshot, [{_key: 'k3'}])).toEqual({
       node: testbed.span2,
       path: [{_key: 'k3'}, 'children', {_key: 'k2'}],
     })
   })
 
   test('last descendant of code block', () => {
-    expect(getLastChild(testbed.context, [{_key: 'k11'}])).toEqual({
+    expect(getLastChild(testbed.snapshot, [{_key: 'k11'}])).toEqual({
       node: testbed.codeLine2,
       path: [{_key: 'k11'}, 'code', {_key: 'k10'}],
     })
   })
 
   test('last descendant of table', () => {
-    expect(getLastChild(testbed.context, [{_key: 'k26'}])).toEqual({
+    expect(getLastChild(testbed.snapshot, [{_key: 'k26'}])).toEqual({
       node: testbed.row2,
       path: [{_key: 'k26'}, 'rows', {_key: 'k25'}],
     })
@@ -39,17 +39,17 @@ describe(getLastChild.name, () => {
 
   test('leaf node returns undefined', () => {
     expect(
-      getLastChild(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
+      getLastChild(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
     ).toBeUndefined()
   })
 
   test('void block object returns undefined', () => {
-    expect(getLastChild(testbed.context, [{_key: 'k4'}])).toBeUndefined()
+    expect(getLastChild(testbed.snapshot, [{_key: 'k4'}])).toBeUndefined()
   })
 
   test('invalid path returns undefined', () => {
     expect(
-      getLastChild(testbed.context, [{_key: 'nonexistent'}]),
+      getLastChild(testbed.snapshot, [{_key: 'nonexistent'}]),
     ).toBeUndefined()
   })
 
@@ -59,9 +59,13 @@ describe(getLastChild.name, () => {
       tableContainers,
     )
     expect(
-      getLastChild({...testbed.context, containers: tableOnly}, [
-        {_key: 'k11'},
-      ]),
+      getLastChild(
+        {
+          ...testbed.snapshot,
+          context: {...testbed.snapshot.context, containers: tableOnly},
+        },
+        [{_key: 'k11'}],
+      ),
     ).toBeUndefined()
   })
 })

--- a/packages/editor/src/node-traversal/get-last-child.ts
+++ b/packages/editor/src/node-traversal/get-last-child.ts
@@ -1,21 +1,16 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the last child of a node at a given path.
  */
 export function getLastChild(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: Node; path: Path} | undefined {
-  const children = getChildren(context, path)
+  const children = getChildren(snapshot, path)
 
   return children.at(-1)
 }

--- a/packages/editor/src/node-traversal/get-leaf.test.ts
+++ b/packages/editor/src/node-traversal/get-leaf.test.ts
@@ -6,13 +6,13 @@ describe(getLeaf.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('first leaf from root (start edge)', () => {
-    const entry = getLeaf(testbed.context, [], {edge: 'start'})
+    const entry = getLeaf(testbed.snapshot, [], {edge: 'start'})
     expect(entry?.node).toBe(testbed.span1)
     expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k0'}])
   })
 
   test('last leaf from root (end edge)', () => {
-    const entry = getLeaf(testbed.context, [], {edge: 'end'})
+    const entry = getLeaf(testbed.snapshot, [], {edge: 'end'})
     expect(entry?.node).toBe(testbed.emptySpan)
     expect(entry?.path).toEqual([
       {_key: 'k26'},
@@ -28,20 +28,20 @@ describe(getLeaf.name, () => {
   })
 
   test('first leaf from text block', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k3'}], {edge: 'start'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k3'}], {edge: 'start'})
     expect(entry?.node).toBe(testbed.span1)
     expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k0'}])
   })
 
   test('last leaf from text block', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k3'}], {edge: 'end'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k3'}], {edge: 'end'})
     expect(entry?.node).toBe(testbed.span2)
     expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k2'}])
   })
 
   test('span is already a leaf', () => {
     const entry = getLeaf(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k3'}, 'children', {_key: 'k0'}],
       {edge: 'start'},
     )
@@ -50,14 +50,14 @@ describe(getLeaf.name, () => {
   })
 
   test('void block object is a leaf', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k4'}], {edge: 'start'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k4'}], {edge: 'start'})
     expect(entry?.node).toBe(testbed.image)
     expect(entry?.path).toEqual([{_key: 'k4'}])
   })
 
   test('inline object is a leaf', () => {
     const entry = getLeaf(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k3'}, 'children', {_key: 'k1'}],
       {edge: 'start'},
     )
@@ -67,8 +67,8 @@ describe(getLeaf.name, () => {
 
   test('empty document returns undefined', () => {
     const emptyContext = {
-      ...testbed.context,
-      value: [],
+      ...testbed.snapshot,
+      context: {...testbed.snapshot.context, value: []},
     }
     expect(getLeaf(emptyContext, [], {edge: 'start'})).toBeUndefined()
     expect(getLeaf(emptyContext, [], {edge: 'end'})).toBeUndefined()
@@ -76,11 +76,11 @@ describe(getLeaf.name, () => {
 
   test('invalid path returns undefined', () => {
     expect(
-      getLeaf(testbed.context, [{_key: 'nonexistent'}], {edge: 'start'}),
+      getLeaf(testbed.snapshot, [{_key: 'nonexistent'}], {edge: 'start'}),
     ).toBeUndefined()
     expect(
       getLeaf(
-        testbed.context,
+        testbed.snapshot,
         [{_key: 'k3'}, 'children', {_key: 'nonexistent'}],
         {edge: 'end'},
       ),
@@ -88,7 +88,7 @@ describe(getLeaf.name, () => {
   })
 
   test('first leaf from code block', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k11'}], {edge: 'start'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k11'}], {edge: 'start'})
     expect(entry?.node).toBe(testbed.codeSpan1)
     expect(entry?.path).toEqual([
       {_key: 'k11'},
@@ -100,7 +100,7 @@ describe(getLeaf.name, () => {
   })
 
   test('last leaf from code block', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k11'}], {edge: 'end'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k11'}], {edge: 'end'})
     expect(entry?.node).toBe(testbed.codeSpan2)
     expect(entry?.path).toEqual([
       {_key: 'k11'},
@@ -112,7 +112,7 @@ describe(getLeaf.name, () => {
   })
 
   test('first leaf from table', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k26'}], {edge: 'start'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k26'}], {edge: 'start'})
     expect(entry?.node).toBe(testbed.cellSpan1)
     expect(entry?.path).toEqual([
       {_key: 'k26'},
@@ -128,7 +128,7 @@ describe(getLeaf.name, () => {
   })
 
   test('last leaf from table', () => {
-    const entry = getLeaf(testbed.context, [{_key: 'k26'}], {edge: 'end'})
+    const entry = getLeaf(testbed.snapshot, [{_key: 'k26'}], {edge: 'end'})
     expect(entry?.node).toBe(testbed.emptySpan)
     expect(entry?.path).toEqual([
       {_key: 'k26'},

--- a/packages/editor/src/node-traversal/get-leaf.ts
+++ b/packages/editor/src/node-traversal/get-leaf.ts
@@ -1,9 +1,8 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getChildren} from './get-children'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the deepest leaf node starting from a path, walking toward either the
@@ -11,11 +10,7 @@ import {getNode} from './get-node'
  * traversal context.
  */
 export function getLeaf(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   options: {edge: 'start' | 'end'},
 ): {node: Node; path: Path} | undefined {
@@ -25,23 +20,23 @@ export function getLeaf(
 
   // If starting from root (empty path), descend into first/last child
   if (currentPath.length === 0) {
-    const children = getChildren(context, [])
+    const children = getChildren(snapshot, [])
     if (children.length === 0) {
       return undefined
     }
     const firstOrLast = edge === 'end' ? children.at(-1)! : children.at(0)!
-    const nodeChildren = getChildren(context, firstOrLast.path)
+    const nodeChildren = getChildren(snapshot, firstOrLast.path)
     if (nodeChildren.length === 0) {
       return firstOrLast
     }
     currentPath = firstOrLast.path
   } else {
     // Check if the node at path is already a leaf
-    const entry = getNode(context, currentPath)
+    const entry = getNode(snapshot, currentPath)
     if (!entry) {
       return undefined
     }
-    const children = getChildren(context, currentPath)
+    const children = getChildren(snapshot, currentPath)
     if (children.length === 0) {
       return entry
     }
@@ -49,9 +44,9 @@ export function getLeaf(
 
   // Descend to deepest leaf
   while (true) {
-    const children = getChildren(context, currentPath)
+    const children = getChildren(snapshot, currentPath)
     if (children.length === 0) {
-      const entry = getNode(context, currentPath)
+      const entry = getNode(snapshot, currentPath)
       return entry ?? undefined
     }
     const child = edge === 'end' ? children.at(-1)! : children.at(0)!

--- a/packages/editor/src/node-traversal/get-node.test.ts
+++ b/packages/editor/src/node-traversal/get-node.test.ts
@@ -10,17 +10,17 @@ describe(getNode.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('empty path', () => {
-    expect(getNode(testbed.context, [])).toBeUndefined()
+    expect(getNode(testbed.snapshot, [])).toBeUndefined()
   })
 
   test('text block', () => {
-    const entry = getNode(testbed.context, [{_key: 'k3'}])
+    const entry = getNode(testbed.snapshot, [{_key: 'k3'}])
     expect(entry?.node).toBe(testbed.textBlock1)
     expect(entry?.path).toEqual([{_key: 'k3'}])
   })
 
   test('span', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k3'},
       'children',
       {_key: 'k0'},
@@ -30,7 +30,7 @@ describe(getNode.name, () => {
   })
 
   test('inline object', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k3'},
       'children',
       {_key: 'k1'},
@@ -40,29 +40,29 @@ describe(getNode.name, () => {
   })
 
   test('block object', () => {
-    const entry = getNode(testbed.context, [{_key: 'k4'}])
+    const entry = getNode(testbed.snapshot, [{_key: 'k4'}])
     expect(entry?.node).toBe(testbed.image)
     expect(entry?.path).toEqual([{_key: 'k4'}])
   })
 
   test('second text block', () => {
-    const entry = getNode(testbed.context, [{_key: 'k6'}])
+    const entry = getNode(testbed.snapshot, [{_key: 'k6'}])
     expect(entry?.node).toBe(testbed.textBlock2)
     expect(entry?.path).toEqual([{_key: 'k6'}])
   })
 
   test('out of bounds', () => {
-    expect(getNode(testbed.context, [{_key: 'nonexistent'}])).toBeUndefined()
+    expect(getNode(testbed.snapshot, [{_key: 'nonexistent'}])).toBeUndefined()
   })
 
   test('code block', () => {
-    const entry = getNode(testbed.context, [{_key: 'k11'}])
+    const entry = getNode(testbed.snapshot, [{_key: 'k11'}])
     expect(entry?.node).toBe(testbed.codeBlock)
     expect(entry?.path).toEqual([{_key: 'k11'}])
   })
 
   test('code block -> first line', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k8'},
@@ -72,7 +72,7 @@ describe(getNode.name, () => {
   })
 
   test('code block -> second line', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k10'},
@@ -82,7 +82,7 @@ describe(getNode.name, () => {
   })
 
   test('code block -> line -> span', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k8'},
@@ -100,7 +100,7 @@ describe(getNode.name, () => {
   })
 
   test('table -> row', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -110,7 +110,7 @@ describe(getNode.name, () => {
   })
 
   test('table -> row -> first cell', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -128,7 +128,7 @@ describe(getNode.name, () => {
   })
 
   test('table -> row -> second cell', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -146,7 +146,7 @@ describe(getNode.name, () => {
   })
 
   test('cell -> first block', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -168,7 +168,7 @@ describe(getNode.name, () => {
   })
 
   test('cell -> second block', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -190,7 +190,7 @@ describe(getNode.name, () => {
   })
 
   test('span inside cell block', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -216,7 +216,7 @@ describe(getNode.name, () => {
   })
 
   test('inline object inside cell block', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -242,7 +242,7 @@ describe(getNode.name, () => {
   })
 
   test('second row', () => {
-    const entry = getNode(testbed.context, [
+    const entry = getNode(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k25'},
@@ -257,11 +257,13 @@ describe(getNode.name, () => {
       tableContainers,
     )
     expect(
-      getNode({...testbed.context, containers: tableOnly}, [
-        {_key: 'k11'},
-        'code',
-        {_key: 'k8'},
-      ]),
+      getNode(
+        {
+          ...testbed.snapshot,
+          context: {...testbed.snapshot.context, containers: tableOnly},
+        },
+        [{_key: 'k11'}, 'code', {_key: 'k8'}],
+      ),
     ).toBeUndefined()
   })
 })

--- a/packages/editor/src/node-traversal/get-node.ts
+++ b/packages/editor/src/node-traversal/get-node.ts
@@ -1,9 +1,8 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getNodeChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the node at a given path.
@@ -17,18 +16,14 @@ import {getNodeChildren} from './get-children'
  * contained numeric indices.
  */
 export function getNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-    blockIndexMap?: Map<string, number>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: Node; path: Path} | undefined {
   if (path.length === 0) {
     return undefined
   }
 
+  const {context, blockIndexMap} = snapshot
   let currentChildren: Array<Node> = context.value
   let scopePath = ''
   let node: Node | undefined
@@ -44,12 +39,8 @@ export function getNode(
     }
 
     if (isKeyedSegment(segment)) {
-      if (
-        isRootLevel &&
-        context.blockIndexMap &&
-        context.blockIndexMap.size === currentChildren.length
-      ) {
-        const index = context.blockIndexMap.get(segment._key)
+      if (isRootLevel && blockIndexMap.size === currentChildren.length) {
+        const index = blockIndexMap.get(segment._key)
         if (index !== undefined) {
           const candidate = currentChildren[index]
           if (candidate && candidate._key === segment._key) {

--- a/packages/editor/src/node-traversal/get-nodes.test.ts
+++ b/packages/editor/src/node-traversal/get-nodes.test.ts
@@ -18,7 +18,7 @@ describe(getNodes.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('all nodes from root', () => {
-    const nodes = [...getNodes(testbed.context)]
+    const nodes = [...getNodes(testbed.snapshot)]
     const nodeValues = nodes.map((entry) => entry.node)
 
     expect(nodeValues).toEqual([
@@ -53,7 +53,7 @@ describe(getNodes.name, () => {
   })
 
   test('paths are correct', () => {
-    const nodes = [...getNodes(testbed.context)]
+    const nodes = [...getNodes(testbed.snapshot)]
     const paths = nodes.map((entry) => entry.path)
 
     expect(paths).toEqual([
@@ -170,7 +170,7 @@ describe(getNodes.name, () => {
   })
 
   test('from a subtree', () => {
-    const nodes = [...getNodes(testbed.context, {at: [{_key: 'k11'}]})]
+    const nodes = [...getNodes(testbed.snapshot, {at: [{_key: 'k11'}]})]
     const nodeValues = nodes.map((entry) => entry.node)
 
     expect(nodeValues).toEqual([
@@ -183,7 +183,7 @@ describe(getNodes.name, () => {
 
   test('from a leaf returns empty', () => {
     const nodes = [
-      ...getNodes(testbed.context, {
+      ...getNodes(testbed.snapshot, {
         at: [{_key: 'k3'}, 'children', {_key: 'k0'}],
       }),
     ]
@@ -193,7 +193,7 @@ describe(getNodes.name, () => {
 
   test('reverse order', () => {
     const nodes = [
-      ...getNodes(testbed.context, {at: [{_key: 'k11'}], reverse: true}),
+      ...getNodes(testbed.snapshot, {at: [{_key: 'k11'}], reverse: true}),
     ]
     const nodeValues = nodes.map((entry) => entry.node)
 
@@ -210,7 +210,12 @@ describe(getNodes.name, () => {
       testbed.context.schema,
       tableContainers,
     )
-    const nodes = [...getNodes({...testbed.context, containers: tableOnly})]
+    const nodes = [
+      ...getNodes({
+        ...testbed.snapshot,
+        context: {...testbed.snapshot.context, containers: tableOnly},
+      }),
+    ]
     const nodeValues = nodes.map((entry) => entry.node)
 
     // code-block itself appears (it's a root child) but its children don't
@@ -228,7 +233,7 @@ describe(getNodes.name, () => {
   describe('match predicate', () => {
     test('filters by isSpan', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           match: (node) => isSpan({schema: testbed.schema}, node),
         }),
       ]
@@ -249,7 +254,7 @@ describe(getNodes.name, () => {
 
     test('filters by isTextBlock', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           match: (node) => isTextBlock({schema: testbed.schema}, node),
         }),
       ]
@@ -269,7 +274,7 @@ describe(getNodes.name, () => {
 
     test('filters with custom predicate on subtree', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           at: [{_key: 'k26'}],
           match: (node) => isSpan({schema: testbed.schema}, node),
         }),
@@ -286,7 +291,7 @@ describe(getNodes.name, () => {
 
     test('match with reverse', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           at: [{_key: 'k3'}],
           match: (node) => isSpan({schema: testbed.schema}, node),
           reverse: true,
@@ -301,7 +306,7 @@ describe(getNodes.name, () => {
   describe('from/to range', () => {
     test('range within flat blocks', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k0'}],
           to: [{_key: 'k4'}],
         }),
@@ -319,7 +324,7 @@ describe(getNodes.name, () => {
 
     test('range within a single block', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k1'}],
           to: [{_key: 'k3'}, 'children', {_key: 'k2'}],
         }),
@@ -335,7 +340,7 @@ describe(getNodes.name, () => {
 
     test('range spanning into container', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k6'}],
           to: [{_key: 'k11'}, 'code', {_key: 'k8'}],
         }),
@@ -352,7 +357,7 @@ describe(getNodes.name, () => {
 
     test('range within container', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [
             {_key: 'k26'},
             'rows',
@@ -388,7 +393,7 @@ describe(getNodes.name, () => {
 
     test('range spanning across cells', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [
             {_key: 'k26'},
             'rows',
@@ -429,7 +434,7 @@ describe(getNodes.name, () => {
 
     test('range spanning across rows', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [
             {_key: 'k26'},
             'rows',
@@ -469,7 +474,7 @@ describe(getNodes.name, () => {
 
     test('from at document start', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}],
           to: [{_key: 'k3'}, 'children', {_key: 'k1'}],
         }),
@@ -485,7 +490,7 @@ describe(getNodes.name, () => {
 
     test('to at document end', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k26'}, 'rows', {_key: 'k25'}],
           to: [
             {_key: 'k26'},
@@ -513,7 +518,7 @@ describe(getNodes.name, () => {
 
     test('from equals to (single node)', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k4'}],
           to: [{_key: 'k4'}],
         }),
@@ -525,7 +530,7 @@ describe(getNodes.name, () => {
 
     test('from equals to (single leaf node)', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k0'}],
           to: [{_key: 'k3'}, 'children', {_key: 'k0'}],
         }),
@@ -537,7 +542,7 @@ describe(getNodes.name, () => {
 
     test('from only (no to)', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k26'}, 'rows', {_key: 'k25'}],
         }),
       ]
@@ -554,7 +559,7 @@ describe(getNodes.name, () => {
 
     test('to only (no from)', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           to: [{_key: 'k4'}],
         }),
       ]
@@ -573,7 +578,7 @@ describe(getNodes.name, () => {
   describe('from/to with match', () => {
     test('range with span filter', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}],
           to: [{_key: 'k11'}],
           match: (node) => isSpan({schema: testbed.schema}, node),
@@ -586,7 +591,7 @@ describe(getNodes.name, () => {
 
     test('range with text block filter', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k11'}],
           match: (node) => isTextBlock({schema: testbed.schema}, node),
         }),
@@ -605,7 +610,7 @@ describe(getNodes.name, () => {
 
     test('range within container with match', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k26'}],
           to: [
             {_key: 'k26'},
@@ -635,7 +640,7 @@ describe(getNodes.name, () => {
   describe('reverse with from/to', () => {
     test('reverse range within flat blocks', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k0'}],
           to: [{_key: 'k4'}],
           reverse: true,
@@ -654,7 +659,7 @@ describe(getNodes.name, () => {
 
     test('reverse range within a single block', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k1'}],
           to: [{_key: 'k3'}, 'children', {_key: 'k2'}],
           reverse: true,
@@ -671,7 +676,7 @@ describe(getNodes.name, () => {
 
     test('reverse range spanning container', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k6'}],
           to: [{_key: 'k11'}, 'code', {_key: 'k8'}],
           reverse: true,
@@ -689,7 +694,7 @@ describe(getNodes.name, () => {
 
     test('reverse from equals to (single node)', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k4'}],
           to: [{_key: 'k4'}],
           reverse: true,
@@ -702,7 +707,7 @@ describe(getNodes.name, () => {
 
     test('reverse with match', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [{_key: 'k3'}, 'children', {_key: 'k0'}],
           to: [{_key: 'k11'}, 'code', {_key: 'k10'}, 'children', {_key: 'k9'}],
           reverse: true,
@@ -722,7 +727,7 @@ describe(getNodes.name, () => {
 
     test('reverse range within container', () => {
       const nodes = [
-        ...getNodes(testbed.context, {
+        ...getNodes(testbed.snapshot, {
           from: [
             {_key: 'k26'},
             'rows',

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -5,6 +5,7 @@ import type {Path} from '../slate/interfaces/path'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildrenInternal} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the descendant nodes of the node at a given path.
@@ -22,12 +23,7 @@ import {getChildrenInternal} from './get-children'
  * instead of the root.
  */
 export function* getNodes(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-    blockIndexMap: Map<string, number>
-  },
+  snapshot: TraversalSnapshot,
   options: {
     at?: Path
     from?: Path
@@ -38,11 +34,11 @@ export function* getNodes(
 ): Generator<{node: Node; path: Path}, void, undefined> {
   const {at = [], from, to, match, reverse = false} = options
   const traversalContext = {
-    schema: context.schema,
-    containers: context.containers,
-    blockIndexMap: context.blockIndexMap,
+    schema: snapshot.context.schema,
+    containers: snapshot.context.containers,
+    blockIndexMap: snapshot.blockIndexMap,
   }
-  const root = {value: context.value}
+  const root = {value: snapshot.context.value}
 
   // When from/to are not provided, use the simple recursive DFS
   if (from === undefined && to === undefined) {

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -4,7 +4,7 @@ import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isAncestorPath} from '../slate/path/is-ancestor-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getChildrenInternal} from './get-children'
+import {getChildren, getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
@@ -33,25 +33,13 @@ export function* getNodes(
   } = {},
 ): Generator<{node: Node; path: Path}, void, undefined> {
   const {at = [], from, to, match, reverse = false} = options
-  const traversalContext = {
-    schema: snapshot.context.schema,
-    containers: snapshot.context.containers,
-    blockIndexMap: snapshot.blockIndexMap,
-  }
-  const root = {value: snapshot.context.value}
 
-  // When from/to are not provided, use the simple recursive DFS
   if (from === undefined && to === undefined) {
-    yield* getNodesSimple(traversalContext, root, at, {match, reverse})
+    yield* getNodesSimple(snapshot, at, {match, reverse})
     return
   }
 
-  yield* getNodesInRange(traversalContext, root, at, {
-    from,
-    to,
-    match,
-    reverse,
-  })
+  yield* getNodesInRange(snapshot, at, {from, to, match, reverse})
 }
 
 /**
@@ -65,7 +53,36 @@ export function* getNodeDescendants(
   },
   node: Node | {value: Array<Node>},
 ): Generator<{node: Node; path: Path}, void, undefined> {
-  yield* getNodesSimple(context, node, [], {})
+  // The editor root wrapper ({value: [...]}) is not a real node, so its field
+  // name is not part of paths. For standalone nodes (a real {_key, _type, ...}
+  // passed in by callers like getDirtyPaths), the field name IS part of the
+  // path.
+  const isRoot = !('_key' in node) && !('_type' in node)
+  yield* walkStandalone(context, node, '', [], isRoot)
+}
+
+function* walkStandalone(
+  context: {
+    schema: EditorSchema
+    containers: Containers
+  },
+  node: Node | {value: Array<Node>},
+  scopePath: string,
+  path: Path,
+  isRoot: boolean,
+): Generator<{node: Node; path: Path}, void, undefined> {
+  const next = getNodeChildren(context, node, scopePath)
+  if (!next) {
+    return
+  }
+
+  for (const child of next.children) {
+    const childPath: Path = isRoot
+      ? [{_key: child._key}]
+      : [...path, next.fieldName, {_key: child._key}]
+    yield {node: child, path: childPath}
+    yield* walkStandalone(context, child, next.scopePath, childPath, false)
+  }
 }
 
 /**
@@ -73,11 +90,7 @@ export function* getNodeDescendants(
  * Yields all descendants of the node at `path`.
  */
 function* getNodesSimple(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   path: Path,
   options: {
     match?: (node: Node, path: Path) => boolean
@@ -86,7 +99,7 @@ function* getNodesSimple(
 ): Generator<{node: Node; path: Path}, void, undefined> {
   const {match, reverse = false} = options
 
-  const children = getChildrenInternal(context, root, path)
+  const children = getChildren(snapshot, path)
 
   const entries = reverse ? [...children].reverse() : children
 
@@ -95,7 +108,7 @@ function* getNodesSimple(
       yield entry
     }
 
-    yield* getNodesSimple(context, root, entry.path, options)
+    yield* getNodesSimple(snapshot, entry.path, options)
   }
 }
 
@@ -106,12 +119,7 @@ function* getNodesSimple(
  * sibling-array lookup for deeper segments.
  */
 function comparePathsInTree(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    blockIndexMap: Map<string, number>
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   pathA: Path,
   pathB: Path,
 ): -1 | 0 | 1 {
@@ -128,10 +136,10 @@ function comparePathsInTree(
     const keyB = keysB[depth]!
 
     if (keyA._key === keyB._key) {
-      if (isRootLevel && context.blockIndexMap.has(keyA._key)) {
+      if (isRootLevel && snapshot.blockIndexMap.has(keyA._key)) {
         currentPath = [keyA]
       } else {
-        const children = getChildrenInternal(context, root, currentPath)
+        const children = getChildren(snapshot, currentPath)
         const child = children.find((c) => c.node._key === keyA._key)
         if (child) {
           currentPath = child.path
@@ -142,8 +150,8 @@ function comparePathsInTree(
     }
 
     if (isRootLevel) {
-      const indexA = context.blockIndexMap.get(keyA._key) ?? -1
-      const indexB = context.blockIndexMap.get(keyB._key) ?? -1
+      const indexA = snapshot.blockIndexMap.get(keyA._key) ?? -1
+      const indexB = snapshot.blockIndexMap.get(keyB._key) ?? -1
       if (indexA !== -1 && indexB !== -1) {
         if (indexA < indexB) {
           return -1
@@ -155,7 +163,7 @@ function comparePathsInTree(
       }
     }
 
-    const siblings = getChildrenInternal(context, root, currentPath)
+    const siblings = getChildren(snapshot, currentPath)
     let indexA = -1
     let indexB = -1
 
@@ -201,12 +209,7 @@ function comparePathsInTree(
  * later), regardless of traversal direction.
  */
 function* getNodesInRange(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    blockIndexMap: Map<string, number>
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   path: Path,
   options: {
     from?: Path
@@ -217,25 +220,25 @@ function* getNodesInRange(
 ): Generator<{node: Node; path: Path}, void, undefined> {
   const {from, to, match, reverse = false} = options
 
-  const children = getChildrenInternal(context, root, path)
+  const children = getChildren(snapshot, path)
   const entries = reverse ? [...children].reverse() : children
 
   for (const entry of entries) {
-    if (canStopTraversal(context, root, entry.path, from, to, reverse)) {
+    if (canStopTraversal(snapshot, entry.path, from, to, reverse)) {
       return
     }
 
-    if (!couldContainInRangeNodes(context, root, entry.path, from, to)) {
+    if (!couldContainInRangeNodes(snapshot, entry.path, from, to)) {
       continue
     }
 
-    if (isInRange(context, root, entry.path, from, to)) {
+    if (isInRange(snapshot, entry.path, from, to)) {
       if (!match || match(entry.node, entry.path)) {
         yield entry
       }
     }
 
-    yield* getNodesInRange(context, root, entry.path, options)
+    yield* getNodesInRange(snapshot, entry.path, options)
   }
 }
 
@@ -245,29 +248,21 @@ function* getNodesInRange(
  * considered in range since they contain the range boundary.
  */
 function isInRange(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    blockIndexMap: Map<string, number>
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   nodePath: Path,
   from: Path | undefined,
   to: Path | undefined,
 ): boolean {
   if (
     from !== undefined &&
-    comparePathsInTree(context, root, nodePath, from) === -1
+    comparePathsInTree(snapshot, nodePath, from) === -1
   ) {
     if (!isAncestorPath(nodePath, from)) {
       return false
     }
   }
 
-  if (
-    to !== undefined &&
-    comparePathsInTree(context, root, nodePath, to) === 1
-  ) {
+  if (to !== undefined && comparePathsInTree(snapshot, nodePath, to) === 1) {
     if (!isAncestorPath(nodePath, to)) {
       return false
     }
@@ -281,17 +276,12 @@ function isInRange(
  * [from, to] range.
  */
 function couldContainInRangeNodes(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    blockIndexMap: Map<string, number>
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   nodePath: Path,
   from: Path | undefined,
   to: Path | undefined,
 ): boolean {
-  if (isInRange(context, root, nodePath, from, to)) {
+  if (isInRange(snapshot, nodePath, from, to)) {
     return true
   }
 
@@ -310,12 +300,7 @@ function couldContainInRangeNodes(
  * Check if all remaining nodes in iteration order will be outside the range.
  */
 function canStopTraversal(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    blockIndexMap: Map<string, number>
-  },
-  root: Node | {value: Array<Node>},
+  snapshot: TraversalSnapshot,
   nodePath: Path,
   from: Path | undefined,
   to: Path | undefined,
@@ -327,7 +312,7 @@ function canStopTraversal(
     }
 
     return (
-      comparePathsInTree(context, root, nodePath, from) === -1 &&
+      comparePathsInTree(snapshot, nodePath, from) === -1 &&
       !isAncestorPath(nodePath, from)
     )
   }
@@ -336,5 +321,5 @@ function canStopTraversal(
     return false
   }
 
-  return comparePathsInTree(context, root, nodePath, to) === 1
+  return comparePathsInTree(snapshot, nodePath, to) === 1
 }

--- a/packages/editor/src/node-traversal/get-parent.test.ts
+++ b/packages/editor/src/node-traversal/get-parent.test.ts
@@ -6,11 +6,11 @@ describe(getParent.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('parent of top-level block', () => {
-    expect(getParent(testbed.context, [{_key: 'k3'}])).toBeUndefined()
+    expect(getParent(testbed.snapshot, [{_key: 'k3'}])).toBeUndefined()
   })
 
   test('parent of span', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k3'},
       'children',
       {_key: 'k0'},
@@ -20,7 +20,7 @@ describe(getParent.name, () => {
   })
 
   test('parent of row', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -30,7 +30,7 @@ describe(getParent.name, () => {
   })
 
   test('parent of cell', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -42,7 +42,7 @@ describe(getParent.name, () => {
   })
 
   test('parent of block inside cell', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -62,7 +62,7 @@ describe(getParent.name, () => {
   })
 
   test('parent of span inside cell block', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k26'},
       'rows',
       {_key: 'k21'},
@@ -86,7 +86,7 @@ describe(getParent.name, () => {
   })
 
   test('parent of code line', () => {
-    const entry = getParent(testbed.context, [
+    const entry = getParent(testbed.snapshot, [
       {_key: 'k11'},
       'code',
       {_key: 'k8'},
@@ -96,6 +96,6 @@ describe(getParent.name, () => {
   })
 
   test('empty path returns undefined', () => {
-    expect(getParent(testbed.context, [])).toBeUndefined()
+    expect(getParent(testbed.snapshot, [])).toBeUndefined()
   })
 })

--- a/packages/editor/src/node-traversal/get-parent.ts
+++ b/packages/editor/src/node-traversal/get-parent.ts
@@ -1,19 +1,14 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the parent of a node at a given path.
  */
 export function getParent(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: Node; path: Path} | undefined {
   if (path.length === 0) {
@@ -26,5 +21,5 @@ export function getParent(
     return undefined
   }
 
-  return getNode(context, parent)
+  return getNode(snapshot, parent)
 }

--- a/packages/editor/src/node-traversal/get-sibling.test.ts
+++ b/packages/editor/src/node-traversal/get-sibling.test.ts
@@ -6,35 +6,37 @@ describe(getSibling.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('empty path returns undefined', () => {
-    expect(getSibling(testbed.context, [], 'next')).toBeUndefined()
-    expect(getSibling(testbed.context, [], 'previous')).toBeUndefined()
+    expect(getSibling(testbed.snapshot, [], 'next')).toBeUndefined()
+    expect(getSibling(testbed.snapshot, [], 'previous')).toBeUndefined()
   })
 
   test('next sibling of first top-level block', () => {
-    const entry = getSibling(testbed.context, [{_key: 'k3'}], 'next')
+    const entry = getSibling(testbed.snapshot, [{_key: 'k3'}], 'next')
     expect(entry?.node).toBe(testbed.image)
     expect(entry?.path).toEqual([{_key: 'k4'}])
   })
 
   test('previous sibling of second top-level block', () => {
-    const entry = getSibling(testbed.context, [{_key: 'k4'}], 'previous')
+    const entry = getSibling(testbed.snapshot, [{_key: 'k4'}], 'previous')
     expect(entry?.node).toBe(testbed.textBlock1)
     expect(entry?.path).toEqual([{_key: 'k3'}])
   })
 
   test('next sibling of last top-level block returns undefined', () => {
-    expect(getSibling(testbed.context, [{_key: 'k26'}], 'next')).toBeUndefined()
+    expect(
+      getSibling(testbed.snapshot, [{_key: 'k26'}], 'next'),
+    ).toBeUndefined()
   })
 
   test('previous sibling of first top-level block returns undefined', () => {
     expect(
-      getSibling(testbed.context, [{_key: 'k3'}], 'previous'),
+      getSibling(testbed.snapshot, [{_key: 'k3'}], 'previous'),
     ).toBeUndefined()
   })
 
   test('next sibling of span in text block', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k3'}, 'children', {_key: 'k0'}],
       'next',
     )
@@ -44,7 +46,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of last span in text block', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k3'}, 'children', {_key: 'k2'}],
       'previous',
     )
@@ -55,7 +57,7 @@ describe(getSibling.name, () => {
   test('next sibling of last span in text block returns undefined', () => {
     expect(
       getSibling(
-        testbed.context,
+        testbed.snapshot,
         [{_key: 'k3'}, 'children', {_key: 'k2'}],
         'next',
       ),
@@ -65,7 +67,7 @@ describe(getSibling.name, () => {
   test('previous sibling of first span in text block returns undefined', () => {
     expect(
       getSibling(
-        testbed.context,
+        testbed.snapshot,
         [{_key: 'k3'}, 'children', {_key: 'k0'}],
         'previous',
       ),
@@ -74,7 +76,7 @@ describe(getSibling.name, () => {
 
   test('next sibling of first block in cell', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -100,7 +102,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of second block in cell', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -127,7 +129,7 @@ describe(getSibling.name, () => {
   test('next sibling of last block in cell returns undefined', () => {
     expect(
       getSibling(
-        testbed.context,
+        testbed.snapshot,
         [
           {_key: 'k26'},
           'rows',
@@ -144,7 +146,7 @@ describe(getSibling.name, () => {
 
   test('next sibling of first cell in row', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k26'}, 'rows', {_key: 'k21'}, 'cells', {_key: 'k17'}],
       'next',
     )
@@ -160,7 +162,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of second cell in row', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k26'}, 'rows', {_key: 'k21'}, 'cells', {_key: 'k20'}],
       'previous',
     )
@@ -176,7 +178,7 @@ describe(getSibling.name, () => {
 
   test('next sibling of first row in table', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k26'}, 'rows', {_key: 'k21'}],
       'next',
     )
@@ -186,7 +188,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of second row in table', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k26'}, 'rows', {_key: 'k25'}],
       'previous',
     )
@@ -196,7 +198,7 @@ describe(getSibling.name, () => {
 
   test('next sibling of span inside cell block', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -226,7 +228,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of inline object inside cell block', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [
         {_key: 'k26'},
         'rows',
@@ -256,16 +258,16 @@ describe(getSibling.name, () => {
 
   test('out of bounds path returns undefined', () => {
     expect(
-      getSibling(testbed.context, [{_key: 'nonexistent'}], 'next'),
+      getSibling(testbed.snapshot, [{_key: 'nonexistent'}], 'next'),
     ).toBeUndefined()
     expect(
-      getSibling(testbed.context, [{_key: 'nonexistent'}], 'previous'),
+      getSibling(testbed.snapshot, [{_key: 'nonexistent'}], 'previous'),
     ).toBeUndefined()
   })
 
   test('next sibling of code line', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k11'}, 'code', {_key: 'k8'}],
       'next',
     )
@@ -275,7 +277,7 @@ describe(getSibling.name, () => {
 
   test('previous sibling of second code line', () => {
     const entry = getSibling(
-      testbed.context,
+      testbed.snapshot,
       [{_key: 'k11'}, 'code', {_key: 'k10'}],
       'previous',
     )

--- a/packages/editor/src/node-traversal/get-sibling.ts
+++ b/packages/editor/src/node-traversal/get-sibling.ts
@@ -1,20 +1,15 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {parentPath} from '../slate/path/parent-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the next or previous sibling of the node at a given path.
  */
 export function getSibling(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
   direction: 'next' | 'previous',
 ): {node: Node; path: Path} | undefined {
@@ -29,7 +24,7 @@ export function getSibling(
   }
 
   const parent = parentPath(path)
-  const children = getChildren(context, parent)
+  const children = getChildren(snapshot, parent)
 
   const currentIndex = children.findIndex(
     (child) => child.node._key === lastSegment._key,

--- a/packages/editor/src/node-traversal/get-span-node.ts
+++ b/packages/editor/src/node-traversal/get-span-node.ts
@@ -1,28 +1,22 @@
 import {isSpan, type PortableTextSpan} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the span node at a given path.
  */
 export function getSpanNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextSpan; path: Path} | undefined {
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
   if (!entry) {
     return undefined
   }
 
-  if (!isSpan({schema: context.schema}, entry.node)) {
+  if (!isSpan({schema: snapshot.context.schema}, entry.node)) {
     return undefined
   }
 

--- a/packages/editor/src/node-traversal/get-text-block-node.ts
+++ b/packages/editor/src/node-traversal/get-text-block-node.ts
@@ -1,28 +1,22 @@
 import {isTextBlock, type PortableTextTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the text block node at a given path.
  */
 export function getTextBlockNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextTextBlock; path: Path} | undefined {
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
   if (!entry) {
     return undefined
   }
 
-  if (!isTextBlock({schema: context.schema}, entry.node)) {
+  if (!isTextBlock({schema: snapshot.context.schema}, entry.node)) {
     return undefined
   }
 

--- a/packages/editor/src/node-traversal/get-text.test.ts
+++ b/packages/editor/src/node-traversal/get-text.test.ts
@@ -6,50 +6,50 @@ describe(getText.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('text of a text block', () => {
-    expect(getText(testbed.context, [{_key: 'k3'}])).toBe('hello  world')
+    expect(getText(testbed.snapshot, [{_key: 'k3'}])).toBe('hello  world')
   })
 
   test('text of a span', () => {
     expect(
-      getText(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
+      getText(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k0'}]),
     ).toBe('hello ')
   })
 
   test('text of second span', () => {
     expect(
-      getText(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k2'}]),
+      getText(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k2'}]),
     ).toBe(' world')
   })
 
   test('text of an inline object', () => {
     expect(
-      getText(testbed.context, [{_key: 'k3'}, 'children', {_key: 'k1'}]),
+      getText(testbed.snapshot, [{_key: 'k3'}, 'children', {_key: 'k1'}]),
     ).toBe('')
   })
 
   test('text of a block object with no children', () => {
-    expect(getText(testbed.context, [{_key: 'k4'}])).toBe('')
+    expect(getText(testbed.snapshot, [{_key: 'k4'}])).toBe('')
   })
 
   test('text of second text block', () => {
-    expect(getText(testbed.context, [{_key: 'k6'}])).toBe('second block')
+    expect(getText(testbed.snapshot, [{_key: 'k6'}])).toBe('second block')
   })
 
   test('text of code block', () => {
-    expect(getText(testbed.context, [{_key: 'k11'}])).toBe(
+    expect(getText(testbed.snapshot, [{_key: 'k11'}])).toBe(
       'const a = 1console.log(a)',
     )
   })
 
   test('text of code line', () => {
     expect(
-      getText(testbed.context, [{_key: 'k11'}, 'code', {_key: 'k8'}]),
+      getText(testbed.snapshot, [{_key: 'k11'}, 'code', {_key: 'k8'}]),
     ).toBe('const a = 1')
   })
 
   test('text of code span', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k11'},
         'code',
         {_key: 'k8'},
@@ -61,7 +61,7 @@ describe(getText.name, () => {
 
   test('text of cell block with inline object', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -75,7 +75,7 @@ describe(getText.name, () => {
 
   test('text of cell span', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -91,7 +91,7 @@ describe(getText.name, () => {
 
   test('text of second cell block', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -105,7 +105,7 @@ describe(getText.name, () => {
 
   test('text of cell block in second cell', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -119,7 +119,7 @@ describe(getText.name, () => {
 
   test('text of empty block', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k25'},
@@ -133,7 +133,7 @@ describe(getText.name, () => {
 
   test('text of empty span', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k25'},
@@ -148,26 +148,26 @@ describe(getText.name, () => {
   })
 
   test('out of bounds returns undefined', () => {
-    expect(getText(testbed.context, [{_key: 'nonexistent'}])).toBeUndefined()
+    expect(getText(testbed.snapshot, [{_key: 'nonexistent'}])).toBeUndefined()
   })
 
   test('empty path returns undefined', () => {
-    expect(getText(testbed.context, [])).toBeUndefined()
+    expect(getText(testbed.snapshot, [])).toBeUndefined()
   })
 
   test('text of table includes all cell text', () => {
-    expect(getText(testbed.context, [{_key: 'k26'}])).toBe('a bc')
+    expect(getText(testbed.snapshot, [{_key: 'k26'}])).toBe('a bc')
   })
 
   test('text of row includes all cell text', () => {
     expect(
-      getText(testbed.context, [{_key: 'k26'}, 'rows', {_key: 'k21'}]),
+      getText(testbed.snapshot, [{_key: 'k26'}, 'rows', {_key: 'k21'}]),
     ).toBe('a bc')
   })
 
   test('text of cell includes all block text', () => {
     expect(
-      getText(testbed.context, [
+      getText(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},

--- a/packages/editor/src/node-traversal/get-text.ts
+++ b/packages/editor/src/node-traversal/get-text.ts
@@ -1,37 +1,30 @@
 import {isSpan} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
 import {getNodes} from './get-nodes'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Get the concatenated text content of the node at a given path.
  */
 export function getText(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-    blockIndexMap: Map<string, number>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): string | undefined {
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
   if (!entry) {
     return undefined
   }
 
-  if (isSpan({schema: context.schema}, entry.node)) {
+  if (isSpan({schema: snapshot.context.schema}, entry.node)) {
     return entry.node.text
   }
 
   let text = ''
 
-  for (const descendant of getNodes(context, {at: path})) {
-    if (isSpan({schema: context.schema}, descendant.node)) {
+  for (const descendant of getNodes(snapshot, {at: path})) {
+    if (isSpan({schema: snapshot.context.schema}, descendant.node)) {
       text += descendant.node.text
     }
   }

--- a/packages/editor/src/node-traversal/get-void-ancestor.ts
+++ b/packages/editor/src/node-traversal/get-void-ancestor.ts
@@ -1,10 +1,8 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isVoidNode} from '../slate/node/is-void-node'
 import {getAncestor} from './get-ancestor'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Find the nearest ancestor that is a void (non-editable) object node.
@@ -14,14 +12,10 @@ import {getAncestor} from './get-ancestor'
  * subtree is a single selectable void" should use this instead.
  */
 export function getVoidAncestor(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextObject; path: Path} | undefined {
-  return getAncestor(context, path, (node, ancestorPath) =>
-    isVoidNode(context, node, ancestorPath),
+  return getAncestor(snapshot, path, (node, ancestorPath) =>
+    isVoidNode(snapshot, node, ancestorPath),
   )
 }

--- a/packages/editor/src/node-traversal/has-node.test.ts
+++ b/packages/editor/src/node-traversal/has-node.test.ts
@@ -6,12 +6,12 @@ describe(hasNode.name, () => {
   const testbed = createNodeTraversalTestbed()
 
   test('root level', () => {
-    expect(hasNode(testbed.context, [{_key: 'k3'}])).toBe(true)
+    expect(hasNode(testbed.snapshot, [{_key: 'k3'}])).toBe(true)
   })
 
   test('deep path', () => {
     expect(
-      hasNode(testbed.context, [
+      hasNode(testbed.snapshot, [
         {_key: 'k26'},
         'rows',
         {_key: 'k21'},
@@ -26,10 +26,10 @@ describe(hasNode.name, () => {
   })
 
   test('out of bounds', () => {
-    expect(hasNode(testbed.context, [{_key: 'nonexistent'}])).toBe(false)
+    expect(hasNode(testbed.snapshot, [{_key: 'nonexistent'}])).toBe(false)
   })
 
   test('empty path', () => {
-    expect(hasNode(testbed.context, [])).toBe(false)
+    expect(hasNode(testbed.snapshot, [])).toBe(false)
   })
 })

--- a/packages/editor/src/node-traversal/has-node.ts
+++ b/packages/editor/src/node-traversal/has-node.ts
@@ -1,20 +1,10 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getNode} from './get-node'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Check if a node exists at a given path.
  */
-export function hasNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-    blockIndexMap?: Map<string, number>
-  },
-  path: Path,
-): boolean {
-  return getNode(context, path) !== undefined
+export function hasNode(snapshot: TraversalSnapshot, path: Path): boolean {
+  return getNode(snapshot, path) !== undefined
 }

--- a/packages/editor/src/node-traversal/is-block.ts
+++ b/packages/editor/src/node-traversal/is-block.ts
@@ -1,12 +1,10 @@
 import type {PortableTextBlock} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isSpanNode} from '../slate/node/is-span-node'
 import {isTextBlockNode} from '../slate/node/is-text-block-node'
 import {getNode} from './get-node'
 import {getParent} from './get-parent'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Determine if a node at the given path is a block.
@@ -16,21 +14,14 @@ import {getParent} from './get-parent'
  * (spans and inline objects) are not blocks. Children of containers are
  * blocks within that container.
  */
-export function isBlock(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
-  path: Path,
-): boolean {
-  const parent = getParent(context, path)
+export function isBlock(snapshot: TraversalSnapshot, path: Path): boolean {
+  const parent = getParent(snapshot, path)
 
   if (!parent) {
     return true
   }
 
-  return !isTextBlockNode({schema: context.schema}, parent.node)
+  return !isTextBlockNode({schema: snapshot.context.schema}, parent.node)
 }
 
 /**
@@ -40,26 +31,22 @@ export function isBlock(
  * doesn't exist or is not a block.
  */
 export function getBlock(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): {node: PortableTextBlock; path: Path} | undefined {
-  const entry = getNode(context, path)
+  const entry = getNode(snapshot, path)
 
   if (!entry) {
     return undefined
   }
 
-  if (!isBlock(context, path)) {
+  if (!isBlock(snapshot, path)) {
     return undefined
   }
 
   // Narrow the type: a block is never a span (spans always have a text block
   // parent, so isBlock returns false for them).
-  if (isSpanNode({schema: context.schema}, entry.node)) {
+  if (isSpanNode({schema: snapshot.context.schema}, entry.node)) {
     return undefined
   }
 

--- a/packages/editor/src/node-traversal/is-empty-container.ts
+++ b/packages/editor/src/node-traversal/is-empty-container.ts
@@ -1,22 +1,19 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {getChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * True if the node at `path` is an editable container whose only child
  * is an empty text block.
  */
 export function isEmptyContainer(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): boolean {
-  const children = getChildren(context, path)
-  return children.length === 1 && isEmptyTextBlock(context, children[0]!.node)
+  const children = getChildren(snapshot, path)
+  return (
+    children.length === 1 &&
+    isEmptyTextBlock(snapshot.context, children[0]!.node)
+  )
 }

--- a/packages/editor/src/node-traversal/is-inline.ts
+++ b/packages/editor/src/node-traversal/is-inline.ts
@@ -1,8 +1,6 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
-import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isBlock} from './is-block'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Determine if a node at the given path is inline.
@@ -10,13 +8,6 @@ import {isBlock} from './is-block'
  * A node is inline if its parent is a text block. This is the inverse of
  * `isBlock`. Top-level nodes are never inline.
  */
-export function isInline(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
-  path: Path,
-): boolean {
-  return !isBlock(context, path)
+export function isInline(snapshot: TraversalSnapshot, path: Path): boolean {
+  return !isBlock(snapshot, path)
 }

--- a/packages/editor/src/node-traversal/is-leaf.ts
+++ b/packages/editor/src/node-traversal/is-leaf.ts
@@ -1,9 +1,8 @@
-import type {EditorSchema} from '../editor/editor-schema'
-import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getNodeChildren} from './get-children'
+import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
  * Determine if a node at the given path is a leaf.
@@ -11,24 +10,17 @@ import {getNodeChildren} from './get-children'
  * A leaf node cannot have children. Spans and non-editable object nodes are
  * leaves. Text blocks and editable container objects are not.
  */
-export function isLeaf(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
-  path: Path,
-): boolean {
+export function isLeaf(snapshot: TraversalSnapshot, path: Path): boolean {
   if (path.length === 0) {
     return false
   }
 
   const traversalContext = {
-    schema: context.schema,
-    containers: context.containers,
+    schema: snapshot.context.schema,
+    containers: snapshot.context.containers,
   }
 
-  let currentChildren: Array<Node> = context.value
+  let currentChildren: Array<Node> = snapshot.context.value
   let scopePath = ''
 
   for (let i = 0; i < path.length; i++) {

--- a/packages/editor/src/node-traversal/is-leaf.ts
+++ b/packages/editor/src/node-traversal/is-leaf.ts
@@ -15,11 +15,6 @@ export function isLeaf(snapshot: TraversalSnapshot, path: Path): boolean {
     return false
   }
 
-  const traversalContext = {
-    schema: snapshot.context.schema,
-    containers: snapshot.context.containers,
-  }
-
   let currentChildren: Array<Node> = snapshot.context.value
   let scopePath = ''
 
@@ -39,7 +34,7 @@ export function isLeaf(snapshot: TraversalSnapshot, path: Path): boolean {
       return false
     }
 
-    const next = getNodeChildren(traversalContext, node, scopePath)
+    const next = getNodeChildren(snapshot.context, node, scopePath)
 
     if (i === path.length - 1) {
       return next === undefined

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -253,9 +253,15 @@ export function createNodeTraversalTestbed() {
     blockIndexMap,
   }
 
+  const snapshot = {
+    context: {schema, containers, value},
+    blockIndexMap,
+  }
+
   return {
     schema,
     context,
+    snapshot,
     textBlock1,
     span1,
     stockTicker1,

--- a/packages/editor/src/node-traversal/traversal-snapshot.ts
+++ b/packages/editor/src/node-traversal/traversal-snapshot.ts
@@ -1,0 +1,18 @@
+import type {EditorSchema} from '../editor/editor-schema'
+import type {Containers} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
+
+/**
+ * Snapshot-shaped input for traversal utilities.
+ *
+ * Mirrors the shape of `EditorSnapshot`: ambient state lives under
+ * `context`, the `blockIndexMap` perf cache sits as a sibling.
+ */
+export type TraversalSnapshot = {
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  }
+  blockIndexMap: Map<string, number>
+}

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -89,8 +89,8 @@ export const addAnnotationOperationImplementation: OperationImplementation<
       // Inside an editable container the sub-schema is authoritative:
       // skip blocks whose sub-schema doesn't declare this annotation type.
       // At root we remain permissive so unknown annotations pass through.
-      if (isInsideEditableContainer(context, blockPath)) {
-        const subSchema = getBlockSubSchema(context, blockPath)
+      if (isInsideEditableContainer(snapshot, blockPath)) {
+        const subSchema = getBlockSubSchema(snapshot, blockPath)
         if (
           !subSchema.annotations.some(
             (annotation) => annotation.name === parsedAnnotation._type,

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -28,7 +28,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const addAnnotationOperationImplementation: OperationImplementation<
   'annotation.add'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const parsedAnnotation = parseAnnotation({
     annotation: {
       _type: operation.annotation.name,

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -26,7 +26,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const removeAnnotationOperationImplementation: OperationImplementation<
   'annotation.remove'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const editor = operation.editor
 
   const at = operation.at

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -27,7 +27,6 @@ import type {OperationImplementation} from './operation.types'
 export const removeAnnotationOperationImplementation: OperationImplementation<
   'annotation.remove'
 > = ({snapshot, operation}) => {
-  const {context} = snapshot
   const editor = operation.editor
 
   const at = operation.at
@@ -42,7 +41,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
 
   if (isCollapsedRange(effectiveSelection)) {
     const blockEntry = getAncestorTextBlock(
-      context,
+      snapshot,
       effectiveSelection.focus.path,
     )
 

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -10,7 +10,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const blockEntry = getNode(operation.editor, operation.at)
 
   if (!blockEntry) {

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -21,7 +21,7 @@ export const blockSetOperationImplementation: OperationImplementation<
   const slateBlock = blockEntry.node
 
   if (isTextBlockNode(context, slateBlock)) {
-    const subSchema = getBlockSubSchema(context, blockEntry.path)
+    const subSchema = getBlockSubSchema(snapshot, blockEntry.path)
     const filteredProps: Record<string, unknown> = {}
 
     for (const key of Object.keys(operation.props)) {
@@ -75,7 +75,7 @@ export const blockSetOperationImplementation: OperationImplementation<
     setNodeProperties(operation.editor, filteredProps, blockEntry.path)
   } else {
     const schemaDefinition = getBlockObjectSchema(
-      context,
+      snapshot,
       slateBlock,
       blockEntry.path,
     )

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -6,7 +6,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const blockEntry = getNode(operation.editor, operation.at)
 
   if (!blockEntry) {

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -10,7 +10,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const childSetOperationImplementation: OperationImplementation<
   'child.set'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const childEntry = getNode(operation.editor, operation.at)
 
   if (!childEntry) {

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -11,7 +11,6 @@ import type {OperationImplementation} from './operation.types'
 export const childSetOperationImplementation: OperationImplementation<
   'child.set'
 > = ({snapshot, operation}) => {
-  const {context} = snapshot
   const childEntry = getNode(operation.editor, operation.at)
 
   if (!childEntry) {
@@ -61,7 +60,7 @@ export const childSetOperationImplementation: OperationImplementation<
 
   if (isObjectNode({schema: operation.editor.schema}, child)) {
     const blockPath = parentPath(childPath)
-    const {inlineObjects} = getBlockSubSchema(context, blockPath)
+    const {inlineObjects} = getBlockSubSchema(snapshot, blockPath)
     const definition = inlineObjects.find(
       (definition) => definition.name === child._type,
     )

--- a/packages/editor/src/operations/operation.child.unset.ts
+++ b/packages/editor/src/operations/operation.child.unset.ts
@@ -7,7 +7,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const childUnsetOperationImplementation: OperationImplementation<
   'child.unset'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const childEntry = getNode(operation.editor, operation.at)
 
   if (!childEntry) {

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -22,7 +22,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const decoratorAddOperationImplementation: OperationImplementation<
   'decorator.add'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const editor = operation.editor
   const mark = operation.decorator
 

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -23,7 +23,6 @@ import type {OperationImplementation} from './operation.types'
 export const decoratorAddOperationImplementation: OperationImplementation<
   'decorator.add'
 > = ({snapshot, operation}) => {
-  const {context} = snapshot
   const editor = operation.editor
   const mark = operation.decorator
 
@@ -92,8 +91,8 @@ export const decoratorAddOperationImplementation: OperationImplementation<
         // decorator. At root we remain permissive and allow unknown
         // decorators to be tracked optimistically.
         const blockPath = parentPath(spanPath)
-        if (isInsideEditableContainer(context, blockPath)) {
-          const subSchema = getBlockSubSchema(context, blockPath)
+        if (isInsideEditableContainer(snapshot, blockPath)) {
+          const subSchema = getBlockSubSchema(snapshot, blockPath)
           if (
             !subSchema.decorators.some((decorator) => decorator.name === mark)
           ) {
@@ -123,7 +122,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
       return
     }
 
-    const blockEntry = getAncestorTextBlock(context, at.focus.path)
+    const blockEntry = getAncestorTextBlock(snapshot, at.focus.path)
     if (!blockEntry) {
       return
     }
@@ -133,8 +132,8 @@ export const decoratorAddOperationImplementation: OperationImplementation<
     // when the block's sub-schema doesn't declare this decorator. At root
     // we remain permissive so unknown decorators are tracked in
     // `decoratorState` (the existing root-level behaviour).
-    if (isInsideEditableContainer(context, blockPath)) {
-      const subSchema = getBlockSubSchema(context, blockPath)
+    if (isInsideEditableContainer(snapshot, blockPath)) {
+      const subSchema = getBlockSubSchema(snapshot, blockPath)
       if (!subSchema.decorators.some((decorator) => decorator.name === mark)) {
         return
       }

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -21,7 +21,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const decoratorRemoveOperationImplementation: OperationImplementation<
   'decorator.remove'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const editor = operation.editor
   const mark = operation.decorator
   const at = operation.at

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -100,7 +100,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
       }
     }) // end withoutNormalizing
   } else {
-    const textBlockEntry = getAncestorTextBlock(context, at.focus.path)
+    const textBlockEntry = getAncestorTextBlock(snapshot, at.focus.path)
     if (!textBlockEntry) {
       return
     }

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -35,7 +35,10 @@ import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {parseBlock} from '../utils/parse-blocks'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import type {OperationContext, OperationImplementation} from './operation.types'
+import type {
+  OperationImplementation,
+  OperationSnapshot,
+} from './operation.types'
 
 /**
  * Describes a concrete insertion strategy resolved from the operation's
@@ -53,7 +56,8 @@ type InsertTarget =
 
 export const insertBlockOperationImplementation: OperationImplementation<
   'insert.block'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const parsedBlock = parseBlock({
     block: operation.block,
     context,
@@ -237,7 +241,7 @@ function resolveTarget(args: {
 
 function dispatchInsert(args: {
   editor: PortableTextSlateEditor
-  context: OperationContext
+  context: OperationSnapshot['context']
   block: Node
   target: InsertTarget
   select: 'start' | 'end' | 'none'
@@ -437,7 +441,7 @@ function splitBlockAndInsert(
  */
 function mergeTextBlockFragment(args: {
   editor: PortableTextSlateEditor
-  context: OperationContext
+  context: OperationSnapshot['context']
   block: Node
   at: Point
   endBlockPath: Path
@@ -544,7 +548,7 @@ function applyPostInsertSelection(
  */
 function executeDeleteThenInsert(args: {
   editor: PortableTextSlateEditor
-  context: OperationContext
+  context: OperationSnapshot['context']
   block: Node
   range: Range
   select: 'start' | 'end' | 'none'
@@ -661,7 +665,7 @@ function executeDeleteThenInsert(args: {
  */
 function removeAdjacentEmptyTextBlock(args: {
   editor: PortableTextSlateEditor
-  context: OperationContext
+  context: OperationSnapshot['context']
   insertedPath: Path
 }): void {
   const {editor, context, insertedPath} = args
@@ -702,7 +706,7 @@ function resolveChildIndex(
  * markDefs (to be merged into the end block).
  */
 function adjustFragmentKeys(args: {
-  context: OperationContext
+  context: OperationSnapshot['context']
   block: Node
   endBlock: Node
 }): {adjustedBlock: Node; adjustedMarkDefs: Array<{_key: string}> | undefined} {

--- a/packages/editor/src/operations/operation.insert.child.ts
+++ b/packages/editor/src/operations/operation.insert.child.ts
@@ -13,7 +13,8 @@ import type {OperationImplementation} from './operation.types'
 
 export const insertChildOperationImplementation: OperationImplementation<
   'insert.child'
-> = ({context, operation}) => {
+> = ({snapshot, operation}) => {
+  const {context} = snapshot
   const focus = operation.editor.selection?.focus
 
   if (!focus) {

--- a/packages/editor/src/operations/operation.perform.ts
+++ b/packages/editor/src/operations/operation.perform.ts
@@ -20,8 +20,8 @@ import {moveForwardOperationImplementation} from './operation.move.forward'
 import {selectOperationImplementation} from './operation.select'
 import type {
   Operation,
-  OperationContext,
   OperationImplementations,
+  OperationSnapshot,
 } from './operation.types'
 
 const operationImplementations: OperationImplementations = {
@@ -46,18 +46,18 @@ const operationImplementations: OperationImplementations = {
 }
 
 export function performOperation({
-  context,
+  snapshot,
   operation,
 }: {
-  context: OperationContext
+  snapshot: OperationSnapshot
   operation: Operation
 }) {
   const perform = () => {
     try {
       const implementation = operationImplementations[
         operation.type
-      ] as (args: {context: OperationContext; operation: Operation}) => void
-      implementation({context, operation})
+      ] as (args: {snapshot: OperationSnapshot; operation: Operation}) => void
+      implementation({snapshot, operation})
     } catch (error) {
       console.error(
         new Error(

--- a/packages/editor/src/operations/operation.types.ts
+++ b/packages/editor/src/operations/operation.types.ts
@@ -2,21 +2,23 @@ import type {
   AbstractBehaviorEventType,
   SyntheticBehaviorEvent,
 } from '../behaviors/behavior.types.event'
-import type {EditorContext} from '../editor/editor-snapshot'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {OmitFromUnion, PickFromUnion} from '../type-utils'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 
-export type OperationContext = Pick<
-  EditorContext,
-  'keyGenerator' | 'schema' | 'containers' | 'value'
->
+export type OperationSnapshot = {
+  context: TraversalSnapshot['context'] & {
+    keyGenerator: () => string
+  }
+  blockIndexMap: TraversalSnapshot['blockIndexMap']
+}
 
 export type OperationImplementation<TOperationType extends Operation['type']> =
   ({
-    context,
+    snapshot,
     operation,
   }: {
-    context: OperationContext
+    snapshot: OperationSnapshot
     operation: PickFromUnion<Operation, 'type', TOperationType>
   }) => void
 

--- a/packages/editor/src/paths/get-child-field-name.ts
+++ b/packages/editor/src/paths/get-child-field-name.ts
@@ -20,11 +20,7 @@ export function getChildFieldName(
   },
   path: Path,
 ): string | undefined {
-  let nodeChildren = getNodeChildren(
-    {schema: context.schema, containers: context.containers},
-    {value: context.value},
-    '',
-  )
+  let nodeChildren = getNodeChildren(context, {value: context.value}, '')
 
   for (let i = 0; i < path.length; i++) {
     if (!nodeChildren) {
@@ -50,19 +46,11 @@ export function getChildFieldName(
     }
 
     if (i === path.length - 1) {
-      const targetInfo = getNodeChildren(
-        {schema: context.schema, containers: context.containers},
-        node,
-        nodeChildren.scopePath,
-      )
+      const targetInfo = getNodeChildren(context, node, nodeChildren.scopePath)
       return targetInfo?.fieldName
     }
 
-    nodeChildren = getNodeChildren(
-      {schema: context.schema, containers: context.containers},
-      node,
-      nodeChildren.scopePath,
-    )
+    nodeChildren = getNodeChildren(context, node, nodeChildren.scopePath)
   }
 
   return undefined

--- a/packages/editor/src/schema/get-block-object-schema.test.ts
+++ b/packages/editor/src/schema/get-block-object-schema.test.ts
@@ -22,7 +22,10 @@ describe(getBlockObjectSchema.name, () => {
         ],
       }),
     )
-    const context = {schema, containers: new Map(), value: []}
+    const context = {
+      context: {schema, containers: new Map(), value: []},
+      blockIndexMap: new Map(),
+    }
     const node = {_type: 'image', _key: 'i0', src: 'foo.png'}
 
     expect(getBlockObjectSchema(context, node, [{_key: 'i0'}])).toEqual({
@@ -109,7 +112,10 @@ describe(getBlockObjectSchema.name, () => {
         ],
       },
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
 
     // Look up the `row` block-object schema (inline-declared under table.rows.of)
     const rowNode = {_type: 'row', _key: 'r0', cells: []}
@@ -166,7 +172,10 @@ describe(getBlockObjectSchema.name, () => {
     )
     const containers = resolveContainers(schema, containerConfigs)
 
-    const context = {schema, containers, value: []}
+    const context = {
+      context: {schema, containers, value: []},
+      blockIndexMap: new Map(),
+    }
     // `image` is in root `blockObjects` but not inline-declared inside callout.
     // Looking it up at a callout-internal position falls back to root.
     const imageNode = {_type: 'image', _key: 'i0', src: 'foo.png'}
@@ -186,7 +195,10 @@ describe(getBlockObjectSchema.name, () => {
         blockObjects: [{name: 'image'}],
       }),
     )
-    const context = {schema, containers: new Map(), value: []}
+    const context = {
+      context: {schema, containers: new Map(), value: []},
+      blockIndexMap: new Map(),
+    }
     const node = {_type: 'unknown', _key: 'u0'}
 
     expect(getBlockObjectSchema(context, node, [{_key: 'u0'}])).toBeUndefined()

--- a/packages/editor/src/schema/get-block-object-schema.ts
+++ b/packages/editor/src/schema/get-block-object-schema.ts
@@ -1,9 +1,8 @@
 import type {BaseDefinition, FieldDefinition} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getEnclosingContainer} from './get-enclosing-container'
-import type {Containers} from './resolve-containers'
 
 /**
  * Minimal view of a block-object schema definition: its name and its
@@ -25,17 +24,13 @@ export type BlockObjectSchema = BaseDefinition & {
  * Returns `undefined` when the type is not declared at the effective scope.
  */
 export function getBlockObjectSchema(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   node: Node,
   path: Path,
 ): BlockObjectSchema | undefined {
   const typeName = node._type
 
-  const enclosing = getEnclosingContainer(context, path)
+  const enclosing = getEnclosingContainer(snapshot, path)
 
   if (enclosing) {
     const inline = enclosing.of.find(
@@ -56,7 +51,7 @@ export function getBlockObjectSchema(
     }
   }
 
-  return context.schema.blockObjects.find(
+  return snapshot.context.schema.blockObjects.find(
     (definition) => definition.name === typeName,
   )
 }

--- a/packages/editor/src/schema/get-block-sub-schema.test.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.test.ts
@@ -21,9 +21,12 @@ describe(getBlockSubSchema.name, () => {
     )
 
     const context = {
-      schema,
-      containers: new Map(),
-      value: [{_type: 'block', _key: 'b0', children: []}],
+      context: {
+        schema,
+        containers: new Map(),
+        value: [{_type: 'block', _key: 'b0', children: []}],
+      },
+      blockIndexMap: new Map(),
     }
 
     const subSchema = getBlockSubSchema(context, [{_key: 'b0'}])
@@ -77,7 +80,10 @@ describe(getBlockSubSchema.name, () => {
         content: [{_type: 'block', _key: 'b0', children: []}],
       },
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
 
     const subSchema = getBlockSubSchema(context, [
       {_key: 'c0'},
@@ -129,7 +135,10 @@ describe(getBlockSubSchema.name, () => {
         content: [{_type: 'block', _key: 'b0', children: []}],
       },
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
 
     const subSchema = getBlockSubSchema(context, [
       {_key: 'c0'},
@@ -236,7 +245,10 @@ describe(getBlockSubSchema.name, () => {
         ],
       },
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
 
     const subSchema = getBlockSubSchema(context, [
       {_key: 't0'},

--- a/packages/editor/src/schema/get-block-sub-schema.ts
+++ b/packages/editor/src/schema/get-block-sub-schema.ts
@@ -8,10 +8,9 @@ import type {
   StyleSchemaType,
 } from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
-import type {Node} from '../slate/interfaces/node'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Path} from '../slate/interfaces/path'
 import {getEnclosingContainer} from './get-enclosing-container'
-import type {Containers} from './resolve-containers'
 import {asFieldedTypes, asNamedTypes} from './schema-type-projections'
 
 /**
@@ -51,34 +50,31 @@ type ResolvedBlockOfDefinition = {
  * returns the sub-schema from its `{type: 'block'}` entry.
  */
 export function getBlockSubSchema(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): BlockSubSchema {
-  const nestedBlock = findEnclosingNestedBlock(context, path)
+  const nestedBlock = findEnclosingNestedBlock(snapshot, path)
 
   if (!nestedBlock) {
-    return rootSubSchema(context.schema)
+    return rootSubSchema(snapshot.context.schema)
   }
 
   return {
     styles:
       asNamedTypes<StyleSchemaType>(nestedBlock.styles) ??
-      context.schema.styles,
+      snapshot.context.schema.styles,
     decorators:
       asNamedTypes<DecoratorSchemaType>(nestedBlock.decorators) ??
-      context.schema.decorators,
+      snapshot.context.schema.decorators,
     annotations:
       asFieldedTypes<AnnotationSchemaType>(nestedBlock.annotations) ??
-      context.schema.annotations,
+      snapshot.context.schema.annotations,
     lists:
-      asNamedTypes<ListSchemaType>(nestedBlock.lists) ?? context.schema.lists,
+      asNamedTypes<ListSchemaType>(nestedBlock.lists) ??
+      snapshot.context.schema.lists,
     inlineObjects:
       asFieldedTypes<InlineObjectSchemaType>(nestedBlock.inlineObjects) ??
-      context.schema.inlineObjects,
+      snapshot.context.schema.inlineObjects,
   }
 }
 
@@ -90,14 +86,10 @@ export function getBlockSubSchema(
  * sub-schema is authoritative and those operations should be filtered.
  */
 export function isInsideEditableContainer(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): boolean {
-  return findEnclosingNestedBlock(context, path) !== undefined
+  return findEnclosingNestedBlock(snapshot, path) !== undefined
 }
 
 function rootSubSchema(schema: EditorSchema): BlockSubSchema {
@@ -111,14 +103,10 @@ function rootSubSchema(schema: EditorSchema): BlockSubSchema {
 }
 
 function findEnclosingNestedBlock(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ): ResolvedBlockOfDefinition | undefined {
-  const enclosing = getEnclosingContainer(context, path)
+  const enclosing = getEnclosingContainer(snapshot, path)
 
   if (!enclosing) {
     return undefined

--- a/packages/editor/src/schema/get-container-scoped-name.ts
+++ b/packages/editor/src/schema/get-container-scoped-name.ts
@@ -1,9 +1,8 @@
-import type {EditorSchema} from '../editor/editor-schema'
 import {getAncestors} from '../node-traversal/get-ancestors'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
-import type {Containers} from './resolve-containers'
 
 /**
  * Build the scoped type name for a node at a given path.
@@ -13,21 +12,17 @@ import type {Containers} from './resolve-containers'
  * the ancestors are a 'table' and a 'row', producing: 'table.row.cell'
  */
 export function getContainerScopedName(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   node: Node,
   path: Path,
 ): string {
-  const ancestors = getAncestors(context, path)
+  const ancestors = getAncestors(snapshot, path)
 
   const typeSegments: Array<string> = []
 
   for (let i = ancestors.length - 1; i >= 0; i--) {
     const ancestor = ancestors[i]!
-    if (isObjectNode({schema: context.schema}, ancestor.node)) {
+    if (isObjectNode({schema: snapshot.context.schema}, ancestor.node)) {
       typeSegments.push(ancestor.node._type)
     }
   }

--- a/packages/editor/src/schema/get-enclosing-container.ts
+++ b/packages/editor/src/schema/get-enclosing-container.ts
@@ -1,26 +1,16 @@
 import type {OfDefinition} from '@portabletext/schema'
-import type {EditorSchema} from '../editor/editor-schema'
 import {getAncestors} from '../node-traversal/get-ancestors'
-import type {Node} from '../slate/interfaces/node'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {getContainerScopedName} from './get-container-scoped-name'
-import type {Containers} from './resolve-containers'
 
 /**
  * Walk ancestors from `path` and return the nearest registered editable
- * container — its resolved field definition, the raw `of` array, and the
- * path at which it lives.
- *
- * Returns `undefined` when no ancestor is a registered container (the
- * caller falls back to root-level schema views).
+ * container.
  */
 export function getEnclosingContainer(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   path: Path,
 ):
   | {
@@ -28,17 +18,17 @@ export function getEnclosingContainer(
       path: Path
     }
   | undefined {
-  for (const ancestor of getAncestors(context, path)) {
-    if (!isObjectNode({schema: context.schema}, ancestor.node)) {
+  for (const ancestor of getAncestors(snapshot, path)) {
+    if (!isObjectNode({schema: snapshot.context.schema}, ancestor.node)) {
       continue
     }
 
     const scopedName = getContainerScopedName(
-      context,
+      snapshot,
       ancestor.node,
       ancestor.path,
     )
-    const container = context.containers.get(scopedName)
+    const container = snapshot.context.containers.get(scopedName)
 
     if (!container) {
       continue

--- a/packages/editor/src/schema/get-type-chain.test.ts
+++ b/packages/editor/src/schema/get-type-chain.test.ts
@@ -41,7 +41,10 @@ describe(getTypeChain.name, () => {
         style: 'normal',
       } as unknown as Node,
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
     const path = [{_key: 'b1'}, 'children', {_key: 's1'}]
     const entry = getNode(context, path)!
     expect(getTypeChain(context, entry.node, entry.path)).toEqual([
@@ -66,7 +69,10 @@ describe(getTypeChain.name, () => {
         ],
       } as unknown as Node,
     ]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
     const path = [
       {_key: 'c1'},
       'content',
@@ -84,7 +90,10 @@ describe(getTypeChain.name, () => {
 
   test('root void block object: ["image"]', () => {
     const value: Array<Node> = [{_type: 'image', _key: 'i1'} as unknown as Node]
-    const context = {schema, containers, value}
+    const context = {
+      context: {schema, containers, value},
+      blockIndexMap: new Map(),
+    }
     const entry = getNode(context, [{_key: 'i1'}])!
     expect(getTypeChain(context, entry.node, entry.path)).toEqual(['image'])
   })

--- a/packages/editor/src/schema/get-type-chain.ts
+++ b/packages/editor/src/schema/get-type-chain.ts
@@ -1,8 +1,7 @@
-import type {EditorSchema} from '../editor/editor-schema'
 import {getAncestors} from '../node-traversal/get-ancestors'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
-import type {Containers} from './resolve-containers'
 
 /**
  * Build the full type chain for a node at a given path, from root to the
@@ -15,16 +14,12 @@ import type {Containers} from './resolve-containers'
  * the chain is `['table', 'row', 'cell', 'block', 'span']`.
  */
 export function getTypeChain(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   node: Node,
   path: Path,
 ): Array<string> {
   const chain: Array<string> = []
-  const ancestors = getAncestors(context, path)
+  const ancestors = getAncestors(snapshot, path)
 
   for (let i = ancestors.length - 1; i >= 0; i--) {
     chain.push(ancestors[i]!.node._type)

--- a/packages/editor/src/schema/is-editable-container.ts
+++ b/packages/editor/src/schema/is-editable-container.ts
@@ -1,25 +1,20 @@
-import type {EditorSchema} from '../editor/editor-schema'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getContainerScopedName} from './get-container-scoped-name'
-import type {Containers} from './resolve-containers'
 
 /**
  * Check if a node at the given path is a registered editable container.
  */
 export function isEditableContainer(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   node: Node,
   path: Path,
 ): boolean {
-  if (context.containers.size === 0) {
+  if (snapshot.context.containers.size === 0) {
     return false
   }
 
-  const scopedName = getContainerScopedName(context, node, path)
-  return context.containers.has(scopedName)
+  const scopedName = getContainerScopedName(snapshot, node, path)
+  return snapshot.context.containers.has(scopedName)
 }

--- a/packages/editor/src/selectors/selector.get-active-annotations.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotations.ts
@@ -21,7 +21,7 @@ export const getActiveAnnotations: EditorSelector<Array<PortableTextObject>> = (
   // that aren't decorators in any in-scope sub-schema are annotations.
   const decoratorNames = new Set<string>()
   for (const block of selectedBlocks) {
-    for (const decorator of getBlockSubSchema(snapshot.context, block.path)
+    for (const decorator of getBlockSubSchema(snapshot, block.path)
       .decorators) {
       decoratorNames.add(decorator.name)
     }

--- a/packages/editor/src/selectors/selector.get-active-decorators.ts
+++ b/packages/editor/src/selectors/selector.get-active-decorators.ts
@@ -14,7 +14,7 @@ export function getActiveDecorators(snapshot: EditorSnapshot) {
   const selectedBlocks = getSelectedTextBlocks(snapshot)
   const decorators = new Set<string>()
   for (const block of selectedBlocks) {
-    for (const decorator of getBlockSubSchema(snapshot.context, block.path)
+    for (const decorator of getBlockSubSchema(snapshot, block.path)
       .decorators) {
       decorators.add(decorator.name)
     }

--- a/packages/editor/src/selectors/selector.get-anchor-block.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-block.ts
@@ -17,5 +17,5 @@ export const getAnchorBlock: EditorSelector<
     return undefined
   }
 
-  return getEnclosingBlock(snapshot.context, selection.anchor.path)
+  return getEnclosingBlock(snapshot, selection.anchor.path)
 }

--- a/packages/editor/src/selectors/selector.get-anchor-child.ts
+++ b/packages/editor/src/selectors/selector.get-anchor-child.ts
@@ -22,5 +22,5 @@ export const getAnchorChild: EditorSelector<
     return undefined
   }
 
-  return getInline(snapshot.context, selection.anchor.path)
+  return getInline(snapshot, selection.anchor.path)
 }

--- a/packages/editor/src/selectors/selector.get-block-offsets.ts
+++ b/packages/editor/src/selectors/selector.get-block-offsets.ts
@@ -22,11 +22,11 @@ export const getBlockOffsets: EditorSelector<
   }
 
   const start = spanSelectionPointToBlockOffset({
-    context: snapshot.context,
+    snapshot,
     selectionPoint: selectionStartPoint,
   })
   const end = spanSelectionPointToBlockOffset({
-    context: snapshot.context,
+    snapshot,
     selectionPoint: selectionEndPoint,
   })
 

--- a/packages/editor/src/selectors/selector.get-caret-word-selection.ts
+++ b/packages/editor/src/selectors/selector.get-caret-word-selection.ts
@@ -35,7 +35,7 @@ export const getCaretWordSelection: EditorSelector<EditorSelection> = (
   const selectionStartPoint = getSelectionStartPoint(snapshot)
   const selectionStartOffset = selectionStartPoint
     ? spanSelectionPointToBlockOffset({
-        context: snapshot.context,
+        snapshot,
         selectionPoint: selectionStartPoint,
       })
     : undefined
@@ -103,12 +103,12 @@ export const getCaretWordSelection: EditorSelector<EditorSelection> = (
     : selectionStartOffset
 
   const caretWordStartSelectionPoint = blockOffsetToSpanSelectionPoint({
-    context: snapshot.context,
+    snapshot,
     blockOffset: caretWordStartOffset,
     direction: 'backward',
   })
   const caretWordEndSelectionPoint = blockOffsetToSpanSelectionPoint({
-    context: snapshot.context,
+    snapshot,
     blockOffset: caretWordEndOffset,
     direction: 'forward',
   })

--- a/packages/editor/src/selectors/selector.get-default-style.ts
+++ b/packages/editor/src/selectors/selector.get-default-style.ts
@@ -17,8 +17,7 @@ export const getDefaultStyle: EditorSelector<string | undefined> = (
 ) => {
   const focusTextBlock = getFocusTextBlock(snapshot)
   if (focusTextBlock) {
-    return getBlockSubSchema(snapshot.context, focusTextBlock.path).styles[0]
-      ?.name
+    return getBlockSubSchema(snapshot, focusTextBlock.path).styles[0]?.name
   }
   return snapshot.context.schema.styles[0]?.name
 }

--- a/packages/editor/src/selectors/selector.get-first-block.ts
+++ b/packages/editor/src/selectors/selector.get-first-block.ts
@@ -22,11 +22,11 @@ export const getFirstBlock: EditorSelector<
   const focusBlock = getFocusBlock(snapshot)
 
   if (focusBlock) {
-    const siblings = getChildren(snapshot.context, parentPath(focusBlock.path))
+    const siblings = getChildren(snapshot, parentPath(focusBlock.path))
     const first = siblings.at(0)
 
     if (first) {
-      return getBlock(snapshot.context, first.path)
+      return getBlock(snapshot, first.path)
     }
   }
 

--- a/packages/editor/src/selectors/selector.get-focus-block-object.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block-object.ts
@@ -27,7 +27,7 @@ export const getFocusBlockObject: EditorSelector<
     return undefined
   }
 
-  if (isEditableContainer(snapshot.context, focusBlock.node, focusBlock.path)) {
+  if (isEditableContainer(snapshot, focusBlock.node, focusBlock.path)) {
     return undefined
   }
 

--- a/packages/editor/src/selectors/selector.get-focus-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block.ts
@@ -21,5 +21,5 @@ export const getFocusBlock: EditorSelector<
     return undefined
   }
 
-  return getEnclosingBlock(snapshot.context, selection.focus.path)
+  return getEnclosingBlock(snapshot, selection.focus.path)
 }

--- a/packages/editor/src/selectors/selector.get-focus-child.ts
+++ b/packages/editor/src/selectors/selector.get-focus-child.ts
@@ -22,5 +22,5 @@ export const getFocusChild: EditorSelector<
     return undefined
   }
 
-  return getInline(snapshot.context, selection.focus.path)
+  return getInline(snapshot, selection.focus.path)
 }

--- a/packages/editor/src/selectors/selector.get-last-block.ts
+++ b/packages/editor/src/selectors/selector.get-last-block.ts
@@ -22,11 +22,11 @@ export const getLastBlock: EditorSelector<
   const focusBlock = getFocusBlock(snapshot)
 
   if (focusBlock) {
-    const siblings = getChildren(snapshot.context, parentPath(focusBlock.path))
+    const siblings = getChildren(snapshot, parentPath(focusBlock.path))
     const last = siblings.at(-1)
 
     if (last) {
-      return getBlock(snapshot.context, last.path)
+      return getBlock(snapshot, last.path)
     }
   }
 

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -39,7 +39,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
 
   if (isBlockPath(selection.anchor.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
-      context: snapshot.context,
+      snapshot,
       blockOffset: {
         path: selection.anchor.path,
         offset: selection.anchor.offset,
@@ -57,7 +57,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
 
   if (isBlockPath(selection.focus.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
-      context: snapshot.context,
+      snapshot,
       blockOffset: {
         path: selection.focus.path,
         offset: selection.focus.offset,

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -100,13 +100,12 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
     // the mark cannot apply) don't disqualify the mark across the
     // selection.
     const spanInfo = selectedSpans.map((span) => {
-      const block = getAncestorTextBlock(snapshot.context, span.path)
+      const block = getAncestorTextBlock(snapshot, span.path)
       return {
         marks: span.node.marks ?? [],
-        decoratorNames: getBlockSubSchema(
-          snapshot.context,
-          span.path,
-        ).decorators.map((decorator) => decorator.name),
+        decoratorNames: getBlockSubSchema(snapshot, span.path).decorators.map(
+          (decorator) => decorator.name,
+        ),
         markDefKeys: (block?.node.markDefs ?? []).map(
           (markDef) => markDef._key,
         ),
@@ -150,7 +149,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
     }
   }
 
-  const focusSubSchema = getBlockSubSchema(snapshot.context, focusSpan.path)
+  const focusSubSchema = getBlockSubSchema(snapshot, focusSpan.path)
   const decorators = focusSubSchema.decorators.map(
     (decorator) => decorator.name,
   )

--- a/packages/editor/src/selectors/selector.get-next-block.ts
+++ b/packages/editor/src/selectors/selector.get-next-block.ts
@@ -23,11 +23,11 @@ export const getNextBlock: EditorSelector<
     return undefined
   }
 
-  const next = getSibling(snapshot.context, selectionEndBlock.path, 'next')
+  const next = getSibling(snapshot, selectionEndBlock.path, 'next')
 
   if (!next) {
     return undefined
   }
 
-  return getBlock(snapshot.context, next.path)
+  return getBlock(snapshot, next.path)
 }

--- a/packages/editor/src/selectors/selector.get-next-inline-object.ts
+++ b/packages/editor/src/selectors/selector.get-next-inline-object.ts
@@ -21,7 +21,7 @@ export const getNextInlineObject: EditorSelector<
   }
 
   const sibling = findSibling(
-    snapshot.context,
+    snapshot,
     point.path,
     'next',
     (entry): entry is {node: PortableTextObject; path: ChildPath} =>

--- a/packages/editor/src/selectors/selector.get-next-inline-objects.ts
+++ b/packages/editor/src/selectors/selector.get-next-inline-objects.ts
@@ -29,7 +29,7 @@ export const getNextInlineObjects: EditorSelector<
     return []
   }
 
-  const children = getChildren(snapshot.context, parentPath(point.path))
+  const children = getChildren(snapshot, parentPath(point.path))
   const inlineObjects: Array<{node: PortableTextObject; path: ChildPath}> = []
   let endFound = false
 

--- a/packages/editor/src/selectors/selector.get-next-span.ts
+++ b/packages/editor/src/selectors/selector.get-next-span.ts
@@ -20,7 +20,7 @@ export const getNextSpan: EditorSelector<
   }
 
   return findSibling(
-    snapshot.context,
+    snapshot,
     point.path,
     'next',
     (entry): entry is {node: PortableTextSpan; path: Path} =>

--- a/packages/editor/src/selectors/selector.get-previous-block.ts
+++ b/packages/editor/src/selectors/selector.get-previous-block.ts
@@ -23,15 +23,11 @@ export const getPreviousBlock: EditorSelector<
     return undefined
   }
 
-  const previous = getSibling(
-    snapshot.context,
-    selectionStartBlock.path,
-    'previous',
-  )
+  const previous = getSibling(snapshot, selectionStartBlock.path, 'previous')
 
   if (!previous) {
     return undefined
   }
 
-  return getBlock(snapshot.context, previous.path)
+  return getBlock(snapshot, previous.path)
 }

--- a/packages/editor/src/selectors/selector.get-previous-inline-object.ts
+++ b/packages/editor/src/selectors/selector.get-previous-inline-object.ts
@@ -21,7 +21,7 @@ export const getPreviousInlineObject: EditorSelector<
   }
 
   const sibling = findSibling(
-    snapshot.context,
+    snapshot,
     point.path,
     'previous',
     (entry): entry is {node: PortableTextObject; path: ChildPath} =>

--- a/packages/editor/src/selectors/selector.get-previous-inline-objects.ts
+++ b/packages/editor/src/selectors/selector.get-previous-inline-objects.ts
@@ -29,7 +29,7 @@ export const getPreviousInlineObjects: EditorSelector<
     return []
   }
 
-  const children = getChildren(snapshot.context, parentPath(point.path))
+  const children = getChildren(snapshot, parentPath(point.path))
   const inlineObjects: Array<{node: PortableTextObject; path: ChildPath}> = []
 
   for (const child of children) {

--- a/packages/editor/src/selectors/selector.get-previous-span.ts
+++ b/packages/editor/src/selectors/selector.get-previous-span.ts
@@ -20,7 +20,7 @@ export const getPreviousSpan: EditorSelector<
   }
 
   return findSibling(
-    snapshot.context,
+    snapshot,
     point.path,
     'previous',
     (entry): entry is {node: PortableTextSpan; path: Path} =>

--- a/packages/editor/src/selectors/selector.get-selected-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-blocks.ts
@@ -37,18 +37,12 @@ export const getSelectedBlocks: EditorSelector<
 
   const result: Array<{node: PortableTextBlock; path: BlockPath}> = []
 
-  for (const entry of getNodes(
-    {
-      ...snapshot.context,
-      blockIndexMap: snapshot.blockIndexMap,
-    },
-    {
-      from: startPoint.path,
-      to: endPoint.path,
-      match: (_, path) => path.length === 1,
-    },
-  )) {
-    const block = getBlock(snapshot.context, entry.path)
+  for (const entry of getNodes(snapshot, {
+    from: startPoint.path,
+    to: endPoint.path,
+    match: (_, path) => path.length === 1,
+  })) {
+    const block = getBlock(snapshot, entry.path)
     if (block) {
       result.push({node: block.node, path: block.path})
     }

--- a/packages/editor/src/selectors/selector.get-selected-children.ts
+++ b/packages/editor/src/selectors/selector.get-selected-children.ts
@@ -44,14 +44,11 @@ export function getSelectedChildren<
 
     const result: Array<SelectedChild<TChild>> = []
 
-    for (const entry of getNodes(
-      {...snapshot.context, blockIndexMap: snapshot.blockIndexMap},
-      {
-        from: startPoint.path,
-        to: endPoint.path,
-        match: (_, path) => isInline(snapshot.context, path),
-      },
-    )) {
+    for (const entry of getNodes(snapshot, {
+      from: startPoint.path,
+      to: endPoint.path,
+      match: (_, path) => isInline(snapshot, path),
+    })) {
       const child = entry.node as PortableTextChild
 
       // Skip the start child when the selection begins exactly at its end

--- a/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
@@ -32,17 +32,11 @@ export const getSelectedTextBlocks: EditorSelector<
 
   const result: Array<{node: PortableTextTextBlock; path: Path}> = []
 
-  for (const entry of getNodes(
-    {
-      ...snapshot.context,
-      blockIndexMap: snapshot.blockIndexMap,
-    },
-    {
-      from: startPoint.path,
-      to: endPoint.path,
-      match: (node) => isTextBlock(snapshot.context, node),
-    },
-  )) {
+  for (const entry of getNodes(snapshot, {
+    from: startPoint.path,
+    to: endPoint.path,
+    match: (node) => isTextBlock(snapshot.context, node),
+  })) {
     if (isTextBlock(snapshot.context, entry.node)) {
       result.push({node: entry.node, path: entry.path})
     }

--- a/packages/editor/src/selectors/selector.get-selected-value.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.ts
@@ -126,11 +126,7 @@ function sliceArray({
       continue
     }
 
-    const childInfo = getNodeChildren(
-      {schema: context.schema, containers: context.containers},
-      block,
-      scopePath,
-    )
+    const childInfo = getNodeChildren(context, block, scopePath)
 
     if (!childInfo) {
       result.push(block)

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -23,10 +23,10 @@ export function isOverlappingSelection(
     }
 
     if (
-      !hasNode(snapshot.context, selection.anchor.path) ||
-      !hasNode(snapshot.context, selection.focus.path) ||
-      !hasNode(snapshot.context, editorSelection.anchor.path) ||
-      !hasNode(snapshot.context, editorSelection.focus.path)
+      !hasNode(snapshot, selection.anchor.path) ||
+      !hasNode(snapshot, selection.focus.path) ||
+      !hasNode(snapshot, editorSelection.anchor.path) ||
+      !hasNode(snapshot, editorSelection.focus.path)
     ) {
       return false
     }

--- a/packages/editor/src/slate-plugins/slate-plugin.patches.ts
+++ b/packages/editor/src/slate-plugins/slate-plugin.patches.ts
@@ -112,7 +112,7 @@ export function createPatchesPlugin({
       previousValue = editor.children
 
       const snapshot = editorActor.getSnapshot()
-      const {containers, initialValue, schema} = snapshot.context
+      const {initialValue, schema} = snapshot.context
 
       const editorWasEmpty =
         previousValue.length === 1 &&
@@ -140,28 +140,10 @@ export function createPatchesPlugin({
 
       switch (operation.type) {
         case 'insert_text':
-          patches = [
-            ...patches,
-            ...textPatch(
-              schema,
-              containers,
-              editor.children,
-              operation,
-              previousValue,
-            ),
-          ]
+          patches = [...patches, ...textPatch(editor, operation, previousValue)]
           break
         case 'remove_text':
-          patches = [
-            ...patches,
-            ...textPatch(
-              schema,
-              containers,
-              editor.children,
-              operation,
-              previousValue,
-            ),
-          ]
+          patches = [...patches, ...textPatch(editor, operation, previousValue)]
           break
         case 'insert':
           patches = [...patches, ...insertNodePatch(operation)]

--- a/packages/editor/src/slate/core/apply-operation.ts
+++ b/packages/editor/src/slate/core/apply-operation.ts
@@ -199,15 +199,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       }
 
       // Check if the node path resolves to a known node
-      const setNodeEntry = getNode(
-        {
-          schema: editor.schema,
-          containers: editor.containers,
-          value: editor.children,
-          blockIndexMap: editor.blockIndexMap,
-        },
-        setNodePath,
-      )
+      const setNodeEntry = getNode(editor, setNodePath)
 
       if (setNodeEntry) {
         // Node found: use modifyDescendant
@@ -420,15 +412,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       }
 
       // Check if the node path resolves to a known node
-      const unsetNodeEntry = getNode(
-        {
-          schema: editor.schema,
-          containers: editor.containers,
-          value: editor.children,
-          blockIndexMap: editor.blockIndexMap,
-        },
-        unsetNodePath,
-      )
+      const unsetNodeEntry = getNode(editor, unsetNodePath)
 
       if (unsetNodeEntry) {
         // Node found: use modifyDescendant

--- a/packages/editor/src/slate/create-editor.ts
+++ b/packages/editor/src/slate/create-editor.ts
@@ -23,6 +23,14 @@ export const createEditor = (): Editor => {
     get value() {
       return this.children
     },
+    get context() {
+      return {
+        schema: this.schema,
+        containers: this.containers,
+        value: this.children,
+        keyGenerator: this.keyGenerator,
+      }
+    },
     operations: [],
     selection: null,
     marks: null,

--- a/packages/editor/src/slate/editor/unhang-range.test.ts
+++ b/packages/editor/src/slate/editor/unhang-range.test.ts
@@ -20,9 +20,7 @@ function buildContext(...value: Array<Node>) {
     blockIndexMap.set((node as {_key: string})._key, index)
   })
   return {
-    schema,
-    containers: new Map(),
-    value,
+    context: {schema, containers: new Map(), value},
     blockIndexMap,
   }
 }
@@ -349,9 +347,7 @@ function buildContainerContext(...value: Array<Node>) {
     blockIndexMap.set((node as {_key: string})._key, index)
   })
   return {
-    schema,
-    containers,
-    value,
+    context: {schema, containers, value},
     blockIndexMap,
   }
 }

--- a/packages/editor/src/slate/editor/unhang-range.ts
+++ b/packages/editor/src/slate/editor/unhang-range.ts
@@ -1,11 +1,9 @@
 import {isSpan} from '@portabletext/schema'
-import type {EditorSchema} from '../../editor/editor-schema'
 import {getAncestorTextBlock} from '../../node-traversal/get-ancestor-text-block'
 import {getNodes} from '../../node-traversal/get-nodes'
 import {getSibling} from '../../node-traversal/get-sibling'
+import type {TraversalSnapshot} from '../../node-traversal/traversal-snapshot'
 import {isEditableContainer} from '../../schema/is-editable-container'
-import type {Containers} from '../../schema/resolve-containers'
-import type {Node} from '../interfaces/node'
 import type {Path} from '../interfaces/path'
 import type {Range} from '../interfaces/range'
 import {isVoidNode} from '../node/is-void-node'
@@ -27,15 +25,8 @@ import {rangeEdges} from '../range/range-edges'
  *   end (the user's range explicitly covers it, and unhanging would silently
  *   change the deletion target)
  */
-export function unhangRange(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-    blockIndexMap: Map<string, number>
-  },
-  range: Range,
-): Range {
+export function unhangRange(snapshot: TraversalSnapshot, range: Range): Range {
+  const {context} = snapshot
   let [start, end] = rangeEdges(range, {children: context.value})
 
   // PERF: exit early if we can guarantee that the range isn't hanging.
@@ -44,24 +35,24 @@ export function unhangRange(
     start.offset !== 0 ||
     end.offset !== 0 ||
     isCollapsedRange(range) ||
-    getSibling(context, end.path, 'previous') !== undefined
+    getSibling(snapshot, end.path, 'previous') !== undefined
   ) {
     return range
   }
 
-  const endBlock = getAncestorTextBlock(context, end.path)
+  const endBlock = getAncestorTextBlock(snapshot, end.path)
   const blockPath: Path = endBlock ? endBlock.path : []
 
   // If a void block or editable container sits strictly between the
   // endpoints, the range explicitly covers it. Unhanging would walk back
   // through spans and silently change the deletion target, so we leave the
   // range alone.
-  for (const {path} of getNodes(context, {
+  for (const {path} of getNodes(snapshot, {
     from: start.path,
     to: end.path,
     match: (candidate, candidatePath) =>
-      isVoidNode(context, candidate, candidatePath) ||
-      isEditableContainer(context, candidate, candidatePath),
+      isVoidNode(snapshot, candidate, candidatePath) ||
+      isEditableContainer(snapshot, candidate, candidatePath),
   })) {
     if (!isAncestorPath(path, start.path) && !isAncestorPath(path, end.path)) {
       return range
@@ -70,7 +61,7 @@ export function unhangRange(
 
   let skip = true
 
-  for (const {node, path: nodePath} of getNodes(context, {
+  for (const {node, path: nodePath} of getNodes(snapshot, {
     from: start.path,
     to: end.path,
     match: (n) => isSpan({schema: context.schema}, n),

--- a/packages/editor/src/slate/node/is-void-node.test.ts
+++ b/packages/editor/src/slate/node/is-void-node.test.ts
@@ -20,25 +20,25 @@ describe(isVoidNode.name, () => {
   describe('root-level nodes', () => {
     test('text block is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.textBlock1, [{_key: 'k3'}]),
+        isVoidNode(testbed.snapshot, testbed.textBlock1, [{_key: 'k3'}]),
       ).toBe(false)
     })
 
     test('block object without container registration is void', () => {
-      expect(isVoidNode(testbed.context, testbed.image, [{_key: 'k4'}])).toBe(
+      expect(isVoidNode(testbed.snapshot, testbed.image, [{_key: 'k4'}])).toBe(
         true,
       )
     })
 
     test('block object with container registration is not void', () => {
-      expect(isVoidNode(testbed.context, testbed.table, [{_key: 'k26'}])).toBe(
+      expect(isVoidNode(testbed.snapshot, testbed.table, [{_key: 'k26'}])).toBe(
         false,
       )
     })
 
     test('code block with container registration is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.codeBlock, [{_key: 'k11'}]),
+        isVoidNode(testbed.snapshot, testbed.codeBlock, [{_key: 'k11'}]),
       ).toBe(false)
     })
   })
@@ -46,7 +46,7 @@ describe(isVoidNode.name, () => {
   describe('inline objects', () => {
     test('inline object at root level is void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.stockTicker1, [
+        isVoidNode(testbed.snapshot, testbed.stockTicker1, [
           {_key: 'k3'},
           'children',
           {_key: 'k1'},
@@ -56,7 +56,7 @@ describe(isVoidNode.name, () => {
 
     test('inline object inside container is void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.stockTicker2, [
+        isVoidNode(testbed.snapshot, testbed.stockTicker2, [
           {_key: 'k26'},
           'rows',
           {_key: 'k21'},
@@ -74,7 +74,7 @@ describe(isVoidNode.name, () => {
   describe('nested container nodes', () => {
     test('row inside table is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.row1, [
+        isVoidNode(testbed.snapshot, testbed.row1, [
           {_key: 'k26'},
           'rows',
           {_key: 'k21'},
@@ -84,7 +84,7 @@ describe(isVoidNode.name, () => {
 
     test('cell inside table row is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.cell1, [
+        isVoidNode(testbed.snapshot, testbed.cell1, [
           {_key: 'k26'},
           'rows',
           {_key: 'k21'},
@@ -98,7 +98,7 @@ describe(isVoidNode.name, () => {
   describe('text nodes inside containers', () => {
     test('text block inside container is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.cellBlock1, [
+        isVoidNode(testbed.snapshot, testbed.cellBlock1, [
           {_key: 'k26'},
           'rows',
           {_key: 'k21'},
@@ -112,7 +112,7 @@ describe(isVoidNode.name, () => {
 
     test('span inside container is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.cellSpan1, [
+        isVoidNode(testbed.snapshot, testbed.cellSpan1, [
           {_key: 'k26'},
           'rows',
           {_key: 'k21'},
@@ -128,7 +128,7 @@ describe(isVoidNode.name, () => {
 
     test('text block inside code block is not void', () => {
       expect(
-        isVoidNode(testbed.context, testbed.codeLine1, [
+        isVoidNode(testbed.snapshot, testbed.codeLine1, [
           {_key: 'k11'},
           'code',
           {_key: 'k8'},
@@ -216,7 +216,10 @@ describe(isVoidNode.name, () => {
       ],
     ])
 
-    const context = {schema, containers, value: [table]}
+    const context = {
+      context: {schema, containers, value: [table]},
+      blockIndexMap: new Map(),
+    }
 
     test('image inside cell is void', () => {
       expect(
@@ -285,7 +288,10 @@ describe(isVoidNode.name, () => {
       ],
     ])
 
-    const context = {schema, containers, value: [gallery]}
+    const context = {
+      context: {schema, containers, value: [gallery]},
+      blockIndexMap: new Map(),
+    }
 
     test('gallery is not void', () => {
       expect(isVoidNode(context, gallery, [{_key: 'g1'}])).toBe(false)
@@ -321,8 +327,8 @@ describe(isVoidNode.name, () => {
   describe('empty containers', () => {
     test('all object nodes are void when no containers are registered', () => {
       const emptyContext = {
-        ...testbed.context,
-        containers: new Map(),
+        ...testbed.snapshot,
+        context: {...testbed.snapshot.context, containers: new Map()},
       }
 
       expect(isVoidNode(emptyContext, testbed.image, [{_key: 'k4'}])).toBe(true)
@@ -338,8 +344,8 @@ describe(isVoidNode.name, () => {
 
     test('text blocks are never void regardless of container registration', () => {
       const emptyContext = {
-        ...testbed.context,
-        containers: new Map(),
+        ...testbed.snapshot,
+        context: {...testbed.snapshot.context, containers: new Map()},
       }
 
       expect(isVoidNode(emptyContext, testbed.textBlock1, [{_key: 'k3'}])).toBe(

--- a/packages/editor/src/slate/node/is-void-node.ts
+++ b/packages/editor/src/slate/node/is-void-node.ts
@@ -1,8 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import type {EditorSchema} from '../../editor/editor-schema'
+import type {TraversalSnapshot} from '../../node-traversal/traversal-snapshot'
 import {isEditableContainer} from '../../schema/is-editable-container'
-import type {Containers} from '../../schema/resolve-containers'
-import type {Node} from '../interfaces/node'
 import type {Path} from '../interfaces/path'
 import {isObjectNode} from './is-object-node'
 
@@ -12,16 +10,12 @@ import {isObjectNode} from './is-object-node'
  * registered editable content (containers).
  */
 export function isVoidNode(
-  context: {
-    schema: EditorSchema
-    containers: Containers
-    value: Array<Node>
-  },
+  snapshot: TraversalSnapshot,
   node: unknown,
   path: Path,
 ): node is PortableTextObject {
   return (
-    isObjectNode({schema: context.schema}, node) &&
-    !isEditableContainer(context, node, path)
+    isObjectNode({schema: snapshot.context.schema}, node) &&
+    !isEditableContainer(snapshot, node, path)
   )
 }

--- a/packages/editor/src/slate/utils/modify.ts
+++ b/packages/editor/src/slate/utils/modify.ts
@@ -59,14 +59,7 @@ export const modifyDescendant = <N extends Node>(
     schema: editor.schema,
     containers: editor.containers,
   }
-  const nodeEntry = getNode(
-    {
-      ...context,
-      value: editor.children,
-      blockIndexMap: editor.blockIndexMap,
-    },
-    path,
-  )
+  const nodeEntry = getNode(editor, path)
   if (!nodeEntry) {
     return
   }
@@ -142,14 +135,7 @@ export const modifyDescendant = <N extends Node>(
     const ancestorPath =
       ancestorPathEnd > 0 ? path.slice(0, ancestorPathEnd) : []
 
-    const ancestorEntry = getNode(
-      {
-        ...context,
-        value: editor.children,
-        blockIndexMap: editor.blockIndexMap,
-      },
-      ancestorPath,
-    )
+    const ancestorEntry = getNode(editor, ancestorPath)
     if (!ancestorEntry) {
       return
     }
@@ -230,14 +216,7 @@ export const modifyChildren = (
       containers: editor.containers,
     }
 
-    const nodeEntry = getNode(
-      {
-        ...context,
-        value: editor.children,
-        blockIndexMap: editor.blockIndexMap,
-      },
-      path,
-    )
+    const nodeEntry = getNode(editor, path)
     if (!nodeEntry) {
       return
     }

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -167,7 +167,7 @@ async function assertEditorState(
     // Accept any boundary-equivalent selection that produces the expected
     // textspec.
     for (const variant of boundaryEquivalentSelections(
-      {schema, containers, value},
+      {context: {schema, containers, value}, blockIndexMap: new Map()},
       selection,
     )) {
       if (renderActual(variant) === expected) {

--- a/packages/editor/src/types/slate-editor.ts
+++ b/packages/editor/src/types/slate-editor.ts
@@ -31,6 +31,17 @@ export interface PortableTextSlateEditor extends DOMEditor {
   keyGenerator: () => string
   containers: ResolvedContainers
 
+  /**
+   * Snapshot-shaped view onto the editor's traversal state. Mirrors the
+   * shape of `EditorSnapshot.context`.
+   */
+  readonly context: {
+    schema: EditorSchema
+    containers: ResolvedContainers
+    value: PortableTextBlock[]
+    keyGenerator: () => string
+  }
+
   decoratedRanges: Array<DecoratedRange>
   decoratorState: Record<string, boolean | undefined>
   blockIndexMap: Map<string, number>

--- a/packages/editor/src/utils/util.at-the-beginning-of-block.ts
+++ b/packages/editor/src/utils/util.at-the-beginning-of-block.ts
@@ -1,25 +1,25 @@
 import {isTextBlock, type PortableTextBlock} from '@portabletext/schema'
-import type {EditorContext} from '../editor/editor-snapshot'
+import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {isKeyedSegment} from './util.is-keyed-segment'
 import {isSelectionCollapsed} from './util.is-selection-collapsed'
 
 export function isAtTheBeginningOfBlock({
-  context,
+  snapshot,
   block,
 }: {
-  context: EditorContext
+  snapshot: EditorSnapshot
   block: PortableTextBlock
 }) {
-  if (!isTextBlock(context, block)) {
+  if (!isTextBlock(snapshot.context, block)) {
     return false
   }
 
-  if (!context.selection) {
+  if (!snapshot.context.selection) {
     return false
   }
 
-  if (!isSelectionCollapsed(context.selection)) {
+  if (!isSelectionCollapsed(snapshot.context.selection)) {
     return false
   }
 
@@ -27,8 +27,8 @@ export function isAtTheBeginningOfBlock({
   // and not in some unrelated structural position. Then read the child key
   // from the last keyed segment of the focus path; the field name (`children`,
   // or whatever the container declares) is irrelevant.
-  const focusPath = context.selection.focus.path
-  const ancestorTextBlock = getAncestorTextBlock(context, focusPath)
+  const focusPath = snapshot.context.selection.focus.path
+  const ancestorTextBlock = getAncestorTextBlock(snapshot, focusPath)
 
   if (!ancestorTextBlock || ancestorTextBlock.node._key !== block._key) {
     return false
@@ -41,6 +41,6 @@ export function isAtTheBeginningOfBlock({
 
   return (
     focusChildKey === block.children[0]?._key &&
-    context.selection.focus.offset === 0
+    snapshot.context.selection.focus.offset === 0
   )
 }

--- a/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
+++ b/packages/editor/src/utils/util.block-offset-to-block-selection-point.ts
@@ -1,16 +1,16 @@
-import type {EditorContext} from '../editor/editor-snapshot'
 import {getNode} from '../node-traversal/get-node'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 
 export function blockOffsetToBlockSelectionPoint({
-  context,
+  snapshot,
   blockOffset,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   blockOffset: BlockOffset
 }): EditorSelectionPoint | undefined {
-  const blockEntry = getNode(context, blockOffset.path)
+  const blockEntry = getNode(snapshot, blockOffset.path)
 
   if (!blockEntry) {
     return undefined

--- a/packages/editor/src/utils/util.block-offset-to-selection-point.ts
+++ b/packages/editor/src/utils/util.block-offset-to-selection-point.ts
@@ -1,27 +1,27 @@
-import type {EditorContext} from '../editor/editor-snapshot'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 import {blockOffsetToSpanSelectionPoint} from './util.block-offset'
 import {blockOffsetToBlockSelectionPoint} from './util.block-offset-to-block-selection-point'
 
 export function blockOffsetToSelectionPoint({
-  context,
+  snapshot,
   blockOffset,
   direction,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   blockOffset: BlockOffset
   direction: 'forward' | 'backward'
 }): EditorSelectionPoint | undefined {
   const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
-    context,
+    snapshot,
     blockOffset,
     direction,
   })
 
   if (!spanSelectionPoint) {
     return blockOffsetToBlockSelectionPoint({
-      context,
+      snapshot,
       blockOffset,
     })
   }

--- a/packages/editor/src/utils/util.block-offset.test.ts
+++ b/packages/editor/src/utils/util.block-offset.test.ts
@@ -32,10 +32,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction forward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -52,10 +51,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction backward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -74,10 +72,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction forward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -94,10 +91,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction backward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -139,10 +135,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction forward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -159,10 +154,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction backward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -181,10 +175,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction forward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -201,10 +194,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction backward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -223,10 +215,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction forward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -243,10 +234,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       test('direction backward', () => {
         expect(
           blockOffsetToSpanSelectionPoint({
-            context: {
-              schema,
-              value,
-              containers: new Map(),
+            snapshot: {
+              context: {schema, value, containers: new Map()},
+              blockIndexMap: new Map(),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -291,10 +281,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
 
     expect(
       blockOffsetToSpanSelectionPoint({
-        context: {
-          schema,
-          value,
-          containers: new Map(),
+        snapshot: {
+          context: {schema, value, containers: new Map()},
+          blockIndexMap: new Map(),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -305,10 +294,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
     ).toBeUndefined()
     expect(
       blockOffsetToSpanSelectionPoint({
-        context: {
-          schema,
-          value,
-          containers: new Map(),
+        snapshot: {
+          context: {schema, value, containers: new Map()},
+          blockIndexMap: new Map(),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -331,10 +319,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
 
     expect(
       blockOffsetToSpanSelectionPoint({
-        context: {
-          schema,
-          value,
-          containers: new Map(),
+        snapshot: {
+          context: {schema, value, containers: new Map()},
+          blockIndexMap: new Map(),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -373,10 +360,9 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
 
     expect(
       blockOffsetToSpanSelectionPoint({
-        context: {
-          schema,
-          value,
-          containers: new Map(),
+        snapshot: {
+          context: {schema, value, containers: new Map()},
+          blockIndexMap: new Map(),
         },
         blockOffset: {
           path: [{_key: b1}],

--- a/packages/editor/src/utils/util.block-offset.ts
+++ b/packages/editor/src/utils/util.block-offset.ts
@@ -1,7 +1,7 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
-import type {EditorContext} from '../editor/editor-snapshot'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
 import {getNode} from '../node-traversal/get-node'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 import type {ChildPath} from '../types/paths'
@@ -11,17 +11,17 @@ import {isKeyedSegment} from './util.is-keyed-segment'
  * @public
  */
 export function blockOffsetToSpanSelectionPoint({
-  context,
+  snapshot,
   blockOffset,
   direction,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   blockOffset: BlockOffset
   direction: 'forward' | 'backward'
 }) {
-  const blockEntry = getNode(context, blockOffset.path)
+  const blockEntry = getNode(snapshot, blockOffset.path)
 
-  if (!blockEntry || !isTextBlock(context, blockEntry.node)) {
+  if (!blockEntry || !isTextBlock(snapshot.context, blockEntry.node)) {
     return undefined
   }
 
@@ -34,7 +34,7 @@ export function blockOffsetToSpanSelectionPoint({
 
   for (const child of block.children) {
     if (direction === 'forward') {
-      if (!isSpan(context, child)) {
+      if (!isSpan(snapshot.context, child)) {
         continue
       }
 
@@ -51,7 +51,7 @@ export function blockOffsetToSpanSelectionPoint({
       continue
     }
 
-    if (!isSpan(context, child)) {
+    if (!isSpan(snapshot.context, child)) {
       skippedInlineObject = true
       continue
     }
@@ -92,10 +92,10 @@ export function blockOffsetToSpanSelectionPoint({
  * @public
  */
 export function spanSelectionPointToBlockOffset({
-  context,
+  snapshot,
   selectionPoint,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   selectionPoint: EditorSelectionPoint
 }): BlockOffset | undefined {
   const spanSegment = selectionPoint.path.at(-1)
@@ -104,7 +104,7 @@ export function spanSelectionPointToBlockOffset({
     return undefined
   }
 
-  const textBlock = getAncestorTextBlock(context, selectionPoint.path)
+  const textBlock = getAncestorTextBlock(snapshot, selectionPoint.path)
 
   if (!textBlock) {
     return undefined
@@ -113,7 +113,7 @@ export function spanSelectionPointToBlockOffset({
   let offset = 0
 
   for (const child of textBlock.node.children) {
-    if (!isSpan(context, child)) {
+    if (!isSpan(snapshot.context, child)) {
       continue
     }
 

--- a/packages/editor/src/utils/util.block-offsets-to-selection.ts
+++ b/packages/editor/src/utils/util.block-offsets-to-selection.ts
@@ -1,4 +1,4 @@
-import type {EditorContext} from '../editor/editor-snapshot'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelection} from '../types/editor'
 import {blockOffsetToSelectionPoint} from './util.block-offset-to-selection-point'
@@ -7,21 +7,21 @@ import {blockOffsetToSelectionPoint} from './util.block-offset-to-selection-poin
  * @public
  */
 export function blockOffsetsToSelection({
-  context,
+  snapshot,
   offsets,
   backward,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   offsets: {anchor: BlockOffset; focus: BlockOffset}
   backward?: boolean
 }): EditorSelection {
   const anchor = blockOffsetToSelectionPoint({
-    context,
+    snapshot,
     blockOffset: offsets.anchor,
     direction: backward ? 'backward' : 'forward',
   })
   const focus = blockOffsetToSelectionPoint({
-    context,
+    snapshot,
     blockOffset: offsets.focus,
     direction: backward ? 'forward' : 'backward',
   })

--- a/packages/editor/src/utils/util.child-selection-point-to-block-offset.ts
+++ b/packages/editor/src/utils/util.child-selection-point-to-block-offset.ts
@@ -1,6 +1,6 @@
 import {isSpan} from '@portabletext/schema'
-import type {EditorContext} from '../editor/editor-snapshot'
 import {getAncestorTextBlock} from '../node-traversal/get-ancestor-text-block'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {BlockOffset} from '../types/block-offset'
 import type {EditorSelectionPoint} from '../types/editor'
 import {isKeyedSegment} from './util.is-keyed-segment'
@@ -9,10 +9,10 @@ import {isKeyedSegment} from './util.is-keyed-segment'
  * @public
  */
 export function childSelectionPointToBlockOffset({
-  context,
+  snapshot,
   selectionPoint,
 }: {
-  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  snapshot: TraversalSnapshot
   selectionPoint: EditorSelectionPoint
 }): BlockOffset | undefined {
   const childSegment = selectionPoint.path.at(-1)
@@ -21,7 +21,7 @@ export function childSelectionPointToBlockOffset({
     return undefined
   }
 
-  const textBlock = getAncestorTextBlock(context, selectionPoint.path)
+  const textBlock = getAncestorTextBlock(snapshot, selectionPoint.path)
 
   if (!textBlock) {
     return undefined
@@ -37,7 +37,7 @@ export function childSelectionPointToBlockOffset({
       }
     }
 
-    if (isSpan(context, child)) {
+    if (isSpan(snapshot.context, child)) {
       offset += child.text.length
     }
   }

--- a/packages/editor/test-utils/boundary-equivalent.test.ts
+++ b/packages/editor/test-utils/boundary-equivalent.test.ts
@@ -8,7 +8,10 @@ const containers = new Map()
 describe(boundaryEquivalentSelections.name, () => {
   test('returns no variants when selection is null', () => {
     expect(
-      boundaryEquivalentSelections({schema, value: [], containers}, null),
+      boundaryEquivalentSelections(
+        {context: {schema, value: [], containers}, blockIndexMap: new Map()},
+        null,
+      ),
     ).toEqual([])
   })
 
@@ -27,7 +30,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: point, focus: point, backward: false},
       ),
     ).toEqual([])
@@ -45,7 +51,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: endOfS1, focus: endOfS1, backward: false},
       ),
     ).toEqual([])
@@ -70,7 +79,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: endOfS1, focus: endOfS1, backward: false},
       ),
     ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: false}])
@@ -95,7 +107,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: startOfS2, focus: startOfS2, backward: false},
       ),
     ).toEqual([{anchor: endOfS1, focus: endOfS1, backward: false}])
@@ -116,7 +131,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: endOfS1, focus: endOfS1, backward: false},
       ),
     ).toEqual([])
@@ -150,7 +168,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: endOfS1, focus: endOfS2, backward: false},
       ),
     ).toEqual([
@@ -179,7 +200,10 @@ describe(boundaryEquivalentSelections.name, () => {
     }
     expect(
       boundaryEquivalentSelections(
-        {schema, value: [block], containers},
+        {
+          context: {schema, value: [block], containers},
+          blockIndexMap: new Map(),
+        },
         {anchor: endOfS1, focus: endOfS1, backward: true},
       ),
     ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: true}])

--- a/packages/editor/test-utils/boundary-equivalent.ts
+++ b/packages/editor/test-utils/boundary-equivalent.ts
@@ -8,9 +8,12 @@ import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 import {isEqualSelectionPoints} from '../src/utils/util.is-equal-selection-points'
 
 type Context = {
-  schema: EditorSchema
-  containers: Containers
-  value: Array<Node>
+  context: {
+    schema: EditorSchema
+    containers: Containers
+    value: Array<Node>
+  }
+  blockIndexMap: Map<string, number>
 }
 
 /**
@@ -77,14 +80,14 @@ function pointVariants(
 
   if (point.offset === 0) {
     const previous = getSibling(context, span.path, 'previous')
-    if (previous && isSpan({schema: context.schema}, previous.node)) {
+    if (previous && isSpan({schema: context.context.schema}, previous.node)) {
       variants.push({path: previous.path, offset: previous.node.text.length})
     }
   }
 
   if (point.offset === span.node.text.length) {
     const next = getSibling(context, span.path, 'next')
-    if (next && isSpan({schema: context.schema}, next.node)) {
+    if (next && isSpan({schema: context.context.schema}, next.node)) {
       variants.push({path: next.path, offset: 0})
     }
   }

--- a/packages/editor/tests/behavior.snapshot-leak.test.tsx
+++ b/packages/editor/tests/behavior.snapshot-leak.test.tsx
@@ -1,0 +1,105 @@
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Behaviors are the consumer-facing extension surface. The snapshot they
+ * receive must not expose internal slate-engine state. Capture the actual
+ * snapshot object that lands inside a guard and an action, then assert
+ * the exact set of own keys.
+ */
+describe('Snapshot leak surface', () => {
+  test('Scenario: guard receives a snapshot with the expected keys', async () => {
+    const captured: Array<object> = []
+
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({snapshot, event}) => {
+                if (event.text === 'a') {
+                  captured.push(snapshot)
+                }
+                return true
+              },
+              actions: [],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.type(locator, 'a')
+
+    await vi.waitFor(() => {
+      expect(captured.length).toBeGreaterThan(0)
+    })
+
+    const snapshot = captured[0]! as {context: object}
+
+    expect(Object.keys(snapshot).sort()).toEqual([
+      'blockIndexMap',
+      'context',
+      'decoratorState',
+    ])
+    expect(Object.keys(snapshot.context).sort()).toEqual([
+      'containers',
+      'converters',
+      'keyGenerator',
+      'readOnly',
+      'schema',
+      'selection',
+      'value',
+    ])
+  })
+
+  test('Scenario: action receives a snapshot with the expected keys', async () => {
+    const captured: Array<object> = []
+
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [
+                ({snapshot}) => {
+                  captured.push(snapshot)
+                  return []
+                },
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.type(locator, 'a')
+
+    await vi.waitFor(() => {
+      expect(captured.length).toBeGreaterThan(0)
+    })
+
+    const snapshot = captured[0]! as {context: object}
+
+    expect(Object.keys(snapshot).sort()).toEqual([
+      'blockIndexMap',
+      'context',
+      'decoratorState',
+    ])
+    expect(Object.keys(snapshot.context).sort()).toEqual([
+      'containers',
+      'converters',
+      'keyGenerator',
+      'readOnly',
+      'schema',
+      'selection',
+      'value',
+    ])
+  })
+})

--- a/packages/plugin-character-pair-decorator/src/behavior.character-pair-decorator.ts
+++ b/packages/plugin-character-pair-decorator/src/behavior.character-pair-decorator.ts
@@ -55,7 +55,7 @@ export function createCharacterPairDecoratorBehavior(config: {
       const selectionStartPoint = selectors.getSelectionStartPoint(snapshot)
       const selectionStartOffset = selectionStartPoint
         ? utils.spanSelectionPointToBlockOffset({
-            context: snapshot.context,
+            snapshot,
             selectionPoint: selectionStartPoint,
           })
         : undefined
@@ -108,7 +108,7 @@ export function createCharacterPairDecoratorBehavior(config: {
       // there is an inline object inside it
       if (prefixOffsets.focus.offset - prefixOffsets.anchor.offset > 1) {
         const prefixSelection = utils.blockOffsetsToSelection({
-          context: snapshot.context,
+          snapshot,
           offsets: prefixOffsets,
         })
         const inlineObjectBeforePrefixFocus = selectors.getPreviousInlineObject(
@@ -128,7 +128,7 @@ export function createCharacterPairDecoratorBehavior(config: {
         const inlineObjectBeforePrefixFocusOffset =
           inlineObjectBeforePrefixFocus
             ? utils.childSelectionPointToBlockOffset({
-                context: snapshot.context,
+                snapshot,
                 selectionPoint: {
                   path: inlineObjectBeforePrefixFocus.path,
                   offset: 0,
@@ -153,7 +153,7 @@ export function createCharacterPairDecoratorBehavior(config: {
         const previousInlineObject = selectors.getPreviousInlineObject(snapshot)
         const previousInlineObjectOffset = previousInlineObject
           ? utils.childSelectionPointToBlockOffset({
-              context: snapshot.context,
+              snapshot,
               selectionPoint: {
                 path: previousInlineObject.path,
                 offset: 0,

--- a/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
+++ b/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
@@ -108,11 +108,11 @@ const selectionListenerCallback: CallbackLogicFunction<
         }
 
         const anchor = utils.spanSelectionPointToBlockOffset({
-          context: snapshot.context,
+          snapshot,
           selectionPoint: event.at.anchor,
         })
         const focus = utils.spanSelectionPointToBlockOffset({
-          context: snapshot.context,
+          snapshot,
           selectionPoint: event.at.focus,
         })
 

--- a/packages/plugin-input-rule/src/input-rule-match-location.ts
+++ b/packages/plugin-input-rule/src/input-rule-match-location.ts
@@ -73,12 +73,12 @@ export function getInputRuleMatchLocation({
   }
 
   const anchorBackwards = blockOffsetToSpanSelectionPoint({
-    context: snapshot.context,
+    snapshot,
     blockOffset: normalizedOffsets.anchor,
     direction: 'backward',
   })
   const focusForwards = blockOffsetToSpanSelectionPoint({
-    context: snapshot.context,
+    snapshot,
     blockOffset: normalizedOffsets.focus,
     direction: 'forward',
   })


### PR DESCRIPTION
Traversal utilities, schema utilities, and operations all needed access to `{schema, containers, value}` plus the optional `blockIndexMap` cache. Each subsystem accepted a slightly different shape: traversal utilities took a flat `{schema, containers, value, blockIndexMap?}`, operations took `OperationContext`, public block-offset utilities took `Pick<EditorContext, 'schema' | 'value' | 'containers'>`. Public selectors built bespoke wrappers at every call site to bridge them.

This PR aligns the surfaces under a single `TraversalSnapshot` shape that mirrors `EditorSnapshot`: ambient state under `context`, `blockIndexMap` as a sibling.

`PortableTextSlateEditor` gains a `context` getter projecting `{schema, containers, value, keyGenerator}` from its existing fields, so the editor itself satisfies `TraversalSnapshot` natively. Operations receive `{snapshot, operation}`. The 25 node-traversal utilities, six schema utilities (`getEnclosingContainer`, `getContainerScopedName`, `getTypeChain`, `getBlockObjectSchema`, `getBlockSubSchema`, `isEditableContainer`), `isVoidNode`, `unhangRange`, `getSelectionState`, and `getUnwrapTarget` all take `TraversalSnapshot`.

The five public block-offset utilities (`blockOffsetToSpanSelectionPoint`, `spanSelectionPointToBlockOffset`, `blockOffsetToBlockSelectionPoint`, `childSelectionPointToBlockOffset`, `blockOffsetsToSelection`) move from `{context: Pick<EditorContext, ...>, ...}` to `{snapshot: TraversalSnapshot, ...}`. Callers pass the editor snapshot directly instead of unwrapping it to `snapshot.context`. This is the only consumer-visible change in the PR.

## Breaking change

The five block-offset utilities listed above accept a `snapshot` field instead of a `context` field on their argument object.

```ts
// Before
blockOffsetToSpanSelectionPoint({
  context: snapshot.context,
  blockOffset,
  direction,
})

// After
blockOffsetToSpanSelectionPoint({
  snapshot,
  blockOffset,
  direction,
})
```
