### PR TITLE
feat: support GFM task lists in markdown round-trip

### DIFF
--- a/.changeset/markdown-task-lists.md
+++ b/.changeset/markdown-task-lists.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: support GFM task lists in markdown round-trip
+
+`markdownToPortableText` now recognizes GitHub-Flavored Markdown task list items (`- [ ] foo` and `- [x] foo`) and converts them into Portable Text blocks with `listItem: 'task'` and a boolean `checked` field. `portableTextToMarkdown` renders these blocks back to the same syntax. The default schema declares the `task` list type and a `checked` block field, so consumers using the default schema get round-tripping for free. Schemas without a `task` list type fall back to `bullet` and discard the checkbox prefix.

--- a/packages/markdown/src/default-schema.ts
+++ b/packages/markdown/src/default-schema.ts
@@ -56,6 +56,10 @@ export const defaultUnorderedListItemDefinition = {
   name: 'bullet',
 } as const satisfies ListDefinition
 
+export const defaultTaskListItemDefinition = {
+  name: 'task',
+} as const satisfies ListDefinition
+
 /********************
  * Default decorator definitions
  ********************/
@@ -141,6 +145,9 @@ export const defaultCalloutObjectDefinition = {
  */
 export const defaultSchema = compileSchema(
   defineSchema({
+    block: {
+      fields: [{name: 'checked', type: 'boolean'}],
+    },
     styles: [
       normalStyleDefinition,
       h1StyleDefinition,
@@ -154,6 +161,7 @@ export const defaultSchema = compileSchema(
     lists: [
       defaultOrderedListItemDefinition,
       defaultUnorderedListItemDefinition,
+      defaultTaskListItemDefinition,
     ],
     decorators: [
       defaultStrongDecoratorDefinition,

--- a/packages/markdown/src/from-portable-text/renderers/list-item.ts
+++ b/packages/markdown/src/from-portable-text/renderers/list-item.ts
@@ -10,14 +10,20 @@ export const DefaultListItemRenderer: PortableTextListItemRenderer = ({
 }) => {
   const listStyle = value.listItem || 'bullet'
   const level = value.level || 1
+  const indent = '   '.repeat(level - 1)
 
   if (listStyle === 'number') {
-    const indent = '   '.repeat(level - 1)
-
     return `${indent}${listIndex ?? 1}. ${children}`
   }
 
-  const indent = '   '.repeat(level - 1)
+  if (listStyle === 'task') {
+    const checked =
+      'checked' in value && typeof value.checked === 'boolean'
+        ? value.checked
+        : false
+    const marker = checked ? '[x]' : '[ ]'
+    return `${indent}- ${marker} ${children}`
+  }
 
   return `${indent}- ${children}`
 }

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -1342,6 +1342,167 @@ describe(markdownToPortableText.name, () => {
       })
     })
 
+    describe('task', () => {
+      test('default unchecked task', () => {
+        const keyGenerator = createTestKeyGenerator()
+        expect(markdownToPortableText('- [ ] foo', {keyGenerator})).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 1,
+            checked: false,
+          },
+        ])
+      })
+
+      test('default checked task', () => {
+        const keyGenerator = createTestKeyGenerator()
+        expect(markdownToPortableText('- [x] foo', {keyGenerator})).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 1,
+            checked: true,
+          },
+        ])
+      })
+
+      test('uppercase X is also checked', () => {
+        const keyGenerator = createTestKeyGenerator()
+        expect(markdownToPortableText('- [X] foo', {keyGenerator})).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 1,
+            checked: true,
+          },
+        ])
+      })
+
+      test('custom task list type', () => {
+        const keyGenerator = createTestKeyGenerator()
+        expect(
+          markdownToPortableText('- [x] foo', {
+            keyGenerator,
+            schema: compileSchema(defineSchema({lists: [{name: 'todo'}]})),
+            listItem: {
+              task: ({context}) => {
+                return context.schema.lists.find((list) => list.name === 'todo')
+                  ?.name
+              },
+            },
+          }),
+        ).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'todo',
+            level: 1,
+            checked: true,
+          },
+        ])
+      })
+
+      test('falls back to bullet when schema does not declare a task list', () => {
+        const keyGenerator = createTestKeyGenerator()
+        expect(
+          markdownToPortableText('- [x] foo', {
+            keyGenerator,
+            schema: compileSchema(defineSchema({lists: [{name: 'bullet'}]})),
+          }),
+        ).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'bullet',
+            level: 1,
+          },
+        ])
+      })
+
+      test('mixed task and plain bullet items', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const markdown = ['- [ ] todo', '- done', '- [x] also done'].join('\n')
+        expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'todo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 1,
+            checked: false,
+          },
+          {
+            _type: 'block',
+            _key: 'k2',
+            children: [{_type: 'span', _key: 'k3', text: 'done', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'bullet',
+            level: 1,
+          },
+          {
+            _type: 'block',
+            _key: 'k4',
+            children: [
+              {_type: 'span', _key: 'k5', text: 'also done', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 1,
+            checked: true,
+          },
+        ])
+      })
+
+      test('task nested under bullet', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const markdown = ['- foo', '   - [x] bar'].join('\n')
+        expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'bullet',
+            level: 1,
+          },
+          {
+            _type: 'block',
+            _key: 'k2',
+            children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+            markDefs: [],
+            style: 'normal',
+            listItem: 'task',
+            level: 2,
+            checked: true,
+          },
+        ])
+      })
+    })
+
     describe('with code block', () => {
       const markdown = [
         '1. foo',

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -614,6 +614,65 @@ describe(portableTextToMarkdown.name, () => {
         expect(portableTextToMarkdown(portableText)).toBe('foo')
       })
     })
+
+    describe('task', () => {
+      test('unchecked task round-trip', () => {
+        const markdown = '- [ ] foo'
+        const portableText = markdownToPortableText(markdown)
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
+      })
+
+      test('checked task round-trip', () => {
+        const markdown = '- [x] foo'
+        const portableText = markdownToPortableText(markdown)
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
+      })
+
+      test('mixed task and bullet round-trip', () => {
+        const markdown = ['- [ ] todo', '- done', '- [x] also done'].join('\n')
+        const portableText = markdownToPortableText(markdown)
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
+      })
+
+      test('task nested under bullet round-trip', () => {
+        const markdown = ['- foo', '   - [x] bar'].join('\n')
+        const portableText = markdownToPortableText(markdown)
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
+      })
+
+      test('renders unchecked task from explicit portable text', () => {
+        expect(
+          portableTextToMarkdown([
+            {
+              _type: 'block',
+              _key: 'k0',
+              children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'task',
+              level: 1,
+              checked: false,
+            },
+          ]),
+        ).toBe('- [ ] foo')
+      })
+
+      test('missing checked field renders as unchecked', () => {
+        expect(
+          portableTextToMarkdown([
+            {
+              _type: 'block',
+              _key: 'k0',
+              children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'task',
+              level: 1,
+            },
+          ]),
+        ).toBe('- [ ] foo')
+      })
+    })
   })
 
   describe('lists', () => {

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -21,6 +21,7 @@ import {
   defaultSchema,
   defaultStrikeThroughDecoratorDefinition,
   defaultStrongDecoratorDefinition,
+  defaultTaskListItemDefinition,
   defaultUnorderedListItemDefinition,
   h1StyleDefinition,
   h2StyleDefinition,
@@ -69,6 +70,7 @@ type Options = {
   listItem?: {
     number?: ListItemMatcher
     bullet?: ListItemMatcher
+    task?: ListItemMatcher
   }
   types?: {
     code?: ObjectMatcher<{language: string | undefined; code: string}>
@@ -154,6 +156,7 @@ const defaultOptions = {
   listItem: {
     number: buildListItemMatcher(defaultOrderedListItemDefinition),
     bullet: buildListItemMatcher(defaultUnorderedListItemDefinition),
+    task: buildListItemMatcher(defaultTaskListItemDefinition),
   },
   marks: {
     strong: buildDecoratorMatcher(defaultStrongDecoratorDefinition),
@@ -243,6 +246,54 @@ export function markdownToPortableText(
     .use(alert)
 
   const tokens = md.parse(markdown, {})
+
+  // Pre-pass: detect GFM task-list checkbox prefixes (`[ ]`, `[x]`, `[X]`)
+  // on the first inline content of each list item. Strip the prefix from the
+  // inline content and remember which list items are tasks (and their checked
+  // state) so the main walk can apply `listItem: 'task'` and `checked` when
+  // processing the corresponding `list_item_open` token.
+  const taskCheckedByListItemIndex = new Map<number, boolean>()
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]
+    if (token?.type !== 'list_item_open') {
+      continue
+    }
+    // Find the first inline token within this list item.
+    let inlineIndex = -1
+    for (let j = i + 1; j < tokens.length; j++) {
+      const candidate = tokens[j]
+      if (!candidate) {
+        continue
+      }
+      if (candidate.type === 'list_item_close') {
+        break
+      }
+      if (candidate.type === 'inline') {
+        inlineIndex = j
+        break
+      }
+    }
+    if (inlineIndex === -1) {
+      continue
+    }
+    const inlineToken = tokens[inlineIndex]
+    if (!inlineToken) {
+      continue
+    }
+    const match = inlineToken.content.match(/^\[([ xX])\] /)
+    if (!match) {
+      continue
+    }
+    const checked = match[1] !== ' '
+    taskCheckedByListItemIndex.set(i, checked)
+    // Strip the prefix from the content and the first child text token so the
+    // resulting span doesn't include the checkbox marker.
+    inlineToken.content = inlineToken.content.slice(match[0].length)
+    const firstChild = inlineToken.children?.[0]
+    if (firstChild && typeof firstChild.content === 'string') {
+      firstChild.content = firstChild.content.slice(match[0].length)
+    }
+  }
 
   const portableText: Array<PortableTextBlock> = []
 
@@ -359,7 +410,7 @@ export function markdownToPortableText(
 
   // Helpers for lists
   const listLevel = () => currentListStack.length
-  const ensureListBlock = (listItem: string) => {
+  const ensureListBlock = (listItem: string, checked?: boolean) => {
     if (!currentBlock) {
       // Use blockquote style if inside a blockquote, otherwise use normal style
       const style =
@@ -387,10 +438,20 @@ export function markdownToPortableText(
       currentBlock.listItem = listItem
       currentBlock.level = listLevel()
     }
+
+    if (checked !== undefined) {
+      ;(currentBlock as PortableTextTextBlock & {checked?: boolean}).checked =
+        checked
+    }
   }
 
   // Walk tokens
-  for (const token of tokens) {
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    const token = tokens[tokenIndex]
+    if (!token) {
+      continue
+    }
+
     switch (token.type) {
       // Paragraphs
       case 'paragraph_open': {
@@ -527,9 +588,9 @@ export function markdownToPortableText(
         currentListStack.pop()
         break
       case 'list_item_open': {
-        const listType = currentListStack.at(-1)
+        const baseListType = currentListStack.at(-1)
 
-        if (listType === undefined) {
+        if (baseListType === undefined) {
           throw new Error('Expected an open list')
         }
 
@@ -537,6 +598,24 @@ export function markdownToPortableText(
         // This is needed for proper separation of list items
         if (currentBlock) {
           flushBlock()
+        }
+
+        // Resolve task list type and checked state for this specific item.
+        // If the schema declares a `task` list definition, GFM checkboxes
+        // (`- [ ]` / `- [x]`) override the surrounding list's type for this
+        // item. Otherwise the prefix has already been stripped by the
+        // pre-pass and we render as the surrounding list type.
+        const taskChecked = taskCheckedByListItemIndex.get(tokenIndex)
+        let listType = baseListType
+        let checked: boolean | undefined
+        if (taskChecked !== undefined) {
+          const taskListType = consolidatedOptions.listItem.task?.({
+            context: {schema: consolidatedOptions.schema},
+          })
+          if (taskListType) {
+            listType = taskListType
+            checked = taskChecked
+          }
         }
 
         // If listType is null, it means there's no list definition in the schema
@@ -559,7 +638,7 @@ export function markdownToPortableText(
           break
         }
 
-        ensureListBlock(listType)
+        ensureListBlock(listType, checked)
         inListItem = true
         break
       }


### PR DESCRIPTION
GitHub-Flavored Markdown task lists (`- [ ] foo` and `- [x] foo`) are everywhere — README files, issue templates, project notes — but `@portabletext/markdown` had no way to round-trip them. Pasting a markdown task list into an editor lost the checkbox prefix entirely; rendering Portable Text back to markdown couldn't produce GFM task syntax even when consumers had a task-list type in their schema.

This adds first-class task list support on both sides of the round-trip.

A task list item is encoded in Portable Text as a regular text block with `listItem: 'task'`, the surrounding list level, and a boolean `checked` field on the block. The default schema declares a `task` list type and a `checked` block field, so consumers using the default schema get `- [ ] foo` ↔ `{ listItem: 'task', checked: false, ... }` ↔ `- [ ] foo` for free.

`markdownToPortableText` recognizes the GFM checkbox prefix on the first inline content of any list item, strips it from the resulting span, and applies the task list type when the schema declares one. Mixed lists work: `- [ ] todo / - done / - [x] also done` round-trips cleanly. Tasks nest under bullets and vice versa. Schemas without a `task` list type fall through to `bullet` and discard the checkbox marker.

`portableTextToMarkdown` renders any block with `listItem: 'task'` as `- [x] ...` or `- [ ] ...` based on the `checked` field. Other list types render as before.

A new `listItem.task` matcher option lets consumers name the task list type something other than `task`.