### PR TITLE
fix: open the annotation popover when the annotated text block is inside an editable container

### DIFF
--- a/.changeset/toolbar-annotation-popover-container-aware.md
+++ b/.changeset/toolbar-annotation-popover-container-aware.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/toolbar': patch
+---
+
+fix: open the annotation popover when the annotated text block is inside an editable container

--- a/packages/toolbar/src/use-annotation-popover.ts
+++ b/packages/toolbar/src/use-annotation-popover.ts
@@ -70,11 +70,7 @@ const activeListener = fromCallback<
         return {
           value: annotation,
           schemaType,
-          at: [
-            {_key: focusBlock.node._key},
-            'markDefs',
-            {_key: annotation._key},
-          ],
+          at: [...focusBlock.path, 'markDefs', {_key: annotation._key}],
         }
       }),
       elementRef,


### PR DESCRIPTION
`useAnnotationPopover` in `@portabletext/toolbar` constructed the `at` path for `annotation.set` and `annotation.remove` events as a hardcoded depth-2 shape:

```ts
at: [
  {_key: focusBlock.node._key},
  'markDefs',
  {_key: annotation._key},
],
```

When the focus is inside an editable container (a callout's `content` text block, a fact-box's nested text block, etc.), the real path is `[...focusBlock.path, 'markDefs', {_key: annotation._key}]`. The hardcoded shape failed to resolve and the popover's edit/remove events silently no-op'd.

The selectors the popover composes (`getActiveAnnotations`, `getFocusBlock`) are already container-aware. The fix is to use `focusBlock.path` directly when constructing the annotation path.

Other toolbar popovers (`useBlockObjectPopover`, `useInlineObjectPopover`) already pass `focusX.path` directly, so this was the only site with the hardcoded shape.
