### PR TITLE
chore: anchor the stock ticker selection at any depth

### DIFF
--- a/packages/plugin-input-rule/src/rule.stock-ticker.container.test.tsx
+++ b/packages/plugin-input-rule/src/rule.stock-ticker.container.test.tsx
@@ -1,0 +1,139 @@
+import {defineContainer} from '@portabletext/editor'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {describe, expect, test, vi} from 'vitest'
+import {InputRulePlugin} from './plugin.input-rule'
+import {createStockTickerRule} from './rule.stock-ticker'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  inlineObjects: [{name: 'stock-ticker'}],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const containers = [
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..callout',
+    field: 'content',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+]
+
+const stockTickerRule = createStockTickerRule({
+  stockTickerObject: (context) => ({
+    name: 'stock-ticker',
+    value: {
+      symbol: context.symbol,
+    },
+  }),
+})
+
+describe('stock-ticker rule (container awareness)', () => {
+  test('triggers inside an editable container at depth and lands selection on the inserted ticker', async () => {
+    const calloutKey = 'k0'
+    const blockKey = 'k1'
+    const spanKey = 'k2'
+
+    let i = 3
+    const testKeyGenerator = () => `k${i++}`
+
+    const {editor} = await createTestEditor({
+      keyGenerator: testKeyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: blockKey,
+              children: [{_type: 'span', _key: spanKey, text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <>
+          <ContainerPlugin containers={containers} />
+          <InputRulePlugin rules={[stockTickerRule]} />
+        </>
+      ),
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: blockKey},
+            'children',
+            {_key: spanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: blockKey},
+            'children',
+            {_key: spanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'insert.text', text: '{AAPL}'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'k1',
+              _type: 'block',
+              children: [
+                {_key: 'k2', _type: 'span', marks: [], text: ''},
+                {_key: 'k5', _type: 'stock-ticker'},
+                {_key: 'k6', _type: 'span', marks: [], text: ''},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        offset: 0,
+        path: [{_key: 'k0'}, 'content', {_key: 'k1'}, 'children', {_key: 'k5'}],
+      },
+      backward: false,
+      focus: {
+        offset: 0,
+        path: [{_key: 'k0'}, 'content', {_key: 'k1'}, 'children', {_key: 'k5'}],
+      },
+    })
+  })
+})

--- a/packages/plugin-input-rule/src/rule.stock-ticker.ts
+++ b/packages/plugin-input-rule/src/rule.stock-ticker.ts
@@ -56,7 +56,7 @@ export function createStockTickerRule(config: {
             at: {
               anchor: {
                 path: [
-                  {_key: event.focusBlock.node._key},
+                  ...event.focusBlock.path,
                   'children',
                   {_key: stockTickerKey},
                 ],
@@ -64,7 +64,7 @@ export function createStockTickerRule(config: {
               },
               focus: {
                 path: [
-                  {_key: event.focusBlock.node._key},
+                  ...event.focusBlock.path,
                   'children',
                   {_key: stockTickerKey},
                 ],


### PR DESCRIPTION
When the stock-ticker input rule fires inside an editable container — a callout's `content` text block, a fact-box's nested text block, etc. — the post-insert selection clears instead of anchoring on the inserted ticker.

The rule raises a `select` event after `insert.child`, with the anchor and focus paths hand-built as:

```ts
path: [
  {_key: event.focusBlock.node._key},
  'children',
  {_key: stockTickerKey},
],
```

That shape hardcodes a depth-2 assumption. When the focus is at root, the path resolves correctly. When the focus is inside a container, the real path is `[...event.focusBlock.path, 'children', {_key: stockTickerKey}]` — the leading container segments are missing, the path doesn't resolve, and `editor.selection` becomes null.

`event.focusBlock` already carries `{path: BlockPath, node: PortableTextBlock}` from `getFocusBlock` (which is container-aware). The fix is to use `focusBlock.path` directly. Works at any depth.

`createStockTickerRule` is not exported from `@portabletext/plugin-input-rule`; the rule is a playground example used only by `apps/playground` and the test. No changeset.

Found via the cross-package audit that surfaced the matching annotation popover bug fixed in `12a557d14`. Audit covered all `packages/` source for hand-built `[{_key: ...}, ...]` paths; only the annotation popover and this rule hardcoded the depth.