### PR TITLE
feat: pass `focused`, `selected`, and `path` to `defineContainer` render

### DIFF
--- a/.changeset/container-render-focused-selected.md
+++ b/.changeset/container-render-focused-selected.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: pass `focused`, `selected`, and `path` to `defineContainer` render
+
+The render callback registered via `defineContainer` now receives `focused`, `selected`, and `path` props alongside the existing `attributes`, `children`, and `node`. `defineLeaf` already exposes these; the new fields close the asymmetry.
+
+`focused` is `true` when the container is the innermost container that holds the caret. `selected` is `true` when the container is in the path of any leaf in the selection range. It cascades up the ancestor chain. `path` is the container's keyed path.

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -1,19 +1,33 @@
 import type {PortableTextBlock} from '@portabletext/schema'
-import type {ReactElement} from 'react'
+import {useContext, type ReactElement} from 'react'
+import {serializePath} from '../paths/serialize-path'
 import type {ContainerConfig} from '../renderers/renderer.types'
+import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
+import {SelectionStateContext} from './selection-state-context'
 
 export function RenderContainer(props: {
   attributes: RenderElementProps['attributes']
   children: ReactElement
   element: PortableTextBlock
   containerConfig: ContainerConfig
+  path: Path
 }) {
+  const {focusedContainerPath, selectedContainerPaths} = useContext(
+    SelectionStateContext,
+  )
+  const serializedPath = serializePath(props.path)
+  const focused = focusedContainerPath === serializedPath
+  const selected = selectedContainerPaths.has(serializedPath)
+
   if (props.containerConfig.container.render) {
     const rendered = props.containerConfig.container.render({
       attributes: props.attributes,
       children: props.children,
+      focused,
       node: props.element,
+      path: props.path,
+      selected,
     })
 
     if (rendered !== null) {

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -57,6 +57,7 @@ export function RenderElement(props: {
         attributes={props.attributes}
         element={props.element}
         containerConfig={containerConfig}
+        path={props.path}
       >
         {props.children}
       </RenderContainer>

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -3,6 +3,7 @@ import type {ReactElement} from 'react'
 import type {ChildArrayField} from '../schema/resolve-containers'
 import type {ParsedScope} from '../scope/parse-scope'
 import type {AllContainers, ContainerScope} from '../scope/scope.types'
+import type {Path} from '../slate/interfaces/path'
 
 /**
  * @alpha
@@ -13,7 +14,10 @@ export type ContainerDefinition = {
   render?: (props: {
     attributes: Record<string, unknown>
     children: ReactElement
+    focused: boolean
     node: PortableTextBlock
+    path: Path
+    selected: boolean
   }) => ReactElement | null
 }
 
@@ -75,7 +79,10 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
             render?: (props: {
               attributes: Record<string, unknown>
               children: ReactElement
+              focused: boolean
               node: PortableTextBlock
+              path: Path
+              selected: boolean
             }) => ReactElement | null
           }
         : never

--- a/packages/editor/tests/container-render-focused-selected.test.tsx
+++ b/packages/editor/tests/container-render-focused-selected.test.tsx
@@ -1,0 +1,443 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import type {Path} from '../src/slate/interfaces/path'
+import {createTestEditor} from '../src/test/vitest'
+
+const calloutSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const tableSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+describe('container render focused, selected, and path', () => {
+  test('Only the innermost container is focused; ancestors are selected', async () => {
+    const calloutValues: Array<{
+      focused: boolean
+      selected: boolean
+      path: Path
+    }> = []
+    const calloutBlockValues: Array<{
+      focused: boolean
+      selected: boolean
+      path: Path
+    }> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'callout',
+          content: [
+            {
+              _type: 'block',
+              _key: 'inner',
+              children: [
+                {_type: 'span', _key: 'span', text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof calloutSchema>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children, focused, selected, path}) => {
+                calloutValues.push({focused, selected, path})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+            defineContainer<typeof calloutSchema>({
+              scope: '$..callout.block',
+              field: 'children',
+              render: ({attributes, children, focused, selected, path}) => {
+                calloutBlockValues.push({focused, selected, path})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const caret = {
+      path: [
+        {_key: 'callout'},
+        'content',
+        {_key: 'inner'},
+        'children',
+        {_key: 'span'},
+      ],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: caret, focus: caret}})
+
+    await vi.waitFor(() => {
+      expect(calloutBlockValues.at(-1)).toEqual({
+        focused: true,
+        selected: true,
+        path: [{_key: 'callout'}, 'content', {_key: 'inner'}],
+      })
+      expect(calloutValues.at(-1)).toEqual({
+        focused: false,
+        selected: true,
+        path: [{_key: 'callout'}],
+      })
+    })
+  })
+
+  test('A container is neither focused nor selected when the caret is in a different block', async () => {
+    const calloutValues: Array<{focused: boolean; selected: boolean}> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'outside',
+          children: [
+            {_type: 'span', _key: 'outside-span', text: 'outside', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'callout',
+          _key: 'callout',
+          content: [
+            {
+              _type: 'block',
+              _key: 'inner',
+              children: [
+                {_type: 'span', _key: 'inner-span', text: 'inside', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof calloutSchema>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children, focused, selected}) => {
+                calloutValues.push({focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const caret = {
+      path: [{_key: 'outside'}, 'children', {_key: 'outside-span'}],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: caret, focus: caret}})
+
+    await vi.waitFor(() => {
+      expect(calloutValues.at(-1)).toEqual({focused: false, selected: false})
+    })
+  })
+
+  test('selected cascades up nested containers; focused stays on the innermost', async () => {
+    const tableValues: Array<{focused: boolean; selected: boolean}> = []
+    const rowValues: Array<{focused: boolean; selected: boolean}> = []
+    const cellValues: Array<{focused: boolean; selected: boolean}> = []
+    const cellBlockValues: Array<{focused: boolean; selected: boolean}> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: tableSchema,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 'table',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'block',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'span',
+                          text: 'cell text',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof tableSchema>({
+              scope: '$..table',
+              field: 'rows',
+              render: ({attributes, children, focused, selected}) => {
+                tableValues.push({focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+            defineContainer<typeof tableSchema>({
+              scope: '$..table.row',
+              field: 'cells',
+              render: ({attributes, children, focused, selected}) => {
+                rowValues.push({focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+            defineContainer<typeof tableSchema>({
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: ({attributes, children, focused, selected}) => {
+                cellValues.push({focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+            defineContainer<typeof tableSchema>({
+              scope: '$..table.row.cell.block',
+              field: 'children',
+              render: ({attributes, children, focused, selected}) => {
+                cellBlockValues.push({focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const caret = {
+      path: [
+        {_key: 'table'},
+        'rows',
+        {_key: 'row'},
+        'cells',
+        {_key: 'cell'},
+        'content',
+        {_key: 'block'},
+        'children',
+        {_key: 'span'},
+      ],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: caret, focus: caret}})
+
+    await vi.waitFor(() => {
+      expect(tableValues.at(-1)).toEqual({focused: false, selected: true})
+      expect(rowValues.at(-1)).toEqual({focused: false, selected: true})
+      expect(cellValues.at(-1)).toEqual({focused: false, selected: true})
+      expect(cellBlockValues.at(-1)).toEqual({focused: true, selected: true})
+    })
+  })
+
+  test('An expanded selection across cells marks both as selected and none as focused', async () => {
+    const cellValues: Array<{
+      key: string
+      focused: boolean
+      selected: boolean
+    }> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: tableSchema,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 'table',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cell-1-block',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'cell-1-span',
+                          text: 'cell 1',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'cell-2',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cell-2-block',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 'cell-2-span',
+                          text: 'cell 2',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof tableSchema>({
+              scope: '$..table',
+              field: 'rows',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+            defineContainer<typeof tableSchema>({
+              scope: '$..table.row',
+              field: 'cells',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+            defineContainer<typeof tableSchema>({
+              scope: '$..table.row.cell',
+              field: 'content',
+              render: ({attributes, children, focused, selected, node}) => {
+                cellValues.push({key: node._key, focused, selected})
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'table'},
+            'rows',
+            {_key: 'row'},
+            'cells',
+            {_key: 'cell-1'},
+            'content',
+            {_key: 'cell-1-block'},
+            'children',
+            {_key: 'cell-1-span'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'table'},
+            'rows',
+            {_key: 'row'},
+            'cells',
+            {_key: 'cell-2'},
+            'content',
+            {_key: 'cell-2-block'},
+            'children',
+            {_key: 'cell-2-span'},
+          ],
+          offset: 6,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      const cell1Last = [...cellValues]
+        .reverse()
+        .find((v) => v.key === 'cell-1')
+      const cell2Last = [...cellValues]
+        .reverse()
+        .find((v) => v.key === 'cell-2')
+      expect(cell1Last).toEqual({key: 'cell-1', focused: false, selected: true})
+      expect(cell2Last).toEqual({key: 'cell-2', focused: false, selected: true})
+    })
+  })
+})


### PR DESCRIPTION
`defineLeaf({render})` receives `focused`, `selected`, and `path`. `defineContainer({render})` does not. This closes the asymmetry.

`focused` is `true` only on the innermost container that holds the caret. When the caret is inside a cell's text block, the text block container is focused; the cell, row, and table around it are not.

`selected` cascades. Every container whose subtree contains a leaf in the selection range gets `selected: true`.

`path` is the container's keyed path.

The wiring is reused from `SelectionStateContext`, which already drives the legacy text-block and block-object renderers.