### PR TITLE
feat: escape an editable container when Enter is pressed on a trailing empty line with an empty previous sibling

### DIFF
--- a/.changeset/container-enter-escape.md
+++ b/.changeset/container-enter-escape.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/editor': patch
+---
+
+feat: escape an editable container when Enter is pressed on a trailing empty line with an empty previous sibling
+
+When the caret is on the last block of an editable container, that
+block is empty, and the previous block is also empty, pressing Enter
+removes the empty trailing block, removes the empty previous block,
+and inserts a fresh text block AFTER the container at the container's
+parent level. Mirrors the familiar "double-Enter to escape" affordance
+from rich-text editors elsewhere.

--- a/packages/editor/src/behaviors/behavior.core.containers.ts
+++ b/packages/editor/src/behaviors/behavior.core.containers.ts
@@ -1,5 +1,8 @@
+import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block'
 import {getAncestor} from '../node-traversal/get-ancestor'
 import {getSibling} from '../node-traversal/get-sibling'
+import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
+import {getEnclosingContainer} from '../schema/get-enclosing-container'
 import {isEditableContainer} from '../schema/is-editable-container'
 import {getFirstBlock} from '../selectors/selector.get-first-block'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
@@ -7,7 +10,10 @@ import {getLastBlock} from '../selectors/selector.get-last-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
 import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
+import type {Path} from '../slate/interfaces/path'
 import {pathEquals} from '../slate/path/path-equals'
+import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
+import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 /**
@@ -90,7 +96,97 @@ function isAtContainerDeadEnd(
   return sibling === undefined
 }
 
+/**
+ * Enter at the bottom of an editable container, on an empty trailing line
+ * whose previous sibling is also an empty text block, escapes the container
+ * by deleting both empty trailing blocks and inserting a fresh text block
+ * after the deepest editable container ancestor whose parent accepts a
+ * text block.
+ */
+const breakingOutOfContainer = defineBehavior({
+  on: 'insert.break',
+  guard: ({snapshot}) => {
+    if (!isSelectionCollapsed(snapshot)) {
+      return false
+    }
+
+    const focusTextBlock = getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      return false
+    }
+
+    const lastBlock = getLastBlock(snapshot)
+    if (!lastBlock || !pathEquals(lastBlock.path, focusTextBlock.path)) {
+      return false
+    }
+
+    if (!isEmptyTextBlock(snapshot.context, focusTextBlock.node)) {
+      return false
+    }
+
+    const previousBlock = getSibling(snapshot, focusTextBlock.path, 'previous')
+    if (
+      !previousBlock ||
+      !isEmptyTextBlock(snapshot.context, previousBlock.node)
+    ) {
+      return false
+    }
+
+    const escapeAfter = getEscapeTarget(snapshot, focusTextBlock.path)
+    if (!escapeAfter) {
+      return false
+    }
+
+    return {
+      focusBlockPath: focusTextBlock.path,
+      previousBlockPath: previousBlock.path,
+      escapeAfter,
+    }
+  },
+  actions: [
+    ({snapshot}, {focusBlockPath, previousBlockPath, escapeAfter}) => [
+      raise({type: 'delete.block', at: focusBlockPath}),
+      raise({type: 'delete.block', at: previousBlockPath}),
+      raise({
+        type: 'insert.block',
+        block: createPlaceholderBlock(snapshot, escapeAfter),
+        placement: 'after',
+        at: {
+          anchor: {path: escapeAfter, offset: 0},
+          focus: {path: escapeAfter, offset: 0},
+        },
+        select: 'start',
+      }),
+    ],
+  ],
+})
+
+/**
+ * Find the deepest editable container ancestor whose immediate parent
+ * accepts a text block. The new text block is inserted as the next
+ * sibling of this container.
+ */
+function getEscapeTarget(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): Path | undefined {
+  return getAncestor(snapshot, path, (node, ancestorPath) => {
+    if (!isEditableContainer(snapshot, node, ancestorPath)) {
+      return false
+    }
+    const enclosing = getEnclosingContainer(snapshot, ancestorPath)
+    if (!enclosing) {
+      // The container is at root level; the editor root accepts text blocks.
+      return true
+    }
+    return enclosing.of.some(
+      (member) => member.type === snapshot.context.schema.block.name,
+    )
+  })?.path
+}
+
 export const coreContainerBehaviors = {
   arrowDownOutOfContainer,
   arrowUpOutOfContainer,
+  breakingOutOfContainer,
 }

--- a/packages/editor/src/behaviors/behavior.core.ts
+++ b/packages/editor/src/behaviors/behavior.core.ts
@@ -22,6 +22,7 @@ const coreBehaviors = [
   coreBlockObjectBehaviors.arrowUpOnLonelyBlockObject,
   coreContainerBehaviors.arrowDownOutOfContainer,
   coreContainerBehaviors.arrowUpOutOfContainer,
+  coreContainerBehaviors.breakingOutOfContainer,
   coreBlockObjectBehaviors.breakingBlockObject,
   coreBlockObjectBehaviors.deletingEmptyTextBlockAfterBlockObject,
   coreBlockObjectBehaviors.deletingEmptyTextBlockBeforeBlockObject,

--- a/packages/editor/tests/container-enter-escape.test.tsx
+++ b/packages/editor/tests/container-enter-escape.test.tsx
@@ -1,0 +1,244 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {userEvent} from '@vitest/browser/context'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const codeBlockSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const codeBlockContainer = defineContainer<typeof codeBlockSchema>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre data-testid="code-block" {...attributes}>
+      {children}
+    </pre>
+  ),
+})
+
+describe('container Enter escape', () => {
+  test('Scenario: Enter on empty last line with empty previous sibling escapes to editor root', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const line1Key = keyGenerator()
+    const line1SpanKey = keyGenerator()
+    const line2Key = keyGenerator()
+    const line2SpanKey = keyGenerator()
+    const line3Key = keyGenerator()
+    const line3SpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: codeBlockSchema,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: line1Key,
+              children: [
+                {_type: 'span', _key: line1SpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: line2Key,
+              children: [
+                {_type: 'span', _key: line2SpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: line3Key,
+              children: [
+                {_type: 'span', _key: line3SpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[codeBlockContainer]} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: line3Key},
+            'children',
+            {_key: line3SpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: line3Key},
+            'children',
+            {_key: line3SpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Enter}')
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toEqual([
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: line1Key,
+              children: [
+                {_type: 'span', _key: line1SpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'k9',
+          children: [{_type: 'span', _key: 'k10', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Enter on empty last line with non-empty previous sibling does NOT escape', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const line1Key = keyGenerator()
+    const line1SpanKey = keyGenerator()
+    const line2Key = keyGenerator()
+    const line2SpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: codeBlockSchema,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: line1Key,
+              children: [
+                {_type: 'span', _key: line1SpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: line2Key,
+              children: [
+                {_type: 'span', _key: line2SpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[codeBlockContainer]} />,
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: line2Key},
+            'children',
+            {_key: line2SpanKey},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: codeBlockKey},
+            'lines',
+            {_key: line2Key},
+            'children',
+            {_key: line2SpanKey},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    await userEvent.keyboard('{Enter}')
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toEqual([
+        {
+          _type: 'code-block',
+          _key: codeBlockKey,
+          lines: [
+            {
+              _type: 'block',
+              _key: line1Key,
+              children: [
+                {_type: 'span', _key: line1SpanKey, text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: line2Key,
+              children: [
+                {_type: 'span', _key: line2SpanKey, text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: 'k7',
+              children: [{_type: 'span', _key: 'k8', text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
When the caret is on the last block of an editable container, that block is empty, and the previous block is also empty, pressing Enter removes both trailing empty blocks and inserts a fresh text block AFTER the container. Mirrors the familiar "double-Enter to escape" affordance from rich-text editors elsewhere.

Cherry-picked from #2609 to land independently. The remaining behavior-layer work in #2609 still depends on a rebase.

```
[callout]
  Hello world
  |              ← caret here, empty
                 ← previous sibling empty
[callout]
```

Press Enter. Both trailing empty lines disappear; a new text block appears as the next sibling of the callout.

If the caret is on an empty trailing block but the previous sibling has content, the behavior does NOT escape — Enter keeps building blocks inside the container as usual.

Cascades through nested editable containers: the new text block is inserted after the OUTERMOST container that sits between the focus and an ancestor whose child field accepts text blocks.