### PR TITLE
fix: remove every container the range fully covers when deleting across containers

### DIFF
--- a/.changeset/fix-cross-container-fully-covered-between.md
+++ b/.changeset/fix-cross-container-fully-covered-between.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: remove every container the range fully covers when deleting across containers
+
+Selecting an entire mix of editable and structural containers (e.g. a code-block, a callout and a table) and pressing Delete now removes all of them. Previously the operation removed the start and end shells but left any container fully covered between them in place.

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -21,6 +21,7 @@ import type {PortableTextSlateEditor} from '../types/slate-editor'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {applyMergeNode} from './apply-merge-node'
 import {createPlaceholderBlock} from './create-placeholder-block'
+import {getFullyCoveredContainers} from './get-fully-covered-container'
 import {setNodeProperties} from './set-node-properties'
 
 /**
@@ -328,6 +329,14 @@ function deleteCrossParentRange(
   start: Point,
   end: Point,
 ): void {
+  // Compute fully-covered containers up front, before any trim mutates
+  // the leaves. After trimming, container endpoints shrink and the
+  // original range would falsely match shells that aren't fully covered.
+  const fullyCovered = getFullyCoveredContainers(editor, {
+    anchor: start,
+    focus: end,
+  })
+
   const lca = commonPath(startBlockPath, endBlockPath)
   const startBranchRoot = startBlockPath.slice(0, lca.length + 1)
   const endBranchRoot = endBlockPath.slice(0, lca.length + 1)
@@ -401,6 +410,25 @@ function deleteCrossParentRange(
     if (firstChild) {
       removeTextUpToOffset(editor, firstChild.path, end.offset)
     }
+  }
+
+  // 6. Unset every container the range fully covers. The trim and
+  //    walk-up steps above modified content inside fully-covered
+  //    shells; that's harmless because the shells get unset here.
+  //    Unset the end side first so the start path stays valid.
+  if (
+    fullyCovered.start &&
+    fullyCovered.end &&
+    pathEquals(fullyCovered.start, fullyCovered.end)
+  ) {
+    editor.apply({type: 'unset', path: fullyCovered.start})
+    return
+  }
+  if (fullyCovered.end) {
+    editor.apply({type: 'unset', path: fullyCovered.end})
+  }
+  if (fullyCovered.start) {
+    editor.apply({type: 'unset', path: fullyCovered.start})
   }
 }
 

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -2,7 +2,6 @@ import {resolveSelection} from '../internal-utils/apply-selection'
 import {deleteCollapsed} from '../internal-utils/delete-collapsed'
 import {deleteRange} from '../internal-utils/delete-range'
 import {findCurrentLineRange} from '../internal-utils/find-current-line-range'
-import {getFullyCoveredContainers} from '../internal-utils/get-fully-covered-container'
 import {unsetMatchedNodesInRange} from '../internal-utils/unset-matched-in-range'
 import {unwrapContainer} from '../internal-utils/unwrap-container'
 import {getAncestor} from '../node-traversal/get-ancestor'
@@ -132,30 +131,6 @@ export const deleteOperationImplementation: OperationImplementation<
       direction,
       selection,
     })
-    return
-  }
-
-  // If the range fully covers a container on either endpoint side,
-  // unset those containers before running the textual delete. The
-  // textual primitive alone would unhang the range and then trim each
-  // end, leaving each container's empty shell behind.
-  const fullyCovered = getFullyCoveredContainers(operation.editor, at)
-  if (fullyCovered.start || fullyCovered.end) {
-    if (
-      fullyCovered.start &&
-      fullyCovered.end &&
-      pathEquals(fullyCovered.start, fullyCovered.end)
-    ) {
-      operation.editor.apply({type: 'unset', path: fullyCovered.start})
-      return
-    }
-    // Unset the end side first so the start path stays valid.
-    if (fullyCovered.end) {
-      operation.editor.apply({type: 'unset', path: fullyCovered.end})
-    }
-    if (fullyCovered.start) {
-      operation.editor.apply({type: 'unset', path: fullyCovered.start})
-    }
     return
   }
 

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -24,6 +24,38 @@ const schemaDefinition = defineSchema({
       ],
     },
     {name: 'image'},
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 })
 
@@ -35,6 +67,21 @@ const containers = [
   }),
   defineContainer<typeof schemaDefinition>({
     scope: '$..callout',
+    field: 'content',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table',
+    field: 'rows',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table.row',
+    field: 'cells',
+    render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+  }),
+  defineContainer<typeof schemaDefinition>({
+    scope: '$..table.row.cell',
     field: 'content',
     render: ({attributes, children}) => <div {...attributes}>{children}</div>,
   }),
@@ -2342,6 +2389,120 @@ describe('cross-container range delete: deep structures', () => {
         },
       },
     })
+
+    expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+  })
+
+  test('Cmd-A + Delete via keyboard across code-block, callout and table removes all', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const codeLineKey = keyGenerator()
+    const codeSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const calloutBlockKey = keyGenerator()
+    const calloutSpanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cell1Key = keyGenerator()
+    const cell1BlockKey = keyGenerator()
+    const cell1SpanKey = keyGenerator()
+    const cell2Key = keyGenerator()
+    const cell2BlockKey = keyGenerator()
+    const cell2SpanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition,
+      keyGenerator,
+      initialValue: [
+        {
+          _key: codeBlockKey,
+          _type: 'code-block',
+          lines: [
+            {
+              _key: codeLineKey,
+              _type: 'block',
+              children: [
+                {_key: codeSpanKey, _type: 'span', text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: calloutBlockKey,
+              _type: 'block',
+              children: [
+                {_key: calloutSpanKey, _type: 'span', text: '', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cell1Key,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cell1BlockKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cell1SpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+                {
+                  _key: cell2Key,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cell2BlockKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cell2SpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={containers} />,
+    })
+
+    await userEvent.click(locator)
+    await userEvent.keyboard('{Control>}a{/Control}')
+    await userEvent.keyboard('{Delete}')
 
     expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
   })


### PR DESCRIPTION
Selecting a mix of editable and structural containers and pressing Delete left any container that was fully covered _between_ the endpoints in place. The user reported this when selecting a code-block, a callout and a table with Cmd+A and pressing Delete: the code-block and the table went away, the callout stayed.

The pre-existing operation-level short-circuit unset only the containers reached by walking up from each endpoint. Anything fully covered in the middle (here, the callout) was never visited.

The fix moves the concern into `deleteCrossParentRange`, which already removes children at the LCA between the two branches via `removeChildrenBetween`. After the algorithm has trimmed each side and removed everything between, it unsets the start and end branches' fully covered ancestors. The fully-covered lookup runs up front, before any trim, since trimming shrinks container endpoints and would otherwise produce false matches.

Net effect: one less special case at the operation layer, the cross-parent algorithm grows one final step, and the bug is gone.

Closes the failing scenario captured in `tests/cross-container-range-delete.test.tsx` ("Cmd-A + Delete via keyboard across code-block, callout and table removes all").