### PR TITLE
fix: render containers with a clean data-pt-* DOM and route the engine through it

### DIFF
--- a/.changeset/engine-queries-pure-data-pt.md
+++ b/.changeset/engine-queries-pure-data-pt.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: render containers with a clean data-pt-* DOM and route the engine through it

--- a/packages/editor/src/dom-traversal/get-dom-node.ts
+++ b/packages/editor/src/dom-traversal/get-dom-node.ts
@@ -33,7 +33,7 @@ export function getDomNode(
 
       if (blockNode instanceof HTMLElement) {
         if (blockNode.matches(selector)) {
-          const ownerEditor = blockNode.closest('[data-slate-editor]')
+          const ownerEditor = blockNode.closest('[data-pt-editor]')
 
           if (ownerEditor !== editorElement) {
             return undefined
@@ -45,7 +45,7 @@ export function getDomNode(
         const domNode = blockNode.querySelector(selector)
 
         if (domNode instanceof HTMLElement) {
-          const ownerEditor = domNode.closest('[data-slate-editor]')
+          const ownerEditor = domNode.closest('[data-pt-editor]')
 
           if (ownerEditor !== editorElement) {
             return undefined
@@ -63,7 +63,7 @@ export function getDomNode(
     return undefined
   }
 
-  const ownerEditor = domNode.closest('[data-slate-editor]')
+  const ownerEditor = domNode.closest('[data-pt-editor]')
 
   if (ownerEditor !== editorElement) {
     return undefined

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -57,7 +57,7 @@ export function RenderBlockObject(props: {
         leafConfig={props.leafConfig}
         attributes={{
           ...ptAttributes,
-          'data-block-type': 'object',
+          'data-pt-block-type': 'object',
         }}
         focused={focused}
         node={props.element}
@@ -94,6 +94,7 @@ export function RenderBlockObject(props: {
     'data-block-key': props.element._key,
     'data-block-name': props.element._type,
     'data-block-type': 'object',
+    'data-pt-block-type': 'object',
   }
 
   return (

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -71,7 +71,7 @@ export function RenderElement(props: {
     if (containerScope) {
       const {'data-slate-node': _sn, ...rest} = props.attributes
       return (
-        <div {...rest} data-block-type="text">
+        <div {...rest} data-pt-block-type="text">
           {props.children}
         </div>
       )
@@ -103,13 +103,12 @@ export function RenderElement(props: {
     if (containerScope && !leafConfig) {
       const {
         'data-slate-node': _sn,
-        'data-slate-inline': _si,
         'data-slate-void': _sv,
         'contentEditable': _ce,
         ...rest
       } = props.attributes
       return (
-        <span {...rest} data-child-type="object">
+        <span {...rest} data-pt-child-type="object">
           {props.children}
           <span contentEditable={false}>
             [{props.element._type}: {props.element._key}]
@@ -139,7 +138,7 @@ export function RenderElement(props: {
       ...rest
     } = props.attributes
     return (
-      <div {...rest} data-block-type="object">
+      <div {...rest} data-pt-block-type="object">
         {props.children}
         <div contentEditable={false}>
           [{props.element._type}: {props.element._key}]

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -46,7 +46,7 @@ export function RenderInlineObject(props: {
     const {
       'data-slate-node': _slateNode,
       'data-slate-void': _slateVoid,
-      'data-slate-inline': _slateInline,
+      'contentEditable': _contentEditable,
       ...ptAttributes
     } = props.attributes
     return (
@@ -54,7 +54,7 @@ export function RenderInlineObject(props: {
         leafConfig={props.leafConfig}
         attributes={{
           ...ptAttributes,
-          'data-child-type': 'object',
+          'data-pt-child-type': 'object',
         }}
         focused={focused}
         node={props.element}
@@ -92,6 +92,7 @@ export function RenderInlineObject(props: {
     'data-child-key': inlineObject._key,
     'data-child-name': inlineObject._type,
     'data-child-type': 'object',
+    'data-pt-child-type': 'object',
   }
 
   return (

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -132,6 +132,7 @@ export function RenderTextBlock(props: {
       data-block-key={props.textBlock._key}
       data-block-name={props.textBlock._type}
       data-block-type="text"
+      data-pt-block-type="text"
       {...(props.textBlock.listItem !== undefined
         ? {
             'data-list-item': props.textBlock.listItem,

--- a/packages/editor/src/editor/render.text.tsx
+++ b/packages/editor/src/editor/render.text.tsx
@@ -15,7 +15,7 @@ export function RenderText(props: RenderTextProps) {
         'data-slate-node'?: string
       }
     return (
-      <span {...rest} data-child-type="span">
+      <span {...rest} data-pt-child-type="span">
         {props.children}
       </span>
     )
@@ -27,6 +27,7 @@ export function RenderText(props: RenderTextProps) {
       data-child-key={props.text._key}
       data-child-name={props.text._type}
       data-child-type="span"
+      data-pt-child-type="span"
     >
       {props.children}
     </span>

--- a/packages/editor/src/slate/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/slate/dom/plugin/dom-editor.ts
@@ -307,14 +307,14 @@ export const DOMEditor: DOMEditorInterface = {
     }
 
     return (
-      closestShadowAware(targetEl, `[data-slate-editor]`) === editorEl &&
+      closestShadowAware(targetEl, `[data-pt-editor]`) === editorEl &&
       (!editable || targetEl.isContentEditable
         ? true
         : (typeof targetEl.isContentEditable === 'boolean' && // isContentEditable exists only on HTMLElement, and on other nodes it will be undefined
             // this is the core logic that lets you know you got the right editor.selection instead of null when editor is contenteditable="false"(readOnly)
             closestShadowAware(targetEl, '[contenteditable="false"]') ===
               editorEl) ||
-          !!targetEl.getAttribute('data-slate-zero-width'))
+          !!targetEl.getAttribute('data-pt-zero-width'))
     )
   },
 
@@ -344,7 +344,7 @@ export const DOMEditor: DOMEditorInterface = {
 
     const el = isDOMElement(target) ? target : target.parentElement
     return !!el?.closest(
-      '[data-slate-void], [data-block-type="object"], [data-child-type="object"]',
+      '[data-pt-block-type="object"], [data-pt-child-type="object"]',
     )
   },
 
@@ -359,7 +359,7 @@ export const DOMEditor: DOMEditorInterface = {
     let domPoint: DOMPoint | undefined
 
     if (nodeEntry && isVoidNode(editor, nodeEntry.node, point.path)) {
-      const spacer = el.querySelector('[data-slate-zero-width]')
+      const spacer = el.querySelector('[data-pt-zero-width]')
       if (spacer) {
         const domText = spacer.childNodes[0]
         if (domText) {
@@ -395,7 +395,7 @@ export const DOMEditor: DOMEditorInterface = {
     // For each leaf, we need to isolate its content, which means filtering
     // to its direct text and zero-width spans. (We have to filter out any
     // other siblings that may have been rendered alongside them.)
-    const selector = `[data-slate-string], [data-slate-zero-width]`
+    const selector = `[data-pt-string], [data-pt-zero-width]`
     const texts = Array.from(el.querySelectorAll(selector))
     let start = 0
 
@@ -408,7 +408,7 @@ export const DOMEditor: DOMEditorInterface = {
       }
 
       const {length} = domNode.textContent
-      const trueLength = text.hasAttribute('data-slate-zero-width') ? 0 : length
+      const trueLength = text.hasAttribute('data-pt-zero-width') ? 0 : length
       const end = start + trueLength
 
       if (point.offset <= end) {
@@ -448,11 +448,11 @@ export const DOMEditor: DOMEditorInterface = {
     const startEl = (
       isDOMElement(startNode) ? startNode : startNode.parentElement
     ) as HTMLElement
-    const isStartAtZeroWidth = !!startEl.getAttribute('data-slate-zero-width')
+    const isStartAtZeroWidth = !!startEl.getAttribute('data-pt-zero-width')
     const endEl = (
       isDOMElement(endNode) ? endNode : endNode.parentElement
     ) as HTMLElement
-    const isEndAtZeroWidth = !!endEl.getAttribute('data-slate-zero-width')
+    const isEndAtZeroWidth = !!endEl.getAttribute('data-pt-zero-width')
 
     domRange.setStart(startNode, isStartAtZeroWidth ? 1 : startOffset)
     domRange.setEnd(endNode, isEndAtZeroWidth ? 1 : endOffset)
@@ -484,7 +484,7 @@ export const DOMEditor: DOMEditorInterface = {
       }
 
       const potentialVoidNode = parentNode.closest(
-        '[data-slate-void="true"], [data-block-type="object"], [data-child-type="object"]',
+        '[data-pt-block-type="object"], [data-pt-child-type="object"]',
       )
       // Need to ensure that the closest void node is actually a void node
       // within this editor, and not a void node within some parent editor. This can happen
@@ -502,15 +502,13 @@ export const DOMEditor: DOMEditorInterface = {
         containsShadowAware(editorEl, potentialNonEditableNode)
           ? potentialNonEditableNode
           : null
-      let leafNode = parentNode.closest('[data-slate-leaf]')
+      let leafNode = parentNode.closest('[data-pt-mark]')
       let domNode: DOMElement | null = null
 
       // Calculate how far into the text node the `nearestNode` is, so that we
       // can determine what the offset relative to the text node is.
       if (leafNode) {
-        textNode = leafNode.closest(
-          '[data-slate-node="text"], [data-child-type="span"]',
-        )
+        textNode = leafNode.closest('[data-pt-child-type="span"]')
 
         if (textNode) {
           const window = DOMEditor.getWindow(editor)
@@ -521,7 +519,7 @@ export const DOMEditor: DOMEditorInterface = {
           const contents = range.cloneContents()
           const removals = [
             ...Array.prototype.slice.call(
-              contents.querySelectorAll('[data-slate-zero-width]'),
+              contents.querySelectorAll('[data-pt-zero-width]'),
             ),
             ...Array.prototype.slice.call(
               contents.querySelectorAll('[contenteditable=false]'),
@@ -534,7 +532,7 @@ export const DOMEditor: DOMEditorInterface = {
             if (
               IS_ANDROID &&
               !exactMatch &&
-              el.hasAttribute('data-slate-zero-width') &&
+              el.hasAttribute('data-pt-zero-width') &&
               el.textContent.length > 0 &&
               el.textContext !== '\uFEFF'
             ) {
@@ -560,7 +558,7 @@ export const DOMEditor: DOMEditorInterface = {
         // For void nodes, the element with the offset key will be a cousin, not an
         // ancestor, so find it by going down from the nearest void parent and taking the
         // first one that isn't inside a nested editor.
-        const leafNodes = voidNode.querySelectorAll('[data-slate-leaf]')
+        const leafNodes = voidNode.querySelectorAll('[data-pt-mark]')
         for (let index = 0; index < leafNodes.length; index++) {
           const current = leafNodes[index]!
           if (DOMEditor.hasDOMNode(editor, current)) {
@@ -573,12 +571,10 @@ export const DOMEditor: DOMEditorInterface = {
         if (!leafNode) {
           offset = 1
         } else {
-          textNode = leafNode.closest(
-            '[data-slate-node="text"], [data-child-type="span"]',
-          )!
+          textNode = leafNode.closest('[data-pt-child-type="span"]')!
           domNode = leafNode
           offset = domNode.textContent!.length
-          domNode.querySelectorAll('[data-slate-zero-width]').forEach((el) => {
+          domNode.querySelectorAll('[data-pt-zero-width]').forEach((el) => {
             offset -= el.textContent!.length
           })
         }
@@ -588,12 +584,10 @@ export const DOMEditor: DOMEditorInterface = {
           node
             ? node.querySelectorAll(
                 // Exclude leaf nodes in nested editors
-                '[data-slate-leaf]:not(:scope [data-slate-editor] [data-slate-leaf])',
+                '[data-pt-mark]:not(:scope [data-pt-editor] [data-pt-mark])',
               )
             : []
-        const elementNode = nonEditableNode.closest(
-          '[data-slate-node="element"], [data-block-type="text"], [data-block-type="object"], [data-block-type="container"]',
-        )
+        const elementNode = nonEditableNode.closest('[data-pt-block-type]')
 
         if (searchDirection === 'backward' || !searchDirection) {
           const leafNodes = [
@@ -625,19 +619,15 @@ export const DOMEditor: DOMEditorInterface = {
         }
 
         if (leafNode) {
-          textNode = leafNode.closest(
-            '[data-slate-node="text"], [data-child-type="span"]',
-          )!
+          textNode = leafNode.closest('[data-pt-child-type="span"]')!
           domNode = leafNode
           if (searchDirection === 'forward') {
             offset = 0
           } else {
             offset = domNode.textContent!.length
-            domNode
-              .querySelectorAll('[data-slate-zero-width]')
-              .forEach((el) => {
-                offset -= el.textContent!.length
-              })
+            domNode.querySelectorAll('[data-pt-zero-width]').forEach((el) => {
+              offset -= el.textContent!.length
+            })
           }
         }
       }
@@ -648,14 +638,14 @@ export const DOMEditor: DOMEditorInterface = {
         // COMPAT: Android IMEs might remove the zero width space while composing,
         // and we don't add it for line-breaks.
         IS_ANDROID &&
-        domNode.getAttribute('data-slate-zero-width') === 'z' &&
+        domNode.getAttribute('data-pt-zero-width') === 'z' &&
         domNode.textContent?.startsWith('\uFEFF') &&
         // COMPAT: If the parent node is a Slate zero-width space, editor is
         // because the text node should have no characters. However, during IME
         // composition the ASCII characters will be prepended to the zero-width
         // space, so subtract 1 from the offset to account for the zero-width
         // space character.
-        (parentNode.hasAttribute('data-slate-zero-width') ||
+        (parentNode.hasAttribute('data-pt-zero-width') ||
           // COMPAT: In Firefox, `range.cloneContents()` returns an extra trailing '\n'
           // when the document ends with a new-line character. This results in the offset
           // length being off by one, so we need to subtract one to account for this.
@@ -667,14 +657,11 @@ export const DOMEditor: DOMEditorInterface = {
 
     if (IS_ANDROID && !textNode && !exactMatch) {
       const node =
-        parentNode.hasAttribute('data-slate-node') ||
-        parentNode.getAttribute('data-block-type') === 'text' ||
-        parentNode.getAttribute('data-block-type') === 'object' ||
-        parentNode.getAttribute('data-block-type') === 'container' ||
-        parentNode.getAttribute('data-child-type') === 'span'
+        parentNode.hasAttribute('data-pt-block-type') ||
+        parentNode.getAttribute('data-pt-child-type') === 'span'
           ? parentNode
           : parentNode.closest(
-              '[data-slate-node], [data-block-type="text"], [data-block-type="object"], [data-block-type="container"], [data-child-type="span"]',
+              '[data-pt-block-type], [data-pt-child-type="span"]',
             )
 
       if (node && DOMEditor.hasDOMNode(editor, node, {editable: true})) {
@@ -691,7 +678,7 @@ export const DOMEditor: DOMEditorInterface = {
 
         let {path, offset} = editorStart(editor, nodePath)
 
-        if (!node.querySelector('[data-slate-leaf]')) {
+        if (!node.querySelector('[data-pt-mark]')) {
           offset = nearestOffset
         }
 
@@ -702,8 +689,7 @@ export const DOMEditor: DOMEditorInterface = {
     if (!textNode && parentNode) {
       if (
         nearestNode instanceof HTMLElement &&
-        (nearestNode.hasAttribute('data-slate-node') ||
-          nearestNode.getAttribute('data-block-type') === 'container')
+        nearestNode.getAttribute('data-pt-block-type') === 'container'
       ) {
         const childEl = nearestNode.childNodes[nearestOffset]
         if (
@@ -711,7 +697,7 @@ export const DOMEditor: DOMEditorInterface = {
           DOMEditor.hasDOMNode(editor, childEl)
         ) {
           const voidEl = childEl.closest(
-            '[data-slate-void], [data-block-type="object"], [data-child-type="object"]',
+            '[data-pt-block-type="object"], [data-pt-child-type="object"]',
           )
 
           if (voidEl) {
@@ -725,19 +711,12 @@ export const DOMEditor: DOMEditorInterface = {
       }
 
       const elementNode =
-        parentNode.closest(
-          '[data-slate-node="element"], [data-block-type="text"], [data-block-type="object"], [data-block-type="container"]',
-        ) ??
-        (parentNode.hasAttribute('data-slate-node') ||
-        parentNode.getAttribute('data-block-type') === 'text' ||
-        parentNode.getAttribute('data-block-type') === 'object' ||
-        parentNode.getAttribute('data-block-type') === 'container'
-          ? parentNode
-          : null)
+        parentNode.closest('[data-pt-block-type]') ??
+        (parentNode.hasAttribute('data-pt-block-type') ? parentNode : null)
 
       if (elementNode && DOMEditor.hasDOMNode(editor, elementNode)) {
         const voidEl = elementNode.closest(
-          '[data-slate-void], [data-block-type="object"], [data-child-type="object"]',
+          '[data-pt-block-type="object"], [data-pt-child-type="object"]',
         )
 
         if (voidEl) {

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -96,8 +96,7 @@ export interface RenderElementProps {
   path: Path
   attributes: {
     'data-slate-node'?: 'element'
-    'data-block-type'?: 'container'
-    'data-slate-inline'?: true
+    'data-pt-block-type'?: 'container'
     'data-slate-void'?: true
     'data-pt-path': string
     'contentEditable'?: false
@@ -119,7 +118,8 @@ export interface RenderLeafProps {
   text: PortableTextSpan
   path: Path
   attributes: {
-    'data-slate-leaf': true
+    'data-slate-leaf'?: true
+    'data-pt-mark': true
   }
   /**
    * The position of the leaf within the Text node, only present when the text node is split by decorations.
@@ -134,7 +134,7 @@ export interface RenderTextProps {
   text: PortableTextSpan
   children: any
   attributes: {
-    'data-slate-node': 'text'
+    'data-slate-node'?: 'text'
     'data-pt-path': string
   }
 }
@@ -1017,6 +1017,7 @@ export const Editable = forwardRef(
                   : 'false'
               }
               data-slate-editor
+              data-pt-editor
               data-slate-node="value"
               data-pt-path=""
               // explicitly set this
@@ -1137,7 +1138,7 @@ export const Editable = forwardRef(
                   // the editor to inside a void node's spacer element.
                   if (
                     isDOMElement(relatedTarget) &&
-                    relatedTarget.hasAttribute('data-slate-spacer')
+                    relatedTarget.hasAttribute('data-pt-spacer')
                   ) {
                     return
                   }

--- a/packages/editor/src/slate/react/components/element.tsx
+++ b/packages/editor/src/slate/react/components/element.tsx
@@ -64,17 +64,13 @@ const Element = (props: {
   // custom node renderer component.
   const attributes: RenderElementProps['attributes'] = isContainer
     ? {
-        'data-block-type': 'container',
+        'data-pt-block-type': 'container',
         'data-pt-path': dataPath,
       }
     : {
         'data-slate-node': 'element',
         'data-pt-path': dataPath,
       }
-
-  if (isInline) {
-    attributes['data-slate-inline'] = true
-  }
 
   // If it's a block node with inline children, add the proper `dir` attribute
   // for text direction.

--- a/packages/editor/src/slate/react/components/leaf.tsx
+++ b/packages/editor/src/slate/react/components/leaf.tsx
@@ -3,7 +3,8 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {type JSX} from 'react'
+import React, {useContext, type JSX} from 'react'
+import {ContainerScopeContext} from '../../../editor/container-scope-context'
 import type {Path} from '../../interfaces/path'
 import type {LeafPosition} from '../../interfaces/text'
 import {textEquals} from '../../text/text-equals'
@@ -34,6 +35,8 @@ const Leaf = (props: {
     leafPosition,
   } = props
 
+  const containerScope = useContext(ContainerScopeContext)
+
   const children = (
     <SlateString
       isLast={isLast}
@@ -48,10 +51,16 @@ const Leaf = (props: {
   // in certain misbehaving browsers they aren't weirdly cloned/destroyed by
   // contenteditable behaviors. (2019/05/08)
   const attributes: {
-    'data-slate-leaf': true
-  } = {
-    'data-slate-leaf': true,
-  }
+    'data-slate-leaf'?: true
+    'data-pt-mark': true
+  } = containerScope
+    ? {
+        'data-pt-mark': true,
+      }
+    : {
+        'data-slate-leaf': true,
+        'data-pt-mark': true,
+      }
 
   return renderLeaf({
     attributes,

--- a/packages/editor/src/slate/react/components/object-node.tsx
+++ b/packages/editor/src/slate/react/components/object-node.tsx
@@ -1,5 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import React, {type JSX} from 'react'
+import React, {useContext, type JSX} from 'react'
+import {ContainerScopeContext} from '../../../editor/container-scope-context'
 import {serializePath} from '../../../paths/serialize-path'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -39,16 +40,19 @@ const ObjectNodeComponent = (props: {
   } = props
   const dataPath = serializePath(path)
   const readOnly = useReadOnly()
+  const containerScope = useContext(ContainerScopeContext)
 
-  const attributes: RenderElementProps['attributes'] = {
-    'data-slate-node': 'element',
-    'data-slate-void': true,
-    'data-pt-path': dataPath,
-  }
+  const attributes: RenderElementProps['attributes'] = containerScope
+    ? {
+        'data-pt-path': dataPath,
+      }
+    : {
+        'data-slate-node': 'element',
+        'data-slate-void': true,
+        'data-pt-path': dataPath,
+      }
 
   if (isInline) {
-    attributes['data-slate-inline'] = true
-
     if (!readOnly) {
       attributes.contentEditable = false
     }
@@ -56,9 +60,26 @@ const ObjectNodeComponent = (props: {
 
   const Tag = isInline ? 'span' : 'div'
 
-  const children = (
+  const children = containerScope ? (
+    <Tag
+      data-pt-spacer
+      style={{
+        height: '0',
+        color: 'transparent',
+        outline: 'none',
+        position: 'absolute',
+      }}
+    >
+      <span>
+        <span data-pt-mark>
+          <span data-pt-zero-width="z">{'\uFEFF'}</span>
+        </span>
+      </span>
+    </Tag>
+  ) : (
     <Tag
       data-slate-spacer
+      data-pt-spacer
       style={{
         height: '0',
         color: 'transparent',
@@ -67,8 +88,10 @@ const ObjectNodeComponent = (props: {
       }}
     >
       <span data-slate-node="text">
-        <span data-slate-leaf>
-          <span data-slate-zero-width="z">{'\uFEFF'}</span>
+        <span data-slate-leaf data-pt-mark>
+          <span data-slate-zero-width="z" data-pt-zero-width="z">
+            {'\uFEFF'}
+          </span>
         </span>
       </span>
     </Tag>

--- a/packages/editor/src/slate/react/components/string.tsx
+++ b/packages/editor/src/slate/react/components/string.tsx
@@ -5,7 +5,8 @@ import {
   type PortableTextSpan,
   type PortableTextTextBlock,
 } from '@portabletext/schema'
-import {forwardRef, memo, useRef, useState} from 'react'
+import {forwardRef, memo, useContext, useRef, useState} from 'react'
+import {ContainerScopeContext} from '../../../editor/container-scope-context'
 import {getNodes} from '../../../node-traversal/get-nodes'
 import {IS_ANDROID} from '../../dom/utils/environment'
 import {end as editorEnd} from '../../editor/end'
@@ -92,6 +93,7 @@ const SlateString = (props: {
  */
 const TextString = (props: {text: string; isTrailing?: boolean}) => {
   const {text, isTrailing = false} = props
+  const containerScope = useContext(ContainerScopeContext)
   const ref = useRef<HTMLSpanElement>(null)
   const getTextContent = () => {
     return `${text ?? ''}${isTrailing ? '\n' : ''}`
@@ -121,17 +123,30 @@ const TextString = (props: {text: string; isTrailing?: boolean}) => {
 
   // We intentionally render a memoized <span> that only receives the initial text content when the component is mounted.
   // We defer to the layout effect above to update the `textContent` of the span element when needed.
-  return <MemoizedText ref={ref}>{initialText}</MemoizedText>
+  return (
+    <MemoizedText ref={ref} containerScope={containerScope !== undefined}>
+      {initialText}
+    </MemoizedText>
+  )
 }
 
 const MemoizedText = memo(
-  forwardRef<HTMLSpanElement, {children: string}>((props, ref) => {
-    return (
-      <span data-slate-string ref={ref}>
-        {props.children}
-      </span>
-    )
-  }),
+  forwardRef<HTMLSpanElement, {children: string; containerScope: boolean}>(
+    (props, ref) => {
+      if (props.containerScope) {
+        return (
+          <span data-pt-string ref={ref}>
+            {props.children}
+          </span>
+        )
+      }
+      return (
+        <span data-slate-string data-pt-string ref={ref}>
+          {props.children}
+        </span>
+      )
+    },
+  ),
 )
 
 /**
@@ -140,12 +155,20 @@ const MemoizedText = memo(
 
 const ZeroWidthString = (props: {isLineBreak?: boolean}) => {
   const {isLineBreak = false} = props
+  const containerScope = useContext(ContainerScopeContext)
 
+  const value = isLineBreak ? 'n' : 'z'
   const attributes: {
-    'data-slate-zero-width': string
-  } = {
-    'data-slate-zero-width': isLineBreak ? 'n' : 'z',
-  }
+    'data-slate-zero-width'?: string
+    'data-pt-zero-width': string
+  } = containerScope
+    ? {
+        'data-pt-zero-width': value,
+      }
+    : {
+        'data-slate-zero-width': value,
+        'data-pt-zero-width': value,
+      }
 
   // FIXME: Inserting the \uFEFF on iOS breaks capitalization at the start of an
   // empty editor (https://github.com/ianstormtaylor/slate/issues/5199).

--- a/packages/editor/src/slate/react/components/text.tsx
+++ b/packages/editor/src/slate/react/components/text.tsx
@@ -2,7 +2,8 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {type JSX} from 'react'
+import React, {useContext, type JSX} from 'react'
+import {ContainerScopeContext} from '../../../editor/container-scope-context'
 import {serializePath} from '../../../paths/serialize-path'
 import {isTextDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -60,14 +61,19 @@ const Text = (props: {
   }
 
   const dataPath = serializePath(path)
+  const containerScope = useContext(ContainerScopeContext)
 
   const attributes: {
-    'data-slate-node': 'text'
+    'data-slate-node'?: 'text'
     'data-pt-path': string
-  } = {
-    'data-slate-node': 'text',
-    'data-pt-path': dataPath,
-  }
+  } = containerScope
+    ? {
+        'data-pt-path': dataPath,
+      }
+    : {
+        'data-slate-node': 'text',
+        'data-pt-path': dataPath,
+      }
 
   return renderText({
     text,

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -88,60 +88,45 @@ describe('container rendering', () => {
 
       expect(editorElement!.innerHTML).toEqual(
         [
-          // root text block
-          '<div data-slate-node="element"',
+          '<div',
+          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;k0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="k0"',
           ' data-block-name="block"',
           ' data-block-type="text"',
-          ' data-style="normal"',
-          '>',
-          // text block inner wrapper
+          ' data-pt-block-type="text"',
+          ' data-style="normal">',
           '<div>',
-          // span
-          '<span data-slate-node="text"',
+          '<span',
+          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;k0&quot;].children[_key==&quot;k1&quot;]"',
           ' data-child-key="k1"',
           ' data-child-name="span"',
           ' data-child-type="span"',
-          '>',
-          // leaf
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">hello</span>',
+          ' data-pt-child-type="span">',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-string="true" data-pt-string="true">',
+          'hello',
           '</span>',
-          // /span
           '</span>',
-          // /text block inner wrapper
+          '</span>',
           '</div>',
-          // /root text block
           '</div>',
-          // callout container
-          '<div data-testid="callout"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k2&quot;]"',
-          '>',
-          // inner text block
+          '<div data-testid="callout" data-pt-block-type="container" data-pt-path="[_key==&quot;k2&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k2&quot;].content[_key==&quot;content-block&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // inner text block wrapper
-          // inner span
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k2&quot;].content[_key==&quot;content-block&quot;].children[_key==&quot;content-span&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          // inner leaf
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">inside callout</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'inside callout',
           '</span>',
-          // /inner span
           '</span>',
-          // /inner text block wrapper
-          // /inner text block
+          '</span>',
           '</div>',
-          // /callout container
           '</div>',
         ].join(''),
       )
@@ -335,48 +320,32 @@ describe('table with nested rows and cells', () => {
 
       expect(editorElement!.innerHTML).toEqual(
         [
-          // table container
-          '<table data-testid="table"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
+          '<table data-testid="table" data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<tbody>',
-          // row container
-          '<tr data-testid="row"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;]"',
-          '>',
-          // cell container
-          '<td data-testid="cell"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;]"',
-          '>',
-          // text block inside cell
+          '<tr',
+          ' data-testid="row"',
+          ' data-pt-block-type="container"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;]">',
+          '<td',
+          ' data-testid="cell"',
+          ' data-pt-block-type="container"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // text block inner wrapper
-          // span
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;].children[_key==&quot;span-0&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          // leaf
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">cell text</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'cell text',
           '</span>',
-          // /span
           '</span>',
-          // /text block inner wrapper
-          // /text block inside cell
+          '</span>',
           '</div>',
-          // /cell container
           '</td>',
-          // /row container
           '</tr>',
           '</tbody>',
-          // /table container
           '</table>',
         ].join(''),
       )
@@ -454,32 +423,20 @@ describe('container with non-editable fields', () => {
 
       expect(editorElement!.innerHTML).toEqual(
         [
-          // card container
-          '<div data-testid="card"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
-          // body text block
+          '<div data-testid="card" data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].body[_key==&quot;body-block&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // body text block inner wrapper
-          // body span
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].body[_key==&quot;body-block&quot;].children[_key==&quot;body-span&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          // body leaf
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">card body</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'card body',
           '</span>',
-          // /body span
           '</span>',
-          // /body text block inner wrapper
-          // /body text block
+          '</span>',
           '</div>',
-          // /card container (no tags in DOM)
           '</div>',
         ].join(''),
       )
@@ -746,31 +703,20 @@ describe('container and renderer independence', () => {
 
       expect(editorElement!.innerHTML).toEqual(
         [
-          // callout default div wrapper
-          '<div data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
-          // inner text block
+          '<div data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].content[_key==&quot;content-block&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // inner text block wrapper
-          // inner span
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].content[_key==&quot;content-block&quot;].children[_key==&quot;content-span&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          // inner leaf
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">inside callout</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'inside callout',
           '</span>',
-          // /inner span
           '</span>',
-          // /inner text block wrapper
-          // /inner text block
+          '</span>',
           '</div>',
-          // /callout default div wrapper
           '</div>',
         ].join(''),
       )
@@ -908,37 +854,27 @@ describe('code block container', () => {
       expect(editorElement).not.toEqual(null)
       expect(editorElement!.innerHTML).toEqual(
         [
-          // code-block container
-          '<pre data-testid="code-block"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
+          '<pre data-testid="code-block" data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<code>',
-          // line 1 text block
-          '<div',
-          ' data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-0&quot;]"',
-          ' data-block-type="text"',
-          '>',
+          '<div data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-0&quot;]" data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-0&quot;].children[_key==&quot;span-0&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">const a = 1</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'const a = 1',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // line 2 text block
-          '<div',
-          ' data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-1&quot;]"',
-          ' data-block-type="text"',
-          '>',
+          '<div data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-1&quot;]" data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].code[_key==&quot;line-1&quot;].children[_key==&quot;span-1&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">console.log(a)</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'console.log(a)',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
@@ -1013,52 +949,43 @@ describe('gallery with void block objects', () => {
       expect(editorElement).not.toEqual(null)
       expect(normalizeInnerHTML(editorElement!.innerHTML)).toEqual(
         [
-          // gallery container
-          '<div data-testid="gallery"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
-          // image 1 (void block object)
+          '<div data-testid="gallery" data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].items[_key==&quot;img-0&quot;]"',
-          ' data-block-type="object"',
-          '>',
-          // void spacer
-          '<div data-slate-spacer="true"',
-          ' style="height: 0px; color: transparent; outline: none; position: absolute;"',
-          '>',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-pt-spacer="true"',
+          ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // void content
           '<div contenteditable="false">',
           '[image: img-0]',
           '</div>',
           '</div>',
-          // image 2 (void block object)
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].items[_key==&quot;img-1&quot;]"',
-          ' data-block-type="object"',
-          '>',
-          // void spacer
-          '<div data-slate-spacer="true"',
-          ' style="height: 0px; color: transparent; outline: none; position: absolute;"',
-          '>',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-pt-spacer="true"',
+          ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // void content
           '<div contenteditable="false">',
           '[image: img-1]',
           '</div>',
           '</div>',
-          // /gallery container
           '</div>',
         ].join(''),
       )
@@ -1210,76 +1137,63 @@ describe('cell with mixed content', () => {
       expect(editorElement).not.toEqual(null)
       expect(normalizeInnerHTML(editorElement!.innerHTML)).toEqual(
         [
-          // table container
-          '<table data-testid="table"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;]"',
-          '>',
+          '<table data-testid="table" data-pt-block-type="container" data-pt-path="[_key==&quot;k0&quot;]">',
           '<tbody>',
-          // row container
-          '<tr data-testid="row"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;]"',
-          '>',
-          // cell container
-          '<td data-testid="cell"',
-          ' data-block-type="container"',
-          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;]"',
-          '>',
-          // text block before image
+          '<tr',
+          ' data-testid="row"',
+          ' data-pt-block-type="container"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;]">',
+          '<td',
+          ' data-testid="cell"',
+          ' data-pt-block-type="container"',
+          ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;]">',
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;]"',
-          ' data-block-type="text"',
-          '>',
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-0&quot;].children[_key==&quot;span-0&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">text before image</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'text before image',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // void image block object inside cell
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;img-0&quot;]"',
-          ' data-block-type="object"',
-          '>',
-          // void spacer
-          '<div data-slate-spacer="true"',
-          ' style="height: 0px; color: transparent; outline: none; position: absolute;"',
-          '>',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-pt-spacer="true"',
+          ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // void content
           '<div contenteditable="false">',
           '[image: img-0]',
           '</div>',
           '</div>',
-          // text block after image
           '<div',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-1&quot;]"',
-          ' data-block-type="text"',
-          '>',
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;k0&quot;].rows[_key==&quot;row-0&quot;].cells[_key==&quot;cell-0&quot;].content[_key==&quot;block-1&quot;].children[_key==&quot;span-1&quot;]"',
-          ' data-child-type="span"',
-          '>',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">text after image</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'text after image',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // /cell container
           '</td>',
-          // /row container
           '</tr>',
           '</tbody>',
-          // /table container
           '</table>',
         ].join(''),
       )

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -33,24 +33,27 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // text block: b0
-          '<div data-slate-node="element"',
+          '<div',
+          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
           ' data-block-name="block"',
           ' data-block-type="text"',
+          ' data-pt-block-type="text"',
           ' data-style="normal">',
           '<div>',
-          // span: s0 (empty)
-          '<span data-slate-node="text"',
+          '<span',
+          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="n">',
-          '\uFEFF<br>',
+          ' data-child-type="span"',
+          ' data-pt-child-type="span">',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-zero-width="n" data-pt-zero-width="n">',
+          '﻿',
+          '<br>',
           '</span>',
           '</span>',
           '</span>',
@@ -85,57 +88,68 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // text block: b0
-          '<div data-slate-node="element"',
+          '<div',
+          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
           ' data-block-name="block"',
           ' data-block-type="text"',
+          ' data-pt-block-type="text"',
           ' data-style="normal">',
           '<div>',
-          // span: hello
-          '<span data-slate-node="text"',
+          '<span',
+          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">hello </span>',
+          ' data-child-type="span"',
+          ' data-pt-child-type="span">',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-string="true" data-pt-string="true">',
+          'hello ',
           '</span>',
           '</span>',
-          // inline void: stock-ticker
-          '<span data-slate-node="element"',
+          '</span>',
+          '<span',
+          ' data-slate-node="element"',
           ' data-slate-void="true"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;i0&quot;]"',
-          ' data-slate-inline="true"',
           ' contenteditable="false"',
           ' class="pt-inline-object"',
           ' data-child-key="i0"',
           ' data-child-name="stock-ticker"',
-          ' data-child-type="object">',
-          // spacer
-          '<span data-slate-spacer="true"',
+          ' data-child-type="object"',
+          ' data-pt-child-type="object">',
+          '<span',
+          ' data-slate-spacer="true"',
+          ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
           '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-zero-width="z" data-pt-zero-width="z">',
+          '﻿',
           '</span>',
           '</span>',
           '</span>',
-          // inline object render
+          '</span>',
           '<span draggable="true" style="display: inline-block;">',
-          '<span>[stock-ticker: i0]</span>',
+          '<span>',
+          '[stock-ticker: i0]',
           '</span>',
           '</span>',
-          // span: world
-          '<span data-slate-node="text"',
+          '</span>',
+          '<span',
+          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s1&quot;]"',
           ' data-child-key="s1"',
           ' data-child-name="span"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true"> world</span>',
+          ' data-child-type="span"',
+          ' data-pt-child-type="span">',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-string="true" data-pt-string="true">',
+          ' world',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
@@ -166,47 +180,56 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // text block: b0
-          '<div data-slate-node="element"',
+          '<div',
+          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
           ' data-block-name="block"',
           ' data-block-type="text"',
+          ' data-pt-block-type="text"',
           ' data-style="normal">',
           '<div>',
-          // span: hello
-          '<span data-slate-node="text"',
+          '<span',
+          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">hello</span>',
+          ' data-child-type="span"',
+          ' data-pt-child-type="span">',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-string="true" data-pt-string="true">',
+          'hello',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
           '</div>',
-          // void block object: image
-          '<div data-slate-node="element"',
+          '<div',
+          ' data-slate-node="element"',
           ' data-slate-void="true"',
           ' data-pt-path="[_key==&quot;img0&quot;]"',
           ' class="pt-block pt-object-block"',
           ' data-block-key="img0"',
           ' data-block-name="image"',
-          ' data-block-type="object">',
-          // spacer
-          '<div data-slate-spacer="true"',
+          ' data-block-type="object"',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-slate-spacer="true"',
+          ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
           '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          '<span data-slate-leaf="true" data-pt-mark="true">',
+          '<span data-slate-zero-width="z" data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // block object render
           '<div contenteditable="false" draggable="true">',
-          '<div>[image: img0]</div>',
+          '<div>',
+          '[image: img0]',
+          '</div>',
           '</div>',
           '</div>',
         ].join(''),
@@ -252,44 +275,39 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // gallery container: g0
-          '<div data-block-type="container"',
-          ' data-pt-path="[_key==&quot;g0&quot;]"',
-          ' class="gallery">',
-          // void leaf: img0
+          '<div data-pt-block-type="container" data-pt-path="[_key==&quot;g0&quot;]" class="gallery">',
           '<div',
           ' data-pt-path="[_key==&quot;g0&quot;].items[_key==&quot;img0&quot;]"',
-          ' data-block-type="object"',
-          '>',
-          // spacer
-          '<div data-slate-spacer="true"',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // image render
           '<div contenteditable="false">',
           '[image: img0]',
           '</div>',
           '</div>',
-          // void leaf: img1
           '<div',
           ' data-pt-path="[_key==&quot;g0&quot;].items[_key==&quot;img1&quot;]"',
-          ' data-block-type="object"',
-          '>',
-          // spacer
-          '<div data-slate-spacer="true"',
+          ' data-pt-block-type="object">',
+          '<div',
+          ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // image render
           '<div contenteditable="false">',
           '[image: img1]',
           '</div>',
@@ -403,54 +421,49 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // table container: t0
-          '<table data-block-type="container"',
-          ' data-pt-path="[_key==&quot;t0&quot;]">',
+          '<table data-pt-block-type="container" data-pt-path="[_key==&quot;t0&quot;]">',
           '<tbody>',
-          // row: r0
-          '<tr data-block-type="container"',
-          ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;]">',
-          // cell: c0
-          '<td data-block-type="container"',
+          '<tr data-pt-block-type="container" data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;]">',
+          '<td',
+          ' data-pt-block-type="container"',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;]">',
-          // text block: b0
           '<div',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;].content[_key==&quot;b0&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // span: price:
+          ' data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;].content[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">price: </span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'price: ',
           '</span>',
           '</span>',
-          // inline void: stock-ticker
+          '</span>',
           '<span',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;].content[_key==&quot;b0&quot;].children[_key==&quot;i0&quot;]"',
-          ' data-child-type="object"',
-          '>',
-          // spacer
-          '<span data-slate-spacer="true"',
+          ' data-pt-child-type="object">',
+          '<span',
+          ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-zero-width="z">\uFEFF</span>',
+          '<span>',
+          '<span data-pt-mark="true">',
+          '<span data-pt-zero-width="z">',
+          '﻿',
           '</span>',
           '</span>',
           '</span>',
-          // inline object render
+          '</span>',
           '<span contenteditable="false">',
           '[stock-ticker: i0]',
           '</span>',
           '</span>',
-          // span: USD
           '<span',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;].content[_key==&quot;b0&quot;].children[_key==&quot;s1&quot;]"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true"> USD</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          ' USD',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
@@ -516,35 +529,27 @@ describe('DOM structure', () => {
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
-          // code container: c0
-          '<pre data-block-type="container"',
-          ' data-pt-path="[_key==&quot;c0&quot;]">',
+          '<pre data-pt-block-type="container" data-pt-path="[_key==&quot;c0&quot;]">',
           '<code>',
-          // line: l0
-          '<div',
-          ' data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l0&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // span: const x = 1
+          '<div data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l0&quot;]" data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l0&quot;].children[_key==&quot;s0&quot;]"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">const x = 1</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'const x = 1',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
-          // line: l1
-          '<div',
-          ' data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l1&quot;]"',
-          ' data-block-type="text"',
-          '>',
-          // span: const y = 2
+          '<div data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l1&quot;]" data-pt-block-type="text">',
           '<span',
           ' data-pt-path="[_key==&quot;c0&quot;].lines[_key==&quot;l1&quot;].children[_key==&quot;s1&quot;]"',
-          ' data-child-type="span">',
-          '<span data-slate-leaf="true">',
-          '<span data-slate-string="true">const y = 2</span>',
+          ' data-pt-child-type="span">',
+          '<span data-pt-mark="true">',
+          '<span data-pt-string="true">',
+          'const y = 2',
+          '</span>',
           '</span>',
           '</span>',
           '</div>',
@@ -552,6 +557,88 @@ describe('DOM structure', () => {
           '</pre>',
         ].join(''),
       )
+    })
+  })
+
+  test('7. container DOM does not contain any `data-slate-*` attributes', async () => {
+    const calloutSchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'h1'}, {name: 'normal'}],
+                  lists: [{name: 'bullet'}],
+                },
+                {type: 'image'},
+              ],
+            },
+          ],
+        },
+        {name: 'image'},
+      ],
+    })
+    const calloutContainer = defineContainer<typeof calloutSchemaDefinition>({
+      scope: '$..callout',
+      field: 'content',
+      render: ({attributes, children}) => (
+        <div {...attributes} className="callout">
+          {children}
+        </div>
+      ),
+    })
+    await createTestEditor({
+      schemaDefinition: calloutSchemaDefinition,
+      initialValue: [
+        {
+          _key: 'c0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+              markDefs: [],
+              style: 'h1',
+            },
+            {_key: 'img0', _type: 'image'},
+            {
+              _key: 'b1',
+              _type: 'block',
+              children: [{_key: 's1', _type: 'span', text: 'item', marks: []}],
+              level: 1,
+              listItem: 'bullet',
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[calloutContainer]} />,
+    })
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('.callout')
+      expect(calloutEl).not.toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-slate-/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/(?<!pt-)data-block-type/g)).toEqual(
+        null,
+      )
+      expect(calloutEl!.innerHTML.match(/(?<!pt-)data-child-type/g)).toEqual(
+        null,
+      )
+      expect(calloutEl!.innerHTML.match(/data-style/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-list-item/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-level/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-list-index/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-block-key/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-block-name/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-child-key/g)).toEqual(null)
+      expect(calloutEl!.innerHTML.match(/data-child-name/g)).toEqual(null)
     })
   })
 })


### PR DESCRIPTION
## What

The container rendering pipeline now emits a single, namespaced `data-pt-*` DOM. The engine no longer depends on `data-slate-*` attributes existing; it answers every internal question by querying `data-pt-*` only. The legacy pipeline still emits all of its pre-existing attributes for consumer styling, plus `data-pt-block-type` / `data-pt-child-type` twins so the engine can read it.

## Why

Two namespaces coexisted in the editor's emitted DOM: the legacy `data-slate-*` set inherited from the original Slate fork, and the newer `data-pt-*` set introduced for the container pipeline. The engine queried both, sometimes in the same selector. That coupling made any further DOM cleanup risky, and removing `data-slate-*` from emission would have broken the engine itself.

This PR cuts the engine's dependency on `data-slate-*`, gives the new container pipeline a clean namespaced DOM, and leaves `data-slate-*` as a back-compat surface emitted purely for consumer styling.

## Container pipeline

A registered container's emitted DOM is now pure `data-pt-*`:

- `data-pt-block-type="container"` on the wrapper (was `data-block-type="container"`)
- `data-pt-block-type="text"` on a text block inside the container
- `data-pt-block-type="object"` on a void block-object inside the container
- `data-pt-child-type="object"` on an inline object inside the container
- `data-pt-child-type="span"` on a span inside the container
- `data-pt-spacer`, `data-pt-mark`, `data-pt-zero-width`, `data-pt-string`, `data-pt-path` on the underlying spacer/leaf/string/zero-width nodes

The bare `data-block-type` / `data-child-type` are no longer emitted in the container pipeline. Neither are `data-slate-*`, `data-block-key`, `data-block-name`, `data-child-key`, `data-child-name`, `data-style`, `data-list-item`, `data-level`, `data-list-index`, or `pt-*` classNames. Consumers spread `{...attributes}` and add whatever else they want.

## Legacy pipeline

The legacy pipeline (text blocks at root, void block-objects at root, inline objects in text blocks at root) keeps emitting every attribute it used to. Consumer CSS targeting `data-slate-*`, `data-block-*`, `data-child-*`, `data-style`, `data-list-item`, `data-level`, `data-list-index`, or any `pt-*` className continues to work unchanged.

In addition, every legacy emission site now also emits its `data-pt-*` twin where one was missing:

| Existing | New twin |
| --- | --- |
| `data-slate-editor` | `data-pt-editor` |
| `data-slate-leaf` | `data-pt-mark` |
| `data-slate-spacer` | `data-pt-spacer` |
| `data-slate-string` | `data-pt-string` |
| `data-slate-zero-width` | `data-pt-zero-width` |
| `data-block-type` | `data-pt-block-type` |
| `data-child-type` | `data-pt-child-type` |

`data-slate-node` and `data-slate-void` are not twinned. Their semantics are already covered by `data-pt-block-type` / `data-pt-child-type`. `data-slate-inline` was set but never read anywhere and is dropped entirely.

## Engine internals

Every `closest`, `querySelector`, `getAttribute`, and `hasAttribute` call in `dom-editor.ts`, `get-dom-node.ts`, and `editable.tsx` now targets `data-pt-*` only. Combined selectors that previously listed both namespaces simplify accordingly:

```ts
// before
'[data-slate-void], [data-block-type="object"], [data-child-type="object"]'

// after
'[data-pt-block-type="object"], [data-pt-child-type="object"]'
```

A grep for `data-slate-*` queries inside `packages/editor/src/` returns zero matches. The engine no longer depends on `data-slate-*` attributes existing.
