### PR TITLE
fix: strip undefined fields when parsing block objects and inline objects

### DIFF
--- a/.changeset/parse-object-strip-undefined-fields.md
+++ b/.changeset/parse-object-strip-undefined-fields.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: strip undefined fields when parsing block objects and inline objects

--- a/packages/editor/src/utils/parse-blocks.test.ts
+++ b/packages/editor/src/utils/parse-blocks.test.ts
@@ -729,6 +729,49 @@ describe(parseInlineObject.name, () => {
         foo: 'bar',
       })
     })
+
+    describe('known prop set to undefined', () => {
+      test('validateFields: true on inline object strips the field', () => {
+        const result = parseInlineObject({
+          inlineObject: {_type: 'stock-ticker', foo: undefined},
+          keyGenerator: createTestKeyGenerator(),
+          options: {validateFields: true},
+          schema: compileSchema(
+            defineSchema({
+              inlineObjects: [
+                {
+                  name: 'stock-ticker',
+                  fields: [{name: 'foo', type: 'string'}],
+                },
+              ],
+            }),
+          ),
+        })
+        expect(result).toStrictEqual({_key: 'k0', _type: 'stock-ticker'})
+        expect(result).not.toHaveProperty('foo')
+      })
+
+      test('validateFields: true on block object strips the field', () => {
+        const result = parseBlock({
+          block: {_type: 'image', _key: 'k0', alt: undefined},
+          keyGenerator: createTestKeyGenerator(),
+          options: {
+            normalize: false,
+            removeUnusedMarkDefs: true,
+            validateFields: true,
+          },
+          schema: compileSchema(
+            defineSchema({
+              blockObjects: [
+                {name: 'image', fields: [{name: 'alt', type: 'string'}]},
+              ],
+            }),
+          ),
+        })
+        expect(result).toStrictEqual({_key: 'k0', _type: 'image'})
+        expect(result).not.toHaveProperty('alt')
+      })
+    })
   })
 })
 

--- a/packages/editor/src/utils/parse-blocks.ts
+++ b/packages/editor/src/utils/parse-blocks.ts
@@ -626,6 +626,10 @@ function parseObject({
       continue
     }
 
+    if (value === undefined) {
+      continue
+    }
+
     const field = fieldsByName.get(key)
 
     if (options.validateFields && !field) {


### PR DESCRIPTION
When a plugin produces a block via object-spread where some fields are explicitly `undefined` (a common shape: `{...block, _map: mapping}` where `mapping` may be `undefined`), the field key survives into the parsed document with `value === undefined`. JSON.stringify hides it, but `Object.keys(block)` and `'field' in block` see it.

Surfaced in Canvas's `RetainMappingPlugin`, which stamps `_map: mapping` on dragged blocks at `deserialization.success` time. When the destination is unmapped, `mapping` is `undefined`. In v6 the parser stripped that key; on PTE main it survives.

The cause is in `parseObject`. The v6 implementation did:

```ts
const values = options.validateFields
  ? schemaType.fields.reduce((fieldValues, field) => {
      const fieldValue = object[field.name]
      if (fieldValue !== undefined) {
        fieldValues[field.name] = fieldValue
      }
      return fieldValues
    }, {})
  : customFields
```

The container-aware rewrite (`feat: make engine internals container-aware`) replaced the reducer with a loop over `Object.entries(customFields)`, but the `value !== undefined` guard was lost.

This change restores the guard inside the loop, so an explicit-undefined custom field is dropped after `parseObject` runs. Two regression tests cover the inline-object and block-object paths.