### PR TITLE
fix: avoid stack overflow when a Sanity schema contains a recursive object type

### DIFF
--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
@@ -303,4 +303,243 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
       },
     ])
   })
+
+  test('compiled schema with a deep non-recursive structure unfolds fully', () => {
+    // table-like nesting: table -> row -> cell -> block
+    const cellType = defineType({
+      type: 'object',
+      name: 'cell',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'content',
+          of: [defineArrayMember({type: 'block', name: 'block'})],
+        }),
+      ],
+    })
+    const rowType = defineType({
+      type: 'object',
+      name: 'row',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'cells',
+          of: [defineArrayMember({type: 'cell'})],
+        }),
+      ],
+    })
+    const tableType = defineType({
+      type: 'object',
+      name: 'table',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'rows',
+          of: [defineArrayMember({type: 'row'})],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'table'}),
+      ],
+    })
+
+    const sanitySchema = SanitySchema.compile({
+      types: [portableTextType, tableType, rowType, cellType],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(sanitySchema.get('body'))
+    const table = schema.blockObjects?.find((b) => b.name === 'table')
+
+    expect(table?.fields).toEqual([
+      {
+        name: 'rows',
+        type: 'array',
+        title: 'Rows',
+        of: [
+          {
+            type: 'row',
+            name: 'row',
+            title: 'Row',
+            fields: [
+              {
+                name: 'cells',
+                type: 'array',
+                title: 'Cells',
+                of: [
+                  {
+                    type: 'cell',
+                    name: 'cell',
+                    title: 'Cell',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        title: 'Content',
+                        of: [{type: 'block'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('compiled schema with a deeply nested table that contains itself in cells unfolds until the recursion is detected', () => {
+    const cellType = defineType({
+      type: 'object',
+      name: 'cell',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'content',
+          of: [
+            defineArrayMember({type: 'block', name: 'block'}),
+            defineArrayMember({type: 'table'}),
+          ],
+        }),
+      ],
+    })
+    const rowType = defineType({
+      type: 'object',
+      name: 'row',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'cells',
+          of: [defineArrayMember({type: 'cell'})],
+        }),
+      ],
+    })
+    const tableType = defineType({
+      type: 'object',
+      name: 'table',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'rows',
+          of: [defineArrayMember({type: 'row'})],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'table'}),
+      ],
+    })
+
+    const sanitySchema = SanitySchema.compile({
+      types: [portableTextType, tableType, rowType, cellType],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(sanitySchema.get('body'))
+    const table = schema.blockObjects?.find((b) => b.name === 'table')
+
+    // The nested `table` member inside a cell's `content` is detected as
+    // a cycle (its name is already an ancestor on the walk) and emitted
+    // as a stub `{type, name, title}` without fields. Everything before
+    // that point unfolds fully.
+    expect(table?.fields).toEqual([
+      {
+        name: 'rows',
+        type: 'array',
+        title: 'Rows',
+        of: [
+          {
+            type: 'row',
+            name: 'row',
+            title: 'Row',
+            fields: [
+              {
+                name: 'cells',
+                type: 'array',
+                title: 'Cells',
+                of: [
+                  {
+                    type: 'cell',
+                    name: 'cell',
+                    title: 'Cell',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        title: 'Content',
+                        of: [
+                          {type: 'block'},
+                          {type: 'table', name: 'table', title: 'Table'},
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('compiled schema with a recursive object type unfolds until the recursion is detected', () => {
+    // canvas's `canvasAiTask` shape: a block-object whose `input` field is
+    // an array that contains the same type as a member, so the hydrated
+    // sanity schema is a cycle.
+    const aiTaskType = defineType({
+      type: 'object',
+      name: 'aiTask',
+      fields: [
+        defineField({name: 'instruction', type: 'string'}),
+        defineField({
+          type: 'array',
+          name: 'input',
+          of: [
+            defineArrayMember({type: 'block', name: 'block'}),
+            defineArrayMember({type: 'aiTask'}),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'aiTask'}),
+      ],
+    })
+
+    const sanitySchema = SanitySchema.compile({
+      types: [portableTextType, aiTaskType],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(sanitySchema.get('body'))
+    const aiTask = schema.blockObjects?.find((b) => b.name === 'aiTask')
+
+    // The nested `aiTask` reference inside `input.of` is detected as a
+    // cycle (its name is already an ancestor on the walk) and emitted
+    // as a stub `{type, name, title}` without fields.
+    expect(aiTask?.fields).toEqual([
+      {name: 'instruction', type: 'string', title: 'Instruction'},
+      {
+        name: 'input',
+        type: 'array',
+        title: 'Input',
+        of: [
+          {type: 'block'},
+          {type: 'aiTask', name: 'aiTask', title: 'Ai Task'},
+        ],
+      },
+    ])
+  })
 })

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
@@ -120,17 +120,23 @@ function sanitySchemaTypeToSchema(
     annotations: annotations.map((annotation) => ({
       name: annotation.name,
       title: annotation.title,
-      fields: annotation.fields.map(sanityFieldToSchemaField),
+      fields: annotation.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set()),
+      ),
     })),
     blockObjects: blockObjectTypes.map((blockObject) => ({
       name: blockObject.name,
       title: blockObject.title,
-      fields: blockObject.fields.map(sanityFieldToSchemaField),
+      fields: blockObject.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set([blockObject.name])),
+      ),
     })),
     inlineObjects: inlineObjectTypes.map((inlineObject) => ({
       name: inlineObject.name,
       title: inlineObject.title,
-      fields: inlineObject.fields.map(sanityFieldToSchemaField),
+      fields: inlineObject.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set([inlineObject.name])),
+      ),
     })),
   }
 }
@@ -147,17 +153,24 @@ function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
   return undefined
 }
 
-function sanityFieldToSchemaField(field: {
-  name: string
-  type: SchemaType
-}): FieldDefinition {
+function sanityFieldToSchemaField(
+  field: {
+    name: string
+    type: SchemaType
+  },
+  ancestorNames: ReadonlySet<string>,
+): FieldDefinition {
   if (field.type.jsonType === 'array') {
     const ofMembers = safeGetOf(field.type)
     return {
       name: field.name,
       type: 'array',
       ...(field.type.title ? {title: field.type.title} : {}),
-      of: ofMembers ? ofMembers.map(sanityOfMemberToOfDefinition) : [],
+      of: ofMembers
+        ? ofMembers.map((member) =>
+            sanityOfMemberToOfDefinition(member, ancestorNames),
+          )
+        : [],
     }
   }
 
@@ -168,7 +181,10 @@ function sanityFieldToSchemaField(field: {
   }
 }
 
-function sanityOfMemberToOfDefinition(memberType: SchemaType): OfDefinition {
+function sanityOfMemberToOfDefinition(
+  memberType: SchemaType,
+  ancestorNames: ReadonlySet<string>,
+): OfDefinition {
   if (findBlockType(memberType)) {
     return {type: 'block'}
   }
@@ -184,10 +200,15 @@ function sanityOfMemberToOfDefinition(memberType: SchemaType): OfDefinition {
     'fields' in memberType &&
     Array.isArray((memberType as ObjectSchemaType).fields)
   ) {
+    if (ancestorNames.has(memberType.name)) {
+      return result
+    }
+    const nextAncestors = new Set(ancestorNames)
+    nextAncestors.add(memberType.name)
     return {
       ...result,
-      fields: (memberType as ObjectSchemaType).fields.map(
-        sanityFieldToSchemaField,
+      fields: (memberType as ObjectSchemaType).fields.map((field) =>
+        sanityFieldToSchemaField(field, nextAncestors),
       ),
     }
   }


### PR DESCRIPTION
A field can declare itself as a member of its own array `of` (e.g. a block-object with an `input` array that contains itself). The hydrated Sanity schema points at the same object on each recursion, so the walk in `sanityFieldToSchemaField` and `sanityOfMemberToOfDefinition` never terminates.

Surfaced in Canvas's `canvasAiTask` shape, where the block-object has a field:

```ts
defineField({
  type: 'array',
  name: 'input',
  of: commonCanvasPteTypes, // ← contains canvasAiTask itself
})
```

Track already-visited object types in a `WeakSet` and emit a stub `OfDefinition` (no `fields`) the second time the same type is reached. The first occurrence still emits the full field definition. Each top-level call site (`annotations`, `blockObjects`, `inlineObjects`) starts with a fresh set; block/inline-object cases pre-seed it with the outer type itself so a self-referential outer type is treated as already-seen on its first inner encounter.