### PR TITLE
feat(playground): support GFM task lists

### DIFF
--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -37,6 +37,14 @@
   font-size: 0.4rem;
 }
 
+[data-list-item='task'] {
+  display: block;
+  grid-template-columns: none;
+}
+[data-list-item='task']::before {
+  content: none;
+}
+
 /**
  * Then, the counter for each level is manually set to 1 whenever a list item
  * with index 1 is encountered.

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -4,6 +4,8 @@ import {
   useEditor,
   useEditorSelector,
   type BlockDecoratorRenderProps,
+  type BlockListItemRenderProps,
+  type BlockPath,
   type BlockRenderProps,
   type BlockStyleRenderProps,
   type EditorEmittedEvent,
@@ -402,7 +404,49 @@ const renderDecorator: RenderDecoratorFunction = (props) => {
   return (decoratorMap.get(props.value) ?? ((props) => props.children))(props)
 }
 
+function TaskListCheckbox(props: {
+  block: BlockListItemRenderProps['block']
+  path: BlockPath
+}) {
+  const editor = useEditor()
+  const checked = (props.block as {checked?: boolean}).checked === true
+
+  return (
+    <button
+      type="button"
+      contentEditable={false}
+      className="inline-flex items-center justify-center size-4 align-middle shrink-0 border border-gray-400 dark:border-gray-600 rounded-sm hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer transition-colors data-[checked=true]:bg-blue-500 data-[checked=true]:border-blue-500 data-[checked=true]:text-white"
+      data-checked={checked}
+      onMouseDown={(event) => {
+        event.preventDefault()
+      }}
+      onClick={() => {
+        editor.send({
+          type: 'block.set',
+          props: {checked: !checked},
+          at: props.path,
+        })
+      }}
+      aria-label={checked ? 'Mark task as not done' : 'Mark task as done'}
+    >
+      {checked ? <CheckIcon className="size-3" /> : null}
+    </button>
+  )
+}
+
 const renderListItem: RenderListItemFunction = (props) => {
+  if (props.value === 'task') {
+    const checked = (props.block as {checked?: boolean}).checked === true
+    return (
+      <span
+        className="flex items-center gap-2 data-[checked=true]:text-gray-400 data-[checked=true]:line-through [&>*:last-child]:flex-1"
+        data-checked={checked}
+      >
+        <TaskListCheckbox block={props.block} path={props.path} />
+        {props.children}
+      </span>
+    )
+  }
   return props.children
 }
 

--- a/apps/playground/src/playground-schema-definition.tsx
+++ b/apps/playground/src/playground-schema-definition.tsx
@@ -2,6 +2,9 @@ import {defineSchema} from '@portabletext/editor'
 import {z} from 'zod'
 
 export const playgroundSchemaDefinition = defineSchema({
+  block: {
+    fields: [{name: 'checked', title: 'Checked', type: 'boolean'}],
+  },
   decorators: [
     {
       title: 'Strong',
@@ -52,6 +55,10 @@ export const playgroundSchemaDefinition = defineSchema({
     {
       title: 'Numbered list',
       name: 'number',
+    },
+    {
+      title: 'Task list',
+      name: 'task',
     },
   ],
   styles: [
@@ -174,6 +181,7 @@ export const playgroundSchemaDefinition = defineSchema({
               lists: [
                 {title: 'Bulleted list', name: 'bullet'},
                 {title: 'Numbered list', name: 'number'},
+                {title: 'Task list', name: 'task'},
               ],
               inlineObjects: [
                 {

--- a/apps/playground/src/previews/portable-text-components.tsx
+++ b/apps/playground/src/previews/portable-text-components.tsx
@@ -128,5 +128,51 @@ export const portableTextComponents: Partial<PortableTextReactComponents> = {
         {children}
       </ol>
     ),
+    task: ({children}) => (
+      <ul className="list-none pl-0 mb-4 text-gray-900 dark:text-gray-100">
+        {children}
+      </ul>
+    ),
+  },
+  listItem: {
+    task: ({value, children}) => {
+      const checked = (value as {checked?: boolean}).checked === true
+      return (
+        <li className="flex items-start gap-2 mb-1">
+          <span
+            aria-hidden="true"
+            className={`inline-flex items-center justify-center size-4 mt-1 shrink-0 border rounded-sm ${
+              checked
+                ? 'bg-blue-500 border-blue-500 text-white'
+                : 'border-gray-400 dark:border-gray-600'
+            }`}
+          >
+            {checked ? (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="size-3"
+                aria-hidden="true"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            ) : null}
+          </span>
+          <span
+            className={
+              checked
+                ? 'line-through text-gray-400 dark:text-gray-500 flex-1'
+                : 'flex-1'
+            }
+          >
+            {children}
+          </span>
+        </li>
+      )
+    },
   },
 }

--- a/apps/playground/src/slash-command-picker.tsx
+++ b/apps/playground/src/slash-command-picker.tsx
@@ -16,6 +16,7 @@ import {
   InfoIcon,
   ListIcon,
   ListOrderedIcon,
+  ListTodoIcon,
   SeparatorHorizontalIcon,
   TableIcon,
   TextQuoteIcon,
@@ -99,6 +100,14 @@ const commands: CommandMatch[] = [
     icon: <ListOrderedIcon className="size-4" />,
     keywords: ['number', 'ol', 'list', 'ordered'],
     action: {type: 'list item.toggle', listItem: 'number'},
+  },
+  {
+    key: 'task',
+    label: 'Task List',
+    description: 'Checkbox list',
+    icon: <ListTodoIcon className="size-4" />,
+    keywords: ['task', 'todo', 'checkbox', 'check', 'list'],
+    action: {type: 'list item.toggle', listItem: 'task'},
   },
   {
     key: 'image',

--- a/apps/playground/src/toolbar/portable-text-toolbar.tsx
+++ b/apps/playground/src/toolbar/portable-text-toolbar.tsx
@@ -41,6 +41,7 @@ import {
   LinkIcon,
   ListIcon,
   ListOrderedIcon,
+  ListTodoIcon,
   MessageSquareTextIcon,
   PilcrowIcon,
   SeparatorHorizontalIcon,
@@ -232,6 +233,13 @@ const extendList: ExtendListSchemaType = (list) => {
     return {
       ...list,
       icon: ListOrderedIcon,
+    }
+  }
+
+  if (list.name === 'task') {
+    return {
+      ...list,
+      icon: ListTodoIcon,
     }
   }
 


### PR DESCRIPTION
Wires up GFM task list support in the playground end-to-end on top of [#2604](https://github.com/portabletext/editor/pull/2604):

- The schema gains a `task` list type and a `checked` boolean field on text blocks, matching the markdown package's default schema. This lets pasted GFM task lists round-trip through the existing markdown deserializer plugin without extra wiring.
- The toolbar's list group gains a Task List button using `ListTodoIcon`, and a new `/task` slash command toggles the focused block to a task list item.
- Task list items render with a clickable checkbox before the content. Clicking toggles `checked` via `block.set`. Checked items render strikethrough.

The callout's sub-schema also gets the `task` list type. Cell and one-line sub-schemas keep their narrower list sets.

What this doesn't add: a `[ ] ` / `[x] ` keystroke shortcut. That belongs in `@portabletext/plugin-markdown-shortcuts` next to the existing list and heading rules and is best done as its own package change.