### PR TITLE
chore: tidy v7 changesets

### DIFF
--- a/.changeset/containers-editor-context.md
+++ b/.changeset/containers-editor-context.md
@@ -1,5 +1,5 @@
 ---
-'@portabletext/editor': patch
+'@portabletext/editor': minor
 ---
 
 feat: add `containers` to editor context

--- a/.changeset/fully-covered-container-per-endpoint.md
+++ b/.changeset/fully-covered-container-per-endpoint.md
@@ -3,3 +3,5 @@
 ---
 
 fix: remove every container the range fully covers when deleting across containers
+
+A delete range that fully covers more than one editable container (Cmd+A across multiple code-blocks, or selecting all of two callouts) used to leave one or more containers behind. The cross-container range delete now walks up from each endpoint independently and removes every container the range fully covers, regardless of how many of them sit between the endpoints.

--- a/.changeset/insert-block-stale-selection.md
+++ b/.changeset/insert-block-stale-selection.md
@@ -3,3 +3,5 @@
 ---
 
 fix: keep `insert.block` inside an editable container when the prior delete left it without text
+
+A behavior chain that deletes a container's content and then inserts a fresh block (slash-command paths, paste-replace, format-toggle on a fresh selection) used to drop the new block at the document root instead of inside the container, because the container's editable field had become empty between the two events. `insert.block` now detects "endBlock is a registered editable container with an empty editable field" and inserts the block as the container's first child.

--- a/.changeset/keep-text-block-shell-on-full-text-delete.md
+++ b/.changeset/keep-text-block-shell-on-full-text-delete.md
@@ -3,3 +3,5 @@
 ---
 
 fix: preserve a text block's shell when delete covers all of its text and the block is registered as an editable container
+
+When a consumer registers a text block itself as an editable container (e.g. a callout's content block via `defineContainer({scope: '$..callout.block', field: 'children'})`), selecting all of its text and pressing Delete used to remove the text block entirely. The shell is now preserved with an empty placeholder span inside, matching the behavior for object-level editable containers and for plain text blocks.

--- a/.changeset/toolbar-annotation-popover-container-aware.md
+++ b/.changeset/toolbar-annotation-popover-container-aware.md
@@ -3,3 +3,5 @@
 ---
 
 fix: open the annotation popover when the annotated text block is inside an editable container
+
+The annotation popover hook constructed its target path as `[{_key: focusBlock._key}, 'markDefs', {_key: annotation._key}]`, hardcoding a depth-2 path that only resolved at the document root. Annotations on text blocks inside callouts, fact-boxes, table cells, or any other editable container silently noop'd when the popover tried to set or remove them. The hook now uses the focus block's full path, so annotation actions work at any depth.


### PR DESCRIPTION
A small hygiene pass over the v7 changesets before we cut the release.

`containers-editor-context` is bumped from patch to minor. It exports `Container`, `ContainerDefinition`, `Containers`, and `ResolvedContainers` to the public API, which is a feature-level change.

Four title-only changesets get a sentence of context that the changelog reader will actually want:

- `fully-covered-container-per-endpoint`
- `insert-block-stale-selection`
- `keep-text-block-shell-on-full-text-delete`
- `toolbar-annotation-popover-container-aware`

No code changes.