### PR TITLE
feat: accept the deprecated function-form on Editor.subscribe

### DIFF
--- a/.changeset/editor-subscribe-function-form.md
+++ b/.changeset/editor-subscribe-function-form.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': minor
+---
+
+`Editor.subscribe` now accepts both the observer-form (`{next, error, complete}`) and the deprecated function-form (`subscribe(next, error?, complete?)`). The function-form satisfies xstate's wider `Subscribable<T>` constraint, so `useSelector(editor, selector)` from `@xstate/react` accepts the editor directly without a cast.
+
+Internally the function-form re-routes to the observer-form. New code should prefer the observer-form; the function-form exists for structural compatibility with libraries that still type their constraints to include it.

--- a/packages/editor/src/editor.subscribable.test-d.ts
+++ b/packages/editor/src/editor.subscribable.test-d.ts
@@ -1,0 +1,101 @@
+import {useSelector} from '@xstate/react'
+import {useSyncExternalStore} from 'react'
+import {describe, test} from 'vitest'
+import type {Editor} from './editor'
+import type {EditorSnapshot} from './editor/editor-snapshot'
+
+declare const editor: Editor
+
+/**
+ * The v7 release post claims the public `Editor` type satisfies
+ * a standard `subscribe(observer) + getSnapshot()` contract that
+ * three integration shapes consume directly:
+ *
+ * 1. React's `useSyncExternalStore`
+ * 2. xstate's `useSelector` (from `@xstate/react`)
+ * 3. rxjs `Observable` (constructed manually around `editor.subscribe`)
+ *
+ * This file pins those claims at the type level.
+ */
+describe('Editor as Subscribable<EditorSnapshot>', () => {
+  test('Editor.subscribe accepts an observer-only argument and returns an unsubscribe handle', () => {
+    const subscription = editor.subscribe({
+      next: (snapshot: EditorSnapshot) => {
+        snapshot.context.value
+      },
+      error: (err: unknown) => {
+        err
+      },
+      complete: () => {},
+    })
+    const unsub: () => void = subscription.unsubscribe
+    void unsub
+  })
+
+  test('Editor.subscribe accepts an observer with only a `next` handler', () => {
+    const subscription = editor.subscribe({next: () => {}})
+    const unsub: () => void = subscription.unsubscribe
+    void unsub
+  })
+
+  test('Editor.getSnapshot returns an EditorSnapshot synchronously', () => {
+    const snapshot: EditorSnapshot = editor.getSnapshot()
+    void snapshot.context.value
+  })
+
+  test('useSyncExternalStore consumes editor.subscribe via a small adapter', () => {
+    // The post shows this exact shape; it must compile.
+    const length = useSyncExternalStore(
+      (notify) => {
+        const sub = editor.subscribe({next: () => notify()})
+        return () => sub.unsubscribe()
+      },
+      () => editor.getSnapshot().context.value.length,
+    )
+    void length
+  })
+
+  test('Manual rxjs-style Observable wrapper compiles', () => {
+    // The post shows wrapping the editor in `new Observable<T>(subscriber => ...)`.
+    // We don't depend on rxjs in this package; replicate the relevant shape.
+    type Subscriber<T> = {
+      next: (value: T) => void
+      error: (err: unknown) => void
+      complete: () => void
+    }
+    type Teardown = () => void
+    function createObservable<T>(
+      factory: (subscriber: Subscriber<T>) => Teardown,
+    ): {subscribe: (s: Subscriber<T>) => {unsubscribe: Teardown}} {
+      return {
+        subscribe(s) {
+          const teardown = factory(s)
+          return {unsubscribe: teardown}
+        },
+      }
+    }
+
+    const editor$ = createObservable<EditorSnapshot>((subscriber) => {
+      const sub = editor.subscribe({
+        next: (snap) => subscriber.next(snap),
+        error: (err) => subscriber.error(err),
+        complete: () => subscriber.complete(),
+      })
+      return () => sub.unsubscribe()
+    })
+    void editor$
+  })
+
+  test('xstate useSelector accepts the public Editor type directly', () => {
+    // The function-form overload on `Editor.subscribe` is what allows direct
+    // assignment to xstate's `Subscribable<T>` constraint, which still
+    // includes the deprecated function-form overload alongside the
+    // observer-form. PTE's implementation routes the function-form to the
+    // observer-form internally.
+    const length = useSelector(
+      editor,
+      (snap: EditorSnapshot) => snap.context.value.length,
+    )
+    void length
+  })
+})

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -76,4 +76,18 @@ export type Editor = {
     error?: (err: unknown) => void
     complete?: () => void
   }): {unsubscribe: () => void}
+  /**
+   * Deprecated function-form overload kept for structural compatibility with
+   * libraries that type their `Subscribable<T>` constraint to include both
+   * the modern observer-form and the legacy function-form (notably
+   * `@xstate/react`'s `useSelector`). Internally this re-routes to the
+   * observer-form. Prefer the observer-form in new code.
+   *
+   * @deprecated Use the observer-form: `editor.subscribe({next, error, complete})`.
+   */
+  subscribe(
+    next: (snapshot: EditorSnapshot) => void,
+    error?: (err: unknown) => void,
+    complete?: () => void,
+  ): {unsubscribe: () => void}
 }

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -14,6 +14,7 @@ import {createEditorDom} from './editor-dom'
 import type {EditorActor} from './editor-machine'
 import {editorMachine, rerouteExternalBehaviorEvent} from './editor-machine'
 import {getEditorSnapshot} from './editor-selector'
+import type {EditorSnapshot} from './editor-snapshot'
 import {mutationMachine, type MutationActor} from './mutation-machine'
 import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
@@ -148,7 +149,21 @@ export function createInternalEditor(config: EditorConfig): {
 
       return subscription
     },
-    subscribe(observer) {
+    subscribe(
+      observerOrNext:
+        | {
+            next?: (snapshot: EditorSnapshot) => void
+            error?: (err: unknown) => void
+            complete?: () => void
+          }
+        | ((snapshot: EditorSnapshot) => void),
+      error?: (err: unknown) => void,
+      complete?: () => void,
+    ) {
+      const observer =
+        typeof observerOrNext === 'function'
+          ? {next: observerOrNext, error, complete}
+          : observerOrNext
       const actorSubscription = editorActor.subscribe({
         next: () => observer.next?.(editor.getSnapshot()),
         error: observer.error,

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -1,5 +1,4 @@
 import {useSelector} from '@xstate/react'
-import type {AnyActorRef} from 'xstate'
 import type {Editor} from '../editor'
 import type {PortableTextSlateEditor} from '../types/slate-editor'
 import type {EditorActor} from './editor-machine'
@@ -43,15 +42,7 @@ export function useEditorSelector<TSelected>(
   selector: EditorSelector<TSelected>,
   compare: (a: TSelected, b: TSelected) => boolean = defaultCompare,
 ) {
-  // `useSelector` is typed against xstate's `Subscribable<T>` which has both
-  // observer-form and the deprecated function-form `subscribe` overloads.
-  // We only expose the modern observer-form; the cast bridges that gap
-  // without leaking the deprecated overload into our public `Editor` type.
-  return useSelector(
-    editor as unknown as Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>,
-    selector,
-    compare,
-  )
+  return useSelector(editor, selector, compare)
 }
 
 export function getEditorSnapshot({

--- a/packages/editor/tests/editor.subscribable.runtime.test.tsx
+++ b/packages/editor/tests/editor.subscribable.runtime.test.tsx
@@ -1,0 +1,59 @@
+import {useSelector} from '@xstate/react'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {useEditor} from '../src/editor/use-editor'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * The v7 release post claims `useSelector(editor, selector)` from
+ * `@xstate/react` works because the editor satisfies the
+ * `Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>` constraint.
+ *
+ * At the type level the constraint is too narrow: xstate types `subscribe`
+ * to also accept the deprecated function-form overload PTE deliberately
+ * doesn't expose, so direct assignment fails. That's pinned in
+ * `editor.subscribable.test-d.ts`.
+ *
+ * At runtime however, `useSelector`'s implementation only invokes
+ * `actor.subscribe({next, error})` (observer-form) and `actor.getSnapshot()`,
+ * both of which the editor implements. This test verifies the runtime
+ * pass-through works end-to-end with a single cast at the call site.
+ */
+describe('useSelector(editor, ...) runtime contract', () => {
+  test('Scenario: useSelector reads editor state and re-renders on mutations', async () => {
+    const selectorResults: Array<number> = []
+
+    function ValueLengthDisplay() {
+      const editor = useEditor()
+      const length = useSelector(editor, (snapshot) => {
+        return snapshot.context.value.length
+      })
+      selectorResults.push(length)
+      return <span data-testid="length-display">{length}</span>
+    }
+
+    const {locator} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: '', marks: []}],
+        },
+      ],
+      children: <ValueLengthDisplay />,
+    })
+
+    await userEvent.click(locator)
+    await userEvent.keyboard('hello')
+    await userEvent.keyboard('{Enter}')
+    await userEvent.keyboard('world')
+
+    await vi.waitFor(() => {
+      // The selector observed at least one block-count change to 2.
+      expect(selectorResults).toContain(2)
+    })
+
+    // Confirm the most recent selector run reflects the live value length.
+    expect(selectorResults[selectorResults.length - 1]).toBe(2)
+  })
+})


### PR DESCRIPTION
`useSelector(editor, selector)` from `@xstate/react` works at runtime — xstate only calls observer-form `subscribe` and `getSnapshot`, both already on `Editor`. The blocker was purely at the type level: xstate's `Subscribable<T>` constraint also includes the deprecated function-form `subscribe(next, error?, complete?)`, which `Editor.subscribe` didn't expose.

This PR adds the function-form as a `@deprecated` overload on `Editor.subscribe`. The implementation re-routes to the observer-form internally. With the overload in place, `useSelector(editor, selector)` accepts the editor directly with no cast.

The internal `useEditorSelector` no longer needs to cast to `Pick<AnyActorRef, ...>`.

Two test files lock the contract:

- `editor.subscribable.test-d.ts` pins the type-level shape: `editor.subscribe(observer)` returns `{unsubscribe}`, `editor.getSnapshot()` returns `EditorSnapshot`, `useSyncExternalStore` accepts the editor via the adapter shape from the release post, a manual rxjs `Observable` wrapper around `editor.subscribe` compiles, and `useSelector(editor, selector)` compiles directly.
- `editor.subscribable.runtime.test.tsx` mounts a component using `useSelector` against the live editor and asserts the selector observes value-length changes after typing.

The trade-off is one extra overload in the public `Editor` type, marked `@deprecated`. The alternative is keeping `subscribe` observer-only and asking every consumer who reaches for `useSelector` to cast at the call site.