### PR TITLE
feat(markdown): add `types.list` matcher for list-as-container

### DIFF
--- a/.changeset/markdown-list-as-container.md
+++ b/.changeset/markdown-list-as-container.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: add `types.list` matcher to `markdownToPortableText` for list-as-container
+
+Lets consumers take ownership of structural list emission on the way in, mirroring the existing `types.table` pattern. When a `types.list` matcher is provided, list tokens become `{_type: 'list', kind, items: [...]}` block-objects whose `list-item.content` arrays can hold any block — text blocks, code blocks, callouts, images, even nested lists. The default flat path (text blocks with `listItem` and `level` fields) is unchanged for consumers who don't register the matcher.
+
+Pair with `defineContainer({scope: '$..list', field: 'items'})` and `defineContainer({scope: '$..list-item', field: 'content'})` in PTE v7 to get list items that hold rich content.

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -70,6 +70,7 @@ const markdown = portableTextToMarkdown([
 | Blockquotes      | ✅                       | ✅                       |
 | Ordered lists    | ✅                       | ✅                       |
 | Unordered lists  | ✅                       | ✅                       |
+| Task lists       | ✅\*                     | ✅\*                     |
 | Nested lists     | ✅                       | ✅                       |
 | Code blocks      | ✅                       | ✅\*                     |
 | Horizontal rules | ✅                       | ✅\*                     |
@@ -206,6 +207,7 @@ Matchers map Markdown concepts to Portable Text types defined in the Schema. Eac
 |            | `blockquote`     | `>` blockquotes         | `'blockquote'`      |
 | `listItem` | `bullet`         | `- ` or `* ` lists      | `'bullet'`          |
 |            | `number`         | `1. ` ordered lists     | `'number'`          |
+|            | `task`           | `- [ ]` / `- [x]` items | `'task'`            |
 | `marks`    | `strong`         | `**bold**`              | `'strong'`          |
 |            | `em`             | `*italic*`              | `'em'`              |
 |            | `code`           | `` `inline code` ``     | `'code'`            |
@@ -284,6 +286,36 @@ markdownToPortableText(markdown, {
 The matcher receives `value.items` already assembled. Each item's `content` array holds whatever blocks the markdown produced inside the item: text blocks, code blocks, callouts, images, even nested lists. `kind` is promoted to `'task'` automatically when any item carries a GFM checkbox (`- [ ]` / `- [x]`); items only carry a `checked` field when the markdown actually has one. If the matcher returns `undefined`, the parser falls back to flat-list parsing for that list.
 
 Without `types.list`, the existing flat-block path runs unchanged.
+
+**GFM task lists** (`- [ ]` / `- [x]`): Task lists are recognized when the schema declares a `task` list item. Without a `task` definition, the checkbox markers are stripped from the text and the items render as their surrounding list type (bullet or number). With a `task` definition, items carrying a checkbox become text blocks with `listItem: 'task'` and a `checked: boolean` field; items without a checkbox keep their surrounding list type.
+
+```ts
+markdownToPortableText('- [x] done\n- [ ] todo', {
+  schema: compileSchema(
+    defineSchema({
+      lists: [{name: 'bullet'}, {name: 'task'}],
+    }),
+  ),
+})
+// → [
+//   {_type: 'block', listItem: 'task', level: 1, checked: true,  children: [{text: 'done', ...}], ...},
+//   {_type: 'block', listItem: 'task', level: 1, checked: false, children: [{text: 'todo', ...}], ...},
+// ]
+```
+
+If your schema uses a different name for the task list type (e.g. `'todo'`), provide a custom `listItem.task` matcher:
+
+```ts
+markdownToPortableText(markdown, {
+  schema: compileSchema(defineSchema({lists: [{name: 'todo'}]})),
+  listItem: {
+    task: ({context}) =>
+      context.schema.lists.find((list) => list.name === 'todo')?.name,
+  },
+})
+```
+
+When emitting Portable Text back to Markdown, blocks with `listItem: 'task'` render as `- [x] ` or `- [ ] ` based on the `checked` field.
 
 Matchers receive:
 
@@ -395,24 +427,24 @@ The conversion is driven by **Renderers**: functions that render Portable Text e
 
 #### Default renderers
 
-| Group               | Renderer         | Renders                      | Output                |
-| ------------------- | ---------------- | ---------------------------- | --------------------- |
-| `block`             | `normal`         | Paragraphs                   | `{children}`          |
-|                     | `h1`–`h6`        | Headings                     | `# `–`###### `        |
-|                     | `blockquote`     | Blockquotes                  | `> {children}`        |
-| `marks`             | `strong`         | Bold text                    | `**{children}**`      |
-|                     | `em`             | Italic text                  | `_{children}_`        |
-|                     | `code`           | Inline code                  | `` `{children}` ``    |
-|                     | `underline`      | Underlined text              | `<u>{children}</u>`   |
-|                     | `strike-through` | Strikethrough                | `~~{children}~~`      |
-|                     | `link`           | Links                        | `[{children}](url)`   |
-| `listItem`          |                  | List items (bullet & number) | `- ` or `1. `         |
-| `hardBreak`         |                  | Line breaks within blocks    | `  \n` (two spaces)   |
-| `blockSpacing`      |                  | Spacing between blocks       | `\n\n`, `\n`, `\n>\n` |
-| `unknownType`       |                  | Unknown block types          | JSON code block       |
-| `unknownBlockStyle` |                  | Unknown block styles         | `{children}`          |
-| `unknownListItem`   |                  | Unknown list item types      | `- {children}`        |
-| `unknownMark`       |                  | Unknown marks                | `{children}`          |
+| Group               | Renderer         | Renders                           | Output                   |
+| ------------------- | ---------------- | --------------------------------- | ------------------------ |
+| `block`             | `normal`         | Paragraphs                        | `{children}`             |
+|                     | `h1`–`h6`        | Headings                          | `# `–`###### `           |
+|                     | `blockquote`     | Blockquotes                       | `> {children}`           |
+| `marks`             | `strong`         | Bold text                         | `**{children}**`         |
+|                     | `em`             | Italic text                       | `_{children}_`           |
+|                     | `code`           | Inline code                       | `` `{children}` ``       |
+|                     | `underline`      | Underlined text                   | `<u>{children}</u>`      |
+|                     | `strike-through` | Strikethrough                     | `~~{children}~~`         |
+|                     | `link`           | Links                             | `[{children}](url)`      |
+| `listItem`          |                  | List items (bullet, number, task) | `- `, `1. `, or `- [x] ` |
+| `hardBreak`         |                  | Line breaks within blocks         | `  \n` (two spaces)      |
+| `blockSpacing`      |                  | Spacing between blocks            | `\n\n`, `\n`, `\n>\n`    |
+| `unknownType`       |                  | Unknown block types               | JSON code block          |
+| `unknownBlockStyle` |                  | Unknown block styles              | `{children}`             |
+| `unknownListItem`   |                  | Unknown list item types           | `- {children}`           |
+| `unknownMark`       |                  | Unknown marks                     | `{children}`             |
 
 Unknown types render as JSON code blocks by default; unknown styles, list items, and marks pass through their children.
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -216,6 +216,7 @@ Matchers map Markdown concepts to Portable Text types defined in the Schema. Eac
 |            | `image`          | `![alt](src)`           | `'image'`           |
 |            | `html`           | HTML blocks             | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.       | `'callout'`         |
+|            | `list`           | `- ` or `1. ` lists     | `'list'`            |
 
 #### Configuring matchers
 
@@ -263,6 +264,26 @@ markdownToPortableText(markdown, {
   },
 })
 ```
+
+**List matcher:** By default, lists are emitted as flat text blocks with `listItem` and `level` fields, and adjacent blocks form a list at render time. If your schema models lists as a structural block-object instead (a `list` type with an `items` array holding `list-item` objects, each with a `content` array), provide a `types.list` matcher to opt into that shape:
+
+```ts
+markdownToPortableText(markdown, {
+  schema: schemaWithList,
+  types: {
+    list: ({context, value}) => ({
+      _type: 'list',
+      _key: context.keyGenerator(),
+      kind: value.kind, // 'bullet' | 'number' | 'task'
+      items: value.items, // each item: {_type, _key, checked?, content: [...]}
+    }),
+  },
+})
+```
+
+The matcher receives `value.items` already assembled. Each item's `content` array holds whatever blocks the markdown produced inside the item: text blocks, code blocks, callouts, images, even nested lists. `kind` is promoted to `'task'` automatically when any item carries a GFM checkbox (`- [ ]` / `- [x]`); items only carry a `checked` field when the markdown actually has one. If the matcher returns `undefined`, the parser falls back to flat-list parsing for that list.
+
+Without `types.list`, the existing flat-block path runs unchanged.
 
 Matchers receive:
 
@@ -434,6 +455,7 @@ import {
   DefaultHorizontalRuleRenderer,
   DefaultHtmlRenderer,
   DefaultImageRenderer,
+  DefaultListRenderer,
   DefaultTableRenderer,
   portableTextToMarkdown,
 } from '@portabletext/markdown'
@@ -445,19 +467,21 @@ portableTextToMarkdown(blocks, {
     'horizontal-rule': DefaultHorizontalRuleRenderer,
     'html': DefaultHtmlRenderer,
     'image': DefaultImageRenderer,
+    'list': DefaultListRenderer,
     'table': DefaultTableRenderer,
   },
 })
 ```
 
-| Renderer                        | Expected value                                 | Output                 |
-| ------------------------------- | ---------------------------------------------- | ---------------------- |
-| `DefaultCalloutRenderer`        | `{tone: string, content: PortableTextBlock[]}` | `> [!TYPE]\n> content` |
-| `DefaultCodeBlockRenderer`      | `{code: string, language?: string}`            | ` ```lang\ncode\n``` ` |
-| `DefaultHorizontalRuleRenderer` | (no fields required)                           | `---`                  |
-| `DefaultHtmlRenderer`           | `{html: string}`                               | Raw HTML               |
-| `DefaultImageRenderer`          | `{src: string, alt?: string, title?: string}`  | `![alt](src "title")`  |
-| `DefaultTableRenderer`          | `{rows: [...], headerRows?: number}`           | Markdown table         |
+| Renderer                        | Expected value                                         | Output                 |
+| ------------------------------- | ------------------------------------------------------ | ---------------------- |
+| `DefaultCalloutRenderer`        | `{tone: string, content: PortableTextBlock[]}`         | `> [!TYPE]\n> content` |
+| `DefaultCodeBlockRenderer`      | `{code: string, language?: string}`                    | ` ```lang\ncode\n``` ` |
+| `DefaultHorizontalRuleRenderer` | (no fields required)                                   | `---`                  |
+| `DefaultHtmlRenderer`           | `{html: string}`                                       | Raw HTML               |
+| `DefaultImageRenderer`          | `{src: string, alt?: string, title?: string}`          | `![alt](src "title")`  |
+| `DefaultListRenderer`           | `{kind: 'bullet' \| 'number' \| 'task', items: [...]}` | Markdown list          |
+| `DefaultTableRenderer`          | `{rows: [...], headerRows?: number}`                   | Markdown table         |
 
 #### What renderers receive
 

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -1,4 +1,4 @@
-import type {PortableTextBlock} from '@portabletext/types'
+import type {PortableTextBlock, TypedObject} from '@portabletext/types'
 import {escapeImageAndLinkText, escapeImageAndLinkTitle} from '../../escape'
 import type {PortableTextTypeRenderer} from '../types'
 
@@ -139,6 +139,77 @@ export const DefaultCalloutRenderer: PortableTextTypeRenderer<{
     .join('\n')
 
   return `> [!${value.tone.toUpperCase()}]\n${prefixed}`
+}
+
+/**
+ * Renders a structural list block-object (the `types.list` shape produced by
+ * `markdownToPortableText` when a `types.list` matcher is provided) back to
+ * Markdown. Items render as `- ` for `kind: 'bullet'`, `1. `/`2. ` for `'number'`,
+ * and `- [x] ` / `- [ ] ` for `'task'`. Items can hold any blocks - text blocks,
+ * code blocks, callouts, images, and nested lists - and content other than the
+ * leading text block is indented to keep it inside the item.
+ *
+ * @public
+ */
+export const DefaultListRenderer: PortableTextTypeRenderer<{
+  _type: 'list'
+  kind: 'bullet' | 'number' | 'task'
+  items: Array<{
+    _type: 'list-item'
+    _key: string
+    checked?: boolean
+    content: Array<PortableTextBlock | TypedObject>
+  }>
+}> = ({value, renderNode}) => {
+  const indent = '  '
+  const lines = value.items.map((item, itemIndex) => {
+    const marker = getListMarker(value.kind, itemIndex, item.checked)
+    const renderedBlocks = item.content.map((block, blockIndex) => ({
+      isNestedList: (block as TypedObject)._type === 'list',
+      text: renderNode({
+        node: block as TypedObject,
+        index: blockIndex,
+        isInline: false,
+        renderNode,
+      }),
+    }))
+
+    const [first, ...rest] = renderedBlocks
+    const head = `${marker}${first?.text ?? ''}`
+    if (rest.length === 0) {
+      return head
+    }
+
+    const tail = rest
+      .map((rendered) => {
+        const indented = rendered.text
+          .split('\n')
+          .map((line) => (line === '' ? '' : `${indent}${line}`))
+          .join('\n')
+        // Nested lists hug the previous block (tight list); other content
+        // gets a blank line separator (paragraph break).
+        return rendered.isNestedList ? `\n${indented}` : `\n\n${indented}`
+      })
+      .join('')
+
+    return `${head}${tail}`
+  })
+
+  return lines.join('\n')
+}
+
+function getListMarker(
+  kind: 'bullet' | 'number' | 'task',
+  itemIndex: number,
+  checked: boolean | undefined,
+): string {
+  if (kind === 'number') {
+    return `${itemIndex + 1}. `
+  }
+  if (kind === 'task') {
+    return checked ? '- [x] ' : '- [ ] '
+  }
+  return '- '
 }
 
 /**

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -29,6 +29,7 @@ export {
   DefaultHorizontalRuleRenderer,
   DefaultHtmlRenderer,
   DefaultImageRenderer,
+  DefaultListRenderer,
   DefaultTableRenderer,
 } from './from-portable-text/renderers/type'
 export type {

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -4840,4 +4840,810 @@ describe(markdownToPortableText.name, () => {
       }
     })
   })
+
+  describe('list as container (`types.list`)', () => {
+    const listItemDefinition = {
+      name: 'list-item',
+      fields: [
+        {name: 'checked', type: 'boolean'},
+        {name: 'content', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const listObjectDefinition = {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {name: 'items', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const tableObjectDefinition = {
+      name: 'table',
+      fields: [
+        {name: 'headerRows', type: 'number'},
+        {name: 'rows', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithList = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          listObjectDefinition,
+          listItemDefinition,
+        ],
+      }),
+    )
+
+    const schemaWithListAndTable = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          listObjectDefinition,
+          listItemDefinition,
+          tableObjectDefinition,
+        ],
+      }),
+    )
+
+    const getListTestOptions = (keyGenerator: () => string) => ({
+      keyGenerator,
+      schema: schemaWithList,
+      types: {
+        list: buildObjectMatcher(listObjectDefinition),
+      },
+    })
+
+    test('simple bullet list', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['- one', '- two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k6',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+            {
+              _key: 'k3',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k4',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k5',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'bullet',
+        },
+      ])
+    })
+
+    test('ordered list', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['1. one', '2. two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k6',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+            {
+              _key: 'k3',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k4',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k5',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'number',
+        },
+      ])
+    })
+
+    test('task list with checked state', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['- [ ] todo', '- [x] done'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k6',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              checked: false,
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'todo',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+            {
+              _key: 'k3',
+              _type: 'list-item',
+              checked: true,
+              content: [
+                {
+                  _key: 'k4',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k5',
+                      _type: 'span',
+                      marks: [],
+                      text: 'done',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'task',
+        },
+      ])
+    })
+
+    test('list item with code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          [
+            '- one',
+            '',
+            '    ```ts',
+            '    const x = 1',
+            '    ```',
+            '',
+            '- two',
+          ].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k7',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+                {
+                  _key: 'k3',
+                  _type: 'code',
+                  code: 'const x = 1',
+                  language: 'ts',
+                },
+              ],
+            },
+            {
+              _key: 'k4',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k5',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k6',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'bullet',
+        },
+      ])
+    })
+
+    test('nested bullet list', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['- one', '  - nested', '- two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k10',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+                {
+                  _key: 'k6',
+                  _type: 'list',
+                  items: [
+                    {
+                      _key: 'k3',
+                      _type: 'list-item',
+                      content: [
+                        {
+                          _key: 'k4',
+                          _type: 'block',
+                          children: [
+                            {
+                              _key: 'k5',
+                              _type: 'span',
+                              marks: [],
+                              text: 'nested',
+                            },
+                          ],
+                          markDefs: [],
+                          style: 'normal',
+                        },
+                      ],
+                    },
+                  ],
+                  kind: 'bullet',
+                },
+              ],
+            },
+            {
+              _key: 'k7',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k8',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k9',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'bullet',
+        },
+      ])
+    })
+
+    test('mixed nested kinds (bullet outside, ordered inside)', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['- one', '  1. nested', '- two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k10',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+                {
+                  _key: 'k6',
+                  _type: 'list',
+                  items: [
+                    {
+                      _key: 'k3',
+                      _type: 'list-item',
+                      content: [
+                        {
+                          _key: 'k4',
+                          _type: 'block',
+                          children: [
+                            {
+                              _key: 'k5',
+                              _type: 'span',
+                              marks: [],
+                              text: 'nested',
+                            },
+                          ],
+                          markDefs: [],
+                          style: 'normal',
+                        },
+                      ],
+                    },
+                  ],
+                  kind: 'number',
+                },
+              ],
+            },
+            {
+              _key: 'k7',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k8',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k9',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'bullet',
+        },
+      ])
+    })
+
+    test('matcher returning undefined falls back to flat list parsing', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(['- one', '- two'].join('\n'), {
+          keyGenerator,
+          schema: schemaWithList,
+          types: {
+            list: () => undefined,
+          },
+        }),
+      ).toEqual([
+        {
+          _key: 'k1',
+          _type: 'block',
+          children: [
+            {
+              _key: 'k2',
+              _type: 'span',
+              marks: [],
+              text: 'one',
+            },
+          ],
+          level: 1,
+          listItem: 'bullet',
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: 'k4',
+          _type: 'block',
+          children: [
+            {
+              _key: 'k5',
+              _type: 'span',
+              marks: [],
+              text: 'two',
+            },
+          ],
+          level: 1,
+          listItem: 'bullet',
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    test('without `types.list`, lists fall back to flat blocks', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(['- one', '- two'].join('\n'), {keyGenerator}),
+      ).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [
+            {
+              _key: 'k1',
+              _type: 'span',
+              marks: [],
+              text: 'one',
+            },
+          ],
+          level: 1,
+          listItem: 'bullet',
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: 'k2',
+          _type: 'block',
+          children: [
+            {
+              _key: 'k3',
+              _type: 'span',
+              marks: [],
+              text: 'two',
+            },
+          ],
+          level: 1,
+          listItem: 'bullet',
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    test('list inside a callout', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['> [!NOTE]', '> - one', '> - two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k7',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'k6',
+              _type: 'list',
+              items: [
+                {
+                  _key: 'k0',
+                  _type: 'list-item',
+                  content: [
+                    {
+                      _key: 'k1',
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: 'k2',
+                          _type: 'span',
+                          marks: [],
+                          text: 'one',
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'blockquote',
+                    },
+                  ],
+                },
+                {
+                  _key: 'k3',
+                  _type: 'list-item',
+                  content: [
+                    {
+                      _key: 'k4',
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: 'k5',
+                          _type: 'span',
+                          marks: [],
+                          text: 'two',
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'blockquote',
+                    },
+                  ],
+                },
+              ],
+              kind: 'bullet',
+            },
+          ],
+          tone: 'note',
+        },
+      ])
+    })
+
+    test('list inside a table cell', () => {
+      // GFM pipe tables only allow inline content in cells, so `- one`
+      // inside a cell stays as plain text.
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['| Header |', '|--------|', '| - one  |', '| - two  |'].join('\n'),
+          {
+            keyGenerator,
+            schema: schemaWithListAndTable,
+            types: {
+              table: buildObjectMatcher(tableObjectDefinition),
+              list: buildObjectMatcher(listObjectDefinition),
+            },
+          },
+        ),
+      ).toEqual([
+        {
+          _key: 'k12',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k3',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'k2',
+                  _type: 'cell',
+                  value: [
+                    {
+                      _key: 'k0',
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: 'k1',
+                          _type: 'span',
+                          marks: [],
+                          text: 'Header',
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k7',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'k6',
+                  _type: 'cell',
+                  value: [
+                    {
+                      _key: 'k4',
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: 'k5',
+                          _type: 'span',
+                          marks: [],
+                          text: '- one',
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k11',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'k10',
+                  _type: 'cell',
+                  value: [
+                    {
+                      _key: 'k8',
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: 'k9',
+                          _type: 'span',
+                          marks: [],
+                          text: '- two',
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('blockquote-styled block inside a list item', () => {
+      // The GFM alert plugin does not recognize `[!NOTE]` inside a list
+      // item, but regular blockquotes ARE recognized and land in the
+      // item's content with `style: 'blockquote'`.
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['- one', '', '  > a quote', '', '- two'].join('\n'),
+          getListTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k8',
+          _type: 'list',
+          items: [
+            {
+              _key: 'k0',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k1',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k2',
+                      _type: 'span',
+                      marks: [],
+                      text: 'one',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+                {
+                  _key: 'k3',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k4',
+                      _type: 'span',
+                      marks: [],
+                      text: 'a quote',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'blockquote',
+                },
+              ],
+            },
+            {
+              _key: 'k5',
+              _type: 'list-item',
+              content: [
+                {
+                  _key: 'k6',
+                  _type: 'block',
+                  children: [
+                    {
+                      _key: 'k7',
+                      _type: 'span',
+                      marks: [],
+                      text: 'two',
+                    },
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+          kind: 'bullet',
+        },
+      ])
+    })
+  })
 })

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1,16 +1,22 @@
-import {compileSchema, defineSchema} from '@portabletext/schema'
+import {
+  compileSchema,
+  defineSchema,
+  type BlockObjectDefinition,
+} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {
   isPortableTextBlock,
   isPortableTextListItemBlock,
 } from '@portabletext/toolkit'
 import {describe, expect, test} from 'vitest'
+import {defaultSchema} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
 import {DefaultListItemRenderer} from './from-portable-text/renderers/list-item'
 import {
   DefaultCalloutRenderer,
   DefaultCodeBlockRenderer,
   DefaultImageRenderer,
+  DefaultListRenderer,
   DefaultTableRenderer,
 } from './from-portable-text/renderers/type'
 import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
@@ -721,6 +727,113 @@ describe(portableTextToMarkdown.name, () => {
       ].join('\n')
       const portableText = markdownToPortableText(markdown, {keyGenerator})
       expect(portableTextToMarkdown(portableText)).toBe(markdown)
+    })
+  })
+
+  describe('list as container (`types.list`)', () => {
+    const listItemDefinition = {
+      name: 'list-item',
+      fields: [
+        {name: 'checked', type: 'boolean'},
+        {name: 'content', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const listObjectDefinition = {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {name: 'items', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithList = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          listObjectDefinition,
+          listItemDefinition,
+        ],
+      }),
+    )
+
+    const inOpts = (keyGenerator: () => string) => ({
+      keyGenerator,
+      schema: schemaWithList,
+      types: {
+        list: buildObjectMatcher(listObjectDefinition),
+      },
+    })
+
+    const outOpts = {
+      types: {
+        list: DefaultListRenderer,
+      },
+    }
+
+    test('simple bullet list', () => {
+      const markdown = ['- one', '- two'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('ordered list', () => {
+      const markdown = ['1. first', '2. second', '3. third'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('task list with checked state', () => {
+      const markdown = ['- [x] done', '- [ ] todo'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('nested bullet list', () => {
+      const markdown = ['- one', '  - nested', '- two'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('list item with code block', () => {
+      const markdown = [
+        '- hello',
+        '',
+        '  ```js',
+        "  console.log('hi')",
+        '  ```',
+        '- world',
+      ].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(
+        portableTextToMarkdown(portableText, {
+          types: {
+            list: DefaultListRenderer,
+            code: DefaultCodeBlockRenderer,
+          },
+        }),
+      ).toBe(markdown)
     })
   })
 

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -90,6 +90,15 @@ type Options = {
     }>
     image?: ObjectMatcher<{src: string; alt: string; title: string | undefined}>
     callout?: ObjectMatcher<{tone: string; content: Array<PortableTextBlock>}>
+    list?: ObjectMatcher<{
+      kind: 'bullet' | 'number' | 'task'
+      items: Array<{
+        _type: 'list-item'
+        _key: string
+        checked?: boolean
+        content: Array<PortableTextBlock | PortableTextObject>
+      }>
+    }>
   }
   html?: {
     /**
@@ -307,6 +316,8 @@ export function markdownToPortableText(
 
   // Callout state
   let calloutStartIndex: number | null = null
+  let calloutStartTarget: Array<PortableTextBlock | PortableTextObject> | null =
+    null
   let calloutType: string | null = null
 
   // Table state
@@ -328,6 +339,54 @@ export function markdownToPortableText(
     value: Array<PortableTextBlock>
   }> | null = null
   let inTableHead = false
+
+  // List container state. When `types.list` is defined and the parser enters
+  // a `bullet_list_open` / `ordered_list_open`, a structural-list frame is
+  // pushed here. Block emissions inside the surrounding `list_item_open` /
+  // `list_item_close` pair are diverted into the item's `content` array
+  // instead of the top-level `portableText`. At list-close, the matcher is
+  // called to materialize a `list` block-object, which is pushed into the
+  // enclosing target (parent list item's content if nested, else top-level).
+  type ListContainerItem = {
+    _type: 'list-item'
+    _key: string
+    checked?: boolean
+    content: Array<PortableTextBlock | PortableTextObject>
+  }
+  type ListContainerFrame = {
+    kind: 'bullet' | 'number' | 'task'
+    items: Array<ListContainerItem>
+    currentItem: ListContainerItem | null
+  }
+  // A null entry marks a list that is being handled by the flat path (either
+  // because `types.list` is undefined, or because a nested list inside a
+  // flat-path list should also stay flat). Parallel to `currentListStack`.
+  const listContainerStack: Array<ListContainerFrame | null> = []
+
+  /**
+   * Returns the array that block emissions should land in. If the innermost
+   * structural list frame has an open `currentItem`, blocks land in that
+   * item's `content`. Otherwise blocks land at the top level.
+   */
+  const blockTarget = (): Array<PortableTextBlock | PortableTextObject> => {
+    for (let i = listContainerStack.length - 1; i >= 0; i--) {
+      const frame = listContainerStack[i]
+      if (frame && frame.currentItem) {
+        return frame.currentItem.content
+      }
+    }
+    return portableText
+  }
+
+  /**
+   * Pushes a block into the current target (innermost open list item, or
+   * top-level `portableText` if none). Use instead of direct
+   * `portableText.push(...)` for any block emission that should be captured
+   * by an enclosing list container.
+   */
+  const pushBlock = (block: PortableTextBlock | PortableTextObject): void => {
+    blockTarget().push(block as PortableTextBlock)
+  }
 
   const startBlock = (style: string) => {
     flushBlock()
@@ -359,7 +418,7 @@ export function markdownToPortableText(
     // Assign accumulated markDefs to the block
     currentBlock.markDefs = currentMarkDefs
 
-    portableText.push(currentBlock)
+    pushBlock(currentBlock)
 
     currentBlock = null
     currentMarkDefs = []
@@ -458,6 +517,24 @@ export function markdownToPortableText(
         // If we're in a list item but have no current block (e.g., after a code block),
         // we need to create a new list item block
         if (inListItem) {
+          // Structural list path: start a plain text block; the paragraph
+          // lands in the current list item's `content` via `pushBlock`.
+          if (listContainerStack.at(-1)) {
+            if (!currentBlock) {
+              // Use blockquote style if inside a blockquote, otherwise use normal style
+              const style =
+                currentBlockquoteStyle ??
+                consolidatedOptions.block.normal({
+                  context: {schema: consolidatedOptions.schema},
+                }) ??
+                'normal'
+              startBlock(style)
+            }
+            break
+          }
+
+          // Flat list path: ensure the current text block carries
+          // `listItem` + `level` fields.
           if (!currentBlock) {
             const listType = currentListStack.at(-1)
 
@@ -486,8 +563,13 @@ export function markdownToPortableText(
         break
       }
       case 'paragraph_close':
-        // Skip flushing if we're inside a list item (list_item_close will flush)
+        // In a flat list item: skip flushing, list_item_close will flush.
+        // In a structural list item: flush so multiple paragraphs in one
+        // item land as separate text blocks.
         if (inListItem) {
+          if (listContainerStack.at(-1)) {
+            flushBlock()
+          }
           break
         }
         flushBlock()
@@ -556,48 +638,166 @@ export function markdownToPortableText(
       }
       // Lists
       case 'bullet_list_open': {
+        flushBlock()
+
+        // Structural-container path: when the consumer registers a
+        // `types.list` matcher, lists become block-objects with explicit
+        // `items` arrays. Block emissions inside list items are diverted
+        // into `currentItem.content` via `blockTarget()`. Mirrors the
+        // `types.table` pattern.
+        if (consolidatedOptions.types.list) {
+          listContainerStack.push({
+            kind: 'bullet',
+            items: [],
+            currentItem: null,
+          })
+          currentListStack.push(null)
+          break
+        }
+
+        // Flat path: lists are reconstructed from text blocks with
+        // `listItem` + `level` fields at render time.
         const listItem = consolidatedOptions.listItem.bullet({
           context: {schema: consolidatedOptions.schema},
         })
 
+        listContainerStack.push(null)
         if (!listItem) {
-          // No list definition in schema, push null to indicate we should skip list properties
           currentListStack.push(null)
           break
         }
-
         currentListStack.push(listItem)
         break
       }
       case 'ordered_list_open': {
-        const listItem = consolidatedOptions.listItem.number({
-          context: {schema: consolidatedOptions.schema},
-        })
+        flushBlock()
 
-        if (!listItem) {
-          // No list definition in schema, push null to indicate we should skip list properties
+        if (consolidatedOptions.types.list) {
+          listContainerStack.push({
+            kind: 'number',
+            items: [],
+            currentItem: null,
+          })
           currentListStack.push(null)
           break
         }
 
+        const listItem = consolidatedOptions.listItem.number({
+          context: {schema: consolidatedOptions.schema},
+        })
+
+        listContainerStack.push(null)
+        if (!listItem) {
+          currentListStack.push(null)
+          break
+        }
         currentListStack.push(listItem)
         break
       }
       case 'bullet_list_close':
-      case 'ordered_list_close':
+      case 'ordered_list_close': {
+        const frame = listContainerStack.pop()
         currentListStack.pop()
-        break
-      case 'list_item_open': {
-        const baseListType = currentListStack.at(-1)
 
-        if (baseListType === undefined) {
-          throw new Error('Expected an open list')
+        // Structural close: materialize the list block-object and push it
+        // into the enclosing target (parent list item's content if nested,
+        // else top-level).
+        if (frame && consolidatedOptions.types.list) {
+          // Promote `kind` to 'task' if any item carries a checked state.
+          const kind: 'bullet' | 'number' | 'task' = frame.items.some(
+            (item) => 'checked' in item,
+          )
+            ? 'task'
+            : frame.kind
+
+          const listObject = consolidatedOptions.types.list({
+            context: {
+              schema: consolidatedOptions.schema,
+              keyGenerator: consolidatedOptions.keyGenerator,
+            },
+            value: {kind, items: frame.items},
+            isInline: false,
+          })
+
+          if (listObject) {
+            pushBlock(listObject)
+          } else {
+            // Matcher returned undefined: fall back to the flat path by
+            // re-emitting each item's content. Text blocks get the same
+            // `listItem` + `level` fields the flat path would produce so
+            // adjacent blocks form a list at render time. Non-text-block
+            // content (code blocks, etc.) gets pushed as-is, mirroring
+            // how the flat path handles those when they appear inside a
+            // list item.
+            const flatListItem =
+              (kind === 'task'
+                ? consolidatedOptions.listItem.task?.({
+                    context: {schema: consolidatedOptions.schema},
+                  })
+                : kind === 'number'
+                  ? consolidatedOptions.listItem.number({
+                      context: {schema: consolidatedOptions.schema},
+                    })
+                  : consolidatedOptions.listItem.bullet({
+                      context: {schema: consolidatedOptions.schema},
+                    })) ?? null
+            // The just-popped list was nested at depth = remaining stack
+            // length + 1 (since we already popped).
+            const level = listContainerStack.length + 1
+            for (const item of frame.items) {
+              for (const block of item.content) {
+                if (
+                  block._type === 'block' &&
+                  flatListItem !== null &&
+                  !('listItem' in block)
+                ) {
+                  const flatBlock = {
+                    ...(block as PortableTextTextBlock),
+                    listItem: flatListItem,
+                    level,
+                    ...(item.checked === undefined
+                      ? {}
+                      : {checked: item.checked}),
+                  }
+                  pushBlock(flatBlock)
+                } else {
+                  pushBlock(block)
+                }
+              }
+            }
+          }
         }
+        break
+      }
+      case 'list_item_open': {
+        const frame = listContainerStack.at(-1)
 
         // Flush any previous list item block before starting a new one
         // This is needed for proper separation of list items
         if (currentBlock) {
           flushBlock()
+        }
+
+        // Structural path: start a new `list-item` whose `content` becomes
+        // the divert target for subsequent block emissions until
+        // `list_item_close`.
+        if (frame) {
+          const taskChecked = taskCheckedByListItemIndex.get(tokenIndex)
+          frame.currentItem = {
+            _type: 'list-item',
+            _key: consolidatedOptions.keyGenerator(),
+            ...(taskChecked === undefined ? {} : {checked: taskChecked}),
+            content: [],
+          }
+          inListItem = true
+          break
+        }
+
+        // Flat path
+        const baseListType = currentListStack.at(-1)
+
+        if (baseListType === undefined) {
+          throw new Error('Expected an open list')
         }
 
         // Resolve task list type and checked state for this specific item.
@@ -642,10 +842,24 @@ export function markdownToPortableText(
         inListItem = true
         break
       }
-      case 'list_item_close':
+      case 'list_item_close': {
+        const frame = listContainerStack.at(-1)
+
+        // Structural path: flush any current block into the item's content,
+        // then push the completed item onto the frame.
+        if (frame && frame.currentItem) {
+          flushBlock()
+          frame.items.push(frame.currentItem)
+          frame.currentItem = null
+          inListItem = false
+          break
+        }
+
+        // Flat path
         inListItem = false
         flushBlock()
         break
+      }
 
       // Code fences / blocks
       case 'fence': {
@@ -682,7 +896,7 @@ export function markdownToPortableText(
           break
         }
 
-        portableText.push(codeObject)
+        pushBlock(codeObject)
 
         break
       }
@@ -718,7 +932,7 @@ export function markdownToPortableText(
           break
         }
 
-        portableText.push(hrObject)
+        pushBlock(hrObject)
 
         break
       }
@@ -760,7 +974,7 @@ export function markdownToPortableText(
           break
         }
 
-        portableText.push(htmlObject)
+        pushBlock(htmlObject)
 
         break
       }
@@ -796,7 +1010,7 @@ export function markdownToPortableText(
           addSpan(code)
           flushBlock()
         } else {
-          portableText.push(codeObject)
+          pushBlock(codeObject)
         }
 
         break
@@ -831,14 +1045,17 @@ export function markdownToPortableText(
           })
 
           if (tableObject) {
-            portableText.push(tableObject)
+            pushBlock(tableObject)
           } else {
             // If table object couldn't be created, flatten the table
-            flattenTable(currentTable, portableText)
+            flattenTable(
+              currentTable,
+              blockTarget() as Array<PortableTextBlock>,
+            )
           }
         } else {
           // If there's no table definition in the schema, flatten the table
-          flattenTable(currentTable, portableText)
+          flattenTable(currentTable, blockTarget() as Array<PortableTextBlock>)
         }
 
         currentTable = null
@@ -898,14 +1115,15 @@ export function markdownToPortableText(
         flushBlock()
 
         // Get all blocks that were added since this cell started
-        // We need to extract them from portableText array
+        // We need to extract them from the current target array
         const cellBlocks: Array<PortableTextBlock> = []
+        const target = blockTarget()
 
         // Check if we have blocks to extract (added after table_open)
-        if (portableText.length > 0) {
-          const lastBlock = portableText.at(-1)
+        if (target.length > 0) {
+          const lastBlock = target.at(-1)
           if (lastBlock && lastBlock._type === 'block') {
-            cellBlocks.push(portableText.pop()!)
+            cellBlocks.push(target.pop()! as PortableTextBlock)
           }
         }
 
@@ -1020,7 +1238,7 @@ export function markdownToPortableText(
                 currentBlock = null
                 currentMarkDefs = []
               }
-              portableText.push(blockImageObject)
+              pushBlock(blockImageObject)
             }
             break
           }
@@ -1039,10 +1257,20 @@ export function markdownToPortableText(
             // Ensure we have a block to add the inline image to
             if (!currentBlock) {
               if (inListItem) {
-                const listType = currentListStack.at(-1)
+                // Structural list: start a plain text block; the image
+                // lands in the current item's content via flushBlock.
+                if (listContainerStack.at(-1)) {
+                  const style =
+                    consolidatedOptions.block.normal({
+                      context: {schema: consolidatedOptions.schema},
+                    }) ?? 'normal'
+                  startBlock(style)
+                } else {
+                  const listType = currentListStack.at(-1)
 
-                if (listType) {
-                  ensureListBlock(listType)
+                  if (listType) {
+                    ensureListBlock(listType)
+                  }
                 }
               } else {
                 const style = consolidatedOptions.block.normal({
@@ -1309,7 +1537,7 @@ export function markdownToPortableText(
 
               // Not in table - flush current block, add image as block, start new block
               flushBlock()
-              portableText.push(blockImageObject)
+              pushBlock(blockImageObject)
 
               // Start a new block for any remaining content
               const style = consolidatedOptions.block.normal({
@@ -1341,7 +1569,8 @@ export function markdownToPortableText(
       // Callouts (GFM alerts)
       case 'alert_open': {
         flushBlock()
-        calloutStartIndex = portableText.length
+        calloutStartTarget = blockTarget()
+        calloutStartIndex = calloutStartTarget.length
         calloutType = token.markup
 
         // Set blockquote style so content blocks inside the callout
@@ -1367,8 +1596,14 @@ export function markdownToPortableText(
       case 'alert_close': {
         flushBlock()
 
-        if (calloutStartIndex !== null && calloutType !== null) {
-          const contentBlocks = portableText.splice(calloutStartIndex)
+        if (
+          calloutStartIndex !== null &&
+          calloutType !== null &&
+          calloutStartTarget !== null
+        ) {
+          const contentBlocks = calloutStartTarget.splice(
+            calloutStartIndex,
+          ) as Array<PortableTextBlock>
 
           const calloutObject = consolidatedOptions.types.callout?.({
             context: {
@@ -1380,13 +1615,16 @@ export function markdownToPortableText(
           })
 
           if (calloutObject) {
-            portableText.push(calloutObject)
+            pushBlock(calloutObject)
           } else {
-            portableText.push(...contentBlocks)
+            for (const block of contentBlocks) {
+              pushBlock(block)
+            }
           }
         }
 
         calloutStartIndex = null
+        calloutStartTarget = null
         calloutType = null
         currentBlockquoteStyle = null
         break


### PR DESCRIPTION
`markdownToPortableText` has always emitted flat lists: every list item becomes a regular text block with `listItem` and `level` fields, and adjacent blocks form a list at render time. That's fine for plain bullets, but it can't represent a list item that holds anything other than a single text block. No code blocks inside an item, no callouts, no nested arbitrary content.

This adds a `types.list?` matcher to the options, mirroring the existing `types.table` pattern. When the matcher is registered, the parser switches to a structural path that emits a `list` block-object whose items hold their own content arrays:

```ts
markdownToPortableText(md, {
  schema: schemaWithList,
  types: {
    list: buildObjectMatcher(listObjectDefinition),
  },
})
```

Output for `- one\n- two`:

```ts
[
  {
    _type: 'list',
    _key: 'k6',
    kind: 'bullet',
    items: [
      {
        _type: 'list-item',
        _key: 'k0',
        content: [
          {
            _type: 'block',
            _key: 'k1',
            style: 'normal',
            children: [{_type: 'span', _key: 'k2', text: 'one', marks: []}],
            markDefs: [],
          },
        ],
      },
      {
        _type: 'list-item',
        _key: 'k3',
        content: [
          {
            _type: 'block',
            _key: 'k4',
            style: 'normal',
            children: [{_type: 'span', _key: 'k5', text: 'two', marks: []}],
            markDefs: [],
          },
        ],
      },
    ],
  },
]
```

`kind` is `'bullet' | 'number' | 'task'` and gets promoted to `'task'` automatically when any item carries a GFM checkbox. Items only carry a `checked` field when the markdown actually has one; non-task items omit it entirely. Each item's `content` accepts whatever the consumer's schema allows there: nested lists fall out for free, code blocks inside an item land in its `content`, callouts and images too.

### Nesting

The matcher works at any level: a list inside a callout becomes part of the callout's `content`, a callout (or any block) inside a list item becomes part of the item's `content`. Block emissions inside list items are diverted into the active item's content, and existing collectors (callouts, tables) capture from the same target so the round-trip stays intact regardless of nesting depth.

The one place where the matcher doesn't fire is inside table cells: GFM pipe tables only allow inline content in cells at the markdown-it parser level, so a `- one` inside a cell is plain text, not a list. That's a markdown-it constraint, not a parser-side decision.

GFM alert syntax (`> [!NOTE]`) likewise doesn't fire when nested inside a list item; the markdown-it alert plugin only matches the syntax at the document root. Regular blockquotes nested in list items are preserved correctly with `style: 'blockquote'`.

Default behavior is unchanged. Consumers who don't register `types.list` still get flat blocks with `listItem` and `level` fields exactly as before. The 231 existing tests pass without modification.

If the matcher returns `undefined`, the parser falls back by lifting items' content blocks to the enclosing target, same shape as the table fallback.

The from-PT side already supports the structural shape via the generic `types.X` slot, so no library change is needed there.

## Open design questions

Three things to settle before flipping out of draft:

- **`kind` field name.** I used `kind: 'bullet' | 'number' | 'task'` for symmetry with `tone` on callouts. The flat model uses `listItem` as the field name on the block; reusing `listItem` on the structural list reads oddly ("the list's listItem is bullet"). `kind` is shorter and reads better; open to alternatives.
- **Tight vs loose lists.** Currently every paragraph in an item gets wrapped in a block. CommonMark distinguishes tight lists (inline children directly inside the item) from loose lists (paragraph blocks). Preserving the distinction in the structural shape would round-trip more faithfully but adds complexity. Defaulting to "always wrap in a block" is consistent with how the editor renders.
- **Self-referential schema.** `{type: 'list'}` inside a `list-item.content.of` array works in `compileSchema` and the nested-list test passes. Worth confirming this is a documented capability vs a happy accident before we lean on it in docs.
