### PR TITLE
feat: add types.blockquote matcher to markdownToPortableText for structured blockquotes

### DIFF
--- a/.changeset/markdown-types-blockquote-matcher.md
+++ b/.changeset/markdown-types-blockquote-matcher.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: add `types.blockquote` matcher to `markdownToPortableText` for structured blockquotes
+
+When a `types.blockquote` matcher is provided, plain blockquotes become structural block-objects (`{_type: 'blockquote', content: [...]}`) instead of flat text blocks with `style: 'blockquote'`. This unlocks placing code blocks, images, lists, and nested blockquotes inside a quote without losing attribution. GFM alerts (`> [!NOTE]`, `> [!TIP]`, etc.) keep producing callouts via the separate `types.callout` matcher; the two never compete on the same source.
+
+Without `types.blockquote`, the existing flat-block path runs unchanged. If the matcher returns `undefined` for a given blockquote, the parser falls back to the flat shape for that one.
+
+Adds `DefaultBlockquoteObjectRenderer` for the round-trip back to Markdown.

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -218,6 +218,7 @@ Matchers map Markdown concepts to Portable Text types defined in the Schema. Eac
 |            | `image`          | `![alt](src)`           | `'image'`           |
 |            | `html`           | HTML blocks             | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.       | `'callout'`         |
+|            | `blockquote`     | `>` blockquotes         | `'blockquote'`      |
 |            | `list`           | `- ` or `1. ` lists     | `'list'`            |
 
 #### Configuring matchers
@@ -316,6 +317,27 @@ markdownToPortableText(markdown, {
 ```
 
 When emitting Portable Text back to Markdown, blocks with `listItem: 'task'` render as `- [x] ` or `- [ ] ` based on the `checked` field.
+
+**Blockquote matcher:** By default, blockquotes are emitted as flat text blocks with `style: 'blockquote'`, and adjacent blocks form a visual blockquote at render time. If your schema models a blockquote as a structural block-object instead (a `blockquote` type with a `content` array), provide a `types.blockquote` matcher to opt into that shape:
+
+```ts
+markdownToPortableText(markdown, {
+  schema: schemaWithBlockquote,
+  types: {
+    blockquote: ({context, value}) => ({
+      _type: 'blockquote',
+      _key: context.keyGenerator(),
+      content: value.content, // array of blocks the markdown produced inside the blockquote
+    }),
+  },
+})
+```
+
+The matcher receives `value.content` already assembled. The array holds whatever blocks the markdown produced inside the blockquote: text blocks, code blocks, images, even nested blockquotes. GFM alerts (`> [!NOTE]`, `> [!TIP]`, etc.) use a different token stream and produce callouts instead, so `types.blockquote` and `types.callout` can be registered side-by-side without conflict.
+
+If the matcher returns `undefined`, the parser falls back to flat-style by re-emitting the content blocks with `style: 'blockquote'`.
+
+Without `types.blockquote`, the existing flat-block path runs unchanged.
 
 Matchers receive:
 
@@ -482,6 +504,7 @@ portableTextToMarkdown(blocks, {
 
 ```ts
 import {
+  DefaultBlockquoteObjectRenderer,
   DefaultCalloutRenderer,
   DefaultCodeBlockRenderer,
   DefaultHorizontalRuleRenderer,
@@ -494,6 +517,7 @@ import {
 
 portableTextToMarkdown(blocks, {
   types: {
+    'blockquote': DefaultBlockquoteObjectRenderer,
     'callout': DefaultCalloutRenderer,
     'code': DefaultCodeBlockRenderer,
     'horizontal-rule': DefaultHorizontalRuleRenderer,
@@ -505,15 +529,16 @@ portableTextToMarkdown(blocks, {
 })
 ```
 
-| Renderer                        | Expected value                                         | Output                 |
-| ------------------------------- | ------------------------------------------------------ | ---------------------- |
-| `DefaultCalloutRenderer`        | `{tone: string, content: PortableTextBlock[]}`         | `> [!TYPE]\n> content` |
-| `DefaultCodeBlockRenderer`      | `{code: string, language?: string}`                    | ` ```lang\ncode\n``` ` |
-| `DefaultHorizontalRuleRenderer` | (no fields required)                                   | `---`                  |
-| `DefaultHtmlRenderer`           | `{html: string}`                                       | Raw HTML               |
-| `DefaultImageRenderer`          | `{src: string, alt?: string, title?: string}`          | `![alt](src "title")`  |
-| `DefaultListRenderer`           | `{kind: 'bullet' \| 'number' \| 'task', items: [...]}` | Markdown list          |
-| `DefaultTableRenderer`          | `{rows: [...], headerRows?: number}`                   | Markdown table         |
+| Renderer                          | Expected value                                         | Output                 |
+| --------------------------------- | ------------------------------------------------------ | ---------------------- |
+| `DefaultBlockquoteObjectRenderer` | `{content: PortableTextBlock[]}`                       | `> content`            |
+| `DefaultCalloutRenderer`          | `{tone: string, content: PortableTextBlock[]}`         | `> [!TYPE]\n> content` |
+| `DefaultCodeBlockRenderer`        | `{code: string, language?: string}`                    | ` ```lang\ncode\n``` ` |
+| `DefaultHorizontalRuleRenderer`   | (no fields required)                                   | `---`                  |
+| `DefaultHtmlRenderer`             | `{html: string}`                                       | Raw HTML               |
+| `DefaultImageRenderer`            | `{src: string, alt?: string, title?: string}`          | `![alt](src "title")`  |
+| `DefaultListRenderer`             | `{kind: 'bullet' \| 'number' \| 'task', items: [...]}` | Markdown list          |
+| `DefaultTableRenderer`            | `{rows: [...], headerRows?: number}`                   | Markdown table         |
 
 #### What renderers receive
 

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -161,9 +161,30 @@ export const DefaultListRenderer: PortableTextTypeRenderer<{
     content: Array<PortableTextBlock | TypedObject>
   }>
 }> = ({value, renderNode}) => {
-  const indent = '  '
+  // A list is "loose" when any item carries multiple non-list-block
+  // content entries (a continuation paragraph, a code block, etc).
+  // CommonMark uses blank lines between items in loose lists; tight lists
+  // pack items together with single newlines. A nested list as a second
+  // child of an item does NOT make the list loose, so we ignore those when
+  // counting.
+  const isLoose = value.items.some((item) => {
+    const nonNestedBlocks = item.content.filter(
+      (block) => (block as TypedObject)._type !== 'list',
+    )
+    return nonNestedBlocks.length > 1
+  })
+  const itemSeparator = isLoose ? '\n\n' : '\n'
+
   const lines = value.items.map((item, itemIndex) => {
     const marker = getListMarker(value.kind, itemIndex, item.checked)
+    // Continuation indent matches the marker's width so that subsequent
+    // blocks attach to this item under CommonMark's lazy-continuation rule.
+    // Bullet `- ` indents to 2; ordered `1. ` indents to 3, `10. ` to 4.
+    // Task `- [x] ` is conceptually `- ` + a `[x] ` content prefix at the
+    // markdown-it level, so its continuation indent stays at 2.
+    const indentWidth = value.kind === 'task' ? 2 : marker.length
+    const indent = ' '.repeat(indentWidth)
+
     const renderedBlocks = item.content.map((block, blockIndex) => ({
       isNestedList: (block as TypedObject)._type === 'list',
       text: renderNode({
@@ -175,7 +196,8 @@ export const DefaultListRenderer: PortableTextTypeRenderer<{
     }))
 
     const [first, ...rest] = renderedBlocks
-    const head = `${marker}${first?.text ?? ''}`
+    // Trim trailing whitespace from empty items so `- ` becomes `-`.
+    const head = `${marker}${first?.text ?? ''}`.trimEnd()
     if (rest.length === 0) {
       return head
     }
@@ -195,7 +217,7 @@ export const DefaultListRenderer: PortableTextTypeRenderer<{
     return `${head}${tail}`
   })
 
-  return lines.join('\n')
+  return lines.join(itemSeparator)
 }
 
 function getListMarker(

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -142,6 +142,39 @@ export const DefaultCalloutRenderer: PortableTextTypeRenderer<{
 }
 
 /**
+ * Renders a structural blockquote block-object (the `types.blockquote` shape
+ * produced by `markdownToPortableText` when a `types.blockquote` matcher is
+ * provided) back to Markdown. Each content block is rendered via the
+ * recursive renderer pipeline, joined with blank lines, and every line is
+ * prefixed with `> ` to form a Markdown blockquote.
+ *
+ * Distinct from `DefaultBlockquoteRenderer`, which renders flat-path text
+ * blocks with `style: 'blockquote'`.
+ *
+ * @public
+ */
+export const DefaultBlockquoteObjectRenderer: PortableTextTypeRenderer<{
+  _type: 'blockquote'
+  content: Array<PortableTextBlock>
+}> = ({value, renderNode}) => {
+  const renderedContent = value.content
+    .map((block, index) =>
+      renderNode({
+        node: {...block, style: 'normal'},
+        index,
+        isInline: false,
+        renderNode,
+      }),
+    )
+    .join('\n\n')
+
+  return renderedContent
+    .split('\n')
+    .map((line) => (line === '' ? '>' : `> ${line}`))
+    .join('\n')
+}
+
+/**
  * Renders a structural list block-object (the `types.list` shape produced by
  * `markdownToPortableText` when a `types.list` matcher is provided) back to
  * Markdown. Items render as `- ` for `kind: 'bullet'`, `1. `/`2. ` for `'number'`,

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -24,6 +24,7 @@ export {
   DefaultUnderlineRenderer,
 } from './from-portable-text/renderers/marks'
 export {
+  DefaultBlockquoteObjectRenderer,
   DefaultCalloutRenderer,
   DefaultCodeBlockRenderer,
   DefaultHorizontalRuleRenderer,

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -5646,4 +5646,308 @@ describe(markdownToPortableText.name, () => {
       ])
     })
   })
+
+  describe('blockquote as container (`types.blockquote`)', () => {
+    const blockquoteObjectDefinition = {
+      name: 'blockquote',
+      fields: [{name: 'content', type: 'array'}],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithBlockquote = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          blockquoteObjectDefinition,
+        ],
+      }),
+    )
+
+    const getBlockquoteTestOptions = (keyGenerator: () => string) => ({
+      keyGenerator,
+      schema: schemaWithBlockquote,
+      types: {
+        blockquote: buildObjectMatcher(blockquoteObjectDefinition),
+      },
+    })
+
+    test('simple blockquote', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText('> one', getBlockquoteTestOptions(keyGenerator)),
+      ).toEqual([
+        {
+          _key: 'k2',
+          _type: 'blockquote',
+          content: [
+            {
+              _type: 'block',
+              style: 'normal',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'one',
+                  marks: [],
+                },
+              ],
+              _key: 'k0',
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('multi-paragraph blockquote', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['> one', '>', '> two'].join('\n'),
+          getBlockquoteTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k4',
+          _type: 'blockquote',
+          content: [
+            {
+              _type: 'block',
+              style: 'normal',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'one',
+                  marks: [],
+                },
+              ],
+              _key: 'k0',
+              markDefs: [],
+            },
+            {
+              _type: 'block',
+              style: 'normal',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k3',
+                  text: 'two',
+                  marks: [],
+                },
+              ],
+              _key: 'k2',
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('nested blockquote', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['> outer', '>', '> > inner'].join('\n'),
+          getBlockquoteTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k5',
+          _type: 'blockquote',
+          content: [
+            {
+              _type: 'block',
+              style: 'normal',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'outer',
+                  marks: [],
+                },
+              ],
+              _key: 'k0',
+              markDefs: [],
+            },
+            {
+              _key: 'k4',
+              _type: 'blockquote',
+              content: [
+                {
+                  _type: 'block',
+                  style: 'normal',
+                  children: [
+                    {
+                      _type: 'span',
+                      _key: 'k3',
+                      text: 'inner',
+                      marks: [],
+                    },
+                  ],
+                  _key: 'k2',
+                  markDefs: [],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('blockquote with code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['> intro', '>', '> ```js', "> console.log('hi')", '> ```'].join(
+            '\n',
+          ),
+          getBlockquoteTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k3',
+          _type: 'blockquote',
+          content: [
+            {
+              _type: 'block',
+              style: 'normal',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'intro',
+                  marks: [],
+                },
+              ],
+              _key: 'k0',
+              markDefs: [],
+            },
+            {
+              _key: 'k2',
+              _type: 'code',
+              language: 'js',
+              code: "console.log('hi')",
+            },
+          ],
+        },
+      ])
+    })
+
+    test('GFM alert is still a callout, not a blockquote', () => {
+      // When both `types.callout` and `types.blockquote` are registered, GFM
+      // alerts (`> [!NOTE]`) hit the alert_open/close tokens and produce
+      // callouts; only plain blockquotes hit blockquote_open/close.
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['> [!NOTE]', '> heads up'].join('\n'),
+          getBlockquoteTestOptions(keyGenerator),
+        ),
+      ).toEqual([
+        {
+          _key: 'k2',
+          _type: 'callout',
+          tone: 'note',
+          content: [
+            {
+              _type: 'block',
+              style: 'blockquote',
+              children: [
+                {
+                  _type: 'span',
+                  _key: 'k1',
+                  text: 'heads up',
+                  marks: [],
+                },
+              ],
+              _key: 'k0',
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('matcher returning undefined falls back to flat blockquote-styled blocks', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(['> one', '>', '> two'].join('\n'), {
+          keyGenerator,
+          schema: schemaWithBlockquote,
+          types: {
+            blockquote: () => undefined,
+          },
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          style: 'blockquote',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: 'one',
+              marks: [],
+            },
+          ],
+          _key: 'k0',
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          style: 'blockquote',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k3',
+              text: 'two',
+              marks: [],
+            },
+          ],
+          _key: 'k2',
+          markDefs: [],
+        },
+      ])
+    })
+
+    test("without `types.blockquote`, blockquotes fall back to flat `style: 'blockquote'` blocks", () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(['> one', '>', '> two'].join('\n'), {
+          keyGenerator,
+          schema: schemaWithBlockquote,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          style: 'blockquote',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: 'one',
+              marks: [],
+            },
+          ],
+          _key: 'k0',
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          style: 'blockquote',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k3',
+              text: 'two',
+              marks: [],
+            },
+          ],
+          _key: 'k2',
+          markDefs: [],
+        },
+      ])
+    })
+  })
 })

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -813,12 +813,16 @@ describe(portableTextToMarkdown.name, () => {
     })
 
     test('list item with code block', () => {
+      // A list item with multi-block content (text + code block) is "loose"
+      // and needs blank lines between items in the canonical output. The
+      // input also has the blank line so the round-trip is byte-identical.
       const markdown = [
         '- hello',
         '',
         '  ```js',
         "  console.log('hi')",
         '  ```',
+        '',
         '- world',
       ].join('\n')
       const keyGenerator = createTestKeyGenerator()
@@ -834,6 +838,68 @@ describe(portableTextToMarkdown.name, () => {
           },
         }),
       ).toBe(markdown)
+    })
+
+    test('multi-paragraph item', () => {
+      const markdown = ['- one', '', '  para two', '', '- three'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('mixed nested types', () => {
+      // The continuation indent under `1. ` is 3 columns, not 2. Without
+      // matching the marker width the bullet child gets parsed as a
+      // sibling list rather than a nested one.
+      const markdown = ['1. ordered', '   - nested bullet', '2. second'].join(
+        '\n',
+      )
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('two-digit ordered marker uses 4-column continuation indent', () => {
+      // Items 10 onwards have a 4-character marker (`10. `), so the
+      // continuation indent grows accordingly. A second paragraph attached
+      // to item 10 must indent 4 columns to bind to the same item.
+      const markdown = [
+        '1. item 1',
+        '',
+        '2. item 2',
+        '',
+        '3. item 3',
+        '',
+        '4. item 4',
+        '',
+        '5. item 5',
+        '',
+        '6. item 6',
+        '',
+        '7. item 7',
+        '',
+        '8. item 8',
+        '',
+        '9. item 9',
+        '',
+        '10. item 10',
+        '',
+        '    second paragraph under item 10',
+        '',
+        '11. item 11',
+      ].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
     })
   })
 

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -13,6 +13,7 @@ import {defaultSchema} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
 import {DefaultListItemRenderer} from './from-portable-text/renderers/list-item'
 import {
+  DefaultBlockquoteObjectRenderer,
   DefaultCalloutRenderer,
   DefaultCodeBlockRenderer,
   DefaultImageRenderer,
@@ -900,6 +901,90 @@ describe(portableTextToMarkdown.name, () => {
         inOpts(keyGenerator),
       )
       expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+  })
+
+  describe('blockquote as container (`types.blockquote`)', () => {
+    const blockquoteObjectDefinition = {
+      name: 'blockquote',
+      fields: [{name: 'content', type: 'array'}],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithBlockquote = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          blockquoteObjectDefinition,
+        ],
+      }),
+    )
+
+    const inOpts = (keyGenerator: () => string) => ({
+      keyGenerator,
+      schema: schemaWithBlockquote,
+      types: {
+        blockquote: buildObjectMatcher(blockquoteObjectDefinition),
+      },
+    })
+
+    const outOpts = {
+      types: {
+        blockquote: DefaultBlockquoteObjectRenderer,
+      },
+    }
+
+    test('simple blockquote', () => {
+      const markdown = '> one'
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('multi-paragraph blockquote', () => {
+      const markdown = ['> one', '>', '> two'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('nested blockquote', () => {
+      const markdown = ['> outer', '>', '> > inner'].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
+    })
+
+    test('blockquote with code block', () => {
+      const markdown = [
+        '> intro',
+        '>',
+        '> ```js',
+        "> console.log('hi')",
+        '> ```',
+      ].join('\n')
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = markdownToPortableText(
+        markdown,
+        inOpts(keyGenerator),
+      )
+      expect(
+        portableTextToMarkdown(portableText, {
+          types: {
+            blockquote: DefaultBlockquoteObjectRenderer,
+            code: DefaultCodeBlockRenderer,
+          },
+        }),
+      ).toBe(markdown)
     })
   })
 

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -90,6 +90,7 @@ type Options = {
     }>
     image?: ObjectMatcher<{src: string; alt: string; title: string | undefined}>
     callout?: ObjectMatcher<{tone: string; content: Array<PortableTextBlock>}>
+    blockquote?: ObjectMatcher<{content: Array<PortableTextBlock>}>
     list?: ObjectMatcher<{
       kind: 'bullet' | 'number' | 'task'
       items: Array<{
@@ -319,6 +320,17 @@ export function markdownToPortableText(
   let calloutStartTarget: Array<PortableTextBlock | PortableTextObject> | null =
     null
   let calloutType: string | null = null
+
+  // Blockquote container state. When `types.blockquote` is defined and the
+  // parser enters a `blockquote_open`, a frame is pushed here. Block
+  // emissions inside the surrounding open/close pair are captured and
+  // spliced out at close to wrap them in a `blockquote` block-object.
+  // Nested blockquotes push additional frames; `blockTarget()` already
+  // routes correctly because the splice happens against the same target.
+  const blockquoteStack: Array<{
+    startTarget: Array<PortableTextBlock | PortableTextObject>
+    startIndex: number
+  }> = []
 
   // Table state
   let currentTable: {
@@ -618,7 +630,23 @@ export function markdownToPortableText(
         // Flush any current block before entering blockquote
         flushBlock()
 
-        // Set the blockquote style for paragraphs inside the blockquote
+        // Structural-blockquote path: when the consumer registers a
+        // `types.blockquote` matcher, plain blockquotes (NOT GFM alerts -
+        // those use separate `alert_open`/`alert_close` tokens) become
+        // block-objects with an explicit `content` array. Block emissions
+        // inside the open/close pair are spliced out at close time and
+        // wrapped in a `blockquote` block-object.
+        if (consolidatedOptions.types.blockquote) {
+          const startTarget = blockTarget()
+          blockquoteStack.push({
+            startTarget,
+            startIndex: startTarget.length,
+          })
+          break
+        }
+
+        // Flat path: set the blockquote style for paragraphs inside the
+        // blockquote so they emit text blocks with `style: 'blockquote'`.
         const style =
           consolidatedOptions.block.blockquote({
             context: {schema: consolidatedOptions.schema},
@@ -633,6 +661,58 @@ export function markdownToPortableText(
       case 'blockquote_close': {
         // Flush any blockquote content before exiting
         flushBlock()
+
+        // Structural path: pop the topmost frame and splice its captured
+        // content into a `blockquote` block-object via the matcher. If the
+        // matcher returns undefined, fall back to flat-style by re-emitting
+        // the content blocks with `style: 'blockquote'`.
+        if (
+          consolidatedOptions.types.blockquote &&
+          blockquoteStack.length > 0
+        ) {
+          const frame = blockquoteStack.pop()
+          if (frame) {
+            const contentBlocks = frame.startTarget.splice(
+              frame.startIndex,
+            ) as Array<PortableTextBlock>
+
+            const blockquoteObject = consolidatedOptions.types.blockquote({
+              context: {
+                schema: consolidatedOptions.schema,
+                keyGenerator: consolidatedOptions.keyGenerator,
+              },
+              value: {content: contentBlocks},
+              isInline: false,
+            })
+
+            if (blockquoteObject) {
+              pushBlock(blockquoteObject)
+            } else {
+              // Matcher returned undefined: fall back to flat-style by
+              // re-emitting each content block with `style: 'blockquote'`.
+              const blockquoteStyle =
+                consolidatedOptions.block.blockquote({
+                  context: {schema: consolidatedOptions.schema},
+                }) ??
+                consolidatedOptions.block.normal({
+                  context: {schema: consolidatedOptions.schema},
+                }) ??
+                'blockquote'
+              for (const block of contentBlocks) {
+                if (block._type === 'block') {
+                  pushBlock({
+                    ...(block as PortableTextTextBlock),
+                    style: blockquoteStyle,
+                  })
+                } else {
+                  pushBlock(block)
+                }
+              }
+            }
+          }
+          break
+        }
+
         currentBlockquoteStyle = null
         break
       }


### PR DESCRIPTION
Plain blockquotes parse to flat text blocks with `style: 'blockquote'` today, and adjacent blocks reconstruct as a visual blockquote at render time. That shape can't represent a blockquote whose content is more than text: a code block escapes the blockquote and loses attribution, lists and blockquotes merge awkwardly at render, multi-paragraph quotes lose their grouping.

This PR adds `types.blockquote` as an opt-in structural shape, mirroring the `types.list` and `types.callout` patterns. When a `types.blockquote` matcher is registered, plain blockquotes become block-objects:

```ts
markdownToPortableText('> one', {
  schema: schemaWithBlockquote,
  types: {
    blockquote: ({context, value}) => ({
      _type: 'blockquote',
      _key: context.keyGenerator(),
      content: value.content,
    }),
  },
})
// → [{_type: 'blockquote', content: [{_type: 'block', style: 'normal', children: [...]}]}]
```

Without `types.blockquote`, the flat path runs unchanged. If the matcher returns `undefined` for a given quote, the parser falls back to the flat shape just for that one.

GFM alerts (`> [!NOTE]`, `> [!TIP]`, etc.) and plain blockquotes use separate token streams in markdown-it (`alert_open`/`alert_close` vs `blockquote_open`/`blockquote_close`), so `types.blockquote` and `types.callout` never compete on the same source.

Nested blockquotes (`> outer\n> > inner`), code blocks inside blockquotes, and structural lists inside blockquotes (when `types.list` is also registered) all ride the existing `pushBlock` divert mechanism that the structural-list and callout paths use, so they fall out for free.

`DefaultBlockquoteObjectRenderer` ships for the round-trip back to Markdown. The name is suffixed to disambiguate from the existing `DefaultBlockquoteRenderer`, which is a block-style renderer for flat-path text blocks with `style: 'blockquote'`.

## Also: list renderer round-trip fixes

While auditing the just-shipped `types.list` work I found three correctness issues in `DefaultListRenderer` that this PR fixes in a separate `fix:` commit:

- **Continuation indent now matches marker width.** Bullet `- ` items keep their 2-column indent. Ordered `1. ` items now use 3 columns, `10. ` and beyond use 4. The previous hardcoded 2-column indent caused nested bullets under an ordered list to be parsed back as a sibling list rather than a child.
- **Loose lists emit blank lines between items.** When any item carries multi-block content (a continuation paragraph, a code block, etc.), all items in the list are separated by blank lines so CommonMark parses each item's blocks correctly. Tight lists (single-block items, optionally with nested lists) keep their compact single-newline separators.
- **Empty items render as `-` instead of `- `.**

The existing `list item with code block` round-trip test was asserting the broken (tight) output; it now expects the loose-form output that's needed for the round-trip to actually work. Three new round-trip tests pin the multi-paragraph, mixed-nested-types, and two-digit-marker scenarios.