### PR TITLE
fix: resolve registered containers at any nesting depth

### DIFF
--- a/.changeset/recursive-container-lookup.md
+++ b/.changeset/recursive-container-lookup.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve registered containers at any nesting depth
+
+Self-referential schemas (lists inside list-items inside lists, callouts inside lists, etc.) now render as containers at every depth in the data, not just the depths the resolver pre-emits during schema walk. Container lookup falls back to scope-pattern matching when the runtime type chain is deeper than the schema walk could enumerate.

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -7,6 +7,8 @@ import {useSelector} from '@xstate/react'
 import {useContext, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import {isInline} from '../node-traversal/is-inline'
+import type {ContainerConfig} from '../renderers/renderer.types'
+import {lookupContainer} from '../schema/lookup-container'
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
@@ -48,8 +50,14 @@ export function RenderElement(props: {
     ? `${containerScope}.${props.element._type}`
     : props.element._type
 
-  const containerConfig = useSelector(editorActor, (state) =>
-    state.context.containers.get(scopedTypeName),
+  const containerConfig = useSelector(
+    editorActor,
+    (state) =>
+      // Internal cast: the public `Container` view is narrowed; runtime
+      // values are the full `ContainerConfig` carrying parsedScope/render.
+      lookupContainer(state.context.containers, scopedTypeName) as
+        | ContainerConfig
+        | undefined,
   )
 
   const leafConfig = useLeafConfig(props.element, props.path)

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -7,6 +7,7 @@ import {getSpanNode} from '../node-traversal/get-span-node'
 import {getTextBlockNode} from '../node-traversal/get-text-block-node'
 import {getContainerScopedName} from '../schema/get-container-scoped-name'
 import {getEnclosingContainer} from '../schema/get-enclosing-container'
+import {lookupContainer} from '../schema/lookup-container'
 import {pointRef} from '../slate/editor/point-ref'
 import type {Path} from '../slate/interfaces/path'
 import type {Point} from '../slate/interfaces/point'
@@ -528,7 +529,7 @@ function clearContainerContents(
   }
 
   const scopedName = getContainerScopedName(editor, node, containerPath)
-  const container = editor.containers.get(scopedName)
+  const container = lookupContainer(editor.containers, scopedName)
   if (!container) {
     return
   }

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -3,6 +3,7 @@ import {getAncestor} from '../node-traversal/get-ancestor'
 import {getNode} from '../node-traversal/get-node'
 import {getContainerScopedName} from '../schema/get-container-scoped-name'
 import {isEditableContainer} from '../schema/is-editable-container'
+import {lookupContainer} from '../schema/lookup-container'
 import {end as editorEnd} from '../slate/editor/end'
 import {start as editorStart} from '../slate/editor/start'
 import type {Node} from '../slate/interfaces/node'
@@ -113,7 +114,7 @@ function fieldAcceptsTextBlock(
   path: Path,
 ): boolean {
   const scopedName = getContainerScopedName(editor, node, path)
-  const container = editor.containers.get(scopedName)
+  const container = lookupContainer(editor.containers, scopedName)
   if (!container) {
     return false
   }

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -1,6 +1,7 @@
 import type {OfDefinition} from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import {lookupContainer} from '../schema/lookup-container'
 import type {Containers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
@@ -89,7 +90,7 @@ export function getNodeChildren(
   if (isObjectNode(context, node)) {
     const scopedKey = scopePath ? `${scopePath}.${node._type}` : node._type
 
-    const arrayField = context.containers.get(scopedKey)?.field
+    const arrayField = lookupContainer(context.containers, scopedKey)?.field
 
     if (!arrayField) {
       return undefined

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -12,6 +12,7 @@ import {getSibling} from '../node-traversal/get-sibling'
 import {getSpanNode} from '../node-traversal/get-span-node'
 import {getTextBlockNode} from '../node-traversal/get-text-block-node'
 import {getContainerScopedName} from '../schema/get-container-scoped-name'
+import {lookupContainer} from '../schema/lookup-container'
 import {end as editorEnd} from '../slate/editor/end'
 import {pathRef} from '../slate/editor/path-ref'
 import {rangeRef} from '../slate/editor/range-ref'
@@ -193,7 +194,8 @@ function resolveTarget(args: {
     // when a behavior raises a `delete` followed by an `insert.block`:
     // the raises run as one batch and normalization hasn't yet inserted
     // a placeholder when the second one starts.
-    const containerField = editor.containers.get(
+    const containerField = lookupContainer(
+      editor.containers,
       getContainerScopedName(editor, endBlock, endBlockPath),
     )?.field
     const fieldValue =

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -1,5 +1,6 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import {lookupContainer} from '../schema/lookup-container'
 import type {ResolvedContainers} from '../schema/resolve-containers'
 import type {Node} from '../slate/interfaces/node'
 import type {Operation} from '../slate/interfaces/operation'
@@ -40,7 +41,7 @@ function collectDescendantPaths(
   // For container types, resolve the child array field from the schema
   const scopedName = scopePrefix ? `${scopePrefix}.${node._type}` : node._type
 
-  const arrayField = context.containers.get(scopedName)?.field
+  const arrayField = lookupContainer(context.containers, scopedName)?.field
 
   if (arrayField) {
     const fieldValue = (node as Record<string, unknown>)[arrayField.name]

--- a/packages/editor/src/schema/get-enclosing-container.ts
+++ b/packages/editor/src/schema/get-enclosing-container.ts
@@ -4,6 +4,7 @@ import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Path} from '../slate/interfaces/path'
 import {isObjectNode} from '../slate/node/is-object-node'
 import {getContainerScopedName} from './get-container-scoped-name'
+import {lookupContainer} from './lookup-container'
 
 /**
  * Walk ancestors from `path` and return the nearest registered editable
@@ -28,7 +29,7 @@ export function getEnclosingContainer(
       ancestor.node,
       ancestor.path,
     )
-    const container = snapshot.context.containers.get(scopedName)
+    const container = lookupContainer(snapshot.context.containers, scopedName)
 
     if (!container) {
       continue

--- a/packages/editor/src/schema/is-editable-container.ts
+++ b/packages/editor/src/schema/is-editable-container.ts
@@ -2,6 +2,7 @@ import type {TraversalSnapshot} from '../node-traversal/traversal-snapshot'
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {getContainerScopedName} from './get-container-scoped-name'
+import {lookupContainer} from './lookup-container'
 
 /**
  * Check if a node at the given path is a registered editable container.
@@ -16,5 +17,5 @@ export function isEditableContainer(
   }
 
   const scopedName = getContainerScopedName(snapshot, node, path)
-  return snapshot.context.containers.has(scopedName)
+  return lookupContainer(snapshot.context.containers, scopedName) !== undefined
 }

--- a/packages/editor/src/schema/lookup-container.ts
+++ b/packages/editor/src/schema/lookup-container.ts
@@ -1,0 +1,51 @@
+import {compareSpecificity} from '../scope/compare-specificity'
+import {matchScope} from '../scope/match-scope'
+import type {ParsedScope} from '../scope/parse-scope'
+import type {Container, Containers} from './resolve-containers'
+
+/**
+ * Look up the registered container for a node by its scoped type name.
+ *
+ * Tries an exact match first, which covers all candidates the resolver
+ * pre-emitted from the schema walk. If no exact match exists (e.g. the
+ * data nests deeper than the resolver's bounded cycle traversal), falls
+ * back to scope-pattern matching: iterates registered configs by
+ * specificity and returns the first whose `parsedScope` matches the
+ * runtime type chain.
+ */
+export function lookupContainer(
+  containers: Containers,
+  scopedName: string,
+): Container | undefined {
+  const exact = containers.get(scopedName)
+  if (exact) {
+    return exact
+  }
+
+  const typePath = scopedName.split('.')
+  // Internal cast: the map's value is `ContainerConfig` at runtime,
+  // narrowed to `Container` for public consumption. `parsedScope` is
+  // present when the value was created by `resolveContainers` (the
+  // production path); it may be missing on hand-built test fixtures.
+  const candidates = Array.from(
+    new Set(
+      Array.from(containers.values()) as unknown as ReadonlyArray<
+        Container & {parsedScope?: ParsedScope}
+      >,
+    ),
+  ).filter(
+    (config): config is Container & {parsedScope: ParsedScope} =>
+      config.parsedScope !== undefined,
+  )
+  candidates.sort(
+    (left, right) => -compareSpecificity(left.parsedScope, right.parsedScope),
+  )
+
+  for (const config of candidates) {
+    if (matchScope(config.parsedScope, typePath)) {
+      return config
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -498,14 +498,15 @@ describe(resolveContainers.name, () => {
       ]),
     )
 
-    // The walk reaches `list` (top), `list.list-item` (inline), and stops
-    // at the cycle when `list-item.content` references `list` again.
-    // Only registrations are kept in the resolved map; with the two
-    // configs above we expect both to resolve. The walk terminating
-    // means no infinite candidates were emitted.
+    // The walk reaches `list` (top), `list.list-item` (inline), and emits
+    // a cycle candidate at `list.list-item.list` (where
+    // `list-item.content` references `list` again). The walk terminates -
+    // no infinite candidates - and `$..list` matches both the root list
+    // and the cycle position via terminal-anchored matching.
     expect(Array.from(resolved.keys()).sort()).toEqual([
       'list',
       'list.list-item',
+      'list.list-item.list',
     ])
   })
 
@@ -982,6 +983,7 @@ describe(resolveContainers.name, () => {
       'callout.list.list-item.list',
       'list',
       'list.list-item',
+      'list.list-item.list',
     ])
   })
 })

--- a/packages/editor/src/scope/match-scope.test.ts
+++ b/packages/editor/src/scope/match-scope.test.ts
@@ -224,6 +224,62 @@ describe(matchScope.name, () => {
     })
   })
 
+  describe('self-referential nesting', () => {
+    test('$..list matches list at any depth in a list/list-item cycle', () => {
+      expect(matchScope(parse('$..list'), ['list'])).toBe(true)
+      expect(matchScope(parse('$..list'), ['list', 'list-item', 'list'])).toBe(
+        true,
+      )
+      expect(
+        matchScope(parse('$..list'), [
+          'list',
+          'list-item',
+          'list',
+          'list-item',
+          'list',
+        ]),
+      ).toBe(true)
+    })
+
+    test('$..list-item matches list-item at any depth in a list/list-item cycle', () => {
+      expect(matchScope(parse('$..list-item'), ['list', 'list-item'])).toBe(
+        true,
+      )
+      expect(
+        matchScope(parse('$..list-item'), [
+          'list',
+          'list-item',
+          'list',
+          'list-item',
+        ]),
+      ).toBe(true)
+      expect(
+        matchScope(parse('$..list-item'), [
+          'list',
+          'list-item',
+          'list',
+          'list-item',
+          'list',
+          'list-item',
+        ]),
+      ).toBe(true)
+    })
+
+    test('$..list.list-item matches at any depth', () => {
+      expect(
+        matchScope(parse('$..list.list-item'), ['list', 'list-item']),
+      ).toBe(true)
+      expect(
+        matchScope(parse('$..list.list-item'), [
+          'list',
+          'list-item',
+          'list',
+          'list-item',
+        ]),
+      ).toBe(true)
+    })
+  })
+
   describe('worked examples from spec', () => {
     test('spec example: span in callout-block, various scopes', () => {
       const typePath = ['callout', 'block', 'span']
@@ -256,6 +312,171 @@ describe(matchScope.name, () => {
       expect(matchScope(parse('$.image'), typePath)).toBe(true)
       expect(matchScope(parse('$..image'), typePath)).toBe(true)
       expect(matchScope(parse('$..gallery.image'), typePath)).toBe(false)
+    })
+  })
+
+  describe('type-name comparison is whole-string', () => {
+    test('does not match on substring prefix', () => {
+      expect(matchScope(parse('$.foo'), ['foobar'])).toBe(false)
+      expect(matchScope(parse('$..foo'), ['foobar'])).toBe(false)
+      expect(matchScope(parse('$..foo'), ['callout', 'foobar'])).toBe(false)
+    })
+
+    test('does not match on substring suffix', () => {
+      expect(matchScope(parse('$.item'), ['list-item'])).toBe(false)
+      expect(matchScope(parse('$..item'), ['list-item'])).toBe(false)
+    })
+
+    test('hyphenated type-names match exactly', () => {
+      expect(matchScope(parse('$.list-item'), ['list-item'])).toBe(true)
+      expect(matchScope(parse('$.list-item'), ['list'])).toBe(false)
+    })
+  })
+
+  describe('repeated types in path', () => {
+    test('$.a.a matches consecutive same-type chain', () => {
+      expect(matchScope(parse('$.block.block'), ['block', 'block'])).toBe(true)
+    })
+
+    test('$..a matches when type repeats and is terminal', () => {
+      expect(matchScope(parse('$..a'), ['a', 'a'])).toBe(true)
+      expect(matchScope(parse('$..a'), ['a', 'a', 'a'])).toBe(true)
+    })
+
+    test('$..a does not match when terminal differs even if type appears earlier', () => {
+      expect(matchScope(parse('$..a'), ['a', 'b'])).toBe(false)
+      expect(matchScope(parse('$..a'), ['a', 'a', 'b'])).toBe(false)
+    })
+
+    test('$.a does not match when terminal is `a` but path is deeper than 1', () => {
+      expect(matchScope(parse('$.a'), ['a', 'a'])).toBe(false)
+    })
+  })
+
+  describe('backtracking with ambiguous matches', () => {
+    test('$..foo.bar succeeds when terminal foo+bar pair is later in chain', () => {
+      // First `foo` at idx 0 cannot align: typePath[1]=baz ≠ bar.
+      // Backtrack to second `foo` at idx 2: typePath[3]=bar ✓, terminal.
+      expect(
+        matchScope(parse('$..foo.bar'), ['foo', 'baz', 'foo', 'bar']),
+      ).toBe(true)
+    })
+
+    test('$..foo.bar fails when terminal is not bar even with extra foo', () => {
+      expect(
+        matchScope(parse('$..foo.bar'), ['foo', 'bar', 'foo', 'baz']),
+      ).toBe(false)
+    })
+
+    test('$..a.b backtracks across multiple a-occurrences to align terminal b', () => {
+      expect(matchScope(parse('$..a.b'), ['a', 'a', 'a', 'b'])).toBe(true)
+    })
+
+    test('$..a..b backtracks when intermediate any-descent has multiple match positions', () => {
+      // `any a` could pick idx 0; then `any b` must align terminal.
+      expect(matchScope(parse('$..a..b'), ['a', 'x', 'a', 'y', 'b'])).toBe(true)
+    })
+  })
+
+  describe('repeated any-descent of the same type', () => {
+    test('$..a..a requires two a-occurrences with terminal alignment', () => {
+      expect(matchScope(parse('$..a..a'), ['a', 'a'])).toBe(true)
+      expect(matchScope(parse('$..a..a'), ['a', 'b', 'a'])).toBe(true)
+      expect(matchScope(parse('$..a..a'), ['a'])).toBe(false)
+      expect(matchScope(parse('$..a..a'), ['a', 'b'])).toBe(false)
+    })
+  })
+
+  describe('root-anchored chains', () => {
+    test('$.a.b.c.d.e fails when path is one segment short', () => {
+      expect(matchScope(parse('$.a.b.c.d.e'), ['a', 'b', 'c', 'd'])).toBe(false)
+    })
+
+    test('$.a.b.c.d.e fails when path is one segment longer', () => {
+      expect(
+        matchScope(parse('$.a.b.c.d.e'), ['a', 'b', 'c', 'd', 'e', 'f']),
+      ).toBe(false)
+    })
+
+    test('$.a.b.c.d.e matches exact length and content', () => {
+      expect(matchScope(parse('$.a.b.c.d.e'), ['a', 'b', 'c', 'd', 'e'])).toBe(
+        true,
+      )
+    })
+
+    test('$.a..b allows extra segments between root a and terminal b', () => {
+      expect(matchScope(parse('$.a..b'), ['a', 'b'])).toBe(true)
+      expect(matchScope(parse('$.a..b'), ['a', 'x', 'y', 'b'])).toBe(true)
+      expect(matchScope(parse('$.a..b'), ['x', 'a', 'b'])).toBe(false)
+    })
+  })
+
+  describe('terminal-alignment failures', () => {
+    test('$..a fails when a is in the middle but never terminal', () => {
+      expect(matchScope(parse('$..a'), ['x', 'a', 'y'])).toBe(false)
+    })
+
+    test('$..a.b fails when a appears but is never followed by terminal b', () => {
+      expect(matchScope(parse('$..a.b'), ['a', 'c'])).toBe(false)
+      expect(matchScope(parse('$..a.b'), ['a', 'c', 'a', 'd'])).toBe(false)
+    })
+
+    test('$..a..b fails when a appears but b is never terminal after a', () => {
+      expect(matchScope(parse('$..a..b'), ['a', 'b', 'c'])).toBe(false)
+    })
+  })
+
+  describe('mixed root and descendant in long chains', () => {
+    test('$.callout..block fails when callout is not at root', () => {
+      expect(
+        matchScope(parse('$.callout..block'), [
+          'table',
+          'callout',
+          'cell',
+          'block',
+        ]),
+      ).toBe(false)
+    })
+
+    test('$.callout..block matches with intermediate any-depth', () => {
+      expect(
+        matchScope(parse('$.callout..block'), [
+          'callout',
+          'list',
+          'list-item',
+          'block',
+        ]),
+      ).toBe(true)
+    })
+
+    test('$.callout..block.span matches terminal exact pair after any descent', () => {
+      expect(
+        matchScope(parse('$.callout..block.span'), [
+          'callout',
+          'list',
+          'list-item',
+          'block',
+          'span',
+        ]),
+      ).toBe(true)
+    })
+
+    test('$.callout..block.span fails when terminal pair adjacency is broken', () => {
+      expect(
+        matchScope(parse('$.callout..block.span'), [
+          'callout',
+          'block',
+          'list',
+          'span',
+        ]),
+      ).toBe(false)
+    })
+  })
+
+  describe('case sensitivity', () => {
+    test('type-name match is case-sensitive', () => {
+      expect(matchScope(parse('$.Block'), ['block'])).toBe(false)
+      expect(matchScope(parse('$.block'), ['Block'])).toBe(false)
     })
   })
 })

--- a/packages/editor/src/scope/match-scope.ts
+++ b/packages/editor/src/scope/match-scope.ts
@@ -4,20 +4,19 @@ import type {ParsedScope} from './parse-scope'
  * Checks whether a parsed scope matches a type-path from the root of the
  * editor down to the node being rendered.
  *
- * The match is terminal: the scope's last segment must align with the last
- * element of `typePath`. This is the semantics used by `defineContainer` and
- * `defineLeaf`.
+ * The match is terminal-anchored: the scope's last segment must align with
+ * the last element of `typePath`. Earlier segments are matched in order:
  *
- * The algorithm walks the scope's segments left-to-right over `typePath`:
- *
- * - An `exact` segment must sit at the current cursor position in the path.
- * - An `any` segment can skip over zero or more path positions to find a match.
- * - After processing all segments, the cursor must have consumed the entire
- *   path (so the last segment aligns with the last path element).
+ * - `exact` segments must sit at the current cursor position.
+ * - `any` segments can skip zero or more positions before matching.
  *
  * The scope's anchor (`$.` vs `$..`) is encoded in the first segment's
- * descent: `$.` produces an `exact` first segment (must start at position 0),
- * `$..` produces an `any` first segment (may start anywhere).
+ * descent: `$.` produces an `exact` first segment (must start at position
+ * 0), `$..` produces an `any` first segment (may start anywhere).
+ *
+ * Implemented as a backtracking match so an `any` segment can pick the
+ * LAST viable position that still allows the remaining segments to align
+ * with the terminal of `typePath`.
  *
  * @internal
  */
@@ -28,32 +27,39 @@ export function matchScope(
   if (scope.segments.length === 0) {
     return false
   }
+  if (typePath.length === 0) {
+    return false
+  }
+  return tryMatch(scope.segments, 0, typePath, 0)
+}
 
-  let pathIdx = 0
-
-  for (const segment of scope.segments) {
-    if (segment.descent === 'exact') {
-      if (pathIdx >= typePath.length || typePath[pathIdx] !== segment.type) {
-        return false
-      }
-      pathIdx++
-      continue
-    }
-
-    let found = -1
-    for (let i = pathIdx; i < typePath.length; i++) {
-      if (typePath[i] === segment.type) {
-        found = i
-        break
-      }
-    }
-
-    if (found === -1) {
+function tryMatch(
+  segments: ParsedScope['segments'],
+  segIdx: number,
+  typePath: ReadonlyArray<string>,
+  pathIdx: number,
+): boolean {
+  if (segIdx === segments.length) {
+    // Terminal-anchored: must have consumed the entire path.
+    return pathIdx === typePath.length
+  }
+  const segment = segments[segIdx]
+  if (!segment) {
+    return false
+  }
+  if (segment.descent === 'exact') {
+    if (pathIdx >= typePath.length || typePath[pathIdx] !== segment.type) {
       return false
     }
-
-    pathIdx = found + 1
+    return tryMatch(segments, segIdx + 1, typePath, pathIdx + 1)
   }
-
-  return pathIdx === typePath.length
+  // `any`: try each viable starting position from `pathIdx` to the end.
+  for (let i = pathIdx; i < typePath.length; i++) {
+    if (typePath[i] === segment.type) {
+      if (tryMatch(segments, segIdx + 1, typePath, i + 1)) {
+        return true
+      }
+    }
+  }
+  return false
 }

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -15,6 +15,7 @@ import {getParent} from '../../node-traversal/get-parent'
 import {getTextBlockNode} from '../../node-traversal/get-text-block-node'
 import {getChildFieldName} from '../../paths/get-child-field-name'
 import {getContainerScopedName} from '../../schema/get-container-scoped-name'
+import {lookupContainer} from '../../schema/lookup-container'
 import {withoutPatching} from '../../slate-plugins/slate-plugin.without-patching'
 import {getPathSubSchema} from '../../traversal/get-path-sub-schema'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
@@ -417,7 +418,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // non-empty.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = editor.containers.get(scopedName)?.field
+    const arrayField = lookupContainer(editor.containers, scopedName)?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -9,6 +9,7 @@ import {
   ContainerScopeContext,
   useContainerScope,
 } from '../../../editor/container-scope-context'
+import {lookupContainer} from '../../../schema/lookup-container'
 import {
   isElementDecorationsEqual,
   splitDecorationsByChild,
@@ -76,7 +77,7 @@ const useChildren = (props: {
       ? `${containerScope}.${node._type}`
       : node._type
 
-    const containerConfig = editor.containers.get(scopedKey)
+    const containerConfig = lookupContainer(editor.containers, scopedKey)
 
     if (containerConfig) {
       const fieldValue = (node as Record<string, unknown>)[
@@ -181,7 +182,7 @@ const useChildren = (props: {
     }
     if (isObjectNode({schema: editor.schema}, n)) {
       const scopedName = childScope ? `${childScope}.${n._type}` : n._type
-      if (editor.containers.has(scopedName)) {
+      if (lookupContainer(editor.containers, scopedName)) {
         return renderElementComponent(n, i)
       }
       return renderObjectNodeComponent(n, i)

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -1204,3 +1204,96 @@ describe('cell with mixed content', () => {
     })
   })
 })
+
+describe('self-referential containers', () => {
+  const listSchema = defineSchema({
+    blockObjects: [
+      {
+        name: 'list',
+        fields: [
+          {
+            name: 'items',
+            type: 'array',
+            of: [
+              {
+                type: 'object',
+                name: 'list-item',
+                fields: [
+                  {
+                    name: 'content',
+                    type: 'array',
+                    of: [{type: 'block'}, {type: 'list'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  const listContainer = defineContainer<typeof listSchema>({
+    scope: '$..list',
+    field: 'items',
+    render: ({attributes, children}) => (
+      <ul data-testid="list" {...attributes}>
+        {children}
+      </ul>
+    ),
+  })
+
+  const listItemContainer = defineContainer<typeof listSchema>({
+    scope: '$..list.list-item',
+    field: 'content',
+    render: ({attributes, children}) => (
+      <li data-testid="list-item" {...attributes}>
+        {children}
+      </li>
+    ),
+  })
+
+  test('list nested 3 levels deep renders all levels as containers', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const k = () => keyGenerator()
+    const block = (text: string) => ({
+      _type: 'block' as const,
+      _key: k(),
+      children: [{_type: 'span', _key: k(), text, marks: []}],
+      markDefs: [],
+      style: 'normal',
+    })
+    const item = (content: any[]) => ({
+      _type: 'list-item',
+      _key: k(),
+      content,
+    })
+    const list = (items: any[]) => ({_type: 'list', _key: k(), items})
+
+    // Three levels: list > list-item > list > list-item > list > list-item
+    const value = [
+      list([
+        item([
+          block('outer'),
+          list([item([block('middle'), list([item([block('inner')])])])]),
+        ]),
+      ]),
+    ]
+
+    const {locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: listSchema,
+      initialValue: value,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(locator.getByTestId('list').elements()).toHaveLength(3)
+    })
+    await vi.waitFor(() => {
+      expect(locator.getByTestId('list-item').elements()).toHaveLength(3)
+    })
+  })
+})

--- a/packages/editor/tests/recursive-schema.test.tsx
+++ b/packages/editor/tests/recursive-schema.test.tsx
@@ -1,0 +1,649 @@
+import {applyAll, type Patch} from '@portabletext/patches'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {safeParse, safeStringify} from '../src/internal-utils/safe-json'
+import {EventListenerPlugin} from '../src/plugins'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Tests for self-referential / recursive schemas.
+ *
+ * The schema declares a `list` block-object whose items are `list-item`
+ * objects, and whose `list-item.content.of` references back to `list`.
+ * This reproduces the kind of nesting markdown deserializers (and other
+ * recursive sources) produce, where the runtime data is deeper than the
+ * resolver's bounded schema walk can pre-emit candidates for.
+ */
+
+const recursiveListSchema = defineSchema({
+  decorators: [{name: 'strong'}],
+  blockObjects: [
+    {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {
+          name: 'items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'list-item',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}, {type: 'list'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const listContainer = defineContainer<typeof recursiveListSchema>({
+  scope: '$..list',
+  field: 'items',
+  render: ({attributes, children}) => (
+    <ul data-testid="list" {...attributes}>
+      {children}
+    </ul>
+  ),
+})
+
+const listItemContainer = defineContainer<typeof recursiveListSchema>({
+  scope: '$..list.list-item',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <li data-testid="list-item" {...attributes}>
+      {children}
+    </li>
+  ),
+})
+
+/**
+ * Read a nested field from a PortableTextBlock, asserting it exists.
+ * Keeps the deep-walk test code readable without type casts at every hop.
+ */
+function field<T>(node: unknown, key: string): T {
+  const value = (node as Record<string, unknown>)[key]
+  if (value === undefined) {
+    throw new Error(`Expected field "${key}" to exist on node`)
+  }
+  return value as T
+}
+
+/**
+ * Walk `[outer-list].items[0].content[1]` repeatedly to step `depth`
+ * levels into a nested-list-of-list-items structure. Returns the
+ * deepest list-item.
+ */
+function deepestListItem(
+  outerList: PortableTextBlock,
+  depth: number,
+): PortableTextBlock {
+  let cursor: PortableTextBlock = outerList
+  for (let i = 0; i < depth; i++) {
+    const items = field<Array<PortableTextBlock>>(cursor, 'items')
+    const item = items[0]
+    if (!item) {
+      throw new Error(`No item at depth ${i + 1}`)
+    }
+    if (i === depth - 1) {
+      return item
+    }
+    const content = field<Array<PortableTextBlock>>(item, 'content')
+    const nestedList = content[1]
+    if (!nestedList) {
+      throw new Error(`No nested list at depth ${i + 1}`)
+    }
+    cursor = nestedList
+  }
+  throw new Error('unreachable')
+}
+
+/**
+ * Build a list nested `depth` levels deep, where each level contains a
+ * single list-item whose content holds a single text block (and, for
+ * non-leaf levels, a nested list).
+ *
+ * For depth=3 the shape is:
+ *   list[k1] -> items[k2] -> content[k3 text-block, k4 list[...]]
+ */
+function buildNestedList(
+  keyGenerator: () => string,
+  depth: number,
+): PortableTextBlock {
+  if (depth < 1) {
+    throw new Error('depth must be >= 1')
+  }
+
+  const wrap = (level: number): PortableTextBlock => {
+    const listKey = keyGenerator()
+    const itemKey = keyGenerator()
+    const textBlockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const content: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: textBlockKey,
+        children: [
+          {
+            _type: 'span',
+            _key: spanKey,
+            text: `level-${level}`,
+            marks: [],
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      } as PortableTextBlock,
+    ]
+
+    if (level < depth) {
+      content.push(wrap(level + 1))
+    }
+
+    return {
+      _type: 'list',
+      _key: listKey,
+      kind: 'bullet',
+      items: [
+        {
+          _type: 'list-item',
+          _key: itemKey,
+          content,
+        } as PortableTextBlock,
+      ],
+    } as PortableTextBlock
+  }
+
+  return wrap(1)
+}
+
+describe('recursive schemas (lists in list-items in lists)', () => {
+  test('Scenario: renders all three nesting levels as containers', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [buildNestedList(keyGenerator, 3)]
+
+    const {locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(locator.getByTestId('list').elements()).toHaveLength(3)
+      expect(locator.getByTestId('list-item').elements()).toHaveLength(3)
+    })
+  })
+
+  test('Scenario: incoming `set` patch on a deep span text applies correctly', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [buildNestedList(keyGenerator, 3)]
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    const outerList = editor.getSnapshot().context.value[0] as PortableTextBlock
+    const outerItem = field<Array<PortableTextBlock>>(outerList, 'items')[0]!
+    const middleList = field<Array<PortableTextBlock>>(outerItem, 'content')[1]!
+    const middleItem = field<Array<PortableTextBlock>>(middleList, 'items')[0]!
+    const innerList = field<Array<PortableTextBlock>>(middleItem, 'content')[1]!
+    const innerItem = field<Array<PortableTextBlock>>(innerList, 'items')[0]!
+    const innerTextBlock = field<Array<PortableTextBlock>>(
+      innerItem,
+      'content',
+    )[0]!
+    const innerSpan = field<Array<{_key: string; text: string}>>(
+      innerTextBlock,
+      'children',
+    )[0]!
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [
+            {_key: outerList._key!},
+            'items',
+            {_key: outerItem._key!},
+            'content',
+            {_key: middleList._key!},
+            'items',
+            {_key: middleItem._key!},
+            'content',
+            {_key: innerList._key!},
+            'items',
+            {_key: innerItem._key!},
+            'content',
+            {_key: innerTextBlock._key!},
+            'children',
+            {_key: innerSpan._key},
+            'text',
+          ],
+          value: 'remote-edit',
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      const updated = editor.getSnapshot().context.value[0] as PortableTextBlock
+      const i3 = deepestListItem(updated, 3)
+      const tb = field<Array<PortableTextBlock>>(i3, 'content')[0]!
+      const span = field<Array<{text: string}>>(tb, 'children')[0]!
+      expect(span.text).toBe('remote-edit')
+    })
+  })
+
+  test('Scenario: typing at a deep span emits patches that round-trip through applyAll', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [buildNestedList(keyGenerator, 3)]
+
+    const emittedPatches: Array<Patch> = []
+    let remoteValue = safeParse(
+      safeStringify(initialValue),
+    ) as Array<PortableTextBlock>
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <>
+          <ContainerPlugin containers={[listContainer, listItemContainer]} />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                const {origin: _, ...patch} = event.patch
+                remoteValue = applyAll(remoteValue, [patch])
+                emittedPatches.push(patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    const outer = editor.getSnapshot().context.value[0] as PortableTextBlock
+    const i3 = deepestListItem(outer, 3)
+    const innerTextBlock = field<Array<PortableTextBlock>>(i3, 'content')[0]!
+    const innerSpan = field<Array<{_key: string; text: string}>>(
+      innerTextBlock,
+      'children',
+    )[0]!
+
+    const outerItem = field<Array<PortableTextBlock>>(outer, 'items')[0]!
+    const middleList = field<Array<PortableTextBlock>>(outerItem, 'content')[1]!
+    const middleItem = field<Array<PortableTextBlock>>(middleList, 'items')[0]!
+    const innerList = field<Array<PortableTextBlock>>(middleItem, 'content')[1]!
+
+    const innerSpanPath = [
+      {_key: outer._key!},
+      'items',
+      {_key: outerItem._key!},
+      'content',
+      {_key: middleList._key!},
+      'items',
+      {_key: middleItem._key!},
+      'content',
+      {_key: innerList._key!},
+      'items',
+      {_key: i3._key!},
+      'content',
+      {_key: innerTextBlock._key!},
+      'children',
+      {_key: innerSpan._key},
+    ]
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: innerSpanPath, offset: innerSpan.text.length},
+        focus: {path: innerSpanPath, offset: innerSpan.text.length},
+      },
+    })
+
+    await userEvent.keyboard('!')
+
+    await vi.waitFor(() => {
+      expect(emittedPatches.length).toBeGreaterThan(0)
+      // The remote value (built by applying patches in order) must equal
+      // the editor's authoritative value.
+      expect(remoteValue).toEqual(editor.getSnapshot().context.value)
+    })
+  })
+
+  test('Scenario: Enter on empty trailing line in deepest list with empty previous sibling escapes one level out', async () => {
+    // Build depth=3, then append two empty trailing text blocks to the
+    // INNER list-item's content (after the existing text block + nested
+    // list-or-block at content[1]). The escape should land as a sibling
+    // of the inner list, inside the middle list-item's content.
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [
+              {
+                _type: 'block',
+                _key: 'T1',
+                children: [
+                  {_type: 'span', _key: 'S1', text: 'outer', marks: []},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _type: 'list',
+                _key: 'L2',
+                kind: 'bullet',
+                items: [
+                  {
+                    _type: 'list-item',
+                    _key: 'I2',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'T2',
+                        children: [
+                          {
+                            _type: 'span',
+                            _key: 'S2',
+                            text: 'middle',
+                            marks: [],
+                          },
+                        ],
+                        markDefs: [],
+                        style: 'normal',
+                      },
+                      {
+                        _type: 'list',
+                        _key: 'L3',
+                        kind: 'bullet',
+                        items: [
+                          {
+                            _type: 'list-item',
+                            _key: 'I3',
+                            content: [
+                              {
+                                _type: 'block',
+                                _key: 'T3',
+                                children: [
+                                  {
+                                    _type: 'span',
+                                    _key: 'S3',
+                                    text: 'inner',
+                                    marks: [],
+                                  },
+                                ],
+                                markDefs: [],
+                                style: 'normal',
+                              },
+                              {
+                                _type: 'block',
+                                _key: 'EMPTY-PREV',
+                                children: [
+                                  {
+                                    _type: 'span',
+                                    _key: 'EMPTY-PREV-S',
+                                    text: '',
+                                    marks: [],
+                                  },
+                                ],
+                                markDefs: [],
+                                style: 'normal',
+                              },
+                              {
+                                _type: 'block',
+                                _key: 'EMPTY-LAST',
+                                children: [
+                                  {
+                                    _type: 'span',
+                                    _key: 'EMPTY-LAST-S',
+                                    text: '',
+                                    marks: [],
+                                  },
+                                ],
+                                markDefs: [],
+                                style: 'normal',
+                              },
+                            ],
+                          } as PortableTextBlock,
+                        ],
+                      } as PortableTextBlock,
+                    ],
+                  } as PortableTextBlock,
+                ],
+              } as PortableTextBlock,
+            ],
+          } as PortableTextBlock,
+        ],
+      } as PortableTextBlock,
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    const emptyLastSpanPath = [
+      {_key: 'L1'},
+      'items',
+      {_key: 'I1'},
+      'content',
+      {_key: 'L2'},
+      'items',
+      {_key: 'I2'},
+      'content',
+      {_key: 'L3'},
+      'items',
+      {_key: 'I3'},
+      'content',
+      {_key: 'EMPTY-LAST'},
+      'children',
+      {_key: 'EMPTY-LAST-S'},
+    ]
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: emptyLastSpanPath, offset: 0},
+        focus: {path: emptyLastSpanPath, offset: 0},
+      },
+    })
+
+    await userEvent.keyboard('{Enter}')
+
+    // After Enter: both empty trailing blocks are removed from L3's
+    // inner list-item content. A fresh text block is inserted as a
+    // sibling of L3 inside I2's content (one level out from the deepest
+    // list). I2.content should now be: [T2 ('middle'), L3 (with only T3
+    // remaining), <new empty block>].
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toHaveLength(1)
+      const l1 = value[0] as unknown as {items: Array<PortableTextBlock>}
+      const i1 = l1.items[0] as unknown as {
+        content: Array<PortableTextBlock>
+      }
+      expect(i1.content).toHaveLength(2)
+      const l2 = i1.content[1] as unknown as {
+        items: Array<PortableTextBlock>
+      }
+      const i2 = l2.items[0] as unknown as {
+        content: Array<PortableTextBlock>
+      }
+      // I2's content should be [T2, L3 (cleaned), new empty text block].
+      expect(i2.content).toHaveLength(3)
+      expect((i2.content[0] as PortableTextBlock)._key).toBe('T2')
+      expect((i2.content[1] as PortableTextBlock)._key).toBe('L3')
+      expect((i2.content[2] as PortableTextBlock)._type).toBe('block')
+      const l3 = i2.content[1] as unknown as {
+        items: Array<PortableTextBlock>
+      }
+      const i3 = l3.items[0] as unknown as {
+        content: Array<PortableTextBlock>
+      }
+      // The two empty trailing blocks are gone; only T3 remains.
+      expect(i3.content).toHaveLength(1)
+      expect((i3.content[0] as PortableTextBlock)._key).toBe('T3')
+    })
+  })
+
+  test('Scenario: typing at a deep position appends to the deep span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [buildNestedList(keyGenerator, 3)]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    const outer = editor.getSnapshot().context.value[0] as PortableTextBlock
+    const outerItem = field<Array<PortableTextBlock>>(outer, 'items')[0]!
+    const middleList = field<Array<PortableTextBlock>>(outerItem, 'content')[1]!
+    const middleItem = field<Array<PortableTextBlock>>(middleList, 'items')[0]!
+    const innerList = field<Array<PortableTextBlock>>(middleItem, 'content')[1]!
+    const i3 = deepestListItem(outer, 3)
+    const innerTextBlock = field<Array<PortableTextBlock>>(i3, 'content')[0]!
+    const innerSpan = field<Array<{_key: string; text: string}>>(
+      innerTextBlock,
+      'children',
+    )[0]!
+
+    const innerSpanPath = [
+      {_key: outer._key!},
+      'items',
+      {_key: outerItem._key!},
+      'content',
+      {_key: middleList._key!},
+      'items',
+      {_key: middleItem._key!},
+      'content',
+      {_key: innerList._key!},
+      'items',
+      {_key: i3._key!},
+      'content',
+      {_key: innerTextBlock._key!},
+      'children',
+      {_key: innerSpan._key},
+    ]
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: innerSpanPath, offset: innerSpan.text.length},
+        focus: {path: innerSpanPath, offset: innerSpan.text.length},
+      },
+    })
+
+    await userEvent.keyboard('!')
+
+    await vi.waitFor(() => {
+      const out = editor.getSnapshot().context.value[0] as PortableTextBlock
+      const item3 = deepestListItem(out, 3)
+      const tb = field<Array<PortableTextBlock>>(item3, 'content')[0]!
+      const span = field<Array<{text: string}>>(tb, 'children')[0]!
+      expect(span.text).toBe('level-3!')
+    })
+  })
+
+  test('Scenario: decorator toggle on a deep span emits a strong mark', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [buildNestedList(keyGenerator, 3)]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    const outer = editor.getSnapshot().context.value[0] as PortableTextBlock
+    const outerItem = field<Array<PortableTextBlock>>(outer, 'items')[0]!
+    const middleList = field<Array<PortableTextBlock>>(outerItem, 'content')[1]!
+    const middleItem = field<Array<PortableTextBlock>>(middleList, 'items')[0]!
+    const innerList = field<Array<PortableTextBlock>>(middleItem, 'content')[1]!
+    const i3 = deepestListItem(outer, 3)
+    const innerTextBlock = field<Array<PortableTextBlock>>(i3, 'content')[0]!
+    const innerSpan = field<Array<{_key: string; text: string}>>(
+      innerTextBlock,
+      'children',
+    )[0]!
+
+    const innerSpanPath = [
+      {_key: outer._key!},
+      'items',
+      {_key: outerItem._key!},
+      'content',
+      {_key: middleList._key!},
+      'items',
+      {_key: middleItem._key!},
+      'content',
+      {_key: innerList._key!},
+      'items',
+      {_key: i3._key!},
+      'content',
+      {_key: innerTextBlock._key!},
+      'children',
+      {_key: innerSpan._key},
+    ]
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: innerSpanPath, offset: 0},
+        focus: {path: innerSpanPath, offset: innerSpan.text.length},
+      },
+    })
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const out = editor.getSnapshot().context.value[0] as PortableTextBlock
+      const item3 = deepestListItem(out, 3)
+      const tb = field<Array<PortableTextBlock>>(item3, 'content')[0]!
+      const span = field<Array<{marks: Array<string>}>>(tb, 'children')[0]!
+      expect(span.marks).toEqual(['strong'])
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Self-referential schemas — a list whose items contain lists, a callout that holds a list of items containing more lists, and so on — registered fewer container instances than the data actually contained.

The schema resolver enumerates positions by walking the schema graph with cycle detection: it stops one level past a self-reference. The runtime then looked up containers by exact-string match against the resolver's pre-emitted map. For data that nested deeper than the resolver's bounded walk, the lookup missed and the engine fell through to a stripped-down rendering path that ignored the consumer's registered `render`.

In the wild this shows up as: a markdown source with three-deep nested lists deserializes correctly into nested `_type: 'list'` blocks, but only the outer two render through `defineContainer`. The third level renders as a placeholder.

## Fix

The runtime lookup now falls back to scope-pattern matching when the exact-string key is not in the resolver's map. It iterates registered configs by specificity and returns the first whose `parsedScope` matches the runtime type chain. With matcher correctness, the resolver's emission completeness stops being load-bearing — `..` segments cover any depth.

A new `lookupContainer(containers, scopedName)` helper centralises this. All nine sites that previously called `containers.get(scopedName)` go through it, plus `isEditableContainer` (which gates whether the engine emits `data-pt-block-type="container"` and recurses into editable children) and the engine's element-routing site in `use-children`.

The matcher itself is rewritten from a first-match-and-advance walk to a backtracking match. The old version greedily consumed `any` segments at the first match position and missed terminal-aligned matches deeper in the chain. Two pre-existing tests in `resolve-containers.test.ts` had assertions encoding the old behavior; they're updated to match the corrected semantics (`$..list` against `[list, list-item, list]` correctly resolves now, where it didn't before).

## Test

`tests/container-rendering.test.tsx` gains a self-referential containers describe block with a list nested three levels deep. Verify-by-breaking confirmed the test discriminates the bug:

- Before fix: `<ul data-testid="list">` count = 3 ✓ (the consumer render IS called), but `<li data-testid="list-item">` count = 2 — the deepest list-item is missing because `isEditableContainer` returned false at that depth, so the engine emitted a stripped void wrapper instead of recursing.
- After fix: 3 lists + 3 list-items render as proper containers, each with `data-pt-block-type="container"` and the full registered render output.

Plus 56 lines of new `match-scope.test.ts` cases covering `$..list`, `$..list-item`, and `$..list.list-item` matching at depths 1, 2, and 3.

## Out of scope

The change is bounded to lookup correctness. The resolver still emits one bounded set of candidates from the schema walk; data that nests deeper than the walk now resolves via the matcher fallback, but the resolver's output set is unchanged in shape. There's no change to public types or the `Containers` map structure.