### PR TITLE
feat(markdown-editor): three-pane stress test app

### DIFF
--- a/apps/markdown-editor/biome.json
+++ b/apps/markdown-editor/biome.json
@@ -1,0 +1,8 @@
+{
+  "extends": "//",
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  }
+}

--- a/apps/markdown-editor/eslint.config.js
+++ b/apps/markdown-editor/eslint.config.js
@@ -1,0 +1,19 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import {globalIgnores} from 'eslint/config'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  reactHooks.configs.flat.recommended,
+  {
+    files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {'react-hooks/exhaustive-deps': 'error'},
+  },
+])

--- a/apps/markdown-editor/index.html
+++ b/apps/markdown-editor/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portable Text Markdown Editor</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/markdown-editor/package.json
+++ b/apps/markdown-editor/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "markdown-editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "check:lint": "biome lint .",
+    "check:react-compiler": "eslint --cache .",
+    "check:types": "tsc --noEmit --pretty --project tsconfig.app.json",
+    "check:types:watch": "tsc --watch --project tsconfig.app.json",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "vite",
+    "lint:fix": "biome lint --write .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@portabletext/editor": "workspace:*",
+    "@portabletext/markdown": "workspace:*",
+    "@portabletext/plugin-markdown-shortcuts": "workspace:*",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.16",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "tailwindcss": "^4.1.16",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.1"
+  }
+}

--- a/apps/markdown-editor/src/app.tsx
+++ b/apps/markdown-editor/src/app.tsx
@@ -1,0 +1,110 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+import {
+  markdownToPortableText,
+  portableTextToMarkdown,
+} from '@portabletext/markdown'
+import {useEffect, useRef, useState} from 'react'
+import {PortableTextSurface} from './editor/editor'
+import {
+  markdownToPortableTextOptions,
+  portableTextToMarkdownTypes,
+} from './editor/markdown-options'
+import kitchenSinkSource from './kitchen-sink.md?raw'
+
+export function App() {
+  const [markdown, setMarkdown] = useState<string>(kitchenSinkSource)
+  const [initialValue] = useState<Array<PortableTextBlock>>(() =>
+    markdownToPortableText(kitchenSinkSource, markdownToPortableTextOptions),
+  )
+  const [value, setValue] = useState<Array<PortableTextBlock>>(initialValue)
+  const focused = useRef<'markdown' | 'editor' | null>(null)
+  const replaceEditorValueRef = useRef<
+    ((blocks: Array<PortableTextBlock>) => void) | null
+  >(null)
+
+  // Markdown -> editor: when the textarea has focus, deserialize and feed.
+  useEffect(() => {
+    if (focused.current !== 'markdown') {
+      return
+    }
+    const blocks = markdownToPortableText(
+      markdown,
+      markdownToPortableTextOptions,
+    )
+    replaceEditorValueRef.current?.(blocks)
+  }, [markdown])
+
+  // Editor -> markdown: when the editor has focus, derive markdown from value.
+  useEffect(() => {
+    if (focused.current !== 'editor') {
+      return
+    }
+    setMarkdown(
+      portableTextToMarkdown(value, {types: portableTextToMarkdownTypes}),
+    )
+  }, [value])
+
+  return (
+    <div className="grid h-full grid-cols-1 lg:grid-cols-[2fr_1fr] gap-2 p-2">
+      <Pane label="Portable Text Editor" tone="primary">
+        <PortableTextSurface
+          initialValue={initialValue}
+          onMutation={setValue}
+          onFocus={() => {
+            focused.current = 'editor'
+          }}
+          replaceValueRef={replaceEditorValueRef}
+        />
+      </Pane>
+      <div className="grid grid-rows-2 gap-2 min-h-0">
+        <Pane label="Portable Text (JSON)">
+          <pre
+            className="h-full overflow-auto p-3 font-mono text-xs text-gray-700 dark:text-gray-300 whitespace-pre"
+            data-pane="pt-json"
+          >
+            {JSON.stringify(value, null, 2)}
+          </pre>
+        </Pane>
+        <Pane label="Markdown">
+          <textarea
+            value={markdown}
+            onFocus={() => {
+              focused.current = 'markdown'
+            }}
+            onChange={(e) => setMarkdown(e.target.value)}
+            spellCheck={false}
+            className="h-full w-full resize-none bg-transparent p-3 font-mono text-xs text-gray-800 outline-none dark:text-gray-200"
+          />
+        </Pane>
+      </div>
+    </div>
+  )
+}
+
+function Pane({
+  label,
+  tone,
+  children,
+}: {
+  label: string
+  tone?: 'primary'
+  children: React.ReactNode
+}) {
+  return (
+    <section
+      className={[
+        'flex min-h-0 flex-col overflow-hidden rounded-md border',
+        tone === 'primary'
+          ? 'border-gray-300 dark:border-gray-700'
+          : 'border-gray-200 dark:border-gray-800',
+      ].join(' ')}
+    >
+      <header className="border-b border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
+        <span className="font-medium text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
+          {label}
+        </span>
+      </header>
+      <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
+    </section>
+  )
+}

--- a/apps/markdown-editor/src/editor/containers.tsx
+++ b/apps/markdown-editor/src/editor/containers.tsx
@@ -1,0 +1,169 @@
+import {defineContainer} from '@portabletext/editor'
+import type {schemaDefinition} from './schema'
+
+const calloutToneClassName: Record<string, string> = {
+  note: 'border-sky-400 bg-sky-50 text-sky-900 dark:bg-sky-950/40 dark:text-sky-100',
+  tip: 'border-emerald-400 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100',
+  important:
+    'border-violet-400 bg-violet-50 text-violet-900 dark:bg-violet-950/40 dark:text-violet-100',
+  warning:
+    'border-amber-400 bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100',
+  caution:
+    'border-rose-400 bg-rose-50 text-rose-900 dark:bg-rose-950/40 dark:text-rose-100',
+}
+
+export const tableContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..table',
+  field: 'rows',
+  render: ({attributes, children, node}) => {
+    const headerRows = (node as {headerRows?: number}).headerRows ?? 0
+    return (
+      <table
+        {...attributes}
+        data-header-rows={headerRows}
+        className="my-3 border-collapse text-sm"
+      >
+        <tbody>{children}</tbody>
+      </table>
+    )
+  },
+})
+
+export const rowContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..table.row',
+  field: 'cells',
+  render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
+})
+
+export const cellContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..table.row.cell',
+  field: 'value',
+  render: ({attributes, children}) => (
+    <td
+      {...attributes}
+      className="border border-gray-200 dark:border-gray-700 px-2 py-1 align-top"
+    >
+      {children}
+    </td>
+  ),
+})
+
+export const calloutContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..callout',
+  field: 'content',
+  render: ({attributes, children, node}) => {
+    const tone = (node as {tone?: string}).tone ?? 'note'
+    const toneClass = calloutToneClassName[tone] ?? calloutToneClassName.note!
+    return (
+      <aside
+        {...attributes}
+        data-tone={tone}
+        className={`my-3 rounded-md border-l-4 px-4 py-3 ${toneClass}`}
+      >
+        {children}
+      </aside>
+    )
+  },
+})
+
+export const calloutBlockContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..callout.block',
+  field: 'children',
+  render: ({attributes, children}) => (
+    <p {...attributes} className="my-1">
+      {children}
+    </p>
+  ),
+})
+
+export const blockquoteContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..blockquote',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <blockquote
+      {...attributes}
+      className="my-2 border-gray-300 border-l-4 pl-3 text-gray-600 italic dark:border-gray-600 dark:text-gray-400"
+    >
+      {children}
+    </blockquote>
+  ),
+})
+
+export const codeBlockContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre
+      {...attributes}
+      className="my-3 overflow-x-auto rounded-md border border-gray-200 bg-gray-50 p-3 font-mono text-gray-700 text-sm leading-relaxed dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+    >
+      {children}
+    </pre>
+  ),
+})
+
+export const listContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..list',
+  field: 'items',
+  render: ({attributes, children, node}) => {
+    const kind = (node as {kind?: string}).kind ?? 'bullet'
+    if (kind === 'number') {
+      return (
+        <ol {...attributes} className="my-2 list-decimal space-y-1 pl-6">
+          {children}
+        </ol>
+      )
+    }
+    return (
+      <ul
+        {...attributes}
+        data-kind={kind}
+        className={
+          kind === 'task'
+            ? 'my-2 list-none space-y-1 pl-2'
+            : 'my-2 list-disc space-y-1 pl-6'
+        }
+      >
+        {children}
+      </ul>
+    )
+  },
+})
+
+export const listItemContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..list.list-item',
+  field: 'content',
+  render: ({attributes, children, node}) => {
+    const checked = (node as {checked?: boolean}).checked
+    if (typeof checked === 'boolean') {
+      return (
+        <li {...attributes} className="flex items-start gap-2">
+          <input
+            type="checkbox"
+            checked={checked}
+            readOnly
+            className="mt-1.5 flex-none"
+          />
+          <div
+            className={checked ? 'flex-1 line-through opacity-60' : 'flex-1'}
+          >
+            {children}
+          </div>
+        </li>
+      )
+    }
+    return <li {...attributes}>{children}</li>
+  },
+})
+
+export const allContainers = [
+  tableContainer,
+  rowContainer,
+  cellContainer,
+  calloutContainer,
+  calloutBlockContainer,
+  blockquoteContainer,
+  codeBlockContainer,
+  listContainer,
+  listItemContainer,
+]

--- a/apps/markdown-editor/src/editor/containers.tsx
+++ b/apps/markdown-editor/src/editor/containers.tsx
@@ -102,6 +102,27 @@ export const codeBlockContainer = defineContainer<typeof schemaDefinition>({
   ),
 })
 
+export const htmlContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..html',
+  field: 'code',
+  render: ({attributes, children}) => (
+    <div
+      {...attributes}
+      className="my-3 overflow-hidden rounded-md border border-gray-200 dark:border-gray-700"
+    >
+      <div
+        className="border-b border-gray-200 bg-gray-50 px-3 py-1 text-gray-500 text-xs uppercase tracking-wide dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+        contentEditable={false}
+      >
+        html
+      </div>
+      <pre className="overflow-x-auto bg-gray-50 p-3 font-mono text-gray-700 text-sm leading-relaxed dark:bg-gray-800 dark:text-gray-200">
+        {children}
+      </pre>
+    </div>
+  ),
+})
+
 export const listContainer = defineContainer<typeof schemaDefinition>({
   scope: '$..list',
   field: 'items',
@@ -164,6 +185,7 @@ export const allContainers = [
   calloutBlockContainer,
   blockquoteContainer,
   codeBlockContainer,
+  htmlContainer,
   listContainer,
   listItemContainer,
 ]

--- a/apps/markdown-editor/src/editor/editor.tsx
+++ b/apps/markdown-editor/src/editor/editor.tsx
@@ -1,0 +1,150 @@
+import {
+  EditorProvider,
+  PortableTextEditable,
+  useEditor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {
+  ContainerPlugin,
+  EventListenerPlugin,
+  LeafPlugin,
+} from '@portabletext/editor/plugins'
+import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+import {useEffect, type RefObject} from 'react'
+import {allContainers} from './containers'
+import {allLeafs} from './leafs'
+import {markdownShortcutsProps} from './markdown-shortcuts'
+import {schemaDefinition} from './schema'
+
+type Props = {
+  initialValue: Array<PortableTextBlock>
+  onMutation: (value: Array<PortableTextBlock>) => void
+  onFocus: () => void
+  replaceValueRef: RefObject<
+    ((blocks: Array<PortableTextBlock>) => void) | null
+  >
+}
+
+export function PortableTextSurface({
+  initialValue,
+  onMutation,
+  onFocus,
+  replaceValueRef,
+}: Props) {
+  return (
+    <EditorProvider
+      initialConfig={{
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'mutation') {
+            onMutation(event.value ?? [])
+          }
+        }}
+      />
+      <ContainerPlugin containers={allContainers} />
+      <LeafPlugin leafs={allLeafs} />
+      <MarkdownShortcutsPlugin {...markdownShortcutsProps} />
+      <ReplaceValueBridge replaceRef={replaceValueRef} />
+      <PortableTextEditable
+        onFocus={onFocus}
+        className="prose prose-sm dark:prose-invert h-full max-w-none overflow-y-auto p-6 outline-none"
+        renderStyle={(props) => {
+          if (props.value === 'h1') {
+            return (
+              <h1 className="mt-4 mb-2 font-bold text-3xl">{props.children}</h1>
+            )
+          }
+          if (props.value === 'h2') {
+            return (
+              <h2 className="mt-4 mb-2 font-bold text-2xl">{props.children}</h2>
+            )
+          }
+          if (props.value === 'h3') {
+            return (
+              <h3 className="mt-3 mb-2 font-bold text-xl">{props.children}</h3>
+            )
+          }
+          if (props.value === 'h4') {
+            return (
+              <h4 className="mt-3 mb-2 font-bold text-lg">{props.children}</h4>
+            )
+          }
+          if (props.value === 'h5') {
+            return (
+              <h5 className="mt-2 mb-1 font-bold text-base">
+                {props.children}
+              </h5>
+            )
+          }
+          if (props.value === 'h6') {
+            return (
+              <h6 className="mt-2 mb-1 font-bold text-sm uppercase tracking-wide">
+                {props.children}
+              </h6>
+            )
+          }
+          return <p className="mb-2">{props.children}</p>
+        }}
+        renderDecorator={(props) => {
+          if (props.value === 'strong') {
+            return <strong>{props.children}</strong>
+          }
+          if (props.value === 'em') {
+            return <em>{props.children}</em>
+          }
+          if (props.value === 'code') {
+            return (
+              <code className="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-800">
+                {props.children}
+              </code>
+            )
+          }
+          if (props.value === 'strike-through') {
+            return <s>{props.children}</s>
+          }
+          return props.children
+        }}
+        renderAnnotation={(props) => {
+          if (props.schemaType.name === 'link') {
+            const href = (props.value as {href?: string}).href
+            return (
+              <a
+                href={href}
+                className="text-blue-700 underline dark:text-blue-400"
+              >
+                {props.children}
+              </a>
+            )
+          }
+          return props.children
+        }}
+        renderPlaceholder={() => (
+          <span className="text-gray-400 dark:text-gray-500">
+            Start writing markdown
+          </span>
+        )}
+      />
+    </EditorProvider>
+  )
+}
+
+function ReplaceValueBridge({
+  replaceRef,
+}: {
+  replaceRef: RefObject<((blocks: Array<PortableTextBlock>) => void) | null>
+}) {
+  const editor = useEditor()
+  useEffect(() => {
+    replaceRef.current = (blocks) => {
+      editor.send({type: 'update value', value: blocks})
+    }
+    return () => {
+      replaceRef.current = null
+    }
+  }, [editor, replaceRef])
+  return null
+}

--- a/apps/markdown-editor/src/editor/leafs.tsx
+++ b/apps/markdown-editor/src/editor/leafs.tsx
@@ -93,9 +93,26 @@ export const inlineImageLeaf = defineLeaf<typeof schemaDefinition>({
   },
 })
 
+// Raw HTML block. Container holds the source as a single editable text-block
+// inside `code`, mirroring the code-block shape so the user types raw HTML
+// directly without escaping. Markdown matcher (md→pt) splits the html string
+// into one text-block per line; pt→md joins them back.
+//
+// Defined as a defineContainer below; the leaf below renders the inner spans
+// in a monospace style.
+export const htmlSpanLeaf = defineLeaf<typeof schemaDefinition>({
+  scope: '$..html.block.span',
+  render: ({attributes, children}) => (
+    <span {...attributes} className="font-mono">
+      {children}
+    </span>
+  ),
+})
+
 export const allLeafs = [
   codeBlockSpanLeaf,
   horizontalRuleLeaf,
   imageLeaf,
   inlineImageLeaf,
+  htmlSpanLeaf,
 ]

--- a/apps/markdown-editor/src/editor/leafs.tsx
+++ b/apps/markdown-editor/src/editor/leafs.tsx
@@ -1,0 +1,101 @@
+import {defineLeaf} from '@portabletext/editor'
+import type {schemaDefinition} from './schema'
+
+export const codeBlockSpanLeaf = defineLeaf<typeof schemaDefinition>({
+  scope: '$..code-block.block.span',
+  render: ({attributes, children}) => (
+    <span {...attributes} className="font-mono">
+      {children}
+    </span>
+  ),
+})
+
+export const horizontalRuleLeaf = defineLeaf<typeof schemaDefinition>({
+  scope: '$..horizontal-rule',
+  render: ({attributes, children}) => (
+    <div {...attributes} className="my-4">
+      <div contentEditable={false}>
+        <hr className="border-0 border-t border-gray-200 dark:border-gray-700" />
+      </div>
+      {children}
+    </div>
+  ),
+})
+
+// Block-level image (root, inside lists/callouts/blockquotes).
+export const imageLeaf = defineLeaf<typeof schemaDefinition>({
+  scope: '$..image',
+  render: ({attributes, children, node, focused, selected}) => {
+    const v = node as {src?: string; alt?: string; title?: string}
+    return (
+      <div {...attributes}>
+        {children}
+        <figure
+          contentEditable={false}
+          className={[
+            'my-3 inline-flex flex-col gap-1 rounded border-2',
+            selected
+              ? 'border-blue-400 dark:border-blue-500'
+              : 'border-gray-200 dark:border-gray-700',
+            focused ? 'bg-blue-50 dark:bg-blue-900/30' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <img
+            src={v.src}
+            alt={v.alt ?? ''}
+            title={v.title}
+            className="max-w-full rounded-t object-contain"
+          />
+          {v.alt && (
+            <figcaption className="px-2 pb-1 text-gray-500 text-xs dark:text-gray-400">
+              {v.alt}
+            </figcaption>
+          )}
+        </figure>
+      </div>
+    )
+  },
+})
+
+// Inline image (used in paragraphs as ![alt](src) inline). Cannot render
+// <figure>/<figcaption> here because those are flow content and would
+// produce an invalid descendant of <p> at hydration time.
+export const inlineImageLeaf = defineLeaf<typeof schemaDefinition>({
+  scope: '$..block.image',
+  render: ({attributes, children, node, focused, selected}) => {
+    const v = node as {src?: string; alt?: string; title?: string}
+    return (
+      <span {...attributes}>
+        {children}
+        <span
+          contentEditable={false}
+          className={[
+            'mx-0.5 inline-block align-middle rounded border',
+            selected
+              ? 'border-blue-400 dark:border-blue-500'
+              : 'border-gray-200 dark:border-gray-700',
+            focused ? 'bg-blue-50 dark:bg-blue-900/30' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <img
+            src={v.src}
+            alt={v.alt ?? ''}
+            title={v.title}
+            className="inline-block max-h-6 align-middle"
+          />
+        </span>
+      </span>
+    )
+  },
+})
+
+export const allLeafs = [
+  codeBlockSpanLeaf,
+  horizontalRuleLeaf,
+  imageLeaf,
+  inlineImageLeaf,
+]

--- a/apps/markdown-editor/src/editor/markdown-options.ts
+++ b/apps/markdown-editor/src/editor/markdown-options.ts
@@ -94,6 +94,45 @@ export const markdownToPortableTextOptions = {
       _type: 'blockquote',
       content: value.content,
     }),
+    // md → pt: split the raw HTML string into one text-block per line so the
+    // editor can edit it as Portable Text inside an `html` container with a
+    // `code` field. Mirrors the fenced code-block shape.
+    html: ({
+      context,
+      value,
+    }: {
+      context: {keyGenerator: () => string}
+      value: {html: string}
+    }) => {
+      const sourceLines = (value.html ?? '').split('\n')
+      // markdown-it emits a trailing empty line; drop it so the editor's
+      // line count matches the visible source.
+      if (
+        sourceLines.length > 0 &&
+        sourceLines[sourceLines.length - 1] === ''
+      ) {
+        sourceLines.pop()
+      }
+      const code = sourceLines.map((text) => ({
+        _type: 'block',
+        _key: context.keyGenerator(),
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: context.keyGenerator(),
+            text,
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      }))
+      return {
+        _key: context.keyGenerator(),
+        _type: 'html',
+        code,
+      }
+    },
   },
 } as const
 
@@ -119,6 +158,18 @@ export const portableTextToMarkdownTypes: NonNullable<
     return `\`\`\`${v.language ?? ''}\n${code}\n\`\`\``
   },
   'horizontal-rule': DefaultHorizontalRuleRenderer,
+  'html': ({value}: {value: unknown}) => {
+    const v = value as {
+      code?: Array<{children?: Array<{_type: string; text?: string}>}>
+    }
+    return (v.code ?? [])
+      .map((line) =>
+        (line.children ?? [])
+          .map((c) => (c._type === 'span' ? (c.text ?? '') : ''))
+          .join(''),
+      )
+      .join('\n')
+  },
   'image': DefaultImageRenderer,
   'list': DefaultListRenderer,
   'table': DefaultTableRenderer,

--- a/apps/markdown-editor/src/editor/markdown-options.ts
+++ b/apps/markdown-editor/src/editor/markdown-options.ts
@@ -1,0 +1,125 @@
+import {
+  DefaultBlockquoteObjectRenderer,
+  DefaultCalloutRenderer,
+  DefaultHorizontalRuleRenderer,
+  DefaultImageRenderer,
+  DefaultListRenderer,
+  DefaultTableRenderer,
+  type PortableTextRenderers,
+} from '@portabletext/markdown'
+
+export const markdownToPortableTextOptions = {
+  types: {
+    // md → pt: split fenced code into one text block per line, mirroring
+    // playground's plugin.markdown-deserializer.tsx.
+    code: ({
+      context,
+      value,
+      isInline,
+    }: {
+      context: {keyGenerator: () => string}
+      value: {language: string | undefined; code: string}
+      isInline: boolean
+    }) => {
+      if (isInline) {
+        return undefined
+      }
+      const sourceLines = (value.code ?? '').split('\n')
+      // markdown-it always emits a trailing empty line for fenced blocks.
+      if (
+        sourceLines.length > 0 &&
+        sourceLines[sourceLines.length - 1] === ''
+      ) {
+        sourceLines.pop()
+      }
+      const lines = sourceLines.map((text) => ({
+        _type: 'block',
+        _key: context.keyGenerator(),
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: context.keyGenerator(),
+            text,
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      }))
+      return {
+        _type: 'code-block',
+        _key: context.keyGenerator(),
+        language: value.language,
+        lines,
+      }
+    },
+    table: ({
+      context,
+      value,
+    }: {
+      context: {keyGenerator: () => string}
+      value: {
+        headerRows: number | undefined
+        rows: Array<{_key: string; _type: 'row'; cells: unknown[]}>
+      }
+    }) => ({
+      _key: context.keyGenerator(),
+      _type: 'table',
+      headerRows: value.headerRows,
+      rows: value.rows,
+    }),
+    list: ({
+      context,
+      value,
+    }: {
+      context: {keyGenerator: () => string}
+      value: {
+        kind: 'bullet' | 'number' | 'task'
+        items: Array<unknown>
+      }
+    }) => ({
+      _key: context.keyGenerator(),
+      _type: 'list',
+      kind: value.kind,
+      items: value.items,
+    }),
+    blockquote: ({
+      context,
+      value,
+    }: {
+      context: {keyGenerator: () => string}
+      value: {content: Array<unknown>}
+    }) => ({
+      _key: context.keyGenerator(),
+      _type: 'blockquote',
+      content: value.content,
+    }),
+  },
+} as const
+
+export const portableTextToMarkdownTypes: NonNullable<
+  PortableTextRenderers['types']
+> = {
+  'blockquote': DefaultBlockquoteObjectRenderer,
+  'callout': DefaultCalloutRenderer,
+  'code-block': ({value}: {value: unknown}) => {
+    const v = value as {
+      language?: string
+      lines?: Array<{
+        children?: Array<{_type: string; text?: string}>
+      }>
+    }
+    const code = (v.lines ?? [])
+      .map((line) =>
+        (line.children ?? [])
+          .map((c) => (c._type === 'span' ? (c.text ?? '') : ''))
+          .join(''),
+      )
+      .join('\n')
+    return `\`\`\`${v.language ?? ''}\n${code}\n\`\`\``
+  },
+  'horizontal-rule': DefaultHorizontalRuleRenderer,
+  'image': DefaultImageRenderer,
+  'list': DefaultListRenderer,
+  'table': DefaultTableRenderer,
+}

--- a/apps/markdown-editor/src/editor/markdown-shortcuts.ts
+++ b/apps/markdown-editor/src/editor/markdown-shortcuts.ts
@@ -1,0 +1,35 @@
+import type {MarkdownShortcutsPluginProps} from '@portabletext/plugin-markdown-shortcuts'
+
+export const markdownShortcutsProps: MarkdownShortcutsPluginProps = {
+  boldDecorator: ({context}) =>
+    context.schema.decorators.find((d) => d.name === 'strong')?.name,
+  italicDecorator: ({context}) =>
+    context.schema.decorators.find((d) => d.name === 'em')?.name,
+  codeDecorator: ({context}) =>
+    context.schema.decorators.find((d) => d.name === 'code')?.name,
+  strikeThroughDecorator: ({context}) =>
+    context.schema.decorators.find((d) => d.name === 'strike-through')?.name,
+  defaultStyle: ({context}) =>
+    context.schema.styles[0]?.value ?? context.schema.styles[0]?.name,
+  headingStyle: ({context, props}) =>
+    context.schema.styles.find((s) => s.name === `h${props.level}`)?.name,
+  horizontalRuleObject: ({context}) => {
+    const schemaType = context.schema.blockObjects.find(
+      (o) => o.name === 'horizontal-rule',
+    )
+    if (!schemaType) {
+      return undefined
+    }
+    return {_type: schemaType.name}
+  },
+  linkObject: ({context, props}) => {
+    const schemaType = context.schema.annotations.find((a) => a.name === 'link')
+    const hrefField = schemaType?.fields.find(
+      (f) => f.name === 'href' && f.type === 'string',
+    )
+    if (!schemaType || !hrefField) {
+      return undefined
+    }
+    return {_type: schemaType.name, [hrefField.name]: props.href}
+  },
+}

--- a/apps/markdown-editor/src/editor/schema.ts
+++ b/apps/markdown-editor/src/editor/schema.ts
@@ -141,7 +141,24 @@ export const schemaDefinition = defineSchema({
       ],
     },
     {name: 'horizontal-rule'},
-    {name: 'html', fields: [{name: 'html', type: 'string'}]},
+    {
+      name: 'html',
+      fields: [
+        {
+          name: 'code',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              styles: [],
+              decorators: [],
+              annotations: [],
+              inlineObjects: [],
+            },
+          ],
+        },
+      ],
+    },
     {
       name: 'image',
       fields: [

--- a/apps/markdown-editor/src/editor/schema.ts
+++ b/apps/markdown-editor/src/editor/schema.ts
@@ -1,0 +1,315 @@
+import {defineSchema} from '@portabletext/editor'
+
+// Mirrors @portabletext/markdown's defaults so values produced by
+// markdownToPortableText pass the editor's schema validation. Lists are
+// declared as structural `list` block-objects (not flat `lists` items) so
+// list items can hold rich nested content like code blocks and callouts.
+export const schemaDefinition = defineSchema({
+  block: {
+    fields: [{name: 'checked', type: 'boolean'}],
+  },
+  styles: [
+    {name: 'normal'},
+    {name: 'h1'},
+    {name: 'h2'},
+    {name: 'h3'},
+    {name: 'h4'},
+    {name: 'h5'},
+    {name: 'h6'},
+  ],
+  decorators: [
+    {name: 'strong'},
+    {name: 'em'},
+    {name: 'code'},
+    {name: 'strike-through'},
+  ],
+  annotations: [
+    {
+      name: 'link',
+      fields: [
+        {name: 'href', type: 'string'},
+        {name: 'title', type: 'string'},
+      ],
+    },
+  ],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {name: 'tone', type: 'string'},
+        {
+          name: 'content',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              decorators: [
+                {name: 'strong'},
+                {name: 'em'},
+                {name: 'code'},
+                {name: 'strike-through'},
+              ],
+              styles: [{name: 'normal'}],
+              annotations: [
+                {
+                  name: 'link',
+                  fields: [
+                    {name: 'href', type: 'string'},
+                    {name: 'title', type: 'string'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'blockquote',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              decorators: [
+                {name: 'strong'},
+                {name: 'em'},
+                {name: 'code'},
+                {name: 'strike-through'},
+              ],
+              styles: [{name: 'normal'}],
+              annotations: [
+                {
+                  name: 'link',
+                  fields: [
+                    {name: 'href', type: 'string'},
+                    {name: 'title', type: 'string'},
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'code-block',
+              fields: [
+                {name: 'language', type: 'string'},
+                {
+                  name: 'lines',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      styles: [],
+                      decorators: [],
+                      annotations: [],
+                      inlineObjects: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'image',
+              fields: [
+                {name: 'src', type: 'string'},
+                {name: 'alt', type: 'string'},
+                {name: 'title', type: 'string'},
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'code-block',
+      fields: [
+        {name: 'language', type: 'string'},
+        {
+          name: 'lines',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              styles: [],
+              decorators: [],
+              annotations: [],
+              inlineObjects: [],
+            },
+          ],
+        },
+      ],
+    },
+    {name: 'horizontal-rule'},
+    {name: 'html', fields: [{name: 'html', type: 'string'}]},
+    {
+      name: 'image',
+      fields: [
+        {name: 'src', type: 'string'},
+        {name: 'alt', type: 'string'},
+        {name: 'title', type: 'string'},
+      ],
+    },
+    {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {
+          name: 'items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'list-item',
+              fields: [
+                {name: 'checked', type: 'boolean'},
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      decorators: [
+                        {name: 'strong'},
+                        {name: 'em'},
+                        {name: 'code'},
+                        {name: 'strike-through'},
+                      ],
+                      styles: [{name: 'normal'}],
+                      annotations: [
+                        {
+                          name: 'link',
+                          fields: [
+                            {name: 'href', type: 'string'},
+                            {name: 'title', type: 'string'},
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'code-block',
+                      fields: [
+                        {name: 'language', type: 'string'},
+                        {
+                          name: 'lines',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'block',
+                              styles: [],
+                              decorators: [],
+                              annotations: [],
+                              inlineObjects: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'callout',
+                      fields: [
+                        {name: 'tone', type: 'string'},
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'block',
+                              decorators: [
+                                {name: 'strong'},
+                                {name: 'em'},
+                                {name: 'code'},
+                                {name: 'strike-through'},
+                              ],
+                              styles: [{name: 'normal'}],
+                              annotations: [
+                                {
+                                  name: 'link',
+                                  fields: [
+                                    {name: 'href', type: 'string'},
+                                    {name: 'title', type: 'string'},
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {type: 'list'},
+                    {type: 'image'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'table',
+      fields: [
+        {name: 'headerRows', type: 'number'},
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'block',
+                              decorators: [
+                                {name: 'strong'},
+                                {name: 'em'},
+                                {name: 'code'},
+                                {name: 'strike-through'},
+                              ],
+                              styles: [{name: 'normal'}],
+                              annotations: [
+                                {
+                                  name: 'link',
+                                  fields: [
+                                    {name: 'href', type: 'string'},
+                                    {name: 'title', type: 'string'},
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  inlineObjects: [
+    {
+      name: 'image',
+      fields: [
+        {name: 'src', type: 'string'},
+        {name: 'alt', type: 'string'},
+        {name: 'title', type: 'string'},
+      ],
+    },
+  ],
+})

--- a/apps/markdown-editor/src/env.d.ts
+++ b/apps/markdown-editor/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.md?raw' {
+  const content: string
+  export default content
+}

--- a/apps/markdown-editor/src/index.css
+++ b/apps/markdown-editor/src/index.css
@@ -1,0 +1,20 @@
+@import 'tailwindcss';
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}

--- a/apps/markdown-editor/src/kitchen-sink.md
+++ b/apps/markdown-editor/src/kitchen-sink.md
@@ -1,0 +1,157 @@
+# Portable Text, in markdown
+
+This document is a stress test. It exercises every markdown concept the editor and `@portabletext/markdown` can represent. Edit on either side and watch the other follow.
+
+## Headings and paragraphs
+
+Six heading levels.
+
+# h1
+
+## h2
+
+### h3
+
+#### h4
+
+##### h5
+
+###### h6
+
+Paragraphs separate with a blank line.
+
+A second paragraph, with **strong**, _em_, `inline code`, and ~~strikethrough~~ inline marks. Plus a [link](https://portabletext.org 'the Portable Text spec') and a bare autolink: <https://github.com/portabletext/editor>.
+
+## Lists
+
+A bullet list:
+
+- First item.
+- Second item, with **bold** and `code`.
+- Third item.
+
+A numbered list:
+
+1. First.
+2. Second.
+3. Third.
+
+A task list:
+
+- [x] Schema enforcement applies at every depth.
+- [ ] Migrate custom plugins.
+  - [x] Audit `renderBlock` callbacks.
+  - [ ] Register containers where it pays off.
+
+Nested, three levels deep, with rich content inside list items:
+
+- Outer bullet.
+  - Inner bullet that holds a code block:
+    ```ts
+    const works = 'A code block, inside a list item, two levels deep'
+    ```
+  - Inner bullet that holds a callout:
+    > [!TIP]
+    > Containers nest. Callouts inside list items inside lists.
+  - Three levels in:
+    - Same `defineContainer` registration handles every depth.
+
+      ![Image, three lists deep](https://placehold.co/400x80/0ea5e9/white?text=Image+three+lists+deep)
+
+## Blockquotes
+
+> A simple blockquote. The kind you'd find on a personal blog circa 2008.
+
+> Multiple lines.
+> Same blockquote, soft-wrapped.
+
+> A blockquote that holds a code block:
+>
+> ```ts
+> markdownToPortableText(input)
+> ```
+
+## Code
+
+A fenced code block, with language:
+
+```ts
+import {defineContainer, defineLeaf} from '@portabletext/editor'
+
+const calloutContainer = defineContainer({
+  scope: '$..callout',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <aside {...attributes}>{children}</aside>
+  ),
+})
+```
+
+A fenced code block, no language:
+
+```
+plain code, no syntax highlighting
+```
+
+A code block with mermaid syntax (TODO: render as a diagram):
+
+```mermaid
+graph TD
+  A[Start] --> B{Decide}
+  B -->|Yes| C[Ship]
+  B -->|No| D[Iterate]
+```
+
+## Tables
+
+| Feature     | v6                    | v7                     |
+| ----------- | --------------------- | ---------------------- |
+| Code blocks | flat string           | container, line blocks |
+| Tables      | block-object, opaque  | container, editable    |
+| Callouts    | not supported         | container with tone    |
+| Lists       | flat `listItem` field | flat _or_ container    |
+
+## Callouts
+
+> [!NOTE]
+> A note. The neutral tone, sky blue.
+
+> [!TIP]
+> A tip. Emerald, encouraging.
+
+> [!IMPORTANT]
+> Important. Violet, demanding attention.
+
+> [!WARNING]
+> A warning. Amber, cautionary.
+
+> [!CAUTION]
+> Caution. Rose, this is the serious one.
+
+## Images
+
+Block image:
+
+![A placeholder](https://placehold.co/600x200/0ea5e9/white?text=Block+image)
+
+Inline image (in a paragraph): here's an inline ![inline](https://placehold.co/24/f97316/white?text=I) badge.
+
+## Horizontal rule
+
+Above the rule.
+
+---
+
+Below the rule.
+
+## HTML
+
+A raw HTML block:
+
+<div style="padding: 8px; background: #fef3c7; border-radius: 4px;">
+  Raw HTML, passed through as a block-object.
+</div>
+
+## Closing
+
+That's the kitchen sink. Anything missing? File a friction note in `apps/markdown-editor`'s spec.

--- a/apps/markdown-editor/src/main.tsx
+++ b/apps/markdown-editor/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import {App} from './app.tsx'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/apps/markdown-editor/tsconfig.app.json
+++ b/apps/markdown-editor/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/markdown-editor/tsconfig.json
+++ b/apps/markdown-editor/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/markdown-editor/tsconfig.node.json
+++ b/apps/markdown-editor/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/markdown-editor/vite.config.ts
+++ b/apps/markdown-editor/vite.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import {defineConfig} from 'vite'
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: (id) => {
+        const isVendoredSlate =
+          id.includes('/src/slate/') ||
+          id.includes('/src/slate-dom/') ||
+          id.includes('/src/slate-react/')
+        return {
+          plugins: isVendoredSlate
+            ? []
+            : [['babel-plugin-react-compiler', {target: '19'}]],
+        }
+      },
+    }),
+    tailwindcss(),
+  ],
+  resolve: {
+    alias: {
+      '@portabletext/editor': path.resolve(
+        __dirname,
+        '../../packages/editor/src',
+      ),
+      '@portabletext/markdown': path.resolve(
+        __dirname,
+        '../../packages/markdown/src',
+      ),
+      '@portabletext/plugin-markdown-shortcuts': path.resolve(
+        __dirname,
+        '../../packages/plugin-markdown-shortcuts/src',
+      ),
+      '@portabletext/schema': path.resolve(
+        __dirname,
+        '../../packages/schema/src',
+      ),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,58 @@ importers:
         specifier: ^4.8.0
         version: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
 
+  apps/markdown-editor:
+    dependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      '@portabletext/markdown':
+        specifier: workspace:*
+        version: link:../../packages/markdown
+      '@portabletext/plugin-markdown-shortcuts':
+        specifier: workspace:*
+        version: link:../../packages/plugin-markdown-shortcuts
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.16
+        version: 4.1.18(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      tailwindcss:
+        specifier: ^4.1.16
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
   apps/playground:
     dependencies:
       '@floating-ui/react-dom':
@@ -8567,46 +8619,6 @@ packages:
       terser:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8998,12 +9010,12 @@ snapshots:
       '@astrojs/internal-helpers': 0.8.0
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       devalue: 5.6.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       ultrahtml: 1.6.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13414,18 +13426,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -14593,10 +14593,6 @@ snapshots:
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -17737,23 +17733,6 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.2
       terser: 5.44.1
-
-  vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.10
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.8.3
 
   vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
Superseded by #2650 (`pilcrow` skeleton). The draft work here (three-pane PT editor + JSON + markdown textarea stress test) survives on the branch and can be cherry-picked onto the long-running Pilcrow feature branch when we get there.

Closing in favor of the new name and a clean narrative.
