### PR TITLE
test: pin Enter-escape from a deeply nested list-item

### DIFF
--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -14,6 +14,7 @@ import type {
   TextBlock,
   Selection as TextspecSelection,
 } from '@textspec/notation'
+import {lookupContainer} from '../src/schema/lookup-container'
 import type {Containers} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
@@ -356,7 +357,7 @@ function convertBlockToTextspec(
     return convertTextBlock(schema, block, annotationKeys)
   }
 
-  if (containers.has(block._type)) {
+  if (lookupContainer(containers, block._type)) {
     return convertContainerBlock(
       schema,
       containers,
@@ -380,7 +381,7 @@ function convertContainerBlock(
   block: Record<string, unknown>,
   scopePath: string,
 ): ContainerBlock {
-  const containerField = containers.get(scopePath)?.field
+  const containerField = lookupContainer(containers, scopePath)?.field
 
   if (!containerField) {
     return {
@@ -408,7 +409,7 @@ function convertContainerBlock(
         const typedItem = item as Record<string, unknown>
         const childScopePath = `${scopePath}.${item._type}`
 
-        if (containers.has(childScopePath)) {
+        if (lookupContainer(containers, childScopePath)) {
           children.push(
             convertContainerBlock(
               schema,

--- a/packages/editor/tests/recursive-schema.test.tsx
+++ b/packages/editor/tests/recursive-schema.test.tsx
@@ -8,6 +8,7 @@ import {EventListenerPlugin} from '../src/plugins'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Tests for self-referential / recursive schemas.
@@ -645,5 +646,213 @@ describe('recursive schemas (lists in list-items in lists)', () => {
       const span = field<Array<{marks: Array<string>}>>(tb, 'children')[0]!
       expect(span.marks).toEqual(['strong'])
     })
+  })
+
+  test('Scenario: pressing Enter from the deepest list-item escapes one level per pair of presses, all the way to root', async () => {
+    // Build:
+    //   - level-1
+    //     - level-2
+    //       - level-3
+    //
+    // Caret at end of "level-3". Repeated Enters trace this pattern:
+    //   #1: inserts empty trailing block in I3 (deepest list-item)
+    //   #2: inserts another empty in I3 (now empty-prev + empty-last)
+    //   #3: ESCAPE to I2 — empties collapse, new block sibling of L3 in I2
+    //   #4: inserts another empty in I2
+    //   #5: ESCAPE to I1
+    //   #6: inserts another empty in I1
+    //   #7: ESCAPE to root (sibling of the outermost list)
+    //
+    // Total: 2 Enters + (3 Enters per level of escape) - 1 = 7 Enters to
+    // escape from depth 3 to root. The pattern is deterministic at any depth.
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      buildNestedList(keyGenerator, 3),
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: recursiveListSchema,
+      initialValue,
+      children: (
+        <ContainerPlugin containers={[listContainer, listItemContainer]} />
+      ),
+    })
+
+    // Walk the value to find the deepest span ('level-3') and place caret
+    // at its end.
+    const initialL1 = editor.getSnapshot().context.value[0] as PortableTextBlock
+    const i1 = (initialL1 as unknown as {items: Array<PortableTextBlock>})
+      .items[0]!
+    const i1Content = (i1 as unknown as {content: Array<PortableTextBlock>})
+      .content
+    const l2 = i1Content[1] as PortableTextBlock
+    const i2 = (l2 as unknown as {items: Array<PortableTextBlock>}).items[0]!
+    const i2Content = (i2 as unknown as {content: Array<PortableTextBlock>})
+      .content
+    const l3 = i2Content[1] as PortableTextBlock
+    const i3 = (l3 as unknown as {items: Array<PortableTextBlock>}).items[0]!
+    const i3Content = (i3 as unknown as {content: Array<PortableTextBlock>})
+      .content
+    const t3 = i3Content[0] as PortableTextBlock
+    const t3Children = (t3 as unknown as {children: Array<{_key: string}>})
+      .children
+    const s3 = t3Children[0]!
+
+    const deepSpanPath = [
+      {_key: initialL1._key!},
+      'items',
+      {_key: i1._key!},
+      'content',
+      {_key: l2._key!},
+      'items',
+      {_key: i2._key!},
+      'content',
+      {_key: l3._key!},
+      'items',
+      {_key: i3._key!},
+      'content',
+      {_key: t3._key!},
+      'children',
+      {_key: s3._key},
+    ]
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: deepSpanPath, offset: 'level-3'.length},
+        focus: {path: deepSpanPath, offset: 'level-3'.length},
+      },
+    })
+
+    async function pressEnter() {
+      await userEvent.keyboard('{Enter}')
+      await vi.waitFor(() => {
+        editor.getSnapshot().context.value
+      })
+    }
+
+    // #1: split inserts an empty trailing block in I3.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '            B: |',
+      ].join('\n'),
+    )
+
+    // #2: another empty trailing block in I3 (now empty-prev + empty-last).
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '            B: ',
+        '            B: |',
+      ].join('\n'),
+    )
+
+    // #3: ESCAPE — empties collapse, new sibling of L3 in I2.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '        B: |',
+      ].join('\n'),
+    )
+
+    // #4: another empty trailing block in I2.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '        B: ',
+        '        B: |',
+      ].join('\n'),
+    )
+
+    // #5: ESCAPE to I1.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '    B: |',
+      ].join('\n'),
+    )
+
+    // #6: another empty trailing block in I1.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        '    B: ',
+        '    B: |',
+      ].join('\n'),
+    )
+
+    // #7: ESCAPE to root.
+    await pressEnter()
+    expect(toTextspec(editor.getSnapshot().context)).toEqual(
+      [
+        'LIST:',
+        '  LIST-ITEM:',
+        '    B: level-1',
+        '    LIST:',
+        '      LIST-ITEM:',
+        '        B: level-2',
+        '        LIST:',
+        '          LIST-ITEM:',
+        '            B: level-3',
+        'B: |',
+      ].join('\n'),
+    )
   })
 })


### PR DESCRIPTION
Adds a browser test that walks through pressing `Enter` repeatedly from the end of `level-3` in a list nested three levels deep (`list → list-item → list → list-item → list → list-item → block`), asserting the textspec output at each step.

The test confirms what the existing `Scenario: Enter on empty trailing line in deepest list with empty previous sibling escapes one level out` already proves for a single level, but extends it to the full chain: from any depth, pressing `Enter` eventually escapes to root, costing two presses per level (one to add an empty trailing line, one to fire the escape against the prior empty sibling).

While writing the assertions, `toTextspec` was producing `{LIST-ITEM}` block-object placeholders for list-items at depth 2+ because it called `containers.has(scopedName)` directly. The runtime container resolution post-#2631 uses `lookupContainer` with a scope-pattern fallback for the case where the resolver couldn't pre-emit a candidate at every depth a recursive schema admits. `toTextspec` now goes through the same helper, so deeply nested containers serialize as `CONTAINER:` blocks with their children visible — which is what makes the per-step textspec assertions in this scenario readable at all.

No changeset — both changes are internal to the editor package's test surface.
