### PR TITLE
test: add a structured-lists plugin composing list-item sink/lift from primitive events

### DIFF
--- a/packages/editor/gherkin-tests/plugin.structured-lists.feature
+++ b/packages/editor/gherkin-tests/plugin.structured-lists.feature
@@ -1,0 +1,333 @@
+Feature: Structured Lists Plugin
+  A plugin that represents lists as containers (a `list` block-object whose
+  `items` field holds `list-item` objects whose `content` field holds text
+  blocks and nested lists), preserving the user-facing keyboard semantics of
+  the core flat-list behaviors.
+
+  The same primitives drive the keyboard shortcuts:
+  Tab        sinks the focus list-item one level deeper
+  Shift+Tab  lifts the focus list-item one level out
+
+  Scenario: Pressing Tab sinks a list-item into the preceding sibling
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+        LIST-ITEM:
+          B: second
+      """
+    When the editor is focused
+    And the caret is put before "second"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: |second
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+        LIST-ITEM:
+          B: |second
+      """
+
+  Scenario: Pressing Tab on the first list-item wraps it in an empty parent list-item
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: only
+      """
+    When the editor is focused
+    And the caret is put before "only"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: |only
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |only
+      """
+
+  Scenario: Pressing Tab merges into a trailing list (kind-agnostic)
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+        LIST-ITEM:
+          B: second
+      """
+    When the editor is focused
+    And the caret is put before "second"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+            LIST-ITEM:
+              B: |second
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+        LIST-ITEM:
+          B: |second
+      """
+
+  Scenario: Pressing Shift+Tab lifts a nested list-item to be a sibling of its enclosing list-item
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+          LIST:
+            LIST-ITEM:
+              B: inner
+      """
+    When the editor is focused
+    And the caret is put before "inner"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+        LIST-ITEM:
+          B: |inner
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+          LIST:
+            LIST-ITEM:
+              B: |inner
+      """
+
+  Scenario: Pressing Shift+Tab from a middle nested item leaves leading siblings, carries trailing siblings as nested children
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+            LIST-ITEM:
+              B: middle
+            LIST-ITEM:
+              B: c
+      """
+    When the editor is focused
+    And the caret is put before "middle"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+        LIST-ITEM:
+          B: |middle
+          LIST:
+            LIST-ITEM:
+              B: c
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+            LIST-ITEM:
+              B: |middle
+            LIST-ITEM:
+              B: c
+      """
+
+  Scenario: Pressing Shift+Tab on the only item under an empty wrapper list-item removes the wrapper too
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: only
+      """
+    When the editor is focused
+    And the caret is put before "only"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |only
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: |only
+      """
+
+  Scenario: Pressing Shift+Tab on the first nested item removes the (now-empty) original nested list
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: only-nested
+      """
+    When the editor is focused
+    And the caret is put before "only-nested"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+        LIST-ITEM:
+          B: |only-nested
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: |only-nested
+      """
+
+  Scenario: Pressing Shift+Tab at the outermost list is a no-op
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: alpha
+        LIST-ITEM:
+          B: beta
+      """
+    When the editor is focused
+    And the caret is put before "alpha"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |alpha
+        LIST-ITEM:
+          B: beta
+      """
+
+  Scenario: Sinking a list-item preserves an image in the preceding sibling
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+        LIST-ITEM:
+          B: next
+      """
+    When the editor is focused
+    And the caret is put before "next"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+          LIST:
+            LIST-ITEM:
+              B: |next
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+        LIST-ITEM:
+          B: |next
+      """
+
+  Scenario: Lifting a list-item carries the rest of its content (text + image) along
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: mixed
+              {IMAGE src="graph.png"}
+      """
+    When the editor is focused
+    And the caret is put before "mixed"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+        LIST-ITEM:
+          B: |mixed
+          {IMAGE src="graph.png"}
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: |mixed
+              {IMAGE src="graph.png"}
+      """

--- a/packages/editor/gherkin-tests/plugin.structured-lists.test.tsx
+++ b/packages/editor/gherkin-tests/plugin.structured-lists.test.tsx
@@ -1,0 +1,487 @@
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import {useEffect} from 'react'
+import {useEditor} from '../src'
+import {raise} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {defaultKeyboardShortcuts} from '../src/editor/default-keyboard-shortcuts'
+import type {EditorSnapshot} from '../src/editor/editor-snapshot'
+import {getAncestor} from '../src/node-traversal/get-ancestor'
+import {getSibling} from '../src/node-traversal/get-sibling'
+import {defineContainer} from '../src/renderers/renderer.types'
+import type {Node} from '../src/slate/interfaces/node'
+import type {Path} from '../src/slate/interfaces/path'
+import {parameterTypes} from '../src/test'
+import {createTestEditor, stepDefinitions} from '../src/test/vitest'
+import type {Context} from '../src/test/vitest/step-context'
+import pluginStructuredListsFeature from './plugin.structured-lists.feature?raw'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  blockObjects: [
+    {name: 'image', fields: [{name: 'src', type: 'string'}]},
+    {
+      name: 'code-block',
+      fields: [
+        {name: 'language', type: 'string'},
+        {name: 'lines', type: 'array', of: [{type: 'block'}]},
+      ],
+    },
+    {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {
+          name: 'items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'list-item',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {type: 'block'},
+                    {type: 'list'},
+                    {type: 'image'},
+                    {type: 'code-block'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const listContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..list',
+  field: 'items',
+  render: ({attributes, children}) => (
+    <ul data-testid="list" {...attributes}>
+      {children}
+    </ul>
+  ),
+})
+
+const listItemContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..list.list-item',
+  field: 'content',
+  render: ({attributes, children}) => (
+    <li data-testid="list-item" {...attributes}>
+      {children}
+    </li>
+  ),
+})
+
+const codeBlockContainer = defineContainer<typeof schemaDefinition>({
+  scope: '$..code-block',
+  field: 'lines',
+  render: ({attributes, children}) => (
+    <pre data-testid="code-block" {...attributes}>
+      {children}
+    </pre>
+  ),
+})
+
+// ---------------------------------------------------------------------------
+// Domain shape + helpers
+// ---------------------------------------------------------------------------
+
+type Keyed = {_key: string}
+type ListNode = Keyed & {
+  _type: 'list'
+  kind?: string
+  items: Array<ListItemNode>
+}
+type ListItemNode = Keyed & {_type: 'list-item'; content: Array<Node>}
+
+const isList = (node: Node): node is ListNode =>
+  (node as {_type?: unknown})._type === 'list'
+const isListItem = (node: Node): node is ListItemNode =>
+  (node as {_type?: unknown})._type === 'list-item'
+
+/**
+ * Build a path to a node inside an array field of a parent.
+ */
+const childPath = (parentPath: Path, field: string, child: Keyed): Path => [
+  ...parentPath,
+  field,
+  {_key: child._key},
+]
+
+/**
+ * Build a new `list` value.
+ */
+const newList = (
+  keyGen: () => string,
+  kind: string | undefined,
+  items: Array<ListItemNode>,
+): ListNode => ({
+  _type: 'list',
+  _key: keyGen(),
+  ...(kind !== undefined ? {kind} : {}),
+  items,
+})
+
+/**
+ * Build a new `list-item` value with given content.
+ */
+const newListItem = (
+  keyGen: () => string,
+  content: Array<Node>,
+): ListItemNode => ({
+  _type: 'list-item',
+  _key: keyGen(),
+  content,
+})
+
+/**
+ * Replace the prefix of `focusPath` up to and including the keyed segment for
+ * `oldKey` with `newPrefix`. Used to follow a moved subtree.
+ */
+function rebaseFocus(
+  focusPath: Path,
+  oldKey: string,
+  newPrefix: Path,
+): Path | undefined {
+  const idx = focusPath.findIndex(
+    (segment) =>
+      typeof segment === 'object' &&
+      segment !== null &&
+      '_key' in segment &&
+      (segment as Keyed)._key === oldKey,
+  )
+  if (idx < 0) {
+    return undefined
+  }
+  return [...newPrefix, ...focusPath.slice(idx + 1)]
+}
+
+/**
+ * Resolve "the list-item the focus is inside" plus its enclosing list and
+ * the item's index within the list. Returns `undefined` when the cursor
+ * isn't inside a list-item.
+ */
+function resolveFocus(snapshot: EditorSnapshot) {
+  const focusPath = snapshot.context.selection?.focus.path
+  if (!focusPath) {
+    return undefined
+  }
+
+  const listItem = getAncestor(snapshot, focusPath, isListItem)
+  if (!listItem) {
+    return undefined
+  }
+
+  const list = getAncestor(snapshot, listItem.path, isList)
+  if (!list) {
+    return undefined
+  }
+
+  const itemIndex = list.node.items.findIndex(
+    (item) => item._key === listItem.node._key,
+  )
+  if (itemIndex < 0) {
+    return undefined
+  }
+
+  return {listItem, list, itemIndex}
+}
+
+/**
+ * Build a `select` raise at a collapsed caret, preserving the snapshot's
+ * focus offset. Returns `undefined` when the focus path can't be rebased.
+ */
+function selectAt(snapshot: EditorSnapshot, path: Path | undefined) {
+  if (!path) {
+    return undefined
+  }
+  const offset = snapshot.context.selection?.focus.offset ?? 0
+  return raise({
+    type: 'select' as const,
+    at: {anchor: {path, offset}, focus: {path, offset}},
+  })
+}
+
+type Raise = ReturnType<typeof raise>
+
+// ---------------------------------------------------------------------------
+// Behaviors
+// ---------------------------------------------------------------------------
+
+/**
+ * Tab: sink the focus list-item one level deeper.
+ *
+ * - First item in its list: wrap the item in a fresh list inside a fresh
+ *   parent list-item, replacing itself.
+ * - Previous sibling's last child is a list: append the focus item to it
+ *   (kind-agnostic - the destination list owns its kind).
+ * - Otherwise: append a fresh list (source kind) holding the focus item to
+ *   the previous sibling's content.
+ */
+const sinkOnTab = defineBehavior({
+  on: 'keyboard.keydown',
+  guard: ({snapshot, event}) => {
+    if (!defaultKeyboardShortcuts.tab.guard(event.originEvent)) {
+      return false
+    }
+    const focus = resolveFocus(snapshot)
+    if (!focus) {
+      return false
+    }
+    const focusPath = snapshot.context.selection?.focus.path
+    if (!focusPath) {
+      return false
+    }
+
+    const {listItem, list, itemIndex} = focus
+    const keyGen = snapshot.context.keyGenerator
+    const sourceKind = list.node.kind
+    const raises: Array<Raise> = []
+
+    if (itemIndex === 0) {
+      // Wrap self in a fresh list inside a fresh parent list-item.
+      const wrapperList = newList(keyGen, sourceKind, [listItem.node])
+      const wrapper = newListItem(keyGen, [wrapperList])
+      raises.push(
+        raise({type: 'unset', at: listItem.path}),
+        raise({
+          type: 'insert',
+          at: [...list.path, 'items', 0],
+          value: wrapper,
+          position: 'before',
+        }),
+      )
+      const select = selectAt(
+        snapshot,
+        rebaseFocus(focusPath, listItem.node._key, [
+          ...childPath(list.path, 'items', wrapper),
+          ...childPath([], 'content', wrapperList),
+          'items',
+          {_key: listItem.node._key},
+        ]),
+      )
+      if (select) {
+        raises.push(select)
+      }
+      return {raises}
+    }
+
+    const prevSibling = getSibling(snapshot, listItem.path, 'previous')
+    if (!prevSibling || !isListItem(prevSibling.node)) {
+      return false
+    }
+    const prevContent = prevSibling.node.content
+    const trailing = prevContent[prevContent.length - 1]
+
+    if (trailing && isList(trailing)) {
+      // Merge into the trailing list.
+      const trailingListPath = childPath(prevSibling.path, 'content', trailing)
+      const lastItem = trailing.items[trailing.items.length - 1]!
+      raises.push(
+        raise({type: 'unset', at: listItem.path}),
+        raise({
+          type: 'insert',
+          at: childPath(trailingListPath, 'items', lastItem),
+          value: listItem.node,
+          position: 'after',
+        }),
+      )
+      const select = selectAt(
+        snapshot,
+        rebaseFocus(focusPath, listItem.node._key, [
+          ...trailingListPath,
+          'items',
+          {_key: listItem.node._key},
+        ]),
+      )
+      if (select) {
+        raises.push(select)
+      }
+      return {raises}
+    }
+
+    // Wrap in a fresh list, append to prev sibling's content.
+    const fresh = newList(keyGen, sourceKind, [listItem.node])
+    const hasContent = prevContent.length > 0
+    raises.push(
+      raise({type: 'unset', at: listItem.path}),
+      raise({
+        type: 'insert',
+        at: hasContent
+          ? childPath(
+              prevSibling.path,
+              'content',
+              prevContent[prevContent.length - 1] as Keyed,
+            )
+          : [...prevSibling.path, 'content', 0],
+        value: fresh,
+        position: hasContent ? 'after' : 'before',
+      }),
+    )
+    const select = selectAt(
+      snapshot,
+      rebaseFocus(focusPath, listItem.node._key, [
+        ...childPath(prevSibling.path, 'content', fresh),
+        'items',
+        {_key: listItem.node._key},
+      ]),
+    )
+    if (select) {
+      raises.push(select)
+    }
+    return {raises}
+  },
+  actions: [(_, {raises}) => raises],
+})
+
+/**
+ * Shift+Tab: lift the focus list-item one level out.
+ *
+ * - Promoted to be a sibling of its enclosing list-item.
+ * - Trailing siblings in the original nested list come along as a nested list
+ *   under the lifted item (preserves document order).
+ * - Leading siblings stay in the original nested list. If it becomes empty,
+ *   it's removed.
+ * - If the enclosing list-item's only content was the original nested list,
+ *   it's removed too.
+ * - At the outermost list (no parent list-item), Shift+Tab is a no-op.
+ */
+const liftOnShiftTab = defineBehavior({
+  on: 'keyboard.keydown',
+  guard: ({snapshot, event}) => {
+    if (!defaultKeyboardShortcuts.shiftTab.guard(event.originEvent)) {
+      return false
+    }
+    const focus = resolveFocus(snapshot)
+    if (!focus) {
+      return false
+    }
+    const focusPath = snapshot.context.selection?.focus.path
+    if (!focusPath) {
+      return false
+    }
+
+    const {listItem, list, itemIndex} = focus
+    const keyGen = snapshot.context.keyGenerator
+
+    const parentListItem = getAncestor(snapshot, list.path, isListItem)
+    if (!parentListItem) {
+      return false
+    }
+    const parentList = getAncestor(snapshot, parentListItem.path, isList)
+    if (!parentList) {
+      return false
+    }
+
+    const itemsAfter = list.node.items.slice(itemIndex + 1)
+    const isFirstItem = itemIndex === 0
+    const sourceKind = list.node.kind
+
+    // Trailing siblings (if any) come along as a nested list of the source kind.
+    const liftedItem: ListItemNode =
+      itemsAfter.length > 0
+        ? {
+            ...listItem.node,
+            content: [
+              ...listItem.node.content,
+              newList(keyGen, sourceKind, itemsAfter),
+            ],
+          }
+        : listItem.node
+
+    const raises: Array<Raise> = [
+      // Insert first - source paths still resolve against the snapshot's tree,
+      // and the destination anchor (parent list-item) is still valid.
+      raise({
+        type: 'insert',
+        at: childPath(parentList.path, 'items', parentListItem.node),
+        value: liftedItem,
+        position: 'after',
+      }),
+    ]
+
+    if (isFirstItem) {
+      // Original nested list is now empty; remove it.
+      raises.push(raise({type: 'unset', at: list.path}))
+      // If the parent list-item held only that list, remove it too.
+      if (parentListItem.node.content.length === 1) {
+        raises.push(raise({type: 'unset', at: parentListItem.path}))
+      }
+    } else {
+      // Remove the lifted item and any trailing siblings (they came along).
+      raises.push(raise({type: 'unset', at: listItem.path}))
+      for (const item of itemsAfter) {
+        raises.push(
+          raise({type: 'unset', at: childPath(list.path, 'items', item)}),
+        )
+      }
+    }
+
+    const select = selectAt(
+      snapshot,
+      rebaseFocus(
+        focusPath,
+        listItem.node._key,
+        childPath(parentList.path, 'items', listItem.node),
+      ),
+    )
+    if (select) {
+      raises.push(select)
+    }
+
+    return {raises}
+  },
+  actions: [(_, {raises}) => raises],
+})
+
+// ---------------------------------------------------------------------------
+// Plugin component + test runner wiring
+// ---------------------------------------------------------------------------
+
+function StructuredListsPlugin() {
+  const editor = useEditor()
+  useEffect(() => {
+    const unregisters = [
+      editor.registerContainer(listContainer),
+      editor.registerContainer(listItemContainer),
+      editor.registerContainer(codeBlockContainer),
+      editor.registerBehavior({behavior: sinkOnTab}),
+      editor.registerBehavior({behavior: liftOnShiftTab}),
+    ]
+    return () => {
+      for (const unregister of unregisters) {
+        unregister()
+      }
+    }
+  }, [editor])
+  return null
+}
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        schemaDefinition,
+        children: <StructuredListsPlugin />,
+      })
+
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: pluginStructuredListsFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -540,3 +540,89 @@ describe('round-trip', () => {
     ).toBe(input)
   })
 })
+
+describe('fromTextspec with self-referential schemas', () => {
+  // Schema with a self-referential list (list-item.content.of can hold
+  // another list). The resolver pre-emits two depth levels of candidates;
+  // anything deeper relies on lookupContainer's scope-pattern fallback.
+  const recursiveListSchema = compileSchema(
+    defineSchema({
+      blockObjects: [
+        {
+          name: 'list',
+          fields: [
+            {name: 'kind', type: 'string'},
+            {
+              name: 'items',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'list-item',
+                  fields: [
+                    {
+                      name: 'content',
+                      type: 'array',
+                      of: [{type: 'block'}, {type: 'list'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+  const recursiveContainers: Containers = resolveContainers(
+    recursiveListSchema,
+    new Map([
+      [
+        '$..list',
+        makeContainerConfig(recursiveListSchema, {
+          scope: '$..list',
+          field: 'items',
+        }),
+      ],
+      [
+        '$..list.list-item',
+        makeContainerConfig(recursiveListSchema, {
+          scope: '$..list.list-item',
+          field: 'content',
+        }),
+      ],
+    ]),
+  )
+
+  test('parses a list nested three levels deep with a deep text block', () => {
+    const input = [
+      'LIST:',
+      '  LIST-ITEM:',
+      '    LIST:',
+      '      LIST-ITEM:',
+      '        LIST:',
+      '          LIST-ITEM:',
+      '            B: deepest',
+    ].join('\n')
+
+    const {blocks} = fromTextspec(
+      {
+        schema: recursiveListSchema,
+        keyGenerator: createTestKeyGenerator(),
+        containers: recursiveContainers,
+      },
+      input,
+    )
+
+    // Round-trip: the parsed value, when serialized back, equals the input.
+    expect(
+      toTextspec({
+        schema: recursiveListSchema,
+        value: blocks,
+        selection: null,
+        containers: recursiveContainers,
+      }),
+    ).toBe(input)
+  })
+})

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -14,6 +14,7 @@ import type {
   Block as TextspecBlock,
 } from '@textspec/notation'
 import {parse} from '@textspec/notation'
+import {lookupContainer} from '../src/schema/lookup-container'
 import type {Containers} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
@@ -356,12 +357,16 @@ function isListContainer(type: string): boolean {
 /**
  * Resolve the scope path for a container block type.
  *
- * For root-level containers, finds the matching key in the containers map
- * by comparing uppercased type names.
+ * For root-level containers, walks the parent schema's root types (read
+ * from registered root containers) and matches by uppercased type name.
  *
  * For nested containers, looks through the parent container's `of` array
  * to find a member whose uppercased type matches the textspec type,
  * then builds the scoped name.
+ *
+ * Uses `lookupContainer` so the resolved scope path resolves at any
+ * nesting depth (including depths beyond the resolver's pre-emitted
+ * candidate set, for self-referential schemas).
  */
 function resolveContainerScopePath(
   containers: Containers,
@@ -371,7 +376,6 @@ function resolveContainerScopePath(
   if (parentScopePath === '') {
     // Root-level: find a container key whose uppercased form matches
     for (const key of containers.keys()) {
-      // Root-level keys have no dots
       if (!key.includes('.') && key.toUpperCase() === textspecType) {
         return key
       }
@@ -380,7 +384,7 @@ function resolveContainerScopePath(
   }
 
   // Nested: look through parent container's `of` array
-  const parentField = containers.get(parentScopePath)?.field
+  const parentField = lookupContainer(containers, parentScopePath)?.field
 
   if (!parentField) {
     return undefined
@@ -390,7 +394,7 @@ function resolveContainerScopePath(
     const memberType = ofMember.name ?? ofMember.type
     if (memberType.toUpperCase() === textspecType) {
       const childScopePath = `${parentScopePath}.${memberType}`
-      if (containers.has(childScopePath)) {
+      if (lookupContainer(containers, childScopePath)) {
         return childScopePath
       }
     }
@@ -406,7 +410,7 @@ function convertContainerToPTE(
   keyGenerator: () => string,
   scopePath: string,
 ): PortableTextObject {
-  const containerField = containers.get(scopePath)?.field
+  const containerField = lookupContainer(containers, scopePath)?.field
 
   if (!containerField) {
     return {

--- a/packages/editor/test-utils/text-selection.ts
+++ b/packages/editor/test-utils/text-selection.ts
@@ -1,10 +1,82 @@
-import {isSpan, isTextBlock} from '@portabletext/schema'
+import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {EditorContext} from '../src/editor/editor-snapshot'
 import {safeStringify} from '../src/internal-utils/safe-json'
+import {lookupContainer} from '../src/schema/lookup-container'
+import type {Path, PathSegment} from '../src/slate/interfaces/path'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 import {collapseSelection} from './collapse-selection'
 import {splitString} from './split-string'
 import {stringOverlap} from './string-overlap'
+
+type TextBlockEntry = {
+  block: PortableTextBlock
+  path: Path
+}
+
+/**
+ * Recursively walk the value to collect every text block paired with its
+ * full path, descending through registered editable containers.
+ */
+function collectTextBlocks(
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
+): Array<TextBlockEntry> {
+  const entries: Array<TextBlockEntry> = []
+  walkBlocks(context, context.value, [], '', entries)
+  return entries
+}
+
+function walkBlocks(
+  context: Pick<EditorContext, 'schema' | 'containers'>,
+  blocks: ReadonlyArray<unknown>,
+  basePath: Path,
+  scopePath: string,
+  entries: Array<TextBlockEntry>,
+): void {
+  for (const block of blocks) {
+    if (
+      typeof block !== 'object' ||
+      block === null ||
+      typeof (block as {_key?: unknown})._key !== 'string'
+    ) {
+      continue
+    }
+    const _key = (block as {_key: string})._key
+    const path: Path = [...basePath, {_key} as PathSegment]
+
+    if (isTextBlock(context, block as PortableTextBlock)) {
+      entries.push({block: block as PortableTextBlock, path})
+      continue
+    }
+
+    const containerScope =
+      typeof (block as {_type?: unknown})._type === 'string'
+        ? scopePath === ''
+          ? (block as {_type: string})._type
+          : `${scopePath}.${(block as {_type: string})._type}`
+        : ''
+    if (!containerScope) {
+      continue
+    }
+    const container = lookupContainer(context.containers, containerScope)
+    if (!container) {
+      continue
+    }
+
+    const fieldName = container.field.name
+    const fieldValue = (block as Record<string, unknown>)[fieldName]
+    if (!Array.isArray(fieldValue)) {
+      continue
+    }
+
+    walkBlocks(
+      context,
+      fieldValue,
+      [...path, fieldName],
+      containerScope,
+      entries,
+    )
+  }
+}
 
 /**
  * Throw an error if the selection cannot be found.
@@ -12,87 +84,69 @@ import {stringOverlap} from './string-overlap'
  * Only to be used in tests.
  */
 export function getTextSelection(
-  context: Pick<EditorContext, 'schema' | 'value'>,
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   text: string,
 ): NonNullable<EditorSelection> {
   let anchor: EditorSelectionPoint | undefined
   let focus: EditorSelectionPoint | undefined
 
-  for (const block of context.value) {
-    if (isTextBlock(context, block)) {
-      for (const child of block.children) {
-        if (isSpan(context, child)) {
-          if (child.text === text) {
+  for (const {block, path} of collectTextBlocks(context)) {
+    if (!isTextBlock(context, block)) {
+      continue
+    }
+    for (const child of block.children) {
+      if (isSpan(context, child)) {
+        const childPath: Path = [...path, 'children', {_key: child._key}]
+
+        if (child.text === text) {
+          anchor = {path: childPath, offset: 0}
+          focus = {path: childPath, offset: text.length}
+          break
+        }
+
+        const splitChildText = splitString(child.text, text)
+
+        if (splitChildText[0] === '' && splitChildText[1] !== '') {
+          anchor = {path: childPath, offset: 0}
+          focus = {path: childPath, offset: text.length}
+          break
+        }
+
+        if (
+          splitChildText[0] !== '' &&
+          splitChildText[1] === '' &&
+          child.text.indexOf(text) !== -1
+        ) {
+          anchor = {
+            path: childPath,
+            offset: child.text.length - text.length,
+          }
+          focus = {path: childPath, offset: child.text.length}
+          break
+        }
+
+        if (splitChildText[0] !== '' && splitChildText[1] !== '') {
+          anchor = {path: childPath, offset: splitChildText[0].length}
+          focus = {
+            path: childPath,
+            offset: splitChildText[0].length + text.length,
+          }
+          break
+        }
+
+        const overlap = stringOverlap(child.text, text)
+
+        if (overlap !== '') {
+          if (child.text.lastIndexOf(overlap) >= 0 && !anchor) {
             anchor = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: 0,
+              path: childPath,
+              offset: child.text.lastIndexOf(overlap),
             }
-            focus = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: text.length,
-            }
-            break
+            continue
           }
 
-          const splitChildText = splitString(child.text, text)
-
-          if (splitChildText[0] === '' && splitChildText[1] !== '') {
-            anchor = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: 0,
-            }
-            focus = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: text.length,
-            }
-            break
-          }
-
-          if (
-            splitChildText[0] !== '' &&
-            splitChildText[1] === '' &&
-            child.text.indexOf(text) !== -1
-          ) {
-            anchor = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: child.text.length - text.length,
-            }
-            focus = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: child.text.length,
-            }
-            break
-          }
-
-          if (splitChildText[0] !== '' && splitChildText[1] !== '') {
-            anchor = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: splitChildText[0].length,
-            }
-            focus = {
-              path: [{_key: block._key}, 'children', {_key: child._key}],
-              offset: splitChildText[0].length + text.length,
-            }
-            break
-          }
-
-          const overlap = stringOverlap(child.text, text)
-
-          if (overlap !== '') {
-            if (child.text.lastIndexOf(overlap) >= 0 && !anchor) {
-              anchor = {
-                path: [{_key: block._key}, 'children', {_key: child._key}],
-                offset: child.text.lastIndexOf(overlap),
-              }
-              continue
-            }
-
-            if (child.text.indexOf(overlap) === 0) {
-              focus = {
-                path: [{_key: block._key}, 'children', {_key: child._key}],
-                offset: overlap.length,
-              }
-            }
+          if (child.text.indexOf(overlap) === 0) {
+            focus = {path: childPath, offset: overlap.length}
           }
         }
       }
@@ -118,7 +172,7 @@ export function getTextSelection(
  * Only to be used in tests.
  */
 export function getSelectionBeforeText(
-  context: Pick<EditorContext, 'schema' | 'value'>,
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   text: string,
 ): NonNullable<EditorSelection> {
   return collapseSelection(getTextSelection(context, text), 'start')
@@ -130,7 +184,7 @@ export function getSelectionBeforeText(
  * Only to be used in tests.
  */
 export function getSelectionAfterText(
-  context: Pick<EditorContext, 'schema' | 'value'>,
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   text: string,
 ): NonNullable<EditorSelection> {
   return collapseSelection(getTextSelection(context, text), 'end')

--- a/packages/editor/tests/event.select.test.tsx
+++ b/packages/editor/tests/event.select.test.tsx
@@ -79,10 +79,7 @@ describe('event.select', () => {
     await initialSelectionPromise
 
     const beforeFooSelection = getSelectionBeforeText(
-      {
-        schema: editor.getSnapshot().context.schema,
-        value: editor.getSnapshot().context.value,
-      },
+      editor.getSnapshot().context,
       'foo',
     )
     editor.send({

--- a/packages/editor/tests/self-solving.test.tsx
+++ b/packages/editor/tests/self-solving.test.tsx
@@ -90,7 +90,11 @@ describe('Feature: Self-solving', () => {
     editor.send({
       type: 'select',
       at: getTextSelection(
-        {schema: compileSchema(schemaDefinition), value: initialValue},
+        {
+          schema: compileSchema(schemaDefinition),
+          value: initialValue,
+          containers: new Map(),
+        },
         'foo',
       ),
     })


### PR DESCRIPTION
A real PTE plugin that represents lists as recursive containers and exercises a small set of gherkin scenarios for `Tab` and `Shift+Tab`. The point is to prove that the keyboard semantics customers expect from a list editor are expressible by composing a few primitive behavior events - `unset`, `insert`, and `select` - against a fully-typed schema. No `update value` calls, no behavior-internal tree rewrites.

### The schema

`list` and `list-item` are block-objects.

- `list.items` is an array of `list-item`.
- `list-item.content` is an array of text blocks, images, code-blocks, or another `list`.
- `list.kind` is a string ("number", "bullet", etc).

The same shape backs the demo in the v7 release post.

### What the plugin does

#### `Tab` - sink the focus list-item

If the previous sibling's last child is already a list, the focus item is appended to that list - kind-agnostic, because the destination list owns its kind. If the previous sibling's last child is anything else, the focus item is wrapped in a fresh list using the source list's kind.

#### `Shift+Tab` - lift the focus list-item

The focus item is promoted to be a sibling of its enclosing list-item.

- Trailing siblings come along as a nested list under the lifted item (so document order is preserved without auto-promoting items the user didn't ask to move).
- Leading siblings stay in the original nested list. If it ends up empty, the original list is removed.
- At the outermost list - when there's no parent list-item to be a sibling of - `Shift+Tab` is a no-op.

Both behaviors compose the same primitives: `unset` the focus item from its current location, `insert` the moved subtree at the destination, then explicit `select` to re-anchor the cursor (the engine's `transformPoint` nullifies a selection when its path-ancestor is `unset`, matching every existing core structural-move behavior).

### Commits

1. `test: resolve container scopes recursively when parsing textspec into portable text` - the `fromTextspec` test util used `containers.has`/`containers.get` directly, so depth-3+ recursive containers fell through to void block-objects when parsing textspec input. Three sites migrated to `lookupContainer`. Mirrors the `toTextspec` work in #2633 and the runtime fix in #2631.
2. `test: resolve container scopes recursively in textspec caret lookup` - the textspec caret helpers (`getSelectionBeforeText`/`getSelectionAfterText`/`getTextSelection`) only inspected root-level text blocks, so caret placement against text inside a list-item or code-block silently fell through to an empty selection. The helpers now traverse registered editable containers.
3. `test: add a structured-lists plugin composing list-item sink/lift from primitive events` - the plugin itself and nine gherkin scenarios covering Tab, Shift+Tab, first-item-no-op, trailing-list-merge, middle-item-with-trailing-siblings, sole-nested-item, outermost-no-op, image-preserved-on-sink, and content-mix-on-lift.