### PR TITLE
fix: resolve container scopes recursively when parsing textspec into portable text

### DIFF
--- a/.changeset/from-textspec-recursive-containers.md
+++ b/.changeset/from-textspec-recursive-containers.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve container scopes recursively when parsing textspec into portable text
+
+Tests using `@portabletext/editor/test/vitest` step definitions to drive scenarios with self-referential containers (e.g. lists nested inside list-items nested inside lists) can now express any nesting depth. Previously, the textspec → portable text parser used exact-key lookups against the schema resolver's bounded candidate set, so containers nested deeper than two levels fell through to void block-objects.

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -540,3 +540,89 @@ describe('round-trip', () => {
     ).toBe(input)
   })
 })
+
+describe('fromTextspec with self-referential schemas', () => {
+  // Schema with a self-referential list (list-item.content.of can hold
+  // another list). The resolver pre-emits two depth levels of candidates;
+  // anything deeper relies on lookupContainer's scope-pattern fallback.
+  const recursiveListSchema = compileSchema(
+    defineSchema({
+      blockObjects: [
+        {
+          name: 'list',
+          fields: [
+            {name: 'kind', type: 'string'},
+            {
+              name: 'items',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'list-item',
+                  fields: [
+                    {
+                      name: 'content',
+                      type: 'array',
+                      of: [{type: 'block'}, {type: 'list'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+  const recursiveContainers: Containers = resolveContainers(
+    recursiveListSchema,
+    new Map([
+      [
+        '$..list',
+        makeContainerConfig(recursiveListSchema, {
+          scope: '$..list',
+          field: 'items',
+        }),
+      ],
+      [
+        '$..list.list-item',
+        makeContainerConfig(recursiveListSchema, {
+          scope: '$..list.list-item',
+          field: 'content',
+        }),
+      ],
+    ]),
+  )
+
+  test('parses a list nested three levels deep with a deep text block', () => {
+    const input = [
+      'LIST:',
+      '  LIST-ITEM:',
+      '    LIST:',
+      '      LIST-ITEM:',
+      '        LIST:',
+      '          LIST-ITEM:',
+      '            B: deepest',
+    ].join('\n')
+
+    const {blocks} = fromTextspec(
+      {
+        schema: recursiveListSchema,
+        keyGenerator: createTestKeyGenerator(),
+        containers: recursiveContainers,
+      },
+      input,
+    )
+
+    // Round-trip: the parsed value, when serialized back, equals the input.
+    expect(
+      toTextspec({
+        schema: recursiveListSchema,
+        value: blocks,
+        selection: null,
+        containers: recursiveContainers,
+      }),
+    ).toBe(input)
+  })
+})

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -14,6 +14,7 @@ import type {
   Block as TextspecBlock,
 } from '@textspec/notation'
 import {parse} from '@textspec/notation'
+import {lookupContainer} from '../src/schema/lookup-container'
 import type {Containers} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
@@ -356,12 +357,16 @@ function isListContainer(type: string): boolean {
 /**
  * Resolve the scope path for a container block type.
  *
- * For root-level containers, finds the matching key in the containers map
- * by comparing uppercased type names.
+ * For root-level containers, walks the parent schema's root types (read
+ * from registered root containers) and matches by uppercased type name.
  *
  * For nested containers, looks through the parent container's `of` array
  * to find a member whose uppercased type matches the textspec type,
  * then builds the scoped name.
+ *
+ * Uses `lookupContainer` so the resolved scope path resolves at any
+ * nesting depth (including depths beyond the resolver's pre-emitted
+ * candidate set, for self-referential schemas).
  */
 function resolveContainerScopePath(
   containers: Containers,
@@ -371,7 +376,6 @@ function resolveContainerScopePath(
   if (parentScopePath === '') {
     // Root-level: find a container key whose uppercased form matches
     for (const key of containers.keys()) {
-      // Root-level keys have no dots
       if (!key.includes('.') && key.toUpperCase() === textspecType) {
         return key
       }
@@ -380,7 +384,7 @@ function resolveContainerScopePath(
   }
 
   // Nested: look through parent container's `of` array
-  const parentField = containers.get(parentScopePath)?.field
+  const parentField = lookupContainer(containers, parentScopePath)?.field
 
   if (!parentField) {
     return undefined
@@ -390,7 +394,7 @@ function resolveContainerScopePath(
     const memberType = ofMember.name ?? ofMember.type
     if (memberType.toUpperCase() === textspecType) {
       const childScopePath = `${parentScopePath}.${memberType}`
-      if (containers.has(childScopePath)) {
+      if (lookupContainer(containers, childScopePath)) {
         return childScopePath
       }
     }
@@ -406,7 +410,7 @@ function convertContainerToPTE(
   keyGenerator: () => string,
   scopePath: string,
 ): PortableTextObject {
-  const containerField = containers.get(scopePath)?.field
+  const containerField = lookupContainer(containers, scopePath)?.field
 
   if (!containerField) {
     return {


### PR DESCRIPTION
Surfaced while building gherkin scenarios for a future structured-lists plugin (#2635) — `fromTextspec` falls back to void block-objects when a container nests deeper than the schema resolver's bounded candidate set, the same bug class fixed in `toTextspec` by #2633.

For a self-referential schema where a `list-item.content.of` references the parent `list`, the resolver pre-emits depth-2 candidates (`list`, `list.list-item`, `list.list-item.list`). Runtime data nested at depth 3+ used `containers.has(scopedName)` and `containers.get(scopedName)?.field`, which both miss for keys outside that set. Routes through `lookupContainer` now, picking up the scope-pattern fallback that was already wired for runtime rendering.

The new round-trip test in `from-textspec.test.ts` parses a list nested three levels deep and asserts that serializing it back via `toTextspec` produces the original input. Verified by breaking: reverting the `lookupContainer` swap in `convertContainerToPTE` makes the test fail (the deepest list-item drops out of the round-trip).