### PR TITLE
feat: promote primitive operations as @alpha behavior events

### DIFF
--- a/.changeset/promote-primitive-events.md
+++ b/.changeset/promote-primitive-events.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote primitive operations as `@alpha` behavior events
+
+Five primitive events expose the apply-layer surface to plugins that need to express tree mutations the synthetic tier doesn't cover: `set`, `unset`, `insert`, `remove.text` are new, and `insert.text` evolves to accept optional `at` and `offset` (existing callers raising `{type: 'insert.text', text}` keep working). Plugins composing structural moves can now raise `[unset, insert]` directly instead of working around the synthetic shape.

--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -1,4 +1,9 @@
-import type {PortableTextBlock} from '@portabletext/schema'
+import type {
+  PortableTextBlock,
+  PortableTextObject,
+  PortableTextSpan,
+  PortableTextTextBlock,
+} from '@portabletext/schema'
 import type {EventPosition} from '../internal-utils/event-position'
 import type {MIMEType} from '../internal-utils/mime-type'
 import type {OmitFromUnion, PickFromUnion, StrictExtract} from '../type-utils'
@@ -7,7 +12,7 @@ import type {
   ChildWithOptionalKey,
 } from '../types/block-with-optional-key'
 import type {EditorSelection} from '../types/editor'
-import type {AnnotationPath, BlockPath, ChildPath} from '../types/paths'
+import type {AnnotationPath, BlockPath, ChildPath, Path} from '../types/paths'
 
 /**
  * @beta
@@ -72,13 +77,17 @@ const syntheticBehaviorEventTypes = [
   'delete',
   'history.redo',
   'history.undo',
+  'insert',
   'insert.block',
   'insert.child',
   'insert.text',
   'move.backward',
   'move.block',
   'move.forward',
+  'remove.text',
   'select',
+  'set',
+  'unset',
 ] as const
 
 type SyntheticBehaviorEventType =
@@ -157,6 +166,34 @@ export type SyntheticBehaviorEvent =
       type: StrictExtract<SyntheticBehaviorEventType, 'history.undo'>
     }
   | {
+      /**
+       * @alpha
+       *
+       * Primitive: insert a node into an array.
+       *
+       * The last segment of `at` resolves the insertion point:
+       * - A keyed `{_key}` segment inserts relative to that sibling.
+       * - A numeric index inserts relative to that slot.
+       *
+       * `position` ('before' or 'after') is always meaningful: `before: [2]`
+       * inserts at index 2, `after: [2]` inserts at index 3.
+       *
+       * @example
+       * ```ts
+       * raise({
+       *   type: 'insert',
+       *   at: [{_key: 'list'}, 'items', {_key: 'item3'}],
+       *   value: newItem,
+       *   position: 'after',
+       * })
+       * ```
+       */
+      type: StrictExtract<SyntheticBehaviorEventType, 'insert'>
+      at: Path
+      value: PortableTextTextBlock | PortableTextObject | PortableTextSpan
+      position: 'before' | 'after'
+    }
+  | {
       type: StrictExtract<SyntheticBehaviorEventType, 'insert.block'>
       block: BlockWithOptionalKey
       placement: InsertPlacement
@@ -168,7 +205,33 @@ export type SyntheticBehaviorEvent =
       child: ChildWithOptionalKey
     }
   | {
+      /**
+       * Inserts text into a span.
+       *
+       * Without `at`/`offset`, text is inserted at the current caret position.
+       * This is the form used by typing handlers.
+       *
+       * @alpha
+       * With `at` and `offset`, text is inserted at the explicit position.
+       * Recommended for plugin behaviors and collaborative-edit contexts.
+       *
+       * @example
+       * ```ts
+       * // Caret form
+       * raise({type: 'insert.text', text: 'x'})
+       *
+       * // Primitive form (@alpha)
+       * raise({
+       *   type: 'insert.text',
+       *   at: [{_key: 'b1'}, 'children', {_key: 's1'}],
+       *   offset: 5,
+       *   text: 'world',
+       * })
+       * ```
+       */
       type: StrictExtract<SyntheticBehaviorEventType, 'insert.text'>
+      at?: Path
+      offset?: number
       text: string
     }
   | {
@@ -185,8 +248,86 @@ export type SyntheticBehaviorEvent =
       distance: number
     }
   | {
+      /**
+       * @alpha
+       *
+       * Primitive: remove text from a span at the given offset.
+       *
+       * The `text` field carries the exact text being removed (matches the
+       * apply-layer shape so the inverse can be computed without re-reading
+       * the span).
+       *
+       * Recommended for collaborative-edit contexts (concurrent edits compose
+       * cleanly under operational transform).
+       *
+       * @example
+       * ```ts
+       * raise({
+       *   type: 'remove.text',
+       *   at: [{_key: 'b1'}, 'children', {_key: 's1'}],
+       *   offset: 5,
+       *   text: 'world',
+       * })
+       * ```
+       */
+      type: StrictExtract<SyntheticBehaviorEventType, 'remove.text'>
+      at: Path
+      offset: number
+      text: string
+    }
+  | {
       type: StrictExtract<SyntheticBehaviorEventType, 'select'>
       at: EditorSelection
+    }
+  | {
+      /**
+       * @alpha
+       *
+       * Primitive: set a property on a node, or replace a node wholesale.
+       *
+       * The last segment of `at` is the property name (a string) for property
+       * updates, OR a keyed/indexed segment for full-node replacement.
+       *
+       * Note: `set` on span text (`{at: [...spanPath, 'text'], value: '...'}`)
+       * is legal but not recommended in collaborative-edit contexts. Use
+       * `insert.text` and `remove.text` for text edits that compose under
+       * operational transform.
+       *
+       * @example
+       * ```ts
+       * // Set a block's style
+       * raise({type: 'set', at: [{_key: 'b1'}, 'style'], value: 'h1'})
+       *
+       * // Replace a block wholesale
+       * raise({type: 'set', at: [{_key: 'b1'}], value: newBlock})
+       * ```
+       */
+      type: StrictExtract<SyntheticBehaviorEventType, 'set'>
+      at: Path
+      value: unknown
+    }
+  | {
+      /**
+       * @alpha
+       *
+       * Primitive: unset a property on an object, OR remove a node from an
+       * array.
+       *
+       * When the last segment of `at` is a string, the property is removed.
+       * When the last segment is a keyed `{_key}` segment or a numeric index,
+       * the node at that array position is removed.
+       *
+       * @example
+       * ```ts
+       * // Remove a property
+       * raise({type: 'unset', at: [{_key: 'b1'}, 'level']})
+       *
+       * // Remove a node from an array
+       * raise({type: 'unset', at: [{_key: 'list'}, 'items', {_key: 'item3'}]})
+       * ```
+       */
+      type: StrictExtract<SyntheticBehaviorEventType, 'unset'>
+      at: Path
     }
   | AbstractBehaviorEvent
 

--- a/packages/editor/src/operations/operation.insert.text.ts
+++ b/packages/editor/src/operations/operation.insert.text.ts
@@ -11,6 +11,25 @@ export const insertTextOperationImplementation: OperationImplementation<
   'insert.text'
 > = ({operation}) => {
   const {editor} = operation
+
+  // Primitive form: caller provided explicit position. Apply directly without
+  // touching selection.
+  if (operation.at !== undefined && operation.offset !== undefined) {
+    if (operation.text.length === 0) {
+      return
+    }
+
+    operation.editor.apply({
+      type: 'insert_text',
+      path: operation.at,
+      offset: operation.offset,
+      text: operation.text,
+    })
+
+    return
+  }
+
+  // Caret form: resolve position from the current selection.
   const {selection} = editor
 
   if (!selection || !isCollapsedRange(selection)) {

--- a/packages/editor/src/operations/operation.insert.ts
+++ b/packages/editor/src/operations/operation.insert.ts
@@ -1,0 +1,12 @@
+import type {OperationImplementation} from './operation.types'
+
+export const insertOperationImplementation: OperationImplementation<
+  'insert'
+> = ({operation}) => {
+  operation.editor.apply({
+    type: 'insert',
+    path: operation.at,
+    node: operation.value,
+    position: operation.position,
+  })
+}

--- a/packages/editor/src/operations/operation.perform.ts
+++ b/packages/editor/src/operations/operation.perform.ts
@@ -11,18 +11,22 @@ import {decoratorRemoveOperationImplementation} from './operation.decorator.remo
 import {deleteOperationImplementation} from './operation.delete'
 import {historyRedoOperationImplementation} from './operation.history.redo'
 import {historyUndoOperationImplementation} from './operation.history.undo'
+import {insertOperationImplementation} from './operation.insert'
 import {insertBlockOperationImplementation} from './operation.insert.block'
 import {insertChildOperationImplementation} from './operation.insert.child'
 import {insertTextOperationImplementation} from './operation.insert.text'
 import {moveBackwardOperationImplementation} from './operation.move.backward'
 import {moveBlockOperationImplementation} from './operation.move.block'
 import {moveForwardOperationImplementation} from './operation.move.forward'
+import {removeTextOperationImplementation} from './operation.remove.text'
 import {selectOperationImplementation} from './operation.select'
+import {setOperationImplementation} from './operation.set'
 import type {
   Operation,
   OperationImplementations,
   OperationSnapshot,
 } from './operation.types'
+import {unsetOperationImplementation} from './operation.unset'
 
 const operationImplementations: OperationImplementations = {
   'annotation.add': addAnnotationOperationImplementation,
@@ -36,13 +40,17 @@ const operationImplementations: OperationImplementations = {
   'delete': deleteOperationImplementation,
   'history.redo': historyRedoOperationImplementation,
   'history.undo': historyUndoOperationImplementation,
+  'insert': insertOperationImplementation,
   'insert.block': insertBlockOperationImplementation,
   'insert.child': insertChildOperationImplementation,
   'insert.text': insertTextOperationImplementation,
   'move.backward': moveBackwardOperationImplementation,
   'move.block': moveBlockOperationImplementation,
   'move.forward': moveForwardOperationImplementation,
+  'remove.text': removeTextOperationImplementation,
   'select': selectOperationImplementation,
+  'set': setOperationImplementation,
+  'unset': unsetOperationImplementation,
 }
 
 export function performOperation({

--- a/packages/editor/src/operations/operation.remove.text.ts
+++ b/packages/editor/src/operations/operation.remove.text.ts
@@ -1,0 +1,12 @@
+import type {OperationImplementation} from './operation.types'
+
+export const removeTextOperationImplementation: OperationImplementation<
+  'remove.text'
+> = ({operation}) => {
+  operation.editor.apply({
+    type: 'remove_text',
+    path: operation.at,
+    offset: operation.offset,
+    text: operation.text,
+  })
+}

--- a/packages/editor/src/operations/operation.set.ts
+++ b/packages/editor/src/operations/operation.set.ts
@@ -1,0 +1,11 @@
+import type {OperationImplementation} from './operation.types'
+
+export const setOperationImplementation: OperationImplementation<'set'> = ({
+  operation,
+}) => {
+  operation.editor.apply({
+    type: 'set',
+    path: operation.at,
+    value: operation.value,
+  })
+}

--- a/packages/editor/src/operations/operation.unset.ts
+++ b/packages/editor/src/operations/operation.unset.ts
@@ -1,0 +1,10 @@
+import type {OperationImplementation} from './operation.types'
+
+export const unsetOperationImplementation: OperationImplementation<'unset'> = ({
+  operation,
+}) => {
+  operation.editor.apply({
+    type: 'unset',
+    path: operation.at,
+  })
+}

--- a/packages/editor/tests/event.insert.test.tsx
+++ b/packages/editor/tests/event.insert.test.tsx
@@ -1,0 +1,47 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.insert', () => {
+  test('Scenario: insert a node into an array', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'insert',
+      at: [{_key: 'b0'}, 'children', {_key: 's0'}],
+      value: {_key: 's1', _type: 'span', text: 'bar', marks: ['strong']},
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [
+            {_key: 's0', _type: 'span', text: 'foo', marks: []},
+            {_key: 's1', _type: 'span', text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.insert.text.test.tsx
+++ b/packages/editor/tests/event.insert.text.test.tsx
@@ -453,4 +453,42 @@ describe('event.insert.text', () => {
       )
     })
   })
+
+  test('Scenario: `insert.text` at an explicit position', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'insert.text',
+      at: [{_key: 'b0'}, 'children', {_key: 's0'}],
+      offset: 5,
+      text: ' world',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello world', marks: []},
+          ],
+          markDefs: [],
+        },
+      ])
+    })
+  })
 })

--- a/packages/editor/tests/event.remove.text.test.tsx
+++ b/packages/editor/tests/event.remove.text.test.tsx
@@ -1,0 +1,44 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.remove.text', () => {
+  test('Scenario: remove.text at an explicit position', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello world', marks: []},
+          ],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'remove.text',
+      at: [{_key: 'b0'}, 'children', {_key: 's0'}],
+      offset: 5,
+      text: ' world',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.set.test.tsx
+++ b/packages/editor/tests/event.set.test.tsx
@@ -1,0 +1,39 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.set', () => {
+  test('Scenario: set on a block property', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        styles: [{name: 'normal'}, {name: 'h1'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({type: 'set', at: [{_key: 'b0'}, 'style'], value: 'h1'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'h1',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.unset.test.tsx
+++ b/packages/editor/tests/event.unset.test.tsx
@@ -1,0 +1,82 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.unset', () => {
+  test('Scenario: unset a property on a block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        styles: [{name: 'normal'}],
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          listItem: 'bullet',
+          level: 1,
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({type: 'unset', at: [{_key: 'b0'}, 'level']})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          listItem: 'bullet',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: unset removes a node from an array', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [
+            {_key: 's0', _type: 'span', text: 'foo', marks: []},
+            {_key: 's1', _type: 'span', text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'unset',
+      at: [{_key: 'b0'}, 'children', {_key: 's1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Today's behavior events are a synthetic tier (`block.set`, `child.set`, `insert.block`, etc.) that resolve through `operation.X.ts` files into apply-layer primitives. The apply-layer primitives already exist and are correct. They just aren't reachable from behaviors.

Plugins that need to express tree mutations the synthetic tier doesn't cover end up reimplementing tree-restructuring logic in user code, or working around the synthetic shape with helpers like the selection-rebuild logic in the structured-lists plugin.

This PR exposes the apply-layer primitives as first-class behavior events at `@alpha`. Plugins that need primitive shape get it. The synthetic tier stays as conveniences for the cases it already handles well.

## What's new

Five `@alpha` events:

```ts
{type: 'set', at: Path, value: unknown}
{type: 'unset', at: Path}
{type: 'insert', at: Path, value: PortableTextTextBlock | PortableTextObject | PortableTextSpan, position: 'before' | 'after'}
{type: 'remove.text', at: Path, offset: number, text: string}
```

Each event mirrors the apply-layer op shape 1:1. Operation handlers forward straight through.

Plus today's `insert.text` event evolves: the `at` and `offset` fields become optional. When omitted, position is resolved from `editor.selection` (the existing typing-handler behavior). When provided, text is inserted at the explicit position.

```ts
// Caret form (existing, unchanged)
raise({type: 'insert.text', text: 'x'})

// Primitive form (@alpha, new)
raise({
  type: 'insert.text',
  at: [{_key: 'b1'}, 'children', {_key: 's1'}],
  offset: 5,
  text: 'world',
})
```

Existing consumers raising `{type: 'insert.text', text: 'x'}` keep working unchanged.

## Why this shape, not a new event

The apply-layer op is `insert_text` with `path/offset/text`. Today's `insert.text` is the high-level "insert at caret" wrapper around it. Both are valuable. Renaming today's event would break consumers (Studio's typing handlers raise it directly). Adding a parallel event with a different name duplicates the API surface.

Decomposing the existing event with optional position is the cleanest path: existing callers untouched, new callers can be precise, one operation handler with a single fallback branch.

## Convention: text edits

`set` and `unset` are LEGAL on span text:
- `set {at: [...spanPath, 'text'], value: 'newText'}` replaces span text wholesale
- `unset {at: [...spanPath, 'text']}` removes span text

But they are NOT recommended for collaborative editing. Wholesale text replacement breaks operational transform: concurrent edits get clobbered by last-write-wins. First-class behaviors (keyboard handlers, IME handlers, paste handlers, plugin behaviors that mutate text in response to user actions) should use `insert.text` and `remove.text` instead.

`set`/`unset` on text are appropriate for migrations, programmatic value loaders, test fixtures, and contexts that aren't participating in real-time collab. JSDoc on each event calls this out.

## What's NOT in this PR

- Renaming or removing today's synthetic events. `block.set`, `child.set`, `insert.block`, etc. stay. They become thinner wrappers over the new primitives over time, but their public surface doesn't change.
- Selection auto-tracking through `[unset, insert]` for cross-depth move. `unset`'s apply layer already transforms selection points; `insert` doesn't auto-rebase. Behaviors composing structural moves currently raise an explicit `select` after, which works today. Auto-tracking is a follow-up.
- Migrating the structured-lists plugin to use `[unset, insert]` instead of `block.set`. Follow-up.
- History plugin rework. Today works; cleanups possible as primitives stabilize.
- Patches plugin rework. Today works.
- Operations directory cleanup. Operation files keep existing.

## Tests

Each new event has its own home alongside the existing `event.*.test.tsx` convention:
- `event.set.test.tsx` (1 scenario)
- `event.unset.test.tsx` (2 scenarios: property removal + array-member removal)
- `event.insert.test.tsx` (1 scenario)
- `event.remove.text.test.tsx` (1 scenario)
- `event.insert.text.test.tsx` gains 1 scenario for the explicit-position form alongside the existing 9 caret-form tests

All existing event tests continue to pass: the `insert.text` decomposition is purely additive.