### PR TITLE
fix: match drop-position by full path

### DIFF
--- a/.changeset/drop-position-path-match.md
+++ b/.changeset/drop-position-path-match.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: match drop-position by full path so the indicator is unambiguous when a deep block shares a `_key` with a root-level sibling

--- a/packages/editor/src/behaviors/behavior.core.drop-position.ts
+++ b/packages/editor/src/behaviors/behavior.core.drop-position.ts
@@ -6,12 +6,13 @@ import {getDragSelection} from '../selectors/drag-selection'
 import {getFocusBlock} from '../selectors/selector.get-focus-block'
 import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
+import type {Path} from '../slate/interfaces/path'
 import {forward} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 export type DropPosition = {
-  blockKey: string
-  positionBlock: EventPositionBlock
+  path: Path
+  position: EventPositionBlock
 }
 
 export function createDropPositionBehaviorsConfig({
@@ -84,8 +85,8 @@ export function createDropPositionBehaviorsConfig({
               type: 'effect',
               effect: () => {
                 setDropPosition({
-                  blockKey: dropFocusBlock.node._key,
-                  positionBlock: event.position.block,
+                  path: dropFocusBlock.path,
+                  position: event.position.block,
                 })
               },
             },

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -15,7 +15,7 @@ import {SelectionStateContext} from './selection-state-context'
 export function RenderBlockObject(props: {
   attributes: RenderElementProps['attributes']
   blockObject: PortableTextObject | undefined
-  dropPosition?: DropPosition['positionBlock']
+  dropPosition?: DropPosition['position']
   children: ReactElement
   element: PortableTextObject
   leafConfig?: LeafConfig

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -26,6 +26,7 @@ import {RenderContainer} from './render.container'
 import {RenderInlineObject} from './render.inline-object'
 import {useLeafConfig} from './render.leaf-config'
 import {RenderTextBlock} from './render.text-block'
+import {resolveElementDropPosition} from './resolve-element-drop-position'
 
 export function RenderElement(props: {
   attributes: RenderElementProps['attributes']
@@ -87,11 +88,10 @@ export function RenderElement(props: {
     return (
       <RenderTextBlock
         attributes={props.attributes}
-        dropPosition={
-          props.dropPosition?.blockKey === props.element._key
-            ? props.dropPosition.positionBlock
-            : undefined
-        }
+        dropPosition={resolveElementDropPosition(
+          props.dropPosition,
+          props.path,
+        )}
         element={props.element}
         path={props.path}
         readOnly={props.readOnly}
@@ -159,11 +159,7 @@ export function RenderElement(props: {
     <RenderBlockObject
       attributes={props.attributes}
       blockObject={props.element}
-      dropPosition={
-        props.dropPosition?.blockKey === props.element._key
-          ? props.dropPosition.positionBlock
-          : undefined
-      }
+      dropPosition={resolveElementDropPosition(props.dropPosition, props.path)}
       element={props.element}
       leafConfig={leafConfig}
       path={props.path}

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -24,7 +24,7 @@ import {useBlockSubSchema} from './use-block-sub-schema'
 export function RenderTextBlock(props: {
   attributes: RenderElementProps['attributes']
   children: ReactElement
-  dropPosition?: DropPosition['positionBlock']
+  dropPosition?: DropPosition['position']
   element: PortableTextTextBlock
   path: Path
   readOnly: boolean

--- a/packages/editor/src/editor/resolve-element-drop-position.test.ts
+++ b/packages/editor/src/editor/resolve-element-drop-position.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, test} from 'vitest'
+import {resolveElementDropPosition} from './resolve-element-drop-position'
+
+describe(resolveElementDropPosition.name, () => {
+  test('returns undefined when no drop position is active', () => {
+    expect(resolveElementDropPosition(undefined, [{_key: 'k0'}])).toEqual(
+      undefined,
+    )
+  })
+
+  test('matches the drop target by full path', () => {
+    expect(
+      resolveElementDropPosition({path: [{_key: 'k0'}], position: 'start'}, [
+        {_key: 'k0'},
+      ]),
+    ).toEqual('start')
+
+    expect(
+      resolveElementDropPosition({path: [{_key: 'k0'}], position: 'end'}, [
+        {_key: 'k0'},
+      ]),
+    ).toEqual('end')
+  })
+
+  test('returns undefined when the element is not the drop target', () => {
+    expect(
+      resolveElementDropPosition({path: [{_key: 'k0'}], position: 'start'}, [
+        {_key: 'k1'},
+      ]),
+    ).toEqual(undefined)
+  })
+
+  test('does not match a deep block that shares a key with the drop target at root', () => {
+    // _keys are sibling-unique, not tree-unique. A root block at
+    // [{_key:'k0'}] and a deep block at
+    // [{_key:'callout'}, 'content', {_key:'k0'}] can both legally have
+    // `_key: 'k0'`. A key-only match would paint the drop indicator on
+    // both. Path-based match correctly disambiguates.
+    expect(
+      resolveElementDropPosition({path: [{_key: 'k0'}], position: 'start'}, [
+        {_key: 'callout'},
+        'content',
+        {_key: 'k0'},
+      ]),
+    ).toEqual(undefined)
+  })
+
+  test('matches a deep block targeted by its full path', () => {
+    expect(
+      resolveElementDropPosition(
+        {
+          path: [{_key: 'callout'}, 'content', {_key: 'k0'}],
+          position: 'end',
+        },
+        [{_key: 'callout'}, 'content', {_key: 'k0'}],
+      ),
+    ).toEqual('end')
+  })
+})

--- a/packages/editor/src/editor/resolve-element-drop-position.ts
+++ b/packages/editor/src/editor/resolve-element-drop-position.ts
@@ -1,0 +1,27 @@
+import type {DropPosition} from '../behaviors/behavior.core.drop-position'
+import type {Path} from '../slate/interfaces/path'
+import {pathEquals} from '../slate/path/path-equals'
+
+/**
+ * Returns the `position` of a drop hover when the hover targets the given
+ * element path; `undefined` otherwise.
+ *
+ * Path-based match — works at any depth. Comparing by `_key` alone is
+ * ambiguous because keys are sibling-unique, not tree-unique: two blocks
+ * at different depths can share the same `_key` and a key-only match
+ * would paint the indicator on both.
+ */
+export function resolveElementDropPosition(
+  dropPosition: DropPosition | undefined,
+  elementPath: Path,
+): DropPosition['position'] | undefined {
+  if (!dropPosition) {
+    return undefined
+  }
+
+  if (!pathEquals(dropPosition.path, elementPath)) {
+    return undefined
+  }
+
+  return dropPosition.position
+}


### PR DESCRIPTION
Today the drop-position payload threaded into `RenderContainer`, `RenderTextBlock`, and `RenderBlockObject` is `{blockKey, positionBlock}`. Per-element matching compares `dropPosition.blockKey === element._key`. That comparison is ambiguous: keys are sibling-unique, not tree-unique. A root block at `[{_key:'k0'}]` and a deep block inside a container at `[{_key:'callout'},'content',{_key:'k0'}]` can both legally carry `_key: 'k0'` - `normalize-node` only fixes duplicate keys among siblings, not across branches. Today's flat document is fine because `_key` IS unique among root-level blocks; the moment content nests, the indicator can paint on both blocks during a drag.

This PR switches the payload to `{path, position}` and matches per-element via `pathEquals`. Same indicator behavior at the root, unambiguous at any depth.

The match is extracted to `resolveElementDropPosition` - a pure helper with unit tests covering: root-level match, deep match, the shared-key disambiguation case (where a key-only matcher would paint the indicator on the wrong block), no-match between siblings, and absence of a drop position. Verify-by-breaking on the helper's path comparison: replaced with a key-only match, the deep-vs-root test fails as expected; restored, all five tests pass.

## What changed

- `behavior.core.drop-position.ts`: `DropPosition` shape is now `{path: Path, position: EventPositionBlock}`. Producer reads `dropFocusBlock.path` instead of `dropFocusBlock.node._key`.
- `render.element.tsx`: replaces the inlined `dropPosition?.blockKey === element._key` comparisons with the shared `resolveElementDropPosition` helper.
- New `resolve-element-drop-position.ts` and `resolve-element-drop-position.test.ts` - 5 unit tests, including the depth-shared-key case.
- `RenderTextBlock` / `RenderBlockObject` keep the `dropPosition?: DropPosition['position']` prop name (renamed type accessor only).

The 7 existing `event.drag.drop` tests continue to pass.