### PR TITLE
fix: compare drag origin against drop target by full path, not key

### DIFF
--- a/.changeset/dragover-key-collision.md
+++ b/.changeset/dragover-key-collision.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: compare drag origin against drop target by full path, not key

--- a/packages/editor/src/behaviors/behavior.core.drop-position.ts
+++ b/packages/editor/src/behaviors/behavior.core.drop-position.ts
@@ -7,6 +7,7 @@ import {getFocusBlock} from '../selectors/selector.get-focus-block'
 import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import type {Path} from '../slate/interfaces/path'
+import {pathEquals} from '../slate/path/path-equals'
 import {forward} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -57,9 +58,8 @@ export function createDropPositionBehaviorsConfig({
           })
 
           if (
-            draggedBlocks.some(
-              (draggedBlock) =>
-                draggedBlock.node._key === dropFocusBlock.node._key,
+            draggedBlocks.some((draggedBlock) =>
+              pathEquals(draggedBlock.path, dropFocusBlock.path),
             )
           ) {
             return false


### PR DESCRIPTION
The `drag.dragover` self-drop guard in `behavior.core.drop-position.ts` discriminates "is the cursor over a dragged block?" by comparing `_key` strings. Same bug class as #2638 fixed in the render layer: keys are sibling-unique, not tree-unique. `normalize-node` fixes duplicates among siblings (`src/slate/core/normalize-node.ts:163, :480`), never across branches. Today's flat document hides it because root-level keys are unique among siblings. The moment content nests inside containers, two cells in two rows can have the same `_key`, and dragging onto one suppresses the indicator on the other.

One-line swap: `draggedBlock.node._key === dropFocusBlock.node._key` → `pathEquals(draggedBlock.path, dropFocusBlock.path)`. Closes the depth-shared-key bug class wherever dnd discrimination runs.

7/7 existing dnd browser tests green.