### PR TITLE
feat: pass dropPosition to defineContainer's render callback

### DIFF
--- a/.changeset/container-render-drop-position.md
+++ b/.changeset/container-render-drop-position.md
@@ -1,0 +1,19 @@
+---
+"@portabletext/editor": minor
+---
+
+feat: pass `dropPosition` to `defineContainer`'s render callback
+
+Containers receive the resolved drop position (`'start' | 'end' | undefined`) when a drag targets the container's block boundary. Consumers paint their own drop indicator using whatever DOM and styling they prefer:
+
+```tsx
+defineContainer({
+  scope: '$..callout',
+  field: 'content',
+  render: ({attributes, children, dropPosition}) => (
+    <div {...attributes} data-drop-position={dropPosition}>
+      {children}
+    </div>
+  ),
+})
+```

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -42,14 +42,15 @@ function ToneIcon({tone}: {tone: string}): JSX.Element {
 const calloutContainer = defineContainer<typeof playgroundSchemaDefinition>({
   scope: '$..callout',
   field: 'content',
-  render: ({attributes, children, node, selected}) => {
+  render: ({attributes, children, dropPosition, node, selected}) => {
     const tone = typeof node.tone === 'string' ? node.tone : 'note'
     const toneStyle = toneClassName[tone] ?? defaultToneClassName
     return (
       <aside
         {...attributes}
+        data-drop-position={dropPosition}
         data-selected={selected ? '' : undefined}
-        className={`my-3 flex gap-2.5 rounded-md border-l-4 px-4 py-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
+        className={`relative my-3 flex gap-2.5 rounded-md border-l-4 px-4 py-3 transition-shadow data-[drop-position=end]:after:absolute data-[drop-position=start]:before:absolute data-[drop-position=end]:after:inset-x-0 data-[drop-position=start]:before:inset-x-0 data-[drop-position=end]:after:-bottom-px data-[drop-position=start]:before:-top-px data-[drop-position=end]:after:h-[2px] data-[drop-position=start]:before:h-[2px] data-[drop-position=end]:after:bg-current data-[drop-position=start]:before:bg-current data-[selected]:shadow-md ${toneStyle}`}
       >
         <span
           contentEditable={false}

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -12,8 +12,9 @@ import {SelectionStateContext} from './selection-state-context'
 export function RenderContainer(props: {
   attributes: RenderElementProps['attributes']
   children: ReactElement
-  element: PortableTextBlock
   containerConfig: ContainerConfig
+  dropPosition: 'start' | 'end' | undefined
+  element: PortableTextBlock
   path: Path
 }) {
   const {focusedContainerPath, selectedContainerPaths} = useContext(
@@ -49,6 +50,7 @@ export function RenderContainer(props: {
     const rendered = props.containerConfig.container.render({
       attributes: augmentedAttributes,
       children: props.children,
+      dropPosition: props.dropPosition,
       focused,
       node: props.element,
       path: props.path,

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -67,8 +67,12 @@ export function RenderElement(props: {
     return (
       <RenderContainer
         attributes={props.attributes}
-        element={props.element}
         containerConfig={containerConfig}
+        dropPosition={resolveElementDropPosition(
+          props.dropPosition,
+          props.path,
+        )}
+        element={props.element}
         path={props.path}
       >
         {props.children}

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -24,6 +24,7 @@ export type ContainerDefinition = {
   render?: (props: {
     attributes: Record<string, unknown>
     children: ReactElement
+    dropPosition: 'start' | 'end' | undefined
     focused: boolean
     node: PortableTextBlock
     path: Path
@@ -108,6 +109,7 @@ type SchemaContainerConfig<TSchema extends SchemaDefinition> =
             render?: (props: {
               attributes: Record<string, unknown>
               children: ReactElement
+              dropPosition: 'start' | 'end' | undefined
               focused: boolean
               node: ScopedContainerNode<TScope>
               path: Path

--- a/packages/editor/tests/container-render-drop-position.test.tsx
+++ b/packages/editor/tests/container-render-drop-position.test.tsx
@@ -1,0 +1,158 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const calloutSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+describe('container render dropPosition', () => {
+  test('passes dropPosition undefined to the render callback when no drag is in progress', async () => {
+    const dropPositions: Array<'start' | 'end' | undefined> = []
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'callout',
+          content: [
+            {
+              _type: 'block',
+              _key: 'inner',
+              children: [{_type: 'span', _key: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof calloutSchema>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children, dropPosition}) => {
+                dropPositions.push(dropPosition)
+                return <div {...attributes}>{children}</div>
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    expect(dropPositions.length).toBeGreaterThan(0)
+    expect(dropPositions.every((p) => p === undefined)).toBe(true)
+  })
+
+  test('passes dropPosition to the render callback when a drag targets the container', async () => {
+    const dropPositions: Array<'start' | 'end' | undefined> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'callout',
+          content: [
+            {
+              _type: 'block',
+              _key: 'inner',
+              children: [{_type: 'span', _key: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'sibling',
+          children: [
+            {_type: 'span', _key: 'sibling-span', text: 'sibling', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <ContainerPlugin
+          containers={[
+            defineContainer<typeof calloutSchema>({
+              scope: '$..callout',
+              field: 'content',
+              render: ({attributes, children, dropPosition}) => {
+                dropPositions.push(dropPosition)
+                return (
+                  <aside {...attributes} data-drop-position={dropPosition}>
+                    {children}
+                  </aside>
+                )
+              },
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const siblingSelection = {
+      anchor: {
+        path: [{_key: 'sibling'}, 'children', {_key: 'sibling-span'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'sibling'}, 'children', {_key: 'sibling-span'}],
+        offset: 7,
+      },
+    }
+
+    const calloutStartSelection = {
+      anchor: {
+        path: [{_key: 'callout'}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: 'callout'}],
+        offset: 0,
+      },
+    }
+
+    const dataTransfer = new DataTransfer()
+
+    // Start drag from the sibling text block (drag-origin is required for
+    // the drop-position behavior to track the drop target).
+    editor.send({
+      type: 'drag.dragstart',
+      originEvent: {clientX: 0, clientY: 0, dataTransfer},
+      position: {selection: siblingSelection},
+    })
+
+    // Drag over the callout block at its start edge.
+    editor.send({
+      type: 'drag.dragover',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: siblingSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: calloutStartSelection,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(dropPositions.at(-1)).toBe('start')
+    })
+  })
+})


### PR DESCRIPTION
Today `defineContainer`'s render callback receives the engine's path-resolved focused/selected/readOnly state for the container, but not the resolved drop position. Legacy block-objects already auto-paint a drop indicator via the engine. Containers couldn't, because the data wasn't plumbed through.

This passes `dropPosition: 'start' | 'end' | undefined` to the render callback when a drag targets the container's block boundary. Consumers paint their own indicator using whatever DOM and styling they prefer:

```tsx
defineContainer({
  scope: '$..callout',
  field: 'content',
  render: ({attributes, children, dropPosition}) => (
    <aside {...attributes} data-drop-position={dropPosition}>
      {children}
    </aside>
  ),
})
```

The resolution reuses the same path-based match the legacy pipeline uses (`resolveElementDropPosition`). No new engine logic, no new subscriptions, no new public hooks. Containers that don't reference `dropPosition` in their render callback pay zero extra cost during a drag.

The playground callout demonstrates the pattern with a thin top/bottom border painted via Tailwind data-attribute selectors.