### PR TITLE
test(editor): scope `createTestEditor`'s returned locator to the rendered editor

### DIFF
--- a/packages/editor/src/test/vitest/test-editor.tsx
+++ b/packages/editor/src/test/vitest/test-editor.tsx
@@ -83,7 +83,7 @@ export async function createTestEditor(
         ))
   }
 
-  const locator = page.getByRole('textbox')
+  const locator = renderResult.locator.getByRole('textbox')
 
   await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
 

--- a/packages/editor/tests/test-editor.test.tsx
+++ b/packages/editor/tests/test-editor.test.tsx
@@ -1,0 +1,33 @@
+import {expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+/**
+ * Regression test for `createTestEditor`'s locator scoping.
+ *
+ * Each call to `createTestEditor` mounts its own editor into a fresh
+ * container via `render()`. The returned locator must target that
+ * specific editor instance - not any other `[role="textbox"]` that
+ * happens to live in the same document, in document order.
+ *
+ * Before the fix, the function discarded the scoped locator from
+ * `render()` and built a document-wide `page.getByRole('textbox')`
+ * lookup, so any second editor in the DOM would be addressed by the
+ * first call's locator. Vitest's iframe-per-test isolation kept this
+ * latent in CI; embedders that share a DOM across editors hit it.
+ */
+
+test('returns a locator scoped to the rendered editor', async () => {
+  const first = await createTestEditor()
+  const second = await createTestEditor()
+
+  await userEvent.type(first.locator, 'first')
+  await userEvent.type(second.locator, 'second')
+
+  await vi.waitFor(() => {
+    expect(toTextspec(first.editor.getSnapshot().context)).toEqual('B: first|')
+  })
+
+  expect(toTextspec(second.editor.getSnapshot().context)).toEqual('B: second|')
+})


### PR DESCRIPTION
`createTestEditor` from `@portabletext/editor/test/vitest` mounts the editor through `vitest-browser-react`'s `render()`, which returns a locator scoped to the freshly-mounted container. It then discarded that scoped locator and reached for `page.getByRole('textbox')` instead.

```ts
const renderResult = await render(<EditorProvider>...</EditorProvider>)

// ...

const locator = page.getByRole('textbox')  // unscoped: document-wide
```

Two calls in the same DOM expose the bug. The second call's `page.getByRole('textbox')` matches both editors in document order, returns the first match, so the second locator addresses the first editor instead of its own. Vitest's iframe-per-test isolation hid this in CI; embedders running multiple editors in the same DOM (a Sanity Studio form with two PT inputs, an integration host with a playground next to a test target, anything driven by Playwright that doesn't iframe each scenario) trip it.

Fix is one line: use the scoped locator that `render()` already returned.

The accompanying regression test mounts two editors, types into each, and asserts each editor ends up with its own content. The test fails on `main` because the second editor's locator targets the first, so the second `userEvent.type` writes into the first editor and the second editor's snapshot stays empty.

`createTestEditors` (plural) already scopes by `data-testid` per-editor; nothing changes there.
