### PR TITLE
feat(racetrack): a hosted playground and scenario-driven test runner for PTE plugins

### DIFF
--- a/.changeset/test-editor-scoped-locator.md
+++ b/.changeset/test-editor-scoped-locator.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: scope `createTestEditor`'s returned locator to the rendered editor
+
+`createTestEditor` from `@portabletext/editor/test/vitest` discarded the scoped locator from its underlying `render()` and built a document-wide `page.getByRole('textbox')` lookup. Two calls in the same DOM would have the second one's locator address the first editor. Vitest's iframe-per-test isolation hid this; embedders that share a DOM across editors hit it.
+
+Use the scoped locator from `render()` so each editor's locator targets exactly that editor.

--- a/apps/racetrack/README.md
+++ b/apps/racetrack/README.md
@@ -1,19 +1,44 @@
-# Racetrack
+# Racetrack (v0 POC)
 
-A hosted playground and scenario-driven test runner for Portable Text Editor plugins.
+Hosted playground and scenario-driven test runner for Portable Text Editor
+plugins. The customer writes their plugin once, drops it into Racetrack,
+authors scenarios visually, and watches them go green. The same `.feature`
+file runs here AND in the customer's vitest CI, with identical results.
 
-This directory is the skeleton of the Racetrack app. The actual functionality (visual scenario authoring, in-browser scenario runner, plugin garage, engine viewer) is being built on the `feat/racetrack` long-running branch and lands on this skeleton over time.
+This v0 POC is hard-coded to the mention-picker plugin and exists to
+prove the loop end-to-end across three panels:
 
-## Develop
+1. **Scenarios** (left): the `.feature` file rendered with a status dot
+   per step.
+2. **Playground** (centre): a live editor with the mention-picker plugin
+   wired in for human exploration.
+3. **Runner** (right): a "Run scenarios" button that spins up an isolated
+   editor and drives it through every scenario, painting pass/fail
+   results back into the left panel.
+
+## How the shim works
+
+Step definitions live in `@portabletext/editor/test/vitest` and import
+from `vitest/browser` (for `userEvent`, `page`, `expect.element`) and
+`vitest` (for `vi.waitFor`, `expect`, `assert`). Those are virtual
+modules that vitest's runtime injects during browser tests.
+
+Racetrack does not run inside vitest, so `vite.config.ts` aliases
+`vitest/browser`, `vitest`, and `vitest-browser-react` to local shims
+in `src/runner/`. The shims implement just enough surface to cover the
+call sites in `step-definitions.tsx` and `test-editor.tsx`. Anything
+not covered throws a loud error so missing coverage shows up
+immediately rather than silently passing.
+
+The same source code therefore runs in two contexts:
+
+- in the customer's vitest CI, against the real `vitest/browser` runtime
+- in Racetrack, against our shims that wrap `@testing-library/user-event`
+  and a tiny `page` / `expect` polyfill
+
+## Local dev
 
 ```
+pnpm install
 pnpm --filter racetrack dev
 ```
-
-## Build
-
-```
-pnpm --filter racetrack build
-```
-
-The build output goes to `apps/racetrack/dist/` and is suitable for static hosting.

--- a/apps/racetrack/package.json
+++ b/apps/racetrack/package.json
@@ -14,6 +14,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@cucumber/gherkin": "^39.0.0",
+    "@cucumber/messages": "^32.2.0",
+    "@portabletext/editor": "workspace:*",
+    "@portabletext/plugin-input-rule": "workspace:*",
+    "@portabletext/plugin-typeahead-picker": "workspace:*",
+    "@portabletext/schema": "workspace:*",
+    "@testing-library/user-event": "^14.5.2",
+    "racejar": "workspace:*",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/apps/racetrack/src/App.tsx
+++ b/apps/racetrack/src/App.tsx
@@ -1,23 +1,110 @@
-/**
- * Racetrack landing page.
- *
- * A teaser - just the name. The real app is being built on the
- * `feat/racetrack` long-running branch and replaces this over time
- * via Vercel preview deploys.
- */
+import {useMemo, useState} from 'react'
+import {garage} from './garage'
+import {EnginePanel} from './panels/EnginePanel'
+import {PlaygroundPanel} from './panels/PlaygroundPanel'
+import {RunnerPanel} from './panels/RunnerPanel'
+import {ScenariosPanel} from './panels/ScenariosPanel'
+import type {ScenarioResult, StepStatus} from './runner/browser-runner'
+import {parseFeature} from './runner/feature-parser'
+
+export type StepKey = `${number}-${number}`
+
+export type StepState = {
+  status: StepStatus
+  error?: Error
+}
 
 export function App() {
+  const [entryId, setEntryId] = useState(garage[0]!.id)
+  const entry = garage.find((e) => e.id === entryId) ?? garage[0]!
+
+  const feature = useMemo(() => parseFeature(entry.featureText), [entry])
+
+  const [stepStates, setStepStates] = useState<Map<StepKey, StepState>>(
+    () => new Map(),
+  )
+  const [scenarioResults, setScenarioResults] = useState<Array<ScenarioResult>>(
+    [],
+  )
+  const [isRunning, setIsRunning] = useState(false)
+
+  function resetRun() {
+    setStepStates(new Map())
+    setScenarioResults([])
+  }
+
+  function updateStep(
+    scenarioIndex: number,
+    stepIndex: number,
+    state: StepState,
+  ) {
+    setStepStates((prev) => {
+      const next = new Map(prev)
+      next.set(`${scenarioIndex}-${stepIndex}`, state)
+      return next
+    })
+  }
+
+  function handleEntryChange(nextId: string) {
+    if (isRunning) {
+      return
+    }
+    setEntryId(nextId)
+    resetRun()
+  }
+
   return (
-    <main className="rt-shell">
-      <section className="rt-tease">
-        <div className="rt-tease-mark" aria-hidden>
-          <span className="rt-dot rt-dot--pass" />
-          <span className="rt-dot rt-dot--running" />
-          <span className="rt-dot rt-dot--fail" />
-        </div>
-        <h1 className="rt-tease-name">Racetrack</h1>
-        <p className="rt-tease-tag">Coming to the Portable Text paddock.</p>
-      </section>
-    </main>
+    <div className="rt-app">
+      <header className="rt-header">
+        <span className="rt-header-title">Racetrack</span>
+        <label className="rt-entry-picker">
+          <span className="rt-entry-picker-label">Now racing:</span>
+          <select
+            className="rt-entry-picker-select"
+            value={entry.id}
+            disabled={isRunning}
+            onChange={(event) => handleEntryChange(event.target.value)}
+          >
+            {garage.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+          <span className="rt-entry-picker-description">
+            {entry.description}
+          </span>
+        </label>
+      </header>
+      <div className="rt-panels">
+        <ScenariosPanel
+          feature={feature}
+          stepStates={stepStates}
+          scenarioResults={scenarioResults}
+        />
+        <PlaygroundPanel entry={entry} />
+        <EnginePanel entry={entry} />
+        <RunnerPanel
+          entry={entry}
+          isRunning={isRunning}
+          scenarioResults={scenarioResults}
+          scenarioCount={feature.scenarios.length}
+          onRunStart={() => {
+            resetRun()
+            setIsRunning(true)
+          }}
+          onRunEnd={() => setIsRunning(false)}
+          onStep={(result) => {
+            updateStep(result.scenarioIndex, result.stepIndex, {
+              status: result.status,
+              error: result.error,
+            })
+          }}
+          onScenarioComplete={(result) => {
+            setScenarioResults((prev) => [...prev, result])
+          }}
+        />
+      </div>
+    </div>
   )
 }

--- a/apps/racetrack/src/garage/index.ts
+++ b/apps/racetrack/src/garage/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Registry of Racetrack garage entries. Add new plugins by importing
+ * their entry module and appending to the array.
+ */
+
+import {inputRuleEdgeCasesEntry} from './input-rule-edge-cases/entry'
+import {mentionPickerEntry} from './mention-picker/entry'
+import type {GarageEntry} from './types'
+
+export const garage: Array<GarageEntry> = [
+  mentionPickerEntry,
+  inputRuleEdgeCasesEntry,
+]
+
+export type {GarageEntry} from './types'

--- a/apps/racetrack/src/garage/input-rule-edge-cases/Plugin.tsx
+++ b/apps/racetrack/src/garage/input-rule-edge-cases/Plugin.tsx
@@ -1,0 +1,83 @@
+/**
+ * Plugin host for the input-rule edge-cases garage entry.
+ *
+ * Lifts the rule wiring from
+ * `packages/plugin-input-rule/src/edge-cases.test.tsx` so the same
+ * `.feature` file runs unchanged in Racetrack.
+ */
+
+import {getPreviousInlineObject} from '@portabletext/editor/selectors'
+import {
+  defineTextTransformRule,
+  InputRulePlugin,
+} from '@portabletext/plugin-input-rule'
+
+const longerTransformRule = defineTextTransformRule({
+  on: /\./,
+  transform: () => '...',
+})
+
+const endStringRule = defineTextTransformRule({
+  on: /->$/,
+  transform: () => '→',
+})
+
+const nonGlobalRule = defineTextTransformRule({
+  on: /\(c\)/,
+  transform: () => '©',
+})
+
+const multipleGroupsRule = defineTextTransformRule({
+  on: /(x)[fo]+(y)/,
+  transform: () => 'z',
+})
+
+const replaceAandCRule = defineTextTransformRule({
+  on: /(A).*(C)/,
+  transform: ({location}: {location: {text: string}}) => {
+    return location.text === 'A' ? 'C' : 'A'
+  },
+})
+
+const h1Rule = defineTextTransformRule({
+  on: /^(# )/,
+  transform: () => '',
+})
+
+const betterH2Rule = defineTextTransformRule({
+  on: /^(## )/,
+  guard: ({
+    snapshot,
+  }: {
+    snapshot: Parameters<typeof getPreviousInlineObject>[0]
+  }) => {
+    return !getPreviousInlineObject(snapshot)
+  },
+  transform: () => '',
+})
+
+const unmatchedGroupsRule = defineTextTransformRule({
+  on: /^(---)|^(—-)|^(___)|^(\*\*\*)/,
+  transform: () => '<hr />',
+})
+
+const multiplicationRule = defineTextTransformRule({
+  on: /\d+\s?([*x])\s?\d+/,
+  transform: () => '×',
+})
+
+export function InputRuleEdgeCasesPlugin() {
+  return (
+    <>
+      <InputRulePlugin rules={[longerTransformRule]} />
+      <InputRulePlugin rules={[endStringRule]} />
+      <InputRulePlugin rules={[nonGlobalRule]} />
+      <InputRulePlugin rules={[multipleGroupsRule]} />
+      <InputRulePlugin rules={[h1Rule]} />
+      <InputRulePlugin rules={[betterH2Rule]} />
+      <InputRulePlugin rules={[replaceAandCRule]} />
+      <InputRulePlugin rules={[unmatchedGroupsRule]} />
+      <InputRulePlugin rules={[multiplicationRule]} />
+    </>
+  )
+}

--- a/apps/racetrack/src/garage/input-rule-edge-cases/entry.tsx
+++ b/apps/racetrack/src/garage/input-rule-edge-cases/entry.tsx
@@ -1,0 +1,49 @@
+/**
+ * Garage entry: input-rule edge cases.
+ *
+ * Nine text-transform rules sharing one editor. Lifted from
+ * `packages/plugin-input-rule/src/edge-cases.test.tsx`. Uses only the
+ * default editor step definitions; the entire `.feature` is declarative
+ * `Given/When/Then` against editor state.
+ */
+
+import {parameterTypes} from '@portabletext/editor/test'
+import {createTestEditor, type Context} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import type {GarageEntry} from '../types'
+import entrySource from './entry.tsx?raw'
+import featureText from './feature.feature?raw'
+import {InputRuleEdgeCasesPlugin} from './Plugin'
+import pluginSource from './Plugin.tsx?raw'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  annotations: [{name: 'link'}],
+  inlineObjects: [{name: 'stock-ticker'}],
+})
+
+export const inputRuleEdgeCasesEntry: GarageEntry = {
+  id: 'input-rule-edge-cases',
+  name: 'Input rule: edge cases',
+  description: 'Nine text-transform rules running side by side.',
+  featureText,
+  engine: [
+    {name: 'Plugin.tsx', language: 'tsx', source: pluginSource},
+    {name: 'entry.tsx', language: 'tsx', source: entrySource},
+    {name: 'feature.feature', language: 'feature', source: featureText},
+  ],
+  PlaygroundComponent: InputRuleEdgeCasesPlugin,
+  parameterTypes,
+  buildStepDefinitions: ({editorStepDefinitions}) => editorStepDefinitions,
+  buildHooks: () => [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        children: <InputRuleEdgeCasesPlugin />,
+        schemaDefinition,
+      })
+      context.editor = editor
+      context.locator = locator
+    }),
+  ],
+}

--- a/apps/racetrack/src/garage/input-rule-edge-cases/feature.feature
+++ b/apps/racetrack/src/garage/input-rule-edge-cases/feature.feature
@@ -1,0 +1,230 @@
+Feature: Edge Cases
+
+  Background:
+    Given a global keymap
+
+  Scenario Outline: Longer Transform
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state         | inserted text | new state                |
+      | "B: "         | "."           | "B: ...new\|"            |
+      | "B: foo"      | "."           | "B: foo...new\|"         |
+      | "B: "         | "foo."        | "B: foo...new\|"         |
+      | "B: foo."     | "."           | "B: foo....new\|"        |
+      | "B: "         | "foo.bar."    | "B: foo...bar...new\|"   |
+      | "B: foo.bar." | "baz."        | "B: foo.bar.baz...new\|" |
+
+  Scenario Outline: End String Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state           | inserted text | new state                |
+      | "B: -\|"        | ">"           | "B: →new\|"              |
+      | "B: "           | "->"          | "B: →new\|"              |
+      | "B: foo"        | "->"          | "B: foo→new\|"           |
+      | "B: "           | "foo->"       | "B: foo→new\|"           |
+      | "B: foo-"       | ">bar"        | "B: foo->barnew\|"       |
+      | "B: "           | "foo->bar->"  | "B: foo->bar→new\|"      |
+      | "B: foo->bar->" | "baz->"       | "B: foo->bar->baz→new\|" |
+
+  Scenario Outline: Non-Global Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state             | inserted text  | new state                  |
+      | "B: (c"           | ")"            | "B: ©new\|"                |
+      | "B: "             | "(c)"          | "B: ©new\|"                |
+      | "B: foo"          | "(c)"          | "B: foo©new\|"             |
+      | "B: "             | "foo(c)"       | "B: foo©new\|"             |
+      | "B: foo(c"        | ")bar"         | "B: foo©barnew\|"          |
+      | "B: "             | "foo(c)bar(c)" | "B: foo©bar©new\|"         |
+      | "B: foo(c)bar(c)" | "baz(c)"       | "B: foo(c)bar(c)baz©new\|" |
+
+  Scenario Outline: Writing after Multiple Groups Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state      | inserted text | new state           |
+      | "B: "      | "xfooy"       | "B: zfooznew\|"     |
+      | "B: xfoo"  | "y"           | "B: zfooznew\|"     |
+      | "B: xfooy" | "z"           | "B: xfooyznew\|"    |
+      | "B: "      | "xfyxoy"      | "B: zfzzoznew\|"    |
+      | "B: "      | "xfyxoyxoy"   | "B: zfzzozzoznew\|" |
+
+  Scenario Outline: Replacing 'a' and 'c'
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state   | inserted text | new state     |
+      | "B: "   | "ABC"         | "B: CBAnew\|" |
+      | "B: AB" | "C"           | "B: CBAnew\|" |
+
+  Scenario Outline: Undoing Multiple Groups Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    Then the editor state is <before undo>
+    When undo is performed
+    Then the editor state is <after undo>
+
+    Examples:
+      | state      | inserted text | before undo      | after undo     |
+      | "B: "      | "xfooy"       | "B: zfooz\|"     | "B: xfooy"     |
+      | "B: xfoo"  | "y"           | "B: zfooz\|"     | "B: xfooy"     |
+      | "B: xfooy" | "z"           | "B: xfooyz\|"    | "B: xfooy"     |
+      | "B: "      | "xfyxoy"      | "B: zfzzoz\|"    | "B: xfyxoy"    |
+      | "B: "      | "xfyxoyxoy"   | "B: zfzzozzoz\|" | "B: xfyxoyxoy" |
+
+  Scenario Outline: Preserving inline objects
+    When the editor is focused
+    Given the text <text>
+    When <inserted text> is inserted
+    And "new" is typed
+    Then the text is <new text>
+
+    Examples:
+      | text                                | inserted text | new text                                |
+      | "(,{stock-ticker},c"                | ")"           | "(,{stock-ticker},c)new"                |
+      | "-,{stock-ticker},"                 | ">"           | "-,{stock-ticker},>new"                 |
+      | ",{stock-ticker},-,{stock-ticker}," | ">"           | ",{stock-ticker},-,{stock-ticker},>new" |
+      | ",{stock-ticker},-"                 | ">"           | ",{stock-ticker},→new"                  |
+
+  Scenario: Preserving adjoining inline object and placing caret correctly
+    Given the editor state is "B: (c{stock-ticker}"
+    When the editor is focused
+    And the caret is put after "c"
+    And ")new" is typed
+    Then the editor state is "B: ©new|{stock-ticker}"
+
+  Scenario: Preserving adjoining inline object and placing caret correctly
+    Given the editor state is "B: #{stock-ticker}"
+    When the editor is focused
+    And the caret is put after "#"
+    And " new" is typed
+    Then the editor state is "B: new|{stock-ticker}"
+
+  Scenario Outline: H1 rule
+    Given the editor state is <state>
+    When the editor is focused
+    And the caret is put <position>
+    And <key> is pressed
+    And "# " is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state                  | position    | key           | new state                     |
+      # Pressing Shift is a noop. It only exists so we can press Backspace in
+      # subsequent Scenarios to position to caret at the edge of the inline
+      # object.
+      | "B: "                  | after ""    | "{Shift}"     | "B: new\|"                    |
+      | "B: foo"               | after "foo" | "{Shift}"     | "B: foo# new\|"               |
+      | "B: {stock-ticker}foo" | after "foo" | "{Shift}"     | "B: {stock-ticker}foo# new\|" |
+      # This is an edge case we have to live with. There's no way of knowing
+      # that the inline object before the caret should prevent the rule from
+      # running.
+      | "B: {stock-ticker}f"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"      |
+      | "B: f{stock-ticker}"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"      |
+
+  Scenario Outline: Better H2 rule
+    Given the editor state is <state>
+    When the editor is focused
+    And the caret is put <position>
+    And <key> is pressed
+    And "## " is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state                  | position    | key           | new state                      |
+      # Pressing Shift is a noop. It only exists so we can press Backspace in
+      # subsequent Scenarios to position to caret at the edge of the inline
+      # object.
+      | "B: "                  | after ""    | "{Shift}"     | "B: new\|"                     |
+      | "B: foo"               | after "foo" | "{Shift}"     | "B: foo## new\|"               |
+      | "B: {stock-ticker}foo" | after "foo" | "{Shift}"     | "B: {stock-ticker}foo## new\|" |
+      | "B: {stock-ticker}f"   | after "f"   | "{Backspace}" | "B: {stock-ticker}## new\|"    |
+      | "B: f{stock-ticker}"   | after "f"   | "{Backspace}" | "B: new\|{stock-ticker}"       |
+
+  Scenario Outline: Unmatched Groups Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And the caret is put <position>
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | position | inserted text | new state        |
+      | "B: " | after "" | "---"         | "B: <hr />new\|" |
+
+  Scenario Outline: Expanded selection
+    Given the editor state is <state>
+    When the editor is focused
+    And <selection> is selected
+    And <inserted text> is inserted
+    And "new" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state             | selection | inserted text | new state      |
+      | "B: (foo"         | "foo"     | "c)"          | "B: ©new\|"    |
+      | "B: (foo"         | "oo"      | "c)"          | "B: (fc)new\|" |
+      | "B: (foo"         | "(foo"    | "c)"          | "B: c)new\|"   |
+      | "B: (coo;;B: bar" | "ooba"    | ")"           | "B: ©new\|r"   |
+
+  Scenario Outline: Undo after transform on expanded selection
+    Given the editor state is <state>
+    When the editor is focused
+    And <selection> is selected
+    And <inserted text> is inserted
+    Then the editor state is <before undo>
+    When undo is performed
+    Then the editor state is <after undo>
+
+    Examples:
+      | state    | selection | inserted text | before undo | after undo |
+      | "B: (cf" | "f"       | ")"           | "B: ©\|"    | "B: (c)"   |
+
+  Scenario: Consecutive undo after selection change
+    Given the editor state is "B: "
+    When "->" is typed
+    And undo is performed
+    And "{ArrowLeft}" is pressed
+    And undo is performed
+    Then the editor state is "B: -|"
+
+  Scenario Outline: Multiple overlapping matches in one insertion
+    Given the editor state is "B: "
+    When "1*2*3" is inserted
+    Then the editor state is "B: 1×2×3|"
+
+  Scenario: Backspace after typing following input rule should delete character
+    Given the editor state is "B: "
+    When "->" is typed
+    Then the editor state is "B: →|"
+    When "foo" is typed
+    Then the editor state is "B: →foo"
+    When "{Backspace}" is pressed
+    Then the editor state is "B: →fo|"

--- a/apps/racetrack/src/garage/mention-picker/Plugin.tsx
+++ b/apps/racetrack/src/garage/mention-picker/Plugin.tsx
@@ -1,0 +1,128 @@
+/**
+ * Mention-picker plugin host, lifted from
+ * `packages/plugin-typeahead-picker/src/mention-picker.test.tsx`.
+ *
+ * `MentionPickerPlugin` is the React component that wires the
+ * typeahead picker into the surrounding `EditorProvider` and renders
+ * the diagnostic `data-testid` nodes (`keyword`, `matches`, `state`,
+ * `selectedIndex`). The scenarios assert against those nodes, so the
+ * markup is kept faithful.
+ *
+ * The picker is defined at module scope (matching the original test
+ * file). Building a new picker per component instance via `useMemo`
+ * triggers infinite re-renders under React StrictMode, because the
+ * picker's internal actor subscription invalidates on each remount.
+ */
+
+import {raise} from '@portabletext/editor/behaviors'
+import {
+  defineTypeaheadPicker,
+  useTypeaheadPicker,
+} from '@portabletext/plugin-typeahead-picker'
+
+type MentionMatch = {
+  key: string
+  name: string
+  username: string
+}
+
+const users: Record<string, Array<string>> = {
+  'John Doe': ['john'],
+  'Jane Smith': ['jane'],
+  'Bob Wilson': ['bob'],
+}
+
+let getMatchesCallCount = 0
+
+export function getMatchesCallCountValue(): number {
+  return getMatchesCallCount
+}
+
+export function resetMatchesCallCount(): void {
+  getMatchesCallCount = 0
+}
+
+async function getMatches({
+  keyword,
+}: {
+  keyword: string
+}): Promise<Array<MentionMatch>> {
+  getMatchesCallCount++
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  const foundUsers: Array<MentionMatch> = []
+  if (keyword.length < 1) {
+    return foundUsers
+  }
+
+  for (const name in users) {
+    const usernames = users[name] ?? []
+    for (const username of usernames) {
+      const keywordIndex = username.indexOf(keyword.toLowerCase())
+      if (keywordIndex === -1) {
+        continue
+      }
+      foundUsers.push({key: `${name}-${username}`, name, username})
+    }
+  }
+  return foundUsers
+}
+
+const mentionPicker = defineTypeaheadPicker<MentionMatch>({
+  mode: 'async',
+  trigger: /@/,
+  keyword: /\w*/,
+  getMatches,
+  onSelect: [
+    ({event}) => [
+      raise({type: 'delete', at: event.patternSelection}),
+      raise({type: 'insert.text', text: event.match.name}),
+    ],
+  ],
+})
+
+function getPickerState<TMatch extends object>(
+  picker: ReturnType<typeof useTypeaheadPicker<TMatch>>,
+): string {
+  if (picker.snapshot.matches('idle')) {
+    return 'idle'
+  }
+  if (picker.snapshot.matches({active: 'loading'})) {
+    return 'loading'
+  }
+  if (picker.snapshot.matches({active: 'no matches'})) {
+    return 'no matches'
+  }
+  if (picker.snapshot.matches({active: 'showing matches'})) {
+    return 'showing matches'
+  }
+  return 'unknown'
+}
+
+export function MentionPickerPlugin() {
+  const typeaheadPicker = useTypeaheadPicker(mentionPicker)
+  const currentState = getPickerState(typeaheadPicker)
+
+  return (
+    <div className="rt-state">
+      <span className="rt-state-label">keyword</span>
+      <span className="rt-state-value" data-testid="keyword">
+        {typeaheadPicker.snapshot.context.keyword}
+      </span>
+      <span className="rt-state-label">matches</span>
+      <span className="rt-state-value" data-testid="matches">
+        {typeaheadPicker.snapshot.context.matches
+          .map((match) => match.name)
+          .join(',')}
+      </span>
+      <span className="rt-state-label">state</span>
+      <span className="rt-state-value" data-testid="state">
+        {currentState}
+      </span>
+      <span className="rt-state-label">selectedIndex</span>
+      <span className="rt-state-value" data-testid="selectedIndex">
+        {typeaheadPicker.snapshot.context.selectedIndex}
+      </span>
+    </div>
+  )
+}

--- a/apps/racetrack/src/garage/mention-picker/entry.tsx
+++ b/apps/racetrack/src/garage/mention-picker/entry.tsx
@@ -1,0 +1,67 @@
+/**
+ * Garage entry: mention picker.
+ *
+ * Lifts the playground / runner wiring from the original
+ * `mention-picker.test.tsx` in `@portabletext/plugin-typeahead-picker`
+ * into a Racetrack-loadable entry. The `.feature` file is the same
+ * file the customer's vitest suite runs.
+ */
+
+import {parameterTypes} from '@portabletext/editor/test'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {expect, vi} from 'vitest'
+import type {GarageEntry} from '../types'
+import entrySource from './entry.tsx?raw'
+import featureText from './feature.feature?raw'
+import {MentionPickerPlugin, resetMatchesCallCount} from './Plugin'
+import pluginSource from './Plugin.tsx?raw'
+import {
+  attachLocators,
+  mentionPickerSteps,
+  type MentionPickerContext,
+} from './steps'
+import stepsSource from './steps.ts?raw'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  annotations: [{name: 'link'}],
+})
+
+export const mentionPickerEntry: GarageEntry = {
+  id: 'mention-picker',
+  name: 'Mention Picker',
+  description: 'Type @ to trigger a typeahead picker with async match lookup.',
+  featureText,
+  engine: [
+    {name: 'Plugin.tsx', language: 'tsx', source: pluginSource},
+    {name: 'entry.tsx', language: 'tsx', source: entrySource},
+    {name: 'steps.ts', language: 'ts', source: stepsSource},
+    {name: 'feature.feature', language: 'feature', source: featureText},
+  ],
+  PlaygroundComponent: MentionPickerPlugin,
+  parameterTypes,
+  buildStepDefinitions: ({editorStepDefinitions}) => [
+    ...editorStepDefinitions,
+    ...mentionPickerSteps,
+  ],
+  buildHooks: () => [
+    Before(async (context: MentionPickerContext) => {
+      resetMatchesCallCount()
+      const {editor, locator} = await createTestEditor({
+        children: <MentionPickerPlugin />,
+        schemaDefinition,
+      })
+      context.editor = editor
+      context.locator = locator
+      attachLocators(context)
+      await vi.waitFor(() =>
+        expect.element(context.keywordLocator).toBeInTheDocument(),
+      )
+      await vi.waitFor(() =>
+        expect.element(context.matchesLocator).toBeInTheDocument(),
+      )
+    }),
+  ],
+}

--- a/apps/racetrack/src/garage/mention-picker/feature.feature
+++ b/apps/racetrack/src/garage/mention-picker/feature.feature
@@ -1,0 +1,139 @@
+Feature: Mention Picker
+
+  # Basic triggering
+  Scenario: Triggering picker
+    When the editor is focused
+    And "@j" is typed
+    Then the keyword is "j"
+
+  Scenario: No trigger without @
+    When the editor is focused
+    And "hello" is typed
+    Then the keyword is ""
+    And the picker state is "idle"
+
+  # Async loading
+  Scenario: Shows matches after loading
+    When the editor is focused
+    And "@j" is typed
+    Then the picker state is "showing matches"
+    And the matches are "John Doe,Jane Smith"
+
+  # Selection with Enter and Tab
+  Scenario: Enter selects match
+    When the editor is focused
+    And "@john" is typed
+    Then the matches are "John Doe"
+    When "{Enter}" is pressed
+    Then the editor state is "B: John Doe|"
+    And the picker state is "idle"
+
+  Scenario: Tab selects match
+    When the editor is focused
+    And "@john" is typed
+    Then the matches are "John Doe"
+    When "{Tab}" is pressed
+    Then the editor state is "B: John Doe|"
+    And the picker state is "idle"
+
+  # Dismissing
+  Scenario: Dismissing with Escape
+    When the editor is focused
+    And "@john" is typed
+    When "{Escape}" is pressed
+    Then the editor state is "B: @john|"
+    And the picker state is "idle"
+
+  Scenario: Dismissing by moving cursor left
+    When the editor is focused
+    And "hello @j" is typed
+    Then the picker state is "showing matches"
+    When "{ArrowLeft}{ArrowLeft}{ArrowLeft}" is pressed
+    Then the picker state is "idle"
+
+  # No matches
+  Scenario: No matches state
+    When the editor is focused
+    And "@xyz" is typed
+    Then the picker state is "no matches"
+    And the keyword is "xyz"
+
+  Scenario: Enter dismisses when no matches
+    When the editor is focused
+    And "@xyz" is typed
+    Then the picker state is "no matches"
+    When "{Enter}" is pressed
+    Then the editor state is "B: @xyz|"
+    And the picker state is "idle"
+
+  # Keyboard navigation
+  Scenario: Arrow down navigation
+    When the editor is focused
+    And "@j" is typed
+    Then the picker state is "showing matches"
+    And the selected index is "0"
+    When "{ArrowDown}" is pressed
+    Then the selected index is "1"
+
+  Scenario: Arrow down wraps around
+    When the editor is focused
+    And "@j" is typed
+    Then the picker state is "showing matches"
+    When "{ArrowDown}" is pressed
+    And "{ArrowDown}" is pressed
+    Then the selected index is "0"
+
+  Scenario: Arrow up navigation
+    When the editor is focused
+    And "@j" is typed
+    Then the picker state is "showing matches"
+    And the selected index is "0"
+    When "{ArrowUp}" is pressed
+    Then the selected index is "1"
+
+  Scenario: Arrow navigation then Enter selects correct match
+    When the editor is focused
+    And "@j" is typed
+    Then the picker state is "showing matches"
+    When "{ArrowDown}" is pressed
+    And "{Enter}" is pressed
+    Then the editor state is "B: Jane Smith|"
+
+  # Narrowing search
+  Scenario: Typing more characters narrows results
+    When the editor is focused
+    And "@j" is typed
+    Then the matches are "John Doe,Jane Smith"
+    When "o" is typed
+    Then the matches are "John Doe"
+
+  Scenario: Backspace widens search
+    When the editor is focused
+    And "@john" is typed
+    Then the matches are "John Doe"
+    When "{Backspace}" is pressed
+    Then the matches are "John Doe"
+
+  Scenario: Matches are not loaded when the editor is focused
+    When the editor is focused
+    Then getMatches was called "0" times
+
+  Scenario: Matches are not loaded for a different trigger
+    When the editor is focused
+    And ":j" is typed
+    Then getMatches was called "0" times
+
+  Scenario: Matches are loaded when the trigger is typed
+    When the editor is focused
+    And "@" is typed
+    Then the matches are ""
+
+  Scenario: Consecutive typing calls getMatches each time
+    When the editor is focused
+    And "@" is typed
+    Then the matches are ""
+    When "j" is typed
+    Then the matches are "John Doe,Jane Smith"
+    When "a" is typed
+    Then the matches are "Jane Smith"
+    And getMatches was called "3" times

--- a/apps/racetrack/src/garage/mention-picker/steps.ts
+++ b/apps/racetrack/src/garage/mention-picker/steps.ts
@@ -1,0 +1,78 @@
+/**
+ * Plugin-specific Then-steps for the mention-picker scenarios.
+ *
+ * The first four assert against the `data-testid` nodes that
+ * `MentionPickerPlugin` renders. The fifth asserts against the
+ * module-scoped `getMatchesCallCount` from `./mention-picker`. Each
+ * scenario's Before hook resets that counter; without the reset,
+ * counts accumulate across scenarios.
+ *
+ * The diagnostic nodes are scoped to the runner's test target via
+ * `page.locator('[data-racetrack-test-target]')`. Racetrack runs the
+ * playground and the runner editor in the same DOM, so an unscoped
+ * `page.getByTestId(...)` would match the playground's plugin first.
+ */
+
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Then} from 'racejar'
+import {expect, vi} from 'vitest'
+import {page, type Locator} from 'vitest/browser'
+import {getMatchesCallCountValue} from './Plugin'
+
+export type MentionPickerContext = Context & {
+  keywordLocator: Locator
+  matchesLocator: Locator
+  stateLocator: Locator
+  selectedIndexLocator: Locator
+}
+
+export function attachLocators(context: MentionPickerContext): void {
+  const testTarget = page.locator('[data-racetrack-test-target]')
+  context.keywordLocator = testTarget.getByTestId('keyword')
+  context.matchesLocator = testTarget.getByTestId('matches')
+  context.stateLocator = testTarget.getByTestId('state')
+  context.selectedIndexLocator = testTarget.getByTestId('selectedIndex')
+}
+
+export const mentionPickerSteps = [
+  Then(
+    'the keyword is {string}',
+    async (context: MentionPickerContext, keyword: string) => {
+      await vi.waitFor(() => {
+        expect(context.keywordLocator.element().textContent).toEqual(keyword)
+      })
+    },
+  ),
+  Then(
+    'the matches are {string}',
+    async (context: MentionPickerContext, matches: string) => {
+      await vi.waitFor(() => {
+        expect(context.matchesLocator.element().textContent).toEqual(matches)
+      })
+    },
+  ),
+  Then(
+    'the picker state is {string}',
+    async (context: MentionPickerContext, state: string) => {
+      await vi.waitFor(() => {
+        expect(context.stateLocator.element().textContent).toEqual(state)
+      })
+    },
+  ),
+  Then(
+    'the selected index is {string}',
+    async (context: MentionPickerContext, index: string) => {
+      await vi.waitFor(() => {
+        expect(context.selectedIndexLocator.element().textContent).toEqual(
+          index,
+        )
+      })
+    },
+  ),
+  Then(
+    'getMatches was called {string} times',
+    (_context: MentionPickerContext, count: string) => {
+      expect(getMatchesCallCountValue()).toEqual(Number(count))
+    },
+  ),
+]

--- a/apps/racetrack/src/garage/types.ts
+++ b/apps/racetrack/src/garage/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shape of a Racetrack garage entry: one plugin loadable into the
+ * playground and runner. `featureText` is the same `.feature` file
+ * the underlying plugin's vitest suite runs, lifted at build time via
+ * `?raw` so Racetrack can render and execute it.
+ *
+ * `engine` is the raw source of the car as customers should read it.
+ * Each engine file is loaded via `?raw` at build time so the page can
+ * show exactly what's on disk without bundling a syntax-highlighting
+ * server.
+ */
+
+import type {Hook, ParameterType, StepDefinition} from 'racejar'
+import type {ComponentType} from 'react'
+
+export type EngineFile = {
+  /** File name shown in the tab strip, e.g. `Plugin.tsx`. */
+  name: string
+  /** Language hint, used for the `data-language` attribute. */
+  language: 'tsx' | 'ts' | 'feature'
+  /** File contents. */
+  source: string
+}
+
+export type GarageEntry = {
+  /** Stable slug. Used for selection state and as React key. */
+  id: string
+  /** Display name in the entry picker. */
+  name: string
+  /** One-line description shown next to the entry name. */
+  description: string
+  /** Raw `.feature` file contents. */
+  featureText: string
+  /** Files that make up the car's engine, in tab order. */
+  engine: Array<EngineFile>
+  /** The React component rendered inside the playground editor's `<EditorProvider>`. */
+  PlaygroundComponent: ComponentType<any>
+  /** Custom parameter types for racejar. */
+  parameterTypes: Array<ParameterType<unknown>>
+  /** Build the step definitions array given the shared editor steps. */
+  buildStepDefinitions: (args: {
+    editorStepDefinitions: Array<StepDefinition<any, any, any, any>>
+  }) => Array<StepDefinition<any, any, any, any>>
+  /** Build the Before/After hooks the runner installs per scenario. */
+  buildHooks: () => Array<Hook<any>>
+}

--- a/apps/racetrack/src/panels/EnginePanel.tsx
+++ b/apps/racetrack/src/panels/EnginePanel.tsx
@@ -1,0 +1,50 @@
+import {useState} from 'react'
+import type {GarageEntry} from '../garage'
+
+type EnginePanelProps = {
+  entry: GarageEntry
+}
+
+export function EnginePanel({entry}: EnginePanelProps) {
+  const [activeFileName, setActiveFileName] = useState(
+    () => entry.engine[0]?.name ?? '',
+  )
+
+  // When the entry changes the previous active file name may no longer
+  // exist; resolve to the new entry's first file if so. Reading state
+  // and falling back during render avoids a render-then-effect-then-
+  // re-render flicker.
+  const activeFile =
+    entry.engine.find((file) => file.name === activeFileName) ?? entry.engine[0]
+
+  if (!activeFile) {
+    return null
+  }
+
+  return (
+    <div className="rt-panel">
+      <div className="rt-panel-header">
+        <span className="rt-panel-header-title">Engine</span>
+        <div className="rt-engine-tabs">
+          {entry.engine.map((file) => (
+            <button
+              key={file.name}
+              type="button"
+              className={`rt-engine-tab${
+                file.name === activeFile.name ? ' rt-engine-tab--active' : ''
+              }`}
+              onClick={() => setActiveFileName(file.name)}
+            >
+              {file.name}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="rt-panel-body rt-engine-body">
+        <pre className="rt-engine-source" data-language={activeFile.language}>
+          <code>{activeFile.source}</code>
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/apps/racetrack/src/panels/PlaygroundPanel.tsx
+++ b/apps/racetrack/src/panels/PlaygroundPanel.tsx
@@ -1,0 +1,42 @@
+import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
+import {defineSchema} from '@portabletext/schema'
+import type {GarageEntry} from '../garage'
+
+type PlaygroundPanelProps = {
+  entry: GarageEntry
+}
+
+// A permissive playground schema; entries that need narrower schemas can
+// add a per-entry schema field later. Today both entries are happy with
+// this.
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  annotations: [{name: 'link'}],
+  inlineObjects: [{name: 'stock-ticker'}],
+})
+
+export function PlaygroundPanel({entry}: PlaygroundPanelProps) {
+  const {PlaygroundComponent} = entry
+
+  return (
+    <div className="rt-panel">
+      <div className="rt-panel-header">
+        <span className="rt-panel-header-title">Paddock</span>
+        <span>{entry.name}</span>
+      </div>
+      <div className="rt-panel-body">
+        <EditorProvider
+          key={entry.id}
+          initialConfig={{
+            schemaDefinition,
+          }}
+        >
+          <div className="rt-editor-host">
+            <PortableTextEditable className="rt-editable" />
+            <PlaygroundComponent />
+          </div>
+        </EditorProvider>
+      </div>
+    </div>
+  )
+}

--- a/apps/racetrack/src/panels/RunnerPanel.tsx
+++ b/apps/racetrack/src/panels/RunnerPanel.tsx
@@ -1,0 +1,93 @@
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {GarageEntry} from '../garage'
+import {
+  runFeature,
+  type ScenarioResult,
+  type StepResult,
+} from '../runner/browser-runner'
+import {cleanup} from '../runner/vitest-browser-react-shim'
+
+type RunnerPanelProps = {
+  entry: GarageEntry
+  isRunning: boolean
+  scenarioResults: Array<ScenarioResult>
+  scenarioCount: number
+  onRunStart: () => void
+  onRunEnd: () => void
+  onStep: (result: StepResult) => void
+  onScenarioComplete: (result: ScenarioResult) => void
+}
+
+export function RunnerPanel({
+  entry,
+  isRunning,
+  scenarioResults,
+  scenarioCount,
+  onRunStart,
+  onRunEnd,
+  onStep,
+  onScenarioComplete,
+}: RunnerPanelProps) {
+  async function handleRun() {
+    onRunStart()
+
+    try {
+      await runFeature({
+        featureText: entry.featureText,
+        parameterTypes: entry.parameterTypes,
+        stepDefinitions: entry.buildStepDefinitions({
+          editorStepDefinitions: stepDefinitions,
+        }),
+        hooks: entry.buildHooks(),
+        onStep,
+        onScenarioComplete,
+        betweenScenarios: async () => {
+          await cleanup()
+        },
+      })
+    } finally {
+      onRunEnd()
+    }
+  }
+
+  const passCount = scenarioResults.filter((r) => r.status === 'pass').length
+  const failCount = scenarioResults.filter((r) => r.status === 'fail').length
+  const ranCount = scenarioResults.length
+
+  return (
+    <div className="rt-panel">
+      <div className="rt-panel-header">
+        <span className="rt-panel-header-title">Race control</span>
+        <button
+          type="button"
+          className="rt-button rt-button--primary"
+          onClick={handleRun}
+          disabled={isRunning}
+        >
+          {isRunning ? 'Racing...' : 'Start race'}
+        </button>
+      </div>
+      <div className="rt-panel-body">
+        {ranCount > 0 ? (
+          <div
+            className={`rt-summary ${
+              failCount === 0 ? 'rt-summary--pass' : 'rt-summary--fail'
+            }`}
+          >
+            {failCount === 0
+              ? `${passCount}/${scenarioCount} finished`
+              : `${passCount}/${scenarioCount} finished, ${failCount} crashed`}
+          </div>
+        ) : (
+          <div className="rt-summary">
+            {scenarioCount} races on the grid. Press start.
+          </div>
+        )}
+        <div className="rt-runner-target">
+          <div className="rt-runner-target-label">Test target</div>
+          <div data-racetrack-test-target />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/racetrack/src/panels/ScenariosPanel.tsx
+++ b/apps/racetrack/src/panels/ScenariosPanel.tsx
@@ -1,0 +1,86 @@
+import type {StepKey, StepState} from '../App'
+import type {ScenarioResult, StepStatus} from '../runner/browser-runner'
+import type {ParsedFeature} from '../runner/feature-parser'
+
+type ScenariosPanelProps = {
+  feature: ParsedFeature
+  stepStates: Map<StepKey, StepState>
+  scenarioResults: Array<ScenarioResult>
+}
+
+export function ScenariosPanel({
+  feature,
+  stepStates,
+  scenarioResults,
+}: ScenariosPanelProps) {
+  const passCount = scenarioResults.filter((r) => r.status === 'pass').length
+  const failCount = scenarioResults.filter((r) => r.status === 'fail').length
+
+  return (
+    <div className="rt-panel">
+      <div className="rt-panel-header">
+        <span className="rt-panel-header-title">Track</span>
+        <span>
+          {feature.scenarios.length} races
+          {scenarioResults.length > 0
+            ? ` - ${passCount} finished, ${failCount} crashed`
+            : ''}
+        </span>
+      </div>
+      <div className="rt-panel-body rt-panel-body--monospace">
+        <div className="rt-feature">
+          <div className="rt-feature-title">Feature: {feature.name}</div>
+          {feature.scenarios.map((scenario, scenarioIndex) => (
+            <ScenarioBlock
+              // biome-ignore lint/suspicious/noArrayIndexKey: scenario outlines expand to multiple pickles with the same name; the index is the stable identity in racejar's compiled output.
+              key={`scenario:${scenarioIndex}:${scenario.name}`}
+              scenario={scenario}
+              scenarioIndex={scenarioIndex}
+              stepStates={stepStates}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type ScenarioBlockProps = {
+  scenario: ParsedFeature['scenarios'][number]
+  scenarioIndex: number
+  stepStates: Map<StepKey, StepState>
+}
+
+function ScenarioBlock({
+  scenario,
+  scenarioIndex,
+  stepStates,
+}: ScenarioBlockProps) {
+  return (
+    <div className="rt-scenario">
+      <div className="rt-scenario-name">Scenario: {scenario.name}</div>
+      {scenario.steps.map((step, stepIndex) => {
+        const state = stepStates.get(`${scenarioIndex}-${stepIndex}`)
+        const status: StepStatus = state?.status ?? 'idle'
+        const className = `rt-step${status === 'fail' ? ' rt-step--fail' : ''}`
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: step order within a scenario is fixed and the array never mutates; the index is the stable identity.
+          <div key={stepIndex}>
+            <div className={className}>
+              <span
+                className={`rt-dot rt-dot--${status} rt-step-dot`}
+                title={status}
+              />
+              <span className="rt-step-text">
+                {step.keyword} {step.text}
+              </span>
+            </div>
+            {state?.error ? (
+              <div className="rt-step-error">{state.error.message}</div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/racetrack/src/runner/browser-runner.ts
+++ b/apps/racetrack/src/runner/browser-runner.ts
@@ -1,0 +1,163 @@
+/**
+ * Browser-side mirror of racejar's vitest gherkin driver.
+ *
+ * Compiles a feature file and runs each scenario step-by-step,
+ * emitting `onStep` updates so the UI can paint live status while a
+ * run is in progress. Stops a scenario at its first failure and moves
+ * on to the next.
+ *
+ * The vitest driver wraps each scenario in a `describe`/`test` pair so
+ * vitest owns lifecycle; here we own it ourselves and report through
+ * `onStep`.
+ */
+
+// biome-ignore-all lint/suspicious/noExplicitAny: racejar's StepDefinition
+// and Hook are parametrised across optional arg types we don't constrain
+// for the caller.
+
+import {
+  compileFeature,
+  type Hook,
+  type ParameterType,
+  type StepDefinition,
+} from 'racejar'
+
+export type StepStatus = 'idle' | 'running' | 'pass' | 'fail'
+
+export type StepResult = {
+  scenarioIndex: number
+  stepIndex: number
+  status: StepStatus
+  error?: Error
+}
+
+export type ScenarioResult = {
+  scenarioIndex: number
+  name: string
+  status: 'pass' | 'fail' | 'skip'
+  failedStepIndex?: number
+  error?: Error
+}
+
+export type RunFeatureArgs = {
+  featureText: string
+  stepDefinitions: Array<StepDefinition<any, any, any, any>>
+  parameterTypes?: Array<ParameterType<unknown>>
+  hooks?: Array<Hook<any>>
+  onStep: (result: StepResult) => void
+  onScenarioComplete?: (result: ScenarioResult) => void
+  /**
+   * Called after every scenario (both pass and fail) once all
+   * after-hooks have run. The mention-picker run uses this to unmount
+   * the test editor created by `createTestEditor`, so the next
+   * scenario starts with a clean document.body and `page.getByTestId`
+   * does not match a stale element from the previous editor.
+   */
+  betweenScenarios?: () => Promise<void> | void
+}
+
+export async function runFeature(args: RunFeatureArgs): Promise<{
+  scenarios: Array<ScenarioResult>
+}> {
+  const compiled = compileFeature({
+    featureText: args.featureText,
+    hooks: args.hooks,
+    stepDefinitions: args.stepDefinitions,
+    parameterTypes: args.parameterTypes,
+  })
+
+  const results: Array<ScenarioResult> = []
+
+  for (let s = 0; s < compiled.scenarios.length; s++) {
+    const scenario = compiled.scenarios[s]!
+    if (scenario.tag === 'skip') {
+      results.push({
+        scenarioIndex: s,
+        name: scenario.name,
+        status: 'skip',
+      })
+      args.onScenarioComplete?.(results[results.length - 1]!)
+      continue
+    }
+
+    const stepContext: Record<string, unknown> = {}
+
+    let scenarioFailed = false
+    let failedStepIndex: number | undefined
+    let failedError: Error | undefined
+
+    try {
+      for (const before of compiled.beforeHooks) {
+        await before(stepContext)
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      // Surface a Before-hook failure as a failure on step 0 so the
+      // user sees red in the left panel rather than silent idle dots.
+      args.onStep({
+        scenarioIndex: s,
+        stepIndex: 0,
+        status: 'fail',
+        error: new Error(`Before hook: ${error.message}`),
+      })
+      scenarioFailed = true
+      failedStepIndex = 0
+      failedError = error
+    }
+
+    if (!scenarioFailed) {
+      for (let st = 0; st < scenario.steps.length; st++) {
+        args.onStep({scenarioIndex: s, stepIndex: st, status: 'running'})
+        try {
+          await scenario.steps[st]!(stepContext)
+          args.onStep({scenarioIndex: s, stepIndex: st, status: 'pass'})
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err))
+          args.onStep({
+            scenarioIndex: s,
+            stepIndex: st,
+            status: 'fail',
+            error,
+          })
+          scenarioFailed = true
+          failedStepIndex = st
+          failedError = error
+          break
+        }
+      }
+    }
+
+    for (const after of compiled.afterHooks) {
+      try {
+        await after(stepContext)
+      } catch {
+        // After-hook errors don't fail a scenario in racejar's vitest
+        // driver either; vitest's afterEach reports them but the
+        // scenario result is decided by the steps.
+      }
+    }
+
+    const result: ScenarioResult = scenarioFailed
+      ? {
+          scenarioIndex: s,
+          name: scenario.name,
+          status: 'fail',
+          failedStepIndex,
+          error: failedError,
+        }
+      : {
+          scenarioIndex: s,
+          name: scenario.name,
+          status: 'pass',
+        }
+
+    results.push(result)
+    args.onScenarioComplete?.(result)
+
+    if (args.betweenScenarios) {
+      await args.betweenScenarios()
+    }
+  }
+
+  return {scenarios: results}
+}

--- a/apps/racetrack/src/runner/feature-parser.ts
+++ b/apps/racetrack/src/runner/feature-parser.ts
@@ -1,0 +1,94 @@
+/**
+ * Parse a feature file into the expanded list of pickles racejar
+ * actually runs. Scenario Outlines are expanded one runtime scenario
+ * per Examples row, matching what `compileFeature` produces, so the
+ * left-panel scenario count and indices align with the runner's
+ * `onStep` events.
+ *
+ * Uses `@cucumber/gherkin` directly (the same library racejar uses)
+ * rather than a hand-rolled parser, so outline-expansion semantics
+ * stay in lockstep. `@cucumber/gherkin` is a transitive dependency of
+ * racejar, already in the racetrack module tree.
+ *
+ * Pickle steps drop the original `Given/When/Then/And/But` keyword, so
+ * we walk the gherkin AST once to build an id-to-keyword map and look
+ * each pickle step's source up by `astNodeIds[0]` for display.
+ */
+
+import * as Gherkin from '@cucumber/gherkin'
+import * as Messages from '@cucumber/messages'
+
+export type ParsedStep = {
+  /** "Given" | "When" | "Then" | "And" | "But" - trimmed of trailing space. */
+  keyword: string
+  text: string
+}
+
+export type ParsedScenario = {
+  name: string
+  steps: Array<ParsedStep>
+}
+
+export type ParsedFeature = {
+  name: string
+  scenarios: Array<ParsedScenario>
+}
+
+function collectStepKeywords(
+  document: Messages.GherkinDocument,
+): Map<string, string> {
+  const keywords = new Map<string, string>()
+  const feature = document.feature
+  if (!feature) {
+    return keywords
+  }
+
+  for (const child of feature.children) {
+    const stepSources = [
+      ...(child.background?.steps ?? []),
+      ...(child.scenario?.steps ?? []),
+    ]
+    for (const step of stepSources) {
+      keywords.set(step.id, step.keyword.trim())
+    }
+    for (const rule of [child.rule].filter(Boolean)) {
+      for (const ruleChild of rule!.children) {
+        for (const step of [
+          ...(ruleChild.background?.steps ?? []),
+          ...(ruleChild.scenario?.steps ?? []),
+        ]) {
+          keywords.set(step.id, step.keyword.trim())
+        }
+      }
+    }
+  }
+  return keywords
+}
+
+export function parseFeature(text: string): ParsedFeature {
+  const uuidFn = Messages.IdGenerator.uuid()
+  const builder = new Gherkin.AstBuilder(uuidFn)
+  const matcher = new Gherkin.GherkinClassicTokenMatcher()
+  const parser = new Gherkin.Parser(builder, matcher)
+
+  const document = parser.parse(text)
+  const featureName = document.feature?.name ?? ''
+
+  const pickles = Gherkin.compile(
+    document,
+    featureName.replace(' ', '-'),
+    uuidFn,
+  )
+
+  const keywordMap = collectStepKeywords(document)
+
+  const scenarios: Array<ParsedScenario> = pickles.map((pickle) => ({
+    name: pickle.name,
+    steps: pickle.steps.map((step) => ({
+      keyword: keywordMap.get(step.astNodeIds[0] ?? '') ?? '',
+      text: step.text,
+    })),
+  }))
+
+  return {name: featureName, scenarios}
+}

--- a/apps/racetrack/src/runner/vitest-browser-react-shim.ts
+++ b/apps/racetrack/src/runner/vitest-browser-react-shim.ts
@@ -1,0 +1,92 @@
+/**
+ * Shim for `vitest-browser-react`.
+ *
+ * Replaces the package's `render()` with a plain React 19 createRoot
+ * mount. `createTestEditor` in
+ * `@portabletext/editor/test/vitest/test-editor.tsx` calls `render(ui)`
+ * and expects back something with at least `.rerender(newUi)` and
+ * matching `page.elementLocator(container)` behavior.
+ *
+ * This shim is intentionally tiny. If `createTestEditor` ever starts
+ * using `.unmount`, `.debug`, `.asFragment` or query helpers off the
+ * render result, add them here.
+ */
+
+import {createRoot, type Root} from 'react-dom/client'
+import {page, type Locator} from './vitest-browser-shim'
+
+type RenderResult = {
+  container: Element
+  baseElement: Element
+  locator: Locator
+  unmount: () => Promise<void>
+  rerender: (newUi: React.ReactNode) => Promise<void>
+}
+
+const mountedContainers = new Set<Element>()
+const mountedRoots: Array<{container: Element; root: Root}> = []
+
+export async function render(
+  ui: React.ReactNode,
+  options: {container?: Element; baseElement?: Element} = {},
+): Promise<RenderResult> {
+  // Prefer a Racetrack-supplied target so the test editor renders inside
+  // the right panel rather than free-floating in document.body.
+  const target = document.querySelector('[data-racetrack-test-target]')
+  const baseElement =
+    options.baseElement ??
+    (target instanceof HTMLElement ? target : document.body)
+  let container = options.container
+  if (!container) {
+    container = baseElement.appendChild(document.createElement('div'))
+  }
+
+  let root: Root
+  const existing = mountedRoots.find((entry) => entry.container === container)
+  if (existing) {
+    root = existing.root
+  } else {
+    root = createRoot(container)
+    mountedRoots.push({container, root})
+    mountedContainers.add(container)
+  }
+
+  root.render(ui as React.ReactNode)
+  // Yield once so React commits before the caller queries the DOM.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const locator = page.elementLocator(container)
+
+  return {
+    container,
+    baseElement,
+    locator,
+    async unmount() {
+      root.unmount()
+      if (container && container.parentNode) {
+        container.parentNode.removeChild(container)
+      }
+      await Promise.resolve()
+    },
+    async rerender(newUi: React.ReactNode) {
+      root.render(newUi as React.ReactNode)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    },
+  }
+}
+
+export async function cleanup(): Promise<void> {
+  for (const {root, container} of mountedRoots) {
+    root.unmount()
+    if (container.parentNode) {
+      container.parentNode.removeChild(container)
+    }
+  }
+  mountedRoots.length = 0
+  mountedContainers.clear()
+  await Promise.resolve()
+}
+
+export function renderHook(): never {
+  throw new Error('Not implemented: vitest-browser-react.renderHook')
+}

--- a/apps/racetrack/src/runner/vitest-browser-shim.ts
+++ b/apps/racetrack/src/runner/vitest-browser-shim.ts
@@ -1,0 +1,243 @@
+/**
+ * Shim for `vitest/browser`.
+ *
+ * Step definitions in `@portabletext/editor/test/vitest` and the lifted
+ * `test-editor.tsx` import `userEvent`, `page`, `expect`, and the
+ * `Locator` type from `vitest/browser`. Inside vitest the runtime
+ * injects real implementations of these; here we provide just enough
+ * surface to drive the editor through gherkin scenarios.
+ *
+ * Anything unimplemented throws a loud error so that the next missing
+ * call site is obvious. Do not catch and ignore.
+ */
+
+import userEventLib from '@testing-library/user-event'
+
+/**
+ * Minimal subset of vitest/browser's Locator API used by the editor's
+ * step definitions and test-editor helper.
+ */
+export type Locator = {
+  element(): Element
+  elements(): Array<Element>
+  click(): Promise<void>
+  first(): Locator
+  nth(index: number): Locator
+  getByTestId(id: string): Locator
+  getByRole(role: string, options?: {name?: string}): Locator
+  getByText(text: string): Locator
+  locator(selector: string): Locator
+}
+
+type Resolver = () => Element[]
+
+function locatorFromResolver(resolver: Resolver, label: string): Locator {
+  const resolveAll = (): Element[] => resolver()
+  const resolveFirst = (): Element => {
+    const list = resolveAll()
+    if (list.length === 0) {
+      throw new Error(`Locator ${label}: no element found`)
+    }
+    return list[0]!
+  }
+
+  const loc: Locator = {
+    element: resolveFirst,
+    elements: resolveAll,
+    async click() {
+      const el = resolveFirst()
+      await currentUserEvent().click(el)
+    },
+    first() {
+      return locatorFromResolver(() => {
+        const list = resolveAll()
+        return list.length > 0 ? [list[0]!] : []
+      }, `${label}:first`)
+    },
+    nth(index: number) {
+      return locatorFromResolver(() => {
+        const list = resolveAll()
+        return index < list.length ? [list[index]!] : []
+      }, `${label}:nth(${index})`)
+    },
+    getByTestId(id: string) {
+      return locatorFromResolver(() => {
+        const root = resolveFirst()
+        return Array.from(root.querySelectorAll(`[data-testid="${id}"]`))
+      }, `${label}>>getByTestId(${id})`)
+    },
+    getByRole(role: string, options?: {name?: string}) {
+      return locatorFromResolver(
+        () => {
+          const root = resolveFirst()
+          return queryByRole(root, role, options)
+        },
+        `${label}>>getByRole(${role}${options?.name ? `, ${options.name}` : ''})`,
+      )
+    },
+    getByText(text: string) {
+      return locatorFromResolver(
+        () => queryByText(resolveFirst(), text),
+        `${label}>>getByText(${text})`,
+      )
+    },
+    locator(selector: string) {
+      return locatorFromResolver(
+        () => Array.from(resolveFirst().querySelectorAll(selector)),
+        `${label}>>locator(${selector})`,
+      )
+    },
+  }
+
+  return loc
+}
+
+function queryByRole(
+  root: Element | Document,
+  role: string,
+  options?: {name?: string},
+): Element[] {
+  // Tiny role mapping that covers what step-definitions / test-editor
+  // actually request. `textbox` is the only role used by createTestEditor
+  // and PortableTextEditable renders a `[contenteditable] [role="textbox"]`
+  // or similar; querySelector covers both ARIA-explicit and implicit.
+  let selector = ''
+  if (role === 'textbox') {
+    selector =
+      '[role="textbox"], input[type="text"], textarea, [contenteditable="true"]'
+  } else if (role === 'button') {
+    selector = '[role="button"], button'
+  } else {
+    selector = `[role="${role}"]`
+  }
+  const candidates = Array.from(root.querySelectorAll(selector))
+  if (!options?.name) {
+    return candidates
+  }
+  return candidates.filter((el) => {
+    const label =
+      el.getAttribute('aria-label') ??
+      el.getAttribute('aria-labelledby') ??
+      el.textContent ??
+      ''
+    return label.includes(options.name!)
+  })
+}
+
+function queryByText(root: Element | Document, text: string): Element[] {
+  const results: Element[] = []
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  let node: Node | null = walker.currentNode
+  while (node) {
+    if (node instanceof Element) {
+      const t = node.textContent
+      if (t && t.includes(text)) {
+        results.push(node)
+      }
+    }
+    node = walker.nextNode()
+  }
+  return results
+}
+
+/**
+ * `page` queries from document.body by default and exposes the same
+ * locator API.
+ */
+export const page = {
+  getByTestId(id: string): Locator {
+    return locatorFromResolver(
+      () => Array.from(document.body.querySelectorAll(`[data-testid="${id}"]`)),
+      `page.getByTestId(${id})`,
+    )
+  },
+  getByRole(role: string, options?: {name?: string}): Locator {
+    return locatorFromResolver(
+      () => queryByRole(document.body, role, options),
+      `page.getByRole(${role})`,
+    )
+  },
+  getByText(text: string): Locator {
+    return locatorFromResolver(
+      () => queryByText(document.body, text),
+      `page.getByText(${text})`,
+    )
+  },
+  locator(selector: string): Locator {
+    return locatorFromResolver(
+      () => Array.from(document.body.querySelectorAll(selector)),
+      `page.locator(${selector})`,
+    )
+  },
+  /**
+   * Scope subsequent queries to a specific container. Used by
+   * `vitest-browser-react`'s `render()` result.
+   */
+  elementLocator(container: Element): Locator {
+    return locatorFromResolver(() => [container], 'page.elementLocator')
+  },
+}
+
+/**
+ * Wrap `@testing-library/user-event` so callers can pass either a
+ * Locator (vitest/browser style) or an Element. The library's API
+ * requires `.setup()` first and takes Elements; we hide both.
+ */
+type RawUserEvent = ReturnType<typeof userEventLib.setup>
+
+let cached: RawUserEvent | undefined
+function currentUserEvent(): RawUserEvent {
+  if (!cached) {
+    cached = userEventLib.setup({
+      // Keep the default key map; vitest/browser's userEvent uses the
+      // same `{Enter}`, `{Backspace}`, etc. syntax as testing-library.
+    })
+  }
+  return cached
+}
+
+function resolveElement(target: Locator | Element): Element {
+  if ((target as Locator).element) {
+    return (target as Locator).element()
+  }
+  return target as Element
+}
+
+export const userEvent = {
+  async click(target: Locator | Element) {
+    const el = resolveElement(target)
+    await currentUserEvent().click(el)
+  },
+  async type(target: Locator | Element, text: string) {
+    const el = resolveElement(target)
+    // `testing-library/user-event`'s default `.type()` clicks the
+    // element first, which collapses the contenteditable selection to
+    // wherever the click landed. `vitest/browser`'s `userEvent.type`
+    // (and Playwright's `page.keyboard.type`) types at the current
+    // selection without re-clicking. Step definitions that put the
+    // caret with `editor.send({type: 'select', ...})` and then call
+    // `userEvent.type(locator, text)` rely on that behavior, so we
+    // pass `skipClick: true` and only ensure the element is focused.
+    if (document.activeElement !== el) {
+      ;(el as HTMLElement).focus()
+    }
+    await currentUserEvent().type(el as HTMLElement, text, {skipClick: true})
+  },
+  async keyboard(text: string) {
+    await currentUserEvent().keyboard(text)
+  },
+  async tab() {
+    await currentUserEvent().tab()
+  },
+  async cut() {
+    if (!currentUserEvent().cut) {
+      throw new Error('Not implemented: userEvent.cut')
+    }
+    await currentUserEvent().cut()
+  },
+}
+
+// Re-export expect from the value-matcher shim so callers that import
+// `expect` from `vitest/browser` (for the element matchers) get the
+// same surface. `expect.element(...)` is defined there.
+export {expect} from './vitest-shim'

--- a/apps/racetrack/src/runner/vitest-shim.ts
+++ b/apps/racetrack/src/runner/vitest-shim.ts
@@ -1,0 +1,277 @@
+/**
+ * Shim for `vitest` (NOT `vitest/browser`).
+ *
+ * Step definitions in `@portabletext/editor/test/vitest` import `assert`,
+ * `expect`, and `vi` from `vitest`. Inside vitest these are real
+ * implementations; inside Racetrack we redirect via vite alias to this
+ * file.
+ *
+ * Implement only what step-definitions.tsx and test-editor.tsx actually
+ * use. Anything else throws so missing coverage shows up as a loud
+ * error instead of silently passing.
+ */
+
+type WaitForOptions = {
+  timeout?: number
+  interval?: number
+}
+
+const DEFAULT_TIMEOUT = 1000
+const DEFAULT_INTERVAL = 50
+
+async function waitFor<T>(
+  fn: () => T | Promise<T>,
+  options: WaitForOptions = {},
+): Promise<T> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT
+  const interval = options.interval ?? DEFAULT_INTERVAL
+  const start = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - start < timeout) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, interval))
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+  throw new Error(`vi.waitFor: timed out after ${timeout}ms`)
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a == null || b == null) {
+    return a === b
+  }
+  if (typeof a !== 'object' || typeof b !== 'object') {
+    return false
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    return false
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) {
+        return false
+      }
+    }
+    return true
+  }
+  const ka = Object.keys(a as Record<string, unknown>)
+  const kb = Object.keys(b as Record<string, unknown>)
+  if (ka.length !== kb.length) {
+    return false
+  }
+  for (const key of ka) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) {
+      return false
+    }
+    if (
+      !deepEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      )
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+class Expectation {
+  constructor(
+    private actual: unknown,
+    private message?: string,
+    private negated = false,
+  ) {}
+
+  get not(): Expectation {
+    return new Expectation(this.actual, this.message, !this.negated)
+  }
+
+  private prefix(): string {
+    return this.message ? `${this.message}: ` : ''
+  }
+
+  toEqual(expected: unknown): void {
+    const equal = deepEqual(this.actual, expected)
+    if (this.negated ? equal : !equal) {
+      throw new Error(
+        `${this.prefix()}expected ${stringify(this.actual)} ${
+          this.negated ? 'not ' : ''
+        }toEqual ${stringify(expected)}`,
+      )
+    }
+  }
+
+  toBe(expected: unknown): void {
+    const equal = Object.is(this.actual, expected)
+    if (this.negated ? equal : !equal) {
+      throw new Error(
+        `${this.prefix()}expected ${stringify(this.actual)} ${
+          this.negated ? 'not ' : ''
+        }toBe ${stringify(expected)}`,
+      )
+    }
+  }
+
+  toContain(expected: unknown): void {
+    const actual = this.actual
+    let contains = false
+    if (typeof actual === 'string') {
+      contains = typeof expected === 'string' && actual.includes(expected)
+    } else if (Array.isArray(actual)) {
+      contains = actual.some((item) => deepEqual(item, expected))
+    } else {
+      throw new Error(
+        `${this.prefix()}toContain requires a string or array actual; got ${typeof actual}`,
+      )
+    }
+    if (this.negated ? contains : !contains) {
+      throw new Error(
+        `${this.prefix()}expected ${stringify(this.actual)} ${
+          this.negated ? 'not ' : ''
+        }toContain ${stringify(expected)}`,
+      )
+    }
+  }
+
+  toBeNull(): void {
+    const isNull = this.actual === null
+    if (this.negated ? isNull : !isNull) {
+      throw new Error(
+        `${this.prefix()}expected ${stringify(this.actual)} ${
+          this.negated ? 'not ' : ''
+        }toBeNull`,
+      )
+    }
+  }
+
+  toBeLessThan(expected: number): void {
+    if (typeof this.actual !== 'number') {
+      throw new Error(
+        `${this.prefix()}toBeLessThan requires a number actual; got ${typeof this.actual}`,
+      )
+    }
+    const less = this.actual < expected
+    if (this.negated ? less : !less) {
+      throw new Error(
+        `${this.prefix()}expected ${this.actual} ${
+          this.negated ? 'not ' : ''
+        }toBeLessThan ${expected}`,
+      )
+    }
+  }
+
+  toHaveProperty(key: string): void {
+    const has =
+      this.actual != null &&
+      typeof this.actual === 'object' &&
+      Object.prototype.hasOwnProperty.call(this.actual, key)
+    if (this.negated ? has : !has) {
+      throw new Error(
+        `${this.prefix()}expected ${stringify(this.actual)} ${
+          this.negated ? 'not ' : ''
+        }toHaveProperty ${stringify(key)}`,
+      )
+    }
+  }
+}
+
+type ElementMatchers = {
+  toBeInTheDocument(): void
+}
+
+function elementMatchers(loc: ElementLike, negated = false): ElementMatchers {
+  return {
+    toBeInTheDocument() {
+      const inDoc = (() => {
+        try {
+          const el = loc.element()
+          return !!el && document.contains(el)
+        } catch {
+          return false
+        }
+      })()
+      if (negated ? inDoc : !inDoc) {
+        throw new Error(
+          `expected element ${negated ? 'not ' : ''}to be in the document`,
+        )
+      }
+    },
+  }
+}
+
+// Minimal locator-shape used by `expect.element(...)`. Defined here to
+// avoid an import cycle with vitest-browser-shim.
+type ElementLike = {
+  element(): Element
+}
+
+type ExpectFn = ((actual: unknown, message?: string) => Expectation) & {
+  element(loc: ElementLike): ElementMatchers & {
+    not: ElementMatchers
+  }
+}
+
+const expectFn = ((actual: unknown, message?: string) =>
+  new Expectation(actual, message)) as ExpectFn
+
+expectFn.element = (loc: ElementLike) => {
+  return Object.assign(elementMatchers(loc), {
+    not: elementMatchers(loc, true),
+  })
+}
+
+export const expect = expectFn
+
+export function assert(
+  condition: unknown,
+  message?: string,
+): asserts condition {
+  if (!condition) {
+    throw new Error(message ?? 'Assertion failed')
+  }
+}
+assert.fail = (message?: string): never => {
+  throw new Error(message ?? 'Assertion failed')
+}
+
+type MockedFn<T extends (...args: never[]) => unknown> = T & {
+  mock: {calls: Array<Parameters<T>>}
+}
+
+function vifn<T extends (...args: never[]) => unknown>(
+  implementation?: T,
+): MockedFn<T> {
+  const calls: Array<Parameters<T>> = []
+  const wrapped = ((...args: Parameters<T>) => {
+    calls.push(args)
+    return implementation?.(...args)
+  }) as MockedFn<T>
+  wrapped.mock = {calls}
+  return wrapped
+}
+
+export const vi = {
+  waitFor,
+  fn: vifn,
+}

--- a/apps/racetrack/src/theme.css
+++ b/apps/racetrack/src/theme.css
@@ -1,30 +1,13 @@
-/**
- * Racetrack visual language. Greyscale base with three semantic
- * status colors: pass (green), fail (red), running (blue). 8px grid,
- * 1px borders, no shadows, 4px button radius max, no rounded panel
- * corners. System UI font.
- */
-
 :root {
-  --rt-bg: #ffffff;
-  --rt-bg-elevated: #fafafa;
-  --rt-bg-muted: #f4f4f4;
-  --rt-fg: #1c1c1c;
-  --rt-fg-muted: #555555;
-  --rt-fg-subtle: #777777;
-  --rt-border: #d0d0d0;
-  --rt-border-subtle: #e6e6e6;
-  --rt-pass: #2c7a3e;
-  --rt-fail: #b3261e;
-  --rt-running: #1f5fb3;
-  --rt-idle: #b0b0b0;
-
-  --rt-space-1: 4px;
-  --rt-space-2: 8px;
-  --rt-space-3: 12px;
-  --rt-space-4: 16px;
-  --rt-space-5: 24px;
-  --rt-space-6: 32px;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #6e6e6e;
+  --border: #e5e5e5;
+  --hover: #f5f5f5;
+  --pass: #2da44e;
+  --fail: #cf222e;
+  --running: #4493f8;
+  --idle: #d0d0d0;
 }
 
 * {
@@ -32,91 +15,376 @@
 }
 
 html,
-body,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 #root {
   height: 100%;
-  margin: 0;
+  width: 100%;
 }
 
-body {
-  font-family:
-    system-ui,
-    -apple-system,
-    'Segoe UI',
-    Roboto,
-    'Helvetica Neue',
-    Arial,
-    sans-serif;
-  color: var(--rt-fg);
-  background: var(--rt-bg);
-  font-size: 14px;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+.rt-app {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  height: 100vh;
+  width: 100vw;
 }
 
-.rt-shell {
+.rt-panel {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  min-width: 0;
+  border-right: 1px solid var(--border);
+  overflow: hidden;
 }
 
-.rt-tease {
-  flex: 1 1 auto;
+.rt-panel:last-child {
+  border-right: none;
+}
+
+.rt-panel-header {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: var(--rt-space-4);
-  padding: var(--rt-space-6);
-  text-align: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 0 0 auto;
 }
 
-.rt-tease-mark {
-  display: flex;
-  gap: var(--rt-space-2);
+.rt-panel-header-title {
+  font-weight: 500;
 }
 
+.rt-panel-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 12px 16px;
+}
+
+.rt-panel-body--monospace {
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+/* Button */
+.rt-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.rt-button:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+.rt-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rt-button--primary {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+
+.rt-button--primary:hover:not(:disabled) {
+  background: #000000;
+}
+
+/* Status dots */
 .rt-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--rt-idle);
   display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--idle);
+  flex: 0 0 auto;
 }
 
-.rt-dot--pass {
-  background: var(--rt-pass);
+.rt-dot--idle {
+  background: var(--idle);
 }
 
 .rt-dot--running {
-  background: var(--rt-running);
-  animation: rt-pulse 900ms ease-in-out infinite;
+  background: var(--running);
+}
+
+.rt-dot--pass {
+  background: var(--pass);
 }
 
 .rt-dot--fail {
-  background: var(--rt-fail);
+  background: var(--fail);
 }
 
-@keyframes rt-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
+/* Scenarios panel */
+.rt-feature {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.rt-tease-name {
-  font-size: 2.5rem;
+.rt-feature-title {
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg);
+}
+
+.rt-scenario {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rt-scenario-name {
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.rt-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 2px 0 2px 16px;
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.rt-step-dot {
+  margin-top: 6px;
+}
+
+.rt-step-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rt-step--fail .rt-step-text {
+  color: var(--fail);
+}
+
+.rt-step-error {
+  margin: 4px 0 4px 32px;
+  padding: 8px;
+  background: #fdf2f2;
+  border: 1px solid var(--fail);
+  color: var(--fail);
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Editor surface */
+.rt-editor-host {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rt-editable {
+  min-height: 120px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+
+.rt-editable:focus {
+  border-color: var(--fg);
+}
+
+.rt-state {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+}
+
+.rt-state-label {
+  color: var(--muted);
+}
+
+.rt-state-value {
+  color: var(--fg);
+  word-break: break-all;
+}
+
+/* Runner */
+.rt-summary {
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+}
+
+.rt-summary--pass {
+  border-color: var(--pass);
+  color: var(--pass);
+}
+
+.rt-summary--fail {
+  border-color: var(--fail);
+  color: var(--fail);
+}
+
+.rt-runner-target {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.rt-runner-target-label {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+/* Reset inner editor outline so focus shows on the wrapper only. */
+.rt-editable [contenteditable]:focus {
+  outline: none;
+}
+
+/* Racetrack header + entry picker */
+
+.rt-app {
+  display: flex;
+  flex-direction: column;
+}
+
+.rt-header {
+  display: flex;
+  align-items: center;
+  gap: var(--rt-space-4, 16px);
+  padding: var(--rt-space-3, 12px) var(--rt-space-4, 16px);
+  border-bottom: 1px solid var(--rt-border, #d0d0d0);
+  background: var(--rt-bg-elevated, #fafafa);
+  flex: 0 0 auto;
+}
+
+.rt-header-title {
   font-weight: 600;
-  letter-spacing: 0.01em;
-  margin: 0;
+  letter-spacing: 0.02em;
 }
 
-.rt-tease-tag {
+.rt-entry-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--rt-space-2, 8px);
+  font-size: 0.875rem;
+}
+
+.rt-entry-picker-label {
+  color: var(--rt-fg-muted, #555);
+}
+
+.rt-entry-picker-select {
+  font: inherit;
+  padding: 4px 8px;
+  border: 1px solid var(--rt-border, #d0d0d0);
+  border-radius: 4px;
+  background: var(--rt-bg, #fff);
+}
+
+.rt-entry-picker-select:disabled {
+  opacity: 0.6;
+}
+
+.rt-entry-picker-description {
+  color: var(--rt-fg-muted, #555);
+  font-style: italic;
+}
+
+.rt-panels {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+.rt-panels > .rt-panel {
+  flex: 1 1 0;
+}
+
+/* Engine panel - read-only source viewer with tabs */
+
+.rt-engine-tabs {
+  display: flex;
+  gap: 2px;
+}
+
+.rt-engine-tab {
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+  color: var(--rt-fg-muted, #555);
+  cursor: pointer;
+}
+
+.rt-engine-tab--active {
+  background: var(--rt-bg, #fff);
+  border-color: var(--rt-border, #d0d0d0);
+  color: var(--rt-fg, #1c1c1c);
+}
+
+.rt-engine-tab:not(.rt-engine-tab--active):hover {
+  color: var(--rt-fg, #1c1c1c);
+}
+
+.rt-engine-body {
+  padding: 0;
+}
+
+.rt-engine-source {
   margin: 0;
-  color: var(--rt-fg-muted);
-  font-size: 1rem;
+  padding: 12px 16px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  background: var(--rt-bg, #fff);
+  color: var(--rt-fg, #1c1c1c);
+  overflow: auto;
+  height: 100%;
+  white-space: pre;
 }

--- a/apps/racetrack/tsconfig.app.json
+++ b/apps/racetrack/tsconfig.app.json
@@ -19,7 +19,14 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "vitest/browser": ["./src/runner/vitest-browser-shim.ts"],
+      "vitest-browser-react": ["./src/runner/vitest-browser-react-shim.ts"],
+      "vitest": ["./src/runner/vitest-shim.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/apps/racetrack/tsconfig.node.json
+++ b/apps/racetrack/tsconfig.node.json
@@ -2,22 +2,12 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
-    "module": "ESNext",
     "skipLibCheck": true,
-
+    "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
+    "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noEmit": true
   },
   "include": ["vite.config.ts"]
 }

--- a/apps/racetrack/vite.config.ts
+++ b/apps/racetrack/vite.config.ts
@@ -1,6 +1,58 @@
+import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import {defineConfig} from 'vite'
 
+// Aliases redirect:
+//
+// - `vitest/browser` and `vitest` to our shims (so step-definitions and
+//   test-editor compile and run outside a vitest worker).
+// - `vitest-browser-react` to our shim (so test-editor.tsx's `render()`
+//   resolves to a plain React 19 createRoot mount).
+// - `@portabletext/*` packages to their workspace sources, matching the
+//   playground convention so React Fast Refresh works on the underlying
+//   packages.
+//
+// Order matters: more-specific aliases come first so `vitest/browser` is
+// not caught by the `vitest` alias.
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'vitest/browser': path.resolve(
+        __dirname,
+        'src/runner/vitest-browser-shim.ts',
+      ),
+      'vitest-browser-react': path.resolve(
+        __dirname,
+        'src/runner/vitest-browser-react-shim.ts',
+      ),
+      'vitest': path.resolve(__dirname, 'src/runner/vitest-shim.ts'),
+      '@portabletext/editor': path.resolve(
+        __dirname,
+        '../../packages/editor/src',
+      ),
+      '@portabletext/keyboard-shortcuts': path.resolve(
+        __dirname,
+        '../../packages/keyboard-shortcuts/src',
+      ),
+      '@portabletext/patches': path.resolve(
+        __dirname,
+        '../../packages/patches/src',
+      ),
+      '@portabletext/plugin-input-rule': path.resolve(
+        __dirname,
+        '../../packages/plugin-input-rule/src',
+      ),
+      '@portabletext/plugin-typeahead-picker': path.resolve(
+        __dirname,
+        '../../packages/plugin-typeahead-picker/src',
+      ),
+      '@portabletext/schema': path.resolve(
+        __dirname,
+        '../../packages/schema/src',
+      ),
+      'racejar': path.resolve(__dirname, '../../packages/racejar/src'),
+    },
+  },
 })

--- a/knip.json
+++ b/knip.json
@@ -57,6 +57,20 @@
         "sharp"
       ]
     },
-    "examples/*": {}
+    "examples/*": {},
+    "apps/racetrack": {
+      "entry": [
+        "index.html!",
+        "src/runner/vitest-shim.ts!",
+        "src/runner/vitest-browser-shim.ts!",
+        "src/runner/vitest-browser-react-shim.ts!"
+      ],
+      "ignoreDependencies": [
+        "babel-plugin-react-compiler",
+        "eslint-formatter-gha",
+        "tailwindcss-react-aria-components",
+        "sharp"
+      ]
+    }
   }
 }

--- a/packages/editor/src/internal-utils/global-scope.ts
+++ b/packages/editor/src/internal-utils/global-scope.ts
@@ -1,27 +1,6 @@
 /**
- * Gets the global scope instance in a given environment.
- *
- * The strategy is to return the most modern, and if not, the most common:
- * - The `globalThis` variable is the modern approach to accessing the global scope
- * - The `window` variable is the global scope in a web browser
- * - The `self` variable is the global scope in workers and others
- * - The `global` variable is the global scope in Node.js
+ * Gets the global scope. `globalThis` is universal in every environment
+ * the editor supports (browsers, Node 12+, workers, Deno, Bun), so a single
+ * read suffices.
  */
-function getGlobalScope() {
-  if (typeof globalThis !== 'undefined') {
-    return globalThis
-  }
-  if (typeof window !== 'undefined') {
-    return window
-  }
-  if (typeof self !== 'undefined') {
-    return self
-  }
-  if (typeof global !== 'undefined') {
-    return global
-  }
-
-  throw new Error('@portabletext/editor: could not locate global scope')
-}
-
-export const globalScope = getGlobalScope() as any
+export const globalScope = globalThis as any

--- a/packages/editor/src/test/vitest/test-editor.tsx
+++ b/packages/editor/src/test/vitest/test-editor.tsx
@@ -83,7 +83,7 @@ export async function createTestEditor(
         ))
   }
 
-  const locator = page.getByRole('textbox')
+  const locator = renderResult.locator.getByRole('textbox')
 
   await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
 

--- a/packages/editor/tests/test-editor.test.tsx
+++ b/packages/editor/tests/test-editor.test.tsx
@@ -1,0 +1,33 @@
+import {expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+/**
+ * Regression test for `createTestEditor`'s locator scoping.
+ *
+ * Each call to `createTestEditor` mounts its own editor into a fresh
+ * container via `render()`. The returned locator must target that
+ * specific editor instance - not any other `[role="textbox"]` that
+ * happens to live in the same document, in document order.
+ *
+ * Before the fix, the function discarded the scoped locator from
+ * `render()` and built a document-wide `page.getByRole('textbox')`
+ * lookup, so any second editor in the DOM would be addressed by the
+ * first call's locator. Vitest's iframe-per-test isolation kept this
+ * latent in CI; embedders that share a DOM across editors hit it.
+ */
+
+test('returns a locator scoped to the rendered editor', async () => {
+  const first = await createTestEditor()
+  const second = await createTestEditor()
+
+  await userEvent.type(first.locator, 'first')
+  await userEvent.type(second.locator, 'second')
+
+  await vi.waitFor(() => {
+    expect(toTextspec(first.editor.getSnapshot().context)).toEqual('B: first|')
+  })
+
+  expect(toTextspec(second.editor.getSnapshot().context)).toEqual('B: second|')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,30 @@ importers:
 
   apps/racetrack:
     dependencies:
+      '@cucumber/gherkin':
+        specifier: ^39.0.0
+        version: 39.0.0
+      '@cucumber/messages':
+        specifier: ^32.2.0
+        version: 32.2.0
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      '@portabletext/plugin-input-rule':
+        specifier: workspace:*
+        version: link:../../packages/plugin-input-rule
+      '@portabletext/plugin-typeahead-picker':
+        specifier: workspace:*
+        version: link:../../packages/plugin-typeahead-picker
+      '@portabletext/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      racejar:
+        specifier: workspace:*
+        version: link:../../packages/racejar
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -4975,6 +4999,16 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@textspec/notation@1.0.1':
     resolution: {integrity: sha512-XADhtctcXBykcJ+hlsNPmKG5I2YHmF4eDtahZUUOSR1w/tZUk346uznnntm+FhWXCr9bCSht5PTeHry1m1TC4w==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -4987,6 +5021,9 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -5411,6 +5448,9 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -5815,6 +5855,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -6843,6 +6886,10 @@ packages:
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -7449,6 +7496,10 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@30.3.0:
     resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -7532,6 +7583,9 @@ packages:
     resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
     peerDependencies:
       react: '>=16.13.1'
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -13104,6 +13158,21 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@textspec/notation@1.0.1': {}
 
   '@ts-morph/common@0.28.1':
@@ -13118,6 +13187,8 @@ snapshots:
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -13765,6 +13836,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
@@ -14207,6 +14282,8 @@ snapshots:
   direction@2.0.1: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15534,6 +15611,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -16428,6 +16507,12 @@ snapshots:
 
   pretty-bytes@7.1.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@30.3.0:
     dependencies:
       '@jest/schemas': 30.0.5
@@ -16578,6 +16663,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.2.5
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
Racetrack is a hosted playground and scenario-driven test runner for Portable Text Editor plugins. Wire your plugin in, drive it with scenarios you author visually, watch them go green. The same `.feature` file runs in Racetrack playback AND in the customer's vitest CI - identical results.

This is the long-running branch where Racetrack is built inside the editor monorepo while PTE v7 stabilises. It will not be merged in this shape. Platform fixes that fall out (one already has, #2644) get split into their own PRs and merged independently. Each push to this branch generates a Vercel preview at https://racetrack.sanity.dev/ so the work is continuously testable.

### What's here today

The app at `apps/racetrack/` is private, runs against the monorepo's workspace sources, and currently boots a fixed garage of two cars:

- **Mention picker** - `@portabletext/plugin-typeahead-picker`'s mention picker scenarios, lifted verbatim from `packages/plugin-typeahead-picker/src/mention-picker.test.tsx`. 19 scenarios, all green.
- **Input rule edge cases** - `@portabletext/plugin-input-rule`'s edge-case scenarios, lifted verbatim from `packages/plugin-input-rule/src/edge-cases.test.tsx`. 57 scenarios, all green, matching the vitest CI baseline exactly.

The same `.feature` files run unmodified in their packages' vitest browser tests; the runner here just provides the playback and visualisation surface.

### How it works

Four panels. Scenarios on the left (parsed via `@cucumber/gherkin`, scenario outlines expanded into individual pickles). A live editor in the middle with the car's plugin wired in. A second editor on the right that each scenario drives via racejar's runner-agnostic `compileFeature`. An engine panel surfaces the car's source as read-only tabs - `Plugin.tsx`, `entry.tsx`, `steps.ts`, `feature.feature` - imported via Vite's `?raw` suffix at build time.

A car lives at `src/garage/<name>/` with a fixed shape: an `entry.tsx` that exports a `GarageEntry` manifest pairing the feature file with the React plugin, step definitions, hooks, and parameter types. The App reads from `src/garage/index.ts` and a dropdown switches cars.

The runner re-implements racejar's vitest driver as 49 lines of plain async iteration, then aliases `vitest`, `vitest/browser`, and `vitest-browser-react` to in-app shims so existing step definitions (`@portabletext/editor/test/vitest`) and `createTestEditor` import cleanly outside a vitest worker. The shims diverge from vitest in two places, both deliberate:

- `Locator.locator(selector)` and `page.locator(selector)` are added so step definitions can scope assertions to the test target rather than picking up the playground editor that shares the DOM.
- `@testing-library/user-event`'s `.type()` is invoked with `{skipClick: true}` so typing into a contenteditable doesn't collapse the existing selection - matching Playwright's `page.keyboard.type()` behaviour used by vitest's browser runner.

Both divergences were validated by running the same `.feature` files in vitest CI and confirming identical pass counts.

### What comes next

The current cars validate the runtime; the next chunks are scenario authoring inside the app (drag-from-palette + AI-assisted drafting), exporting `.feature` files back to the consumer's repo, and the structured-lists plugin as the dogfood target.

Brief at `/project-brief.md`. Architecture and design at `/specs/racetrack*.md`.
