### PR TITLE
fix(editor): simplify `globalScope` to `globalThis` and inline at its one call site

### DIFF
--- a/.changeset/inline-global-scope.md
+++ b/.changeset/inline-global-scope.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(editor): inline `globalScope` into `createGloballyScopedContext` and delete the dead `global-scope` helper

--- a/packages/editor/src/internal-utils/global-scope.ts
+++ b/packages/editor/src/internal-utils/global-scope.ts
@@ -1,6 +1,0 @@
-/**
- * Gets the global scope. `globalThis` is universal in every environment
- * the editor supports (browsers, Node 12+, workers, Deno, Bun), so a single
- * read suffices.
- */
-export const globalScope = globalThis as any

--- a/packages/editor/src/internal-utils/global-scope.ts
+++ b/packages/editor/src/internal-utils/global-scope.ts
@@ -1,27 +1,6 @@
 /**
- * Gets the global scope instance in a given environment.
- *
- * The strategy is to return the most modern, and if not, the most common:
- * - The `globalThis` variable is the modern approach to accessing the global scope
- * - The `window` variable is the global scope in a web browser
- * - The `self` variable is the global scope in workers and others
- * - The `global` variable is the global scope in Node.js
+ * Gets the global scope. `globalThis` is universal in every environment
+ * the editor supports (browsers, Node 12+, workers, Deno, Bun), so a single
+ * read suffices.
  */
-function getGlobalScope() {
-  if (typeof globalThis !== 'undefined') {
-    return globalThis
-  }
-  if (typeof window !== 'undefined') {
-    return window
-  }
-  if (typeof self !== 'undefined') {
-    return self
-  }
-  if (typeof global !== 'undefined') {
-    return global
-  }
-
-  throw new Error('@portabletext/editor: could not locate global scope')
-}
-
-export const globalScope = getGlobalScope() as any
+export const globalScope = globalThis as any

--- a/packages/editor/src/internal-utils/globally-scoped-context.ts
+++ b/packages/editor/src/internal-utils/globally-scoped-context.ts
@@ -1,5 +1,4 @@
 import {createContext, type Context} from 'react'
-import {globalScope} from './global-scope'
 
 /**
  * As `@portabletext/editor` is declared as a dependency, and may be
@@ -33,7 +32,8 @@ export function createGloballyScopedContext<
     return createContext<ContextType>(defaultValue)
   }
 
-  globalScope[symbol] = globalScope[symbol] ?? createContext<T>(defaultValue)
+  const scope = globalThis as any
+  scope[symbol] = scope[symbol] ?? createContext<T>(defaultValue)
 
-  return globalScope[symbol]
+  return scope[symbol]
 }


### PR DESCRIPTION
`getGlobalScope` had a four-branch chain - `globalThis` first, then `window`, `self`, `global`. `globalThis` is universal in every environment the editor supports (browsers, Node 12+, workers, Deno, Bun), so the rest of the chain is unreachable.

Beyond being dead code, the `global` branch needs `@types/node` in scope to type-check. Consumers whose tsconfig doesn't pull Node types - any app that aliases `@portabletext/editor` directly to its `src/` rather than going through the built `lib/` - trip on it. The racetrack app at `apps/racetrack/` (PR #2646) ran into it on Vercel where deps build from scratch and stale tsbuildinfo caches don't hide it.

With the four-branch fallback gone, `global-scope.ts` is a one-line passthrough whose only job is to suppress symbol-indexing on `globalThis` with `as any`. There's nothing left to wrap. Inline the cast at the one call site in `createGloballyScopedContext` and delete the file.

No public API change, no behaviour change.