### PR TITLE
fix: align `insert` operation with the patches spec for numeric-index paths

### DIFF
--- a/.changeset/insert-position-numeric-index.md
+++ b/.changeset/insert-position-numeric-index.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: align `insert` operation with the patches spec for numeric-index paths
+
+When an `insert` patch's path ended in a numeric index, the apply layer treated the index as the absolute destination and ignored `position`. So `{type: 'insert', path: [2], position: 'after', items: [X]}` landed at index 2 instead of index 3, diverging from `@portabletext/patches` and the Sanity content-lake spec.
+
+This is reachable from the public `patches` event - a remote insert with `position: 'after'` on a numeric-index path now lands at the correct index.

--- a/packages/editor/src/slate/core/apply-operation.ts
+++ b/packages/editor/src/slate/core/apply-operation.ts
@@ -72,7 +72,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
           }
           index = op.position === 'after' ? siblingIndex + 1 : siblingIndex
         } else if (typeof lastSegment === 'number') {
-          index = lastSegment
+          index = op.position === 'after' ? lastSegment + 1 : lastSegment
         } else {
           throw new Error(
             `Cannot apply an "insert" operation at path [${path}] because the last segment is a field name.`,

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -2947,6 +2947,186 @@ describe('event.patches', () => {
         })
       })
     })
+
+    test('Scenario: `before` on numeric index 0 prepends to a non-empty array', async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const blockAKey = keyGenerator()
+      const spanAKey = keyGenerator()
+      const blockBKey = keyGenerator()
+      const spanBKey = keyGenerator()
+      const newBlockKey = keyGenerator()
+      const newSpanKey = keyGenerator()
+
+      const blockA = {
+        _key: blockAKey,
+        _type: 'block',
+        children: [{_key: spanAKey, _type: 'span', text: 'A', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const blockB = {
+        _key: blockBKey,
+        _type: 'block',
+        children: [{_key: spanBKey, _type: 'span', text: 'B', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const newBlock = {
+        _key: newBlockKey,
+        _type: 'block',
+        children: [{_key: newSpanKey, _type: 'span', text: 'new', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+
+      const {editor} = await createTestEditor({
+        keyGenerator,
+        schemaDefinition: defineSchema({}),
+        initialValue: [blockA, blockB],
+      })
+
+      editor.send({
+        type: 'patches',
+        patches: [
+          {
+            origin: 'remote',
+            type: 'insert',
+            position: 'before',
+            path: [0],
+            items: [newBlock],
+          },
+        ],
+        snapshot: [newBlock, blockA, blockB],
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          newBlock,
+          blockA,
+          blockB,
+        ])
+      })
+    })
+
+    test('Scenario: `after` on a numeric index inserts after the indexed sibling', async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const blockAKey = keyGenerator()
+      const spanAKey = keyGenerator()
+      const blockBKey = keyGenerator()
+      const spanBKey = keyGenerator()
+      const newBlockKey = keyGenerator()
+      const newSpanKey = keyGenerator()
+
+      const blockA = {
+        _key: blockAKey,
+        _type: 'block',
+        children: [{_key: spanAKey, _type: 'span', text: 'A', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const blockB = {
+        _key: blockBKey,
+        _type: 'block',
+        children: [{_key: spanBKey, _type: 'span', text: 'B', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const newBlock = {
+        _key: newBlockKey,
+        _type: 'block',
+        children: [{_key: newSpanKey, _type: 'span', text: 'new', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+
+      const {editor} = await createTestEditor({
+        keyGenerator,
+        schemaDefinition: defineSchema({}),
+        initialValue: [blockA, blockB],
+      })
+
+      editor.send({
+        type: 'patches',
+        patches: [
+          {
+            origin: 'remote',
+            type: 'insert',
+            position: 'after',
+            path: [0],
+            items: [newBlock],
+          },
+        ],
+        snapshot: [blockA, newBlock, blockB],
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          blockA,
+          newBlock,
+          blockB,
+        ])
+      })
+    })
+
+    test('Scenario: `before` on a numeric index inserts before the indexed sibling', async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const blockAKey = keyGenerator()
+      const spanAKey = keyGenerator()
+      const blockBKey = keyGenerator()
+      const spanBKey = keyGenerator()
+      const newBlockKey = keyGenerator()
+      const newSpanKey = keyGenerator()
+
+      const blockA = {
+        _key: blockAKey,
+        _type: 'block',
+        children: [{_key: spanAKey, _type: 'span', text: 'A', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const blockB = {
+        _key: blockBKey,
+        _type: 'block',
+        children: [{_key: spanBKey, _type: 'span', text: 'B', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+      const newBlock = {
+        _key: newBlockKey,
+        _type: 'block',
+        children: [{_key: newSpanKey, _type: 'span', text: 'new', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+
+      const {editor} = await createTestEditor({
+        keyGenerator,
+        schemaDefinition: defineSchema({}),
+        initialValue: [blockA, blockB],
+      })
+
+      editor.send({
+        type: 'patches',
+        patches: [
+          {
+            origin: 'remote',
+            type: 'insert',
+            position: 'before',
+            path: [1],
+            items: [newBlock],
+          },
+        ],
+        snapshot: [blockA, newBlock, blockB],
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          blockA,
+          newBlock,
+          blockB,
+        ])
+      })
+    })
   })
 
   describe('`setIfMissing`', () => {


### PR DESCRIPTION
When an `insert` operation's path ends in a numeric index, the apply layer treats the index as the absolute destination and drops `position`. So today:

```ts
editor.apply({type: 'insert', path: [..., 2], position: 'after', node})
```

inserts AT index 2, just like `position: 'before'`. This diverges from `@portabletext/patches` (`arrayInsert.ts` normalizes `idx + 1` for `'after'`) and the Sanity content-lake spec (where `before: array[2]` is index 2 and `after: array[2]` is index 3).

This is reachable from the public `patches` event: `applyPatch.ts` forwards a patch's `position` straight through to the apply layer. A remote insert with `position: 'after'` and a numeric-index path - a valid shape coming over the wire from Sanity - lands at the wrong index. Editor-generated inserts go through `applyInsertNodeAtPath` which hardcodes `position: 'before'`, so the bug has been dormant for inserts the editor itself produces.

The fix is one line in `apply-operation.ts`:

```diff
   } else if (typeof lastSegment === 'number') {
-    index = lastSegment
+    index = op.position === 'after' ? lastSegment + 1 : lastSegment
   } else {
```

Three scenarios pin the contract inside `event.patches.test.tsx`'s existing `describe('insert', ...)` block:

- `before [0]` on a non-empty array prepends
- `before [1]` on a non-empty array inserts between
- `after [0]` on a non-empty array inserts between (the fix discriminator)

### Why this matters for #2637

The promotion PR exposes `insert` as a primitive behavior event. With the apply layer behaving inconsistently with the patches spec, plugin authors composing `insert` would have to learn to avoid numeric-index paths or special-case them. Aligning the semantics first makes the new event safe to document with the natural reading.