### PR TITLE
fix: parse nested containers recursively at any depth

### DIFF
--- a/.changeset/parse-nested-containers.md
+++ b/.changeset/parse-nested-containers.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: parse nested containers recursively at any depth

--- a/packages/editor/src/utils/parse-blocks.test.ts
+++ b/packages/editor/src/utils/parse-blocks.test.ts
@@ -971,3 +971,125 @@ describe('container-aware parsing', () => {
     })
   })
 })
+
+describe('container-aware parsing (nested containers)', () => {
+  const recursiveListSchema = defineSchema({
+    blockObjects: [
+      {
+        name: 'list',
+        fields: [
+          {name: 'kind', type: 'string'},
+          {
+            name: 'items',
+            type: 'array',
+            of: [
+              {
+                type: 'object',
+                name: 'list-item',
+                fields: [
+                  {
+                    name: 'content',
+                    type: 'array',
+                    of: [{type: 'block'}, {type: 'list'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  test('preserves a nested list inside a list-item at depth 3', () => {
+    const schema = compileSchema(recursiveListSchema)
+    const parsed = parseBlock({
+      block: {
+        _type: 'list',
+        _key: 'L0',
+        kind: 'number',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I0',
+            content: [
+              {
+                _type: 'block',
+                _key: 'b0',
+                children: [
+                  {_type: 'span', _key: 's0', text: 'outer', marks: []},
+                ],
+              },
+              {
+                _type: 'list',
+                _key: 'L1',
+                kind: 'bullet',
+                items: [
+                  {
+                    _type: 'list-item',
+                    _key: 'I1',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'b1',
+                        children: [
+                          {_type: 'span', _key: 's1', text: 'inner', marks: []},
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      keyGenerator: createTestKeyGenerator(),
+      options: {
+        normalize: false,
+        removeUnusedMarkDefs: false,
+        validateFields: true,
+      },
+      schema,
+    })
+
+    expect(parsed).toEqual({
+      _type: 'list',
+      _key: 'L0',
+      kind: 'number',
+      items: [
+        {
+          _type: 'list-item',
+          _key: 'I0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              children: [{_type: 'span', _key: 's0', text: 'outer', marks: []}],
+            },
+            {
+              _type: 'list',
+              _key: 'L1',
+              kind: 'bullet',
+              items: [
+                {
+                  _type: 'list-item',
+                  _key: 'I1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      children: [
+                        {_type: 'span', _key: 's1', text: 'inner', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/editor/src/utils/parse-blocks.ts
+++ b/packages/editor/src/utils/parse-blocks.ts
@@ -708,13 +708,20 @@ function parseObject({
 
 /**
  * Parse the value of an array field whose `of` declares what's allowed at
- * that position. If any member is `{type: 'block'}`, the field is a PTE
- * container: recurse via `parseBlocks` in a child `Schema`. Otherwise it
- * is a structural array of non-PTE members (rows, cells, scalars, objects
- * that sit between containers and the actual text blocks) -- recurse into
- * each typed-object member so deeper PTE arrays still get parsed. The
- * ancestor-fields map carries inline type declarations down to descendants
- * so bare references like `{type: 'list'}` resolve to the inline shape.
+ * that position. Each item is dispatched per its own type:
+ *
+ * - Text blocks (`_type === schema.block.name`) are parsed against a child
+ *   sub-schema derived from the `{type: 'block'}` member of `of` (which
+ *   carries the styles, decorators, annotations, lists, and inline objects
+ *   allowed at this position).
+ *
+ * - Block objects (and structural objects sitting between containers and
+ *   text blocks) are parsed via `resolveOfMember` against the `of` array,
+ *   with `ancestorFields` carrying inline type declarations down to bare
+ *   references like `{type: 'list'}`. This lets nested containers resolve
+ *   to their inline shapes at any depth.
+ *
+ * Items that don't resolve are passed through unchanged.
  */
 function parseContainerFieldValue({
   schema,
@@ -732,14 +739,20 @@ function parseContainerFieldValue({
   options: {validateFields: boolean; normalize?: boolean}
 }): Array<unknown> {
   const hasBlockMember = of.some((member) => member.type === 'block')
+  const childBlockSubSchema = hasBlockMember
+    ? getSubSchema(schema, of)
+    : undefined
 
-  if (hasBlockMember) {
-    const childSubSchema = getSubSchema(schema, of)
-    return value.flatMap((block) => {
-      const parsed = parseBlockInternal({
-        schema: childSubSchema,
+  return value.flatMap((item) => {
+    if (!isTypedObject(item)) {
+      return [item]
+    }
+
+    if (childBlockSubSchema && item._type === childBlockSubSchema.block.name) {
+      const parsed = parseTextBlock({
+        block: item,
+        schema: childBlockSubSchema,
         keyGenerator,
-        block,
         options: {
           normalize: false,
           removeUnusedMarkDefs: false,
@@ -747,13 +760,8 @@ function parseContainerFieldValue({
         },
       })
       return parsed ? [parsed] : []
-    })
-  }
-
-  return value.flatMap((item) => {
-    if (!isTypedObject(item)) {
-      return [item]
     }
+
     const schemaType = resolveOfMember(of, item._type, schema, ancestorFields)
     if (!schemaType) {
       return [item]


### PR DESCRIPTION
Self-referential containers (a `list` whose items can hold nested `list`s, a `code-block` whose lines can hold blocks) lost their nested content when parsed through `parseBlocks` at depth 3 and beyond. The nested container collapsed to a placeholder with only `_type` and `_key`, and every field below the placeholder was dropped.

## The bug

`parseContainerFieldValue` decided how to parse each item by checking whether `of` contained a `{type: 'block'}` member. If yes, EVERY item was parsed against the child sub-schema's text-block shape. The child sub-schema is the slice of the schema that describes what a text block at this position can hold (styles, decorators, annotations, lists, inline objects). It does NOT follow bare references like `{type: 'list'}` to the inline declaration elsewhere in the parent.

Result: when the `of` array mixes `{type: 'block'}` with bare references to nested containers like `{type: 'list'}`, the bare-reference items entered the wrong branch and got reduced to text-block shape, which they don't match, yielding a placeholder.

## The fix

Per-item dispatch:

- Text blocks (matching the child sub-schema's `block.name`) parse against the child sub-schema, same as before.
- Everything else dispatches via `resolveOfMember(of, item._type, schema, ancestorFields)`, which DOES follow bare references via `ancestorFields` carrying inline type declarations from ancestor positions. Inline declarations at any depth resolve to their full shape.
- Items whose type doesn't resolve pass through unchanged (same as the existing non-block branch).

One pass, one helper, no special-casing the structural-versus-text dichotomy.

## Test

A new scenario in `parse-blocks.test.ts`'s container-aware describe block pins a depth-3 recursive list: an outer `list` whose first `list-item.content` holds a text block followed by another `list` whose item holds a text block. Pre-fix the inner list became `{_type: 'list', _key: 'L1'}` with no `items` and no `kind`. Post-fix it round-trips.