### PR TITLE
feat: pilcrow

### DIFF
--- a/.changeset/arrow-nav-nested-containers.md
+++ b/.changeset/arrow-nav-nested-containers.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: arrow navigation out of nested containers walks all ancestors
+
+The arrow dead-end check looked at the innermost editable container only, so being at the last text block of a nested container (e.g. the last list-item in a list) wrongly suppressed the native arrow key even when an ancestor container had a sibling at the document root. The check now walks container ancestors and only suppresses navigation when every ancestor up to the root is at its edge.

--- a/.changeset/pilcrow-convert-patches.md
+++ b/.changeset/pilcrow-convert-patches.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': minor
+---
+
+feat: expose `convertPatches` from `@portabletext/plugin-sdk-value`
+
+Lets consumers reuse the wire-shape to array-path patch conversion that the SDK value sync uses internally. Useful for any flow that sources value changes from outside the editor (e.g. a markdown source pane that round-trips into the editor via `@sanity/diff-patch`).

--- a/.changeset/preserve-user-regex-flags.md
+++ b/.changeset/preserve-user-regex-flags.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/plugin-input-rule': patch
+---
+
+fix: preserve safe flags consumers set on `InputRule.on`
+
+The plugin compiled the rule's regex with a fixed `gd` flag set, silently dropping any flags the consumer had on the source pattern. A rule like `/\[!(note|tip)\]/i` would never fire for `[!NOTE]` because the rebuilt matcher was case-sensitive.
+
+The plugin now preserves a known-safe subset of consumer flags - `i`, `m`, `s`, `u` - while keeping `g` and `d` under its own control. Sticky (`y`) is also stripped: it would conflict with the plugin's `matchAll` loop, which slices and re-feeds text after each match.

--- a/apps/pilcrow/index.html
+++ b/apps/pilcrow/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Pilcrow</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/pilcrow/package.json
+++ b/apps/pilcrow/package.json
@@ -11,9 +11,25 @@
     "clean": "del .turbo && del dist && del node_modules",
     "dev": "vite",
     "lint:fix": "biome lint --write .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:browser:chromium": "vitest --run --project \"browser (chromium)\"",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@portabletext/editor": "workspace:*",
+    "@portabletext/markdown": "workspace:*",
+    "@portabletext/patches": "workspace:*",
+    "@portabletext/plugin-emoji-picker": "workspace:*",
+    "@portabletext/plugin-input-rule": "workspace:*",
+    "@portabletext/plugin-markdown-shortcuts": "workspace:*",
+    "@portabletext/plugin-sdk-value": "workspace:*",
+    "@portabletext/plugin-typeahead-picker": "workspace:*",
+    "@portabletext/plugin-typography": "workspace:*",
+    "@portabletext/schema": "workspace:*",
+    "@portabletext/test": "workspace:*",
+    "@portabletext/toolbar": "workspace:*",
+    "@sanity/diff-patch": "^6.0.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
@@ -21,7 +37,12 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/browser": "^4.1.4",
+    "@vitest/browser-playwright": "^4.1.4",
+    "racejar": "workspace:*",
     "typescript": "catalog:",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.4",
+    "vitest-browser-react": "^2.2.0"
   }
 }

--- a/apps/pilcrow/public/favicon.svg
+++ b/apps/pilcrow/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#1c1c1c"/>
+  <text
+    x="50%"
+    y="50%"
+    dominant-baseline="central"
+    text-anchor="middle"
+    font-family="Crimson Pro, Iowan Old Style, Palatino, Georgia, serif"
+    font-size="48"
+    font-weight="500"
+    fill="#ffffff"
+  >¶</text>
+</svg>

--- a/apps/pilcrow/src/App.tsx
+++ b/apps/pilcrow/src/App.tsx
@@ -1,9 +1,61 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+import {EditorProvider} from '@portabletext/editor'
+import {EventListenerPlugin} from '@portabletext/editor/plugins'
+import type {Patch} from '@portabletext/patches'
+import {useCallback, useRef, useState} from 'react'
+import {PilcrowEditor} from './editor'
+import {Inspector, type PatchEntry} from './inspector'
+import {schemaDefinition} from './schema'
+import {starterDocument} from './starter-document'
+import {ThemeToggle} from './theme-toggle'
+
 export function App() {
+  // Patches are event-driven, not state. We keep a rolling buffer so the
+  // Patches panel can show recent activity. The value lives entirely
+  // inside the editor machine; the inspector reads it via \`useEditorSelector\`
+  // which is per-consumer-subscribed and doesn't bounce through React state.
+  const [patches, setPatches] = useState<Array<PatchEntry>>([])
+  const patchCounter = useRef(0)
+  const onPatch = useCallback((patch: Patch) => {
+    const entry: PatchEntry = {id: patchCounter.current++, patch}
+    setPatches((current) => {
+      const nextEntries = current.concat(entry)
+      return nextEntries.length > 200
+        ? nextEntries.slice(nextEntries.length - 200)
+        : nextEntries
+    })
+  }, [])
+  const onEditorEvent = useCallback(
+    (event: {type: string; patch?: Patch}) => {
+      if (event.type === 'patch' && event.patch) {
+        onPatch(event.patch)
+      }
+    },
+    [onPatch],
+  )
   return (
-    <main className="pc-shell">
-      <span className="pc-mark" aria-hidden>
-        ¶
-      </span>
-    </main>
+    <EditorProvider
+      initialConfig={{
+        schemaDefinition,
+        initialValue: starterDocument satisfies Array<PortableTextBlock>,
+      }}
+    >
+      <EventListenerPlugin on={onEditorEvent} />
+      <main className="pc-shell">
+        <section className="pc-pane pc-pane-editor">
+          <header className="pc-header">
+            <span className="pc-logo" role="img" aria-label="Pilcrow">
+              ¶
+            </span>
+            <span className="pc-header-title">Pilcrow</span>
+            <div className="pc-header-actions">
+              <ThemeToggle />
+            </div>
+          </header>
+          <PilcrowEditor />
+        </section>
+        <Inspector patches={patches} />
+      </main>
+    </EditorProvider>
   )
 }

--- a/apps/pilcrow/src/editor.tsx
+++ b/apps/pilcrow/src/editor.tsx
@@ -1,0 +1,84 @@
+import {PortableTextEditable} from '@portabletext/editor'
+import {TypographyPlugin} from '@portabletext/plugin-typography'
+import {BlockquotePlugin} from './plugins/blockquote'
+import {CalloutPlugin} from './plugins/callout'
+import {CodeBlockPlugin} from './plugins/code-block'
+import {EmojiPickerPlugin} from './plugins/emoji-picker'
+import {HorizontalRulePlugin} from './plugins/horizontal-rule'
+import {ImagePlugin} from './plugins/image'
+import {MarkdownShortcutsPlugin} from './plugins/markdown-shortcuts'
+import {SlashMenuPlugin} from './plugins/slash-menu'
+import {StructuredListsPlugin} from './plugins/structured-lists'
+import {TablesPlugin} from './plugins/tables'
+import {Toolbar} from './toolbar'
+
+export function PilcrowEditor() {
+  return (
+    <>
+      <ImagePlugin />
+      <HorizontalRulePlugin />
+      <CodeBlockPlugin />
+      <BlockquotePlugin />
+      <CalloutPlugin />
+      <TablesPlugin />
+      <StructuredListsPlugin />
+      <MarkdownShortcutsPlugin />
+      <SlashMenuPlugin />
+      <EmojiPickerPlugin />
+      <TypographyPlugin />
+      <div className="pc-editor">
+        <Toolbar />
+        <div className="pc-editor-body">
+          <PortableTextEditable
+            className="pc-editable"
+            renderStyle={(styleProps) => {
+              const tag =
+                styleProps.value === 'normal'
+                  ? 'p'
+                  : (styleProps.value as
+                      | 'h1'
+                      | 'h2'
+                      | 'h3'
+                      | 'h4'
+                      | 'h5'
+                      | 'h6')
+              const Tag = tag
+              return (
+                <Tag className={`pc-style pc-style-${styleProps.value}`}>
+                  {styleProps.children}
+                </Tag>
+              )
+            }}
+            renderDecorator={(decoratorProps) => {
+              const Tag = decoratorMap[decoratorProps.value] ?? 'span'
+              return <Tag>{decoratorProps.children}</Tag>
+            }}
+            renderAnnotation={(annotationProps) => {
+              if (annotationProps.schemaType.name === 'link') {
+                const href =
+                  (annotationProps.value as {href?: string} | undefined)
+                    ?.href ?? '#'
+                return (
+                  <a className="pc-link" href={href}>
+                    {annotationProps.children}
+                  </a>
+                )
+              }
+              return <>{annotationProps.children}</>
+            }}
+            renderChild={(childProps) => <>{childProps.children}</>}
+            renderListItem={(listItemProps) => <>{listItemProps.children}</>}
+            renderBlock={(blockProps) => <>{blockProps.children}</>}
+          />
+        </div>
+      </div>
+    </>
+  )
+}
+
+const decoratorMap: Record<string, 'strong' | 'em' | 'code' | 's'> = {
+  'strong': 'strong',
+  'em': 'em',
+  'code': 'code',
+  'strike-through': 's',
+}

--- a/apps/pilcrow/src/highlight-json.tsx
+++ b/apps/pilcrow/src/highlight-json.tsx
@@ -1,0 +1,54 @@
+import type {ReactNode} from 'react'
+
+/**
+ * Lightweight grayscale JSON syntax highlighter. Produces an array of
+ * React nodes with class names that map to subtle weight + color shifts
+ * via the theme tokens. Avoids any hue - keys are slightly darker and
+ * bolder, strings get a thin underline weight, numbers/booleans stay
+ * muted. The point is hierarchy without rainbows.
+ */
+export function highlightJson(source: string): Array<ReactNode> {
+  const nodes: Array<ReactNode> = []
+  const regex =
+    /("(?:\\.|[^\\"])*")(\s*:)|("(?:\\.|[^\\"])*")|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
+
+  let cursor = 0
+  let key = 0
+  for (const match of source.matchAll(regex)) {
+    const start = match.index ?? 0
+    if (start > cursor) {
+      nodes.push(source.slice(cursor, start))
+    }
+    if (match[1] && match[2]) {
+      nodes.push(
+        <span key={key++} className="pc-json-key">
+          {match[1]}
+        </span>,
+      )
+      nodes.push(match[2])
+    } else if (match[3]) {
+      nodes.push(
+        <span key={key++} className="pc-json-string">
+          {match[3]}
+        </span>,
+      )
+    } else if (match[4]) {
+      nodes.push(
+        <span key={key++} className="pc-json-literal">
+          {match[4]}
+        </span>,
+      )
+    } else if (match[5]) {
+      nodes.push(
+        <span key={key++} className="pc-json-number">
+          {match[5]}
+        </span>,
+      )
+    }
+    cursor = start + match[0].length
+  }
+  if (cursor < source.length) {
+    nodes.push(source.slice(cursor))
+  }
+  return nodes
+}

--- a/apps/pilcrow/src/insert-dialog.tsx
+++ b/apps/pilcrow/src/insert-dialog.tsx
@@ -1,0 +1,406 @@
+import {useEditor, type PortableTextBlock} from '@portabletext/editor'
+import {useEffect, useRef, useState} from 'react'
+
+/**
+ * Modal dialog for inserting block objects with fields. Reads field
+ * definitions from a per-type config and renders a form. Used by the
+ * toolbar's block-insert buttons instead of \`window.prompt\`.
+ */
+type FieldDef =
+  | {
+      type: 'text'
+      name: string
+      label: string
+      defaultValue: string
+      placeholder?: string
+    }
+  | {
+      type: 'select'
+      name: string
+      label: string
+      defaultValue: string
+      options: ReadonlyArray<{value: string; label: string}>
+    }
+  | {
+      type: 'number'
+      name: string
+      label: string
+      defaultValue: number
+      min?: number
+      max?: number
+    }
+  | {
+      type: 'checkbox'
+      name: string
+      label: string
+      defaultValue: boolean
+    }
+
+export type InsertDialogConfig = {
+  blockType: string
+  title: string
+  fields: ReadonlyArray<FieldDef>
+  /**
+   * Override how the inserted block is constructed from the field
+   * values. Defaults to spreading values into the block alongside
+   * \`_type\`. Use for cases like the table dialog where the form
+   * shape doesn't match the block shape directly.
+   */
+  buildBlock?: (
+    values: Record<string, unknown>,
+    keyGen: () => string,
+  ) => Record<string, unknown>
+}
+
+export const insertDialogConfigs: Record<string, InsertDialogConfig> = {
+  'image': {
+    blockType: 'image',
+    title: 'Insert image',
+    fields: [
+      {
+        type: 'text',
+        name: 'src',
+        label: 'Source URL',
+        defaultValue: '',
+        placeholder: 'https://...',
+      },
+      {
+        type: 'text',
+        name: 'alt',
+        label: 'Alt text',
+        defaultValue: '',
+        placeholder: 'Describe the image',
+      },
+      {
+        type: 'text',
+        name: 'caption',
+        label: 'Caption',
+        defaultValue: '',
+        placeholder: 'Optional caption',
+      },
+    ],
+  },
+  'code-block': {
+    blockType: 'code-block',
+    title: 'Insert code block',
+    buildBlock: (values, keyGen) => ({
+      language: values.language ?? 'ts',
+      lines: [
+        {
+          _type: 'block',
+          _key: keyGen(),
+          style: 'normal',
+          children: [{_type: 'span', _key: keyGen(), text: '', marks: []}],
+          markDefs: [],
+        },
+      ],
+    }),
+    fields: [
+      {
+        type: 'select',
+        name: 'language',
+        label: 'Language',
+        defaultValue: 'ts',
+        options: [
+          {value: 'ts', label: 'TypeScript'},
+          {value: 'tsx', label: 'TSX'},
+          {value: 'js', label: 'JavaScript'},
+          {value: 'jsx', label: 'JSX'},
+          {value: 'json', label: 'JSON'},
+          {value: 'html', label: 'HTML'},
+          {value: 'css', label: 'CSS'},
+          {value: 'md', label: 'Markdown'},
+          {value: 'bash', label: 'Shell'},
+          {value: 'python', label: 'Python'},
+          {value: 'rust', label: 'Rust'},
+          {value: 'go', label: 'Go'},
+          {value: 'sql', label: 'SQL'},
+          {value: 'text', label: 'Plain text'},
+        ],
+      },
+    ],
+  },
+  'blockquote': {
+    blockType: 'blockquote',
+    title: 'Insert blockquote',
+    buildBlock: (_values, keyGen) => ({
+      content: [
+        {
+          _type: 'block',
+          _key: keyGen(),
+          style: 'normal',
+          children: [{_type: 'span', _key: keyGen(), text: '', marks: []}],
+          markDefs: [],
+        },
+      ],
+    }),
+    fields: [],
+  },
+  'callout': {
+    blockType: 'callout',
+    title: 'Insert callout',
+    buildBlock: (values, keyGen) => ({
+      tone: values.tone ?? 'note',
+      content: [
+        {
+          _type: 'block',
+          _key: keyGen(),
+          style: 'normal',
+          children: [{_type: 'span', _key: keyGen(), text: '', marks: []}],
+          markDefs: [],
+        },
+      ],
+    }),
+    fields: [
+      {
+        type: 'select',
+        name: 'tone',
+        label: 'Tone',
+        defaultValue: 'note',
+        options: [
+          {value: 'note', label: 'Note'},
+          {value: 'tip', label: 'Tip'},
+          {value: 'warning', label: 'Warning'},
+          {value: 'caution', label: 'Caution'},
+        ],
+      },
+    ],
+  },
+  'table': {
+    blockType: 'table',
+    title: 'Insert table',
+    buildBlock: (values, keyGen) =>
+      buildTableBlock({
+        rows: Math.max(1, Math.min(20, Number(values.rows) || 2)),
+        columns: Math.max(1, Math.min(10, Number(values.columns) || 2)),
+        headerRows: Math.max(0, Math.min(2, Number(values.headerRows) || 0)),
+        keyGen,
+      }),
+    fields: [
+      {
+        type: 'number',
+        name: 'rows',
+        label: 'Rows',
+        defaultValue: 2,
+        min: 1,
+        max: 20,
+      },
+      {
+        type: 'number',
+        name: 'columns',
+        label: 'Columns',
+        defaultValue: 2,
+        min: 1,
+        max: 10,
+      },
+      {
+        type: 'number',
+        name: 'headerRows',
+        label: 'Header rows',
+        defaultValue: 0,
+        min: 0,
+        max: 2,
+      },
+    ],
+  },
+}
+
+/**
+ * Build a fresh table block with the requested dimensions. Each cell
+ * starts with one empty paragraph so the caret has a valid landing
+ * spot when the user moves into the table. Header rows are advisory
+ * - the renderer reads them off the table's \`headerRows\` field.
+ */
+export function buildTableBlock(input: {
+  rows: number
+  columns: number
+  headerRows: number
+  keyGen: () => string
+}): Partial<PortableTextBlock> {
+  const {rows, columns, headerRows, keyGen} = input
+  const rowList = Array.from({length: rows}, () => ({
+    _type: 'row',
+    _key: keyGen(),
+    cells: Array.from({length: columns}, () => ({
+      _type: 'cell',
+      _key: keyGen(),
+      content: [
+        {
+          _type: 'block',
+          _key: keyGen(),
+          style: 'normal',
+          children: [{_type: 'span', _key: keyGen(), text: '', marks: []}],
+          markDefs: [],
+        },
+      ],
+    })),
+  }))
+  return {headerRows, rows: rowList} as Partial<PortableTextBlock>
+}
+
+export function InsertDialog(props: {
+  config: InsertDialogConfig
+  onClose: () => void
+}) {
+  const editor = useEditor()
+  const [values, setValues] = useState<Record<string, unknown>>(() =>
+    Object.fromEntries(
+      props.config.fields.map((field) => [field.name, field.defaultValue]),
+    ),
+  )
+  const firstFieldRef = useRef<HTMLInputElement | HTMLSelectElement | null>(
+    null,
+  )
+  useEffect(() => {
+    firstFieldRef.current?.focus()
+  }, [])
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    const keyGen = editor.getSnapshot().context.keyGenerator
+    const block = props.config.buildBlock
+      ? {
+          _type: props.config.blockType,
+          ...props.config.buildBlock(values, keyGen),
+        }
+      : {_type: props.config.blockType, ...values}
+    editor.send({
+      type: 'insert.block',
+      block,
+      placement: 'auto',
+      select: 'start',
+    })
+    props.onClose()
+  }
+
+  return (
+    <div className="pc-dialog-backdrop" role="presentation">
+      <form
+        className="pc-dialog"
+        onSubmit={handleSubmit}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            props.onClose()
+          }
+        }}
+      >
+        <h2 className="pc-dialog-title">{props.config.title}</h2>
+        <div className="pc-dialog-fields">
+          {props.config.fields.map((field, index) => {
+            const setValue = (value: unknown) =>
+              setValues((current) => ({...current, [field.name]: value}))
+            const id = `pc-dialog-${field.name}`
+            if (field.type === 'text') {
+              return (
+                <label
+                  key={field.name}
+                  className="pc-dialog-field"
+                  htmlFor={id}
+                >
+                  <span className="pc-dialog-field-label">{field.label}</span>
+                  <input
+                    ref={
+                      index === 0
+                        ? (firstFieldRef as React.RefObject<HTMLInputElement>)
+                        : undefined
+                    }
+                    id={id}
+                    className="pc-dialog-input"
+                    type="text"
+                    value={(values[field.name] as string) ?? ''}
+                    placeholder={field.placeholder}
+                    onChange={(event) => setValue(event.target.value)}
+                  />
+                </label>
+              )
+            }
+            if (field.type === 'number') {
+              return (
+                <label
+                  key={field.name}
+                  className="pc-dialog-field"
+                  htmlFor={id}
+                >
+                  <span className="pc-dialog-field-label">{field.label}</span>
+                  <input
+                    ref={
+                      index === 0
+                        ? (firstFieldRef as React.RefObject<HTMLInputElement>)
+                        : undefined
+                    }
+                    id={id}
+                    className="pc-dialog-input"
+                    type="number"
+                    min={field.min}
+                    max={field.max}
+                    value={(values[field.name] as number) ?? field.defaultValue}
+                    onChange={(event) => {
+                      const parsed = Number.parseInt(event.target.value, 10)
+                      if (Number.isFinite(parsed)) {
+                        setValue(parsed)
+                      }
+                    }}
+                  />
+                </label>
+              )
+            }
+            if (field.type === 'checkbox') {
+              return (
+                <label
+                  key={field.name}
+                  className="pc-dialog-field pc-dialog-field-inline"
+                  htmlFor={id}
+                >
+                  <input
+                    ref={
+                      index === 0
+                        ? (firstFieldRef as React.RefObject<HTMLInputElement>)
+                        : undefined
+                    }
+                    id={id}
+                    className="pc-dialog-checkbox"
+                    type="checkbox"
+                    checked={(values[field.name] as boolean) ?? false}
+                    onChange={(event) => setValue(event.target.checked)}
+                  />
+                  <span className="pc-dialog-field-label">{field.label}</span>
+                </label>
+              )
+            }
+            return (
+              <label key={field.name} className="pc-dialog-field" htmlFor={id}>
+                <span className="pc-dialog-field-label">{field.label}</span>
+                <select
+                  ref={
+                    index === 0
+                      ? (firstFieldRef as React.RefObject<HTMLSelectElement>)
+                      : undefined
+                  }
+                  id={id}
+                  className="pc-dialog-select"
+                  value={(values[field.name] as string) ?? field.defaultValue}
+                  onChange={(event) => setValue(event.target.value)}
+                >
+                  {field.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )
+          })}
+        </div>
+        <div className="pc-dialog-actions">
+          <button type="button" className="pc-button" onClick={props.onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="pc-button pc-button-primary">
+            Insert
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/pilcrow/src/inspector.tsx
+++ b/apps/pilcrow/src/inspector.tsx
@@ -1,0 +1,461 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type PortableTextBlock,
+  type PortableTextObject,
+} from '@portabletext/editor'
+import {
+  DefaultBlockquoteObjectRenderer,
+  DefaultHorizontalRuleRenderer,
+  DefaultImageRenderer,
+  DefaultListRenderer,
+  markdownToPortableText,
+  portableTextToMarkdown,
+  type ObjectMatcher,
+  type PortableTextTypeRenderer,
+} from '@portabletext/markdown'
+import type {Patch} from '@portabletext/patches'
+import {convertPatches} from '@portabletext/plugin-sdk-value'
+import {diffValue} from '@sanity/diff-patch'
+import {useEffect, useMemo, useRef, useState} from 'react'
+import {highlightJson} from './highlight-json'
+
+export interface PatchEntry {
+  id: number
+  patch: Patch
+}
+
+interface InspectorProps {
+  patches: Array<PatchEntry>
+}
+
+type View = 'markdown' | 'patches' | 'value'
+
+const views: Array<{id: View; label: string; hint: string}> = [
+  {id: 'markdown', label: 'Markdown', hint: 'GFM source mirror'},
+  {id: 'value', label: 'Value', hint: 'Portable Text JSON'},
+  {id: 'patches', label: 'Patches', hint: 'Live mutation stream'},
+]
+
+export function Inspector(props: InspectorProps) {
+  const [view, setView] = useState<View>('markdown')
+  return (
+    <aside className="pc-mirror" data-view={view}>
+      <header className="pc-mirror-header">
+        <span className="pc-mirror-title">Source</span>
+        <ViewSwitcher value={view} onChange={setView} />
+      </header>
+      <div className="pc-mirror-body">
+        {view === 'markdown' && <MarkdownPanel />}
+        {view === 'patches' && <PatchesPanel patches={props.patches} />}
+        {view === 'value' && <ValuePanel />}
+      </div>
+    </aside>
+  )
+}
+
+function ViewSwitcher(props: {value: View; onChange: (v: View) => void}) {
+  return (
+    <div className="pc-view-switcher" role="tablist" aria-label="Source view">
+      {views.map((view) => (
+        <button
+          key={view.id}
+          type="button"
+          role="tab"
+          aria-selected={props.value === view.id}
+          className={`pc-view-tab${
+            props.value === view.id ? ' pc-view-tab-active' : ''
+          }`}
+          onClick={() => props.onChange(view.id)}
+          title={view.hint}
+        >
+          {view.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// Pilcrow's editor shape stores code-block content as `lines` (an array
+// of text blocks) and table cells as `content`. The default renderers
+// expect `code` (a string) and `value` respectively. The renderers below
+// adapt Pilcrow's shape to markdown output.
+
+const pilcrowCodeBlockRenderer: PortableTextTypeRenderer<{
+  _type: 'code-block'
+  language?: string
+  lines?: Array<{children?: Array<{text?: string}>}>
+}> = ({value}) => {
+  const code = (value.lines ?? [])
+    .map((block) =>
+      (block.children ?? []).map((child) => child.text ?? '').join(''),
+    )
+    .join('\n')
+  return `\`\`\`${value.language ?? ''}\n${code}\n\`\`\``
+}
+
+const pilcrowTableRenderer: PortableTextTypeRenderer<{
+  _type: 'table'
+  headerRows?: number
+  rows?: Array<{
+    _key: string
+    cells?: Array<{
+      _key: string
+      content?: Array<unknown>
+    }>
+  }>
+}> = ({value, renderNode}) => {
+  const headerRows = value.headerRows ?? 0
+  const rows = value.rows ?? []
+  const lines: Array<string> = []
+
+  const renderCell = (blocks: Array<unknown>): string =>
+    blocks
+      .map((block, index) =>
+        renderNode({
+          node: block as {_type: string},
+          index,
+          isInline: false,
+          renderNode,
+        }),
+      )
+      .join(' ')
+      .trim()
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]
+    if (!row) {
+      continue
+    }
+    const cellTexts = (row.cells ?? []).map((cell) =>
+      renderCell(cell.content ?? []),
+    )
+    lines.push(`| ${cellTexts.join(' | ')} |`)
+    if (i === headerRows - 1 && row.cells) {
+      const separators = row.cells.map(() => ' --- ')
+      lines.push(`|${separators.join('|')}|`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+const pilcrowCalloutRenderer: PortableTextTypeRenderer<{
+  _type: 'callout'
+  tone?: string
+  content?: Array<PortableTextBlock>
+}> = ({value, renderNode}) => {
+  const tone = (value.tone ?? 'note').toUpperCase()
+  const content = value.content ?? []
+  const renderedContent = content
+    .map((block, index) =>
+      renderNode({
+        node: {...block, style: 'normal'},
+        index,
+        isInline: false,
+        renderNode,
+      }),
+    )
+    .join('\n\n')
+  const prefixed = renderedContent
+    .split('\n')
+    .map((line) => (line === '' ? '>' : `> ${line}`))
+    .join('\n')
+  return `> [!${tone}]\n${prefixed}`
+}
+
+const markdownTypeRenderers = {
+  'image': DefaultImageRenderer,
+  'horizontal-rule': DefaultHorizontalRuleRenderer,
+  'code-block': pilcrowCodeBlockRenderer,
+  'callout': pilcrowCalloutRenderer,
+  'table': pilcrowTableRenderer,
+  'list': DefaultListRenderer,
+  'blockquote': DefaultBlockquoteObjectRenderer,
+}
+
+// Custom matchers for `markdownToPortableText`. The default matchers produce
+// `{_type: 'code', code: string}` and `{_type: 'table', cells: [{value}]}`
+// shapes, which don't fit Pilcrow's editor schema (`code-block` with a
+// `lines` array of text blocks; `table` with `cells[i].content`). The
+// matchers below reshape the deserializer output to match.
+
+const pilcrowCodeMatcher: ObjectMatcher<{
+  language: string | undefined
+  code: string
+}> = ({value, context}) => {
+  const keyGen = context.keyGenerator
+  const lines = (value.code ?? '').split('\n').map((lineText) => ({
+    _type: 'block',
+    _key: keyGen(),
+    style: 'normal',
+    children: [{_type: 'span', _key: keyGen(), text: lineText, marks: []}],
+    markDefs: [],
+  }))
+  return {
+    _type: 'code-block',
+    _key: keyGen(),
+    language: value.language,
+    lines,
+  }
+}
+
+const pilcrowTableMatcher: ObjectMatcher<{
+  headerRows: number | undefined
+  rows: Array<{
+    _key: string
+    _type: 'row'
+    cells: Array<{
+      _type: 'cell'
+      _key: string
+      value: Array<PortableTextBlock>
+    }>
+  }>
+}> = ({value, context}) => {
+  return {
+    _type: 'table',
+    _key: context.keyGenerator(),
+    headerRows: value.headerRows,
+    rows: value.rows.map((row) => ({
+      _type: 'row',
+      _key: row._key,
+      cells: row.cells.map((cell) => ({
+        _type: 'cell',
+        _key: cell._key,
+        content: cell.value,
+      })),
+    })),
+  }
+}
+
+const pilcrowListMatcher: ObjectMatcher<{
+  kind: 'bullet' | 'number' | 'task'
+  items: Array<{
+    _type: 'list-item'
+    _key: string
+    checked?: boolean
+    content: Array<PortableTextBlock | PortableTextObject>
+  }>
+}> = ({value, context}) => {
+  return {
+    _type: 'list',
+    _key: context.keyGenerator(),
+    kind: value.kind,
+    items: value.items.map((item) => ({
+      _type: 'list-item' as const,
+      _key: item._key,
+      ...(value.kind === 'task' ? {checked: item.checked === true} : {}),
+      content: item.content,
+    })),
+  }
+}
+
+const pilcrowBlockquoteMatcher: ObjectMatcher<{
+  content: Array<PortableTextBlock>
+}> = ({value, context}) => {
+  return {
+    _type: 'blockquote',
+    _key: context.keyGenerator(),
+    content: value.content,
+  }
+}
+
+const pilcrowMarkdownTypeMatchers = {
+  code: pilcrowCodeMatcher,
+  table: pilcrowTableMatcher,
+  list: pilcrowListMatcher,
+  blockquote: pilcrowBlockquoteMatcher,
+}
+
+const SYNC_DEBOUNCE_MS = 250
+
+function MarkdownPanel() {
+  const editor = useEditor()
+  const value = useEditorSelector(editor, (snapshot) => snapshot.context.value)
+  const serialized = useMemo(() => {
+    try {
+      return portableTextToMarkdown(value, {types: markdownTypeRenderers})
+    } catch (error) {
+      return `<!-- Failed to serialize: ${(error as Error).message} -->`
+    }
+  }, [value])
+
+  // `draft` holds the textarea's local state while the user is editing.
+  // `null` means there is no local draft - the textarea mirrors the
+  // editor value via `serialized`. The draft persists across editor
+  // mutations so the user's in-progress typing isn't clobbered, but
+  // clears on blur so editor -> markdown sync resumes.
+  const [draft, setDraft] = useState<string | null>(null)
+  const displayed = draft ?? serialized
+
+  // Track the last value the textarea diffed against so we can use it
+  // as the source for the next `diffValue` call. This lives in a ref
+  // because the diff runs in a debounced callback and we don't want
+  // to re-create the timer every render.
+  const lastSyncedRef = useRef<Array<PortableTextBlock>>(value)
+  useEffect(() => {
+    if (draft === null) {
+      lastSyncedRef.current = value
+    }
+  }, [draft, value])
+
+  const timerRef = useRef<number | null>(null)
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  const [syncError, setSyncError] = useState<string | null>(null)
+
+  const performSync = (markdown: string) => {
+    try {
+      const next = markdownToPortableText(markdown, {
+        types: pilcrowMarkdownTypeMatchers,
+      })
+      const source = lastSyncedRef.current
+      const wirePatches = diffValue(source as never, next as never)
+      const patches = convertPatches(wirePatches)
+      if (patches.length > 0) {
+        editor.send({
+          type: 'patches',
+          patches,
+          snapshot: source as never,
+        })
+        lastSyncedRef.current = next as Array<PortableTextBlock>
+      }
+      setSyncError(null)
+    } catch (error) {
+      setSyncError((error as Error).message)
+    }
+  }
+
+  const scheduleSync = (markdown: string) => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+    }
+    timerRef.current = window.setTimeout(() => {
+      performSync(markdown)
+    }, SYNC_DEBOUNCE_MS)
+  }
+
+  const flushPendingSync = (markdown: string) => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+      performSync(markdown)
+    }
+  }
+
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <div className="pc-panel pc-panel-stretch">
+      <header className="pc-panel-actions">
+        {syncError ? (
+          <span className="pc-panel-error">Sync error: {syncError}</span>
+        ) : null}
+        <button
+          type="button"
+          className="pc-button"
+          onClick={async () => {
+            await navigator.clipboard.writeText(displayed)
+            setCopied(true)
+            window.setTimeout(() => setCopied(false), 1200)
+          }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </header>
+      <textarea
+        className="pc-markdown-textarea"
+        value={displayed}
+        spellCheck={false}
+        onChange={(event) => {
+          const next = event.target.value
+          setDraft(next)
+          scheduleSync(next)
+        }}
+        onBlur={() => {
+          // Flush any pending debounced sync before clearing the draft -
+          // otherwise the textarea reverts to the last-serialized value
+          // because the debounce timer hasn't dispatched yet.
+          if (draft !== null) {
+            flushPendingSync(draft)
+          }
+          setDraft(null)
+        }}
+      />
+    </div>
+  )
+}
+
+function PatchesPanel(props: {patches: Array<PatchEntry>}) {
+  if (props.patches.length === 0) {
+    return (
+      <div className="pc-panel">
+        <p className="pc-panel-empty">No patches yet. Type in the editor.</p>
+      </div>
+    )
+  }
+  return (
+    <div className="pc-panel pc-panel-list">
+      {props.patches.map((entry, index) => (
+        <PatchRow key={entry.id} entry={entry} index={index} />
+      ))}
+    </div>
+  )
+}
+
+function PatchRow(props: {entry: PatchEntry; index: number}) {
+  const {patch} = props.entry
+  return (
+    <article className="pc-patch">
+      <header className="pc-patch-header">
+        <span className="pc-patch-index">{props.index + 1}</span>
+        <span className="pc-patch-type">{patch.type}</span>
+      </header>
+      <pre className="pc-patch-body">
+        {highlightJson(JSON.stringify(omit(patch, ['type']), null, 2))}
+      </pre>
+    </article>
+  )
+}
+
+function ValuePanel() {
+  const editor = useEditor()
+  const value = useEditorSelector(editor, (snapshot) => snapshot.context.value)
+  const text = useMemo(() => JSON.stringify(value, null, 2), [value])
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="pc-panel">
+      <header className="pc-panel-actions">
+        <button
+          type="button"
+          className="pc-button"
+          onClick={async () => {
+            await navigator.clipboard.writeText(text)
+            setCopied(true)
+            window.setTimeout(() => setCopied(false), 1200)
+          }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </header>
+      <pre className="pc-panel-text">{highlightJson(text)}</pre>
+    </div>
+  )
+}
+
+function omit<T extends Record<string, unknown>, K extends keyof T>(
+  source: T,
+  keys: Array<K>,
+): Omit<T, K> {
+  const result = {...source}
+  for (const key of keys) {
+    delete result[key]
+  }
+  return result
+}

--- a/apps/pilcrow/src/plugins/blockquote.tsx
+++ b/apps/pilcrow/src/plugins/blockquote.tsx
@@ -1,0 +1,107 @@
+import {defineContainer} from '@portabletext/editor'
+import {raise} from '@portabletext/editor/behaviors'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import {defineInputRule, InputRulePlugin} from '@portabletext/plugin-input-rule'
+
+/**
+ * Blockquote container. Wraps one or more paragraphs (and nested
+ * blockquotes) in a left-bordered indented region. The actual
+ * styling is a thin left rule plus indentation - no font change,
+ * no italic, no quote glyph - leaving the inner text formatting
+ * intact so the reader sees the quote as quoted content rather
+ * than a decoration.
+ *
+ * Recursive nesting is allowed via the schema's
+ * `blockquote.content.of: [block, blockquote]` declaration. Each
+ * nested level adds another left rule + indent.
+ */
+const blockquoteContainer = defineContainer({
+  type: 'blockquote',
+  childField: 'content',
+  render: ({attributes, children}) => (
+    <blockquote {...attributes} className="pc-blockquote">
+      {children}
+    </blockquote>
+  ),
+})
+
+/**
+ * Markdown shortcut: typing `> ` at the start of a text block
+ * converts the block into a blockquote container whose first
+ * paragraph is the current block (minus the marker).
+ *
+ * The trigger is the space after `>`. The guard requires the focus
+ * block to be a top-level text block (a block that lives directly
+ * under the editor or inside a list-item / cell - not already a
+ * blockquote child, which would be the user's intent to literally
+ * write `> ` inside an existing quote).
+ */
+const blockquoteInputRule = defineInputRule({
+  on: /^> /,
+  guard: ({event}) => {
+    const match = event.matches.at(0)
+    if (!match) {
+      return false
+    }
+    return true
+  },
+  actions: [
+    ({event, snapshot}) => {
+      const keyGen = snapshot.context.keyGenerator
+      const blockKey = keyGen()
+      const spanKey = keyGen()
+      const blockquoteKey = keyGen()
+
+      const blockquote = {
+        _type: 'blockquote',
+        _key: blockquoteKey,
+        content: [
+          {
+            _type: 'block',
+            _key: blockKey,
+            style: 'normal',
+            children: [{_type: 'span', _key: spanKey, text: '', marks: []}],
+            markDefs: [],
+          },
+        ],
+      }
+
+      const focusBlockPath = event.focusBlock.path
+      const parentPath = focusBlockPath.slice(0, -1)
+      const newCaretPath = [
+        ...parentPath,
+        {_key: blockquoteKey},
+        'content',
+        {_key: blockKey},
+        'children',
+        {_key: spanKey},
+      ]
+
+      return [
+        raise({
+          type: 'insert',
+          at: focusBlockPath,
+          value: blockquote as never,
+          position: 'before',
+        }),
+        raise({type: 'unset', at: focusBlockPath}),
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: newCaretPath, offset: 0},
+            focus: {path: newCaretPath, offset: 0},
+          } as never,
+        }),
+      ]
+    },
+  ],
+})
+
+export function BlockquotePlugin() {
+  return (
+    <>
+      <ContainerPlugin containers={[blockquoteContainer]} />
+      <InputRulePlugin rules={[blockquoteInputRule]} />
+    </>
+  )
+}

--- a/apps/pilcrow/src/plugins/callout.tsx
+++ b/apps/pilcrow/src/plugins/callout.tsx
@@ -1,0 +1,190 @@
+import {defineContainer, useEditor, type BlockPath} from '@portabletext/editor'
+import {raise} from '@portabletext/editor/behaviors'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import {defineInputRule, InputRulePlugin} from '@portabletext/plugin-input-rule'
+
+/**
+ * Callout container. Renders as an indented block with a tone icon
+ * and a thin left rule. Variants (note, warning, tip, caution) are
+ * distinguished by icon shape only - no color hue - to stay within
+ * the grayscale palette.
+ *
+ * The tone field is a string; the renderer falls back to 'note' if
+ * an unknown tone is provided. Adding a new tone is a matter of
+ * picking a glyph + a label and adding both maps below.
+ */
+const calloutContainer = defineContainer({
+  type: 'callout',
+  childField: 'content',
+  render: ({attributes, children, node, path}) => {
+    const block = node as {tone?: string}
+    const tone = (block.tone ?? 'note') as Tone
+    const config = tones[tone] ?? tones.note
+    return (
+      <aside
+        {...attributes}
+        className={`pc-callout pc-callout-${tone}`}
+        aria-label={`${config.label} callout`}
+      >
+        <header className="pc-callout-header" contentEditable={false}>
+          <span className="pc-callout-glyph" aria-hidden>
+            {config.glyph}
+          </span>
+          <ToneSelect tone={tone} path={path} />
+        </header>
+        <div className="pc-callout-body">{children}</div>
+      </aside>
+    )
+  },
+})
+
+function ToneSelect(props: {tone: Tone; path: BlockPath}) {
+  const editor = useEditor()
+  return (
+    <select
+      className="pc-callout-tone-select"
+      value={props.tone}
+      onChange={(event) => {
+        editor.send({
+          type: 'set',
+          at: [...props.path, 'tone'],
+          value: event.target.value,
+        } as never)
+      }}
+    >
+      {(Object.keys(tones) as Array<Tone>).map((toneKey) => (
+        <option key={toneKey} value={toneKey}>
+          {tones[toneKey].label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+type Tone = 'note' | 'tip' | 'warning' | 'caution'
+
+const tones: Record<Tone, {glyph: string; label: string}> = {
+  note: {glyph: 'i', label: 'Note'},
+  tip: {glyph: '★', label: 'Tip'},
+  warning: {glyph: '!', label: 'Warning'},
+  caution: {glyph: '⊘', label: 'Caution'},
+}
+
+/**
+ * Callout input rule. The user types `[!NOTE]` (or any other tone)
+ * at the start of a paragraph that lives directly inside a
+ * blockquote container, and the enclosing blockquote becomes a
+ * callout with the matched tone.
+ *
+ * The trigger is the closing `]` keystroke. This mirrors GitHub's
+ * GFM alert syntax (`> [!NOTE]\n> body`) where the alert lives
+ * inside a blockquote: typing the alert marker on the first line
+ * of a quote converts the whole quote into an admonition.
+ */
+const tonePattern = /^\[!(note|tip|warning|caution)\]$/i
+
+const calloutInputRule = defineInputRule({
+  on: /^\[!(note|tip|warning|caution)\]$/i,
+  guard: ({event, snapshot}) => {
+    const focusBlockPath = event.focusBlock.path
+    // Require an enclosing blockquote: the focus block's parent path
+    // must point at a blockquote container's `content` field. The
+    // parent path is the focus block's path with its last segment
+    // (the keyed child reference) removed, then the segment before
+    // that is the blockquote's `{_key}` reference and the one before
+    // is the field name `'content'`.
+    if (focusBlockPath.length < 3) {
+      return false
+    }
+    const grandparentSegment = focusBlockPath.at(-3)
+    const fieldSegment = focusBlockPath.at(-2)
+    if (
+      typeof grandparentSegment !== 'object' ||
+      grandparentSegment === null ||
+      !('_key' in grandparentSegment) ||
+      fieldSegment !== 'content'
+    ) {
+      return false
+    }
+    const blockquotePath = focusBlockPath.slice(0, -2)
+    const blockquoteNode = snapshot.context.value.find(
+      (block) =>
+        typeof block === 'object' &&
+        block !== null &&
+        '_key' in block &&
+        block._key === grandparentSegment._key,
+    ) as {_type?: string} | undefined
+    if (!blockquoteNode || blockquoteNode._type !== 'blockquote') {
+      return false
+    }
+    const match = event.matches.at(0)
+    if (!match) {
+      return false
+    }
+    const toneMatch = match.text.match(tonePattern)
+    if (!toneMatch || !toneMatch[1]) {
+      return false
+    }
+    const keyGen = snapshot.context.keyGenerator
+    const tone = toneMatch[1].toLowerCase() as Tone
+    return {tone, keyGen, blockquotePath}
+  },
+  actions: [
+    (_, {tone, keyGen, blockquotePath}) => {
+      const blockKey = keyGen()
+      const spanKey = keyGen()
+      const calloutKey = keyGen()
+
+      const callout = {
+        _type: 'callout',
+        _key: calloutKey,
+        tone,
+        content: [
+          {
+            _type: 'block',
+            _key: blockKey,
+            style: 'normal',
+            children: [{_type: 'span', _key: spanKey, text: '', marks: []}],
+            markDefs: [],
+          },
+        ],
+      }
+
+      const blockquoteParentPath = blockquotePath.slice(0, -1)
+      const newCaretPath = [
+        ...blockquoteParentPath,
+        {_key: calloutKey},
+        'content',
+        {_key: blockKey},
+        'children',
+        {_key: spanKey},
+      ]
+
+      return [
+        raise({
+          type: 'insert',
+          at: blockquotePath,
+          value: callout as never,
+          position: 'before',
+        }),
+        raise({type: 'unset', at: blockquotePath}),
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: newCaretPath, offset: 0},
+            focus: {path: newCaretPath, offset: 0},
+          } as never,
+        }),
+      ]
+    },
+  ],
+})
+
+export function CalloutPlugin() {
+  return (
+    <>
+      <ContainerPlugin containers={[calloutContainer]} />
+      <InputRulePlugin rules={[calloutInputRule]} />
+    </>
+  )
+}

--- a/apps/pilcrow/src/plugins/code-block.tsx
+++ b/apps/pilcrow/src/plugins/code-block.tsx
@@ -1,0 +1,74 @@
+import {defineContainer, useEditor, type BlockPath} from '@portabletext/editor'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+
+/**
+ * Code block container. The container owns the language label and a
+ * thin left rule; the lines field accepts plain text blocks. The
+ * header renders a `<select>` so users can switch language without
+ * dropping into the JSON inspector. Syntax highlighting in the
+ * editor view is layered separately.
+ */
+const codeBlockLanguages = [
+  'text',
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'json',
+  'css',
+  'html',
+  'markdown',
+  'bash',
+  'sql',
+  'python',
+  'go',
+  'rust',
+  'yaml',
+] as const
+
+function LanguageSelect(props: {language: string; path: BlockPath}) {
+  const editor = useEditor()
+  return (
+    <select
+      className="pc-code-block-language-select"
+      value={props.language}
+      onChange={(event) => {
+        editor.send({
+          type: 'set',
+          at: [...props.path, 'language'],
+          value: event.target.value,
+        } as never)
+      }}
+    >
+      {codeBlockLanguages.map((lang) => (
+        <option key={lang} value={lang}>
+          {lang}
+        </option>
+      ))}
+      {!codeBlockLanguages.includes(
+        props.language as (typeof codeBlockLanguages)[number],
+      ) && <option value={props.language}>{props.language}</option>}
+    </select>
+  )
+}
+
+const codeBlockContainer = defineContainer({
+  type: 'code-block',
+  childField: 'lines',
+  render: ({attributes, children, node, path}) => {
+    const block = node as {language?: string}
+    const language = block.language ?? 'text'
+    return (
+      <div {...attributes} className="pc-code-block">
+        <header className="pc-code-block-header" contentEditable={false}>
+          <LanguageSelect language={language} path={path} />
+        </header>
+        <div className="pc-code-block-body">{children}</div>
+      </div>
+    )
+  },
+})
+
+export function CodeBlockPlugin() {
+  return <ContainerPlugin containers={[codeBlockContainer]} />
+}

--- a/apps/pilcrow/src/plugins/emoji-picker.tsx
+++ b/apps/pilcrow/src/plugins/emoji-picker.tsx
@@ -1,0 +1,188 @@
+import {
+  useEmojiPicker,
+  type EmojiMatch,
+} from '@portabletext/plugin-emoji-picker'
+import {useEffect, useRef} from 'react'
+import {TypeaheadPanel} from './typeahead-panel'
+
+/**
+ * Emoji picker: typing `:` opens a typeahead. As soon as a keyword
+ * matches one of the curated entries, the panel shows hits. Picking
+ * an entry inserts its emoji where the colon-prefix sat. The curated
+ * list is intentionally small - a couple of dozen common emojis
+ * covering reactions, status markers, weather, etc. We avoid the
+ * `emojilib` 276 KB JSON dump until somebody actually asks for it.
+ */
+type EmojiEntry = {emoji: string; keywords: ReadonlyArray<string>}
+
+const emojiTable: ReadonlyArray<EmojiEntry> = [
+  {emoji: '😀', keywords: ['smile', 'happy', 'grin', 'face']},
+  {emoji: '😁', keywords: ['beam', 'grin', 'happy']},
+  {emoji: '😂', keywords: ['joy', 'laugh', 'tears', 'lol']},
+  {emoji: '🤣', keywords: ['rofl', 'laugh', 'lmao']},
+  {emoji: '😊', keywords: ['blush', 'smile', 'happy']},
+  {emoji: '😉', keywords: ['wink']},
+  {emoji: '😍', keywords: ['heart-eyes', 'love']},
+  {emoji: '😎', keywords: ['cool', 'sunglasses']},
+  {emoji: '🤔', keywords: ['thinking', 'hmm', 'think']},
+  {emoji: '🙃', keywords: ['upside-down', 'silly']},
+  {emoji: '🙂', keywords: ['smile', 'slight']},
+  {emoji: '😅', keywords: ['sweat', 'relief', 'phew']},
+  {emoji: '😬', keywords: ['grimace', 'awkward', 'yikes']},
+  {emoji: '😢', keywords: ['cry', 'sad', 'tear']},
+  {emoji: '😭', keywords: ['cry', 'sob', 'weep']},
+  {emoji: '🤯', keywords: ['mind-blown', 'shocked']},
+  {emoji: '😴', keywords: ['sleep', 'tired', 'zzz']},
+  {emoji: '🤝', keywords: ['handshake', 'deal', 'agree']},
+  {emoji: '👍', keywords: ['thumbs-up', 'yes', 'approve', 'lgtm']},
+  {emoji: '👎', keywords: ['thumbs-down', 'no', 'reject']},
+  {emoji: '👏', keywords: ['clap', 'applause', 'bravo']},
+  {emoji: '🙌', keywords: ['hands', 'celebrate', 'praise']},
+  {emoji: '🙏', keywords: ['pray', 'please', 'thanks']},
+  {emoji: '💪', keywords: ['muscle', 'strong', 'flex']},
+  {emoji: '🫡', keywords: ['salute', 'yes-sir', 'ok']},
+  {emoji: '👀', keywords: ['eyes', 'look', 'see']},
+  {emoji: '🧠', keywords: ['brain', 'think', 'smart']},
+  {emoji: '🔥', keywords: ['fire', 'hot', 'lit']},
+  {emoji: '✨', keywords: ['sparkles', 'magic', 'shine']},
+  {emoji: '⭐', keywords: ['star', 'favorite']},
+  {emoji: '🌟', keywords: ['glow', 'star', 'shine']},
+  {emoji: '💯', keywords: ['hundred', 'percent', 'perfect']},
+  {emoji: '🎉', keywords: ['party', 'celebrate', 'tada']},
+  {emoji: '🎊', keywords: ['confetti', 'celebrate']},
+  {emoji: '🚀', keywords: ['rocket', 'ship', 'launch', 'fast']},
+  {emoji: '✅', keywords: ['check', 'done', 'ok', 'yes']},
+  {emoji: '❌', keywords: ['cross', 'no', 'fail', 'wrong']},
+  {emoji: '⚠️', keywords: ['warning', 'caution', 'alert']},
+  {emoji: '❗', keywords: ['exclamation', 'important']},
+  {emoji: '❓', keywords: ['question', 'huh', 'unknown']},
+  {emoji: '💡', keywords: ['idea', 'lightbulb', 'bright']},
+  {emoji: '📝', keywords: ['note', 'memo', 'write']},
+  {emoji: '📌', keywords: ['pin', 'pushpin', 'note']},
+  {emoji: '📎', keywords: ['paperclip', 'attach']},
+  {emoji: '🔗', keywords: ['link', 'chain', 'url']},
+  {emoji: '🛠️', keywords: ['tools', 'fix', 'build']},
+  {emoji: '🐛', keywords: ['bug', 'insect', 'error']},
+  {emoji: '🔧', keywords: ['wrench', 'fix', 'tool']},
+  {emoji: '⚡', keywords: ['lightning', 'fast', 'bolt']},
+  {emoji: '🌈', keywords: ['rainbow', 'pride', 'colors']},
+  {emoji: '☀️', keywords: ['sun', 'sunny', 'day']},
+  {emoji: '🌙', keywords: ['moon', 'night', 'crescent']},
+  {emoji: '☁️', keywords: ['cloud', 'cloudy']},
+  {emoji: '🌧️', keywords: ['rain', 'cloud-rain']},
+  {emoji: '❄️', keywords: ['snow', 'snowflake', 'cold']},
+  {emoji: '☕', keywords: ['coffee', 'tea', 'hot']},
+  {emoji: '🍵', keywords: ['tea', 'green-tea']},
+  {emoji: '🍰', keywords: ['cake', 'dessert']},
+  {emoji: '🍕', keywords: ['pizza', 'food']},
+  {emoji: '🐱', keywords: ['cat', 'kitty']},
+  {emoji: '🐶', keywords: ['dog', 'puppy']},
+  {emoji: '🦄', keywords: ['unicorn', 'magic', 'rare']},
+  {emoji: '🐙', keywords: ['octopus', 'sea']},
+  {emoji: '🎯', keywords: ['target', 'dart', 'bullseye', 'goal']},
+  {emoji: '📚', keywords: ['books', 'library', 'read']},
+  {emoji: '🎨', keywords: ['art', 'palette', 'design']},
+  {emoji: '🎵', keywords: ['music', 'note', 'song']},
+  {emoji: '🎬', keywords: ['movie', 'film', 'clapper']},
+  {emoji: '🏁', keywords: ['flag', 'finish', 'done']},
+  {emoji: '💬', keywords: ['speech', 'chat', 'message']},
+  {emoji: '💭', keywords: ['thought', 'thinking', 'bubble']},
+  {emoji: '❤️', keywords: ['heart', 'love']},
+  {emoji: '🩷', keywords: ['heart', 'pink']},
+  {emoji: '🧡', keywords: ['heart', 'orange']},
+  {emoji: '💛', keywords: ['heart', 'yellow']},
+  {emoji: '💚', keywords: ['heart', 'green']},
+  {emoji: '💙', keywords: ['heart', 'blue']},
+  {emoji: '💜', keywords: ['heart', 'purple']},
+  {emoji: '🖤', keywords: ['heart', 'black']},
+  {emoji: '🤍', keywords: ['heart', 'white']},
+  {emoji: '💔', keywords: ['broken-heart']},
+]
+
+function matchEmojis({keyword}: {keyword: string}): ReadonlyArray<EmojiMatch> {
+  if (!keyword) {
+    return []
+  }
+  const term = keyword.toLowerCase()
+  const exact: Array<EmojiMatch> = []
+  const partial: Array<EmojiMatch> = []
+  for (const entry of emojiTable) {
+    const hit = entry.keywords.find((kw) => kw === term)
+    if (hit) {
+      exact.push({
+        type: 'exact',
+        key: `${entry.emoji}-${hit}`,
+        emoji: entry.emoji,
+        keyword: hit,
+      })
+      continue
+    }
+    const partialKeyword =
+      entry.keywords.find((kw) => kw.startsWith(term)) ??
+      entry.keywords.find((kw) => kw.includes(term))
+    if (partialKeyword) {
+      partial.push({
+        type: 'partial',
+        key: `${entry.emoji}-${partialKeyword}`,
+        emoji: entry.emoji,
+        keyword: partialKeyword,
+        startSlice: '',
+        endSlice: '',
+      })
+    }
+  }
+  return exact.concat(partial).slice(0, 30)
+}
+
+export function EmojiPickerPlugin() {
+  const {keyword, matches, selectedIndex, onNavigateTo, onSelect} =
+    useEmojiPicker({matchEmojis})
+  const isActive = keyword.length >= 1
+  return (
+    <TypeaheadPanel active={isActive}>
+      {matches.length === 0 ? (
+        <div className="pc-typeahead-empty">
+          No emojis matching ":{keyword}"
+        </div>
+      ) : (
+        <ul className="pc-typeahead-list">
+          {matches.map((match, index) => (
+            <EmojiItem
+              key={match.key}
+              match={match}
+              selected={index === selectedIndex}
+              onHover={() => onNavigateTo(index)}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </TypeaheadPanel>
+  )
+}
+
+function EmojiItem(props: {
+  match: EmojiMatch
+  selected: boolean
+  onHover: () => void
+  onSelect: () => void
+}) {
+  const ref = useRef<HTMLLIElement>(null)
+  useEffect(() => {
+    if (props.selected && ref.current) {
+      ref.current.scrollIntoView({block: 'nearest'})
+    }
+  }, [props.selected])
+  return (
+    <li
+      ref={ref}
+      className={`pc-typeahead-item pc-typeahead-item-row${props.selected ? ' pc-typeahead-item-selected' : ''}`}
+      onMouseEnter={props.onHover}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={props.onSelect}
+    >
+      <span className="pc-emoji">{props.match.emoji}</span>
+      <span className="pc-typeahead-item-hint">:{props.match.keyword}:</span>
+    </li>
+  )
+}

--- a/apps/pilcrow/src/plugins/horizontal-rule.tsx
+++ b/apps/pilcrow/src/plugins/horizontal-rule.tsx
@@ -1,0 +1,26 @@
+import {defineLeaf} from '@portabletext/editor'
+import {LeafPlugin} from '@portabletext/editor/plugins'
+
+const horizontalRuleLeaf = defineLeaf({
+  type: 'horizontal-rule',
+  render: ({attributes, children, focused, readOnly, selected}) => {
+    const stateClass =
+      (selected ? ' pc-hr-selected' : '') + (focused ? ' pc-hr-focused' : '')
+    return (
+      <div {...attributes} className="pc-hr-wrapper">
+        {children}
+        <div
+          contentEditable={false}
+          draggable={!readOnly}
+          className={`pc-hr-inner${stateClass}`}
+        >
+          <hr className="pc-hr" />
+        </div>
+      </div>
+    )
+  },
+})
+
+export function HorizontalRulePlugin() {
+  return <LeafPlugin leaves={[horizontalRuleLeaf]} />
+}

--- a/apps/pilcrow/src/plugins/image.tsx
+++ b/apps/pilcrow/src/plugins/image.tsx
@@ -1,0 +1,47 @@
+import {defineLeaf} from '@portabletext/editor'
+import {LeafPlugin} from '@portabletext/editor/plugins'
+
+const imageLeaf = defineLeaf({
+  type: 'image',
+  render: ({attributes, children, focused, node, readOnly, selected}) => {
+    const value = node as {
+      src?: string
+      alt?: string
+      caption?: string
+    }
+    const stateClass =
+      (selected ? ' pc-image-selected' : '') +
+      (focused ? ' pc-image-focused' : '')
+    return (
+      <div {...attributes} className="pc-image-wrapper">
+        {children}
+        <figure
+          contentEditable={false}
+          draggable={!readOnly}
+          className={`pc-image${stateClass}`}
+        >
+          {value.src ? (
+            <img src={value.src} alt={value.alt ?? ''} />
+          ) : (
+            <div
+              className="pc-image-placeholder"
+              role="img"
+              aria-label="Image placeholder"
+            >
+              <span>{value.alt ?? 'Image'}</span>
+            </div>
+          )}
+          {value.caption ? (
+            <figcaption className="pc-image-caption">
+              {value.caption}
+            </figcaption>
+          ) : null}
+        </figure>
+      </div>
+    )
+  },
+})
+
+export function ImagePlugin() {
+  return <LeafPlugin leaves={[imageLeaf]} />
+}

--- a/apps/pilcrow/src/plugins/markdown-shortcuts.tsx
+++ b/apps/pilcrow/src/plugins/markdown-shortcuts.tsx
@@ -1,0 +1,136 @@
+import {raise} from '@portabletext/editor/behaviors'
+import {defineInputRule, InputRulePlugin} from '@portabletext/plugin-input-rule'
+import {MarkdownShortcutsPlugin as LibraryMarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+
+/**
+ * Pilcrow's markdown-shortcuts wiring.
+ *
+ * The upstream `MarkdownShortcutsPlugin` covers headings,
+ * horizontal-rule, links, and inline decorator pairs (`**bold**`,
+ * `*em*`, `\`code\``, `~~strike~~`). Its built-in list rules emit
+ * `block.set` with a `listItem` property, which is the flat-list
+ * shape. Pilcrow uses container-based structured lists, so those
+ * rules are deliberately NOT enabled here; the structured-list
+ * input rules below take their place.
+ *
+ * Blockquotes are also containers (not a style), so we omit
+ * `blockquoteStyle` and rely on the blockquote plugin's own input
+ * rule for `> ` triggers.
+ *
+ * The structured rules emit:
+ *   1. `insert` of a new `list` (with a `list-item` containing an
+ *      empty text block) positioned before the focus block.
+ *   2. `unset` of the original focus block (the `- ` / `1. ` text
+ *      becomes the list item's first line, minus the marker).
+ *   3. `select` at the new list-item's text block.
+ *
+ * The result: typing `- ` at the start of a paragraph turns it into
+ * a bulleted list whose first item is the empty paragraph the caret
+ * is sitting in.
+ */
+export function MarkdownShortcutsPlugin() {
+  return (
+    <>
+      <LibraryMarkdownShortcutsPlugin
+        defaultStyle={() => 'normal'}
+        headingStyle={({props}) => `h${props.level}`}
+        horizontalRuleObject={() => ({_type: 'horizontal-rule'})}
+        linkObject={({props}) => ({_type: 'link', href: props.href})}
+        boldDecorator={() => 'strong'}
+        italicDecorator={() => 'em'}
+        codeDecorator={() => 'code'}
+        strikeThroughDecorator={() => 'strike-through'}
+      />
+      <InputRulePlugin
+        rules={[
+          createStructuredListRule({pattern: /^(-|\*) /, kind: 'bullet'}),
+          createStructuredListRule({pattern: /^1\. /, kind: 'number'}),
+        ]}
+      />
+    </>
+  )
+}
+
+interface StructuredListRuleConfig {
+  pattern: RegExp
+  kind: string
+}
+
+function createStructuredListRule(config: StructuredListRuleConfig) {
+  return defineInputRule({
+    on: config.pattern,
+    guard: ({event}) => {
+      const match = event.matches.at(0)
+      if (!match) {
+        return false
+      }
+      return {match}
+    },
+    actions: [
+      ({event, snapshot}) => {
+        const keyGen = snapshot.context.keyGenerator
+        const blockKey = keyGen()
+        const spanKey = keyGen()
+        const itemKey = keyGen()
+        const listKey = keyGen()
+
+        const newList = {
+          _type: 'list',
+          _key: listKey,
+          kind: config.kind,
+          items: [
+            {
+              _type: 'list-item',
+              _key: itemKey,
+              content: [
+                {
+                  _type: 'block',
+                  _key: blockKey,
+                  style: 'normal',
+                  children: [
+                    {_type: 'span', _key: spanKey, text: '', marks: []},
+                  ],
+                  markDefs: [],
+                },
+              ],
+            },
+          ],
+        }
+
+        const focusBlockPath = event.focusBlock.path
+        // The new list is inserted at the focus block's parent level, so
+        // its path lives under the same parent (top-level OR inside a
+        // callout/table cell/list-item). Compute the parent path so the
+        // select event points at the right place.
+        const parentPath = focusBlockPath.slice(0, -1)
+        const targetTextPath = [
+          ...parentPath,
+          {_key: listKey},
+          'items',
+          {_key: itemKey},
+          'content',
+          {_key: blockKey},
+          'children',
+          {_key: spanKey},
+        ]
+
+        return [
+          raise({
+            type: 'insert',
+            at: focusBlockPath,
+            value: newList as never,
+            position: 'before',
+          }),
+          raise({type: 'unset', at: focusBlockPath}),
+          raise({
+            type: 'select',
+            at: {
+              anchor: {path: targetTextPath, offset: 0},
+              focus: {path: targetTextPath, offset: 0},
+            } as never,
+          }),
+        ]
+      },
+    ],
+  })
+}

--- a/apps/pilcrow/src/plugins/slash-menu.tsx
+++ b/apps/pilcrow/src/plugins/slash-menu.tsx
@@ -1,0 +1,333 @@
+import {raise} from '@portabletext/editor/behaviors'
+import {
+  defineTypeaheadPicker,
+  useTypeaheadPicker,
+} from '@portabletext/plugin-typeahead-picker'
+import {useEffect, useRef} from 'react'
+import {TypeaheadPanel} from './typeahead-panel'
+
+/**
+ * Slash menu: type `/` at the start of a block to open a list of
+ * block-level commands. The list matches by case-insensitive
+ * substring against the command label and keywords. Selecting a
+ * command deletes the `/` pattern and dispatches the matching event
+ * (style toggle, list toggle, or block insert).
+ */
+type SlashAction =
+  | {type: 'style'; style: string}
+  | {type: 'list'; kind: string}
+  | {type: 'block'; blockType: string}
+  | {
+      type: 'table-op'
+      op: 'add-row' | 'remove-row' | 'add-column' | 'remove-column'
+    }
+
+type SlashCommand = {
+  key: string
+  label: string
+  hint: string
+  keywords: ReadonlyArray<string>
+  action: SlashAction
+}
+
+const commands: ReadonlyArray<SlashCommand> = [
+  {
+    key: 'h1',
+    label: 'Heading 1',
+    hint: 'Large section heading',
+    keywords: ['heading', 'h1', 'title'],
+    action: {type: 'style', style: 'h1'},
+  },
+  {
+    key: 'h2',
+    label: 'Heading 2',
+    hint: 'Medium section heading',
+    keywords: ['heading', 'h2'],
+    action: {type: 'style', style: 'h2'},
+  },
+  {
+    key: 'h3',
+    label: 'Heading 3',
+    hint: 'Small section heading',
+    keywords: ['heading', 'h3'],
+    action: {type: 'style', style: 'h3'},
+  },
+  {
+    key: 'quote',
+    label: 'Quote',
+    hint: 'Blockquote',
+    keywords: ['quote', 'blockquote'],
+    action: {type: 'block', blockType: 'blockquote'},
+  },
+  {
+    key: 'bullet',
+    label: 'Bullet list',
+    hint: 'Unordered list',
+    keywords: ['bullet', 'list', 'unordered', 'ul'],
+    action: {type: 'list', kind: 'bullet'},
+  },
+  {
+    key: 'number',
+    label: 'Numbered list',
+    hint: 'Ordered list',
+    keywords: ['numbered', 'number', 'list', 'ordered', 'ol'],
+    action: {type: 'list', kind: 'number'},
+  },
+  {
+    key: 'task',
+    label: 'Task list',
+    hint: 'Checkbox list',
+    keywords: ['task', 'todo', 'checkbox', 'check', 'list'],
+    action: {type: 'list', kind: 'task'},
+  },
+  {
+    key: 'image',
+    label: 'Image',
+    hint: 'Insert an image',
+    keywords: ['image', 'img', 'picture', 'photo'],
+    action: {type: 'block', blockType: 'image'},
+  },
+  {
+    key: 'callout',
+    label: 'Callout',
+    hint: 'Highlighted note or aside',
+    keywords: ['callout', 'note', 'aside', 'info', 'admonition'],
+    action: {type: 'block', blockType: 'callout'},
+  },
+  {
+    key: 'code-block',
+    label: 'Code block',
+    hint: 'Formatted code snippet',
+    keywords: ['code', 'codeblock', 'pre', 'snippet'],
+    action: {type: 'block', blockType: 'code-block'},
+  },
+  {
+    key: 'table',
+    label: 'Table',
+    hint: 'Rows and columns',
+    keywords: ['table', 'grid', 'rows', 'columns'],
+    action: {type: 'block', blockType: 'table'},
+  },
+  {
+    key: 'divider',
+    label: 'Divider',
+    hint: 'Horizontal rule',
+    keywords: ['hr', 'rule', 'divider', 'separator', 'break', 'line'],
+    action: {type: 'block', blockType: 'horizontal-rule'},
+  },
+  {
+    key: 'add-row',
+    label: 'Add row',
+    hint: 'Insert a row after the current row',
+    keywords: ['add', 'insert', 'row', 'table'],
+    action: {type: 'table-op', op: 'add-row'},
+  },
+  {
+    key: 'remove-row',
+    label: 'Remove row',
+    hint: 'Delete the current row',
+    keywords: ['remove', 'delete', 'row', 'table'],
+    action: {type: 'table-op', op: 'remove-row'},
+  },
+  {
+    key: 'add-column',
+    label: 'Add column',
+    hint: 'Insert a column after the current column',
+    keywords: ['add', 'insert', 'column', 'col', 'table'],
+    action: {type: 'table-op', op: 'add-column'},
+  },
+  {
+    key: 'remove-column',
+    label: 'Remove column',
+    hint: 'Delete the current column',
+    keywords: ['remove', 'delete', 'column', 'col', 'table'],
+    action: {type: 'table-op', op: 'remove-column'},
+  },
+]
+
+function matchCommands({
+  keyword,
+}: {
+  keyword: string
+}): ReadonlyArray<SlashCommand> {
+  if (keyword.trim() === '') {
+    return commands
+  }
+  const term = keyword.toLowerCase()
+  // Score: exact label > label-startsWith > keyword-exact > keyword-startsWith > label-substring > keyword-substring.
+  type Scored = {command: SlashCommand; score: number}
+  const scored: Array<Scored> = []
+  for (const command of commands) {
+    const label = command.label.toLowerCase()
+    let best = 0
+    if (label === term) {
+      best = 6
+    } else if (label.startsWith(term)) {
+      best = 5
+    } else {
+      for (const kw of command.keywords) {
+        if (kw === term) {
+          best = Math.max(best, 4)
+        } else if (kw.startsWith(term)) {
+          best = Math.max(best, 3)
+        } else if (kw.includes(term)) {
+          best = Math.max(best, 1)
+        }
+      }
+      if (label.includes(term)) {
+        best = Math.max(best, 2)
+      }
+    }
+    if (best > 0) {
+      scored.push({command, score: best})
+    }
+  }
+  scored.sort((a, b) => b.score - a.score)
+  return scored.map((s) => s.command)
+}
+
+const slashCommandPicker = defineTypeaheadPicker<SlashCommand>({
+  trigger: /^\//,
+  keyword: /[\w-]*/,
+  getMatches: matchCommands,
+  onSelect: [
+    ({event, snapshot}) => {
+      const raises = [raise({type: 'delete', at: event.patternSelection})]
+      const action = event.match.action
+      if (action.type === 'style') {
+        raises.push(raise({type: 'style.toggle', style: action.style}))
+      } else if (action.type === 'list') {
+        // Lists in Pilcrow are containers; the structured-lists plugin
+        // listens for the markdown input rules `- ` / `1. ` and the
+        // [!TONE] callout rule. Slash-menu inserts the list container
+        // directly with one empty list-item.
+        const keyGen = snapshot.context.keyGenerator
+        raises.push(
+          raise({
+            type: 'insert.block',
+            placement: 'auto',
+            block: {
+              _type: 'list',
+              _key: keyGen(),
+              kind: action.kind,
+              items: [
+                {
+                  _type: 'list-item',
+                  _key: keyGen(),
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: keyGen(),
+                      style: 'normal',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGen(),
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            } as never,
+          }),
+        )
+      } else if (action.type === 'table-op') {
+        raises.push(raise({type: `custom.tables.${action.op}` as never}))
+      } else if (action.blockType === 'blockquote') {
+        const keyGen = snapshot.context.keyGenerator
+        raises.push(
+          raise({
+            type: 'insert.block',
+            placement: 'auto',
+            block: {
+              _type: 'blockquote',
+              _key: keyGen(),
+              content: [
+                {
+                  _type: 'block',
+                  _key: keyGen(),
+                  style: 'normal',
+                  children: [
+                    {_type: 'span', _key: keyGen(), text: '', marks: []},
+                  ],
+                  markDefs: [],
+                },
+              ],
+            } as never,
+          }),
+        )
+      } else {
+        const keyGen = snapshot.context.keyGenerator
+        raises.push(
+          raise({
+            type: 'insert.block',
+            placement: 'auto',
+            block: {
+              _type: action.blockType,
+              _key: keyGen(),
+            },
+          }),
+        )
+      }
+      return raises
+    },
+  ],
+})
+
+export function SlashMenuPlugin() {
+  const picker = useTypeaheadPicker(slashCommandPicker)
+  const {matches, selectedIndex, keyword} = picker.snapshot.context
+  const isActive = picker.snapshot.matches('active')
+
+  return (
+    <TypeaheadPanel active={isActive}>
+      {matches.length === 0 ? (
+        <div className="pc-typeahead-empty">
+          No commands matching "{keyword}"
+        </div>
+      ) : (
+        <ul className="pc-typeahead-list">
+          {matches.map((command, index) => (
+            <SlashItem
+              key={command.key}
+              command={command}
+              selected={index === selectedIndex}
+              onHover={() => picker.send({type: 'navigate to', index})}
+              onSelect={() => picker.send({type: 'select'})}
+            />
+          ))}
+        </ul>
+      )}
+    </TypeaheadPanel>
+  )
+}
+
+function SlashItem(props: {
+  command: SlashCommand
+  selected: boolean
+  onHover: () => void
+  onSelect: () => void
+}) {
+  const ref = useRef<HTMLLIElement>(null)
+  useEffect(() => {
+    if (props.selected && ref.current) {
+      ref.current.scrollIntoView({block: 'nearest'})
+    }
+  }, [props.selected])
+  return (
+    <li
+      ref={ref}
+      className={`pc-typeahead-item${props.selected ? ' pc-typeahead-item-selected' : ''}`}
+      onMouseEnter={props.onHover}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={props.onSelect}
+    >
+      <span className="pc-typeahead-item-label">{props.command.label}</span>
+      <span className="pc-typeahead-item-hint">{props.command.hint}</span>
+    </li>
+  )
+}

--- a/apps/pilcrow/src/plugins/structured-lists.tsx
+++ b/apps/pilcrow/src/plugins/structured-lists.tsx
@@ -1,0 +1,1304 @@
+import {
+  defineContainer,
+  useEditor,
+  type BlockPath,
+  type EditorSnapshot,
+} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, ContainerPlugin} from '@portabletext/editor/plugins'
+import {getFocusTextBlock, getNextBlock} from '@portabletext/editor/selectors'
+import {getAncestor, getSibling} from '@portabletext/editor/traversal'
+import {getBlockEndPoint} from '@portabletext/editor/utils'
+import type {
+  PortableTextSpan,
+  PortableTextTextBlock,
+} from '@portabletext/schema'
+import {createContext, useContext} from 'react'
+
+/**
+ * Structured lists: `list` and `list-item` as nested containers.
+ *
+ * A list has a `kind` field (bullet / number / task) and an `items`
+ * array of list-items. Each list-item has a `content` array that
+ * can hold plain text blocks AND nested lists - that is how nesting
+ * works structurally rather than through a `level` field on flat
+ * blocks.
+ *
+ * Tab sinks the focus item one level deeper. Shift+Tab lifts it one
+ * level out, bringing trailing siblings along as a nested list to
+ * preserve document order.
+ *
+ * Ported from `packages/editor/gherkin-tests/plugin.structured-lists`
+ * (PR #2635).
+ */
+
+// ---------------------------------------------------------------------------
+// Domain shape
+// ---------------------------------------------------------------------------
+
+type Keyed = {_key: string}
+type Path = BlockPath
+
+type ListNode = Keyed & {
+  _type: 'list'
+  kind?: string
+  items: Array<ListItemNode>
+}
+
+type ListItemNode = Keyed & {
+  _type: 'list-item'
+  checked?: boolean
+  content: Array<unknown>
+}
+
+function isKeyedSegment(segment: unknown): segment is Keyed {
+  return (
+    typeof segment === 'object' &&
+    segment !== null &&
+    '_key' in (segment as Record<string, unknown>)
+  )
+}
+
+const isList = (node: unknown): node is ListNode =>
+  (node as {_type?: unknown})?._type === 'list'
+
+const isListItem = (node: unknown): node is ListItemNode =>
+  (node as {_type?: unknown})?._type === 'list-item'
+
+// ---------------------------------------------------------------------------
+// Containers
+// ---------------------------------------------------------------------------
+
+const ListKindContext = createContext<string>('bullet')
+
+function ListContainerRender(props: {
+  attributes: Record<string, unknown>
+  children: React.ReactElement
+  node: unknown
+}) {
+  const list = props.node as ListNode
+  const kind = list.kind ?? 'bullet'
+  const Tag = kind === 'number' ? 'ol' : 'ul'
+  return (
+    <ListKindContext.Provider value={kind}>
+      <Tag {...props.attributes} className={`pc-list pc-list-${kind}`}>
+        {props.children}
+      </Tag>
+    </ListKindContext.Provider>
+  )
+}
+
+const listContainer = defineContainer({
+  type: 'list',
+  childField: 'items',
+  render: ({attributes, children, node}) => (
+    <ListContainerRender attributes={attributes} node={node}>
+      {children}
+    </ListContainerRender>
+  ),
+  of: [
+    defineContainer({
+      type: 'list-item',
+      childField: 'content',
+      render: ({attributes, children, node, path}) => (
+        <ListItemContainerRender
+          attributes={attributes}
+          node={node}
+          path={path as Path}
+        >
+          {children}
+        </ListItemContainerRender>
+      ),
+    }),
+  ],
+})
+
+function ListItemContainerRender(props: {
+  attributes: Record<string, unknown>
+  children: React.ReactElement
+  node: unknown
+  path: Path
+}) {
+  const kind = useContext(ListKindContext)
+  const editor = useEditor()
+  const item = props.node as ListItemNode
+  const checked = item.checked === true
+  // A list-item that holds ONLY nested lists (no text block of its own) is
+  // a structural wrapper produced by sinking the first item of a task list
+  // - it has no task text to check off, so its checkbox would be a phantom
+  // affordance toggling a `checked` field on a node the user never sees.
+  // Skip the checkbox in that case.
+  const hasOwnText = item.content.some(
+    (child) =>
+      typeof child === 'object' &&
+      child !== null &&
+      (child as {_type?: string})._type === 'block',
+  )
+  if (kind === 'task' && hasOwnText) {
+    return (
+      <li
+        {...props.attributes}
+        className={`pc-list-item pc-list-item-task${checked ? ' pc-list-item-task-done' : ''}`}
+      >
+        <input
+          type="checkbox"
+          className="pc-task-check"
+          checked={checked}
+          aria-label="Task done"
+          contentEditable={false}
+          onMouseDown={(event) => event.preventDefault()}
+          onChange={() => {
+            editor.send({
+              type: 'set',
+              at: [...props.path, 'checked'] as never,
+              value: !checked,
+            })
+          }}
+        />
+        <span className="pc-task-body">{props.children}</span>
+      </li>
+    )
+  }
+  return (
+    <li {...props.attributes} className="pc-list-item">
+      {props.children}
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const childPath = (parent: Path, field: string, child: Keyed): Path => [
+  ...parent,
+  field,
+  {_key: child._key},
+]
+
+const newList = (
+  keyGen: () => string,
+  kind: string | undefined,
+  items: Array<ListItemNode>,
+): ListNode => ({
+  _type: 'list',
+  _key: keyGen(),
+  ...(kind !== undefined ? {kind} : {}),
+  items,
+})
+
+const newListItem = (
+  keyGen: () => string,
+  content: Array<unknown>,
+): ListItemNode => ({
+  _type: 'list-item',
+  _key: keyGen(),
+  content,
+})
+
+function rebaseFocus(
+  focusPath: Path,
+  oldKey: string,
+  newPrefix: Path,
+): Path | undefined {
+  const idx = focusPath.findIndex(
+    (seg) => isKeyedSegment(seg) && seg._key === oldKey,
+  )
+  if (idx < 0) {
+    return undefined
+  }
+  return [...newPrefix, ...focusPath.slice(idx + 1)]
+}
+
+type Snapshot = EditorSnapshot
+
+export function getEnclosingList(snapshot: Snapshot) {
+  return resolveFocus(snapshot)
+}
+
+function resolveFocus(snapshot: Snapshot) {
+  const focusPath = snapshot.context.selection?.focus.path
+  if (!focusPath) {
+    return undefined
+  }
+  const listItem = getAncestor(snapshot, focusPath as never, isListItem) as
+    | {node: ListItemNode; path: Path}
+    | undefined
+  if (!listItem) {
+    return undefined
+  }
+  const list = getAncestor(snapshot, listItem.path, isList) as
+    | {node: ListNode; path: Path}
+    | undefined
+  if (!list) {
+    return undefined
+  }
+  const itemIndex = list.node.items.findIndex(
+    (item) => item._key === listItem.node._key,
+  )
+  if (itemIndex < 0) {
+    return undefined
+  }
+  return {listItem, list, itemIndex}
+}
+
+function selectAt(snapshot: Snapshot, path: Path | undefined) {
+  if (!path) {
+    return undefined
+  }
+  const offset = snapshot.context.selection?.focus.offset ?? 0
+  return raise({
+    type: 'select' as const,
+    at: {anchor: {path, offset}, focus: {path, offset}} as never,
+  })
+}
+
+type Raise = ReturnType<typeof raise>
+
+// ---------------------------------------------------------------------------
+// Sink / lift behaviors
+// ---------------------------------------------------------------------------
+
+function isTabEvent(originEvent: KeyboardEvent | undefined): boolean {
+  if (!originEvent) {
+    return false
+  }
+  return (
+    originEvent.key === 'Tab' &&
+    !originEvent.shiftKey &&
+    !originEvent.metaKey &&
+    !originEvent.ctrlKey &&
+    !originEvent.altKey
+  )
+}
+
+function isShiftTabEvent(originEvent: KeyboardEvent | undefined): boolean {
+  if (!originEvent) {
+    return false
+  }
+  return (
+    originEvent.key === 'Tab' &&
+    originEvent.shiftKey &&
+    !originEvent.metaKey &&
+    !originEvent.ctrlKey &&
+    !originEvent.altKey
+  )
+}
+
+function computeSinkRaises(snapshot: Snapshot): Array<Raise> | null {
+  const focus = resolveFocus(snapshot)
+  if (!focus) {
+    return null
+  }
+  const focusPath = snapshot.context.selection?.focus.path as Path | undefined
+  if (!focusPath) {
+    return null
+  }
+  const {listItem, list, itemIndex} = focus
+  const keyGen = snapshot.context.keyGenerator
+  const sourceKind = list.node.kind
+  const raises: Array<Raise> = []
+
+  if (itemIndex === 0) {
+    const wrapperList = newList(keyGen, sourceKind, [listItem.node])
+    const wrapper = newListItem(keyGen, [wrapperList])
+    raises.push(
+      raise({type: 'unset', at: listItem.path}),
+      raise({
+        type: 'insert',
+        at: [...list.path, 'items', 0] as never,
+        value: wrapper as never,
+        position: 'before',
+      }),
+    )
+    const select = selectAt(
+      snapshot,
+      rebaseFocus(focusPath, listItem.node._key, [
+        ...childPath(list.path, 'items', wrapper),
+        ...childPath([], 'content', wrapperList),
+        'items',
+        {_key: listItem.node._key},
+      ]),
+    )
+    if (select) {
+      raises.push(select)
+    }
+    return raises
+  }
+
+  const prevSibling = getSibling(snapshot, listItem.path, 'previous') as
+    | {node: unknown; path: Path}
+    | undefined
+  if (!prevSibling || !isListItem(prevSibling.node)) {
+    return null
+  }
+  const prevContent = (prevSibling.node as ListItemNode).content
+  const trailing = prevContent[prevContent.length - 1]
+
+  if (trailing && isList(trailing)) {
+    const trailingListPath = childPath(prevSibling.path, 'content', trailing)
+    const lastItem = trailing.items[trailing.items.length - 1] as ListItemNode
+    raises.push(
+      raise({type: 'unset', at: listItem.path}),
+      raise({
+        type: 'insert',
+        at: childPath(trailingListPath, 'items', lastItem) as never,
+        value: listItem.node as never,
+        position: 'after',
+      }),
+    )
+    const select = selectAt(
+      snapshot,
+      rebaseFocus(focusPath, listItem.node._key, [
+        ...trailingListPath,
+        'items',
+        {_key: listItem.node._key},
+      ]),
+    )
+    if (select) {
+      raises.push(select)
+    }
+    return raises
+  }
+
+  const fresh = newList(keyGen, sourceKind, [listItem.node])
+  const hasContent = prevContent.length > 0
+  raises.push(
+    raise({type: 'unset', at: listItem.path}),
+    raise({
+      type: 'insert',
+      at: (hasContent
+        ? childPath(
+            prevSibling.path,
+            'content',
+            prevContent[prevContent.length - 1] as Keyed,
+          )
+        : [...prevSibling.path, 'content', 0]) as never,
+      value: fresh as never,
+      position: hasContent ? 'after' : 'before',
+    }),
+  )
+  const select = selectAt(
+    snapshot,
+    rebaseFocus(focusPath, listItem.node._key, [
+      ...childPath(prevSibling.path, 'content', fresh),
+      'items',
+      {_key: listItem.node._key},
+    ]),
+  )
+  if (select) {
+    raises.push(select)
+  }
+  return raises
+}
+
+/**
+ * Wires a compute-raises function to one keyboard-event trigger plus
+ * one custom-event trigger. Both behaviors share the same plan
+ * (\`{raises}\`) and the same dispatch action. Avoids hand-duplicating
+ * the same guard/action twice.
+ */
+function defineSinkLiftPair({
+  customType,
+  isKeyboardMatch,
+  compute,
+}: {
+  customType:
+    | 'custom.structured-lists.indent'
+    | 'custom.structured-lists.outdent'
+  isKeyboardMatch: (event: KeyboardEvent | undefined) => boolean
+  compute: (snapshot: Snapshot) => Array<Raise> | null
+}) {
+  const dispatch = (planned: unknown) =>
+    (planned as {raises: Array<Raise>}).raises
+  return [
+    defineBehavior({
+      on: 'keyboard.keydown',
+      guard: ({snapshot, event}) => {
+        if (!isKeyboardMatch(event.originEvent as KeyboardEvent | undefined)) {
+          return false
+        }
+        const raises = compute(snapshot as never)
+        return raises ? {raises} : false
+      },
+      actions: [(_, planned) => dispatch(planned)],
+    }),
+    defineBehavior({
+      on: customType,
+      guard: ({snapshot}) => {
+        const raises = compute(snapshot as never)
+        return raises ? {raises} : false
+      },
+      actions: [(_, planned) => dispatch(planned)],
+    }),
+  ]
+}
+
+const [sinkOnTab, sinkOnCustom] = defineSinkLiftPair({
+  customType: 'custom.structured-lists.indent',
+  isKeyboardMatch: isTabEvent,
+  compute: computeSinkRaises,
+})
+
+function computeLiftRaises(snapshot: Snapshot): Array<Raise> | null {
+  const focus = resolveFocus(snapshot)
+  if (!focus) {
+    return null
+  }
+  const focusPath = snapshot.context.selection?.focus.path as Path | undefined
+  if (!focusPath) {
+    return null
+  }
+  const {listItem, list, itemIndex} = focus
+  const keyGen = snapshot.context.keyGenerator
+
+  const parentListItem = getAncestor(snapshot, list.path, isListItem) as
+    | {node: ListItemNode; path: Path}
+    | undefined
+  if (!parentListItem) {
+    return null
+  }
+  const parentList = getAncestor(snapshot, parentListItem.path, isList) as
+    | {node: ListNode; path: Path}
+    | undefined
+  if (!parentList) {
+    return null
+  }
+
+  const itemsAfter = list.node.items.slice(itemIndex + 1)
+  const isFirstItem = itemIndex === 0
+  const sourceKind = list.node.kind
+
+  const liftedItem: ListItemNode =
+    itemsAfter.length > 0
+      ? {
+          ...listItem.node,
+          content: [
+            ...listItem.node.content,
+            newList(keyGen, sourceKind, itemsAfter),
+          ],
+        }
+      : listItem.node
+
+  const raises: Array<Raise> = [
+    raise({
+      type: 'insert',
+      at: childPath(parentList.path, 'items', parentListItem.node) as never,
+      value: liftedItem as never,
+      position: 'after',
+    }),
+  ]
+
+  if (isFirstItem) {
+    raises.push(raise({type: 'unset', at: list.path}))
+    if (parentListItem.node.content.length === 1) {
+      raises.push(raise({type: 'unset', at: parentListItem.path}))
+    }
+  } else {
+    raises.push(raise({type: 'unset', at: listItem.path}))
+    for (const item of itemsAfter) {
+      raises.push(
+        raise({
+          type: 'unset',
+          at: childPath(list.path, 'items', item) as never,
+        }),
+      )
+    }
+  }
+
+  const select = selectAt(
+    snapshot,
+    rebaseFocus(
+      focusPath,
+      listItem.node._key,
+      childPath(parentList.path, 'items', listItem.node),
+    ),
+  )
+  if (select) {
+    raises.push(select)
+  }
+
+  return raises
+}
+
+const [liftOnShiftTab, liftOnCustom] = defineSinkLiftPair({
+  customType: 'custom.structured-lists.outdent',
+  isKeyboardMatch: isShiftTabEvent,
+  compute: computeLiftRaises,
+})
+
+// ---------------------------------------------------------------------------
+// Split on Enter
+// ---------------------------------------------------------------------------
+
+/**
+ * Pressing Enter inside a list-item's text block splits the list-item:
+ * text before the cursor stays in the current item, text after the
+ * cursor moves into a new sibling list-item. Empty trailing text
+ * blocks at the end of the source list-item move along too.
+ *
+ * If the focus block isn't a direct text-block child of a list-item,
+ * this behavior bails and the default insert.break handler runs.
+ */
+const splitListItemOnEnter = defineBehavior({
+  on: 'insert.break',
+  guard: ({snapshot}) => {
+    const selection = snapshot.context.selection
+    if (!selection) {
+      return false
+    }
+    // Only handle collapsed selection (single caret).
+    const {focus, anchor} = selection
+    if (
+      focus.path.length !== anchor.path.length ||
+      focus.offset !== anchor.offset
+    ) {
+      const sameKeys = focus.path.every((seg, i) => {
+        const other = anchor.path[i]
+        if (typeof seg === 'string' || typeof other === 'string') {
+          return seg === other
+        }
+        if (typeof seg === 'number' || typeof other === 'number') {
+          return seg === other
+        }
+        return (seg as {_key: string})._key === (other as {_key: string})._key
+      })
+      if (!sameKeys) {
+        return false
+      }
+    }
+    const enclosingItem = getAncestor(
+      snapshot,
+      focus.path as never,
+      isListItem,
+    ) as {node: ListItemNode; path: Path} | undefined
+    if (!enclosingItem) {
+      return false
+    }
+    // The focus text block must be a direct content child of the list-item.
+    // focus.path looks like:
+    //   [..., {_key: itemKey}, 'content', {_key: textBlockKey}, 'children', {_key: spanKey}]
+    // We need to find the text block segment immediately under the item's 'content'.
+    const itemPathLength = enclosingItem.path.length
+    // Path after item: 'content', {_key: blockKey}, 'children', {_key: spanKey}
+    if (focus.path.length < itemPathLength + 4) {
+      return false
+    }
+    if (focus.path[itemPathLength] !== 'content') {
+      return false
+    }
+    const blockSeg = focus.path[itemPathLength + 1]
+    if (typeof blockSeg !== 'object' || blockSeg === null) {
+      return false
+    }
+    const blockKey = (blockSeg as {_key: string})._key
+    // Find the block in content - must be a text block we can split.
+    const blockIndex = enclosingItem.node.content.findIndex(
+      (entry) =>
+        (entry as {_key?: string})._key === blockKey &&
+        (entry as {_type?: string})._type === 'block',
+    )
+    if (blockIndex < 0) {
+      return false
+    }
+    const block = enclosingItem.node.content[
+      blockIndex
+    ] as PortableTextTextBlock
+    return {
+      enclosingItem,
+      blockIndex,
+      block,
+      focusPath: focus.path,
+      focusOffset: focus.offset,
+    }
+  },
+  actions: [
+    (
+      {snapshot},
+      {enclosingItem, blockIndex, block, focusPath, focusOffset},
+    ) => {
+      const keyGen = snapshot.context.keyGenerator
+      // Compute what's AFTER the cursor in the focused text block. That
+      // text + any trailing content entries in the list-item move into
+      // a new sibling list-item.
+      const spanSeg = focusPath[focusPath.length - 1]
+      const focusSpanKey =
+        typeof spanSeg === 'object' && spanSeg !== null
+          ? (spanSeg as {_key: string})._key
+          : undefined
+      const afterSpans: Array<PortableTextSpan> = []
+      let pastFocusSpan = false
+      for (const child of block.children) {
+        const span = child as PortableTextSpan
+        if (pastFocusSpan) {
+          afterSpans.push(span)
+          continue
+        }
+        if (span._key === focusSpanKey) {
+          const text = span.text ?? ''
+          afterSpans.push({
+            ...span,
+            _key: keyGen(),
+            text: text.slice(focusOffset),
+          })
+          pastFocusSpan = true
+        }
+      }
+      if (!pastFocusSpan) {
+        return []
+      }
+      const trailingContent = enclosingItem.node.content.slice(blockIndex + 1)
+      const newBlock: PortableTextTextBlock = {
+        ...block,
+        _key: keyGen(),
+        children:
+          afterSpans.length > 0
+            ? afterSpans
+            : [
+                {
+                  _type: 'span',
+                  _key: keyGen(),
+                  text: '',
+                  marks: [],
+                },
+              ],
+      }
+      const newItem: ListItemNode = {
+        _type: 'list-item',
+        _key: keyGen(),
+        content: [newBlock, ...trailingContent] as Array<unknown>,
+      }
+      const newItemPath: Path = [
+        ...enclosingItem.path.slice(0, -1),
+        {_key: newItem._key},
+      ]
+      const newSpanPath: Path = [
+        ...newItemPath,
+        'content',
+        {_key: newBlock._key},
+        'children',
+        {_key: (newBlock.children[0] as PortableTextSpan)._key},
+      ]
+      // Find the END of the focused text block: path to its last span,
+      // offset = length of that span's text.
+      const lastSpan = block.children[
+        block.children.length - 1
+      ] as PortableTextSpan
+      const blockPath: Path = [
+        ...enclosingItem.path,
+        'content',
+        {_key: block._key},
+      ]
+      const blockEndPath: Path = [
+        ...blockPath,
+        'children',
+        {_key: lastSpan._key},
+      ]
+      const blockEndOffset = (lastSpan.text ?? '').length
+      const raises: Array<Raise> = []
+      // 1. Delete the text from cursor to end of the focused text block.
+      raises.push(
+        raise({
+          type: 'delete',
+          at: {
+            anchor: {path: focusPath, offset: focusOffset},
+            focus: {path: blockEndPath, offset: blockEndOffset},
+          } as never,
+        }),
+      )
+      // 2. Unset the trailing content entries in the source list-item;
+      //    they're moving into the new item.
+      for (const entry of trailingContent) {
+        const entryKey = (entry as {_key?: string})._key
+        if (!entryKey) {
+          continue
+        }
+        raises.push(
+          raise({
+            type: 'unset',
+            at: [...enclosingItem.path, 'content', {_key: entryKey}] as never,
+          }),
+        )
+      }
+      // 3. Insert the new list-item as a sibling AFTER the current one.
+      raises.push(
+        raise({
+          type: 'insert',
+          at: enclosingItem.path,
+          value: newItem as never,
+          position: 'after',
+        }),
+      )
+      // 4. Move the caret to the start of the new text block.
+      raises.push(
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: newSpanPath, offset: 0},
+            focus: {path: newSpanPath, offset: 0},
+          } as never,
+        }),
+      )
+      return raises
+    },
+  ],
+})
+
+// ---------------------------------------------------------------------------
+// Merge list-items on Backspace / Delete across container boundaries
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: is the collapsed caret at the start of the given text block.
+ * Inlined from \`@portabletext/editor/utils/util.at-the-beginning-of-block\`
+ * because that helper isn't part of the package's public exports.
+ */
+/**
+ * Walks the FIRST content entry of a list-item, descending into nested
+ * lists' first list-item, to find the visually-leading text block.
+ * Symmetric to {@link findDeepestTrailingTextBlock} and used by the
+ * Delete-merge to find where to splice the next list-item's content
+ * when its first entry is a nested list rather than a text block.
+ */
+function findDeepestLeadingTextBlock(
+  item: ListItemNode,
+  itemPath: Path,
+): {node: PortableTextTextBlock; path: Path} | undefined {
+  const content = item.content
+  for (const entry of content) {
+    const node = entry as {_type?: string; _key?: string} | undefined
+    if (!node || !node._key) {
+      continue
+    }
+    const entryPath: Path = [...itemPath, 'content', {_key: node._key}]
+    if (node._type === 'block') {
+      return {node: node as never as PortableTextTextBlock, path: entryPath}
+    }
+    if (node._type === 'list') {
+      const list = node as never as ListNode
+      const items = list.items ?? []
+      const firstItem = items[0]
+      if (firstItem) {
+        const nested = findDeepestLeadingTextBlock(firstItem, [
+          ...entryPath,
+          'items',
+          {_key: firstItem._key},
+        ])
+        if (nested) {
+          return nested
+        }
+      }
+    }
+    // Skip non-block, non-list entries; they're not valid merge targets.
+  }
+  return undefined
+}
+
+function findDeepestTrailingTextBlock(
+  item: ListItemNode,
+  itemPath: Path,
+): {node: PortableTextTextBlock; path: Path} | undefined {
+  const content = item.content
+  for (let i = content.length - 1; i >= 0; i--) {
+    const entry = content[i] as {_type?: string; _key?: string} | undefined
+    if (!entry || !entry._key) {
+      continue
+    }
+    const entryPath: Path = [...itemPath, 'content', {_key: entry._key}]
+    if (entry._type === 'block') {
+      return {node: entry as never as PortableTextTextBlock, path: entryPath}
+    }
+    if (entry._type === 'list') {
+      const list = entry as never as ListNode
+      const items = list.items ?? []
+      // Walk the last list-item of the trailing list.
+      const lastItem = items[items.length - 1]
+      if (lastItem) {
+        const nested = findDeepestTrailingTextBlock(lastItem, [
+          ...entryPath,
+          'items',
+          {_key: lastItem._key},
+        ])
+        if (nested) {
+          return nested
+        }
+      }
+    }
+    // Skip non-block, non-list entries (images, code-blocks) - they're not
+    // valid merge targets.
+  }
+  return undefined
+}
+
+function isAtBlockStart(
+  snapshot: import('@portabletext/editor').EditorSnapshot,
+  block: {_key: string; children: ReadonlyArray<{_key?: string}>},
+): boolean {
+  const selection = snapshot.context.selection
+  if (!selection) {
+    return false
+  }
+  if (
+    selection.anchor.path.length !== selection.focus.path.length ||
+    selection.anchor.offset !== selection.focus.offset
+  ) {
+    return false
+  }
+  const focusPath = selection.focus.path
+  const lastSeg = focusPath[focusPath.length - 1]
+  if (typeof lastSeg !== 'object' || lastSeg === null) {
+    return false
+  }
+  const focusSpanKey = (lastSeg as {_key: string})._key
+  return (
+    focusSpanKey === block.children[0]?._key && selection.focus.offset === 0
+  )
+}
+
+/**
+ * Backspace at the start of a list-item's first text block, when the
+ * focus text block has no previous sibling at the same level, merges
+ * the current list-item INTO the previous sibling list-item. The
+ * current item's first text block lands at the end of the previous
+ * item's last text block (slate merges the spans). Any extra content
+ * the current item carries (nested lists, images, etc.) is left
+ * alone for now - the common single-text-block case is what most
+ * users hit.
+ */
+const mergeListItemOnBackspace = defineBehavior({
+  on: 'delete.backward',
+  guard: ({snapshot}) => {
+    const focusTextBlock = getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      return false
+    }
+    if (!isAtBlockStart(snapshot, focusTextBlock.node)) {
+      return false
+    }
+    const enclosingItem = getAncestor(
+      snapshot,
+      focusTextBlock.path,
+      isListItem,
+    ) as {node: ListItemNode; path: Path} | undefined
+    if (!enclosingItem) {
+      return false
+    }
+    // Only handle the case where this text block is the FIRST content
+    // entry of its list-item - otherwise the default behavior merges
+    // sibling text blocks within the same item, which is correct.
+    const firstContent = enclosingItem.node.content[0] as
+      | {_key?: string}
+      | undefined
+    if (!firstContent || firstContent._key !== focusTextBlock.node._key) {
+      return false
+    }
+    const previousItem = getSibling(
+      snapshot,
+      enclosingItem.path,
+      'previous',
+    ) as {node: unknown; path: Path} | undefined
+    if (!previousItem || !isListItem(previousItem.node)) {
+      return false
+    }
+    // Walk the previous item's content depth-first, following the LAST
+    // content entry at each step (and if it's a list, then its LAST list-
+    // item) to find the visually-trailing text block. That's the natural
+    // join target for the merge.
+    const trailing = findDeepestTrailingTextBlock(
+      previousItem.node as ListItemNode,
+      previousItem.path,
+    )
+    if (!trailing) {
+      return false
+    }
+    const previousLastBlock = {
+      node: trailing.node as never,
+      path: trailing.path as never,
+    }
+    const previousEndPoint = getBlockEndPoint({
+      context: snapshot.context,
+      block: previousLastBlock,
+    })
+    return {focusTextBlock, previousEndPoint, enclosingItem}
+  },
+  actions: [
+    (_, {focusTextBlock, previousEndPoint, enclosingItem}) => {
+      // Walk each child of the focus block and raise an `insert.child`
+      // event so spans-with-marks (e.g. \`strong\`, \`em\`) survive the
+      // merge - `insert.text` would have inserted plain text and dropped
+      // any decorators. Inline objects flow through the same path.
+      const children = focusTextBlock.node.children as Array<unknown>
+      const inserts: Array<ReturnType<typeof raise>> = children.map((child) =>
+        raise({
+          type: 'insert.child',
+          child: child as Parameters<typeof raise>[0] extends infer T
+            ? T extends {type: 'insert.child'; child: infer C}
+              ? C
+              : never
+            : never,
+        } as never),
+      )
+      return [
+        // Move the caret to the join point first.
+        raise({
+          type: 'select',
+          at: {
+            anchor: previousEndPoint,
+            focus: previousEndPoint,
+          },
+        }),
+        // Insert each child of the focus block at the join point. Marks
+        // come along because the whole span (with its mark refs) is
+        // copied across.
+        ...inserts,
+        // Put the caret back at the join point so users land where the
+        // merge happened, not at the end of the appended children.
+        raise({
+          type: 'select',
+          at: {
+            anchor: previousEndPoint,
+            focus: previousEndPoint,
+          },
+        }),
+        raise({
+          type: 'unset',
+          at: enclosingItem.path,
+        }),
+      ]
+    },
+  ],
+})
+
+/**
+ * Delete at the end of a list-item's last text block, when no next
+ * sibling block exists at the same level, merges the NEXT sibling
+ * list-item's first text block INTO the current one. Symmetric to
+ * Backspace.
+ */
+const mergeListItemOnDelete = defineBehavior({
+  on: 'delete.forward',
+  guard: ({snapshot}) => {
+    const focusTextBlock = getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      return false
+    }
+    const focusPath = snapshot.context.selection?.focus.path as Path | undefined
+    if (!focusPath) {
+      return false
+    }
+    // Verify caret is at the end of the focus text block.
+    const blockEndPoint = getBlockEndPoint({
+      context: snapshot.context,
+      block: focusTextBlock,
+    })
+    const focusOffset = snapshot.context.selection?.focus.offset ?? 0
+    const endSeg = blockEndPoint.path[blockEndPoint.path.length - 1]
+    const focusSeg = focusPath[focusPath.length - 1]
+    if (
+      typeof endSeg !== 'object' ||
+      typeof focusSeg !== 'object' ||
+      endSeg === null ||
+      focusSeg === null
+    ) {
+      return false
+    }
+    if ((endSeg as {_key: string})._key !== (focusSeg as {_key: string})._key) {
+      return false
+    }
+    if (focusOffset !== blockEndPoint.offset) {
+      return false
+    }
+    // Bail if there's a next sibling text block - the default handles it.
+    const nextSibling = getNextBlock(snapshot)
+    if (nextSibling) {
+      return false
+    }
+    const enclosingItem = getAncestor(
+      snapshot,
+      focusTextBlock.path,
+      isListItem,
+    ) as {node: ListItemNode; path: Path} | undefined
+    if (!enclosingItem) {
+      return false
+    }
+    // Focus text block must be the LAST content entry of its list-item.
+    const itemContent = enclosingItem.node.content
+    const lastContent = itemContent[itemContent.length - 1] as
+      | {_key?: string}
+      | undefined
+    if (!lastContent || lastContent._key !== focusTextBlock.node._key) {
+      return false
+    }
+    const nextItem = getSibling(snapshot, enclosingItem.path, 'next') as
+      | {node: unknown; path: Path}
+      | undefined
+    if (!nextItem || !isListItem(nextItem.node)) {
+      return false
+    }
+    const nextItemNode = nextItem.node as ListItemNode
+    // Walk the next item's content depth-first, following the FIRST
+    // content entry at each step (and if it's a list, then its FIRST
+    // list-item) to find the visually-leading text block. That's the
+    // natural source for the merge.
+    const leading = findDeepestLeadingTextBlock(nextItemNode, nextItem.path)
+    if (!leading) {
+      return false
+    }
+    return {focusTextBlock, leading, nextItem}
+  },
+  actions: [
+    (_, {focusTextBlock, leading, nextItem}) => {
+      // Same shape as the Backspace merge: walk each child of the
+      // leading text block and raise an `insert.child` event so spans
+      // with marks survive. `insert.text` would have lost them.
+      const children = leading.node.children as Array<unknown>
+      const inserts: Array<ReturnType<typeof raise>> = []
+      const focusEndPath = focusTextBlock.path
+      // Caret must be at end of focus block (the guard ensured that);
+      // raising `insert.child` repeatedly appends after the caret.
+      for (const child of children) {
+        inserts.push(
+          raise({
+            type: 'insert.child',
+            child: child as never,
+          } as never),
+        )
+      }
+      return [
+        ...inserts,
+        // Put the caret back where the merge joined (just before the
+        // newly-inserted content).
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: focusEndPath, offset: 0},
+            focus: {path: focusEndPath, offset: 0},
+          } as never,
+        }),
+        // The leading text block has been folded into focus; remove the
+        // entire enclosing next list-item. Nested lists inside it (if
+        // any) come along with the unset, which is the right behavior:
+        // the user's intent is "join the next list-item into me".
+        raise({
+          type: 'unset',
+          at: nextItem.path,
+        }),
+      ]
+    },
+  ],
+})
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the focus text block in a fresh \`list\` container of the given
+ * kind. Caret stays inside the wrapped block. Used by the toolbar's
+ * list-toggle buttons when the caret isn't already inside a list.
+ */
+const wrapInListOnCustom = defineBehavior({
+  on: 'custom.structured-lists.wrap',
+  guard: ({snapshot, event}) => {
+    const focusPath = snapshot.context.selection?.focus.path as Path | undefined
+    if (!focusPath) {
+      return false
+    }
+    const focusTextBlock = getFocusTextBlock(snapshot)
+    if (!focusTextBlock) {
+      return false
+    }
+    // If already inside a list, do nothing (toolbar handles kind-change separately).
+    if (resolveFocus(snapshot as never)) {
+      return false
+    }
+    const kind = (event as {kind?: string}).kind ?? 'bullet'
+    const keyGen = snapshot.context.keyGenerator
+    const itemKey = keyGen()
+    const listKey = keyGen()
+    const list = {
+      _type: 'list',
+      _key: listKey,
+      kind,
+      items: [
+        {
+          _type: 'list-item',
+          _key: itemKey,
+          content: [focusTextBlock.node],
+        },
+      ],
+    }
+    const blockKey = (focusTextBlock.node as {_key: string})._key
+    const blockIndex = focusPath.findIndex(
+      (seg) => typeof seg === 'object' && (seg as Keyed)._key === blockKey,
+    )
+    if (blockIndex < 0) {
+      return false
+    }
+    const prefix = focusPath.slice(0, blockIndex)
+    const suffix = focusPath.slice(blockIndex + 1)
+    const newPath = [
+      ...prefix,
+      {_key: listKey},
+      'items',
+      {_key: itemKey},
+      'content',
+      {_key: blockKey},
+      ...suffix,
+    ]
+    return {
+      list,
+      newPath,
+      focusOffset: snapshot.context.selection?.focus.offset ?? 0,
+      focusBlockPath: focusTextBlock.path,
+    }
+  },
+  actions: [
+    (_, planned) => {
+      const p = planned as {
+        list: unknown
+        focusBlockPath: Path
+        newPath: Path
+        focusOffset: number
+      }
+      return [
+        raise({
+          type: 'insert',
+          at: p.focusBlockPath as never,
+          value: p.list as never,
+          position: 'before',
+        }),
+        raise({type: 'unset', at: p.focusBlockPath as never}),
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: p.newPath as never, offset: p.focusOffset},
+            focus: {path: p.newPath as never, offset: p.focusOffset},
+          } as never,
+        }),
+      ]
+    },
+  ],
+})
+
+/**
+ * Unwraps the focus list-item's content out of its enclosing list. If the
+ * list has more siblings, only the focus item is unwrapped; the remaining
+ * items stay in the list. If the focus item was the last one, the list
+ * itself is removed. Used by the toolbar's list-toggle buttons when the
+ * caret is already inside a list of the same kind (toggle off).
+ */
+const unwrapFromListOnCustom = defineBehavior({
+  on: 'custom.structured-lists.unwrap',
+  guard: ({snapshot}) => {
+    const focus = resolveFocus(snapshot as never)
+    if (!focus) {
+      return false
+    }
+    const focusPath = snapshot.context.selection?.focus.path as Path | undefined
+    if (!focusPath) {
+      return false
+    }
+    const focusOffset = snapshot.context.selection?.focus.offset ?? 0
+    const focusBlockKeySegment = focusPath.find(
+      (seg, idx) =>
+        idx > 0 && typeof seg === 'object' && focusPath[idx - 1] === 'content',
+    )
+    const focusBlockKey = focusBlockKeySegment
+      ? (focusBlockKeySegment as Keyed)._key
+      : null
+    if (!focusBlockKey) {
+      return false
+    }
+    // Inserting list-item's content blocks as siblings of the enclosing
+    // list, in order, then removing the list-item from the list.
+    const {listItem, list, itemIndex} = focus
+    const items = list.node.items
+    const onlyChild = items.length === 1
+    return {
+      focus,
+      focusPath,
+      focusOffset,
+      focusBlockKey,
+      onlyChild,
+      itemIndex,
+      listItem,
+      list,
+    }
+  },
+  actions: [
+    (_, planned) => {
+      const p = planned as {
+        focus: {
+          listItem: {node: ListItemNode; path: Path}
+          list: {node: ListNode; path: Path}
+          itemIndex: number
+        }
+        focusPath: Path
+        focusOffset: number
+        focusBlockKey: string
+        onlyChild: boolean
+        listItem: {node: ListItemNode; path: Path}
+        list: {node: ListNode; path: Path}
+      }
+      const blocks = p.listItem.node.content
+      const raises: Array<Raise> = []
+      // Insert each content block as a sibling BEFORE the list, in order.
+      for (let i = 0; i < blocks.length; i++) {
+        raises.push(
+          raise({
+            type: 'insert',
+            at: p.list.path as never,
+            value: blocks[i] as never,
+            position: 'before',
+          }),
+        )
+      }
+      // Remove the focus list-item from the list.
+      raises.push(raise({type: 'unset', at: p.listItem.path as never}))
+      // If list ends up empty, remove it too.
+      if (p.onlyChild) {
+        raises.push(raise({type: 'unset', at: p.list.path as never}))
+      }
+      // Re-establish caret at the (now unwrapped) original block.
+      const parentOfList = p.list.path.slice(0, -1)
+      const newFocusPath = [
+        ...parentOfList,
+        {_key: p.focusBlockKey},
+        'children',
+        ...p.focusPath.slice(p.focusPath.indexOf('children') + 1),
+      ]
+      raises.push(
+        raise({
+          type: 'select',
+          at: {
+            anchor: {path: newFocusPath as never, offset: p.focusOffset},
+            focus: {path: newFocusPath as never, offset: p.focusOffset},
+          } as never,
+        }),
+      )
+      return raises
+    },
+  ],
+})
+
+export function StructuredListsPlugin() {
+  return (
+    <>
+      <ContainerPlugin containers={[listContainer]} />
+      <BehaviorPlugin
+        behaviors={[
+          sinkOnTab,
+          liftOnShiftTab,
+          sinkOnCustom,
+          liftOnCustom,
+          wrapInListOnCustom,
+          unwrapFromListOnCustom,
+          splitListItemOnEnter,
+          mergeListItemOnBackspace,
+          mergeListItemOnDelete,
+        ]}
+      />
+    </>
+  )
+}

--- a/apps/pilcrow/src/plugins/tables.tsx
+++ b/apps/pilcrow/src/plugins/tables.tsx
@@ -1,0 +1,314 @@
+import {
+  defineContainer,
+  type BlockPath,
+  type EditorSnapshot,
+} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, ContainerPlugin} from '@portabletext/editor/plugins'
+import {getAncestor} from '@portabletext/editor/traversal'
+import type {CSSProperties} from 'react'
+
+/**
+ * Tables. Three nested containers - table > row > cell - mirror the
+ * markdown shape (rows of cells with simple text content per cell).
+ *
+ * Custom behavior events let consumers add/remove rows and columns
+ * around the focus cell:
+ *   custom.tables.add-row         insert a new row after the focus row
+ *   custom.tables.remove-row      remove the focus row
+ *   custom.tables.add-column      insert a new cell at focus.colIndex+1 in every row
+ *   custom.tables.remove-column   remove the cell at focus.colIndex in every row
+ */
+const tableContainer = defineContainer({
+  type: 'table',
+  childField: 'rows',
+  render: ({attributes, children, node}) => {
+    const block = node as {headerRows?: number; rows?: Array<unknown>}
+    const firstRow = block.rows?.[0] as {cells?: Array<unknown>} | undefined
+    const columnCount = firstRow?.cells?.length ?? 1
+    return (
+      <div
+        {...attributes}
+        className="pc-table"
+        style={{'--pc-table-columns': columnCount} as CSSProperties}
+        data-header-rows={block.headerRows ?? 0}
+      >
+        {children}
+      </div>
+    )
+  },
+  of: [
+    defineContainer({
+      type: 'row',
+      childField: 'cells',
+      render: ({attributes, children}) => (
+        <div {...attributes} className="pc-table-row">
+          {children}
+        </div>
+      ),
+      of: [
+        defineContainer({
+          type: 'cell',
+          childField: 'content',
+          render: ({attributes, children}) => (
+            <div {...attributes} className="pc-table-cell">
+              {children}
+            </div>
+          ),
+        }),
+      ],
+    }),
+  ],
+})
+
+// ---------------------------------------------------------------------------
+// Row / column operations
+// ---------------------------------------------------------------------------
+
+type TableContext = {
+  tableNode: TableNode
+  tablePath: BlockPath
+  rowNode: RowNode
+  rowPath: BlockPath
+  rowIndex: number
+  cellIndex: number
+}
+
+type CellNode = {_key: string; _type: 'cell'; content: Array<unknown>}
+type RowNode = {_key: string; _type: 'row'; cells: Array<CellNode>}
+type TableNode = {_key: string; _type: 'table'; rows: Array<RowNode>}
+
+function isTable(node: unknown): node is TableNode {
+  return (node as {_type?: unknown})?._type === 'table'
+}
+
+function isRow(node: unknown): node is RowNode {
+  return (node as {_type?: unknown})?._type === 'row'
+}
+
+function resolveTableContext(snapshot: EditorSnapshot): TableContext | null {
+  const focusPath = snapshot.context.selection?.focus.path as
+    | BlockPath
+    | undefined
+  if (!focusPath) {
+    return null
+  }
+  const row = getAncestor(snapshot, focusPath, isRow) as
+    | {node: RowNode; path: BlockPath}
+    | undefined
+  if (!row) {
+    return null
+  }
+  const table = getAncestor(snapshot, row.path, isTable) as
+    | {node: TableNode; path: BlockPath}
+    | undefined
+  if (!table) {
+    return null
+  }
+  const rowIndex = table.node.rows.findIndex((r) => r._key === row.node._key)
+  // Find the cell key in the focus path
+  const cellKeySeg = focusPath.find(
+    (seg, idx) =>
+      idx > 0 &&
+      typeof seg === 'object' &&
+      seg !== null &&
+      focusPath[idx - 1] === 'cells',
+  )
+  const cellKey =
+    cellKeySeg && typeof cellKeySeg === 'object' && '_key' in cellKeySeg
+      ? (cellKeySeg as {_key: string})._key
+      : null
+  if (!cellKey) {
+    return null
+  }
+  const cellIndex = row.node.cells.findIndex((c) => c._key === cellKey)
+  if (cellIndex < 0) {
+    return null
+  }
+  return {
+    tableNode: table.node,
+    tablePath: table.path,
+    rowNode: row.node,
+    rowPath: row.path,
+    rowIndex,
+    cellIndex,
+  }
+}
+
+function newCell(keyGen: () => string, columnCount?: number): CellNode {
+  void columnCount
+  return {
+    _type: 'cell',
+    _key: keyGen(),
+    content: [
+      {
+        _type: 'block',
+        _key: keyGen(),
+        style: 'normal',
+        children: [{_type: 'span', _key: keyGen(), text: '', marks: []}],
+        markDefs: [],
+      } as unknown,
+    ],
+  }
+}
+
+function newRow(keyGen: () => string, columnCount: number): RowNode {
+  const cells: Array<CellNode> = []
+  for (let i = 0; i < columnCount; i++) {
+    cells.push(newCell(keyGen))
+  }
+  return {_type: 'row', _key: keyGen(), cells}
+}
+
+const addRowBehavior = defineBehavior({
+  on: 'custom.tables.add-row',
+  guard: ({snapshot}) => {
+    const ctx = resolveTableContext(snapshot as never)
+    if (!ctx) {
+      return false
+    }
+    const columnCount = ctx.rowNode.cells.length
+    const keyGen = snapshot.context.keyGenerator
+    return {ctx, row: newRow(keyGen, columnCount)}
+  },
+  actions: [
+    (_, planned) => {
+      const {ctx, row} = planned as {ctx: TableContext; row: RowNode}
+      return [
+        raise({
+          type: 'insert',
+          at: ctx.rowPath as never,
+          value: row as never,
+          position: 'after',
+        }),
+      ]
+    },
+  ],
+})
+
+const removeRowBehavior = defineBehavior({
+  on: 'custom.tables.remove-row',
+  guard: ({snapshot}) => {
+    const ctx = resolveTableContext(snapshot as never)
+    if (!ctx) {
+      return false
+    }
+    if (ctx.tableNode.rows.length <= 1) {
+      // Refuse to remove the only row. Caller should remove the whole table.
+      return false
+    }
+    return {ctx}
+  },
+  actions: [
+    (_, planned) => {
+      const {ctx} = planned as {ctx: TableContext}
+      return [raise({type: 'unset', at: ctx.rowPath as never})]
+    },
+  ],
+})
+
+const addColumnBehavior = defineBehavior({
+  on: 'custom.tables.add-column',
+  guard: ({snapshot}) => {
+    const ctx = resolveTableContext(snapshot as never)
+    if (!ctx) {
+      return false
+    }
+    const keyGen = snapshot.context.keyGenerator
+    const inserts: Array<{
+      rowKey: string
+      afterCellKey: string
+      cell: CellNode
+    }> = []
+    for (const r of ctx.tableNode.rows) {
+      const target = r.cells[ctx.cellIndex]
+      if (!target) {
+        continue
+      }
+      inserts.push({
+        rowKey: r._key,
+        afterCellKey: target._key,
+        cell: newCell(keyGen),
+      })
+    }
+    return {ctx, inserts}
+  },
+  actions: [
+    (_, planned) => {
+      const {ctx, inserts} = planned as {
+        ctx: TableContext
+        inserts: Array<{rowKey: string; afterCellKey: string; cell: CellNode}>
+      }
+      return inserts.map((entry) =>
+        raise({
+          type: 'insert',
+          at: [
+            ...ctx.tablePath,
+            'rows',
+            {_key: entry.rowKey},
+            'cells',
+            {_key: entry.afterCellKey},
+          ] as never,
+          value: entry.cell as never,
+          position: 'after',
+        }),
+      )
+    },
+  ],
+})
+
+const removeColumnBehavior = defineBehavior({
+  on: 'custom.tables.remove-column',
+  guard: ({snapshot}) => {
+    const ctx = resolveTableContext(snapshot as never)
+    if (!ctx) {
+      return false
+    }
+    if (ctx.rowNode.cells.length <= 1) {
+      // Refuse to remove the only column. Caller should remove the whole table.
+      return false
+    }
+    return {ctx}
+  },
+  actions: [
+    (_, planned) => {
+      const {ctx} = planned as {ctx: TableContext}
+      const removes: Array<ReturnType<typeof raise>> = []
+      for (const r of ctx.tableNode.rows) {
+        const target = r.cells[ctx.cellIndex]
+        if (!target) {
+          continue
+        }
+        removes.push(
+          raise({
+            type: 'unset',
+            at: [
+              ...ctx.tablePath,
+              'rows',
+              {_key: r._key},
+              'cells',
+              {_key: target._key},
+            ] as never,
+          }),
+        )
+      }
+      return removes
+    },
+  ],
+})
+
+export function TablesPlugin() {
+  return (
+    <>
+      <ContainerPlugin containers={[tableContainer]} />
+      <BehaviorPlugin
+        behaviors={[
+          addRowBehavior,
+          removeRowBehavior,
+          addColumnBehavior,
+          removeColumnBehavior,
+        ]}
+      />
+    </>
+  )
+}

--- a/apps/pilcrow/src/plugins/typeahead-panel.tsx
+++ b/apps/pilcrow/src/plugins/typeahead-panel.tsx
@@ -1,0 +1,44 @@
+import {useEditor} from '@portabletext/editor'
+import type {ReactNode} from 'react'
+import {useEffect, useRef} from 'react'
+
+/**
+ * Floating typeahead panel anchored to the caret rect. Used by the
+ * slash menu and emoji picker. The panel positions itself below the
+ * caret on every render where matches/selection changes, and renders
+ * either an empty-state message or a list-box of consumer-rendered
+ * items.
+ */
+export function TypeaheadPanel(props: {
+  /** Whether to render at all. */
+  active: boolean
+  /** Trigger text used in the empty-state message. */
+  emptyHint?: string
+  children?: ReactNode
+}) {
+  const editor = useEditor()
+  const anchorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!props.active || !anchorRef.current) {
+      return
+    }
+    const rect = editor.dom.getSelectionRect(editor.getSnapshot())
+    if (!rect) {
+      return
+    }
+    const el = anchorRef.current
+    el.style.top = `${window.scrollY + rect.bottom + 4}px`
+    el.style.left = `${window.scrollX + rect.left}px`
+  })
+
+  if (!props.active) {
+    return null
+  }
+
+  return (
+    <div ref={anchorRef} className="pc-typeahead-panel" role="listbox">
+      {props.children}
+    </div>
+  )
+}

--- a/apps/pilcrow/src/schema.ts
+++ b/apps/pilcrow/src/schema.ts
@@ -1,0 +1,283 @@
+import {defineSchema} from '@portabletext/editor'
+
+/**
+ * Pilcrow schema. Covers the full markdown construct set.
+ *
+ * Container types (code-block, callout, table, list, list-item) and
+ * leaf types (image, horizontal-rule) are declared here; their
+ * runtime registration and rendering live in the per-construct
+ * plugin files under `./plugins/`.
+ *
+ * The shape mirrors how a Sanity schema declares these types - this
+ * file is the catalog, the plugins are the wiring.
+ */
+export const schemaDefinition = defineSchema({
+  decorators: [
+    {name: 'strong', title: 'Bold'},
+    {name: 'em', title: 'Italic'},
+    {name: 'code', title: 'Code'},
+    {name: 'strike-through', title: 'Strikethrough'},
+  ],
+  styles: [
+    {name: 'normal', title: 'Paragraph'},
+    {name: 'h1', title: 'Heading 1'},
+    {name: 'h2', title: 'Heading 2'},
+    {name: 'h3', title: 'Heading 3'},
+    {name: 'h4', title: 'Heading 4'},
+    {name: 'h5', title: 'Heading 5'},
+    {name: 'h6', title: 'Heading 6'},
+  ],
+  annotations: [
+    {
+      name: 'link',
+      title: 'Link',
+      fields: [{name: 'href', title: 'URL', type: 'string'}],
+    },
+  ],
+  lists: [
+    {name: 'bullet', title: 'Bulleted list'},
+    {name: 'number', title: 'Numbered list'},
+    {name: 'task', title: 'Task list'},
+  ],
+  blockObjects: [
+    {
+      name: 'list',
+      title: 'List',
+      fields: [
+        {name: 'kind', title: 'Kind', type: 'string'},
+        {
+          name: 'items',
+          title: 'Items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'list-item',
+              fields: [
+                {name: 'checked', title: 'Checked', type: 'boolean'},
+                {
+                  name: 'content',
+                  title: 'Content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      decorators: [
+                        {name: 'strong', title: 'Bold'},
+                        {name: 'em', title: 'Italic'},
+                        {name: 'code', title: 'Code'},
+                        {name: 'strike-through', title: 'Strikethrough'},
+                      ],
+                      annotations: [
+                        {
+                          name: 'link',
+                          title: 'Link',
+                          fields: [
+                            {name: 'href', title: 'URL', type: 'string'},
+                          ],
+                        },
+                      ],
+                      styles: [
+                        {name: 'normal', title: 'Paragraph'},
+                        {name: 'h1', title: 'Heading 1'},
+                        {name: 'h2', title: 'Heading 2'},
+                        {name: 'h3', title: 'Heading 3'},
+                        {name: 'h4', title: 'Heading 4'},
+                        {name: 'h5', title: 'Heading 5'},
+                        {name: 'h6', title: 'Heading 6'},
+                      ],
+                      lists: [],
+                      inlineObjects: [],
+                    },
+                    {type: 'list'},
+                    {type: 'image'},
+                    {type: 'code-block'},
+                    {type: 'blockquote'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'blockquote',
+      title: 'Blockquote',
+      fields: [
+        {
+          name: 'content',
+          title: 'Content',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              decorators: [
+                {name: 'strong', title: 'Bold'},
+                {name: 'em', title: 'Italic'},
+                {name: 'code', title: 'Code'},
+                {name: 'strike-through', title: 'Strikethrough'},
+              ],
+              annotations: [
+                {
+                  name: 'link',
+                  title: 'Link',
+                  fields: [{name: 'href', title: 'URL', type: 'string'}],
+                },
+              ],
+              styles: [
+                {name: 'normal', title: 'Paragraph'},
+                {name: 'h1', title: 'Heading 1'},
+                {name: 'h2', title: 'Heading 2'},
+                {name: 'h3', title: 'Heading 3'},
+                {name: 'h4', title: 'Heading 4'},
+                {name: 'h5', title: 'Heading 5'},
+                {name: 'h6', title: 'Heading 6'},
+              ],
+              lists: [],
+              inlineObjects: [],
+            },
+            {type: 'blockquote'},
+          ],
+        },
+      ],
+    },
+    {
+      name: 'horizontal-rule',
+      title: 'Divider',
+    },
+    {
+      name: 'image',
+      title: 'Image',
+      fields: [
+        {name: 'src', title: 'Source', type: 'string'},
+        {name: 'alt', title: 'Alt text', type: 'string'},
+        {name: 'caption', title: 'Caption', type: 'string'},
+      ],
+    },
+    {
+      name: 'code-block',
+      title: 'Code block',
+      fields: [
+        {name: 'language', title: 'Language', type: 'string'},
+        {
+          name: 'lines',
+          title: 'Lines',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              styles: [],
+              decorators: [],
+              annotations: [],
+              lists: [],
+              inlineObjects: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'callout',
+      title: 'Callout',
+      fields: [
+        {name: 'tone', title: 'Tone', type: 'string'},
+        {
+          name: 'content',
+          title: 'Content',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              decorators: [
+                {name: 'strong', title: 'Bold'},
+                {name: 'em', title: 'Italic'},
+                {name: 'code', title: 'Code'},
+                {name: 'strike-through', title: 'Strikethrough'},
+              ],
+              annotations: [
+                {
+                  name: 'link',
+                  title: 'Link',
+                  fields: [{name: 'href', title: 'URL', type: 'string'}],
+                },
+              ],
+              styles: [{name: 'normal', title: 'Paragraph'}],
+              lists: [],
+              inlineObjects: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'table',
+      title: 'Table',
+      fields: [
+        {name: 'headerRows', title: 'Header rows', type: 'number'},
+        {
+          name: 'rows',
+          title: 'Rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  title: 'Cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          title: 'Content',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'block',
+                              decorators: [
+                                {name: 'strong', title: 'Bold'},
+                                {name: 'em', title: 'Italic'},
+                                {name: 'code', title: 'Code'},
+                                {
+                                  name: 'strike-through',
+                                  title: 'Strikethrough',
+                                },
+                              ],
+                              annotations: [
+                                {
+                                  name: 'link',
+                                  title: 'Link',
+                                  fields: [
+                                    {
+                                      name: 'href',
+                                      title: 'URL',
+                                      type: 'string',
+                                    },
+                                  ],
+                                },
+                              ],
+                              styles: [{name: 'normal', title: 'Paragraph'}],
+                              lists: [],
+                              inlineObjects: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  inlineObjects: [],
+})

--- a/apps/pilcrow/src/starter-document.ts
+++ b/apps/pilcrow/src/starter-document.ts
@@ -1,0 +1,700 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+
+/**
+ * Starter document. Showcases the basic constructs that exist today;
+ * grows as each per-construct plugin lands. Phase 2 introduces a
+ * code-block, image, and horizontal-rule alongside the text content.
+ */
+export const starterDocument: Array<PortableTextBlock> = [
+  {
+    _type: 'block',
+    _key: 'b-title',
+    style: 'h1',
+    children: [{_type: 'span', _key: 's-title', text: 'Pilcrow', marks: []}],
+    markDefs: [],
+  },
+  {
+    _type: 'block',
+    _key: 'b-tag',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-tag',
+        text: 'A writing surface for portable text.',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'horizontal-rule',
+    _key: 'hr-1',
+  },
+  {
+    _type: 'block',
+    _key: 'b-body',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-body-a',
+        text: 'Write here. The source pane shows the markdown representation, and ',
+        marks: [],
+      },
+      {
+        _type: 'span',
+        _key: 's-body-b',
+        text: 'editing the markdown there reflects back into the editor',
+        marks: ['em'],
+      },
+      {
+        _type: 'span',
+        _key: 's-body-c',
+        text: ' via patches so node identities survive.',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'block',
+    _key: 'b-code-intro',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-code-intro',
+        text: 'Code blocks render with a thin left rule and a language label:',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'code-block',
+    _key: 'cb-1',
+    language: 'typescript',
+    lines: [
+      {
+        _type: 'block',
+        _key: 'cb-1-l1',
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: 'cb-1-l1-s',
+            text: "import {EditorProvider} from '@portabletext/editor'",
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      },
+      {
+        _type: 'block',
+        _key: 'cb-1-l2',
+        style: 'normal',
+        children: [{_type: 'span', _key: 'cb-1-l2-s', text: '', marks: []}],
+        markDefs: [],
+      },
+      {
+        _type: 'block',
+        _key: 'cb-1-l3',
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: 'cb-1-l3-s',
+            text: 'export function Editor() {',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      },
+      {
+        _type: 'block',
+        _key: 'cb-1-l4',
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: 'cb-1-l4-s',
+            text: '  return <EditorProvider />',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      },
+      {
+        _type: 'block',
+        _key: 'cb-1-l5',
+        style: 'normal',
+        children: [{_type: 'span', _key: 'cb-1-l5-s', text: '}', marks: []}],
+        markDefs: [],
+      },
+    ],
+  },
+  {
+    _type: 'callout',
+    _key: 'callout-note',
+    tone: 'note',
+    content: [
+      {
+        _type: 'block',
+        _key: 'callout-note-b1',
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: 'callout-note-b1-s',
+            text: 'Callouts come in four tones: note, tip, warning, caution.',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      },
+    ],
+  },
+  {
+    _type: 'callout',
+    _key: 'callout-warn',
+    tone: 'warning',
+    content: [
+      {
+        _type: 'block',
+        _key: 'callout-warn-b1',
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            _key: 'callout-warn-b1-s',
+            text: 'Variants are distinguished by glyph and label, not color, so the grayscale palette stays intact.',
+            marks: [],
+          },
+        ],
+        markDefs: [],
+      },
+    ],
+  },
+  {
+    _type: 'table',
+    _key: 't-1',
+    headerRows: 1,
+    rows: [
+      {
+        _type: 'row',
+        _key: 't-1-r1',
+        cells: [
+          {
+            _type: 'cell',
+            _key: 't-1-r1-c1',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r1-c1-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r1-c1-s',
+                    text: 'Construct',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+          {
+            _type: 'cell',
+            _key: 't-1-r1-c2',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r1-c2-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r1-c2-s',
+                    text: 'Visual',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'row',
+        _key: 't-1-r2',
+        cells: [
+          {
+            _type: 'cell',
+            _key: 't-1-r2-c1',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r2-c1-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r2-c1-s',
+                    text: 'Code block',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+          {
+            _type: 'cell',
+            _key: 't-1-r2-c2',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r2-c2-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r2-c2-s',
+                    text: 'Monospace, left rule, language label',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'row',
+        _key: 't-1-r3',
+        cells: [
+          {
+            _type: 'cell',
+            _key: 't-1-r3-c1',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r3-c1-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r3-c1-s',
+                    text: 'Callout',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+          {
+            _type: 'cell',
+            _key: 't-1-r3-c2',
+            content: [
+              {
+                _type: 'block',
+                _key: 't-1-r3-c2-b',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 't-1-r3-c2-s',
+                    text: 'Indent, glyph, label, body',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'b-lists-intro',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-lists-intro',
+        text: 'Lists are containers. Bullets, numbered lists, and task lists share the same shape:',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'list',
+    _key: 'l-bullet',
+    kind: 'bullet',
+    items: [
+      {
+        _type: 'list-item',
+        _key: 'l-bullet-i1',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-bullet-i1-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-bullet-i1-s',
+                text: 'Nested lists hold lists as siblings of text blocks',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+          {
+            _type: 'list',
+            _key: 'l-bullet-i1-nested',
+            kind: 'bullet',
+            items: [
+              {
+                _type: 'list-item',
+                _key: 'l-bullet-i1-nested-i1',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'l-bullet-i1-nested-i1-b',
+                    style: 'normal',
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: 'l-bullet-i1-nested-i1-s',
+                        text: 'Tab sinks, Shift+Tab lifts',
+                        marks: [],
+                      },
+                    ],
+                    markDefs: [],
+                  },
+                ],
+              },
+              {
+                _type: 'list-item',
+                _key: 'l-bullet-i1-nested-i2',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'l-bullet-i1-nested-i2-b',
+                    style: 'normal',
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: 'l-bullet-i1-nested-i2-s',
+                        text: 'Composes the unset, insert, and select primitives',
+                        marks: [],
+                      },
+                    ],
+                    markDefs: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-bullet-i2',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-bullet-i2-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-bullet-i2-s',
+                text: 'Selection tracks through structural moves via a rebaseFocus helper',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'b-rich-list-intro',
+    style: 'h2',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-rich-list-intro',
+        text: 'Anything can live in a list item',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'block',
+    _key: 'b-rich-list-body',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-rich-list-body',
+        text: 'Because the list-item content array accepts the same block types as the document itself, you can mix prose with images and code blocks.',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'list',
+    _key: 'l-rich',
+    kind: 'bullet',
+    items: [
+      {
+        _type: 'list-item',
+        _key: 'l-rich-i1',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-rich-i1-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-rich-i1-s',
+                text: 'A list item can hold an image:',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+          {
+            _type: 'image',
+            _key: 'l-rich-i1-image',
+            src: 'https://images.unsplash.com/photo-1455390582262-044cdead277a?w=800&q=80',
+            alt: 'A vintage typewriter on a wooden desk',
+            caption: 'Typewriter, by Sergey Zolkin on Unsplash',
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-rich-i2',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-rich-i2-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-rich-i2-s',
+                text: 'Or a code block:',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+          {
+            _type: 'code-block',
+            _key: 'l-rich-i2-code',
+            language: 'typescript',
+            lines: [
+              {
+                _type: 'block',
+                _key: 'l-rich-i2-code-l1',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 'l-rich-i2-code-l1-s',
+                    text: 'const editor = useEditor()',
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+              {
+                _type: 'block',
+                _key: 'l-rich-i2-code-l2',
+                style: 'normal',
+                children: [
+                  {
+                    _type: 'span',
+                    _key: 'l-rich-i2-code-l2-s',
+                    text: "editor.send({type: 'focus'})",
+                    marks: [],
+                  },
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-rich-i3',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-rich-i3-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-rich-i3-s',
+                text: 'Plain text items work the same as before.',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    _type: 'list',
+    _key: 'l-number',
+    kind: 'number',
+    items: [
+      {
+        _type: 'list-item',
+        _key: 'l-number-i1',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-number-i1-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-number-i1-s',
+                text: 'Numbered lists use the same list container with kind: number',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-number-i2',
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-number-i2-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-number-i2-s',
+                text: 'Same shape, different rendering',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'b-task-intro',
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: 's-task-intro',
+        text: 'Task lists are structured lists with kind: task and a checked field on the list-item:',
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+  {
+    _type: 'list',
+    _key: 'l-task',
+    kind: 'task',
+    items: [
+      {
+        _type: 'list-item',
+        _key: 'l-task-i1',
+        checked: true,
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-task-i1-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-task-i1-s',
+                text: 'Pick a name for the markdown editor',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-task-i2',
+        checked: true,
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-task-i2-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-task-i2-s',
+                text: 'Ship the skeleton',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+      {
+        _type: 'list-item',
+        _key: 'l-task-i3',
+        checked: false,
+        content: [
+          {
+            _type: 'block',
+            _key: 'l-task-i3-b',
+            style: 'normal',
+            children: [
+              {
+                _type: 'span',
+                _key: 'l-task-i3-s',
+                text: 'Wire markdown round-trip via diff-patch',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ],
+  },
+]

--- a/apps/pilcrow/src/theme-toggle.tsx
+++ b/apps/pilcrow/src/theme-toggle.tsx
@@ -1,0 +1,24 @@
+import {useTheme} from './use-theme'
+
+/**
+ * Standalone theme toggle used in the app header. The button is
+ * round and reads as a 'persona' switch rather than another
+ * toolbar tool - keeps it visually separate from text-formatting
+ * toggles.
+ */
+export function ThemeToggle() {
+  const {theme, toggle} = useTheme()
+  const isDark = theme === 'dark'
+  return (
+    <button
+      type="button"
+      className="pc-theme-toggle"
+      onClick={toggle}
+      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-pressed={isDark}
+    >
+      <span aria-hidden>{isDark ? '☾' : '☀'}</span>
+    </button>
+  )
+}

--- a/apps/pilcrow/src/theme.css
+++ b/apps/pilcrow/src/theme.css
@@ -1,6 +1,76 @@
+/**
+ * Pilcrow visual language. Grayscale base, distinct-by-typography-and-
+ * rule-not-color, 8px grid, 1px borders, generous vertical rhythm.
+ *
+ * Editable body uses Crimson Pro - a transitional text serif whose
+ * pilcrow has the two-stem structure (the visual P + T logo). UI
+ * chrome (toolbar, tabs, panels) uses system sans.
+ */
+
 :root {
   --pc-bg: #ffffff;
-  --pc-fg-faint: #e0e0e0;
+  --pc-bg-elevated: #fafafa;
+  --pc-bg-muted: #f4f4f4;
+  --pc-bg-code: #f6f6f6;
+  --pc-bg-hover: #f1f1f1;
+  --pc-fg: #1c1c1c;
+  --pc-fg-muted: #555555;
+  --pc-fg-subtle: #777777;
+  --pc-fg-faint: #b0b0b0;
+  --pc-border: #d0d0d0;
+  --pc-border-subtle: #e6e6e6;
+  --pc-rule: #c8c8c8;
+
+  --pc-space-1: 4px;
+  --pc-space-2: 8px;
+  --pc-space-3: 12px;
+  --pc-space-4: 16px;
+  --pc-space-5: 24px;
+  --pc-space-6: 32px;
+  --pc-space-7: 48px;
+  --pc-space-8: 64px;
+
+  --pc-radius: 2px;
+
+  --pc-font-serif:
+    'Crimson Pro', 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia,
+    serif;
+  --pc-font-sans:
+    system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    sans-serif;
+  --pc-font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+
+  --pc-leading: 1.6;
+  --pc-text-size: 17px;
+  --pc-text-size-small: 13px;
+  --pc-text-size-tiny: 11px;
+
+  color-scheme: light;
+}
+
+/**
+ * Dark theme. Activated via \`[data-theme="dark"]\` on the document
+ * element (the \`useTheme\` hook writes this). All visual tokens
+ * invert; semantic structure (1px borders, typography hierarchy,
+ * spacing) stays identical.
+ */
+:root[data-theme='dark'] {
+  --pc-bg: #161617;
+  --pc-bg-elevated: #1c1c1e;
+  --pc-bg-muted: #232325;
+  --pc-bg-code: #1f1f21;
+  --pc-bg-hover: #262629;
+  --pc-fg: #ececec;
+  --pc-fg-muted: #b0b0b0;
+  --pc-fg-subtle: #8b8b8b;
+  --pc-fg-faint: #5a5a5a;
+  --pc-border: #3a3a3c;
+  --pc-border-subtle: #2a2a2c;
+  --pc-rule: #4a4a4c;
+
+  color-scheme: dark;
 }
 
 * {
@@ -15,28 +85,1205 @@ body,
 }
 
 body {
-  font-family:
-    system-ui,
-    -apple-system,
-    'Segoe UI',
-    Roboto,
-    'Helvetica Neue',
-    Arial,
-    sans-serif;
+  font-family: var(--pc-font-sans);
+  color: var(--pc-fg);
   background: var(--pc-bg);
+  font-size: var(--pc-text-size);
+  line-height: var(--pc-leading);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+button {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* Shell. */
+
 .pc-shell {
   height: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+
+.pc-pane {
+  height: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pc-pane-editor {
+  border-right: 1px solid var(--pc-border-subtle);
+}
+
+/* Header. */
+
+.pc-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--pc-space-3);
+  padding: var(--pc-space-4) var(--pc-space-5);
+  border-bottom: 1px solid var(--pc-border-subtle);
+  flex: 0 0 auto;
+}
+
+.pc-logo {
+  font-family: var(--pc-font-serif);
+  font-size: 32px;
+  line-height: 1;
+  color: var(--pc-fg);
+  font-weight: 500;
+  user-select: none;
+}
+
+.pc-header-title {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  letter-spacing: 0.04em;
+  color: var(--pc-fg-subtle);
+  text-transform: uppercase;
+  flex: 1 1 auto;
+}
+
+.pc-header-actions {
   display: flex;
   align-items: center;
+  gap: var(--pc-space-2);
+}
+
+/* Round theme toggle in the app header. Stands apart from toolbar
+ * tools - this is a persona switch, not a content tool. */
+.pc-theme-toggle {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--pc-border-subtle);
+  border-radius: 50%;
+  color: var(--pc-fg-subtle);
+  background: var(--pc-bg);
+  font-size: 13px;
+  line-height: 1;
+}
+
+.pc-theme-toggle:hover {
+  color: var(--pc-fg);
+  border-color: var(--pc-border);
+  background: var(--pc-bg-hover);
+}
+
+.pc-theme-toggle:focus-visible {
+  outline: 1px solid var(--pc-fg);
+  outline-offset: 2px;
+}
+
+/* Editor area. */
+
+.pc-editor {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pc-editor-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: var(--pc-space-6) var(--pc-space-6) 80vh;
+  display: flex;
   justify-content: center;
 }
 
-.pc-mark {
-  font-size: 4rem;
+.pc-editable {
+  font-family: var(--pc-font-serif);
+  font-size: var(--pc-text-size);
+  line-height: var(--pc-leading);
+  max-width: 680px;
+  width: 100%;
+  outline: none;
+}
+
+.pc-editable :focus-visible {
+  outline: none;
+}
+
+.pc-style {
+  margin: 0 0 var(--pc-space-4);
+}
+
+.pc-style-normal {
+  font-family: var(--pc-font-serif);
+}
+
+.pc-style-h1,
+.pc-style-h2,
+.pc-style-h3,
+.pc-style-h4,
+.pc-style-h5,
+.pc-style-h6 {
+  font-family: var(--pc-font-serif);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: var(--pc-space-6) 0 var(--pc-space-3);
+}
+
+.pc-style-h1 {
+  font-size: 2.5rem;
+}
+
+.pc-style-h2 {
+  font-size: 1.85rem;
+}
+
+.pc-style-h3 {
+  font-size: 1.4rem;
+}
+
+.pc-style-h4 {
+  font-size: 1.15rem;
+}
+
+.pc-style-h5,
+.pc-style-h6 {
+  font-size: 1rem;
+}
+
+.pc-link {
+  color: var(--pc-fg);
+  text-decoration: underline;
+  text-decoration-color: var(--pc-rule);
+  text-underline-offset: 3px;
+}
+
+/* Toolbar. */
+
+.pc-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--pc-space-1);
+  padding: var(--pc-space-2) var(--pc-space-4);
+  border-bottom: 1px solid var(--pc-border-subtle);
+  background: var(--pc-bg);
+  flex: 0 0 auto;
+}
+
+.pc-toolbar-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--pc-border-subtle);
+  margin: 0 var(--pc-space-2);
+  flex: 0 0 auto;
+}
+
+.pc-toolbar-divider-grow {
+  width: auto;
+  height: 1px;
+  background: transparent;
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.pc-toolbar-select {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg);
+  background: var(--pc-bg);
+  border: 1px solid var(--pc-border-subtle);
+  border-radius: var(--pc-radius);
+  padding: 4px var(--pc-space-2);
+  cursor: pointer;
+}
+
+.pc-toolbar-button {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--pc-radius);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-muted);
+}
+
+.pc-toolbar-button:hover:not(:disabled) {
+  background: var(--pc-bg-hover);
+  color: var(--pc-fg);
+}
+
+.pc-toolbar-button:disabled {
   color: var(--pc-fg-faint);
+  cursor: default;
+}
+
+.pc-toolbar-button-active {
+  background: var(--pc-bg-muted);
+  color: var(--pc-fg);
+}
+
+.pc-toolbar-symbol-strong {
+  font-weight: 700;
+}
+
+.pc-toolbar-symbol-em {
+  font-style: italic;
+}
+
+.pc-toolbar-symbol-code {
+  font-family: var(--pc-font-mono);
+  font-size: 11px;
+}
+
+.pc-toolbar-symbol-strike {
+  text-decoration: line-through;
+}
+
+/* Mirror pane (right side of shell). The markdown view is primary;
+ * Value / Patches live behind a corner view-switcher button. */
+
+.pc-mirror {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--pc-bg-elevated);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pc-mirror-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  min-height: 0;
+}
+
+/* Mirror header - matches \`.pc-header\` on the editor pane for
+ * symmetry. Title on the left, segmented view switcher on the right. */
+.pc-mirror-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--pc-space-3);
+  padding: var(--pc-space-4) var(--pc-space-5);
+  border-bottom: 1px solid var(--pc-border-subtle);
+  flex: 0 0 auto;
+}
+
+.pc-mirror-title {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  letter-spacing: 0.04em;
+  color: var(--pc-fg-subtle);
+  text-transform: uppercase;
+  flex: 1 1 auto;
+}
+
+.pc-view-switcher {
+  display: inline-flex;
+  border: 1px solid var(--pc-border-subtle);
+  border-radius: var(--pc-radius);
+  overflow: hidden;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-tiny);
+  letter-spacing: 0.04em;
+}
+
+.pc-view-tab {
+  padding: var(--pc-space-1) var(--pc-space-3);
+  color: var(--pc-fg-subtle);
+  border-left: 1px solid var(--pc-border-subtle);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: transparent;
+}
+
+.pc-view-tab:first-child {
+  border-left: 0;
+}
+
+.pc-view-tab:hover {
+  background: var(--pc-bg-hover);
+  color: var(--pc-fg);
+}
+
+.pc-view-tab-active {
+  background: var(--pc-bg-muted);
+  color: var(--pc-fg);
+}
+
+/* Panels (shared). */
+
+.pc-panel {
+  padding: var(--pc-space-4) var(--pc-space-5);
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-small);
+}
+
+.pc-panel-list {
+  padding: var(--pc-space-3) 0;
+}
+
+.pc-panel-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg);
+}
+
+.pc-panel-text-muted {
+  color: var(--pc-fg-subtle);
+}
+
+.pc-panel-note {
+  margin: var(--pc-space-4) 0 0;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-subtle);
+  max-width: 56ch;
+}
+
+.pc-panel-details {
+  margin-top: var(--pc-space-5);
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-subtle);
+}
+
+.pc-panel-details summary {
+  cursor: pointer;
+  padding: var(--pc-space-2) 0;
   user-select: none;
+}
+
+.pc-panel-details pre {
+  margin-top: var(--pc-space-3);
+}
+
+.pc-panel-empty {
+  margin: 0;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-subtle);
+}
+
+.pc-panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--pc-space-3);
+}
+
+.pc-button {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  padding: 4px var(--pc-space-3);
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg);
+  color: var(--pc-fg);
+  cursor: pointer;
+}
+
+.pc-button:hover {
+  background: var(--pc-bg-hover);
+}
+
+/* Patches stream. */
+
+.pc-patch {
+  padding: var(--pc-space-3) var(--pc-space-5);
+  border-bottom: 1px solid var(--pc-border-subtle);
+}
+
+.pc-patch:last-child {
+  border-bottom: 0;
+}
+
+.pc-patch-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--pc-space-3);
+  margin-bottom: var(--pc-space-2);
+}
+
+.pc-patch-index {
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-tiny);
+  color: var(--pc-fg-faint);
+  min-width: 24px;
+}
+
+.pc-patch-type {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  font-weight: 600;
+  color: var(--pc-fg);
+  letter-spacing: 0.02em;
+}
+
+.pc-patch-body {
+  margin: 0;
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-tiny);
+  color: var(--pc-fg-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Blockquote container. Nested quotes stack their left rules by
+   indenting each level, producing the classic '>>' look without any
+   marker glyphs. */
+
+.pc-blockquote {
+  border-left: 2px solid var(--pc-rule);
+  padding-left: var(--pc-space-4);
+  margin: var(--pc-space-5) 0;
+  color: var(--pc-fg-muted);
+}
+
+.pc-blockquote .pc-style {
+  margin: 0;
+}
+
+.pc-blockquote .pc-style + .pc-style {
+  margin-top: var(--pc-space-3);
+}
+
+/* Nested blockquotes get their own indent + rule. The outer
+   blockquote's padding-left already supplies the first indent, so
+   the inner one only needs a margin reset. */
+.pc-blockquote .pc-blockquote {
+  margin: var(--pc-space-3) 0;
+}
+
+/* Horizontal rule. */
+
+.pc-hr-wrapper {
+  padding: var(--pc-space-4) 0;
+  position: relative;
+}
+
+.pc-hr-inner {
+  user-select: none;
+  padding: var(--pc-space-2) var(--pc-space-3);
+  border: 1px solid transparent;
+  border-radius: var(--pc-radius);
+  transition:
+    border-color 80ms ease-out,
+    background 80ms ease-out;
+}
+
+.pc-hr-selected {
+  background: var(--pc-bg-muted);
+  border-color: var(--pc-border-subtle);
+}
+
+.pc-hr-focused {
+  background: var(--pc-bg-muted);
+  border-color: var(--pc-fg-muted);
+}
+
+.pc-hr {
+  border: 0;
+  height: 1px;
+  background: var(--pc-rule);
+  margin: 0;
+}
+
+/* Block-level image. */
+
+.pc-image-wrapper {
+  margin: var(--pc-space-5) 0;
+  position: relative;
+}
+
+.pc-image {
+  margin: 0;
+  text-align: center;
+  border: 1px solid transparent;
+  border-radius: var(--pc-radius);
+  transition: border-color 80ms ease-out;
+}
+
+.pc-image-selected {
+  border-color: var(--pc-border);
+}
+
+.pc-image-focused {
+  border-color: var(--pc-fg-muted);
+}
+
+.pc-image img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--pc-radius);
+}
+
+.pc-image-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 240px;
+  min-height: 120px;
+  background: var(--pc-bg-muted);
+  border: 1px dashed var(--pc-border);
+  color: var(--pc-fg-subtle);
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  border-radius: var(--pc-radius);
+}
+
+.pc-image-caption {
+  margin-top: var(--pc-space-2);
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-subtle);
+  font-style: italic;
+}
+
+/* Code block. */
+
+.pc-code-block {
+  margin: var(--pc-space-5) 0;
+  background: var(--pc-bg-code);
+  border-left: 2px solid var(--pc-rule);
+  border-radius: 0 var(--pc-radius) var(--pc-radius) 0;
+  overflow: hidden;
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-small);
+}
+
+.pc-code-block-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--pc-space-2) var(--pc-space-4);
+  background: var(--pc-bg-muted);
+  border-bottom: 1px solid var(--pc-border-subtle);
+}
+
+.pc-code-block-language {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-tiny);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pc-fg-subtle);
+}
+
+.pc-code-block-body {
+  padding: var(--pc-space-4);
+  line-height: 1.5;
+}
+
+.pc-code-block-body .pc-style {
+  margin: 0;
+  font-family: var(--pc-font-mono);
+}
+
+.pc-code-block-span {
+  font-family: var(--pc-font-mono);
+}
+
+/* Inline code decorator. */
+
+.pc-editable code {
+  font-family: var(--pc-font-mono);
+  font-size: 0.92em;
+  background: var(--pc-bg-code);
+  padding: 1px 4px;
+  border-radius: var(--pc-radius);
+}
+
+/* Mobile / narrow viewports - stack panes. */
+
+@media (max-width: 900px) {
+  .pc-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1.6fr) minmax(0, 1fr);
+  }
+
+  .pc-pane-editor {
+    border-right: 0;
+    border-bottom: 1px solid var(--pc-border-subtle);
+  }
+
+  .pc-editor-body {
+    padding: var(--pc-space-5) var(--pc-space-4) var(--pc-space-6);
+  }
+
+  .pc-toolbar {
+    overflow-x: auto;
+  }
+
+  .pc-toolbar-button {
+    min-width: 36px;
+    min-height: 36px;
+  }
+}
+
+/* Callouts. */
+
+.pc-callout {
+  margin: var(--pc-space-5) 0;
+  padding: var(--pc-space-4) var(--pc-space-4) var(--pc-space-4)
+    var(--pc-space-5);
+  background: var(--pc-bg-elevated);
+  border-left: 2px solid var(--pc-rule);
+  border-radius: 0 var(--pc-radius) var(--pc-radius) 0;
+}
+
+.pc-callout-header {
+  display: flex;
+  align-items: center;
+  gap: var(--pc-space-2);
+  margin-bottom: var(--pc-space-2);
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg-muted);
+  user-select: none;
+}
+
+.pc-callout-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--pc-border);
+  background: var(--pc-bg);
+  font-family: var(--pc-font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--pc-fg-muted);
+  line-height: 1;
+}
+
+.pc-callout-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--pc-text-size-tiny);
+}
+
+.pc-callout-body {
+  color: var(--pc-fg);
+  font-family: var(--pc-font-serif);
+}
+
+.pc-callout-body .pc-style {
+  margin: 0;
+}
+
+.pc-callout-body .pc-style + .pc-style {
+  margin-top: var(--pc-space-3);
+}
+
+/* Tone-specific glyph treatments. The variants share the rule + indent;
+   the glyph differs to make each tone instantly identifiable. */
+
+.pc-callout-warning .pc-callout-glyph {
+  border-color: var(--pc-fg-muted);
+  color: var(--pc-fg);
+  font-weight: 700;
+}
+
+.pc-callout-caution .pc-callout-glyph {
+  border-color: var(--pc-fg-muted);
+  color: var(--pc-fg);
+}
+
+.pc-callout-tip .pc-callout-glyph {
+  border-color: var(--pc-fg-muted);
+  color: var(--pc-fg);
+}
+
+/* Tables. */
+
+.pc-table {
+  margin: var(--pc-space-5) 0;
+  display: grid;
+  grid-template-columns: repeat(var(--pc-table-columns), minmax(0, 1fr));
+  border: 1px solid var(--pc-border-subtle);
+  border-radius: var(--pc-radius);
+  overflow: hidden;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+}
+
+.pc-table-row {
+  display: contents;
+}
+
+.pc-table-cell {
+  padding: var(--pc-space-2) var(--pc-space-3);
+  border-right: 1px solid var(--pc-border-subtle);
+  border-bottom: 1px solid var(--pc-border-subtle);
+  background: var(--pc-bg);
+}
+
+.pc-table-cell:last-child {
+  border-right: 0;
+}
+
+.pc-table-row:last-child .pc-table-cell {
+  border-bottom: 0;
+}
+
+.pc-table-cell .pc-style {
+  margin: 0;
+  font-family: var(--pc-font-sans);
+}
+
+/* Header row treatment. Driven by the table's headerRows attribute -
+   the first N grid rows get heavier weight and a thicker bottom rule. */
+
+.pc-table[data-header-rows='1'] .pc-table-row:first-child .pc-table-cell {
+  background: var(--pc-bg-elevated);
+  font-weight: 600;
+  border-bottom: 1px solid var(--pc-border);
+}
+
+.pc-table[data-header-rows='2'] .pc-table-row:nth-child(-n + 2) .pc-table-cell {
+  background: var(--pc-bg-elevated);
+  font-weight: 600;
+}
+
+.pc-table[data-header-rows='2'] .pc-table-row:nth-child(2) .pc-table-cell {
+  border-bottom: 1px solid var(--pc-border);
+}
+
+/* Task list items. */
+
+.pc-task {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--pc-space-3);
+}
+
+.pc-task-check {
+  flex: 0 0 auto;
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg);
+  cursor: pointer;
+  margin: 4px 0 0;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--pc-font-sans);
+  font-size: 12px;
+  line-height: 1;
+  color: var(--pc-bg);
+  transition: background 80ms ease-out;
+}
+
+.pc-task-check:hover {
+  background: var(--pc-bg-hover);
+}
+
+.pc-task-check:focus-visible {
+  outline: 2px solid var(--pc-fg-muted);
+  outline-offset: 1px;
+}
+
+.pc-task-check:checked {
+  background: var(--pc-fg);
+  border-color: var(--pc-fg);
+}
+
+.pc-task-check:checked::after {
+  content: '✓';
+  color: var(--pc-bg);
+  font-weight: 600;
+}
+
+.pc-task-body {
+  flex: 1 1 auto;
+}
+
+.pc-task-body-done {
+  text-decoration: line-through;
+  text-decoration-color: var(--pc-fg-faint);
+  color: var(--pc-fg-muted);
+}
+
+/* Structured lists. */
+
+.pc-list {
+  margin: var(--pc-space-4) 0;
+  padding-left: var(--pc-space-6);
+}
+
+.pc-list-bullet {
+  list-style: disc;
+}
+
+.pc-list-number {
+  list-style: decimal;
+}
+
+.pc-list-task {
+  list-style: none;
+  padding-left: var(--pc-space-3);
+}
+
+.pc-list-item {
+  margin: var(--pc-space-2) 0;
+}
+
+/*
+ * An empty wrapper list-item (no text content, only a nested list as
+ * its first/only child) shows up after sinking the first item of a
+ * list - the structured-lists plugin wraps the source item in a
+ * fresh list under a wrapper list-item so the move stays representable.
+ * The wrapper is purely structural; hide its marker so it doesn't
+ * read as a phantom bullet next to the actual nested item.
+ */
+.pc-list-item:has(> .pc-list:first-child:last-child) {
+  list-style: none;
+  margin-top: 0;
+}
+
+.pc-list-item-task {
+  list-style: none;
+}
+
+/* Tighten paragraphs inside list-items. */
+
+.pc-list-item .pc-style {
+  margin: 0;
+}
+
+.pc-list-item .pc-style + .pc-style {
+  margin-top: var(--pc-space-2);
+}
+
+.pc-list-item .pc-list {
+  margin: var(--pc-space-2) 0 0;
+}
+
+/* Markdown textarea (bidirectional editing). */
+
+.pc-panel-stretch {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.pc-markdown-textarea {
+  flex: 1 1 auto;
+  width: 100%;
+  margin: 0;
+  padding: var(--pc-space-4) var(--pc-space-5);
+  background: transparent;
+  border: 0;
+  resize: none;
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-small);
+  line-height: 1.55;
+  color: var(--pc-fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+  outline: none;
+}
+
+.pc-markdown-textarea:focus-visible {
+  outline: none;
+  background: var(--pc-bg);
+}
+
+.pc-panel-error {
+  flex: 1 1 auto;
+  margin-right: var(--pc-space-3);
+  font-family: var(--pc-font-mono);
+  font-size: var(--pc-text-size-tiny);
+  color: var(--pc-fg-muted);
+}
+
+/* JSON syntax highlighting (grayscale). Keys are weightier; strings and
+   literals shift through muted shades to give hierarchy without color. */
+
+.pc-json-key {
+  color: var(--pc-fg);
+  font-weight: 600;
+}
+
+.pc-json-string {
+  color: var(--pc-fg-muted);
+}
+
+.pc-json-literal {
+  color: var(--pc-fg);
+  font-weight: 600;
+}
+
+.pc-json-number {
+  color: var(--pc-fg);
+}
+
+.pc-list-item-task {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--pc-space-3);
+  list-style: none;
+}
+
+.pc-list-item-task-done .pc-task-body {
+  text-decoration: line-through;
+  text-decoration-color: var(--pc-fg-faint);
+  color: var(--pc-fg-muted);
+}
+
+/* Typeahead panels (slash menu, emoji picker). */
+
+.pc-typeahead-panel {
+  position: absolute;
+  z-index: 50;
+  min-width: 240px;
+  max-width: 320px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--pc-bg);
+  border: 1px solid var(--pc-border);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  font-family: var(--pc-font-ui);
+  font-size: 13px;
+}
+
+.pc-typeahead-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+}
+
+.pc-typeahead-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--pc-fg);
+}
+
+.pc-typeahead-item-selected {
+  background: var(--pc-bg-muted);
+}
+
+.pc-typeahead-item-label {
+  font-weight: 500;
+}
+
+.pc-typeahead-item-hint {
+  font-size: 11px;
+  color: var(--pc-fg-muted);
+}
+
+.pc-typeahead-empty {
+  padding: 8px 10px;
+  color: var(--pc-fg-muted);
+  font-size: 12px;
+}
+
+.pc-typeahead-item-row {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--pc-space-3);
+}
+
+.pc-emoji {
+  font-size: 18px;
+  line-height: 1;
+  width: 20px;
+  text-align: center;
+}
+
+/* Insert dialog (modal). */
+
+.pc-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(28, 28, 28, 0.12);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+
+.pc-dialog {
+  width: 360px;
+  max-width: calc(100vw - var(--pc-space-5));
+  background: var(--pc-bg);
+  border: 1px solid var(--pc-border);
+  border-radius: 4px;
+  padding: var(--pc-space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pc-space-4);
+  font-family: var(--pc-font-sans);
+}
+
+.pc-dialog-title {
+  margin: 0;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--pc-fg);
+}
+
+.pc-dialog-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pc-space-3);
+}
+
+.pc-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pc-space-1);
+}
+
+.pc-dialog-field-label {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-tiny);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pc-fg-subtle);
+}
+
+.pc-dialog-input,
+.pc-dialog-select {
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-small);
+  padding: 6px var(--pc-space-2);
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg);
+  color: var(--pc-fg);
+  outline: none;
+}
+
+.pc-dialog-input:focus-visible,
+.pc-dialog-select:focus-visible {
+  border-color: var(--pc-fg-muted);
+}
+
+.pc-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--pc-space-2);
+}
+
+.pc-button-primary {
+  background: var(--pc-fg);
+  color: var(--pc-bg);
+  border-color: var(--pc-fg);
+}
+
+.pc-button-primary:hover {
+  background: var(--pc-fg-muted);
+  border-color: var(--pc-fg-muted);
+}
+
+.pc-dialog-field-inline {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--pc-space-2);
+}
+
+.pc-dialog-field-inline .pc-dialog-field-label {
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: var(--pc-text-size-small);
+  color: var(--pc-fg);
+}
+
+.pc-dialog-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: var(--pc-bg);
+  flex: 0 0 auto;
+}
+
+.pc-dialog-checkbox:checked {
+  background: var(--pc-fg);
+  border-color: var(--pc-fg);
+}
+
+.pc-dialog-checkbox:checked::after {
+  content: '✓';
+  color: var(--pc-bg);
+  font-weight: 600;
+}
+
+/* Code-block language switcher in the container header. */
+.pc-code-block-language-select {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--pc-fg-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--pc-text-sm);
+  padding: 0 var(--pc-space-1);
+}
+
+.pc-code-block-language-select:hover {
+  color: var(--pc-fg);
+}
+
+.pc-code-block-language-select:focus-visible {
+  outline: 1px solid var(--pc-border);
+  outline-offset: 2px;
+}
+
+/* Callout tone switcher in the container header. Visually matches the
+ * label it replaces (uppercase tiny sans) so the header doesn't reflow
+ * when the tone changes. */
+.pc-callout-tone-select {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--pc-fg-muted);
+  cursor: pointer;
+  font-family: var(--pc-font-sans);
+  font-size: var(--pc-text-size-tiny);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0;
+}
+
+.pc-callout-tone-select:hover {
+  color: var(--pc-fg);
+}
+
+.pc-callout-tone-select:focus-visible {
+  outline: 1px solid var(--pc-border);
+  outline-offset: 2px;
 }

--- a/apps/pilcrow/src/toolbar.tsx
+++ b/apps/pilcrow/src/toolbar.tsx
@@ -1,0 +1,369 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type EditorSnapshot,
+} from '@portabletext/editor'
+import * as selectors from '@portabletext/editor/selectors'
+import {
+  useApplicableSchema,
+  useDecoratorButton,
+  useHistoryButtons,
+  useStyleSelector,
+  useToolbarSchema,
+  type ToolbarDecoratorSchemaType,
+  type ToolbarStyleSchemaType,
+} from '@portabletext/toolbar'
+import {useState} from 'react'
+import {
+  InsertDialog,
+  insertDialogConfigs,
+  type InsertDialogConfig,
+} from './insert-dialog'
+import {getEnclosingList} from './plugins/structured-lists'
+
+function enclosingListsEqual(
+  a: ReturnType<typeof getEnclosingList>,
+  b: ReturnType<typeof getEnclosingList>,
+) {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  return (
+    (a.list.node as {_key?: string})._key ===
+      (b.list.node as {_key?: string})._key &&
+    (a.list.node as {kind?: string}).kind ===
+      (b.list.node as {kind?: string}).kind &&
+    (a.listItem.node as {_key?: string})._key ===
+      (b.listItem.node as {_key?: string})._key
+  )
+}
+
+/**
+ * Pilcrow toolbar. Style picker, decorator toggles, block-insert
+ * buttons, list indent/outdent, history. Block insertion goes
+ * through `insert.block`, list indent/outdent re-emits the same
+ * `keyboard.keydown` event that the structured-lists plugin
+ * listens for - keeps the indent/outdent path identical to Tab /
+ * Shift+Tab.
+ */
+export function Toolbar() {
+  const schema = useToolbarSchema({})
+  const [dialogConfig, setDialogConfig] = useState<InsertDialogConfig | null>(
+    null,
+  )
+  return (
+    <>
+      <div className="pc-toolbar" role="toolbar">
+        <StyleSelector styles={schema.styles} />
+        <span className="pc-toolbar-divider" aria-hidden />
+        {schema.decorators.map((decorator) => (
+          <DecoratorButton key={decorator.name} schemaType={decorator} />
+        ))}
+        <span className="pc-toolbar-divider" aria-hidden />
+        <ListToggleButton kind="bullet" label="Bullet list" symbol="•" />
+        <ListToggleButton kind="number" label="Numbered list" symbol="1." />
+        <ListToggleButton kind="task" label="Task list" symbol="☐" />
+        <span className="pc-toolbar-divider" aria-hidden />
+        <InsertBlockButton
+          type="image"
+          label="Insert image"
+          symbol="▣"
+          onOpenDialog={setDialogConfig}
+        />
+        <InsertBlockButton
+          type="code-block"
+          label="Insert code block"
+          symbol="{ }"
+          onOpenDialog={setDialogConfig}
+        />
+        <InsertBlockButton
+          type="callout"
+          label="Insert callout"
+          symbol="ℹ"
+          onOpenDialog={setDialogConfig}
+        />
+        <InsertBlockButton
+          type="table"
+          label="Insert table"
+          symbol="▦"
+          onOpenDialog={setDialogConfig}
+        />
+        <InsertBlockButton
+          type="horizontal-rule"
+          label="Insert divider"
+          symbol="―"
+          onOpenDialog={setDialogConfig}
+        />
+        <span className="pc-toolbar-divider" aria-hidden />
+        <ListIndentButtons />
+        <span
+          className="pc-toolbar-divider pc-toolbar-divider-grow"
+          aria-hidden
+        />
+        <HistoryButtons />
+      </div>
+      {dialogConfig ? (
+        <InsertDialog
+          config={dialogConfig}
+          onClose={() => setDialogConfig(null)}
+        />
+      ) : null}
+    </>
+  )
+}
+
+function StyleSelector(props: {styles: ReadonlyArray<ToolbarStyleSchemaType>}) {
+  const styleSelector = useStyleSelector({schemaTypes: props.styles})
+  const applicable = useApplicableSchema()
+  const active = styleSelector.snapshot.context.activeStyle ?? 'normal'
+  const disabled = styleSelector.snapshot.matches('disabled')
+  if (props.styles.length === 0) {
+    return null
+  }
+  return (
+    <select
+      className="pc-toolbar-select"
+      value={active}
+      disabled={disabled}
+      onChange={(event) => {
+        styleSelector.send({type: 'toggle', style: event.target.value})
+      }}
+    >
+      {props.styles.map((style) => {
+        const isApplicable = applicable.styles.has(style.name)
+        return (
+          <option key={style.name} value={style.name} disabled={!isApplicable}>
+            {styleLabels[style.name] ?? style.title ?? style.name}
+          </option>
+        )
+      })}
+    </select>
+  )
+}
+
+const styleLabels: Record<string, string> = {
+  normal: 'Paragraph',
+  h1: 'Heading 1',
+  h2: 'Heading 2',
+  h3: 'Heading 3',
+  h4: 'Heading 4',
+  h5: 'Heading 5',
+  h6: 'Heading 6',
+}
+
+function DecoratorButton(props: {schemaType: ToolbarDecoratorSchemaType}) {
+  const decoratorButton = useDecoratorButton(props)
+  const applicable = useApplicableSchema()
+  const isActive =
+    decoratorButton.snapshot.matches({disabled: 'active'}) ||
+    decoratorButton.snapshot.matches({enabled: 'active'})
+  const isDisabled =
+    !applicable.decorators.has(props.schemaType.name) ||
+    decoratorButton.snapshot.matches('disabled')
+  const label =
+    decoratorLabels[props.schemaType.name] ??
+    props.schemaType.title ??
+    props.schemaType.name
+  const symbol =
+    decoratorSymbols[props.schemaType.name] ?? label.charAt(0).toUpperCase()
+  return (
+    <button
+      type="button"
+      className={`pc-toolbar-button${isActive ? ' pc-toolbar-button-active' : ''}`}
+      disabled={isDisabled}
+      onClick={() => decoratorButton.send({type: 'toggle'})}
+      title={label}
+      aria-pressed={isActive}
+      aria-label={label}
+    >
+      <span className={decoratorClasses[props.schemaType.name] ?? ''}>
+        {symbol}
+      </span>
+    </button>
+  )
+}
+
+const decoratorLabels: Record<string, string> = {
+  'strong': 'Bold',
+  'em': 'Italic',
+  'code': 'Code',
+  'strike-through': 'Strikethrough',
+}
+
+const decoratorSymbols: Record<string, string> = {
+  'strong': 'B',
+  'em': 'I',
+  'code': '<>',
+  'strike-through': 'S',
+}
+
+const decoratorClasses: Record<string, string> = {
+  'strong': 'pc-toolbar-symbol-strong',
+  'em': 'pc-toolbar-symbol-em',
+  'code': 'pc-toolbar-symbol-code',
+  'strike-through': 'pc-toolbar-symbol-strike',
+}
+
+function ListToggleButton(props: {
+  kind: 'bullet' | 'number' | 'task'
+  label: string
+  symbol: string
+}) {
+  const editor = useEditor()
+  const enclosing = useEditorSelector(
+    editor,
+    getEnclosingList,
+    enclosingListsEqual,
+  )
+  const enclosingKind = (enclosing?.list.node as {kind?: string} | undefined)
+    ?.kind
+  const isActive = enclosingKind === props.kind
+  return (
+    <button
+      type="button"
+      className={`pc-toolbar-button${isActive ? ' pc-toolbar-button-active' : ''}`}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (enclosing && enclosingKind === props.kind) {
+          // Same kind: unwrap the focused list-item's content out of the list.
+          editor.send({
+            type: 'custom.structured-lists.unwrap',
+          } as never)
+          return
+        }
+        if (enclosing) {
+          // Different kind: change the enclosing list's kind in place.
+          // Use the `set` primitive with the full property path because
+          // `block.set` filters by `getBlockObjectSchema`, which doesn't
+          // resolve container types (the `list` is a container, not a
+          // root-level block-object), so it would silently drop `kind`.
+          editor.send({
+            type: 'set',
+            at: [...enclosing.list.path, 'kind'],
+            value: props.kind,
+          } as never)
+          return
+        }
+        // Not in a list: wrap the focus block in a fresh list of this kind.
+        editor.send({
+          type: 'custom.structured-lists.wrap',
+          kind: props.kind,
+        } as never)
+      }}
+      title={props.label}
+      aria-label={props.label}
+      aria-pressed={isActive}
+    >
+      <span aria-hidden>{props.symbol}</span>
+    </button>
+  )
+}
+
+function InsertBlockButton(props: {
+  type: string
+  label: string
+  symbol: string
+  onOpenDialog: (config: InsertDialogConfig) => void
+}) {
+  const editor = useEditor()
+  return (
+    <button
+      type="button"
+      className="pc-toolbar-button"
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => {
+        const config = insertDialogConfigs[props.type]
+        if (config) {
+          props.onOpenDialog(config)
+          return
+        }
+        // No field config - just insert the block directly.
+        editor.send({
+          type: 'insert.block',
+          block: {_type: props.type},
+          placement: 'auto',
+        })
+      }}
+      title={props.label}
+      aria-label={props.label}
+    >
+      <span aria-hidden>{props.symbol}</span>
+    </button>
+  )
+}
+
+function isFocusInList(snapshot: EditorSnapshot) {
+  const focusBlock = selectors.getFocusBlock(snapshot)
+  if (!focusBlock) {
+    return false
+  }
+  // A structured-list path includes an 'items' segment somewhere.
+  return focusBlock.path.some((segment) => segment === 'items')
+}
+
+function ListIndentButtons() {
+  const editor = useEditor()
+  const inList = useEditorSelector(editor, isFocusInList)
+  return (
+    <>
+      <button
+        type="button"
+        className="pc-toolbar-button"
+        disabled={!inList}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => {
+          editor.send({type: 'custom.structured-lists.outdent'})
+        }}
+        title="Outdent list item"
+        aria-label="Outdent list item"
+      >
+        <span aria-hidden>⇤</span>
+      </button>
+      <button
+        type="button"
+        className="pc-toolbar-button"
+        disabled={!inList}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => {
+          editor.send({type: 'custom.structured-lists.indent'})
+        }}
+        title="Indent list item"
+        aria-label="Indent list item"
+      >
+        <span aria-hidden>⇥</span>
+      </button>
+    </>
+  )
+}
+
+function HistoryButtons() {
+  const {snapshot, send} = useHistoryButtons()
+  const disabled = snapshot.matches('disabled')
+  return (
+    <>
+      <button
+        type="button"
+        className="pc-toolbar-button"
+        onClick={() => send({type: 'history.undo'})}
+        disabled={disabled}
+        title="Undo"
+        aria-label="Undo"
+      >
+        <span aria-hidden>↩</span>
+      </button>
+      <button
+        type="button"
+        className="pc-toolbar-button"
+        onClick={() => send({type: 'history.redo'})}
+        disabled={disabled}
+        title="Redo"
+        aria-label="Redo"
+      >
+        <span aria-hidden>↪</span>
+      </button>
+    </>
+  )
+}

--- a/apps/pilcrow/src/use-theme.ts
+++ b/apps/pilcrow/src/use-theme.ts
@@ -1,0 +1,52 @@
+import {useEffect, useState} from 'react'
+
+const STORAGE_KEY = 'pilcrow.theme'
+
+export type Theme = 'light' | 'dark'
+
+function readInitialTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+  const stored = window.localStorage?.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark') {
+    return stored
+  }
+  // Fall back to system preference.
+  if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
+    return 'dark'
+  }
+  return 'light'
+}
+
+/**
+ * Tracks the current theme and writes \`data-theme\` on
+ * \`document.documentElement\` so CSS can pick it up. Persists
+ * explicit choices to localStorage; system preference wins when the
+ * user hasn't chosen.
+ */
+export function useTheme(): {theme: Theme; toggle: () => void} {
+  const [theme, setTheme] = useState<Theme>(readInitialTheme)
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return
+    }
+    document.documentElement.dataset.theme = theme
+  }, [theme])
+
+  const toggle = () => {
+    setTheme((current) => {
+      const next = current === 'dark' ? 'light' : 'dark'
+      try {
+        window.localStorage?.setItem(STORAGE_KEY, next)
+      } catch {
+        // Storage access may be denied; the in-memory state still
+        // applies until reload.
+      }
+      return next
+    })
+  }
+
+  return {theme, toggle}
+}

--- a/apps/pilcrow/tests/annotations-across-blocks.feature
+++ b/apps/pilcrow/tests/annotations-across-blocks.feature
@@ -1,0 +1,170 @@
+Feature: Annotations Across Blocks
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Adding annotation across blocks
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foobar" is selected
+    And "link" "l1,l2" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]
+      B: [@link _key="l2":bar|]
+      """
+
+  Scenario: Adding annotation across blocks (backwards selection)
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foobar" is selected backwards
+    And "link" "l1,l2" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":|foo]
+      B: [@link _key="l2":bar^]
+      """
+
+  Scenario: Adding annotation across an image
+    When the editor is focused
+    And "foo|{image}" is inserted at "auto" and selected at the "end"
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foobar" is selected
+    And "link" "l1,l2" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]
+      {IMAGE}
+      B: [@link _key="l2":bar|]
+      """
+
+  Scenario: Adding annotation across an image (backwards selection)
+    When the editor is focused
+    And "foo|{image}" is inserted at "auto" and selected at the "end"
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foobar" is selected backwards
+    And "link" "l1,l2" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":|foo]
+      {IMAGE}
+      B: [@link _key="l2":bar^]
+      """
+
+  Scenario: Splitting an annotation across blocks
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "foobar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]
+      B: [@link _key="l1":bar]
+      """
+
+  Scenario: Splitting an annotation across blocks using a selection
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    When the editor is focused
+    And "bar" is selected
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ]
+      B: [@link _key="l1": baz]
+      """
+
+  Scenario: Splitting a split annotation across blocks
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]
+      B: [@link _key="l1": ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
+
+  Scenario: Splitting text after annotation doesn't touch the annotation
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo"
+    When the editor is focused
+    And the caret is put after "bar"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo] bar
+      B:  baz
+      """
+
+  # Warning: Possible wrong behaviour
+  # "foo" and "bar" should rejoin as one link
+  # Fixing this is possibly a breaking change
+  Scenario: Splitting and merging an annotation across blocks
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "foobar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][@link _key="l2":bar]
+      """
+
+  # Warning: Possible wrong behaviour
+  # The " baz" link should have a unique key
+  # Fixing this is possibly a breaking change
+  Scenario: Toggling part of an annotation off
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    When "bar" is selected
+    And "link" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ]bar[@link _key="l1": baz]
+      """
+
+  Scenario: Splitting block before annotation
+    Given the editor state is "B: foo"
+    And a "link" "l1" around "foo"
+    When the editor is focused
+    And the caret is put before "foo"
+    And "{Enter}" is pressed
+    Then the editor state is "B: ;;B: [@link _key=\"l1\":foo]"
+
+  Scenario: Splitting block after annotation
+    Given the editor state is "B: foo"
+    And a "link" "l1" around "foo"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    Then the editor state is "B: [@link _key=\"l1\":foo];;B: "
+
+  Scenario: Merging blocks with annotations
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foo" is selected
+    And "link" "l1" is toggled
+    And "bar" is selected
+    And "link" "l2" is toggled
+    And the caret is put before "bar"
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][@link _key="l2":bar]
+      """

--- a/apps/pilcrow/tests/annotations-across-blocks.test.tsx
+++ b/apps/pilcrow/tests/annotations-across-blocks.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './annotations-across-blocks.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/annotations-edge-cases.feature
+++ b/apps/pilcrow/tests/annotations-edge-cases.feature
@@ -1,0 +1,50 @@
+Feature: Annotations Edge Cases
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Deleting emphasised paragraph with comment in the middle
+    Given the editor state is "B: foo bar baz"
+    And "em" around "foo bar baz"
+    And a "comment" "c1" around "bar"
+    When the editor is focused
+    And "foo bar baz" is selected
+    And "{Backspace}" is pressed
+    Then the editor state is "B: [em:]"
+
+  Scenario: Deleting half of annotated text
+    Given the editor state is "B: foo bar baz"
+    And a "comment" "c1" around "foo bar baz"
+    When the editor is focused
+    And " baz" is selected
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo bar]
+      """
+
+  Scenario: Deleting annotation in the middle of text
+    Given the editor state is "B: foo bar baz"
+    And a "comment" "c1" around "bar"
+    When the editor is focused
+    And "bar " is selected
+    And "{Backspace}" is pressed
+    Then the editor state is "B: foo baz"
+
+  Scenario: Deleting across annotated blocks
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foo" is selected
+    And "link" "l1" is toggled
+    And "bar" is selected
+    And "link" "l2" is toggled
+    And "ooba" is selected
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: [@link _key="l1":f][@link _key="l2":r]
+      """

--- a/apps/pilcrow/tests/annotations-edge-cases.test.tsx
+++ b/apps/pilcrow/tests/annotations-edge-cases.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './annotations-edge-cases.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/annotations-overlapping-decorators.feature
+++ b/apps/pilcrow/tests/annotations-overlapping-decorators.feature
@@ -1,0 +1,177 @@
+Feature: Annotations Overlapping Decorators
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario Outline: Inserting text at the edge of a decorated annotation
+    Given the editor state is <text>
+    And a "link" "l1" around <annotated>
+    And "strong" around <decorated>
+    When the editor is focused
+    And the caret is put <position>
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | annotated     | decorated     | position      | new text                                                                                 |
+      | "B: foo bar baz" | "bar"         | "bar"         | after "foo "  | "B: foo new[strong:[@link _key=\"l1\":bar]] baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | before "bar"  | "B: foo new[strong:[@link _key=\"l1\":bar]] baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | after "bar"   | "B: foo [strong:[@link _key=\"l1\":bar]]new baz"                                         |
+      | "B: foo bar baz" | "bar"         | "bar"         | before " baz" | "B: foo [strong:[@link _key=\"l1\":bar]]new baz"                                         |
+      | "B: foo"         | "foo"         | "foo"         | before "foo"  | "B: new[strong:[@link _key=\"l1\":foo]]"                                                 |
+      | "B: foo"         | "foo"         | "foo"         | after "foo"   | "B: [strong:[@link _key=\"l1\":foo]]new"                                                 |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | after "foo "  | "B: [@link _key=\"l1\":foo new][strong:[@link _key=\"l1\":bar]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | before "bar"  | "B: [@link _key=\"l1\":foo new][strong:[@link _key=\"l1\":bar]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | after "bar"   | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":barnew]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"         | before " baz" | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":barnew]][@link _key=\"l1\": baz]" |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | after "foo "  | "B: [strong:foo new][strong:[@link _key=\"l1\":bar]][strong: baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | before "bar"  | "B: [strong:foo new][strong:[@link _key=\"l1\":bar]][strong: baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | after "bar"   | "B: [strong:foo ][strong:[@link _key=\"l1\":bar]][strong:new baz]"                       |
+      | "B: foo bar baz" | "bar"         | "foo bar baz" | before " baz" | "B: [strong:foo ][strong:[@link _key=\"l1\":bar]][strong:new baz]"                       |
+
+  Scenario Outline: Toggling decorator at the edge of a decorated annotation
+    Given the editor state is <text>
+    And a "link" "l1" around <annotated>
+    And "strong" around <decorated>
+    When the editor is focused
+    And the caret is put <position>
+    # This one is tricky since it requires the editor to know up-front that
+    # typing at the current position shouldn't produce bold text (since the
+    # strong decorator is contained within the adjoining annotation).
+    #
+    # Therefore, toggling strong should turn on the decorator (not off) to go
+    # against the default behavior and produce bold text.
+    And "strong" is toggled
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | annotated | decorated | position      | new text                                                    |
+      | "B: foo bar baz" | "bar"     | "bar"     | after "foo "  | "B: foo [strong:new\|][strong:[@link _key=\"l1\":bar]] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | before "bar"  | "B: foo [strong:new\|][strong:[@link _key=\"l1\":bar]] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | after "bar"   | "B: foo [strong:[@link _key=\"l1\":bar]][strong:new\|] baz" |
+      | "B: foo bar baz" | "bar"     | "bar"     | before " baz" | "B: foo [strong:[@link _key=\"l1\":bar]][strong:new\|] baz" |
+
+  Scenario Outline: Writing on top of a decorated annotation
+    When the editor is focused
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around <annotated>
+    And "strong" around <decorated>
+    When <selection>
+    And "removed" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | annotated     | decorated | selection                   | new text                                                                                  |
+      | "bar"         | "bar"     | "bar" is selected           | "B: foo [strong:removed] baz"                                                             |
+      | "bar"         | "bar"     | "bar" is selected backwards | "B: foo [strong:removed] baz"                                                             |
+      | "foo bar baz" | "bar"     | "bar" is selected           | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":removed]][@link _key=\"l1\": baz]" |
+      | "foo bar baz" | "bar"     | "bar" is selected backwards | "B: [@link _key=\"l1\":foo ][strong:[@link _key=\"l1\":removed]][@link _key=\"l1\": baz]" |
+
+  Scenario: Splitting block before a decorated annotation
+    Given the editor state is "B: bar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{Enter}" is pressed
+    Then the editor state is "B: ;;B: [strong:[@link _key=\"l1\":bar]]"
+
+  Scenario: Splitting block after a decorated annotation
+    Given the editor state is "B: bar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put after "bar"
+    And "{Enter}" is pressed
+    And "baz" is typed
+    Then the editor state is
+      """
+      B: [strong:[@link _key="l1":bar]]
+      B: baz|
+      """
+
+  Scenario: Splitting block after a decorated annotation #2
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "bar"
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put after "bar"
+    And "{Enter}" is pressed
+    And "baz" is typed
+    Then the editor state is
+      """
+      B: foo[strong:[@link _key="l1":bar]]
+      B: baz|
+      """
+
+  Scenario: Annotation and decorator on the same text
+    Given the editor state is "B: foo bar baz"
+    When "bar" is selected
+    And "strong" is toggled
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: foo [strong:[@link _key="l1":bar]] baz
+      """
+
+  Scenario: Adding decorator inside annotation
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    When "bar" is selected
+    And "strong" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
+
+  Scenario: Adding an annotation across a decorator
+    Given the editor state is "B: foo bar baz"
+    And "strong" around "bar"
+    When "foo bar baz" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz]
+      """
+
+  Scenario: Annotation overlapping decorator
+    Given the editor state is "B: foobar"
+    And "strong" around "bar"
+    When "foob" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][strong:[@link _key="l1":b]][strong:ar]
+      """
+
+  Scenario: Annotation overlapping decorator (backwards selection)
+    Given the editor state is "B: foobar"
+    And "strong" around "bar"
+    When "foob" is selected backwards
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo][strong:[@link _key="l1":b]][strong:ar]
+      """
+
+  Scenario: Annotation overlapping decorator from behind
+    Given the editor state is "B: foobar"
+    And "strong" around "foo"
+    When "obar" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [strong:fo][strong:[@link _key="l1":o]][@link _key="l1":bar]
+      """
+
+  Scenario: Annotation overlapping decorator from behind (backwards selection)
+    Given the editor state is "B: foobar"
+    And "strong" around "foo"
+    When "obar" is selected backwards
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [strong:fo][strong:[@link _key="l1":o]][@link _key="l1":bar]
+      """

--- a/apps/pilcrow/tests/annotations-overlapping-decorators.test.tsx
+++ b/apps/pilcrow/tests/annotations-overlapping-decorators.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './annotations-overlapping-decorators.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/annotations-overlapping.feature
+++ b/apps/pilcrow/tests/annotations-overlapping.feature
@@ -1,0 +1,103 @@
+Feature: Overlapping Annotations
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario Outline: Inserting text at the edge of overlapping annotations
+    Given the editor state is <text>
+    And a "link" "l1" around <link>
+    And a "comment" "c1" around <comment>
+    When the editor is focused
+    And the caret is put <position>
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | link          | comment | position      | new text                                                                                                 |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | after "foo "  | "B: [@link _key=\"l1\":foo new][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\": baz]"   |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | before "bar"  | "B: [@link _key=\"l1\":foo new][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\": baz]"   |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | after "bar"   | "B: [@link _key=\"l1\":foo ][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\":new\| baz]" |
+      | "B: foo bar baz" | "foo bar baz" | "bar"   | before " baz" | "B: [@link _key=\"l1\":foo ][@link _key=\"l1\":[@comment _key=\"c1\":bar]][@link _key=\"l1\":new\| baz]" |
+      | "B: foo"         | "foo"         | "foo"   | before "foo"  | "B: new\|[@link _key=\"l1\":[@comment _key=\"c1\":foo]]"                                                 |
+      | "B: foo"         | "foo"         | "foo"   | after "foo"   | "B: [@link _key=\"l1\":[@comment _key=\"c1\":foo]]new\|"                                                 |
+
+  Scenario: Overlapping annotation
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "bar"
+    When "foob" is selected
+    And "comment" "c1" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo][@link _key="l1":[@comment _key="c1":b]][@link _key="l1":ar]
+      """
+
+  Scenario: Overlapping annotation (backwards selection)
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "bar"
+    When "foob" is selected backwards
+    And "comment" "c1" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo][@link _key="l1":[@comment _key="c1":b]][@link _key="l1":ar]
+      """
+
+  Scenario: Overlapping annotation from behind
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "foo"
+    When "obar" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c1":[@link _key="l1":^o]][@link _key="l1":bar|]
+      """
+
+  Scenario: Overlapping annotation from behind (backwards selection)
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "foo"
+    When "obar" is selected backwards
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c1":[@link _key="l1":|o]][@link _key="l1":bar^]
+      """
+
+  Scenario: Overlapping same-type annotation
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "bar"
+    When "foob" is selected
+    And "comment" "c2" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c2":foob][@comment _key="c1":ar]
+      """
+
+  Scenario: Overlapping same-type annotation (backwards selection)
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "bar"
+    When "foob" is selected backwards
+    And "comment" "c2" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c2":foob][@comment _key="c1":ar]
+      """
+
+  Scenario: Overlapping same-type annotation from behind
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "foo"
+    When "obar" is selected
+    And "comment" "c2" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c2":obar]
+      """
+
+  Scenario: Overlapping same-type annotation from behind (backwards selection)
+    Given the editor state is "B: foobar"
+    And a "comment" "c1" around "foo"
+    When "obar" is selected backwards
+    And "comment" "c2" is toggled
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo][@comment _key="c2":obar]
+      """

--- a/apps/pilcrow/tests/annotations-overlapping.test.tsx
+++ b/apps/pilcrow/tests/annotations-overlapping.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './annotations-overlapping.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/annotations.feature
+++ b/apps/pilcrow/tests/annotations.feature
@@ -1,0 +1,205 @@
+# Complex marks like links
+Feature: Annotations
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Selection after adding an annotation
+    Given the editor state is "B: foo bar baz"
+    When "bar" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: foo [@link _key="l1":^bar|] baz
+      """
+
+  Scenario: Inserting text after an annotation
+    Given the editor state is "B: foo"
+    And a "link" "l1" around "foo"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "bar" is typed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]bar|
+      """
+
+  Scenario Outline: Toggling annotation on with a collapsed selection
+    Given the editor state is "B: foo bar baz"
+    When the caret is put <position>
+    And "link" "l1" is toggled
+    Then the editor state is <new text>
+
+    Examples:
+      | position     | new text                                |
+      | before "bar" | "B: foo [@link _key=\"l1\":^bar\|] baz" |
+      | after "bar"  | "B: foo [@link _key=\"l1\":^bar\|] baz" |
+      | after "ar"   | "B: foo [@link _key=\"l1\":^bar\|] baz" |
+
+  Scenario: Toggling annotation on with a collapsed selection inside split block
+    Given the editor state is "B: foo bar baz"
+    And "strong" around "bar"
+    When the caret is put before "az"
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: foo [strong:bar] [@link _key="l1":^baz|]
+      """
+
+  Scenario: Toggling annotation off with a part-selection inside split block
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    And "strong" around "bar"
+    When "baz" is selected
+    And "link" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": ]^baz|
+      """
+
+  Scenario: Toggling annotation off with a part-selection does not remove sibling annotations
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo "
+    And a "link" "l2" around "bar baz"
+    And "strong" around "bar"
+    When "baz" is selected
+    And "link" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l2":bar]][@link _key="l2": ]^baz|
+      """
+
+  Scenario: Toggling annotation off with a collapsed selection inside split block
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    And "strong" around "bar"
+    When the caret is put before "baz"
+    And "link" is toggled
+    Then the editor state is "B: foo [strong:bar] |baz"
+
+  Scenario: Toggling annotation off with a collapsed selection does not remove sibling annotations to the left
+    Given the editor state is "B: foo bar baz boo baa"
+    And a "link" "l1" around "foo bar baz boo baa"
+    And "strong" around "bar"
+    When "boo" is selected
+    And "link" is toggled
+    And the caret is put before "aa"
+    And "link" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo ][strong:[@link _key="l1":bar]][@link _key="l1": baz ]boo b|aa
+      """
+
+  Scenario: Toggling annotation off with a collapsed selection does not remove sibling annotations to the right
+    Given the editor state is "B: foo bar baz boo baa"
+    And a "link" "l1" around "foo bar baz boo baa"
+    And "strong" around "boo"
+    When "bar" is selected
+    And "link" is toggled
+    And the caret is put before "oo "
+    And "link" is toggled
+    Then the editor state is
+      """
+      B: f|oo bar[@link _key="l1": baz ][strong:[@link _key="l1":boo]][@link _key="l1": baa]
+      """
+
+  Scenario Outline: Toggling annotation off with a collapsed selection
+    Given the editor state is "B: foo bar baz"
+    And a "link" "l1" around "foo bar baz"
+    When the caret is put <position>
+    And "link" is toggled
+    Then the editor state is <new text>
+
+    Examples:
+      | position    | new text         |
+      | before "oo" | "B: foo bar baz" |
+      | after "o b" | "B: foo bar baz" |
+      | after "ba"  | "B: foo bar baz" |
+
+  Scenario Outline: Writing on top of annotation
+    When the editor is focused
+    Given the editor state is "B: foo bar baz"
+    And a "comment" "c1" around "bar"
+    When <selection>
+    And "removed" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | selection                   | new text                                       |
+      | "bar" is selected           | "B: foo removed\| baz"                         |
+      | "bar" is selected backwards | "B: foo removed\| baz"                         |
+      | "ar" is selected            | "B: foo [@comment _key=\"c1\":b]removed\| baz" |
+      | "ar" is selected backwards  | "B: foo [@comment _key=\"c1\":b]removed\| baz" |
+
+  Scenario: Writing inside an annotation
+    Given the editor state is "B: foo baz"
+    And a "link" "l1" around "foo baz"
+    When the editor is focused
+    And the caret is put after "foo"
+    And " bar" is typed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo bar| baz]
+      """
+
+  Scenario Outline: Inserting text at the edge of an annotation
+    Given the editor state is <text>
+    And a "link" "l1" around <annotated>
+    When the editor is focused
+    And the caret is put <position>
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | annotated | position      | new text                                  |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo new[@link _key=\"l1\":bar] baz"   |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo new[@link _key=\"l1\":bar] baz"   |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [@link _key=\"l1\":bar]new\| baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [@link _key=\"l1\":bar]new\| baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: new\|[@link _key=\"l1\":foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [@link _key=\"l1\":foo]new\|"         |
+
+  Scenario: Inserting text between annotations
+    Given the editor state is "B: foobar"
+    And a "link" "l1" around "foo"
+    And a "link" "l2" around "bar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "n" is typed
+    Then the editor state is
+      """
+      B: [@link _key="l1":foo]n|[@link _key="l2":bar]
+      """
+
+  Scenario: Inserting text after inline object, before annotation
+    When the editor is focused
+    And a "stock-ticker" is inserted
+    And "{ArrowRight}" is pressed
+    And "bar" is typed
+    And "bar" is selected
+    And "link" "l1" is toggled
+    And the caret is put before "bar"
+    And "foo " is typed
+    Then the editor state is
+      """
+      B: {stock-ticker}foo |[@link _key="l1":bar]
+      """
+
+  Scenario Outline: Toggling decorator at the edge of an annotation
+    Given the editor state is <text>
+    And a "link" "l1" around <annotated>
+    When the editor is focused
+    And the caret is put <position>
+    And "strong" is toggled
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | annotated | position      | new text                                           |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo [strong:new\|][@link _key=\"l1\":bar] baz" |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo [strong:new\|][@link _key=\"l1\":bar] baz" |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [@link _key=\"l1\":bar][strong:new\|] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [@link _key=\"l1\":bar][strong:new\|] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [strong:new\|][@link _key=\"l1\":foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [@link _key=\"l1\":foo][strong:new\|]"         |

--- a/apps/pilcrow/tests/annotations.test.tsx
+++ b/apps/pilcrow/tests/annotations.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './annotations.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/arrow-navigation.test.tsx
+++ b/apps/pilcrow/tests/arrow-navigation.test.tsx
@@ -1,0 +1,182 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {userEvent} from 'vitest/browser'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Arrow navigation should let the caret leave a list when there is a
+ * block after (ArrowDown) or before (ArrowUp) the list at the parent
+ * level. Reported symptom: arrow navigation gets stuck inside list-
+ * items so you can't reach surrounding paragraphs by keyboard.
+ *
+ * The engine's \`arrowDownOutOfContainer\` / \`arrowUpOutOfContainer\`
+ * behaviors were treating "no sibling at the innermost container" as a
+ * dead-end, suppressing the native arrow event. With nested containers
+ * (list > list-item > content > block) the innermost container is the
+ * list-item, whose siblings are other list-items - so being at the last
+ * list-item was wrongly flagged as a dead-end even when the list itself
+ * had a next sibling.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, locator}
+}
+
+function block(_key: string, spanKey: string, text: string) {
+  return {
+    _type: 'block',
+    _key,
+    style: 'normal' as const,
+    children: [{_type: 'span', _key: spanKey, text, marks: []}],
+    markDefs: [],
+  }
+}
+
+describe('arrow navigation in/out of list-items', () => {
+  test('ArrowDown from last list-item lands in the paragraph after the list', async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [block('B1', 'S1', 'item one')],
+          },
+          {
+            _type: 'list-item',
+            _key: 'I2',
+            content: [block('B2', 'S2', 'item two')],
+          },
+        ],
+      },
+      block('B3', 'S3', 'after list'),
+    ] as Array<PortableTextBlock>
+    const {editor, locator} = await mount(initial)
+    // Place caret at end of last list-item.
+    await locator.element().focus()
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I2'},
+            'content',
+            {_key: 'B2'},
+            'children',
+            {_key: 'S2'},
+          ],
+          offset: 'item two'.length,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I2'},
+            'content',
+            {_key: 'B2'},
+            'children',
+            {_key: 'S2'},
+          ],
+          offset: 'item two'.length,
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 100))
+    await userEvent.keyboard('{ArrowDown}')
+    await new Promise((r) => setTimeout(r, 150))
+    const sel = editor.getSnapshot().context.selection
+    expect(sel?.focus.path.at(-1)).toEqual({_key: 'S3'})
+  })
+
+  test('ArrowUp from first list-item lands in the paragraph before the list', async () => {
+    const initial = [
+      block('B0', 'S0', 'before list'),
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [block('B1', 'S1', 'item one')],
+          },
+          {
+            _type: 'list-item',
+            _key: 'I2',
+            content: [block('B2', 'S2', 'item two')],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, locator} = await mount(initial)
+    await locator.element().focus()
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 100))
+    await userEvent.keyboard('{ArrowUp}')
+    await new Promise((r) => setTimeout(r, 150))
+    const sel = editor.getSnapshot().context.selection
+    expect(sel?.focus.path.at(-1)).toEqual({_key: 'S0'})
+  })
+})

--- a/apps/pilcrow/tests/block-objects.feature
+++ b/apps/pilcrow/tests/block-objects.feature
@@ -1,0 +1,171 @@
+# Objects like images, charts or page breaks
+Feature: Block Objects
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Pressing ArrowUp on a lonely image
+    Given the editor state is "{IMAGE}"
+    When the editor is focused
+    And "{ArrowUp}" is pressed
+    Then the editor state is
+      """
+      B: |
+      {IMAGE}
+      """
+
+  Scenario: Pressing ArrowDown on a lonely image
+    Given the editor state is "{IMAGE}"
+    When the editor is focused
+    And "{ArrowDown}" is pressed
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      """
+
+  Scenario: Pressing ArrowDown on image at the bottom
+    When the editor is focused
+    And "foo|{image}" is inserted at "auto" and selected at the "end"
+    And "{ArrowDown}" is pressed
+    Then the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: |
+      """
+
+  Scenario: ArrowRight before an image selects it
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      """
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{ArrowRight}" is pressed
+    Then "{image}" is selected
+
+  Scenario: ArrowLeft after an image selects it
+    Given the editor state is
+      """
+      {IMAGE}
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{ArrowLeft}" is pressed
+    Then "{image}" is selected
+
+  Scenario: Pressing Delete before an image
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Delete}" is pressed
+    Then the editor state is
+      """
+      B: foo|
+      B: bar
+      """
+
+  Scenario: Pressing Delete in an empty paragraph before an image
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "foo"
+    And "{Delete}" is pressed 4 times
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      B: bar
+      """
+
+  Scenario: Pressing Backspace after an image
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
+
+  Scenario: Pressing Backspace in an empty paragraph after an image
+    When the editor is focused
+    And "foo|{image}" is inserted at "auto" and selected at the "end"
+    And "{Enter}" is pressed
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B: foo
+      ^{IMAGE}|
+      """
+    And "{image}" is selected
+
+  Scenario Outline: Deleting a lonely image
+    Given the editor state is "{IMAGE}"
+    When the editor is focused
+    And <button> is pressed
+    And "foo" is typed
+    Then the editor state is "B: foo|"
+
+    Examples:
+      | button        |
+      | "{Backspace}" |
+      | "{Delete}"    |
+
+  Scenario Outline: Deleting an image with text above
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: b
+      """
+    When the editor is focused
+    And the caret is put after "b"
+    And "{Backspace}" is pressed 2 times
+    And <button> is pressed
+    And "bar" is typed
+    Then the editor state is "B: foobar|"
+
+    Examples:
+      | button        |
+      | "{Backspace}" |
+      | "{Delete}"    |
+
+  Scenario Outline: Deleting an image with text below
+    Given the editor state is
+      """
+      B: b
+      {IMAGE}
+      B: foo
+      """
+    When the editor is focused
+    And the caret is put before "b"
+    And "{Delete}" is pressed 2 times
+    And <button> is pressed
+    And "bar" is typed
+    Then the editor state is "B: bar|foo"
+
+    Examples:
+      | button        |
+      | "{Backspace}" |
+      | "{Delete}"    |

--- a/apps/pilcrow/tests/block-objects.test.tsx
+++ b/apps/pilcrow/tests/block-objects.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './block-objects.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/blockquote.feature
+++ b/apps/pilcrow/tests/blockquote.feature
@@ -1,0 +1,67 @@
+Feature: Structured Blockquotes
+  Blockquotes in Pilcrow are containers, not styles. A `blockquote`
+  block-object holds a `content` array of text blocks (and nested
+  blockquotes). Typing `> ` at the start of a paragraph converts the
+  paragraph into a blockquote. Typing the GFM admonition marker
+  `[!NOTE]` on the first line of a blockquote converts the whole
+  quote into a callout.
+
+  Scenario: Typing `> ` at the start of a paragraph wraps it in a blockquote
+    Given the editor state is "B: |"
+    When the editor is focused
+    And "> " is typed
+    Then the editor state is
+      """
+      BLOCKQUOTE:
+        B: |
+      """
+
+  Scenario: Pre-existing blockquote in initial state renders
+    Given the editor state is
+      """
+      BLOCKQUOTE:
+        B: hello
+      """
+    When the editor is focused
+    Then the editor state is
+      """
+      BLOCKQUOTE:
+        B: hello
+      """
+
+  Scenario: Nested blockquote is preserved
+    Given the editor state is
+      """
+      BLOCKQUOTE:
+        B: outer
+        BLOCKQUOTE:
+          B: inner
+      """
+    When the editor is focused
+    Then the editor state is
+      """
+      BLOCKQUOTE:
+        B: outer
+        BLOCKQUOTE:
+          B: inner
+      """
+
+  Scenario: Typing `[!NOTE]` on the first line of a blockquote converts to callout
+    Given the editor state is
+      """
+      BLOCKQUOTE:
+        B: |
+      """
+    When the editor is focused
+    And "{[}!NOTE{]}" is typed
+    Then the editor state is
+      """
+      CALLOUT:
+        B: |
+      """
+
+  Scenario: Typing `> ` mid-paragraph keeps it intact
+    Given the editor state is "B: foo|"
+    When the editor is focused
+    And " > " is typed
+    Then the editor state is "B: foo > |"

--- a/apps/pilcrow/tests/blockquote.test.tsx
+++ b/apps/pilcrow/tests/blockquote.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import blockquoteFeature from './blockquote.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: blockquoteFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/build-table-block.test.tsx
+++ b/apps/pilcrow/tests/build-table-block.test.tsx
@@ -1,0 +1,44 @@
+import {describe, expect, test} from 'vitest'
+import {buildTableBlock} from '../src/insert-dialog'
+
+describe('buildTableBlock', () => {
+  test('produces a table with the requested dimensions and one empty paragraph per cell', () => {
+    let counter = 0
+    const keyGen = () => `k${counter++}`
+    const block = buildTableBlock({
+      rows: 3,
+      columns: 2,
+      headerRows: 1,
+      keyGen,
+    }) as {headerRows: number; rows: Array<unknown>}
+    expect(block.headerRows).toBe(1)
+    const rows = block.rows
+    expect(rows).toHaveLength(3)
+    for (const row of rows) {
+      const r = row as {_type: string; cells: Array<unknown>}
+      expect(r._type).toBe('row')
+      expect(r.cells).toHaveLength(2)
+      for (const cell of r.cells) {
+        const c = cell as {
+          _type: string
+          content: Array<{_type: string; children: Array<{text: string}>}>
+        }
+        expect(c._type).toBe('cell')
+        expect(c.content).toHaveLength(1)
+        expect(c.content[0]._type).toBe('block')
+        expect(c.content[0].children[0].text).toBe('')
+      }
+    }
+  })
+
+  test('clamps row/column counts inside the dialog bounds at the call site', () => {
+    let counter = 0
+    const keyGen = () => `k${counter++}`
+    const block = buildTableBlock({rows: 1, columns: 1, headerRows: 0, keyGen})
+    expect((block as unknown as {rows: Array<unknown>}).rows).toHaveLength(1)
+    const firstRow = (
+      block as unknown as {rows: Array<{cells: Array<unknown>}>}
+    ).rows[0]
+    expect(firstRow.cells).toHaveLength(1)
+  })
+})

--- a/apps/pilcrow/tests/callout-tone.test.tsx
+++ b/apps/pilcrow/tests/callout-tone.test.tsx
@@ -1,0 +1,103 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Callouts let users change the tone (note / tip / warning / caution)
+ * inline without dropping into the JSON inspector. The header label
+ * becomes a `<select>`; changing it emits a `set` on the tone field.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, container: result.container}
+}
+
+describe('callout tone switcher', () => {
+  test('renders the current tone as a select element', async () => {
+    const initial = [
+      {
+        _type: 'callout',
+        _key: 'C1',
+        tone: 'tip',
+        content: [
+          {
+            _type: 'block',
+            _key: 'B1',
+            style: 'normal',
+            children: [
+              {_type: 'span', _key: 'S1', text: 'Try this', marks: []},
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {container} = await mount(initial)
+    const select = container.querySelector<HTMLSelectElement>(
+      'select.pc-callout-tone-select',
+    )
+    expect(select).toBeTruthy()
+    expect(select?.value).toBe('tip')
+  })
+
+  test('changing the select value updates the callout tone field', async () => {
+    const initial = [
+      {
+        _type: 'callout',
+        _key: 'C1',
+        tone: 'note',
+        content: [
+          {
+            _type: 'block',
+            _key: 'B1',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'S1', text: 'x', marks: []}],
+            markDefs: [],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    const select = container.querySelector<HTMLSelectElement>(
+      'select.pc-callout-tone-select',
+    )
+    expect(select).toBeTruthy()
+    if (!select) {
+      throw new Error('select missing')
+    }
+    select.value = 'warning'
+    select.dispatchEvent(new Event('change', {bubbles: true}))
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect((value[0] as unknown as {tone: string}).tone).toBe('warning')
+    })
+  })
+})

--- a/apps/pilcrow/tests/code-block-language.test.tsx
+++ b/apps/pilcrow/tests/code-block-language.test.tsx
@@ -1,0 +1,99 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * The code-block header should let users change the language without
+ * dropping into the JSON inspector. Renders as a \`<select>\` whose
+ * change handler emits a \`set\` on the language field.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, container: result.container}
+}
+
+describe('code-block language switcher', () => {
+  test('renders the current language as a select element', async () => {
+    const initial = [
+      {
+        _type: 'code-block',
+        _key: 'C1',
+        language: 'ts',
+        lines: [
+          {
+            _type: 'block',
+            _key: 'B1',
+            style: 'normal',
+            children: [
+              {_type: 'span', _key: 'S1', text: 'console.log()', marks: []},
+            ],
+            markDefs: [],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {container} = await mount(initial)
+    const select = container.querySelector<HTMLSelectElement>(
+      'select.pc-code-block-language-select',
+    )
+    expect(select).toBeTruthy()
+    expect(select!.value).toBe('ts')
+  })
+
+  test('changing the select value updates the code-block language field', async () => {
+    const initial = [
+      {
+        _type: 'code-block',
+        _key: 'C1',
+        language: 'ts',
+        lines: [
+          {
+            _type: 'block',
+            _key: 'B1',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'S1', text: 'x', marks: []}],
+            markDefs: [],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    const select = container.querySelector<HTMLSelectElement>(
+      'select.pc-code-block-language-select',
+    )!
+    select.value = 'js'
+    select.dispatchEvent(new Event('change', {bubbles: true}))
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect((value[0] as unknown as {language: string}).language).toBe('js')
+    })
+  })
+})

--- a/apps/pilcrow/tests/decorators-overlapping.feature
+++ b/apps/pilcrow/tests/decorators-overlapping.feature
@@ -1,0 +1,32 @@
+Feature: Overlapping Decorators
+
+  Background:
+    Given one editor
+
+  Scenario: Overlapping same-type decorator
+    Given the editor state is "B: foobar"
+    And "strong" around "bar"
+    When "foob" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [strong:^foob|ar]"
+
+  Scenario: Overlapping same-type decorator (backwards selection)
+    Given the editor state is "B: foobar"
+    And "strong" around "bar"
+    When "foob" is selected backwards
+    And "strong" is toggled
+    Then the editor state is "B: [strong:|foob^ar]"
+
+  Scenario: Overlapping same-type annotation from behind
+    Given the editor state is "B: foobar"
+    And "strong" around "foo"
+    When "obar" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [strong:fo^obar|]"
+
+  Scenario: Overlapping same-type annotation from behind (backwards selection)
+    Given the editor state is "B: foobar"
+    And "strong" around "foo"
+    When "obar" is selected backwards
+    And "strong" is toggled
+    Then the editor state is "B: [strong:fo|obar^]"

--- a/apps/pilcrow/tests/decorators-overlapping.test.tsx
+++ b/apps/pilcrow/tests/decorators-overlapping.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './decorators-overlapping.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/decorators.feature
+++ b/apps/pilcrow/tests/decorators.feature
@@ -1,0 +1,289 @@
+# Simple marks like bold and italic
+Feature: Decorators
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Inserting text at the edge of a decorator
+    Given the editor state is <text>
+    When the editor is focused
+    And <decorated> is selected
+    And "strong" is toggled
+    And the caret is put <position>
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | decorated | position      | new text                     |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo new[strong:bar] baz" |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo new[strong:bar] baz" |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [strong:barnew] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [strong:barnew] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [strong:newfoo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [strong:foonew]"         |
+
+  Scenario Outline: Toggling decorator at the edge of a decorator
+    Given the editor state is <text>
+    And "em" around <decorated>
+    When the editor is focused
+    And the caret is put <position>
+    And "strong" is toggled
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | decorated | position      | new text                                 |
+      | "B: foo bar baz" | "bar"     | after "foo "  | "B: foo [strong:new\|][em:bar] baz"      |
+      | "B: foo bar baz" | "bar"     | before "bar"  | "B: foo [strong:new\|][em:bar] baz"      |
+      | "B: foo bar baz" | "bar"     | after "bar"   | "B: foo [em:bar][em:[strong:new\|]] baz" |
+      | "B: foo bar baz" | "bar"     | before " baz" | "B: foo [em:bar][em:[strong:new\|]] baz" |
+      | "B: foo"         | "foo"     | before "foo"  | "B: [em:[strong:new\|]][em:foo]"         |
+      | "B: foo"         | "foo"     | after "foo"   | "B: [em:foo][em:[strong:new\|]]"         |
+
+  Scenario: Writing on top of a decorator
+    Given the editor state is "B: foo bar baz"
+    When the editor is focused
+    And "bar" is selected
+    And "strong" is toggled
+    And "removed" is typed
+    Then the editor state is "B: foo [strong:removed|] baz"
+
+  Scenario: Toggling bold inside italic
+    Given the editor state is "B: foo bar baz"
+    When "foo bar baz" is selected
+    And "em" is toggled
+    And "bar" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [em:foo ][em:[strong:^bar|]][em: baz]"
+    When "bar" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [em:foo ^bar| baz]"
+
+  Scenario: Toggling bold as you write
+    Given the editor state is "B: "
+    When the editor is focused
+    And the caret is put after ""
+    And "foo" is typed
+    And "strong" is toggled
+    And "bar" is typed
+    Then the editor state is "B: foo[strong:bar|]"
+
+  Scenario: Toggling bold inside italic as you write
+    Given the editor state is "B: "
+    When the editor is focused
+    And the caret is put after ""
+    And "em" is toggled
+    And "foo " is typed
+    And "strong" is toggled
+    And "bar" is typed
+    And "strong" is toggled
+    And " baz" is typed
+    Then the editor state is "B: [em:foo ][em:[strong:bar]][em: baz|]"
+
+  Scenario: Toggling decorator mid-text and navigating left to clear it
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "strong" is toggled
+    And "{ArrowLeft}" is pressed
+    And "{ArrowRight}" is pressed
+    And "bar" is typed
+    Then the editor state is "B: foobar|"
+
+  Scenario: Deleting marked text and writing again, marked
+    Given the editor state is "B: "
+    When the editor is focused
+    And the caret is put after ""
+    And "strong" is toggled
+    And "foo" is typed
+    And "{Backspace}" is pressed 3 times
+    And "bar" is typed
+    Then the editor state is "B: [strong:bar]"
+
+  Scenario Outline: Deleting expanded selection ending in a decorator
+    Given the editor state is <text>
+    When the editor is focused
+    And "bar" is selected
+    And "strong" is toggled
+    And "foobar" is selected <direction>
+    And <button> is pressed
+    Then the editor state is <new text>
+    And the caret is before ""
+
+    Examples:
+      | text                      | direction   | button        | new text |
+      | "B: foo;;B: bar"          | "forwards"  | "{Backspace}" | "B: \|"  |
+      | "B: foo;;B: bar"          | "forwards"  | "{Delete}"    | "B: \|"  |
+      | "B: foo;;B: bar"          | "backwards" | "{Backspace}" | "B: \|"  |
+      | "B: foo;;B: bar"          | "backwards" | "{Delete}"    | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Backspace}" | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Delete}"    | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Backspace}" | "B: \|"  |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Delete}"    | "B: \|"  |
+
+  Scenario Outline: Deleting expanded selection starting in a decorator
+    Given the editor state is <text>
+    When the editor is focused
+    And "foo" is selected
+    And "strong" is toggled
+    And "foobar" is selected <direction>
+    And <button> is pressed
+    Then the editor state is <new text>
+    And the caret is before ""
+
+    Examples:
+      | text                      | direction   | button        | new text         |
+      | "B: foo;;B: bar"          | "forwards"  | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "forwards"  | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "backwards" | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;B: bar"          | "backwards" | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "forwards"  | "{Delete}"    | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Backspace}" | "B: [strong:\|]" |
+      | "B: foo;;{IMAGE};;B: bar" | "backwards" | "{Delete}"    | "B: [strong:\|]" |
+
+  Scenario: Deleting expanded selection with decorator toggled on
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put after "bar"
+    And "strong" is toggled
+    And "foobar" is selected
+    And "{Backspace}" is pressed
+    And "baz" is typed
+    Then the editor state is "B: baz|"
+
+  Scenario: Adding bold across an empty block and typing in the same
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed 2 times
+    And "bar" is typed
+    And "foobar" is selected
+    And "strong" is toggled
+    And the caret is put after "foo"
+    And "{ArrowRight}" is pressed
+    And "bar" is typed
+    Then the editor state is
+      """
+      B: [strong:foo]
+      B: [strong:bar]
+      B: [strong:bar]
+      """
+
+  Scenario: Toggling bold across an empty block
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed 2 times
+    And "bar" is typed
+    Then the editor state is "B: foo;;B: ;;B: bar|"
+    When "ooba" is selected
+    And "strong" is toggled
+    Then the editor state is
+      """
+      B: f[strong:^oo]
+      B: [strong:]
+      B: [strong:ba|]r
+      """
+    When "strong" is toggled
+    Then the editor state is "B: f^oo;;B: ;;B: ba|r"
+
+  Scenario Outline: Toggling bold on a cross-selection with the first line empty
+    Given the editor state is "B: ;;B: foo"
+    When everything is <selection>
+    And "strong" is toggled
+    Then the editor state is <toggled>
+    When "strong" is toggled
+    Then the editor state is <untoggled>
+
+    Examples:
+      | selection          | toggled                            | untoggled        |
+      | selected           | "B: [strong:^];;B: [strong:foo\|]" | "B: ^;;B: foo\|" |
+      | selected backwards | "B: [strong:\|];;B: [strong:foo^]" | "B: \|;;B: foo^" |
+
+  Scenario Outline: Toggling bold on a cross-selection with the last line empty
+    Given the editor state is "B: foo;;B: "
+    When everything is <selection>
+    And "strong" is toggled
+    Then the editor state is <toggled>
+    When "strong" is toggled
+    Then the editor state is <untoggled>
+
+    Examples:
+      | selection          | toggled                            | untoggled        |
+      | selected           | "B: [strong:^foo];;B: [strong:\|]" | "B: ^foo;;B: \|" |
+      | selected backwards | "B: [strong:\|foo];;B: [strong:^]" | "B: \|foo;;B: ^" |
+
+  Scenario: Splitting block before decorator
+    Given the editor state is "B: foo"
+    And "strong" around "foo"
+    When the editor is focused
+    And the caret is put before "foo"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: [strong:]
+      B: [strong:|foo]
+      """
+
+  Scenario Outline: Splitting block at the edge of decorator
+    Given the editor state is "B: foo bar baz"
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put <position>
+    And "{Enter}" is pressed
+    Then the editor state is <new text>
+    And the caret is <new position>
+
+    Examples:
+      | position      | new text                         | new position  |
+      | after "foo "  | "B: foo ;;B: [strong:\|bar] baz" | before "bar"  |
+      | before "bar"  | "B: foo ;;B: [strong:\|bar] baz" | before "bar"  |
+      | after "bar"   | "B: foo [strong:bar];;B: \| baz" | before " baz" |
+      | before " baz" | "B: foo [strong:bar];;B: \| baz" | before " baz" |
+
+  Scenario: Toggling decorators in empty block
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And "{Backspace}" is pressed 3 times
+    And "strong" is toggled
+    Then the editor state is "B: [strong:|]"
+
+  Scenario: Splitting empty decorated block
+    Given the editor state is "B: "
+    When the editor is focused
+    And the caret is put after ""
+    And "strong" is toggled
+    And "{Enter}" is pressed
+    And "foo" is typed
+    Then the editor state is
+      """
+      B: [strong:]
+      B: foo|
+      """
+
+  Scenario: Merging spans with same but different-ordered decorators
+    Given the editor state is "B: foobar"
+    And "strong" around "foo"
+    And "em" around "bar"
+    Then the editor state is "B: [strong:foo][em:bar|]"
+    When "foo" is selected
+    And "em" is toggled
+    And "bar" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [strong:[em:foo^bar|]]"
+
+  Scenario: Toggling decorator with leading block object and trailing empty text
+    Given the editor state is "{IMAGE};;B: foo;;B: "
+    When everything is selected
+    And "strong" is toggled
+    Then the editor state is
+      """
+      {IMAGE}
+      B: [strong:foo]
+      B: [strong:]
+      """
+    When "strong" is toggled
+    Then the editor state is "{IMAGE};;B: foo;;B: "

--- a/apps/pilcrow/tests/decorators.test.tsx
+++ b/apps/pilcrow/tests/decorators.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './decorators.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/delete.feature
+++ b/apps/pilcrow/tests/delete.feature
@@ -1,0 +1,208 @@
+Feature: Delete
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Deleting expanded selection
+    Given the editor state is <text>
+    When the editor is focused
+    And <selection> is selected
+    And "{Delete}" is pressed
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text                     | selection | new text           |
+      | "B: foo;;B: bar"         | "foo"     | "B: new\|;;B: bar" |
+      | "B: foo;;B: bar;;B: baz" | "foobar"  | "B: new\|;;B: baz" |
+
+  Scenario Outline: Deleting word
+    Given the editor state is <text>
+    When the editor is focused
+    And the caret is put <position>
+    And <shortcut> is pressed
+    Then the editor state is <final text>
+
+    Examples:
+      | text             | position        | shortcut              | final text       |
+      | "B: foo bar baz" | after "bar"     | "deleteWord.backward" | "B: foo \| baz"  |
+      | "B: foo bar baz" | after "bar "    | "deleteWord.backward" | "B: foo \|baz"   |
+      | "B: foo bar baz" | after "foo ba"  | "deleteWord.backward" | "B: foo \|r baz" |
+      | "B: foo bar baz" | before "bar"    | "deleteWord.forward"  | "B: foo \| baz"  |
+      | "B: foo bar baz" | before " bar"   | "deleteWord.forward"  | "B: foo\| baz"   |
+      | "B: foo bar baz" | before "ar baz" | "deleteWord.forward"  | "B: foo b\| baz" |
+
+  Scenario Outline: Deleting code points in complex scripts
+    Given the editor state is <text>
+    When the editor is focused
+    And the caret is put after <orig>
+    And "{Backspace}" is pressed
+    Then the editor state is <final text>
+
+    Examples:
+      # Hindi (Devanagari) - "कि" is क (ka) + ि (vowel i), two code points
+      | text    | orig | final text |
+      | "B: कि" | "कि" | "B: क\|"   |
+      # Bengali - "কি" is ক (ka) + ি (vowel i)
+      | "B: কি" | "কি" | "B: ক\|"   |
+      # Thai - "กิ" is ก (ko kai) + ิ (sara i)
+      | "B: กิ" | "กิ" | "B: ก\|"   |
+
+  Scenario Outline: Deleting line backward
+    Given the editor state is <text>
+    When the editor is focused
+    And the caret is put <position>
+    And "deleteLine.backward" is pressed
+    Then the editor state is <final text>
+    When undo is performed
+    Then the editor state is <undone>
+
+    Examples:
+      | text             | position     | final text     | undone             |
+      | "B: foo bar baz" | after "bar"  | "B: \| baz"    | "B: foo bar\| baz" |
+      | "B: foo bar baz" | after "baz"  | "B: \|"        | "B: foo bar baz\|" |
+      | "B: foo bar baz" | after "foo " | "B: \|bar baz" | "B: foo \|bar baz" |
+
+  Scenario: Deleting line backward at start of block merges blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "deleteLine.backward" is pressed
+    Then the editor state is "B: foo|bar"
+    When undo is performed
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
+
+  Scenario: Cutting selected text
+    Given the editor state is "B: foo bar baz"
+    When the editor is focused
+    And "bar" is selected
+    And cut is performed
+    Then the editor state is "B: foo | baz"
+    When undo is performed
+    Then the editor state is "B: foo ^bar| baz"
+
+  Scenario: Cutting across blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And "foobar" is selected
+    And cut is performed
+    Then the editor state is "B: |"
+    When undo is performed
+    Then the editor state is
+      """
+      B: ^foo
+      B: bar|
+      """
+
+  Scenario: Deleting word backward at block boundary merges blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "deleteWord.backward" is pressed
+    Then the editor state is "B: foo|bar"
+    When undo is performed
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
+
+  Scenario: Deleting word forward at block boundary merges blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put after "foo"
+    And "deleteWord.forward" is pressed
+    Then the editor state is "B: foo|bar"
+    When undo is performed
+    Then the editor state is
+      """
+      B: foo|
+      B: bar
+      """
+
+  Scenario: Cutting with collapsed selection is a no-op
+    Given the editor state is "B: foo bar baz"
+    When the editor is focused
+    And the caret is put after "bar"
+    And cut is performed
+    Then the editor state is "B: foo bar| baz"
+
+  Scenario: Deleting line backward in empty block
+    Given the editor state is "B: "
+    When the editor is focused
+    And "deleteLine.backward" is pressed
+    Then the editor state is "B: |"
+
+  Scenario: Deleting line backward only affects current block
+    Given the editor state is
+      """
+      B: foo
+      B: bar baz
+      """
+    When the editor is focused
+    And the caret is put after "bar"
+    And "deleteLine.backward" is pressed
+    Then the editor state is
+      """
+      B: foo
+      B: | baz
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      B: foo
+      B: bar| baz
+      """
+
+  Scenario Outline: Merging blocks preserves marks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    And "strong" around "bar"
+    When the editor is focused
+    And the caret is put <position>
+    And <button> is pressed
+    Then the editor state is <text>
+
+    Examples:
+      | position     | button        | text                   |
+      | before "bar" | "{Backspace}" | "B: foo[strong:\|bar]" |
+      | after "foo"  | "{Delete}"    | "B: foo\|[strong:bar]" |
+
+  Scenario Outline: Merging blocks triggers span normalization
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put <position>
+    And <button> is pressed
+    Then the editor state is "B: foo|bar"
+
+    Examples:
+      | position     | button        |
+      | before "bar" | "{Backspace}" |
+      | after "foo"  | "{Delete}"    |

--- a/apps/pilcrow/tests/delete.test.tsx
+++ b/apps/pilcrow/tests/delete.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './delete.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/inline-objects.feature
+++ b/apps/pilcrow/tests/inline-objects.feature
@@ -1,0 +1,50 @@
+# In-text objects like stock tickers
+Feature: Inline Objects
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Writing after inserting an inline object
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And a "stock-ticker" is inserted
+    And "{ArrowRight}" is pressed
+    And "bar" is typed
+    Then the editor state is "B: foo{stock-ticker}bar|"
+
+  Scenario: Pressing Delete before an inline object
+    Given the editor state is "B: foo{stock-ticker}"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Delete}" is pressed
+    Then the editor state is "B: foo|"
+
+  Scenario: Pressing Backspace after an inline object
+    Given the editor state is "B: foo{stock-ticker}"
+    When the editor is focused
+    And "{Backspace}" is pressed
+    Then the caret is after "foo"
+
+  Scenario: Adding a decorator across an inline object
+    Given the editor state is "B: foo{stock-ticker}bar"
+    When "foobar" is selected
+    And "strong" is toggled
+    Then the editor state is "B: [strong:^foo]{stock-ticker}[strong:bar|]"
+
+  Scenario: Adding an annotation across an inline object
+    Given the editor state is "B: foo{stock-ticker}bar"
+    When "foobar" is selected
+    And "link" "l1" is toggled
+    Then the editor state is
+      """
+      B: [@link _key="l1":^foo]{stock-ticker}[@link _key="l1":bar|]
+      """
+
+  Scenario: Removing an annotation across an inline block
+    Given the editor state is "B: foo{stock-ticker}bar"
+    When "foobar" is selected
+    And "link" is toggled
+    And "link" is toggled
+    Then the editor state is "B: ^foo{stock-ticker}bar|"

--- a/apps/pilcrow/tests/inline-objects.test.tsx
+++ b/apps/pilcrow/tests/inline-objects.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './inline-objects.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/insert.block.feature
+++ b/apps/pilcrow/tests/insert.block.feature
@@ -1,0 +1,455 @@
+Feature: Insert Block
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Inserting block object on an empty editor without selecting it
+    When "{image}" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+    And nothing is selected
+
+    Examples:
+      | placement | text           |
+      | "before"  | "{IMAGE};;B: " |
+      | "after"   | "B: ;;{IMAGE}" |
+      | "auto"    | "{IMAGE}"      |
+
+  Scenario Outline: Inserting block object on an empty editor and selecting it
+    When the editor is focused
+    And "{image}" is inserted at <placement> and selected at the <position>
+    And "bar" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | position | text              |
+      | "before"  | "start"  | "^{IMAGE}\|;;B: " |
+      | "after"   | "start"  | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "start"  | "^{IMAGE}\|"      |
+      | "before"  | "end"    | "^{IMAGE}\|;;B: " |
+      | "after"   | "end"    | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "end"    | "^{IMAGE}\|"      |
+
+  Scenario Outline: Inserting block object on an empty text block
+    Given the editor state is "B: f"
+    When the editor is focused
+    And "{Backspace}" is pressed
+    And "{image}" is inserted at <placement> and selected at the <position>
+    And "bar" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | position | text                |
+      | "before"  | "none"   | "{IMAGE};;B: bar\|" |
+      | "after"   | "none"   | "B: bar\|;;{IMAGE}" |
+      | "auto"    | "none"   | "^{IMAGE}\|"        |
+      | "before"  | "start"  | "^{IMAGE}\|;;B: "   |
+      | "after"   | "start"  | "B: ;;^{IMAGE}\|"   |
+      | "auto"    | "start"  | "^{IMAGE}\|"        |
+      | "before"  | "end"    | "^{IMAGE}\|;;B: "   |
+      | "after"   | "end"    | "B: ;;^{IMAGE}\|"   |
+      | "auto"    | "end"    | "^{IMAGE}\|"        |
+
+  Scenario Outline: Inserting block object on empty heading
+    When "h1:" is inserted at "auto" and selected at the "none"
+    When "{image}" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+
+    Examples:
+      | placement | text                        |
+      | "auto"    | "{IMAGE}"                   |
+      | "before"  | "{IMAGE};;B style=\"h1\": " |
+      | "after"   | "B style=\"h1\": ;;{IMAGE}" |
+
+  Scenario Outline: Inserting block object on empty list item
+    When ">-:" is inserted at "auto" and selected at the "none"
+    When "{image}" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+
+    Examples:
+      | placement | text                               |
+      | "auto"    | "{IMAGE}"                          |
+      | "before"  | "{IMAGE};;B listItem=\"bullet\": " |
+      | "after"   | "B listItem=\"bullet\": ;;{IMAGE}" |
+
+  Scenario Outline: Inserting and selecting block object on text selection
+    Given the editor state is "B: foo"
+    When <selection> is selected
+    And "{image}" is inserted at <placement> and selected at the <position>
+    Then the editor state is <text>
+    And "{image}" is selected
+
+    Examples:
+      | selection | placement | position | text                 |
+      | "foo"     | "auto"    | "start"  | "^{IMAGE}\|"         |
+      | "f"       | "auto"    | "start"  | "^{IMAGE}\|;;B: oo"  |
+      | "oo"      | "auto"    | "start"  | "B: f;;^{IMAGE}\|"   |
+      | "foo"     | "auto"    | "end"    | "^{IMAGE}\|"         |
+      | "f"       | "auto"    | "end"    | "^{IMAGE}\|;;B: oo"  |
+      | "oo"      | "auto"    | "end"    | "B: f;;^{IMAGE}\|"   |
+      | "foo"     | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "f"       | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "oo"      | "before"  | "start"  | "^{IMAGE}\|;;B: foo" |
+      | "foo"     | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "f"       | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "oo"      | "before"  | "end"    | "^{IMAGE}\|;;B: foo" |
+      | "foo"     | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "f"       | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "oo"      | "after"   | "start"  | "B: foo;;^{IMAGE}\|" |
+      | "foo"     | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
+      | "f"       | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
+      | "oo"      | "after"   | "end"    | "B: foo;;^{IMAGE}\|" |
+
+  Scenario Outline: Inserting block object on text selection without selecting it
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And <selection> is selected
+    And "{image}" is inserted at <placement> and selected at the "none"
+    And "bar" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | selection | placement | text                  |
+      | "f"       | "auto"    | "{IMAGE};;B: bar\|oo" |
+      | "oo"      | "auto"    | "B: fbar\|;;{IMAGE}"  |
+      | "foo"     | "auto"    | "^{IMAGE}\|"          |
+      | "f"       | "before"  | "{IMAGE};;B: bar\|oo" |
+      | "oo"      | "before"  | "{IMAGE};;B: fbar\|"  |
+      | "foo"     | "before"  | "{IMAGE};;B: bar\|"   |
+      | "f"       | "after"   | "B: bar\|oo;;{IMAGE}" |
+      | "oo"      | "after"   | "B: fbar\|;;{IMAGE}"  |
+      | "foo"     | "after"   | "B: bar\|;;{IMAGE}"   |
+
+  Scenario Outline: Inserting and selecting block object on cross-block selection
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And <selection> is selected
+    And "{image}" is inserted at <placement> and selected at the <position>
+    Then the editor state is <text>
+    And "{image}" is selected
+
+    Examples:
+      | selection | placement | position | text                         |
+      | "foob"    | "auto"    | "start"  | "^{IMAGE}\|;;B: ar"          |
+      | "obar"    | "auto"    | "start"  | "B: fo;;^{IMAGE}\|"          |
+      | "foob"    | "auto"    | "end"    | "^{IMAGE}\|;;B: ar"          |
+      | "foob"    | "before"  | "start"  | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "start"  | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "end"    | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "end"    | "^{IMAGE}\|;;B: foo;;B: bar" |
+      | "foob"    | "after"   | "start"  | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "obar"    | "after"   | "start"  | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "foob"    | "after"   | "end"    | "B: foo;;B: bar;;^{IMAGE}\|" |
+      | "obar"    | "after"   | "end"    | "B: foo;;B: bar;;^{IMAGE}\|" |
+
+  Scenario Outline: Inserting a block object on a cross-block selection without selecting it
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And <selection> is selected
+    And "{image}" is inserted at <placement> and selected at the "none"
+    And "baz" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | selection | placement | text                  |
+      | "foob"    | "auto"    | "{IMAGE};;B: baz\|ar" |
+      | "obar"    | "auto"    | "B: fobaz\|;;{IMAGE}" |
+      | "foobar"  | "auto"    | "^{IMAGE}\|"          |
+
+  Scenario Outline: Inserting text block on an empty editor
+    When "foo" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+    And nothing is selected
+
+    Examples:
+      | placement | text          |
+      | "before"  | "B: foo;;B: " |
+      | "after"   | "B: ;;B: foo" |
+      | "auto"    | "B: foo"      |
+
+  Scenario Outline: Inserting and selecting text block on an empty editor
+    When the editor is focused
+    When "foo" is inserted at <placement> and selected at the <position>
+    And "bar" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | position | text               |
+      | "before"  | "start"  | "B: bar\|foo;;B: " |
+      | "before"  | "end"    | "B: foobar\|;;B: " |
+      | "before"  | "none"   | "B: foo;;B: bar\|" |
+      | "after"   | "start"  | "B: ;;B: bar\|foo" |
+      | "after"   | "end"    | "B: ;;B: foobar\|" |
+      | "after"   | "none"   | "B: bar\|;;B: foo" |
+      | "auto"    | "start"  | "B: bar\|foo"      |
+      | "auto"    | "end"    | "B: foobar\|"      |
+      | "auto"    | "none"   | "B: bar\|foo"      |
+
+  Scenario Outline: Inserting and selecting text block on an empty selected editor
+    When the editor is focused
+    And "foo" is inserted at <placement> and selected at the <position>
+    And "bar" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | position | text               |
+      | "before"  | "start"  | "B: bar\|foo;;B: " |
+      | "before"  | "end"    | "B: foobar\|;;B: " |
+      | "before"  | "none"   | "B: foo;;B: bar\|" |
+      | "after"   | "start"  | "B: ;;B: bar\|foo" |
+      | "after"   | "end"    | "B: ;;B: foobar\|" |
+      | "after"   | "none"   | "B: bar\|;;B: foo" |
+      | "auto"    | "start"  | "B: bar\|foo"      |
+      | "auto"    | "end"    | "B: foobar\|"      |
+      | "auto"    | "none"   | "B: bar\|foo"      |
+
+  Scenario Outline: Inserting block object on block object
+    When "{image}" is inserted at "auto" and selected at the <block selection>
+    And "{break}" is inserted at <new block placement> and selected at the <new block selection>
+    Then the editor state is <text>
+    And <selection> is selected
+
+    Examples:
+      | block selection | new block placement | new block selection | text                  | selection |
+      | "start"         | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "start"         | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "start"         | "before"            | "none"              | "{BREAK};;^{IMAGE}\|" | "{image}" |
+      | "end"           | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "end"           | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "end"           | "before"            | "none"              | "{BREAK};;^{IMAGE}\|" | "{image}" |
+      | "none"          | "before"            | "start"             | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "none"          | "after"             | "start"             | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "auto"              | "start"             | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "before"            | "end"               | "^{BREAK}\|;;{IMAGE}" | "{break}" |
+      | "none"          | "after"             | "end"               | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "auto"              | "end"               | "{IMAGE};;^{BREAK}\|" | "{break}" |
+      | "none"          | "before"            | "none"              | "{BREAK};;{IMAGE}"    | nothing   |
+      | "none"          | "after"             | "none"              | "{IMAGE};;{BREAK}"    | nothing   |
+      | "none"          | "auto"              | "none"              | "{IMAGE};;{BREAK}"    | nothing   |
+
+  Scenario Outline: Inserting and selecting block object on block object
+    Given the editor state is "{IMAGE}"
+    When "{break}" is inserted at <placement> and selected at the <position>
+    Then <selection> is selected
+
+    Examples:
+      | placement | position | selection |
+      | "before"  | "start"  | "{break}" |
+      | "before"  | "end"    | "{break}" |
+      | "before"  | "none"   | "{image}" |
+      | "after"   | "start"  | "{break}" |
+      | "after"   | "end"    | "{break}" |
+      | "after"   | "none"   | "{image}" |
+      | "auto"    | "start"  | "{break}" |
+      | "auto"    | "end"    | "{break}" |
+      | "auto"    | "none"   | "{image}" |
+
+  Scenario Outline: Inserting block object on block objects
+    Given the editor state is
+      """
+      {IMAGE}
+      {IMAGE}
+      """
+    When the editor is focused
+    And everything is selected
+    And "{break}" is inserted at <placement> and selected at the <position>
+    And "{Enter}" is pressed
+    And "foo" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | position | text                                  |
+      | "before"  | "start"  | "{BREAK};;B: foo\|;;{IMAGE};;{IMAGE}" |
+      | "before"  | "end"    | "{BREAK};;B: foo\|;;{IMAGE};;{IMAGE}" |
+      | "before"  | "none"   | "{BREAK};;B: foo\|"                   |
+      | "after"   | "start"  | "{IMAGE};;{IMAGE};;{BREAK};;B: foo\|" |
+      | "after"   | "end"    | "{IMAGE};;{IMAGE};;{BREAK};;B: foo\|" |
+      | "after"   | "none"   | "B: foo\|;;{BREAK}"                   |
+
+  Scenario Outline: Inserting block object on text block
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And the caret is put <position>
+    And "{image}" is inserted at <placement> and selected at the "none"
+    And "baz" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | position     | placement | text                                |
+      | before "foo" | "before"  | "{IMAGE};;B: baz\|foo;;B: bar"      |
+      | after "f"    | "before"  | "{IMAGE};;B: fbaz\|oo;;B: bar"      |
+      | after "foo"  | "before"  | "{IMAGE};;B: foobaz\|;;B: bar"      |
+      | before "foo" | "after"   | "B: baz\|foo;;{IMAGE};;B: bar"      |
+      | after "f"    | "after"   | "B: fbaz\|oo;;{IMAGE};;B: bar"      |
+      | after "foo"  | "after"   | "B: foobaz\|;;{IMAGE};;B: bar"      |
+      | before "foo" | "auto"    | "{IMAGE};;B: baz\|foo;;B: bar"      |
+      | after "f"    | "auto"    | "B: fbaz\|;;{IMAGE};;B: oo;;B: bar" |
+      | after "foo"  | "auto"    | "B: foobaz\|;;{IMAGE};;B: bar"      |
+
+  Scenario Outline: Inserting text block on block object
+    When "{image}" is inserted at "auto" and selected at the "none"
+    When "foo" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+    And nothing is selected
+
+    Examples:
+      | placement | text              |
+      | "before"  | "B: foo;;{IMAGE}" |
+      | "after"   | "{IMAGE};;B: foo" |
+      | "auto"    | "{IMAGE};;B: foo" |
+
+  Scenario Outline: Inserting text block on text block
+    Given the editor state is "B: foo"
+    When the caret is put <position>
+    And "bar" is inserted at <placement> and selected at the "none"
+    Then the editor state is <text>
+    And the caret is <position>
+
+    Examples:
+      | position     | placement | text               |
+      | after "foo"  | "before"  | "B: bar;;B: foo\|" |
+      | after "foo"  | "after"   | "B: foo\|;;B: bar" |
+      | after "foo"  | "auto"    | "B: foo\|bar"      |
+      | before "foo" | "before"  | "B: bar;;B: \|foo" |
+      | before "foo" | "after"   | "B: \|foo;;B: bar" |
+      | before "foo" | "auto"    | "B: bar\|foo"      |
+      | after "f"    | "before"  | "B: bar;;B: f\|oo" |
+      | after "f"    | "after"   | "B: f\|oo;;B: bar" |
+      | after "f"    | "auto"    | "B: f\|baroo"      |
+
+  Scenario Outline: Inserting and selecting text block on text block
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And the caret is put <position>
+    And "bar" is inserted at <placement> and selected at the <select-position>
+    And "baz" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | position     | placement | select-position | text                  |
+      | after "foo"  | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | after "foo"  | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | after "foo"  | "before"  | "none"          | "B: bar;;B: foobaz\|" |
+      | after "foo"  | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | after "foo"  | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | after "foo"  | "after"   | "none"          | "B: foobaz\|;;B: bar" |
+      | after "foo"  | "auto"    | "start"         | "B: foobaz\|bar"      |
+      | after "foo"  | "auto"    | "end"           | "B: foobarbaz\|"      |
+      | after "foo"  | "auto"    | "none"          | "B: foobaz\|bar"      |
+      | before "foo" | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | before "foo" | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | before "foo" | "before"  | "none"          | "B: bar;;B: baz\|foo" |
+      | before "foo" | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | before "foo" | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | before "foo" | "after"   | "none"          | "B: baz\|foo;;B: bar" |
+      | before "foo" | "auto"    | "start"         | "B: baz\|barfoo"      |
+      | before "foo" | "auto"    | "end"           | "B: barbaz\|foo"      |
+      | before "foo" | "auto"    | "none"          | "B: barbaz\|foo"      |
+      | after "f"    | "before"  | "start"         | "B: baz\|bar;;B: foo" |
+      | after "f"    | "before"  | "end"           | "B: barbaz\|;;B: foo" |
+      | after "f"    | "before"  | "none"          | "B: bar;;B: fbaz\|oo" |
+      | after "f"    | "after"   | "start"         | "B: foo;;B: baz\|bar" |
+      | after "f"    | "after"   | "end"           | "B: foo;;B: barbaz\|" |
+      | after "f"    | "after"   | "none"          | "B: fbaz\|oo;;B: bar" |
+      | after "f"    | "auto"    | "start"         | "B: fbaz\|baroo"      |
+      | after "f"    | "auto"    | "end"           | "B: fbarbaz\|oo"      |
+      | after "f"    | "auto"    | "none"          | "B: fbaz\|baroo"      |
+
+  Scenario Outline: Inserting text block on text selection
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And <selection> is selected
+    And "bar" is inserted at <placement> and selected at the <position>
+    And "baz" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | selection | placement | position | text                  |
+      | "foo"     | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "f"       | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "oo"      | "before"  | "start"  | "B: baz\|bar;;B: foo" |
+      | "foo"     | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "f"       | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "oo"      | "before"  | "end"    | "B: barbaz\|;;B: foo" |
+      | "foo"     | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "f"       | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "oo"      | "after"   | "start"  | "B: foo;;B: baz\|bar" |
+      | "foo"     | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "f"       | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "oo"      | "after"   | "end"    | "B: foo;;B: barbaz\|" |
+      | "foo"     | "auto"    | "start"  | "B: baz\|bar"         |
+      | "f"       | "auto"    | "start"  | "B: baz\|baroo"       |
+      | "oo"      | "auto"    | "start"  | "B: fbaz\|bar"        |
+      | "foo"     | "auto"    | "end"    | "B: barbaz\|"         |
+      | "f"       | "auto"    | "end"    | "B: barbaz\|oo"       |
+      | "oo"      | "auto"    | "end"    | "B: fbarbaz\|"        |
+
+  Scenario Outline: Inserting text block on cross-block text selection
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And <selection> is selected
+    And "baz" is inserted at <placement> and selected at the <position>
+    And "new" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | selection | placement | position | text                          |
+      | "foob"    | "before"  | "start"  | "B: new\|baz;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "start"  | "B: new\|baz;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "end"    | "B: baznew\|;;B: foo;;B: bar" |
+      | "obar"    | "before"  | "end"    | "B: baznew\|;;B: foo;;B: bar" |
+      | "foob"    | "before"  | "none"   | "B: baz;;B: new\|ar"          |
+      | "obar"    | "before"  | "none"   | "B: baz;;B: fonew\|"          |
+      | "foob"    | "after"   | "start"  | "B: foo;;B: bar;;B: new\|baz" |
+      | "obar"    | "after"   | "start"  | "B: foo;;B: bar;;B: new\|baz" |
+      | "foob"    | "after"   | "end"    | "B: foo;;B: bar;;B: baznew\|" |
+      | "obar"    | "after"   | "end"    | "B: foo;;B: bar;;B: baznew\|" |
+      | "foob"    | "after"   | "none"   | "B: new\|ar;;B: baz"          |
+      # Fails on Firefox
+      # | "obar"    | "after"   | "none"   | "B: fonew;;B: baz"           |
+      | "foob"    | "auto"    | "start"  | "B: new\|bazar"               |
+      | "obar"    | "auto"    | "start"  | "B: fonew\|baz"               |
+      | "foob"    | "auto"    | "end"    | "B: baznew\|ar"               |
+      | "obar"    | "auto"    | "end"    | "B: fobaznew\|"               |
+      | "foob"    | "auto"    | "none"   | "B: new\|bazar"               |
+      | "obar"    | "auto"    | "none"   | "B: fonew\|baz"               |
+
+  Scenario Outline: Inserting inline object on block object
+    When "{image}" is inserted at "auto"
+    And ",{stock-ticker}," is inserted at <placement>
+    Then the editor state is <text>
+
+    Examples:
+      | placement | text                           |
+      | "before"  | "B: {stock-ticker}\|;;{IMAGE}" |
+      | "after"   | "{IMAGE};;B: {stock-ticker}\|" |
+      | "auto"    | "{IMAGE};;B: {stock-ticker}\|" |
+
+  Scenario Outline: Inserting block object on inline object
+    When ",{stock-ticker}," is inserted at "auto"
+    And "{image}" is inserted at <placement>
+    Then the editor state is <text>
+
+    Examples:
+      | placement | text                            |
+      | "before"  | "^{IMAGE}\|;;B: {stock-ticker}" |
+      | "after"   | "B: {stock-ticker};;^{IMAGE}\|" |
+      | "auto"    | "B: {stock-ticker};;^{IMAGE}\|" |
+
+  Scenario Outline: Inserting text block on inline object
+    When ",{stock-ticker}," is inserted at "auto"
+    And "foo" is inserted at <placement> and selected at the <select position>
+    Then the editor state is <text>
+
+    Examples:
+      | placement | select position | text                          |
+      | "before"  | "end"           | "B: foo\|;;B: {stock-ticker}" |
+      | "after"   | "start"         | "B: {stock-ticker};;B: \|foo" |
+      | "auto"    | "start"         | "B: {stock-ticker}\|foo"      |

--- a/apps/pilcrow/tests/insert.block.test.tsx
+++ b/apps/pilcrow/tests/insert.block.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './insert.block.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/insert.blocks.feature
+++ b/apps/pilcrow/tests/insert.blocks.feature
@@ -1,0 +1,138 @@
+Feature: Insert Blocks
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Inserting blocks on an empty editor
+    When the editor is focused
+    And "foo|bar" is inserted at <placement> and selected at the <selection>
+    And "baz" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | placement | selection | text                       |
+      | "before"  | "none"    | "B: foo;;B: bar;;B: baz\|" |
+      | "before"  | "start"   | "B: baz\|foo;;B: bar;;B: " |
+      | "before"  | "end"     | "B: foo;;B: barbaz\|;;B: " |
+      | "after"   | "none"    | "B: baz\|;;B: foo;;B: bar" |
+      | "after"   | "start"   | "B: ;;B: baz\|foo;;B: bar" |
+      | "after"   | "end"     | "B: ;;B: foo;;B: barbaz\|" |
+      | "auto"    | "none"    | "B: foo;;B: bar"           |
+      | "auto"    | "start"   | "B: baz\|foo;;B: bar"      |
+
+  Scenario Outline: Inserting block objects an empty editor
+    When "{image}" is inserted at <placement>
+    Then the editor state is <text>
+
+    Examples:
+      | placement | text              |
+      | "before"  | "^{IMAGE}\|;;B: " |
+      | "after"   | "B: ;;^{IMAGE}\|" |
+      | "auto"    | "^{IMAGE}\|"      |
+
+  Scenario Outline: Inserting blocks on a block object
+    When "{image}" is inserted at "auto" and selected at the "end"
+    And "foo|{break}|bar" is inserted at "auto"
+    Then the editor state is <text>
+
+    Examples:
+      | text                                 |
+      | "{IMAGE};;B: foo;;{BREAK};;B: bar\|" |
+
+  Scenario: Inserting text blocks on a block object
+    When "{image}" is inserted at "auto" and selected at the "end"
+    And "foo|bar" is inserted at "auto"
+    Then the editor state is
+      """
+      {IMAGE}
+      B: foo
+      B: bar|
+      """
+
+  Scenario Outline: Inserting blocks on a text block
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And the caret is put <position>
+    And "bar|{image}|baz" is inserted at <placement> and selected at the <select-position>
+    And "new" is typed
+    Then the editor state is <text>
+
+    Examples:
+      | position     | placement | select-position | text                                   |
+      | before "foo" | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | before "foo" | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | before "foo" | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | before "foo" | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | before "foo" | "auto"    | "start"         | "B: new\|bar;;{IMAGE};;B: bazfoo"      |
+      | before "foo" | "auto"    | "end"           | "B: bar;;{IMAGE};;B: baznew\|foo"      |
+      | after "f"    | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | after "f"    | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | after "f"    | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | after "f"    | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | after "f"    | "auto"    | "start"         | "B: fnew\|bar;;{IMAGE};;B: bazoo"      |
+      | after "f"    | "auto"    | "end"           | "B: fbar;;{IMAGE};;B: baznew\|oo"      |
+      | after "foo"  | "before"  | "start"         | "B: new\|bar;;{IMAGE};;B: baz;;B: foo" |
+      | after "foo"  | "before"  | "end"           | "B: bar;;{IMAGE};;B: baznew\|;;B: foo" |
+      | after "foo"  | "after"   | "start"         | "B: foo;;B: new\|bar;;{IMAGE};;B: baz" |
+      | after "foo"  | "after"   | "end"           | "B: foo;;B: bar;;{IMAGE};;B: baznew\|" |
+      | after "foo"  | "auto"    | "start"         | "B: foonew\|bar;;{IMAGE};;B: baz"      |
+      | after "foo"  | "auto"    | "end"           | "B: foobar;;{IMAGE};;B: baznew\|"      |
+
+  Scenario: Pasting text blocks between two text blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the caret is put after "foo"
+    And "fizz|buzz" is inserted at "auto"
+    Then the editor state is
+      """
+      B: foofizz
+      B: buzz|
+      B: bar
+      """
+
+  Scenario Outline: Inserting text block with annotation
+    Given the editor state is <text>
+    When <selection>
+    And blocks are inserted at "auto" and selected at the <select-position>
+      ```
+      [
+        {
+          "_type": "block",
+          "children": [
+            {
+              "_type": "span",
+              "text": "foo "
+            },
+            {
+              "_type": "span",
+              "text": "bar",
+              "marks": ["m0"]
+            },
+            {
+              "_type": "span",
+              "text": " baz"
+            }
+          ],
+          "markDefs": [
+            {
+              "_key": "m0",
+              "_type": "link",
+              "href": "https://example.com"
+            }
+          ]
+        }
+      ]
+      ```
+    Then the editor state is <new text>
+
+    Examples:
+      | text                   | selection                 | select-position | new text                          |
+      | "B: "                  | the caret is put after "" | "start"         | "B: \|foo [@link:bar] baz"        |
+      | "B: "                  | the caret is put after "" | "end"           | "B: foo [@link:bar] baz\|"        |
+      | "B: existing"          | "is" is selected          | "start"         | "B: ex\|foo [@link:bar] bazting"  |
+      | "B: existing"          | "is" is selected          | "end"           | "B: exfoo [@link:bar] baz\|ting"  |
+      | "B: existing;;B: text" | "ingte" is selected       | "start"         | "B: exist\|foo [@link:bar] bazxt" |
+      | "B: existing;;B: text" | "ingte" is selected       | "end"           | "B: existfoo [@link:bar] baz\|xt" |

--- a/apps/pilcrow/tests/insert.blocks.test.tsx
+++ b/apps/pilcrow/tests/insert.blocks.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './insert.blocks.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/insert.break.feature
+++ b/apps/pilcrow/tests/insert.break.feature
@@ -1,0 +1,90 @@
+Feature: Insert Break
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Breaking text block
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And the caret is put <position>
+    And "{Enter}" is pressed
+    And "bar" is inserted
+    Then the editor state is <text>
+    And the caret is <new position>
+
+    Examples:
+      | position     | text               | new position |
+      | before "foo" | "B: ;;B: bar\|foo" | before "foo" |
+      | after "foo"  | "B: foo;;B: bar\|" | after "bar"  |
+      | after "f"    | "B: f;;B: bar\|oo" | after "bar"  |
+
+  @skip
+  Scenario Outline: Breaking second text block
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put <position>
+    And "{Enter}" is pressed
+    And "baz" is inserted
+    Then the editor state is <text>
+    And the caret is <new position>
+    When undo is performed
+    And undo is performed
+    Then the editor state is <undone>
+
+    Examples:
+      | position     | text                       | new position | undone             |
+      | before "bar" | "B: foo;;B: ;;B: baz\|bar" | before "bar" | "B: foo;;B: \|bar" |
+      | after "bar"  | "B: foo;;B: bar;;B: baz\|" | after "baz"  | "B: foo;;B: bar\|" |
+      | after "b"    | "B: foo;;B: b;;B: baz\|ar" | after "baz"  | "B: foo;;B: b\|ar" |
+
+  Scenario: Breaking before inline object
+    Given the editor state is "B: foo{stock-ticker}bar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    And "baz" is inserted
+    Then the editor state is
+      """
+      B: foo
+      B: baz|{stock-ticker}bar
+      """
+
+  Scenario: Pressing Enter when selecting the entire content
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: bar
+      """
+    When the editor is focused
+    And everything is selected
+    And "{Enter}" is pressed
+    Then the editor state is "B: |"
+    When undo is performed
+    Then the editor state is
+      """
+      B: ^foo
+      {IMAGE}
+      B: bar|
+      """
+
+  Scenario: Pressing Enter on a block object
+    Given the editor state is
+      """
+      B: foo
+      {IMAGE}
+      """
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{ArrowRight}" is pressed
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: foo
+      {IMAGE}
+      B: |
+      """

--- a/apps/pilcrow/tests/insert.break.test.tsx
+++ b/apps/pilcrow/tests/insert.break.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './insert.break.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/insert.child.feature
+++ b/apps/pilcrow/tests/insert.child.feature
@@ -1,0 +1,77 @@
+Feature: Insert Child
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Inserting span on span
+    Given the editor state is <text>
+    When the caret is put <position>
+    When a child is inserted
+      ```
+      {
+        "_type": "span",
+        "text": "new"
+      }
+      ```
+    Then the editor state is <new text>
+
+    Examples:
+      | text     | position    | new text      |
+      | "B: "    | after ""    | "B: new\|"    |
+      | "B: foo" | after "foo" | "B: foonew\|" |
+
+  Scenario: Inserting inline object in span
+    Given the editor state is "B: foo bar baz"
+    When the caret is put after "foo"
+    And a child is inserted
+      ```
+      {
+        "_type": "stock-ticker",
+        "symbol": "AAPL"
+      }
+      ```
+    Then the editor state is "B: foo|{stock-ticker} bar baz"
+
+  Scenario: Inserting span on block object
+    Given the editor state is "{IMAGE}"
+    When the editor is focused
+    When a child is inserted
+      ```
+      {
+        "_type": "span",
+        "text": "new"
+      }
+      ```
+    Then the editor state is
+      """
+      {IMAGE}
+      B: new|
+      """
+
+  Scenario: Inserting span on block object without selection
+    When "{image}" is inserted at "auto" and selected at the "none"
+    Then nothing is selected
+    When a child is inserted
+      ```
+      {
+        "_type": "span",
+        "text": "new"
+      }
+      ```
+    Then the editor state is
+      """
+      {IMAGE}
+      B: new|
+      """
+
+  Scenario: Inserting span on text block without selection
+    When "foo" is inserted at "auto" and selected at the "none"
+    Then nothing is selected
+    When a child is inserted
+      ```
+      {
+        "_type": "span",
+        "text": "new"
+      }
+      ```
+    Then the editor state is "B: foonew|"

--- a/apps/pilcrow/tests/insert.child.test.tsx
+++ b/apps/pilcrow/tests/insert.child.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './insert.child.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/insert.text.feature
+++ b/apps/pilcrow/tests/insert.text.feature
@@ -1,0 +1,18 @@
+Feature: Insert text
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Inserting text on expanded selection
+    Given the editor state is <text>
+    When the editor is focused
+    And the selection is <selection>
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | text             | selection           | new text             |
+      | "B: foo;;B: bar" | "B: f^oo\|;;B: bar" | "B: fnew\|;;B: bar"  |
+      | "B: foo;;B: bar" | "B: foo;;B: ^b\|ar" | "B: foo;;B: new\|ar" |
+      | "B: foo;;B: bar" | "B: f^oo;;B: ba\|r" | "B: fnew\|r"         |
+      | "B: foo;;B: bar" | "B: ^foo;;B: bar\|" | "B: new\|"           |

--- a/apps/pilcrow/tests/insert.text.test.tsx
+++ b/apps/pilcrow/tests/insert.text.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './insert.text.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/lists.feature
+++ b/apps/pilcrow/tests/lists.feature
@@ -1,0 +1,296 @@
+Feature: Lists
+
+  Background:
+    Given one editor
+
+  Scenario: Clearing list item on Enter
+    Given the editor state is "B listItem=\"number\": foo;;B listItem=\"number\": "
+    When the editor is focused
+    And the caret is put after ""
+    And "{Enter}" is pressed
+    And "bar" is typed
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B: bar|
+      """
+
+  Scenario: Indenting list item on Tab
+    Given the editor state is "B listItem=\"number\": foo;;B listItem=\"number\": "
+    When the editor is focused
+    And the caret is put after ""
+    And "{Tab}" is pressed
+    And "bar" is typed
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar|
+      """
+
+  Scenario: Unindenting list item on Shift+Tab
+    Given the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B listItem="number": |bar
+      """
+
+  Scenario: Pressing Delete in an empty list item
+    Given the editor state is
+      """
+      B listItem="number": f
+      B style="h1": bar
+      """
+    When the editor is focused
+    And the caret is put before "f"
+    And "{Delete}" is pressed 2 times
+    Then the editor state is
+      """
+      B listItem="number" style="h1": |bar
+      """
+
+  Scenario: Pressing Backspace in an empty list item
+    Given the editor state is "B listItem=\"number\": "
+    When the editor is focused
+    And the caret is put after ""
+    And "{Backspace}" is pressed
+    Then the editor state is "B: |"
+
+  Scenario: Pressing Backspace in an empty list item after a block object
+    Given the editor state is "{IMAGE};;B listItem=\"number\": "
+    When the editor is focused
+    And the caret is put after ""
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      {IMAGE}
+      B: |
+      """
+
+  Scenario Outline: Pressing Backspace after an empty list item
+    When the editor is focused
+    Given the editor state is <text>
+    When the caret is put <caret position>
+    And "{Backspace}" is pressed
+    Then the editor state is <new text>
+
+    Examples:
+      | text                                                                              | caret position | new text                                                                           |
+      | "B listItem=\"number\": ;;B style=\"h1\": foo"                                    | before "foo"   | "B listItem=\"number\" style=\"h1\": \|foo"                                        |
+      | "B listItem=\"number\": foo;;B listItem=\"number\": ;;B listItem=\"number\": bar" | after "bar"    | "B listItem=\"number\": foo;;B listItem=\"number\": ;;B listItem=\"number\": ba\|" |
+
+  Scenario: Inserting indented numbered list in empty text block
+    Given the editor state is "B: "
+    When ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      B level=3 listItem="number": baz|
+      """
+
+  Scenario Outline: Inserting list on list item
+    Given the editor state is <text>
+    When the caret is put <position>
+    And <blocks> is inserted at "auto"
+    Then the editor state is <new text>
+
+    Examples:
+      | text                         | position    | blocks                    | new text                                                                                          |
+      | "B listItem=\"number\": "    | after ""    | ">#:foo\|>#:bar\|>#:baz"  | "B listItem=\"number\": foo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"            |
+      | "B listItem=\"number\": "    | after ""    | ">-:foo\|>-:bar\|>-:baz"  | "B listItem=\"bullet\": foo;;B listItem=\"bullet\": bar;;B listItem=\"bullet\": baz\|"            |
+      | "B listItem=\"number\": foo" | after "foo" | ">#:foo\|>#:bar\|>#:baz"  | "B listItem=\"number\": foofoo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"         |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>-:bar\|>-:baz"  | "B listItem=\"number\": foofoo;;B listItem=\"number\": bar;;B listItem=\"number\": baz\|"         |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>>#:bar\|>-:baz" | "B listItem=\"number\": foofoo;;B level=2 listItem=\"number\": bar;;B listItem=\"number\": baz\|" |
+      | "B listItem=\"number\": foo" | after "foo" | ">-:foo\|>>-:bar\|>-:baz" | "B listItem=\"number\": foofoo;;B level=2 listItem=\"bullet\": bar;;B listItem=\"number\": baz\|" |
+
+  Scenario Outline: Inserting lower-level list on list item
+    Given the editor state is "B level=2 listItem=\"number\": "
+    When the caret is put after ""
+    And ">#:foo|>#:bar|>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      B level=2 listItem="number": bar
+      B level=2 listItem="number": baz|
+      """
+
+  Scenario: Inserting different lower-level list type on list item
+    Given the editor state is "B level=2 listItem=\"number\": "
+    When the caret is put after ""
+    And ">-:foo|>-:bar|>-:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B level=2 listItem="bullet": bar
+      B level=2 listItem="bullet": baz|
+      """
+
+  Scenario: Inserting inverse-indented list on list item
+    Given the editor state is "B level=2 listItem=\"number\": "
+    When the caret is put after ""
+    And ">>-:foo|>-:bar|>>-:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B listItem="bullet": bar
+      B level=2 listItem="bullet": baz|
+      """
+
+  Scenario: Inserting lower-level inverse-indented list on list item
+    Given the editor state is "B level=3 listItem=\"number\": "
+    When the caret is put after ""
+    And ">>-:foo|>-:bar|>>-:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=3 listItem="bullet": foo
+      B level=2 listItem="bullet": bar
+      B level=3 listItem="bullet": baz|
+      """
+
+  Scenario: Inserting lower-level, indented list on list item
+    Given the editor state is "B level=2 listItem=\"number\": "
+    When the caret is put after ""
+    And ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      B level=3 listItem="number": bar
+      B level=4 listItem="number": baz|
+      """
+
+  Scenario: Inserting list that will exceed the maximum level (10)
+    Given the editor state is "B level=9 listItem=\"number\": "
+    When the caret is put after ""
+    And ">#:foo|>>#:bar|>>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=9 listItem="number": foo
+      B level=10 listItem="number": bar
+      B level=10 listItem="number": baz|
+      """
+
+  Scenario: Inserting list that exceeds the maximum level (10)
+    Given the editor state is "B level=9 listItem=\"number\": "
+    When the caret is put after ""
+    And ">>>>>>>>>>>#:foo|>>>>>>>>>>>>#:bar|>>>>>>>>>>>>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=9 listItem="number": foo
+      B level=10 listItem="number": bar
+      B level=10 listItem="number": baz|
+      """
+
+  Scenario: Inserting mixed blocks starting with a list item
+    Given the editor state is "B level=2 listItem=\"bullet\": "
+    When the caret is put after ""
+    And ">#:foo|{image}|>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="number": foo
+      {IMAGE}
+      B level=2 listItem="number": baz|
+      """
+
+  Scenario: Inserting mixed blocks not starting with a list item
+    Given the editor state is "B level=2 listItem=\"bullet\": "
+    When the caret is put after ""
+    And "foo|>#:bar|>>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B level=2 listItem="number": bar
+      B level=3 listItem="number": baz|
+      """
+
+  Scenario: Inserting mixed blocks not starting with list items
+    Given the editor state is "B level=2 listItem=\"bullet\": "
+    When the caret is put after ""
+    And "foo|bar|>#:baz" is inserted at "auto"
+    Then the editor state is
+      """
+      B level=2 listItem="bullet": foo
+      B: bar
+      B listItem="number": baz|
+      """
+
+  Scenario Outline: Inserting two lists preceded by a paragraph
+    Given the editor state is <text>
+    When the caret is put after ""
+    And <blocks> is inserted at "auto"
+    Then the editor state is <new text>
+
+    Examples:
+      | text                              | blocks                                | new text                                                                                                                                             |
+      | "B level=2 listItem=\"bullet\": " | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | "B level=2 listItem=\"bullet\": foo;;B level=2 listItem=\"bullet\": bar;;B level=3 listItem=\"bullet\": baz;;B: fizz;;B listItem=\"bullet\": buzz\|" |
+      | "B level=2 listItem=\"bullet\": " | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | "B level=2 listItem=\"bullet\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz;;B: fizz;;B listItem=\"number\": buzz\|" |
+      | "B level=2 listItem=\"number\": " | "foo\|>#:bar\|>>#:baz\|fizz\|>#:buzz" | "B level=2 listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz;;B: fizz;;B listItem=\"number\": buzz\|" |
+      | "B level=2 listItem=\"number\": " | "foo\|>-:bar\|>>-:baz\|fizz\|>-:buzz" | "B level=2 listItem=\"number\": foo;;B level=2 listItem=\"bullet\": bar;;B level=3 listItem=\"bullet\": baz;;B: fizz;;B listItem=\"bullet\": buzz\|" |
+
+  Scenario: Inserting heading on empty list item
+    Given the editor state is "B listItem=\"bullet\": "
+    When the caret is put after ""
+    And "h1:foo" is inserted at "auto"
+    Then the editor state is
+      """
+      B listItem="bullet" style="h1": foo|
+      """
+
+  Scenario: Inserting heading on non-empty list item
+    Given the editor state is
+      """
+      B listItem="bullet": foo
+      """
+    When the caret is put before "foo"
+    And "h1:bar" is inserted at "auto"
+    Then the editor state is
+      """
+      B listItem="bullet": bar|foo
+      """
+
+  Scenario: Inserting image on empty list item
+    Given the editor state is "B listItem=\"bullet\": "
+    When the caret is put after ""
+    And "{image}" is inserted at "auto"
+    Then the editor state is "^{IMAGE}|"
+
+  Scenario Outline: Deleting list
+    Given the editor state is <text>
+    When the editor is focused
+    And <selection> is selected
+    And "{Backspace}" is pressed
+    Then the editor state is <new text>
+
+    Examples:
+      | text                                                                                                 | selection   | new text                      |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "foobarbaz" | "B listItem=\"number\": \|"   |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "oobarbaz"  | "B listItem=\"number\": f\|"  |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "oobarba"   | "B listItem=\"number\": f\|z" |
+      | "B listItem=\"number\": foo;;B level=2 listItem=\"number\": bar;;B level=3 listItem=\"number\": baz" | "foobarba"  | "B listItem=\"number\": \|z"  |
+
+  Scenario: Undo after deleting list
+    Given the editor state is
+      """
+      B listItem="number": foo
+      B level=2 listItem="number": bar
+      """
+    When the editor is focused
+    And "fooba" is selected
+    And "{Backspace}" is pressed
+    Then the editor state is
+      """
+      B listItem="number": |r
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      B listItem="number": ^foo
+      B level=2 listItem="number": ba|r
+      """

--- a/apps/pilcrow/tests/lists.test.tsx
+++ b/apps/pilcrow/tests/lists.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './lists.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/merge-delete-nested.test.tsx
+++ b/apps/pilcrow/tests/merge-delete-nested.test.tsx
@@ -1,0 +1,165 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {userEvent} from 'vitest/browser'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Delete at the end of a list-item's last text block merges with the
+ * NEXT list-item. When the next item starts with a NESTED LIST instead
+ * of a text block, walk the nested list's first leading text block and
+ * merge that. Marks survive across the merge.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, locator}
+}
+
+describe('Delete-merge across list-items', () => {
+  test('Delete at end of last block merges nested list leading text block, marks preserved', async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [
+              {
+                _type: 'block',
+                _key: 'B1',
+                style: 'normal',
+                children: [
+                  {_type: 'span', _key: 'S1', text: 'first', marks: []},
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+          {
+            _type: 'list-item',
+            _key: 'I2',
+            content: [
+              {
+                _type: 'list',
+                _key: 'L2',
+                kind: 'bullet',
+                items: [
+                  {
+                    _type: 'list-item',
+                    _key: 'I2A',
+                    content: [
+                      {
+                        _type: 'block',
+                        _key: 'B2A',
+                        style: 'normal',
+                        children: [
+                          {
+                            _type: 'span',
+                            _key: 'S2A',
+                            text: 'nested ',
+                            marks: [],
+                          },
+                          {
+                            _type: 'span',
+                            _key: 'S2B',
+                            text: 'bold',
+                            marks: ['strong'],
+                          },
+                        ],
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, locator} = await mount(initial)
+    await locator.element().focus()
+    // Caret at end of B1 (offset 5 = end of "first")
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 5,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 5,
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 100))
+    await userEvent.keyboard('{Delete}')
+    await new Promise((r) => setTimeout(r, 200))
+    const value = editor.getSnapshot().context.value
+    const list = value[0] as unknown as {
+      items: Array<{
+        content: Array<{
+          children?: Array<{text: string; marks?: Array<string>}>
+        }>
+      }>
+    }
+    // After merge: the nested list-item's content should be folded into
+    // B1, and the I2 list-item should be removed. So one list-item left.
+    expect(list.items).toHaveLength(1)
+    const mergedBlock = list.items[0].content[0]
+    const texts = (mergedBlock.children ?? []).map((c) => c.text).join('')
+    expect(texts).toBe('firstnested bold')
+    // The bold span keeps its mark
+    const boldSpan = (mergedBlock.children ?? []).find((c) =>
+      c.marks?.includes('strong'),
+    )
+    expect(boldSpan?.text).toBe('bold')
+  })
+})

--- a/apps/pilcrow/tests/merge-marks.test.tsx
+++ b/apps/pilcrow/tests/merge-marks.test.tsx
@@ -1,0 +1,138 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {userEvent} from 'vitest/browser'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Backspace at the start of a list-item merges its content into the
+ * previous item's last text block. The merged content keeps its marks
+ * (decorators) - flatten-to-string was the wrong shape.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, locator}
+}
+
+describe('Backspace merge preserves marks', () => {
+  test('Backspace at start of second list-item with bold/italic merges marks intact', async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [
+              {
+                _type: 'block',
+                _key: 'B1',
+                style: 'normal',
+                children: [{_type: 'span', _key: 'S1', text: 'one', marks: []}],
+                markDefs: [],
+              },
+            ],
+          },
+          {
+            _type: 'list-item',
+            _key: 'I2',
+            content: [
+              {
+                _type: 'block',
+                _key: 'B2',
+                style: 'normal',
+                children: [
+                  {_type: 'span', _key: 'S2a', text: 'plain ', marks: []},
+                  {_type: 'span', _key: 'S2b', text: 'bold', marks: ['strong']},
+                  {_type: 'span', _key: 'S2c', text: ' end', marks: []},
+                ],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, locator} = await mount(initial)
+    await locator.element().focus()
+    // Caret at start of B2 (= start of "plain ")
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I2'},
+            'content',
+            {_key: 'B2'},
+            'children',
+            {_key: 'S2a'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I2'},
+            'content',
+            {_key: 'B2'},
+            'children',
+            {_key: 'S2a'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 100))
+    await userEvent.keyboard('{Backspace}')
+    await new Promise((r) => setTimeout(r, 200))
+    const value = editor.getSnapshot().context.value
+    const list = value[0] as unknown as {
+      items: Array<{
+        content: Array<{children: Array<{text: string; marks: Array<string>}>}>
+      }>
+    }
+    // After merge: one list-item left, with the merged text block having all spans
+    expect(list.items).toHaveLength(1)
+    const mergedBlock = list.items[0].content[0]
+    // Spans should be: "one", "plain ", "bold"(strong), " end" or similar
+    const texts = mergedBlock.children.map((c) => c.text).join('')
+    expect(texts).toBe('oneplain bold end')
+    // The bold span must have its 'strong' mark intact
+    const boldSpan = mergedBlock.children.find((c) =>
+      c.marks?.includes('strong'),
+    )
+    expect(boldSpan?.text).toBe('bold')
+  })
+})

--- a/apps/pilcrow/tests/paste.feature
+++ b/apps/pilcrow/tests/paste.feature
@@ -1,0 +1,46 @@
+Feature: Paste
+
+  Background:
+    Given one editor
+
+  Scenario Outline: Pasting text block into a text block
+    Given the editor state is "B: foo bar buz"
+    And "strong" around "bar"
+    When <selection>
+    And x-portable-text is pasted
+      ```
+      [
+        {
+          "_type": "block",
+          "children": [
+            {"_type": "span", "text": "foo "},
+            {"_type": "span", "text": "bar", "marks": ["strong"]},
+            {"_type": "span", "text": " buz"}
+          ]
+        }
+      ]
+      ```
+    Then the editor state is <text>
+
+    Examples:
+      | selection                     | text                                                     |
+      | the caret is put after "buz"  | "B: foo [strong:bar] buzfoo [strong:bar] buz\|"          |
+      | the caret is put before "foo" | "B: foo [strong:bar] buz\|foo [strong:bar] buz"          |
+      | the caret is put after "ba"   | "B: foo [strong:ba]foo [strong:bar] buz[strong:\|r] buz" |
+      | "foo bar buz" is selected     | "B: foo [strong:bar] buz\|"                              |
+
+  Scenario: Pasting text/plain into a text block
+    Given the editor state is "B: foo bar buz"
+    And "strong" around "bar"
+    When the caret is put after "ba"
+    And data is pasted
+      | text/plain | new |
+    Then the editor state is "B: foo [strong:banew|r] buz"
+
+  Scenario: Pasting text/html into a text block
+    Given the editor state is "B: foo bar buz"
+    And "strong" around "bar"
+    When the caret is put after "ba"
+    And data is pasted
+      | text/html | <p>new</p> |
+    Then the editor state is "B: foo [strong:ba]new[strong:|r] buz"

--- a/apps/pilcrow/tests/paste.test.tsx
+++ b/apps/pilcrow/tests/paste.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './paste.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/removing-blocks.feature
+++ b/apps/pilcrow/tests/removing-blocks.feature
@@ -1,0 +1,47 @@
+Feature: Removing Blocks
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Pressing Delete in empty block with text below
+    Given the editor state is
+      """
+      B _key="b1": foo
+      B _key="b2": bar
+      B _key="b3": baz
+      """
+    When the editor is focused
+    And the selection is
+      """
+      B: foo
+      B: |bar
+      B: baz
+      """
+    And "{Delete}" is pressed 4 times
+    Then the editor state is
+      """
+      B _key="b1": foo
+      B _key="b3": |baz
+      """
+
+  Scenario: Pressing Backspace in empty block with text below
+    Given the editor state is
+      """
+      B _key="b1": foo
+      B _key="b2": bar
+      B _key="b3": baz
+      """
+    When the editor is focused
+    And the selection is
+      """
+      B: foo
+      B: bar|
+      B: baz
+      """
+    And "{Backspace}" is pressed 4 times
+    Then the editor state is
+      """
+      B _key="b1": foo|
+      B _key="b3": baz
+      """

--- a/apps/pilcrow/tests/removing-blocks.test.tsx
+++ b/apps/pilcrow/tests/removing-blocks.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './removing-blocks.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/selection-adjustment.feature
+++ b/apps/pilcrow/tests/selection-adjustment.feature
@@ -1,0 +1,34 @@
+Feature: Selection Adjustment
+
+  Background:
+    Given two editors
+    And a global keymap
+
+  Scenario: Selection is kept if another editor inserts a line above
+    Given the text "foo"
+    When the caret is put after "foo"
+    And Editor B is focused
+    And the caret is put before "foo" in Editor B
+    And "{Enter}" is pressed in Editor B
+    Then the text is "|foo"
+    And the caret is after "foo"
+
+  Scenario: Selection is kept if another editor deletes the line above
+    Given the text "foo|bar"
+    When the caret is put after "bar"
+    And Editor B is focused
+    And the caret is put before "foo" in Editor B
+    And "{Delete}" is pressed 4 times in Editor B
+    Then the text is "bar"
+    And the caret is after "bar"
+
+  Scenario: Selection is kept if another editor backspace-deletes empty lines above
+    Given the text "foo|bar"
+    When the caret is put after "bar"
+    And Editor B is focused
+    And the caret is put before "foo" in Editor B
+    And "{Enter}" is pressed in Editor B
+    And the caret is put after "foo" in Editor B
+    And "{Backspace}" is pressed 4 times in Editor B
+    Then the text is "|bar"
+    And the caret is after "bar"

--- a/apps/pilcrow/tests/selection-adjustment.test.tsx
+++ b/apps/pilcrow/tests/selection-adjustment.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './selection-adjustment.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/selection.feature
+++ b/apps/pilcrow/tests/selection.feature
@@ -1,0 +1,56 @@
+Feature: Selection
+
+  Background:
+    Given one editor
+
+  Scenario: Expanding collapsed selection backwards from empty line
+    Given the editor state is "B: foo;;B: "
+    When the editor is focused
+    And the caret is put before ""
+    And "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    And "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    Then "o|" is selected
+
+  Scenario: Expanding selection backwards, then forwards
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    And "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    Then "o|" is selected
+    When "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    Then "b" is selected
+
+  Scenario: Reducing hanging selection
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "foo"
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    Then "foo|" is selected
+    When "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    Then "foo" is selected
+
+  Scenario: Reducing selection hanging onto empty line
+    Given the editor state is "B: foo;;B: "
+    When the editor is focused
+    And the caret is put before "foo"
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    And "{Shift>}{ArrowRight}{/Shift}" is pressed
+    Then "foo|" is selected
+    When "{Shift>}{ArrowLeft}{/Shift}" is pressed
+    Then "foo" is selected

--- a/apps/pilcrow/tests/selection.test.tsx
+++ b/apps/pilcrow/tests/selection.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './selection.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/splitting-blocks.feature
+++ b/apps/pilcrow/tests/splitting-blocks.feature
@@ -1,0 +1,236 @@
+Feature: Splitting Blocks
+
+  Background:
+    Given one editor
+    And a global keymap
+
+  Scenario: Splitting block at the beginning
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: |foo"
+    And "{Enter}" is pressed
+    Then the editor state is "B: ;;B _key=\"b1\": |foo"
+
+  Scenario: Splitting block in the middle
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: fo|o"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B _key="b1": fo
+      B: |o
+      """
+
+  Scenario: Splitting block at the end
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: foo|"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B _key="b1": foo
+      B: |
+      """
+
+  Scenario: Splitting empty block creates a new block below
+    Given the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": "
+    When the editor is focused
+    And the selection is
+      """
+      B: foo
+      B: |
+      """
+    And "{Enter}" is pressed
+    And "baz" is typed
+    Then the editor state is "B _key=\"b1\": foo;;B _key=\"b2\": ;;B: baz|"
+
+  Scenario: Soft-splitting block at the beginning
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: |foo"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B _key=\"b1\": \n|foo"
+
+  Scenario: Soft-splitting block in the middle
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: fo|o"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B _key=\"b1\": fo\n|o"
+
+  Scenario: Soft-splitting block at the end
+    Given the editor state is
+      """
+      B _key="b1": foo
+      """
+    When the editor is focused
+    And the selection is "B: foo|"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B _key=\"b1\": foo\n|"
+
+  Scenario: Splitting styled block at the beginning
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": |foo"
+    And "{Enter}" is pressed
+    Then the editor state is "B: ;;B style=\"h1\": |foo"
+
+  Scenario: Splitting styled block in the middle
+    Given the editor state is
+      """
+      B _key="b1" style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": fo|o"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B _key="b1" style="h1": fo
+      B style="h1": |o
+      """
+
+  Scenario: Splitting styled block at the end
+    Given the editor state is
+      """
+      B _key="b1" style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": foo|"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B _key="b1" style="h1": foo
+      B: |
+      """
+
+  Scenario: Soft-splitting styled block at the beginning
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": |foo"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B style=\"h1\": \n|foo"
+
+  Scenario: Soft-splitting styled block in the middle
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": fo|o"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B style=\"h1\": fo\n|o"
+
+  Scenario: Soft-splitting styled block at the end
+    Given the editor state is
+      """
+      B style="h1": foo
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": foo|"
+    And "{Shift>}{Enter}{/Shift}" is pressed
+    Then the editor state is "B style=\"h1\": foo\n|"
+
+  Scenario: Splitting decorated styled block at the beginning
+    Given the editor state is
+      """
+      B style="h1": [strong:foo] bar baz
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": |[strong:foo] bar baz"
+    And "{Enter}" is pressed
+    And "new" is typed
+    Then the editor state is
+      """
+      B: [strong:]
+      B style="h1": [strong:new|foo] bar baz
+      """
+
+  Scenario Outline: Splitting decorated styled block in the middle
+    Given the editor state is <initial>
+    When the editor is focused
+    And the selection is <selection>
+    And "{Enter}" is pressed
+    And "new" is typed
+    Then the editor state is <new text>
+
+    Examples:
+      | initial                                | selection                                | new text                                                      |
+      | "B style=\"h1\": [strong:foo] bar baz" | "B style=\"h1\": [strong:foo\|] bar baz" | "B style=\"h1\": [strong:foo];;B style=\"h1\": new\| bar baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo \|[strong:bar] baz" | "B style=\"h1\": foo ;;B style=\"h1\": [strong:new\|bar] baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:\|bar] baz" | "B style=\"h1\": foo ;;B style=\"h1\": [strong:new\|bar] baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:bar\|] baz" | "B style=\"h1\": foo [strong:bar];;B style=\"h1\": new\| baz" |
+      | "B style=\"h1\": foo [strong:bar] baz" | "B style=\"h1\": foo [strong:bar]\| baz" | "B style=\"h1\": foo [strong:bar];;B style=\"h1\": new\| baz" |
+      | "B style=\"h1\": foo bar [strong:baz]" | "B style=\"h1\": foo bar [strong:\|baz]" | "B style=\"h1\": foo bar ;;B style=\"h1\": [strong:new\|baz]" |
+      | "B style=\"h1\": foo bar [strong:baz]" | "B style=\"h1\": foo bar \|[strong:baz]" | "B style=\"h1\": foo bar ;;B style=\"h1\": [strong:new\|baz]" |
+
+  Scenario: Splitting decorated styled block at the end
+    Given the editor state is
+      """
+      B style="h1": foo bar [strong:baz]
+      """
+    When the editor is focused
+    And the selection is "B style=\"h1\": foo bar [strong:baz|]"
+    And "{Enter}" is pressed
+    And "new" is typed
+    Then the editor state is
+      """
+      B style="h1": foo bar [strong:baz]
+      B: new|
+      """
+
+  Scenario Outline: Splitting block with an expanded selection
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And <selection> is selected
+    And "{Enter}" is pressed
+    Then the editor state is <new text>
+
+    Examples:
+      | selection | new text       |
+      | "foobar"  | "B: \|"        |
+      | "ooba"    | "B: f;;B: \|r" |
+
+  Scenario: Pressing Enter when selecting multiple block objects
+    Given blocks "auto"
+      ```
+      [
+        {
+          "_key": "i0",
+          "_type": "image"
+        },
+        {
+          "_key": "i1",
+          "_type": "image"
+        }
+      ]
+      ```
+    When the editor is focused
+    And everything is selected
+    And "{Enter}" is pressed
+    Then the editor state is "B: |"

--- a/apps/pilcrow/tests/splitting-blocks.test.tsx
+++ b/apps/pilcrow/tests/splitting-blocks.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import featureRaw from './splitting-blocks.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/structured-lists.feature
+++ b/apps/pilcrow/tests/structured-lists.feature
@@ -1,0 +1,333 @@
+Feature: Structured Lists Plugin
+  A plugin that represents lists as containers (a `list` block-object whose
+  `items` field holds `list-item` objects whose `content` field holds text
+  blocks and nested lists), preserving the user-facing keyboard semantics of
+  the core flat-list behaviors.
+
+  The same primitives drive the keyboard shortcuts:
+  Tab        sinks the focus list-item one level deeper
+  Shift+Tab  lifts the focus list-item one level out
+
+  Scenario: Pressing Tab sinks a list-item into the preceding sibling
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+        LIST-ITEM:
+          B: second
+      """
+    When the editor is focused
+    And the caret is put before "second"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: |second
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+        LIST-ITEM:
+          B: |second
+      """
+
+  Scenario: Pressing Tab on the first list-item wraps it in an empty parent list-item
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: only
+      """
+    When the editor is focused
+    And the caret is put before "only"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: |only
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |only
+      """
+
+  Scenario: Pressing Tab merges into a trailing list (kind-agnostic)
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+        LIST-ITEM:
+          B: second
+      """
+    When the editor is focused
+    And the caret is put before "second"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+            LIST-ITEM:
+              B: |second
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: first
+          LIST:
+            LIST-ITEM:
+              B: first.a
+        LIST-ITEM:
+          B: |second
+      """
+
+  Scenario: Pressing Shift+Tab lifts a nested list-item to be a sibling of its enclosing list-item
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+          LIST:
+            LIST-ITEM:
+              B: inner
+      """
+    When the editor is focused
+    And the caret is put before "inner"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+        LIST-ITEM:
+          B: |inner
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: outer
+          LIST:
+            LIST-ITEM:
+              B: |inner
+      """
+
+  Scenario: Pressing Shift+Tab from a middle nested item leaves leading siblings, carries trailing siblings as nested children
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+            LIST-ITEM:
+              B: middle
+            LIST-ITEM:
+              B: c
+      """
+    When the editor is focused
+    And the caret is put before "middle"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+        LIST-ITEM:
+          B: |middle
+          LIST:
+            LIST-ITEM:
+              B: c
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: a
+            LIST-ITEM:
+              B: |middle
+            LIST-ITEM:
+              B: c
+      """
+
+  Scenario: Pressing Shift+Tab on the only item under an empty wrapper list-item removes the wrapper too
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: only
+      """
+    When the editor is focused
+    And the caret is put before "only"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |only
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          LIST:
+            LIST-ITEM:
+              B: |only
+      """
+
+  Scenario: Pressing Shift+Tab on the first nested item removes the (now-empty) original nested list
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: only-nested
+      """
+    When the editor is focused
+    And the caret is put before "only-nested"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+        LIST-ITEM:
+          B: |only-nested
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: |only-nested
+      """
+
+  Scenario: Pressing Shift+Tab at the outermost list is a no-op
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: alpha
+        LIST-ITEM:
+          B: beta
+      """
+    When the editor is focused
+    And the caret is put before "alpha"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: |alpha
+        LIST-ITEM:
+          B: beta
+      """
+
+  Scenario: Sinking a list-item preserves an image in the preceding sibling
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+        LIST-ITEM:
+          B: next
+      """
+    When the editor is focused
+    And the caret is put before "next"
+    And "{Tab}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+          LIST:
+            LIST-ITEM:
+              B: |next
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: caption
+          {IMAGE src="cat.png"}
+        LIST-ITEM:
+          B: |next
+      """
+
+  Scenario: Lifting a list-item carries the rest of its content (text + image) along
+    Given the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: mixed
+              {IMAGE src="graph.png"}
+      """
+    When the editor is focused
+    And the caret is put before "mixed"
+    And "{Shift>}{Tab}{/Shift}" is pressed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+        LIST-ITEM:
+          B: |mixed
+          {IMAGE src="graph.png"}
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      LIST:
+        LIST-ITEM:
+          B: parent
+          LIST:
+            LIST-ITEM:
+              B: |mixed
+              {IMAGE src="graph.png"}
+      """

--- a/apps/pilcrow/tests/structured-lists.test.tsx
+++ b/apps/pilcrow/tests/structured-lists.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import structuredListsFeature from './structured-lists.feature?raw'
+import {createPilcrowTestEditor} from './test-editor'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: structuredListsFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tests/table-operations.test.tsx
+++ b/apps/pilcrow/tests/table-operations.test.tsx
@@ -1,0 +1,195 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Slash-menu and contextual actions for tables: add/remove row,
+ * add/remove column. Each emits a custom behavior event the tables
+ * plugin handles.
+ */
+
+async function mount(initialValue: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, locator}
+}
+
+function cell(_key: string, blockKey: string, spanKey: string, text: string) {
+  return {
+    _type: 'cell',
+    _key,
+    content: [
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal' as const,
+        children: [{_type: 'span', _key: spanKey, text, marks: []}],
+        markDefs: [],
+      },
+    ],
+  }
+}
+
+function tableValue(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'table',
+      _key: 'T1',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'R1',
+          cells: [
+            cell('C1A', 'B1A', 'S1A', 'a'),
+            cell('C1B', 'B1B', 'S1B', 'b'),
+          ],
+        },
+        {
+          _type: 'row',
+          _key: 'R2',
+          cells: [
+            cell('C2A', 'B2A', 'S2A', 'c'),
+            cell('C2B', 'B2B', 'S2B', 'd'),
+          ],
+        },
+      ],
+    },
+  ] as Array<PortableTextBlock>
+}
+
+function focusCell(
+  editor: Editor,
+  cellKey: string,
+  blockKey: string,
+  spanKey: string,
+) {
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {
+        path: [
+          {_key: 'T1'},
+          'rows',
+          {_key: 'R1'},
+          'cells',
+          {_key: cellKey},
+          'content',
+          {_key: blockKey},
+          'children',
+          {_key: spanKey},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'T1'},
+          'rows',
+          {_key: 'R1'},
+          'cells',
+          {_key: cellKey},
+          'content',
+          {_key: blockKey},
+          'children',
+          {_key: spanKey},
+        ],
+        offset: 0,
+      },
+    },
+  })
+}
+
+describe('table row/column operations', () => {
+  test('add-row inserts a new row after the focus row', async () => {
+    const {editor} = await mount(tableValue())
+    focusCell(editor, 'C1A', 'B1A', 'S1A')
+    await new Promise((r) => setTimeout(r, 50))
+    editor.send({type: 'custom.tables.add-row'} as never)
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value[0] as unknown as {
+        rows: Array<{_key: string; cells: Array<unknown>}>
+      }
+      expect(table.rows).toHaveLength(3)
+      expect(table.rows[0]._key).toBe('R1')
+      expect(table.rows[1]._key).not.toBe('R2') // new row inserted between
+      expect(table.rows[2]._key).toBe('R2')
+      // New row has same column count as existing rows
+      expect(table.rows[1].cells).toHaveLength(2)
+    })
+  })
+
+  test('remove-row removes the focus row', async () => {
+    const {editor} = await mount(tableValue())
+    focusCell(editor, 'C1A', 'B1A', 'S1A')
+    await new Promise((r) => setTimeout(r, 50))
+    editor.send({type: 'custom.tables.remove-row'} as never)
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value[0] as unknown as {
+        rows: Array<{_key: string}>
+      }
+      expect(table.rows).toHaveLength(1)
+      expect(table.rows[0]._key).toBe('R2')
+    })
+  })
+
+  test('add-column inserts a new cell at focus column index + 1 in every row', async () => {
+    const {editor} = await mount(tableValue())
+    focusCell(editor, 'C1A', 'B1A', 'S1A') // column index 0
+    await new Promise((r) => setTimeout(r, 50))
+    editor.send({type: 'custom.tables.add-column'} as never)
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value[0] as unknown as {
+        rows: Array<{cells: Array<{_key: string}>}>
+      }
+      expect(table.rows[0].cells).toHaveLength(3)
+      expect(table.rows[1].cells).toHaveLength(3)
+      // Original cells stay
+      expect(table.rows[0].cells[0]._key).toBe('C1A')
+      expect(table.rows[0].cells[2]._key).toBe('C1B')
+      expect(table.rows[1].cells[0]._key).toBe('C2A')
+      expect(table.rows[1].cells[2]._key).toBe('C2B')
+    })
+  })
+
+  test('remove-column removes the focus column from every row', async () => {
+    const {editor} = await mount(tableValue())
+    focusCell(editor, 'C1A', 'B1A', 'S1A') // column index 0
+    await new Promise((r) => setTimeout(r, 50))
+    editor.send({type: 'custom.tables.remove-column'} as never)
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value[0] as unknown as {
+        rows: Array<{cells: Array<{_key: string}>}>
+      }
+      expect(table.rows[0].cells).toHaveLength(1)
+      expect(table.rows[1].cells).toHaveLength(1)
+      expect(table.rows[0].cells[0]._key).toBe('C1B')
+      expect(table.rows[1].cells[0]._key).toBe('C2B')
+    })
+  })
+})

--- a/apps/pilcrow/tests/task-list-wrapper-checkbox.test.tsx
+++ b/apps/pilcrow/tests/task-list-wrapper-checkbox.test.tsx
@@ -1,0 +1,125 @@
+import {expect, test, vi} from 'vitest'
+import {createPilcrowTestEditor} from './test-editor'
+
+/**
+ * Sinking the first item of a task list wraps it in a structural
+ * list-item whose only `content` is a nested list. That wrapper
+ * has no task text of its own, so it should NOT render a checkbox -
+ * otherwise the user sees a phantom checkbox sitting above the
+ * real task, toggling a `checked` field on a wrapper node they
+ * never see in the document outline.
+ */
+test('a list-item that holds only a nested list renders without a checkbox', async () => {
+  const initialValue = [
+    {
+      _type: 'list',
+      _key: 'l1',
+      kind: 'task',
+      items: [
+        {
+          _type: 'list-item',
+          _key: 'wrapper',
+          // No `checked` field, no text block - structural wrapper produced
+          // by sinking the first item.
+          content: [
+            {
+              _type: 'list',
+              _key: 'l2',
+              kind: 'task',
+              items: [
+                {
+                  _type: 'list-item',
+                  _key: 'real',
+                  checked: false,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 's1',
+                          text: 'real task',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+  const {locator} = await createPilcrowTestEditor({
+    initialValue: initialValue as never,
+  })
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+  const editable = locator.element() as HTMLElement
+  await vi.waitFor(() => {
+    expect(editable.querySelectorAll('input[type="checkbox"]').length).toBe(1)
+  })
+})
+
+test('task list-items each render their own checkbox at every depth', async () => {
+  const initialValue = [
+    {
+      _type: 'list',
+      _key: 'l1',
+      kind: 'task',
+      items: [
+        {
+          _type: 'list-item',
+          _key: 'outer',
+          checked: true,
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 's1', text: 'outer', marks: []}],
+            },
+            {
+              _type: 'list',
+              _key: 'l2',
+              kind: 'task',
+              items: [
+                {
+                  _type: 'list-item',
+                  _key: 'inner',
+                  checked: false,
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b2',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's2', text: 'inner', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+  const {locator} = await createPilcrowTestEditor({
+    initialValue: initialValue as never,
+  })
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+  const editable = locator.element() as HTMLElement
+  await vi.waitFor(() => {
+    expect(editable.querySelectorAll('input[type="checkbox"]').length).toBe(2)
+  })
+})

--- a/apps/pilcrow/tests/test-editor.tsx
+++ b/apps/pilcrow/tests/test-editor.tsx
@@ -1,0 +1,48 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {expect, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+
+/**
+ * Mounts a Pilcrow editor with all plugins and the Pilcrow schema for
+ * gherkin / scenario tests. Returns the editor ref and the render
+ * locator so step definitions can drive the editable.
+ */
+export async function createPilcrowTestEditor(
+  options: {
+    initialValue?: Array<PortableTextBlock>
+    keyGenerator?: () => string
+  } = {},
+) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = options.keyGenerator ?? createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue: options.initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('Pilcrow editor ref not set after render')
+  }
+  return {
+    editor: editorRef.current,
+    locator,
+  }
+}

--- a/apps/pilcrow/tests/toolbar-list-toggle.test.tsx
+++ b/apps/pilcrow/tests/toolbar-list-toggle.test.tsx
@@ -1,0 +1,282 @@
+import {
+  EditorProvider,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {PilcrowEditor} from '../src/editor'
+import {schemaDefinition} from '../src/schema'
+import {Toolbar} from '../src/toolbar'
+
+/**
+ * TDD coverage for the toolbar list-toggle buttons:
+ * - In a normal paragraph: button wraps the block in a list of the given kind.
+ * - Inside a list of the same kind: button unwraps the list-item back to a
+ *   normal paragraph.
+ * - Inside a list of a different kind: button changes the enclosing list's
+ *   kind in place.
+ * - In all cases the active state (aria-pressed) reflects whether the focus
+ *   is inside a list of the button's kind.
+ */
+
+async function mount(initialValue?: Array<PortableTextBlock>) {
+  const editorRef = React.createRef<Editor>()
+  const keyGenerator = createTestKeyGenerator()
+  const result = await render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition,
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <Toolbar />
+      <PilcrowEditor />
+    </EditorProvider>,
+  )
+  const locator = result.locator.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  if (!editorRef.current) {
+    throw new Error('editor ref not set')
+  }
+  return {editor: editorRef.current, locator, container: result.container}
+}
+
+function paragraphBlock(_key: string, spanKey: string, text: string) {
+  return {
+    _type: 'block',
+    _key,
+    style: 'normal',
+    children: [{_type: 'span', _key: spanKey, text, marks: []}],
+    markDefs: [],
+  }
+}
+
+describe('list toolbar buttons', () => {
+  test("aria-pressed reflects whether caret is inside a list of the button's kind", async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [paragraphBlock('B1', 'S1', 'hello')],
+          },
+        ],
+      },
+      paragraphBlock('B2', 'S2', 'plain'),
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    const bulletBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Bullet list"]',
+    )!
+    const numberBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Numbered list"]',
+    )!
+
+    // Place caret inside the bullet list item.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+    await vi.waitFor(() =>
+      expect(bulletBtn.getAttribute('aria-pressed')).toBe('true'),
+    )
+    expect(numberBtn.getAttribute('aria-pressed')).toBe('false')
+
+    // Move caret to the plain paragraph.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'B2'}, 'children', {_key: 'S2'}], offset: 0},
+        focus: {path: [{_key: 'B2'}, 'children', {_key: 'S2'}], offset: 0},
+      },
+    })
+    await vi.waitFor(() =>
+      expect(bulletBtn.getAttribute('aria-pressed')).toBe('false'),
+    )
+    expect(numberBtn.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  test('click bullet button on plain paragraph wraps it in a bullet list', async () => {
+    const initial = [
+      paragraphBlock('B1', 'S1', 'hello'),
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'B1'}, 'children', {_key: 'S1'}], offset: 0},
+        focus: {path: [{_key: 'B1'}, 'children', {_key: 'S1'}], offset: 0},
+      },
+    })
+    const bulletBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Bullet list"]',
+    )!
+    bulletBtn.click()
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toHaveLength(1)
+      expect((value[0] as {_type: string})._type).toBe('list')
+    })
+    const value = editor.getSnapshot().context.value
+    expect((value[0] as unknown as {kind: string}).kind).toBe('bullet')
+  })
+
+  test('click bullet button inside bullet list-item unwraps it back to plain paragraph', async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [paragraphBlock('B1', 'S1', 'hello')],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+    const bulletBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Bullet list"]',
+    )!
+    await vi.waitFor(() =>
+      expect(bulletBtn.getAttribute('aria-pressed')).toBe('true'),
+    )
+    bulletBtn.click()
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect((value[0] as {_type: string})._type).toBe('block')
+    })
+    const value = editor.getSnapshot().context.value
+    expect(value).toHaveLength(1)
+    expect((value[0] as {_type: string; style: string}).style).toBe('normal')
+  })
+
+  test('click number button inside bullet list-item changes the list kind to number', async () => {
+    const initial = [
+      {
+        _type: 'list',
+        _key: 'L1',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'I1',
+            content: [paragraphBlock('B1', 'S1', 'hello')],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    const {editor, container} = await mount(initial)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'L1'},
+            'items',
+            {_key: 'I1'},
+            'content',
+            {_key: 'B1'},
+            'children',
+            {_key: 'S1'},
+          ],
+          offset: 0,
+        },
+      },
+    })
+    const numberBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Numbered list"]',
+    )!
+    const bulletBtn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Bullet list"]',
+    )!
+    // Wait for aria-pressed to reflect caret-inside-bullet-list before clicking
+    await vi.waitFor(() =>
+      expect(bulletBtn.getAttribute('aria-pressed')).toBe('true'),
+    )
+    numberBtn.click()
+    await new Promise((r) => setTimeout(r, 200))
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect((value[0] as unknown as {kind: string}).kind).toBe('number')
+    })
+  })
+})

--- a/apps/pilcrow/tests/undo-redo.feature
+++ b/apps/pilcrow/tests/undo-redo.feature
@@ -1,0 +1,217 @@
+Feature: Undo/Redo
+
+  Background:
+    Given a global keymap
+
+  Scenario: Undoing writing two words
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And " bar" is typed
+    And undo is performed
+    Then the editor state is "B: foo|"
+
+  Scenario: Selection change does not affect the undo stack
+    Given the editor state is "B: "
+    When the editor is focused
+    And "foo" is typed
+    And "{ArrowLeft}" is pressed
+    And "bar" is typed
+    Then the editor state is "B: fobar|o"
+    When undo is performed
+    Then the editor state is "B: fo|o"
+
+  Scenario: Undoing annotation
+    Given the editor state is "B: foo"
+    When "foo" is selected
+    And "link" is toggled
+    And undo is performed
+    Then the editor state is "B: ^foo|"
+
+  @skip
+  Scenario: Undoing the deletion of the last char of annotated text
+    Given the editor state is "B: foo"
+    And a "comment" "c1" around "foo"
+    When the editor is focused
+    And "{ArrowRight}" is pressed
+    And "{Backspace}" is pressed
+    And undo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
+
+  @skip
+  Scenario: Redoing the deletion of the last char of annotated text
+    Given the editor state is "B: foo"
+    And a "comment" "c1" around "foo"
+    When the editor is focused
+    And "{ArrowRight}" is pressed
+    And "{Backspace}" is pressed
+    And undo is performed
+    When redo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":fo|]
+      """
+
+  @skip
+  Scenario: Undoing inserting text after annotated text
+    Given the editor state is "B: foo"
+    And a "comment" "c1" around "foo"
+    When the editor is focused
+    And "{ArrowRight}" is pressed
+    And "{Space}" is pressed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo] |
+      """
+    When undo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
+
+  @skip
+  Scenario: Undoing and redoing inserting text after annotated text
+    Given the editor state is "B: foo"
+    And a "comment" "c1" around "foo"
+    When the editor is focused
+    And "{ArrowRight}" is pressed
+    And "{Space}" is pressed
+    And undo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
+    When redo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo] |
+      """
+
+  @skip
+  Scenario: Undoing the deletion of block with annotation at the end
+    Given the editor state is "B: foo bar"
+    And a "comment" "c1" around "bar"
+    When the editor is focused
+    And "foo bar" is selected
+    And "{Backspace}" is pressed
+    And undo is performed
+    Then the editor state is
+      """
+      B: ^foo [@comment _key="c1":bar|]
+      """
+
+  @skip
+  Scenario: Undoing deletion of annotated block
+    Given the editor state is "B: foo"
+    And a "comment" "c1" around "foo"
+    When the editor is focused
+    And "{Backspace}" is pressed
+    And undo is performed
+    Then the editor state is
+      """
+      B: [@comment _key="c1":foo|]
+      """
+
+  Scenario: Undoing annotation across text blocks
+    Given the editor state is "B: foo"
+    When the editor is focused
+    And "{Enter}" is pressed
+    And "bar" is typed
+    And "foobar" is selected
+    And "link" is toggled
+    And undo is performed
+    Then the editor state is
+      """
+      B: ^foo
+      B: bar|
+      """
+
+  @skip
+  Scenario: Undoing action step
+    Given the editor state is "B: -"
+    When the editor is focused
+    And ">" is typed
+    And "new" is typed
+    Then the editor state is "B: →new|"
+    When undo is performed
+    And undo is performed
+    Then the editor state is "B: ->"
+
+  @skip
+  Scenario: Consecutive undo after selection change
+    Given the editor state is "B: -"
+    When the editor is focused
+    And ">" is typed
+    And undo is performed
+    And "{ArrowLeft}" is pressed
+    And undo is performed
+    Then the editor state is "B: -|"
+
+  @skip
+  Scenario: Undo after transform on expanded selection
+    Given the editor state is "B: (cf"
+    When "f" is selected
+    And ")" is inserted
+    Then the editor state is "B: |©"
+    When undo is performed
+    Then the editor state is "B: (c)|"
+    When undo is performed
+    Then the editor state is "B: (c^f|"
+
+  Scenario: Undoing break in the middle of text
+    Given the editor state is "B: foobar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    And "x" is typed
+    Then the editor state is
+      """
+      B: foo
+      B: x|bar
+      """
+    When undo is performed
+    And undo is performed
+    And "y" is typed
+    Then the editor state is "B: fooy|bar"
+
+  Scenario: Undoing delete backward across blocks
+    Given the editor state is
+      """
+      B: foo
+      B: bar
+      """
+    When the editor is focused
+    And the caret is put before "bar"
+    And "{Backspace}" is pressed
+    And "x" is typed
+    Then the editor state is "B: foox|bar"
+    When undo is performed
+    And undo is performed
+    And "y" is typed
+    Then the editor state is
+      """
+      B: foo
+      B: y|bar
+      """
+
+  Scenario: Undoing and redoing break
+    Given the editor state is "B: foobar"
+    When the editor is focused
+    And the caret is put after "foo"
+    And "{Enter}" is pressed
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """
+    When undo is performed
+    Then the editor state is "B: foo|bar"
+    When redo is performed
+    Then the editor state is
+      """
+      B: foo
+      B: |bar
+      """

--- a/apps/pilcrow/tests/undo-redo.test.tsx
+++ b/apps/pilcrow/tests/undo-redo.test.tsx
@@ -1,0 +1,21 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {stepDefinitions} from '@portabletext/editor/test/vitest'
+import type {Context} from '@portabletext/editor/test/vitest'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import {createPilcrowTestEditor} from './test-editor'
+import featureRaw from './undo-redo.feature?raw'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createPilcrowTestEditor()
+      context.keyMap = new Map()
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: featureRaw,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/apps/pilcrow/tsconfig.app.json
+++ b/apps/pilcrow/tsconfig.app.json
@@ -21,5 +21,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/apps/pilcrow/vitest.config.ts
+++ b/apps/pilcrow/vitest.config.ts
@@ -1,0 +1,35 @@
+import react from '@vitejs/plugin-react'
+import {playwright} from '@vitest/browser-playwright'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  server: {
+    // HMR re-imports a test file during the run when chained file
+    // imports are slow, triggering 'Vite unexpectedly reloaded a
+    // test' failures in the chromium orchestrator on CI. Disable it -
+    // tests aren't watched, the runner doesn't need HMR.
+    hmr: false,
+  },
+  test: {
+    projects: [
+      {
+        plugins: [
+          react({
+            babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
+          }),
+        ],
+        test: {
+          name: 'browser',
+          include: ['tests/**/*.test.tsx'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{browser: 'chromium', retry: 2}],
+            screenshotFailures: false,
+          },
+        },
+      },
+    ],
+  },
+})

--- a/knip.json
+++ b/knip.json
@@ -54,7 +54,9 @@
         "babel-plugin-react-compiler",
         "eslint-formatter-gha",
         "tailwindcss-react-aria-components",
-        "sharp"
+        "sharp",
+        "@vitest/browser",
+        "@vitest/browser-playwright"
       ]
     },
     "examples/*": {}

--- a/packages/editor/src/behaviors/behavior.core.containers.ts
+++ b/packages/editor/src/behaviors/behavior.core.containers.ts
@@ -63,14 +63,6 @@ function isAtContainerDeadEnd(
     return false
   }
 
-  const container = getAncestor(snapshot, focusTextBlock.path, (node, path) =>
-    isEditableContainer(snapshot, node, path),
-  )
-
-  if (!container) {
-    return false
-  }
-
   const edgeBlock =
     edge === 'end' ? getLastBlock(snapshot) : getFirstBlock(snapshot)
 
@@ -87,13 +79,34 @@ function isAtContainerDeadEnd(
     return false
   }
 
-  const sibling = getSibling(
-    snapshot,
-    container.path,
-    edge === 'end' ? 'next' : 'previous',
-  )
+  // Walk container ancestors from innermost to outermost. If ANY ancestor
+  // has a sibling at the edge direction, the browser can step out of the
+  // nested structure naturally - not a dead end. Only when every container
+  // ancestor up to the root is at its edge do we suppress the native event.
+  let cursorPath: Path | undefined = focusTextBlock.path
+  let foundEditableContainer = false
+  while (cursorPath !== undefined) {
+    const container: {path: Path; node: unknown} | undefined = getAncestor(
+      snapshot,
+      cursorPath,
+      (node, path) => isEditableContainer(snapshot, node, path),
+    )
+    if (!container) {
+      break
+    }
+    foundEditableContainer = true
+    const sibling = getSibling(
+      snapshot,
+      container.path,
+      edge === 'end' ? 'next' : 'previous',
+    )
+    if (sibling !== undefined) {
+      return false
+    }
+    cursorPath = container.path
+  }
 
-  return sibling === undefined
+  return foundEditableContainer
 }
 
 /**

--- a/packages/plugin-input-rule/src/flag-preservation.feature
+++ b/packages/plugin-input-rule/src/flag-preservation.feature
@@ -1,0 +1,102 @@
+Feature: Flag Preservation
+
+  Background:
+    Given a global keymap
+
+  # ---------------------------------------------------------------------------
+  # `i` (case-insensitive) is preserved.
+  # The pattern `/\[!note\]/i` matches `[!note]` regardless of case. Without
+  # preserving `i`, only the exact lowercase trigger would fire.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Case-Insensitive Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state       |
+      | "B: " | "[!note]"     | "B: NOTE end\|" |
+      | "B: " | "[!NOTE]"     | "B: NOTE end\|" |
+      | "B: " | "[!Note]"     | "B: NOTE end\|" |
+
+  # ---------------------------------------------------------------------------
+  # Unicode (`u`) is preserved.
+  # The pattern `/\p{L}+!/u` uses a Unicode property escape that requires
+  # the `u` flag at construction time, otherwise `new RegExp` throws.
+  # Preserving `u` lets the rule match across Unicode letters.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Unicode Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state      |
+      | "B: " | "hello!"      | "B: HIT end\|" |
+      | "B: " | "héllo!"      | "B: HIT end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `g` is stripped, leaving the plugin's own `g` flag intact.
+  # The rule still fires; no `Invalid flags` error.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `g` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "(c)"         | "B: GMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `d` is stripped, leaving the plugin's own `d` flag intact.
+  # The rule still fires; no `Invalid flags` error.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `d` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "(d)"         | "B: DMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `y` (sticky) is stripped.
+  # With `y` preserved, `matchAll` would only match at `lastIndex` (0 on a
+  # freshly-built matcher), so `foo` inside `xyzfoo` would never match.
+  # Stripping `y` keeps the loop semantics: pattern fires anywhere in the
+  # text.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `y` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state    | inserted text | new state           |
+      | "B: xyz" | "foo"         | "B: xyzYMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # Bare pattern (no consumer flags) still fires. Historical contract pin.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Bare Pattern
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "[!plain]"    | "B: PLAIN end\|" |

--- a/packages/plugin-input-rule/src/flag-preservation.test.tsx
+++ b/packages/plugin-input-rule/src/flag-preservation.test.tsx
@@ -1,0 +1,91 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {
+  createTestEditor,
+  stepDefinitions,
+  type Context,
+} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import flagPreservationFeature from './flag-preservation.feature?raw'
+import {InputRulePlugin} from './plugin.input-rule'
+import {defineTextTransformRule} from './text-transform-rule'
+
+// Case-insensitive rule. Without preserving `i`, only the lowercase trigger
+// matches. With `i` preserved, uppercase and mixed-case also trigger.
+// The rule rewrites the bracket-wrapped trigger to a plain marker so the
+// firing is observable from the rendered text.
+const caseInsensitiveRule = defineTextTransformRule({
+  on: /\[!note\]/i,
+  transform: () => 'NOTE',
+})
+
+// Unicode rule. The pattern `\p{L}+!` uses a Unicode property escape that
+// requires the `u` flag at construction time, otherwise `new RegExp`
+// throws. Preserving `u` lets the rule match Unicode letters followed by
+// `!`. The pattern has no capture group, so the full match is the target.
+const unicodeRule = defineTextTransformRule({
+  on: /\p{L}+!/u,
+  transform: () => 'HIT',
+})
+
+// Rule with user-set `g` flag. The plugin already drives its own `matchAll`
+// loop; user-set `g` is redundant. The fix strips it so the rebuilt regex
+// flags stay valid.
+const userGRule = defineTextTransformRule({
+  on: /\(c\)/g,
+  transform: () => 'GMARK',
+})
+
+// Rule with user-set `d` flag. The plugin sets `d` itself to read indices.
+// User-set `d` is redundant and must be stripped to avoid `Invalid flags`.
+const userDRule = defineTextTransformRule({
+  on: /\(d\)/d,
+  transform: () => 'DMARK',
+})
+
+// Rule with sticky (`y`) flag. Sticky semantics conflict with the plugin's
+// `matchAll` loop, which slices `newText` and re-feeds it. With `y`
+// preserved, the regex only matches at `lastIndex`, breaking any match
+// that isn't at position 0 of the current slice. Stripping `y` keeps the
+// loop's intent: match the pattern anywhere in the remaining text.
+const userYRule = defineTextTransformRule({
+  on: /foo/y,
+  transform: () => 'YMARK',
+})
+
+// Bare pattern, no consumer flags. Pins that the historical contract
+// continues to work.
+const bareRule = defineTextTransformRule({
+  on: /\[!plain\]/,
+  transform: () => 'PLAIN',
+})
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        children: (
+          <>
+            <InputRulePlugin rules={[caseInsensitiveRule]} />
+            <InputRulePlugin rules={[unicodeRule]} />
+            <InputRulePlugin rules={[userGRule]} />
+            <InputRulePlugin rules={[userDRule]} />
+            <InputRulePlugin rules={[userYRule]} />
+            <InputRulePlugin rules={[bareRule]} />
+          </>
+        ),
+        schemaDefinition: defineSchema({
+          decorators: [{name: 'strong'}],
+          annotations: [{name: 'link'}],
+        }),
+      })
+
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: flagPreservationFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/plugin-input-rule/src/plugin.input-rule.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.tsx
@@ -69,7 +69,17 @@ export function defineInputRuleBehavior(config: {
       const foundActions: Array<BehaviorAction> = []
 
       for (const rule of config.rules) {
-        const matcher = new RegExp(rule.on.source, 'gd')
+        // Preserve a known-safe subset of flags from `rule.on`: `i` for
+        // case-insensitive matches, `m` for multi-line anchors, `s` for
+        // dot-matches-newline, `u` for Unicode property escapes. The plugin
+        // sets `g` (to drive `matchAll`) and `d` (to read match indices)
+        // itself, so user-set `g`/`d` are dropped to avoid `Invalid flags`
+        // and keep the loop's contract. `y` (sticky) is also dropped: the
+        // plugin's `matchAll` loop slices and re-feeds `newText` after each
+        // match, which is incompatible with sticky's `lastIndex`-anchored
+        // semantics.
+        const safeUserFlags = rule.on.flags.replace(/[^imsu]/g, '')
+        const matcher = new RegExp(rule.on.source, `gd${safeUserFlags}`)
 
         while (true) {
           // Find matches in the text after the insertion

--- a/packages/plugin-sdk-value/src/index.ts
+++ b/packages/plugin-sdk-value/src/index.ts
@@ -1,1 +1,5 @@
-export {SDKValuePlugin, ValueSyncPlugin} from './plugin.sdk-value'
+export {
+  convertPatches,
+  SDKValuePlugin,
+  ValueSyncPlugin,
+} from './plugin.sdk-value'

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -102,6 +102,15 @@ export function arrayifyPath(pathExpr: string): Path {
   })
 }
 
+/**
+ * Convert wire-shape patches produced by `@sanity/diff-patch`'s
+ * `diffValue` into the array-path `@portabletext/patches` shape
+ * accepted by the editor's `patches` event. Useful when sourcing
+ * value changes from outside the editor - for example a markdown
+ * source pane that round-trips back into the editor via diff-patch.
+ *
+ * @beta
+ */
 export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
   return patches.flatMap((p) => {
     return Object.entries(p).flatMap(([type, values]): PtePatch[] => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,45 @@ importers:
 
   apps/pilcrow:
     dependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      '@portabletext/markdown':
+        specifier: workspace:*
+        version: link:../../packages/markdown
+      '@portabletext/patches':
+        specifier: workspace:*
+        version: link:../../packages/patches
+      '@portabletext/plugin-emoji-picker':
+        specifier: workspace:*
+        version: link:../../packages/plugin-emoji-picker
+      '@portabletext/plugin-input-rule':
+        specifier: workspace:*
+        version: link:../../packages/plugin-input-rule
+      '@portabletext/plugin-markdown-shortcuts':
+        specifier: workspace:*
+        version: link:../../packages/plugin-markdown-shortcuts
+      '@portabletext/plugin-sdk-value':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk-value
+      '@portabletext/plugin-typeahead-picker':
+        specifier: workspace:*
+        version: link:../../packages/plugin-typeahead-picker
+      '@portabletext/plugin-typography':
+        specifier: workspace:*
+        version: link:../../packages/plugin-typography
+      '@portabletext/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@portabletext/test':
+        specifier: workspace:*
+        version: link:../../packages/test
+      '@portabletext/toolbar':
+        specifier: workspace:*
+        version: link:../../packages/toolbar
+      '@sanity/diff-patch':
+        specifier: ^6.0.0
+        version: 6.0.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -205,12 +244,27 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser':
+        specifier: ^4.1.4
+        version: 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.4
+        version: 4.1.4(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      racejar:
+        specifier: workspace:*
+        version: link:../../packages/racejar
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: ^7.3.1
         version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest-browser-react:
+        specifier: ^2.2.0
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4)
 
   apps/playground:
     dependencies:
@@ -6149,9 +6203,6 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -8468,10 +8519,6 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
   tinyexec@1.1.2:
@@ -13919,6 +13966,19 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@vitest/browser': 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@vitest/browser': 4.1.4(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
@@ -13981,6 +14041,23 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/browser@4.1.4(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -14028,7 +14105,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -14044,9 +14121,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -14081,6 +14158,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -14721,8 +14806,6 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-module-lexer@2.0.0: {}
-
   es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
@@ -15075,10 +15158,6 @@ snapshots:
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -17951,14 +18030,12 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyexec@1.1.1: {}
-
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -18341,7 +18418,7 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.1.4(@types/node@20.19.25)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18394,7 +18471,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -18402,7 +18479,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -18425,7 +18502,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -18433,7 +18510,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -18441,6 +18518,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.25
       '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
+      '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
+      jsdom: 27.2.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       jsdom: 27.2.0
@@ -18456,7 +18564,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -18464,7 +18572,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
Long-running feature branch for Pilcrow, the markdown compliance editor / writing surface that round-trips markdown faithfully and shows off PTE v7. Each push gets a Vercel preview deploy.

## Where this is going

The story:

- **PT editor (primary).** The star. Crimson Pro serif body, thin toolbar above. Showcase how writing in PTE feels.
- **Inspector (right).** Tabbed - Markdown / Patches / Value.
  - Markdown round-trips bidirectionally via `@sanity/diff-patch` so `_key`s survive edits made in the source view.
  - Patches stream shows every emitted patch in real time, so you can watch the data structure evolve as you type.
  - Value shows the full PT JSON with a Copy button.
- **Per-construct plugins.** Each markdown construct (structured lists, code blocks, tables, callouts, images) gets its own plugin-style module under `apps/pilcrow/src/plugins/`. Proves these abstractions can become real packages later.
- **Grayscale design.** Distinct-by-typography-and-rule-not-color. Each construct gets a visual treatment that makes it obviously what it is without relying on hue.

Spec at `/specs/pilcrow.md` on the channel board.

## Status

This is a draft. Iteration happens on this branch with previews; merge target is the latest main.

What lands in the first commit: the editor shell (toolbar + tabbed inspector). What is still to come (in subsequent commits on this branch):

- Full schema (lists, code blocks, callouts, tables, blockquotes, hr, images, inline marks).
- Per-construct plugin files.
- Markdown shortcuts plugin + interception from structured-lists.
- PT to markdown serialization in the source pane.
- Markdown to PT via diff-patch pipeline.
- Syntax highlighting + polish.
