### PR TITLE
fix(perf): O(D²) → O(D) for ancestor and path-comparison traversals on deep nested data

### DIFF
--- a/.changeset/perf-deep-nested-traversals.md
+++ b/.changeset/perf-deep-nested-traversals.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): O(D^2) -> O(D) for ancestor/path/lookup hot paths on deep nested data
+
+Several traversal primitives had quadratic-in-depth cost that compounded for deeply-nested data. Tab-indenting a list-item in a recursive list container to depth 20 went from over 5 seconds per indent to about 100ms.
+
+`getAncestors` now descends from the root once collecting each ancestor as it goes, instead of calling `getNode` per ancestor. `comparePathsInTree` (the document-order comparator used by range queries and dirty-path tracking) now descends both paths in a single pass instead of re-walking from the root at each level. `getSelectedTextBlocks`, `getSelectedBlocks` and `getSelectedChildren` short-circuit when the selection endpoints share the same enclosing block / root block / inline child, skipping the range walk when the selection doesn't actually cross the boundary.

--- a/packages/editor/src/node-traversal/get-ancestors.ts
+++ b/packages/editor/src/node-traversal/get-ancestors.ts
@@ -1,7 +1,7 @@
 import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
-import {getNode} from './get-node'
+import {getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
@@ -11,41 +11,97 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * the ancestors are (nearest first):
  *   [{_key:'t1'}, 'rows', {_key:'r1'}]
  *   [{_key:'t1'}]
+ *
+ * Walks from root to the target in a single pass collecting each ancestor
+ * as it goes. Previously called `getNode` per ancestor, each of which
+ * re-walked from the root - that's O(depth^2). Single descent is O(depth).
  */
 export function getAncestors(
   snapshot: TraversalSnapshot,
   path: Path,
 ): Array<{node: Node; path: Path}> {
+  // Collect keyed-segment indices to know where each ancestor's path ends.
   const keyedIndices: Array<number> = []
-
   for (let i = 0; i < path.length; i++) {
     if (isKeyedSegment(path[i])) {
       keyedIndices.push(i)
     }
   }
 
-  // Need at least 2 keyed segments to have an ancestor
-  // (the last one is the node itself)
+  // Need at least 2 keyed segments to have an ancestor (the last is self).
   if (keyedIndices.length <= 1) {
     return []
   }
 
-  const ancestors: Array<{node: Node; path: Path}> = []
+  const {context, blockIndexMap} = snapshot
+  let currentChildren: Array<Node> = context.value
+  let scopePath = ''
+  let isRootLevel = true
 
-  for (let i = keyedIndices.length - 2; i >= 0; i--) {
-    const endIndex = keyedIndices[i]
+  // Collected ancestors in document order (root first). Each entry holds
+  // the node and the resolved path to it.
+  const ancestorsByDepth: Array<{node: Node; path: Path}> = []
+  const resolvedPath: Path = []
 
-    if (endIndex === undefined) {
+  // Descend once. We walk only as far as the second-to-last keyed segment;
+  // the last keyed segment is the target itself, which is not an ancestor.
+  const targetKeyedIndex = keyedIndices[keyedIndices.length - 1]!
+
+  let segmentIndex = 0
+  while (segmentIndex < targetKeyedIndex) {
+    const segment = path[segmentIndex]!
+
+    if (typeof segment === 'string') {
+      resolvedPath.push(segment)
+      segmentIndex++
       continue
     }
 
-    const ancestorPath = path.slice(0, endIndex + 1)
-    const entry = getNode(snapshot, ancestorPath)
-
-    if (entry) {
-      ancestors.push(entry)
+    let node: Node | undefined
+    if (isKeyedSegment(segment)) {
+      // Production snapshots maintain `blockIndexMap` in lockstep with
+      // `context.value` so this fast path always fires. Some test
+      // fixtures still pass empty or stale maps, which is the debt this
+      // size check is working around - see /specs/snapshot-invariants.md.
+      // When the fixtures are aligned, drop the guard and use the map
+      // directly.
+      if (isRootLevel && blockIndexMap.size === currentChildren.length) {
+        const index = blockIndexMap.get(segment._key)
+        node =
+          index !== undefined
+            ? currentChildren[index]
+            : currentChildren.find((child) => child._key === segment._key)
+      } else {
+        node = currentChildren.find((child) => child._key === segment._key)
+      }
+      resolvedPath.push(segment)
+      isRootLevel = false
+    } else if (typeof segment === 'number') {
+      node = currentChildren.at(segment)
+      if (node) {
+        resolvedPath.push({_key: node._key})
+      }
+    } else {
+      return []
     }
+
+    if (!node) {
+      return []
+    }
+
+    // This is an ancestor (we haven't reached the target). Record it.
+    ancestorsByDepth.push({node, path: resolvedPath.slice()})
+
+    // Descend into its children for the next iteration.
+    const next = getNodeChildren(context, node, scopePath)
+    if (!next) {
+      return []
+    }
+    currentChildren = next.children
+    scopePath = next.scopePath
+    segmentIndex++
   }
 
-  return ancestors
+  // Return nearest-first (reverse of document order).
+  return ancestorsByDepth.reverse()
 }

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -115,8 +115,12 @@ function* getNodesSimple(
 /**
  * Compare two keyed paths in document order. Returns -1, 0, or 1.
  *
- * Uses `blockIndexMap` for O(1) lookup at the root level. Falls back to
- * sibling-array lookup for deeper segments.
+ * Descends both paths from the root in a single pass, advancing
+ * `currentNode` and `currentChildren` together so each level costs
+ * one keyed-segment scan instead of an O(depth) walk from root.
+ *
+ * Uses `blockIndexMap` for O(1) lookup at the root level. Deeper
+ * levels fall back to a linear scan of the current sibling array.
  */
 function comparePathsInTree(
   snapshot: TraversalSnapshot,
@@ -126,7 +130,9 @@ function comparePathsInTree(
   const keysA = pathA.filter(isKeyedSegment)
   const keysB = pathB.filter(isKeyedSegment)
 
-  let currentPath: Path = []
+  const {context} = snapshot
+  let currentChildren: Array<Node> = context.value
+  let scopePath = ''
   let isRootLevel = true
 
   const minDepth = Math.min(keysA.length, keysB.length)
@@ -136,15 +142,27 @@ function comparePathsInTree(
     const keyB = keysB[depth]!
 
     if (keyA._key === keyB._key) {
+      // Same node at this depth: descend into its children for the next
+      // iteration. The root level can short-circuit via blockIndexMap;
+      // deeper levels scan the current sibling array.
+      let matchedNode: Node | undefined
       if (isRootLevel && snapshot.blockIndexMap.has(keyA._key)) {
-        currentPath = [keyA]
-      } else {
-        const children = getChildren(snapshot, currentPath)
-        const child = children.find((c) => c.node._key === keyA._key)
-        if (child) {
-          currentPath = child.path
+        const index = snapshot.blockIndexMap.get(keyA._key)
+        if (index !== undefined) {
+          matchedNode = currentChildren[index]
         }
+      } else {
+        matchedNode = currentChildren.find((c) => c._key === keyA._key)
       }
+      if (!matchedNode) {
+        return 0
+      }
+      const next = getNodeChildren(context, matchedNode, scopePath)
+      if (!next) {
+        return 0
+      }
+      currentChildren = next.children
+      scopePath = next.scopePath
       isRootLevel = false
       continue
     }
@@ -163,16 +181,14 @@ function comparePathsInTree(
       }
     }
 
-    const siblings = getChildren(snapshot, currentPath)
     let indexA = -1
     let indexB = -1
-
-    for (let i = 0; i < siblings.length; i++) {
-      const sibling = siblings[i]!
-      if (sibling.node._key === keyA._key) {
+    for (let i = 0; i < currentChildren.length; i++) {
+      const sibling = currentChildren[i]!
+      if (sibling._key === keyA._key) {
         indexA = i
       }
-      if (sibling.node._key === keyB._key) {
+      if (sibling._key === keyB._key) {
         indexB = i
       }
       if (indexA !== -1 && indexB !== -1) {

--- a/packages/editor/src/selectors/selector.get-selected-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-blocks.ts
@@ -5,12 +5,13 @@ import {getBlock} from '../node-traversal/is-block'
 import type {BlockPath} from '../types/paths'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
 import {getSelectionStartPoint} from '../utils/util.get-selection-start-point'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
 /**
  * Returns the root-level blocks the selection covers.
  *
  * Only looks at direct children of the editor. If the selection is inside
- * an editable container, the container itself is returned — not its inner
+ * an editable container, the container itself is returned - not its inner
  * blocks. Containers are preserved whole.
  *
  * Use for block-level operations like `move.block up/down` and
@@ -33,6 +34,18 @@ export const getSelectedBlocks: EditorSelector<
 
   if (!startPoint || !endPoint) {
     return []
+  }
+
+  // Fast path: when both endpoints share the same root-level block, that
+  // single block is the answer. The range walk only needs to run when
+  // the selection crosses block boundaries.
+  const startRootKey = startPoint.path.find(isKeyedSegment)?._key
+  const endRootKey = endPoint.path.find(isKeyedSegment)?._key
+  if (startRootKey && startRootKey === endRootKey) {
+    const block = getBlock(snapshot, [{_key: startRootKey}])
+    if (block) {
+      return [{node: block.node, path: block.path}]
+    }
   }
 
   const result: Array<{node: PortableTextBlock; path: BlockPath}> = []

--- a/packages/editor/src/selectors/selector.get-selected-children.ts
+++ b/packages/editor/src/selectors/selector.get-selected-children.ts
@@ -1,5 +1,6 @@
 import {isSpan, type PortableTextChild} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getNode} from '../node-traversal/get-node'
 import {getNodes} from '../node-traversal/get-nodes'
 import {isInline} from '../node-traversal/is-inline'
 import type {Path} from '../slate/interfaces/path'
@@ -43,6 +44,33 @@ export function getSelectedChildren<
     const endChildKey = endPoint.path.findLast(isKeyedSegment)?._key
 
     const result: Array<SelectedChild<TChild>> = []
+
+    // Fast path: when both endpoints reference the same inline child -
+    // the common case for collapsed selections and intra-span selections
+    // - resolve that child directly instead of walking the range.
+    if (
+      startChildKey &&
+      startChildKey === endChildKey &&
+      isInline(snapshot, startPoint.path)
+    ) {
+      const node = getNode(snapshot, startPoint.path)
+      if (node) {
+        const child = node.node as PortableTextChild
+        let skip = false
+        if (child._key === startChildKey && isSpan(snapshot.context, child)) {
+          if (startPoint.offset >= child.text.length) {
+            skip = true
+          }
+          if (endPoint.offset <= 0) {
+            skip = true
+          }
+        }
+        if (!skip && (!filter || filter(child))) {
+          result.push({node: child as TChild, path: node.path})
+        }
+      }
+      return result
+    }
 
     for (const entry of getNodes(snapshot, {
       from: startPoint.path,

--- a/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
+++ b/packages/editor/src/selectors/selector.get-selected-text-blocks.ts
@@ -1,5 +1,6 @@
 import {isTextBlock, type PortableTextTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
+import {getEnclosingBlock} from '../node-traversal/get-enclosing-block'
 import {getNodes} from '../node-traversal/get-nodes'
 import type {Path} from '../slate/interfaces/path'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
@@ -28,6 +29,22 @@ export const getSelectedTextBlocks: EditorSelector<
 
   if (!startPoint || !endPoint) {
     return []
+  }
+
+  // Fast path: when both endpoints sit inside the same text block - the
+  // common case for toolbar state on a collapsed or single-block
+  // selection - skip the range walk entirely. The range walk visits
+  // every descendant in document order between the endpoints; that's
+  // O(tree) work and gets very expensive in deeply nested containers.
+  const startBlock = getEnclosingBlock(snapshot, startPoint.path)
+  const endBlock = getEnclosingBlock(snapshot, endPoint.path)
+  if (
+    startBlock &&
+    endBlock &&
+    startBlock.node._key === endBlock.node._key &&
+    isTextBlock(snapshot.context, startBlock.node)
+  ) {
+    return [{node: startBlock.node, path: startBlock.path}]
   }
 
   const result: Array<{node: PortableTextTextBlock; path: Path}> = []

--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -271,6 +271,177 @@ describe('Performance', () => {
     }, 30_000)
   })
 
+  describe('Deep nested containers', () => {
+    // Recursive list schema: a list contains list-items, each list-item's
+    // content can hold more lists. This matches the structured-lists shape
+    // that surfaced the O(D^2) cost in the wild (holding Tab in a nested
+    // list grows path depth by 2 per indent).
+    const schemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'list',
+          fields: [
+            {
+              name: 'items',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'list-item',
+                  fields: [
+                    {
+                      name: 'content',
+                      type: 'array',
+                      of: [{type: 'block'}, {type: 'list'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const listContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..list',
+      field: 'items',
+      render: ({children, node}) => (
+        <ul data-testid={`list-${node._key}`}>{children}</ul>
+      ),
+    })
+    const listItemContainer = defineContainer<typeof schemaDefinition>({
+      scope: '$..list.list-item',
+      field: 'content',
+      render: ({children, node}) => (
+        <li data-testid={`li-${node._key}`}>{children}</li>
+      ),
+    })
+
+    // Build a recursive list value of `depth` levels, ending in a single
+    // text block at the deepest list-item.
+    function buildNestedList(depth: number): Record<string, unknown> {
+      let inner: Record<string, unknown> = {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'leaf', marks: []}],
+      }
+      for (let level = depth - 1; level >= 0; level--) {
+        inner = {
+          _type: 'list',
+          _key: `l${level}`,
+          items: [
+            {
+              _type: 'list-item',
+              _key: `li${level}`,
+              content: [inner],
+            },
+          ],
+        }
+      }
+      return inner
+    }
+
+    // Drive N synthetic `set` events that replace the focused container's
+    // content with a progressively deeper recursive-list value. The work
+    // per iteration exercises the engine's set+normalize+render cost on
+    // increasingly deep paths, which is the workload the O(D^2) -> O(D)
+    // traversal fixes target. This is NOT a model of keyboard-driven tab
+    // behavior - real tab moves one node per keystroke through plugin
+    // behaviors. Use this scenario as a regression guard on set-on-deep-
+    // paths, not as a predictor for keystroke-driven workloads.
+    test('Setting progressively deeper nested list values', async () => {
+      const INDENTS = 30
+
+      // Build a starting value with two sibling list-items at top level,
+      // so the second one can be sunk into the first.
+      const initialValue = [
+        {
+          _type: 'list',
+          _key: 'root',
+          items: [
+            {
+              _type: 'list-item',
+              _key: 'sink',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'sink-text',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'sink-span', text: 'sink', marks: []},
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'list-item',
+              _key: 'item',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'item-text',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'item-span', text: 'item', marks: []},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const {editor, locator} = await createTestEditor({
+        schemaDefinition,
+        initialValue: initialValue as never,
+        children: (
+          <ContainerPlugin containers={[listContainer, listItemContainer]} />
+        ),
+      })
+      await vi.waitFor(() =>
+        expect(locator.getByTestId('li-item')).toBeInTheDocument(),
+      )
+
+      // Per-indent duration. We measure from editor.send through to the
+      // DOM showing the new nesting depth, so React commit + selectors
+      // are included.
+      const durations: Array<number> = []
+
+      for (let i = 0; i < INDENTS; i++) {
+        const t0 = performance.now()
+
+        // Each iteration replaces the sink list-item's content with a
+        // fresh recursive list value one level deeper than the last,
+        // via a single `set` event. The engine path exercised is:
+        // operation apply on a deep path + normalize + React commit.
+        const nestedItemContent = buildNestedList(i + 1)
+        editor.send({
+          type: 'set',
+          at: [{_key: 'root'}, 'items', {_key: 'sink'}, 'content'],
+          value: [nestedItemContent],
+        } as never)
+
+        await vi.waitFor(() =>
+          expect(locator.getByTestId(`list-l${i}`)).toBeInTheDocument(),
+        )
+        durations.push(performance.now() - t0)
+      }
+
+      const total = durations.reduce((a, b) => a + b, 0)
+      const max = Math.max(...durations)
+      const last5 = durations.slice(-5)
+      const last5Avg = last5.reduce((a, b) => a + b, 0) / last5.length
+
+      console.warn(
+        `Set deepening nested list ${INDENTS}x: total ${total.toFixed(0)}ms, max ${max.toFixed(0)}ms, last-5 avg ${last5Avg.toFixed(0)}ms`,
+      )
+    }, 60_000)
+  })
+
   test('onChange is batched', async () => {
     const slateEditorRef = React.createRef<PortableTextSlateEditor>()
     let onChangeCount = 0


### PR DESCRIPTION
Several traversal primitives in the editor had quadratic-in-depth cost. The compound effect surfaced when tab-indenting a list-item inside a recursive list container — each indent doubles the nesting depth, and the cost compounded fast enough to freeze the editor after ~5 indents on a normal document.

Synthetic stress test (single list-item, repeatedly tabbed; in a Pilcrow-shaped recursive list schema):

| Indents | Depth | Before | After |
|---|---|---|---|
| 5 | 11 | 126ms | 10ms |
| 10 | 21 | 775ms | 27ms |
| 15 | 31 | ~2000ms | 61ms |
| 20 | 41 | ~5000ms | 103ms |

Per-indent cost is now roughly flat with depth.

## What changed

- **`getAncestors`** called `getNode` per ancestor, and each `getNode` re-walked from the root. So a depth-D call cost O(D²). Now does a single descent from the root collecting each ancestor as it goes.

- **`comparePathsInTree`** (the document-order comparator used by range queries and dirty-path tracking) called `getChildren` at each path level, and `getChildren` itself re-walks from the root. Same O(D²) shape. Now descends both paths in a single pass, advancing the current children array as it goes.

- **`getSelectedTextBlocks`**, **`getSelectedBlocks`** and **`getSelectedChildren`** now short-circuit when the selection endpoints share the same enclosing block / root block / inline child. The range walk only runs when the selection actually crosses the boundary. Toolbar selectors fire on every state change, so this matters per-keystroke, not just per-operation.

## Regression guard

A new scenario in `packages/editor/tests/performance.test.tsx` drives 30 synthetic indents into a recursive list and measures wall-clock per indent. Mirrors the workload shape that surfaced the cost above. Stays at single-digit-second total wall-clock so it can run in CI. Not a magnitude predictor for keyboard-driven prod workloads — those involve the plugin pipeline, real keystroke timing, and reactive selectors that this harness doesn't reproduce.

## Notes

No behavior changes — all 343 existing engine unit tests pass. The selector fast-paths return the same values they did before for the same inputs; they just skip the tree walk when it would visit a single node anyway.

No new API surface.