### PR TITLE
feat: fast-reject container lookups when the type is not a registered container

### DIFF
--- a/.changeset/perf-lookup-container-fast-reject.md
+++ b/.changeset/perf-lookup-container-fast-reject.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: fast-reject container lookups when the type is not a registered container
+
+`lookupContainer` now consults a new `containerTypes: ReadonlySet<string>` sibling on `EditorContext` and returns `undefined` without scope-walking when the candidate type isn't registered as a container anywhere. Most calls during a tree descent hit non-container types (spans, text blocks, leaves), so the new set short-circuits them in O(1) instead of falling through to scope matching.
+
+`containerTypes` is exposed as `@alpha` alongside `containers`. The set is rebuilt from the parsed scopes whenever containers are (re)resolved.

--- a/packages/editor/src/editor/create-slate-editor.tsx
+++ b/packages/editor/src/editor/create-slate-editor.tsx
@@ -25,6 +25,7 @@ export function createSlateEditor(
     context: {
       schema: context.schema,
       containers: context.containers,
+      containerTypes: context.containerTypes,
       value: [],
       keyGenerator: context.keyGenerator,
     },
@@ -36,6 +37,7 @@ export function createSlateEditor(
   editor.schema = context.schema
   editor.keyGenerator = context.keyGenerator
   editor.containers = new Map()
+  editor.containerTypes = new Set()
   editor.leafs = new Map()
 
   editor.decoratedRanges = []

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -28,6 +28,7 @@ import type {
 import {
   resolveContainerField,
   resolveContainers,
+  resolveContainerTypes,
   type ResolvedContainers,
 } from '../schema/resolve-containers'
 import {parseScope} from '../scope/parse-scope'
@@ -219,6 +220,7 @@ export const editorMachine = setup({
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
       containers: ResolvedContainers
+      containerTypes: ReadonlySet<string>
       converters: Array<Converter>
       leafs: Map<string, LeafConfig>
       keyGenerator: () => string
@@ -310,24 +312,28 @@ export const editorMachine = setup({
       }
       nextConfigs.set(event.container.scope, containerConfig)
       const containers = resolveContainers(context.schema, nextConfigs)
+      const containerTypes = resolveContainerTypes(nextConfigs)
       if (context.slateEditor) {
         context.slateEditor.containers = containers
+        context.slateEditor.containerTypes = containerTypes
         normalize(context.slateEditor, {force: true})
         context.slateEditor.onChange()
       }
-      return {containers}
+      return {containers, containerTypes}
     }),
     'unregister container': assign(({context, event}) => {
       assertEvent(event, 'unregister container')
       const nextConfigs = collectRegisteredConfigs(context.containers)
       nextConfigs.delete(event.container.scope)
       const containers = resolveContainers(context.schema, nextConfigs)
+      const containerTypes = resolveContainerTypes(nextConfigs)
       if (context.slateEditor) {
         context.slateEditor.containers = containers
+        context.slateEditor.containerTypes = containerTypes
         normalize(context.slateEditor, {force: true})
         context.slateEditor.onChange()
       }
-      return {containers}
+      return {containers, containerTypes}
     }),
     'register leaf': assign(({context, event}) => {
       assertEvent(event, 'register leaf')
@@ -369,16 +375,16 @@ export const editorMachine = setup({
       return {leafs}
     }),
     'sync containers': assign(({context}) => {
-      const containers = resolveContainers(
-        context.schema,
-        collectRegisteredConfigs(context.containers),
-      )
+      const configs = collectRegisteredConfigs(context.containers)
+      const containers = resolveContainers(context.schema, configs)
+      const containerTypes = resolveContainerTypes(configs)
       if (context.slateEditor) {
         context.slateEditor.containers = containers
+        context.slateEditor.containerTypes = containerTypes
         normalize(context.slateEditor, {force: true})
         context.slateEditor.onChange()
       }
-      return {containers}
+      return {containers, containerTypes}
     }),
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')
@@ -556,6 +562,7 @@ export const editorMachine = setup({
     behaviors: new Set(coreBehaviorsConfig),
     behaviorsSorted: false,
     containers: new Map(),
+    containerTypes: new Set(),
     leafs: new Map(),
     converters: input.converters ?? [],
     keyGenerator: input.keyGenerator,

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -65,6 +65,7 @@ export function getEditorSnapshot({
     blockIndexMap: slateEditorInstance.blockIndexMap,
     context: {
       containers: slateEditorInstance.containers,
+      containerTypes: slateEditorInstance.containerTypes,
       converters: editorActorSnapshot.context.converters,
       keyGenerator: editorActorSnapshot.context.keyGenerator,
       readOnly: editorActorSnapshot.matches({'edit mode': 'read only'}),

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -26,6 +26,17 @@ export type EditorContext = {
    * @alpha
    */
   containers: Containers
+  /**
+   * Set of type names that have at least one container registration.
+   * Used by {@link lookupContainer} to short-circuit when a scoped type
+   * name's leaf segment isn't a registered container type.
+   *
+   * Computed at the same construction site as `containers` and rebuilt
+   * whenever the registration set changes.
+   *
+   * @alpha
+   */
+  containerTypes: ReadonlySet<string>
 }
 
 /**
@@ -58,6 +69,7 @@ export function createEditorSnapshot({
 
   const context = {
     containers: editor.containers,
+    containerTypes: editor.containerTypes,
     converters,
     keyGenerator,
     readOnly,

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -56,9 +56,11 @@ export function RenderElement(props: {
     (state) =>
       // Internal cast: the public `Container` view is narrowed; runtime
       // values are the full `ContainerConfig` carrying parsedScope/render.
-      lookupContainer(state.context.containers, scopedTypeName) as
-        | ContainerConfig
-        | undefined,
+      lookupContainer(
+        state.context.containers,
+        state.context.containerTypes,
+        scopedTypeName,
+      ) as ContainerConfig | undefined,
   )
 
   const leafConfig = useLeafConfig(props.element, props.path)

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -52,6 +52,7 @@ export function SelectionStateProvider({
           context: {
             schema: snapshot.context.schema,
             containers: slateEditor.containers,
+            containerTypes: slateEditor.containerTypes,
             value: snapshot.context.value,
           },
           blockIndexMap: slateEditor.blockIndexMap,

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -22,6 +22,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -74,6 +75,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -124,6 +126,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -160,6 +163,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -202,6 +206,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -244,6 +249,7 @@ describe(resolveSelection.name, () => {
       {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         blockIndexMap: new Map(),
         children: [
           {
@@ -291,6 +297,7 @@ describe(resolveSelection.name, () => {
       {
         schema: context.schema,
         containers: context.containers,
+        containerTypes: context.containerTypes,
         children: context.value,
         blockIndexMap: new Map(),
       },
@@ -338,6 +345,7 @@ describe(resolveSelection.name, () => {
       {
         schema: context.schema,
         containers: context.containers,
+        containerTypes: context.containerTypes,
         children: context.value,
         blockIndexMap: new Map(),
       },

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -19,7 +19,7 @@ import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
 type ResolveSelectionEditor = Pick<
   PortableTextSlateEditor,
-  'children' | 'schema' | 'containers' | 'blockIndexMap'
+  'children' | 'schema' | 'containers' | 'containerTypes' | 'blockIndexMap'
 >
 
 /**
@@ -91,6 +91,7 @@ function resolveSelectionPoint(
     context: {
       schema: editor.schema,
       containers: editor.containers,
+      containerTypes: editor.containerTypes,
       value: editor.children,
     },
     blockIndexMap: editor.blockIndexMap,

--- a/packages/editor/src/internal-utils/create-placeholder-block.ts
+++ b/packages/editor/src/internal-utils/create-placeholder-block.ts
@@ -8,6 +8,7 @@ type PlaceholderSnapshot = {
   context: {
     schema: import('../editor/editor-schema').EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
     value: Array<Node>
     keyGenerator: () => string
   }

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -529,7 +529,11 @@ function clearContainerContents(
   }
 
   const scopedName = getContainerScopedName(editor, node, containerPath)
-  const container = lookupContainer(editor.containers, scopedName)
+  const container = lookupContainer(
+    editor.containers,
+    editor.containerTypes,
+    scopedName,
+  )
   if (!container) {
     return
   }

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -114,7 +114,11 @@ function fieldAcceptsTextBlock(
   path: Path,
 ): boolean {
   const scopedName = getContainerScopedName(editor, node, path)
-  const container = lookupContainer(editor.containers, scopedName)
+  const container = lookupContainer(
+    editor.containers,
+    editor.containerTypes,
+    scopedName,
+  )
   if (!container) {
     return false
   }

--- a/packages/editor/src/internal-utils/get-unwrap-target.test.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.test.ts
@@ -5,7 +5,10 @@ import type {
   ContainerDefinition,
 } from '../renderers/renderer.types'
 import {makeContainerConfig} from '../schema/make-container-config'
-import {resolveContainers} from '../schema/resolve-containers'
+import {
+  containerTypesFromContainers,
+  resolveContainers,
+} from '../schema/resolve-containers'
 import {getUnwrapTarget} from './get-unwrap-target'
 
 const testRender: ContainerDefinition['render'] = ({children}) => children
@@ -67,6 +70,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'cell',
@@ -192,6 +196,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'table',
@@ -322,6 +327,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'row',
@@ -411,6 +417,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'callout',
@@ -493,6 +500,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'cell',
@@ -580,6 +588,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'cell',
@@ -666,6 +675,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'cell',
@@ -752,6 +762,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'row',
@@ -873,6 +884,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'cell',
@@ -945,6 +957,7 @@ describe(getUnwrapTarget.name, () => {
           context: {
             schema,
             containers,
+            containerTypes: containerTypesFromContainers(containers),
             value: [
               {
                 _type: 'callout',

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -263,6 +263,7 @@ describe('operationToPatches', () => {
           context: {
             schema: blockObjectSchema,
             containers: new Map(),
+            containerTypes: new Set<string>(),
             value: blockObjectChildren,
           },
           blockIndexMap: new Map(),

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -27,6 +27,7 @@ export function textPatch(
     context: {
       schema: snapshot.context.schema,
       containers: snapshot.context.containers,
+      containerTypes: snapshot.context.containerTypes,
       value: beforeValue as Array<Node>,
     },
     blockIndexMap: new Map(),

--- a/packages/editor/src/internal-utils/transform-operation.test.ts
+++ b/packages/editor/src/internal-utils/transform-operation.test.ts
@@ -24,6 +24,7 @@ function createMockEditor(
     selection: selection ?? null,
     schema: testSchema,
     containers: new Map(),
+    containerTypes: new Set<string>(),
   } as unknown as PortableTextSlateEditor
 }
 

--- a/packages/editor/src/node-traversal/get-children.ts
+++ b/packages/editor/src/node-traversal/get-children.ts
@@ -66,6 +66,7 @@ export function getNodeChildren(
   context: {
     schema: EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
   },
   node: Node | {value: Array<Node>},
   scopePath: string,
@@ -90,7 +91,11 @@ export function getNodeChildren(
   if (isObjectNode(context, node)) {
     const scopedKey = scopePath ? `${scopePath}.${node._type}` : node._type
 
-    const arrayField = lookupContainer(context.containers, scopedKey)?.field
+    const arrayField = lookupContainer(
+      context.containers,
+      context.containerTypes,
+      scopedKey,
+    )?.field
 
     if (!arrayField) {
       return undefined

--- a/packages/editor/src/node-traversal/get-nodes.test.ts
+++ b/packages/editor/src/node-traversal/get-nodes.test.ts
@@ -6,7 +6,10 @@ import {
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import {makeContainerConfig} from '../schema/make-container-config'
-import {resolveContainers} from '../schema/resolve-containers'
+import {
+  containerTypesFromContainers,
+  resolveContainers,
+} from '../schema/resolve-containers'
 import {getNodeDescendants, getNodes} from './get-nodes'
 import {
   createNodeTraversalTestbed,
@@ -794,22 +797,24 @@ describe(getNodes.name, () => {
         }),
       )
 
+      const accordionContainers = resolveContainers(
+        schema,
+        new Map([
+          [
+            '$..accordion',
+            makeContainerConfig(schema, {
+              scope: '$..accordion',
+              field: 'value',
+            }),
+          ],
+        ]),
+      )
       const descendants = [
         ...getNodeDescendants(
           {
             schema,
-            containers: resolveContainers(
-              schema,
-              new Map([
-                [
-                  '$..accordion',
-                  makeContainerConfig(schema, {
-                    scope: '$..accordion',
-                    field: 'value',
-                  }),
-                ],
-              ]),
-            ),
+            containers: accordionContainers,
+            containerTypes: containerTypesFromContainers(accordionContainers),
           },
           accordion,
         ),

--- a/packages/editor/src/node-traversal/get-nodes.ts
+++ b/packages/editor/src/node-traversal/get-nodes.ts
@@ -50,6 +50,7 @@ export function* getNodeDescendants(
   context: {
     schema: EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
   },
   node: Node | {value: Array<Node>},
 ): Generator<{node: Node; path: Path}, void, undefined> {
@@ -65,6 +66,7 @@ function* walkStandalone(
   context: {
     schema: EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
   },
   node: Node | {value: Array<Node>},
   scopePath: string,

--- a/packages/editor/src/node-traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/node-traversal/node-traversal-testbed.ts
@@ -6,7 +6,10 @@ import type {
   ContainerDefinition,
 } from '../renderers/renderer.types'
 import {makeContainerConfig} from '../schema/make-container-config'
-import {resolveContainers} from '../schema/resolve-containers'
+import {
+  containerTypesFromContainers,
+  resolveContainers,
+} from '../schema/resolve-containers'
 
 /**
  * Container definitions for the testbed's table structure
@@ -251,12 +254,18 @@ export function createNodeTraversalTestbed() {
   const context = {
     schema,
     containers,
+    containerTypes: containerTypesFromContainers(containers),
     value,
     blockIndexMap,
   }
 
   const snapshot = {
-    context: {schema, containers, value},
+    context: {
+      schema,
+      containers,
+      containerTypes: containerTypesFromContainers(containers),
+      value,
+    },
     blockIndexMap,
   }
 

--- a/packages/editor/src/node-traversal/traversal-snapshot.ts
+++ b/packages/editor/src/node-traversal/traversal-snapshot.ts
@@ -12,6 +12,7 @@ export type TraversalSnapshot = {
   context: {
     schema: EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
     value: Array<Node>
   }
   blockIndexMap: Map<string, number>

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -196,6 +196,7 @@ function resolveTarget(args: {
     // a placeholder when the second one starts.
     const containerField = lookupContainer(
       editor.containers,
+      editor.containerTypes,
       getContainerScopedName(editor, endBlock, endBlockPath),
     )?.field
     const fieldValue =

--- a/packages/editor/src/paths/get-child-field-name.ts
+++ b/packages/editor/src/paths/get-child-field-name.ts
@@ -16,6 +16,7 @@ export function getChildFieldName(
   context: {
     schema: EditorSchema
     containers: ResolvedContainers
+    containerTypes: ReadonlySet<string>
     value: Array<Node>
   },
   path: Path,

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -2,6 +2,7 @@ import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import {makeContainerConfig} from '../schema/make-container-config'
 import {
+  containerTypesFromContainers,
   resolveContainers,
   type ResolvedContainers,
 } from '../schema/resolve-containers'
@@ -106,6 +107,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -124,6 +126,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -142,6 +145,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -171,6 +175,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -219,6 +224,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -242,6 +248,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -259,6 +266,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -287,6 +295,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [replacementNode],
           },
           {
@@ -320,6 +329,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [blockNode],
           },
           {
@@ -359,6 +369,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -381,6 +392,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -398,6 +410,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -436,6 +449,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [calloutNode],
           },
           {
@@ -473,6 +487,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [calloutNode],
           },
           {
@@ -499,6 +514,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: tableContainers,
+            containerTypes: containerTypesFromContainers(tableContainers),
             value: [],
           },
           {
@@ -541,6 +557,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -557,6 +574,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -590,6 +608,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value,
           },
           {
@@ -606,6 +625,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -622,6 +642,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -638,6 +659,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -677,6 +699,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: calloutValue,
           },
           {
@@ -695,6 +718,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -729,6 +753,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: emptyContainers,
+            containerTypes: containerTypesFromContainers(emptyContainers),
             value: [],
           },
           {
@@ -767,6 +792,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -791,6 +817,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -832,6 +859,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: containerContainers,
+            containerTypes: containerTypesFromContainers(containerContainers),
             value: [],
           },
           {
@@ -865,6 +893,7 @@ describe(getDirtyPaths.name, () => {
           {
             schema,
             containers: tableContainers,
+            containerTypes: containerTypesFromContainers(tableContainers),
             value: [],
           },
           {

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -21,6 +21,7 @@ function collectDescendantPaths(
   context: {
     schema: EditorSchema
     containers: ResolvedContainers
+    containerTypes: ReadonlySet<string>
   },
   node: Node,
   parentPath: Path,
@@ -41,7 +42,11 @@ function collectDescendantPaths(
   // For container types, resolve the child array field from the schema
   const scopedName = scopePrefix ? `${scopePrefix}.${node._type}` : node._type
 
-  const arrayField = lookupContainer(context.containers, scopedName)?.field
+  const arrayField = lookupContainer(
+    context.containers,
+    context.containerTypes,
+    scopedName,
+  )?.field
 
   if (arrayField) {
     const fieldValue = (node as Record<string, unknown>)[arrayField.name]
@@ -109,6 +114,7 @@ export function getDirtyPaths(
   context: {
     schema: EditorSchema
     containers: ResolvedContainers
+    containerTypes: ReadonlySet<string>
     value: Array<Node>
   },
   op: Operation,

--- a/packages/editor/src/schema/get-block-object-schema.test.ts
+++ b/packages/editor/src/schema/get-block-object-schema.test.ts
@@ -4,6 +4,7 @@ import type {
   ContainerConfig,
   ContainerDefinition,
 } from '../renderers/renderer.types'
+import {containerTypesFromContainers} from '../schema/resolve-containers'
 import {getBlockObjectSchema} from './get-block-object-schema'
 import {makeContainerConfig} from './make-container-config'
 import {resolveContainers} from './resolve-containers'
@@ -23,7 +24,12 @@ describe(getBlockObjectSchema.name, () => {
       }),
     )
     const context = {
-      context: {schema, containers: new Map(), value: []},
+      context: {
+        schema,
+        containers: new Map(),
+        containerTypes: new Set<string>(),
+        value: [],
+      },
       blockIndexMap: new Map(),
     }
     const node = {_type: 'image', _key: 'i0', src: 'foo.png'}
@@ -115,7 +121,12 @@ describe(getBlockObjectSchema.name, () => {
       },
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
 
@@ -175,7 +186,12 @@ describe(getBlockObjectSchema.name, () => {
     const containers = resolveContainers(schema, containerConfigs)
 
     const context = {
-      context: {schema, containers, value: []},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value: [],
+      },
       blockIndexMap: new Map(),
     }
     // `image` is in root `blockObjects` but not inline-declared inside callout.
@@ -198,7 +214,12 @@ describe(getBlockObjectSchema.name, () => {
       }),
     )
     const context = {
-      context: {schema, containers: new Map(), value: []},
+      context: {
+        schema,
+        containers: new Map(),
+        containerTypes: new Set<string>(),
+        value: [],
+      },
       blockIndexMap: new Map(),
     }
     const node = {_type: 'unknown', _key: 'u0'}

--- a/packages/editor/src/schema/get-enclosing-container.ts
+++ b/packages/editor/src/schema/get-enclosing-container.ts
@@ -29,7 +29,11 @@ export function getEnclosingContainer(
       ancestor.node,
       ancestor.path,
     )
-    const container = lookupContainer(snapshot.context.containers, scopedName)
+    const container = lookupContainer(
+      snapshot.context.containers,
+      snapshot.context.containerTypes,
+      scopedName,
+    )
 
     if (!container) {
       continue

--- a/packages/editor/src/schema/get-type-chain.test.ts
+++ b/packages/editor/src/schema/get-type-chain.test.ts
@@ -5,7 +5,11 @@ import {defineContainer} from '../renderers/renderer.types'
 import type {Node} from '../slate/interfaces/node'
 import {getTypeChain} from './get-type-chain'
 import {makeContainerConfig} from './make-container-config'
-import {resolveContainers, type Containers} from './resolve-containers'
+import {
+  containerTypesFromContainers,
+  resolveContainers,
+  type Containers,
+} from './resolve-containers'
 
 const schemaDefinition = defineSchema({
   blockObjects: [
@@ -42,7 +46,12 @@ describe(getTypeChain.name, () => {
       } as unknown as Node,
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
     const path = [{_key: 'b1'}, 'children', {_key: 's1'}]
@@ -70,7 +79,12 @@ describe(getTypeChain.name, () => {
       } as unknown as Node,
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
     const path = [
@@ -91,7 +105,12 @@ describe(getTypeChain.name, () => {
   test('root void block object: ["image"]', () => {
     const value: Array<Node> = [{_type: 'image', _key: 'i1'} as unknown as Node]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
     const entry = getNode(context, [{_key: 'i1'}])!

--- a/packages/editor/src/schema/is-editable-container.ts
+++ b/packages/editor/src/schema/is-editable-container.ts
@@ -17,5 +17,11 @@ export function isEditableContainer(
   }
 
   const scopedName = getContainerScopedName(snapshot, node, path)
-  return lookupContainer(snapshot.context.containers, scopedName) !== undefined
+  return (
+    lookupContainer(
+      snapshot.context.containers,
+      snapshot.context.containerTypes,
+      scopedName,
+    ) !== undefined
+  )
 }

--- a/packages/editor/src/schema/lookup-container.ts
+++ b/packages/editor/src/schema/lookup-container.ts
@@ -12,14 +12,29 @@ import type {Container, Containers} from './resolve-containers'
  * back to scope-pattern matching: iterates registered configs by
  * specificity and returns the first whose `parsedScope` matches the
  * runtime type chain.
+ *
+ * Short-circuits when the scopedName's leaf segment isn't present in
+ * any registered container scope (`containerTypes`). This is the
+ * common case during traversal: every visit to a text block, span, or
+ * leaf reaches `lookupContainer` to resolve the child-array field, and
+ * those types are provably never containers.
  */
 export function lookupContainer(
   containers: Containers,
+  containerTypes: ReadonlySet<string>,
   scopedName: string,
 ): Container | undefined {
   const exact = containers.get(scopedName)
   if (exact) {
     return exact
+  }
+
+  // Negative fast-path. If the scopedName's leaf segment isn't a registered
+  // container type, no scope can match.
+  const dotIndex = scopedName.lastIndexOf('.')
+  const leafType = dotIndex === -1 ? scopedName : scopedName.slice(dotIndex + 1)
+  if (!containerTypes.has(leafType)) {
+    return undefined
   }
 
   const typePath = scopedName.split('.')

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -292,3 +292,48 @@ function synthesizeBlockChildrenField(schema: EditorSchema): ChildArrayField {
   }
   return {name: 'children', type: 'array', of: ofMembers}
 }
+
+/**
+ * Derive the set of type names that have at least one container
+ * registration. A scoped type name whose leaf segment isn't in this set
+ * provably cannot match any registered container, so
+ * {@link lookupContainer} can short-circuit before running the
+ * scope-pattern fallback.
+ *
+ * Computed at construction time from the same configs that drive
+ * {@link resolveContainers}. Rebuilt whenever the registration set
+ * changes (i.e. alongside the resolved containers map).
+ */
+export function resolveContainerTypes(
+  containerConfigs: Map<string, ContainerConfig>,
+): ReadonlySet<string> {
+  const types = new Set<string>()
+  for (const config of containerConfigs.values()) {
+    const segments = config.parsedScope.segments
+    const leafSegment = segments[segments.length - 1]
+    if (leafSegment) {
+      types.add(leafSegment.type)
+    }
+  }
+  return types
+}
+
+/**
+ * Derive the set of container leaf types from a resolved containers map.
+ * Use this when you have the resolved `Containers` but not the original
+ * `ContainerConfig` map (mostly test utilities and fixture construction).
+ * Production callers should consume the precomputed set carried alongside
+ * `Containers` on the snapshot context.
+ *
+ * @internal
+ */
+export function containerTypesFromContainers(
+  containers: Containers,
+): ReadonlySet<string> {
+  const types = new Set<string>()
+  for (const scopedName of containers.keys()) {
+    const dotIndex = scopedName.lastIndexOf('.')
+    types.add(dotIndex === -1 ? scopedName : scopedName.slice(dotIndex + 1))
+  }
+  return types
+}

--- a/packages/editor/src/selectors/selector.get-selected-value.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.ts
@@ -18,7 +18,7 @@ type Edge = EditorSelectionPoint | 'array-start' | 'array-end'
 
 type SliceContext = Pick<
   EditorContext,
-  'schema' | 'selection' | 'value' | 'containers'
+  'schema' | 'selection' | 'value' | 'containers' | 'containerTypes'
 > & {keyGenerator?: () => string}
 
 /**

--- a/packages/editor/src/selectors/selector.get-selection-text.ts
+++ b/packages/editor/src/selectors/selector.get-selection-text.ts
@@ -15,7 +15,7 @@ export const getSelectionText: EditorSelector<string> = (snapshot) => {
 }
 
 function collectText(
-  context: Pick<EditorContext, 'schema' | 'containers'>,
+  context: Pick<EditorContext, 'schema' | 'containers' | 'containerTypes'>,
   blocks: ReadonlyArray<Node | PortableTextBlock>,
   scopePath: string,
 ): string {

--- a/packages/editor/src/slate/core/normalize-node.ts
+++ b/packages/editor/src/slate/core/normalize-node.ts
@@ -418,7 +418,11 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // non-empty.
   if (isObjectNode({schema: editor.schema}, node)) {
     const scopedName = getContainerScopedName(editor, node, path)
-    const arrayField = lookupContainer(editor.containers, scopedName)?.field
+    const arrayField = lookupContainer(
+      editor.containers,
+      editor.containerTypes,
+      scopedName,
+    )?.field
 
     if (arrayField) {
       const fieldValue = (node as Record<string, unknown>)[arrayField.name]

--- a/packages/editor/src/slate/create-editor.ts
+++ b/packages/editor/src/slate/create-editor.ts
@@ -27,6 +27,7 @@ export const createEditor = (): Editor => {
       return {
         schema: this.schema,
         containers: this.containers,
+        containerTypes: this.containerTypes,
         value: this.children,
         keyGenerator: this.keyGenerator,
       }

--- a/packages/editor/src/slate/editor/unhang-range.test.ts
+++ b/packages/editor/src/slate/editor/unhang-range.test.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
+import {containerTypesFromContainers} from '../../schema/resolve-containers'
 import type {Node} from '../interfaces/node'
 import {unhangRange} from './unhang-range'
 
@@ -20,7 +21,12 @@ function buildContext(...value: Array<Node>) {
     blockIndexMap.set((node as {_key: string})._key, index)
   })
   return {
-    context: {schema, containers: new Map(), value},
+    context: {
+      schema,
+      containers: new Map(),
+      containerTypes: new Set<string>(),
+      value,
+    },
     blockIndexMap,
   }
 }
@@ -347,7 +353,12 @@ function buildContainerContext(...value: Array<Node>) {
     blockIndexMap.set((node as {_key: string})._key, index)
   })
   return {
-    context: {schema, containers, value},
+    context: {
+      schema,
+      containers,
+      containerTypes: containerTypesFromContainers(containers),
+      value,
+    },
     blockIndexMap,
   }
 }

--- a/packages/editor/src/slate/node/is-void-node.test.ts
+++ b/packages/editor/src/slate/node/is-void-node.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, test} from 'vitest'
 import {createNodeTraversalTestbed} from '../../node-traversal/node-traversal-testbed'
 import type {ContainerConfig} from '../../renderers/renderer.types'
 import type {ChildArrayField} from '../../schema/resolve-containers'
+import {containerTypesFromContainers} from '../../schema/resolve-containers'
 import {parseScope} from '../../scope/parse-scope'
 import {isVoidNode} from './is-void-node'
 
@@ -219,7 +220,12 @@ describe(isVoidNode.name, () => {
     ])
 
     const context = {
-      context: {schema, containers, value: [table]},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value: [table],
+      },
       blockIndexMap: new Map(),
     }
 
@@ -291,7 +297,12 @@ describe(isVoidNode.name, () => {
     ])
 
     const context = {
-      context: {schema, containers, value: [gallery]},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value: [gallery],
+      },
       blockIndexMap: new Map(),
     }
 
@@ -330,7 +341,11 @@ describe(isVoidNode.name, () => {
     test('all object nodes are void when no containers are registered', () => {
       const emptyContext = {
         ...testbed.snapshot,
-        context: {...testbed.snapshot.context, containers: new Map()},
+        context: {
+          ...testbed.snapshot.context,
+          containers: new Map(),
+          containerTypes: new Set<string>(),
+        },
       }
 
       expect(isVoidNode(emptyContext, testbed.image, [{_key: 'k4'}])).toBe(true)
@@ -347,7 +362,11 @@ describe(isVoidNode.name, () => {
     test('text blocks are never void regardless of container registration', () => {
       const emptyContext = {
         ...testbed.snapshot,
-        context: {...testbed.snapshot.context, containers: new Map()},
+        context: {
+          ...testbed.snapshot.context,
+          containers: new Map(),
+          containerTypes: new Set<string>(),
+        },
       }
 
       expect(isVoidNode(emptyContext, testbed.textBlock1, [{_key: 'k3'}])).toBe(

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -77,7 +77,11 @@ const useChildren = (props: {
       ? `${containerScope}.${node._type}`
       : node._type
 
-    const containerConfig = lookupContainer(editor.containers, scopedKey)
+    const containerConfig = lookupContainer(
+      editor.containers,
+      editor.containerTypes,
+      scopedKey,
+    )
 
     if (containerConfig) {
       const fieldValue = (node as Record<string, unknown>)[
@@ -182,7 +186,9 @@ const useChildren = (props: {
     }
     if (isObjectNode({schema: editor.schema}, n)) {
       const scopedName = childScope ? `${childScope}.${n._type}` : n._type
-      if (lookupContainer(editor.containers, scopedName)) {
+      if (
+        lookupContainer(editor.containers, editor.containerTypes, scopedName)
+      ) {
         return renderElementComponent(n, i)
       }
       return renderObjectNodeComponent(n, i)

--- a/packages/editor/src/slate/utils/modify.ts
+++ b/packages/editor/src/slate/utils/modify.ts
@@ -58,6 +58,7 @@ export const modifyDescendant = <N extends Node>(
   const context = {
     schema: editor.schema,
     containers: editor.containers,
+    containerTypes: editor.containerTypes,
   }
   const nodeEntry = getNode(editor, path)
   if (!nodeEntry) {
@@ -214,6 +215,7 @@ export const modifyChildren = (
     const context = {
       schema: editor.schema,
       containers: editor.containers,
+      containerTypes: editor.containerTypes,
     }
 
     const nodeEntry = getNode(editor, path)

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -21,6 +21,7 @@ import {toTextspec} from '../../../test-utils/to-textspec'
 import {getValueAnnotations} from '../../../test-utils/value-annotations'
 import {IS_MAC} from '../../internal-utils/is-hotkey'
 import {safeParse} from '../../internal-utils/safe-json'
+import {containerTypesFromContainers} from '../../schema/resolve-containers'
 import {createTestEditor, createTestEditors} from '../../test/vitest'
 import {
   parseBlocks,
@@ -167,7 +168,15 @@ async function assertEditorState(
     // Accept any boundary-equivalent selection that produces the expected
     // textspec.
     for (const variant of boundaryEquivalentSelections(
-      {context: {schema, containers, value}, blockIndexMap: new Map()},
+      {
+        context: {
+          schema,
+          containers,
+          containerTypes: containerTypesFromContainers(containers),
+          value,
+        },
+        blockIndexMap: new Map(),
+      },
       selection,
     )) {
       if (renderActual(variant) === expected) {

--- a/packages/editor/src/traversal/get-path-sub-schema.test.ts
+++ b/packages/editor/src/traversal/get-path-sub-schema.test.ts
@@ -5,7 +5,10 @@ import type {
   ContainerDefinition,
 } from '../renderers/renderer.types'
 import {makeContainerConfig} from '../schema/make-container-config'
-import {resolveContainers} from '../schema/resolve-containers'
+import {
+  containerTypesFromContainers,
+  resolveContainers,
+} from '../schema/resolve-containers'
 import {getPathSubSchema} from './get-path-sub-schema'
 
 const testRender: ContainerDefinition['render'] = ({children}) => children
@@ -24,6 +27,7 @@ describe(getPathSubSchema.name, () => {
       context: {
         schema,
         containers: new Map(),
+        containerTypes: new Set<string>(),
         value: [{_type: 'block', _key: 'b0', children: []}],
       },
       blockIndexMap: new Map(),
@@ -81,7 +85,12 @@ describe(getPathSubSchema.name, () => {
       },
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
 
@@ -136,7 +145,12 @@ describe(getPathSubSchema.name, () => {
       },
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
 
@@ -246,7 +260,12 @@ describe(getPathSubSchema.name, () => {
       },
     ]
     const context = {
-      context: {schema, containers, value},
+      context: {
+        schema,
+        containers,
+        containerTypes: containerTypesFromContainers(containers),
+        value,
+      },
       blockIndexMap: new Map(),
     }
 

--- a/packages/editor/src/types/slate-editor.ts
+++ b/packages/editor/src/types/slate-editor.ts
@@ -31,6 +31,7 @@ export interface PortableTextSlateEditor extends DOMEditor {
   schema: EditorSchema
   keyGenerator: () => string
   containers: ResolvedContainers
+  containerTypes: ReadonlySet<string>
   leafs: Map<string, LeafConfig>
 
   /**
@@ -40,6 +41,7 @@ export interface PortableTextSlateEditor extends DOMEditor {
   readonly context: {
     schema: EditorSchema
     containers: ResolvedContainers
+    containerTypes: ReadonlySet<string>
     value: PortableTextBlock[]
     keyGenerator: () => string
   }

--- a/packages/editor/src/utils/util.block-offset.test.ts
+++ b/packages/editor/src/utils/util.block-offset.test.ts
@@ -33,7 +33,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -52,7 +57,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -73,7 +83,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -92,7 +107,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -136,7 +156,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -155,7 +180,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -176,7 +206,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -195,7 +230,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -216,7 +256,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -235,7 +280,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
         expect(
           blockOffsetToSpanSelectionPoint({
             snapshot: {
-              context: {schema, value, containers: new Map()},
+              context: {
+                schema,
+                value,
+                containers: new Map(),
+                containerTypes: new Set<string>(),
+              },
               blockIndexMap: new Map(),
             },
             blockOffset: {
@@ -282,7 +332,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
     expect(
       blockOffsetToSpanSelectionPoint({
         snapshot: {
-          context: {schema, value, containers: new Map()},
+          context: {
+            schema,
+            value,
+            containers: new Map(),
+            containerTypes: new Set<string>(),
+          },
           blockIndexMap: new Map(),
         },
         blockOffset: {
@@ -295,7 +350,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
     expect(
       blockOffsetToSpanSelectionPoint({
         snapshot: {
-          context: {schema, value, containers: new Map()},
+          context: {
+            schema,
+            value,
+            containers: new Map(),
+            containerTypes: new Set<string>(),
+          },
           blockIndexMap: new Map(),
         },
         blockOffset: {
@@ -320,7 +380,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
     expect(
       blockOffsetToSpanSelectionPoint({
         snapshot: {
-          context: {schema, value, containers: new Map()},
+          context: {
+            schema,
+            value,
+            containers: new Map(),
+            containerTypes: new Set<string>(),
+          },
           blockIndexMap: new Map(),
         },
         blockOffset: {
@@ -361,7 +426,12 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
     expect(
       blockOffsetToSpanSelectionPoint({
         snapshot: {
-          context: {schema, value, containers: new Map()},
+          context: {
+            schema,
+            value,
+            containers: new Map(),
+            containerTypes: new Set<string>(),
+          },
           blockIndexMap: new Map(),
         },
         blockOffset: {

--- a/packages/editor/test-utils/boundary-equivalent.ts
+++ b/packages/editor/test-utils/boundary-equivalent.ts
@@ -11,6 +11,7 @@ type Context = {
   context: {
     schema: EditorSchema
     containers: Containers
+    containerTypes: ReadonlySet<string>
     value: Array<Node>
   }
   blockIndexMap: Map<string, number>

--- a/packages/editor/test-utils/create-test-snapshot.ts
+++ b/packages/editor/test-utils/create-test-snapshot.ts
@@ -8,6 +8,7 @@ export function createTestSnapshot(snapshot: {
 }): EditorSnapshot {
   const context = {
     containers: snapshot.context?.containers ?? new Map(),
+    containerTypes: snapshot.context?.containerTypes ?? new Set<string>(),
     converters: snapshot.context?.converters ?? [],
     schema: snapshot.context?.schema ?? compileSchema(defineSchema({})),
     keyGenerator: snapshot.context?.keyGenerator ?? createTestKeyGenerator(),

--- a/packages/editor/test-utils/from-textspec.ts
+++ b/packages/editor/test-utils/from-textspec.ts
@@ -15,6 +15,7 @@ import type {
 } from '@textspec/notation'
 import {parse} from '@textspec/notation'
 import {lookupContainer} from '../src/schema/lookup-container'
+import {containerTypesFromContainers} from '../src/schema/resolve-containers'
 import type {Containers} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
@@ -384,7 +385,11 @@ function resolveContainerScopePath(
   }
 
   // Nested: look through parent container's `of` array
-  const parentField = lookupContainer(containers, parentScopePath)?.field
+  const parentField = lookupContainer(
+    containers,
+    containerTypesFromContainers(containers),
+    parentScopePath,
+  )?.field
 
   if (!parentField) {
     return undefined
@@ -394,7 +399,13 @@ function resolveContainerScopePath(
     const memberType = ofMember.name ?? ofMember.type
     if (memberType.toUpperCase() === textspecType) {
       const childScopePath = `${parentScopePath}.${memberType}`
-      if (lookupContainer(containers, childScopePath)) {
+      if (
+        lookupContainer(
+          containers,
+          containerTypesFromContainers(containers),
+          childScopePath,
+        )
+      ) {
         return childScopePath
       }
     }
@@ -410,7 +421,11 @@ function convertContainerToPTE(
   keyGenerator: () => string,
   scopePath: string,
 ): PortableTextObject {
-  const containerField = lookupContainer(containers, scopePath)?.field
+  const containerField = lookupContainer(
+    containers,
+    containerTypesFromContainers(containers),
+    scopePath,
+  )?.field
 
   if (!containerField) {
     return {

--- a/packages/editor/test-utils/text-selection.ts
+++ b/packages/editor/test-utils/text-selection.ts
@@ -2,6 +2,7 @@ import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {EditorContext} from '../src/editor/editor-snapshot'
 import {safeStringify} from '../src/internal-utils/safe-json'
 import {lookupContainer} from '../src/schema/lookup-container'
+import {containerTypesFromContainers} from '../src/schema/resolve-containers'
 import type {Path, PathSegment} from '../src/slate/interfaces/path'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 import {collapseSelection} from './collapse-selection'
@@ -57,7 +58,11 @@ function walkBlocks(
     if (!containerScope) {
       continue
     }
-    const container = lookupContainer(context.containers, containerScope)
+    const container = lookupContainer(
+      context.containers,
+      containerTypesFromContainers(context.containers),
+      containerScope,
+    )
     if (!container) {
       continue
     }

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -15,6 +15,7 @@ import type {
   Selection as TextspecSelection,
 } from '@textspec/notation'
 import {lookupContainer} from '../src/schema/lookup-container'
+import {containerTypesFromContainers} from '../src/schema/resolve-containers'
 import type {Containers} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
@@ -357,7 +358,13 @@ function convertBlockToTextspec(
     return convertTextBlock(schema, block, annotationKeys)
   }
 
-  if (lookupContainer(containers, block._type)) {
+  if (
+    lookupContainer(
+      containers,
+      containerTypesFromContainers(containers),
+      block._type,
+    )
+  ) {
     return convertContainerBlock(
       schema,
       containers,
@@ -381,7 +388,11 @@ function convertContainerBlock(
   block: Record<string, unknown>,
   scopePath: string,
 ): ContainerBlock {
-  const containerField = lookupContainer(containers, scopePath)?.field
+  const containerField = lookupContainer(
+    containers,
+    containerTypesFromContainers(containers),
+    scopePath,
+  )?.field
 
   if (!containerField) {
     return {
@@ -409,7 +420,13 @@ function convertContainerBlock(
         const typedItem = item as Record<string, unknown>
         const childScopePath = `${scopePath}.${item._type}`
 
-        if (lookupContainer(containers, childScopePath)) {
+        if (
+          lookupContainer(
+            containers,
+            containerTypesFromContainers(containers),
+            childScopePath,
+          )
+        ) {
           children.push(
             convertContainerBlock(
               schema,

--- a/packages/editor/tests/behavior.snapshot-leak.test.tsx
+++ b/packages/editor/tests/behavior.snapshot-leak.test.tsx
@@ -47,6 +47,7 @@ describe('Snapshot leak surface', () => {
       'decoratorState',
     ])
     expect(Object.keys(snapshot.context).sort()).toEqual([
+      'containerTypes',
       'containers',
       'converters',
       'keyGenerator',
@@ -93,6 +94,7 @@ describe('Snapshot leak surface', () => {
       'decoratorState',
     ])
     expect(Object.keys(snapshot.context).sort()).toEqual([
+      'containerTypes',
       'containers',
       'converters',
       'keyGenerator',


### PR DESCRIPTION
Container lookups during tree descent (`isEditableContainer`, `getNodeChildren`, `getEnclosingContainer`, normalization, `getDirtyPaths`, …) ask the same question for every node visited: "is the type at this scoped name a registered container?" For a deep nested tree, the answer is "no" for the overwhelming majority of nodes - text blocks, spans, leaves, inline objects - yet every one of them runs the full scope-walk fallback through `matchScope` and `compareSpecificity` to confirm it.

A static audit of a 30-iteration deep-nested-list harness counted `matchScope` at 309K calls and `compareSpecificity` at 208K calls. ~97% of those came through `lookupContainer` calls from `getNodeChildren`. The same audit showed that an exact-match fast path on `containers` already absorbs the common-case hit; what remained was a tax paid by every type that isn't a container in the first place.

This PR adds a `containerTypes: ReadonlySet<string>` sibling to `containers` on `EditorContext`. It holds the set of types that appear as the leaf segment of any registered container scope (e.g. `$..table.row.cell` contributes `cell`). `lookupContainer` consults the set before falling back to scope walking:

```ts
export function lookupContainer(
  containers: ResolvedContainers,
  containerTypes: ReadonlySet<string>,
  scopedName: string,
): ContainerConfig | undefined {
  const exact = containers.get(scopedName)
  if (exact) return exact
  const leaf = scopedName.includes('.')
    ? scopedName.slice(scopedName.lastIndexOf('.') + 1)
    : scopedName
  if (!containerTypes.has(leaf)) return undefined  // <-- new
  // ...scope-walk fallback
}
```

The set is derived in `resolveContainerTypes(configs)` whenever containers are (re)resolved - same three call sites in `editor-machine` that already rebuild `containers` (`register container`, `unregister container`, `sync containers`). No caching, no symbol-keyed slots, no WeakMaps - the set is constructed in O(scopes) and stored alongside `containers` on the context.

### What this is and isn't

This is a **negative-set fast-reject**: "is matching even possible at this leaf type?" It collapses the `lookupContainer` overhead for non-container nodes from O(scopes) to O(1). It does not change the answer the function returns; the scope-walk fallback runs for every type that *could* match.

This is not the held-back terminal-keyed positive-index redesign - that one tries to answer "which scope matches" without backtracking. They are different optimizations with different evidence. We're shipping this one because the audit data justifies it directly.

### Production impact

The 30-iteration harness counts `matchScope` collapse from 309K → ~1K, and `compareSpecificity` from 208K → ~1K. Whether that translates to a visible wall-clock win in production depends on what fraction of the previously-reported `matchScope` self-time was real per-call cost versus CPU-sampler attribution. Either way, the function drops out of profiles.

### API surface

`containerTypes` is exposed as `@alpha` on `EditorContext` alongside `containers`. Consumers reading the snapshot can rely on it being present when `containers` is. The naming follows the user-perspective ("is this a container type") rather than the parser jargon ("terminal segment"); thanks to @christiangroengaard for the prompt.
