### PR TITLE
fix: strip `data-slate-node` from text blocks rendered via `defineTextBlock` inside a container

### DIFF
--- a/.changeset/text-block-in-container-strip-data-slate-node.md
+++ b/.changeset/text-block-in-container-strip-data-slate-node.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: strip `data-slate-node` and emit `data-pt-block-type="text"` on text blocks rendered via `defineTextBlock` inside a container
+
+A text block registered via `defineTextBlock` and nested inside a container's `of` array was passing its `attributes` straight through to the consumer's `render` callback. Because `attributes` carries `data-slate-node="element"` from the underlying Slate layer, the consumer's outer wrapper element re-emitted that legacy attribute alongside the PT namespace.
+
+The container DOM contract is `data-pt-*` only - no `data-slate-*` leakage. The fix strips `data-slate-node` and injects `data-pt-block-type="text"` into the `attributes` handed to the text block's render callback, matching the behavior of the engine-default text-block branch inside containers.

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -185,8 +185,9 @@ export function RenderElement(props: {
       const serializedPath = serializePath(props.path)
       const focused = focusedContainerPath === serializedPath
       const selected = selectedContainerPaths.has(serializedPath)
+      const {'data-slate-node': _sn, ...rest} = props.attributes
       return effectiveTextBlockConfig.textBlock.render({
-        attributes: props.attributes,
+        attributes: {...rest, 'data-pt-block-type': 'text'},
         children: props.children,
         focused,
         node: props.element,

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -1,7 +1,7 @@
 import {defineSchema} from '@portabletext/schema'
 import {describe, expect, test, vi} from 'vitest'
 import {ContainerPlugin} from '../src/plugins/plugin.container'
-import {defineContainer} from '../src/renderers/renderer.types'
+import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 function normalizeInnerHTML(html: string): string {
@@ -641,6 +641,67 @@ describe('DOM structure', () => {
       expect(calloutEl!.innerHTML.match(/data-block-name/g)).toEqual(null)
       expect(calloutEl!.innerHTML.match(/data-child-key/g)).toEqual(null)
       expect(calloutEl!.innerHTML.match(/data-child-name/g)).toEqual(null)
+    })
+  })
+
+  test('8. text block rendered via `defineTextBlock` inside a container emits `data-pt-block-type="text"`, not `data-slate-node="element"`', async () => {
+    const calloutSchemaDefinition = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    })
+    const calloutContainer = defineContainer({
+      type: 'callout',
+      childField: 'content',
+      render: ({attributes, children}) => (
+        <div {...attributes} className="callout">
+          {children}
+        </div>
+      ),
+      of: [
+        defineTextBlock({
+          type: 'block',
+          render: ({attributes, children}) => (
+            <p {...attributes} className="callout-paragraph">
+              {children}
+            </p>
+          ),
+        }),
+      ],
+    })
+    await createTestEditor({
+      schemaDefinition: calloutSchemaDefinition,
+      initialValue: [
+        {
+          _key: 'c0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[calloutContainer]} />,
+    })
+    await vi.waitFor(() => {
+      const paragraph = document.querySelector('.callout-paragraph')
+      expect(paragraph).not.toEqual(null)
+      expect(paragraph!.getAttribute('data-pt-block-type')).toEqual('text')
+      expect(paragraph!.hasAttribute('data-slate-node')).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
A text block registered via `defineTextBlock` and nested inside a container's `of` array was passing its `attributes` straight through to the consumer's `render` callback. Because `attributes` carries `data-slate-node="element"` from the underlying Slate layer, the consumer's outer wrapper element re-emitted that legacy attribute alongside the PT namespace.

For example, a callout container in the playground with a nested text block was producing:

```html
<aside class="callout">
  <p data-slate-node="element" data-pt-path="..." class="callout-paragraph">
    ...
  </p>
</aside>
```

The container DOM contract is `data-pt-*` only - no `data-slate-*` leakage. Now produces:

```html
<aside class="callout">
  <p data-pt-block-type="text" data-pt-path="..." class="callout-paragraph">
    ...
  </p>
</aside>
```

This matches the behavior of the engine-default text-block branch inside containers, which already strips `data-slate-node` and emits `data-pt-block-type="text"`.

## Tests

Adds a new scenario to `dom-structure.test.tsx` that mirrors the playground's callout shape (a container whose `of` array uses `defineTextBlock`) and asserts the consumer's wrapper element carries `data-pt-block-type="text"` and does not carry `data-slate-node`. Confirmed to fail on `main` and pass with the fix across chromium, firefox, and webkit.