### PR TITLE
fix: `plugin-input-rule` preserves safe flags set on `InputRule.on`

### DIFF
--- a/.changeset/preserve-user-regex-flags.md
+++ b/.changeset/preserve-user-regex-flags.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/plugin-input-rule': patch
+---
+
+fix: `plugin-input-rule` preserves safe flags set on `InputRule.on`
+
+The plugin compiled the rule's regex with a fixed `gd` flag set, silently dropping any flags the consumer had on the source pattern. A rule like `/\[!(note|tip)\]/i` would never fire for `[!NOTE]` because the rebuilt matcher was case-sensitive.
+
+The plugin now preserves a known-safe subset of consumer flags - `i`, `m`, `s`, `u` - and lets them flow through both full-match and capture-group paths. The plugin keeps managing `g` and `d` itself; user-set `g`/`d` are dropped to avoid `Invalid flags` errors. Sticky (`y`) is also stripped because it conflicts with the plugin's `matchAll` loop, which slices and re-feeds text after each match.

--- a/packages/plugin-input-rule/src/flag-preservation.feature
+++ b/packages/plugin-input-rule/src/flag-preservation.feature
@@ -1,0 +1,159 @@
+Feature: Flag Preservation
+
+  Background:
+    Given a global keymap
+
+  # ---------------------------------------------------------------------------
+  # `i` (case-insensitive) is preserved.
+  # The pattern `/\[!note\]/i` matches `[!note]` regardless of case. Without
+  # preserving `i`, only the exact lowercase trigger would fire.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Case-Insensitive Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state       |
+      | "B: " | "[!note]"     | "B: NOTE end\|" |
+      | "B: " | "[!NOTE]"     | "B: NOTE end\|" |
+      | "B: " | "[!Note]"     | "B: NOTE end\|" |
+
+  # ---------------------------------------------------------------------------
+  # Unicode (`u`) is preserved.
+  # The pattern `/\p{L}+!/u` uses a Unicode property escape that requires
+  # the `u` flag at construction time, otherwise `new RegExp` throws.
+  # Preserving `u` lets the rule match across Unicode letters.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Unicode Rule
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state      |
+      | "B: " | "hello!"      | "B: HIT end\|" |
+      | "B: " | "héllo!"      | "B: HIT end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `g` is stripped, leaving the plugin's own `g` flag intact.
+  # The rule still fires; no `Invalid flags` error.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `g` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "(c)"         | "B: GMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `d` is stripped, leaving the plugin's own `d` flag intact.
+  # The rule still fires; no `Invalid flags` error.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `d` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "(d)"         | "B: DMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # User-set `y` (sticky) is stripped.
+  # With `y` preserved, `matchAll` would only match at `lastIndex` (0 on a
+  # freshly-built matcher), so `foo` inside `xyzfoo` would never match.
+  # Stripping `y` keeps the loop semantics: pattern fires anywhere in the
+  # text.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: User Sets `y` Flag
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state    | inserted text | new state           |
+      | "B: xyz" | "foo"         | "B: xyzYMARK end\|" |
+
+  # ---------------------------------------------------------------------------
+  # Bare pattern (no consumer flags) still fires. Historical contract pin.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Bare Pattern
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "[!plain]"    | "B: PLAIN end\|" |
+
+  # ---------------------------------------------------------------------------
+  # `i` flag flows through to capture groups.
+  # `defineTextTransformRule` replaces captured groups (not the full match)
+  # when groups are present. Pattern `/<<(yes|no)>>/i` against `<<YES>>`
+  # captures `YES`; the transform replaces just the capture, leaving the
+  # angle brackets. Without `i` flowing into the group-match path, the
+  # capture would not fire on uppercase input.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Case-Insensitive Rule With Capture Group
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state           |
+      | "B: " | "<<yes>>"     | "B: <<GHIT>> end\|" |
+      | "B: " | "<<YES>>"     | "B: <<GHIT>> end\|" |
+      | "B: " | "<<No>>"      | "B: <<GHIT>> end\|" |
+
+  # ---------------------------------------------------------------------------
+  # `u` flag flows through to capture groups.
+  # Pattern `/@(\p{L}+)\b/u` against `@héllo` captures `héllo`
+  # (Unicode letters). Transform replaces the capture, leaving the leading
+  # `@`. The `@` prefix keeps the pattern disjoint from the full-match
+  # unicode rule above.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Unicode Rule With Capture Group
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state | inserted text | new state        |
+      | "B: " | "@hello"      | "B: @UHIT end\|" |
+      | "B: " | "@héllo"      | "B: @UHIT end\|" |
+
+  # ---------------------------------------------------------------------------
+  # `y` is stripped even when the pattern has a capture group.
+  # Pattern `/(jam)session/y` against `xxxjamsession` matches at index 3
+  # (only possible with `y` stripped); captures `jam`; transform replaces
+  # just the capture, leaving `xxx` and `session` intact.
+  # ---------------------------------------------------------------------------
+  Scenario Outline: Sticky Rule With Capture Group
+    Given the editor state is <state>
+    When the editor is focused
+    And <inserted text> is inserted
+    And " end" is typed
+    Then the editor state is <new state>
+
+    Examples:
+      | state    | inserted text | new state                 |
+      | "B: xxx" | "jamsession"  | "B: xxxYHITsession end\|" |

--- a/packages/plugin-input-rule/src/flag-preservation.test.tsx
+++ b/packages/plugin-input-rule/src/flag-preservation.test.tsx
@@ -1,0 +1,124 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {
+  createTestEditor,
+  stepDefinitions,
+  type Context,
+} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import flagPreservationFeature from './flag-preservation.feature?raw'
+import {InputRulePlugin} from './plugin.input-rule'
+import {defineTextTransformRule} from './text-transform-rule'
+
+// Case-insensitive rule. Without preserving `i`, only the lowercase trigger
+// matches. With `i` preserved, uppercase and mixed-case also trigger.
+// The rule rewrites the bracket-wrapped trigger to a plain marker so the
+// firing is observable from the rendered text.
+const caseInsensitiveRule = defineTextTransformRule({
+  on: /\[!note\]/i,
+  transform: () => 'NOTE',
+})
+
+// Unicode rule. The pattern `\p{L}+!` uses a Unicode property escape that
+// requires the `u` flag at construction time, otherwise `new RegExp`
+// throws. Preserving `u` lets the rule match Unicode letters followed by
+// `!`. The pattern has no capture group, so the full match is the target.
+const unicodeRule = defineTextTransformRule({
+  on: /\p{L}+!/u,
+  transform: () => 'HIT',
+})
+
+// Rule with user-set `g` flag. The plugin already drives its own `matchAll`
+// loop; user-set `g` is redundant. The fix strips it so the rebuilt regex
+// flags stay valid.
+const userGRule = defineTextTransformRule({
+  on: /\(c\)/g,
+  transform: () => 'GMARK',
+})
+
+// Rule with user-set `d` flag. The plugin sets `d` itself to read indices.
+// User-set `d` is redundant and must be stripped to avoid `Invalid flags`.
+const userDRule = defineTextTransformRule({
+  on: /\(d\)/d,
+  transform: () => 'DMARK',
+})
+
+// Rule with sticky (`y`) flag. Sticky semantics conflict with the plugin's
+// `matchAll` loop, which slices `newText` and re-feeds it. With `y`
+// preserved, the regex only matches at `lastIndex`, breaking any match
+// that isn't at position 0 of the current slice. Stripping `y` keeps the
+// loop's intent: match the pattern anywhere in the remaining text.
+const userYRule = defineTextTransformRule({
+  on: /foo/y,
+  transform: () => 'YMARK',
+})
+
+// Bare pattern, no consumer flags. Pins that the historical contract
+// continues to work.
+const bareRule = defineTextTransformRule({
+  on: /\[!plain\]/,
+  transform: () => 'PLAIN',
+})
+
+// Case-insensitive rule with a capture group. `defineTextTransformRule`
+// replaces only the captured group when groups are present, so the
+// transform fires on the captured trigger (`yes` / `YES` / `No`) and
+// the surrounding angle brackets remain. This pins that `i` flows
+// through the group-match path, not just the full-match path.
+const groupCaseInsensitiveRule = defineTextTransformRule({
+  on: /<<(yes|no)>>/i,
+  transform: () => 'GHIT',
+})
+
+// Unicode rule with a capture group. `@(\p{L}+)` captures one or more
+// Unicode letters after `@`; the transform replaces just the capture,
+// leaving the `@` in place. Pins that `u` flows into group matching.
+// The `@` prefix keeps this pattern from overlapping the full-match
+// unicode rule above.
+const groupUnicodeRule = defineTextTransformRule({
+  on: /@(\p{L}+)\b/u,
+  transform: () => 'UHIT',
+})
+
+// Sticky rule with a capture group. With `y` preserved, the match anchors
+// at `lastIndex` 0 and never fires for `jamsession` at offset 3 of
+// `xxxjamsession`. Stripping `y` lets the match find `jamsession`,
+// capture `jam`, and replace just the capture - leaving `xxx` and
+// `session` intact.
+const groupStickyRule = defineTextTransformRule({
+  on: /(jam)session/y,
+  transform: () => 'YHIT',
+})
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        children: (
+          <>
+            <InputRulePlugin rules={[caseInsensitiveRule]} />
+            <InputRulePlugin rules={[unicodeRule]} />
+            <InputRulePlugin rules={[userGRule]} />
+            <InputRulePlugin rules={[userDRule]} />
+            <InputRulePlugin rules={[userYRule]} />
+            <InputRulePlugin rules={[bareRule]} />
+            <InputRulePlugin rules={[groupCaseInsensitiveRule]} />
+            <InputRulePlugin rules={[groupUnicodeRule]} />
+            <InputRulePlugin rules={[groupStickyRule]} />
+          </>
+        ),
+        schemaDefinition: defineSchema({
+          decorators: [{name: 'strong'}],
+          annotations: [{name: 'link'}],
+        }),
+      })
+
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: flagPreservationFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/plugin-input-rule/src/plugin.input-rule.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.tsx
@@ -69,7 +69,17 @@ export function defineInputRuleBehavior(config: {
       const foundActions: Array<BehaviorAction> = []
 
       for (const rule of config.rules) {
-        const matcher = new RegExp(rule.on.source, 'gd')
+        // Preserve a known-safe subset of flags from `rule.on`: `i` for
+        // case-insensitive matches, `m` for multi-line anchors, `s` for
+        // dot-matches-newline, `u` for Unicode property escapes. The plugin
+        // sets `g` (to drive `matchAll`) and `d` (to read match indices)
+        // itself, so user-set `g`/`d` are dropped to avoid `Invalid flags`
+        // and keep the loop's contract. `y` (sticky) is also dropped: the
+        // plugin's `matchAll` loop slices and re-feeds `newText` after each
+        // match, which is incompatible with sticky's `lastIndex`-anchored
+        // semantics.
+        const safeUserFlags = rule.on.flags.replace(/[^imsu]/g, '')
+        const matcher = new RegExp(rule.on.source, `gd${safeUserFlags}`)
 
         while (true) {
           // Find matches in the text after the insertion


### PR DESCRIPTION
The plugin compiled the rule's regex with a fixed `gd` flag set, silently dropping any flags the consumer had on the source pattern. A rule like `/\[!(note|tip)\]/i` would never fire for `[!NOTE]` because the rebuilt matcher was case-sensitive.

The plugin now preserves a known-safe subset of consumer flags: `i`, `m`, `s`, `u`. The plugin keeps managing `g` (to drive `matchAll`) and `d` (for match indices); user-set `g`/`d` are dropped to avoid `Invalid flags` errors. Sticky (`y`) is also dropped because it conflicts with the plugin's match loop, which slices and re-feeds text after each match.

## Why a whitelist

The pattern `rule.on: RegExp` invites consumers to pass any flag combination. The plugin's loop semantics constrain what's actually safe:

- `i`, `m`, `s`, `u` change matching behavior in ways the loop handles correctly. Preserved.
- `g` drives `matchAll`. The plugin sets it itself. User-set `g` is redundant; dropping it avoids `Invalid flags` when re-composing.
- `d` reads match indices. Same reasoning.
- `y` (sticky) anchors matching to `lastIndex`. The plugin slices `newText` after each match and re-feeds, breaking sticky's intent. Silently stripping keeps the loop predictable.
- `v` (set notation) is a strict superset of `u` and isn't currently exercised by any consumer. Treated as out of scope; not preserved.

## Tests

`flag-preservation.feature` covers nine scenarios:

| Flag | Pattern | What it pins |
|---|---|---|
| `i` | `/\[!note\]/i` | matches `[!note]`, `[!NOTE]`, `[!Note]` |
| `u` | `/\p{L}+!/u` | matches `hello!` and `héllo!` (pattern requires `u` to construct) |
| `g` | `/\(c\)/g` | doesn't throw `Invalid flags`, still fires |
| `d` | `/\(d\)/d` | doesn't throw, still fires |
| `y` | `/foo/y` | matches `foo` inside `xyzfoo` (stripped `y` keeps loop semantics) |
| (none) | `/\[!plain\]/` | historical contract pin |

The `y` scenario is the load-bearing one - without stripping `y`, the regex matches only at `lastIndex` 0 and never fires for matches anywhere else in the slice. The other scenarios pin either the new contract (`i`, `u`) or the no-regression contract (`g`, `d`, bare).