### PR TITLE
feat: `getSelectedValue` returns the smallest top-level-valid fragment containing the selection

### DIFF
--- a/.changeset/lca-walk-up-get-selected-value.md
+++ b/.changeset/lca-walk-up-get-selected-value.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: `getSelectedValue` returns the smallest top-level-valid fragment containing the selection
+
+`getSelectedValue` previously walked top-down from `editor.value` and preserved the full ancestor envelope around the selection. A selection inside a single table cell returned the whole table; a selection inside a callout returned the whole callout. The result was a valid `Array<PortableTextBlock>` but typically far larger than needed.
+
+The selector now finds the lowest common ancestor of the selection's endpoints and emits the smallest fragment whose top-level items are valid at the editor's root.
+
+- Selection inside one text block returns just that block, sliced to the selected portion.
+- Selection inside a container whose child field accepts top-level types (e.g. a callout, a table cell) returns the container's children directly; the envelope is dropped.
+- Selection spanning structural children whose types aren't valid at the top level (e.g. across two cells in one row) walks upward through ancestors until the contents fit at the top level, and wraps minimally.
+- Selection across siblings at the editor root continues to return those siblings, with boundary blocks recursively sliced. This case is unchanged.
+
+The return type is unchanged: `Array<PortableTextBlock>`. The clipboard and drag-and-drop payloads consumed via this selector no longer carry redundant ancestor envelopes.

--- a/packages/editor/src/selectors/selector.get-selected-value.test.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.test.ts
@@ -1021,11 +1021,7 @@ describe(`${getSelectedValue.name} with containers`, () => {
     }
 
     expect(getSelectedValue(createSnapshot(value, selection))).toEqual([
-      {
-        _type: 'callout',
-        _key: 'cal1',
-        content: [innerBlock],
-      },
+      innerBlock,
     ])
   })
 
@@ -1156,37 +1152,13 @@ describe(`${getSelectedValue.name} with containers`, () => {
       ),
     ).toEqual([
       {
-        _type: 'table',
-        _key: 'dtable1',
-        rows: [
+        ...deepInnerBlock,
+        children: [
           {
-            _type: 'row',
-            _key: 'drow1',
-            cells: [
-              {
-                _type: 'cell',
-                _key: 'dcell1',
-                content: [
-                  {
-                    _type: 'callout',
-                    _key: 'dcal1',
-                    content: [
-                      {
-                        ...deepInnerBlock,
-                        children: [
-                          {
-                            _type: 'span',
-                            _key: 'dib1c1',
-                            text: 'ee',
-                            marks: [],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
+            _type: 'span',
+            _key: 'dib1c1',
+            text: 'ee',
+            marks: [],
           },
         ],
       },
@@ -1302,6 +1274,251 @@ describe(`${getSelectedValue.name} with containers`, () => {
       getSelectedValue(createSnapshot([table], selection, nestedSchema, defs)),
     ).toEqual([
       {
+        _type: 'block',
+        _key: 'ib1',
+        children: [
+          {
+            _type: 'span',
+            _key: 'ib1c1',
+            text: 'foo ',
+            marks: [],
+          },
+          {
+            _type: 'span',
+            _key: 'ib1c2',
+            text: 'linked',
+            marks: [linkKey],
+          },
+        ],
+        markDefs: [
+          {
+            _type: 'link',
+            _key: linkKey,
+            href: 'https://example.com',
+          },
+        ],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('selection inside one cell across two text blocks unwraps the cell envelope', () => {
+    const tableSchema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      defineContainer({type: 'table', childField: 'rows'}),
+      defineContainer({type: 'row', childField: 'cells'}),
+      defineContainer({type: 'cell', childField: 'content'}),
+    ]
+
+    const block1: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'first', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const block2: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b2',
+      children: [{_type: 'span', _key: 'b2c1', text: 'second', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const cell = {
+      _type: 'cell',
+      _key: 'cell1',
+      content: [block1, block2],
+    }
+    const row = {_type: 'row', _key: 'row1', cells: [cell]}
+    const table = {_type: 'table', _key: 'table1', rows: [row]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 'b1c1'},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b2'},
+          'children',
+          {_key: 'b2c1'},
+        ],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedValue(createSnapshot([table], selection, tableSchema, defs)),
+    ).toEqual([
+      {
+        ...block1,
+        children: [{_type: 'span', _key: 'b1c1', text: 'irst', marks: []}],
+      },
+      {
+        ...block2,
+        children: [{_type: 'span', _key: 'b2c1', text: 'sec', marks: []}],
+      },
+    ])
+  })
+
+  test('selection across two cells in one row wraps up to the table', () => {
+    const tableSchema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      defineContainer({type: 'table', childField: 'rows'}),
+      defineContainer({type: 'row', childField: 'cells'}),
+      defineContainer({type: 'cell', childField: 'content'}),
+    ]
+
+    const c1Block: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'one', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const c2Block: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b2',
+      children: [{_type: 'span', _key: 'b2c1', text: 'two', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const cell1 = {_type: 'cell', _key: 'cell1', content: [c1Block]}
+    const cell2 = {_type: 'cell', _key: 'cell2', content: [c2Block]}
+    const row = {_type: 'row', _key: 'row1', cells: [cell1, cell2]}
+    const table = {_type: 'table', _key: 'table1', rows: [row]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 'b1c1'},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell2'},
+          'content',
+          {_key: 'b2'},
+          'children',
+          {_key: 'b2c1'},
+        ],
+        offset: 2,
+      },
+    }
+
+    expect(
+      getSelectedValue(createSnapshot([table], selection, tableSchema, defs)),
+    ).toEqual([
+      {
         _type: 'table',
         _key: 'table1',
         rows: [
@@ -1314,32 +1531,163 @@ describe(`${getSelectedValue.name} with containers`, () => {
                 _key: 'cell1',
                 content: [
                   {
-                    _type: 'block',
-                    _key: 'ib1',
+                    ...c1Block,
                     children: [
-                      {
-                        _type: 'span',
-                        _key: 'ib1c1',
-                        text: 'foo ',
-                        marks: [],
-                      },
-                      {
-                        _type: 'span',
-                        _key: 'ib1c2',
-                        text: 'linked',
-                        marks: [linkKey],
-                      },
+                      {_type: 'span', _key: 'b1c1', text: 'ne', marks: []},
                     ],
-                    markDefs: [
-                      {
-                        _type: 'link',
-                        _key: linkKey,
-                        href: 'https://example.com',
-                      },
-                    ],
-                    style: 'normal',
                   },
                 ],
+              },
+              {
+                _type: 'cell',
+                _key: 'cell2',
+                content: [
+                  {
+                    ...c2Block,
+                    children: [
+                      {_type: 'span', _key: 'b2c1', text: 'tw', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('selection across two rows in one table emits only the table envelope', () => {
+    const tableSchema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      defineContainer({type: 'table', childField: 'rows'}),
+      defineContainer({type: 'row', childField: 'cells'}),
+      defineContainer({type: 'cell', childField: 'content'}),
+    ]
+
+    const r1Block: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [{_type: 'span', _key: 'b1c1', text: 'one', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const r2Block: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b2',
+      children: [{_type: 'span', _key: 'b2c1', text: 'two', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    const row1 = {
+      _type: 'row',
+      _key: 'row1',
+      cells: [{_type: 'cell', _key: 'cell1', content: [r1Block]}],
+    }
+    const row2 = {
+      _type: 'row',
+      _key: 'row2',
+      cells: [{_type: 'cell', _key: 'cell2', content: [r2Block]}],
+    }
+    const table = {_type: 'table', _key: 'table1', rows: [row1, row2]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 'b1c1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row2'},
+          'cells',
+          {_key: 'cell2'},
+          'content',
+          {_key: 'b2'},
+          'children',
+          {_key: 'b2c1'},
+        ],
+        offset: 3,
+      },
+    }
+
+    expect(
+      getSelectedValue(createSnapshot([table], selection, tableSchema, defs)),
+    ).toEqual([
+      {
+        _type: 'table',
+        _key: 'table1',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'row1',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'cell1',
+                content: [r1Block],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'row2',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'cell2',
+                content: [r2Block],
               },
             ],
           },

--- a/packages/editor/src/selectors/selector.get-selected-value.ts
+++ b/packages/editor/src/selectors/selector.get-selected-value.ts
@@ -7,7 +7,9 @@ import {
 import type {EditorSelector} from '../editor/editor-selector'
 import type {EditorContext} from '../editor/editor-snapshot'
 import {getNodeChildren} from '../node-traversal/get-children'
+import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
 import type {RegisteredContainer} from '../schema/resolve-containers'
+import type {Node} from '../slate/interfaces/node'
 import type {Path} from '../slate/interfaces/path'
 import type {EditorSelectionPoint} from '../types/editor'
 import {getSelectionEndPoint} from '../utils/util.get-selection-end-point'
@@ -23,12 +25,28 @@ type SliceContext = Pick<
 > & {keyGenerator?: () => string}
 
 /**
- * Returns the portion of the document's value covered by the selection,
- * resolved at any depth.
+ * Returns the selected portion of the document's value as the smallest
+ * top-level-valid {@link PortableTextBlock} array.
  *
- * Containers fully inside the selection are preserved verbatim. Containers
- * on the selection boundary are recursed into so only the selected portion
- * of their content is kept. Text blocks on the boundary are span-sliced.
+ * The result is the minimum slice of `value` that still parses as a
+ * legal `Array<PortableTextBlock>` covering the selection:
+ *
+ * - Selection inside a single text block returns `[textBlockSliced]`.
+ * - Selection spanning multiple top-level blocks at the editor root
+ *   returns those blocks, with boundary blocks recursively sliced.
+ * - Selection wholly inside a container whose child field accepts
+ *   top-level types (e.g. a callout or a table cell whose
+ *   `content.of` includes `block`) returns the container's children
+ *   directly - the container envelope is dropped.
+ * - Selection spanning sub-structural children that aren't valid at
+ *   the top level (e.g. across two cells in one row) wraps upward
+ *   through ancestors until reaching a level whose contents fit at
+ *   the top level - the smallest enclosing container goes back into
+ *   the result, sliced to the selected portion.
+ *
+ * No metadata is added to the result. The returned array is plain
+ * portable text - same shape consumers see when reading
+ * `editor.value`.
  *
  * @public
  */
@@ -48,14 +66,305 @@ export const getSelectedValue: EditorSelector<Array<PortableTextBlock>> = (
     return []
   }
 
+  const rootTypes = getRootAcceptedTypes(snapshot.context.schema)
+  const emitTarget = findEmitTarget(
+    snapshot.context,
+    startPoint,
+    endPoint,
+    rootTypes,
+  )
+
+  if (!emitTarget) {
+    return []
+  }
+
   return sliceArray({
     context: snapshot.context,
-    blocks: snapshot.context.value,
-    pathPrefix: [],
-    fieldNameInPrefix: undefined,
+    blocks: emitTarget.children as Array<PortableTextBlock>,
+    pathPrefix: emitTarget.pathPrefix,
+    fieldNameInPrefix: emitTarget.fieldNameInPrefix,
     startEdge: startPoint,
     endEdge: endPoint,
+    parent: emitTarget.parent,
   })
+}
+
+/**
+ * Find the emit target: the array of blocks to slice, framed by the
+ * smallest enclosing scope whose contents fit at the top level.
+ *
+ * Walks down from root along the common-prefix of `startPoint.path`
+ * and `endPoint.path` to find the lowest common ancestor (LCA) at the
+ * node level. From there, decides whether the LCA's children can be
+ * emitted directly, or whether to walk back up to an ancestor whose
+ * children fit at the top level.
+ */
+function findEmitTarget(
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
+  startPoint: EditorSelectionPoint,
+  endPoint: EditorSelectionPoint,
+  rootTypes: Set<string>,
+):
+  | {
+      children: ReadonlyArray<Node>
+      pathPrefix: Path
+      fieldNameInPrefix: string | undefined
+      parent: RegisteredContainer | undefined
+    }
+  | undefined {
+  // Walk from root, descending into the deepest node whose key is a
+  // prefix of both start.path and end.path. Track the parent
+  // container so positional `of` lookups resolve.
+  const descent = descendToLCA(context, startPoint.path, endPoint.path)
+
+  if (!descent) {
+    return undefined
+  }
+
+  // Walk back up the chain until the children field at the current
+  // level accepts only types that are valid at the top level (or we
+  // reach the root).
+  let cursor = descent
+  while (cursor.parentChain.length > 0) {
+    if (childFieldFitsTopLevel(cursor.childInfo, context.schema, rootTypes)) {
+      return {
+        children: cursor.childInfo.children,
+        pathPrefix: cursor.path,
+        fieldNameInPrefix: cursor.childInfo.fieldName,
+        parent: cursor.childInfo.parent,
+      }
+    }
+    cursor = cursor.parentChain[cursor.parentChain.length - 1]!
+  }
+
+  // Reached root.
+  return {
+    children: context.value,
+    pathPrefix: [],
+    fieldNameInPrefix: undefined,
+    parent: undefined,
+  }
+}
+
+type DescentStep = {
+  path: Path
+  childInfo: {
+    children: ReadonlyArray<Node>
+    fieldName: string
+    parent: RegisteredContainer | undefined
+  }
+  parentChain: ReadonlyArray<DescentStep>
+}
+
+/**
+ * Descend from root following the common prefix of two paths. At each
+ * matching node-level segment, capture the node's children info plus
+ * the chain of ancestors leading to that node.
+ *
+ * Stops when:
+ *
+ * - The two paths diverge at the next node-level segment, OR
+ * - One path terminates (the other endpoint sits on the boundary at
+ *   this level), OR
+ * - The current node is a text block (selection points inside text
+ *   blocks share the text block as their LCA).
+ *
+ * Returns the deepest matching step. The step's `path` is the LCA
+ * node's path; `childInfo` describes the LCA's children array.
+ */
+function descendToLCA(
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
+  startPath: Path,
+  endPath: Path,
+): DescentStep | undefined {
+  const rootInfo = getNodeChildren(context, {value: context.value as Node[]})
+
+  if (!rootInfo) {
+    return undefined
+  }
+
+  let current: DescentStep = {
+    path: [],
+    childInfo: rootInfo,
+    parentChain: [],
+  }
+
+  // We compare path segments two at a time: a node-key segment plus
+  // the following field-name segment that follows it (e.g. `{_key},
+  // 'children'`). After descending through `{_key}`, the next segment
+  // in each path should be the same field name and the same `_key`
+  // for the paths to share an ancestor.
+  let startIndex = 0
+  let endIndex = 0
+
+  while (true) {
+    // Need at least one more node-level segment in each path to descend.
+    const startSeg = startPath[startIndex]
+    const endSeg = endPath[endIndex]
+
+    if (startSeg === undefined || endSeg === undefined) {
+      return current
+    }
+
+    if (!isKeyedSegment(startSeg) || !isKeyedSegment(endSeg)) {
+      // Numeric segments at this layer would mean the points use
+      // index addressing; both paths must use the same segment shape.
+      if (typeof startSeg !== typeof endSeg) {
+        return current
+      }
+      if (typeof startSeg === 'number' && startSeg !== endSeg) {
+        return current
+      }
+    }
+
+    if (
+      isKeyedSegment(startSeg) &&
+      isKeyedSegment(endSeg) &&
+      startSeg._key !== endSeg._key
+    ) {
+      return current
+    }
+
+    if (
+      typeof startSeg === 'number' &&
+      typeof endSeg === 'number' &&
+      startSeg !== endSeg
+    ) {
+      return current
+    }
+
+    const nodeKey = isKeyedSegment(startSeg) ? startSeg._key : undefined
+    const node = nodeKey
+      ? current.childInfo.children.find((c) => c._key === nodeKey)
+      : typeof startSeg === 'number'
+        ? current.childInfo.children.at(startSeg)
+        : undefined
+
+    if (!node) {
+      return current
+    }
+
+    const nodePath: Path = [
+      ...current.path,
+      ...(current.childInfo.parent || current.path.length === 0
+        ? [
+            current.childInfo.fieldName === 'value'
+              ? undefined
+              : current.childInfo.fieldName,
+          ]
+        : []),
+      isKeyedSegment(startSeg) ? {_key: nodeKey!} : (startSeg as number),
+    ].filter((s): s is Path[number] => s !== undefined)
+
+    // If the node is a text block, the LCA cannot descend further at
+    // the node level - text-block children are spans/annotations, not
+    // containers. Stop here.
+    if (isTextBlock(context, node)) {
+      // Build a step representing the text block.
+      const textBlockInfo = getNodeChildren(context, node)
+      if (!textBlockInfo) {
+        return current
+      }
+      return {
+        path: nodePath,
+        childInfo: textBlockInfo,
+        parentChain: [...current.parentChain, current],
+      }
+    }
+
+    // Object node. Get its children for the next descent.
+    const nextChildInfo = getNodeChildren(
+      context,
+      node,
+      current.childInfo.parent,
+    )
+
+    if (!nextChildInfo) {
+      return current
+    }
+
+    // Move to the next path-pair index. The next segment should be
+    // the field-name segment (e.g. 'children', 'content'). Skip it in
+    // both paths.
+    let nextStartIndex = startIndex + 1
+    let nextEndIndex = endIndex + 1
+
+    if (
+      typeof startPath[nextStartIndex] === 'string' &&
+      typeof endPath[nextEndIndex] === 'string'
+    ) {
+      if (startPath[nextStartIndex] !== endPath[nextEndIndex]) {
+        // Different field names - paths diverge here. The current
+        // node IS the LCA.
+        return {
+          path: nodePath,
+          childInfo: nextChildInfo,
+          parentChain: [...current.parentChain, current],
+        }
+      }
+      nextStartIndex++
+      nextEndIndex++
+    }
+
+    current = {
+      path: nodePath,
+      childInfo: nextChildInfo,
+      parentChain: [...current.parentChain, current],
+    }
+    startIndex = nextStartIndex
+    endIndex = nextEndIndex
+  }
+}
+
+/**
+ * Returns true if every type accepted by `childInfo`'s field is
+ * valid at the editor's top level.
+ *
+ * The check uses the schema's root accepted-types set
+ * ({@link getRootAcceptedTypes}). A field accepting only `block` and
+ * registered `blockObjects` types passes; a field accepting any
+ * intermediate type (e.g. `cell`, `row`) does not.
+ *
+ * The root level - where `childInfo.parent` is `undefined` and the
+ * field name is `value` - is trivially top-level valid.
+ */
+function childFieldFitsTopLevel(
+  childInfo: {
+    fieldName: string
+    parent: RegisteredContainer | undefined
+  },
+  schema: EditorContext['schema'],
+  rootTypes: Set<string>,
+): boolean {
+  if (!childInfo.parent) {
+    // Root or text block. Text-block children (spans) are NOT
+    // top-level. Discriminate by field name: root uses 'value'.
+    return childInfo.fieldName === 'value'
+  }
+
+  const fieldOf = childInfo.parent.field.of
+
+  for (const member of fieldOf) {
+    const memberTypeName = acceptedTypeName(member, schema)
+    if (!rootTypes.has(memberTypeName)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function acceptedTypeName(
+  member: RegisteredContainer['field']['of'][number],
+  schema: EditorContext['schema'],
+): string {
+  if (member.type === 'block') {
+    return schema.block.name
+  }
+  if (member.type === 'object' && 'name' in member && member.name) {
+    return member.name
+  }
+  return member.type
 }
 
 function sliceArray({


### PR DESCRIPTION
Superseded by #2665 - cleaner cut: keep `getSelectedValue` semantics unchanged (envelope), compose the smaller clipboard/dnd fragment from existing primitives in the converters layer instead of reshaping the public selector.