### PR TITLE
fix: render inline objects with `contenteditable="false"` on their outer wrapper inside containers

### DIFF
--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -231,7 +231,6 @@ export function RenderElement(props: {
       const {
         'data-slate-node': _sn,
         'data-slate-void': _sv,
-        'contentEditable': _ce,
         ...rest
       } = props.attributes
       return (

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -46,7 +46,6 @@ export function RenderInlineObject(props: {
     const {
       'data-slate-node': _slateNode,
       'data-slate-void': _slateVoid,
-      'contentEditable': _contentEditable,
       ...ptAttributes
     } = props.attributes
     return (

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -443,6 +443,7 @@ describe('DOM structure', () => {
           '</span>',
           '<span',
           ' data-pt-path="[_key==&quot;t0&quot;].rows[_key==&quot;r0&quot;].cells[_key==&quot;c0&quot;].content[_key==&quot;b0&quot;].children[_key==&quot;i0&quot;]"',
+          ' contenteditable="false"',
           ' data-pt-child-type="object">',
           '<span',
           ' data-pt-spacer="true"',

--- a/packages/editor/tests/inline-object-contenteditable.test.tsx
+++ b/packages/editor/tests/inline-object-contenteditable.test.tsx
@@ -1,0 +1,112 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {ContainerPlugin} from '../src/plugins/plugin.container'
+import {LeafPlugin} from '../src/plugins/plugin.leaf'
+import {defineContainer, defineLeaf} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('inline-object void wrapper contenteditable', () => {
+  test('the consumer wrapper has `contenteditable="false"` when registered via `defineLeaf`', async () => {
+    const stockTickerLeaf = defineLeaf({
+      type: 'stock-ticker',
+      render: ({attributes, children, node}) => {
+        const ticker = node as {symbol?: string}
+        return (
+          <span {...attributes} data-testid="stock-ticker">
+            {children}
+            {ticker.symbol ?? '?'}
+          </span>
+        )
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        inlineObjects: [{name: 'stock-ticker'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'before ', marks: []},
+            {_key: 'i0', _type: 'stock-ticker', symbol: 'AAPL'},
+            {_key: 's1', _type: 'span', text: ' after', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <LeafPlugin leaves={[stockTickerLeaf]} />,
+    })
+
+    await vi.waitFor(() => {
+      const consumerSpan = document.querySelector(
+        '[data-testid="stock-ticker"]',
+      )
+      expect(consumerSpan).not.toEqual(null)
+      // The legacy pipeline is in play (no `ContainerPlugin`); confirm
+      // by checking that `object-node.tsx` emitted the `data-slate-spacer`
+      // variant of the inline-void spacer.
+      expect(consumerSpan!.querySelector('[data-slate-spacer]')).not.toEqual(
+        null,
+      )
+      expect(consumerSpan!.getAttribute('contenteditable')).toEqual('false')
+    })
+  })
+
+  test('the engine-rendered placeholder wrapper has `contenteditable="false"` inside a container without `defineLeaf`', async () => {
+    const cellContainer = defineContainer({
+      type: 'cell',
+      childField: 'content',
+      render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        inlineObjects: [{name: 'stock-ticker'}],
+        blockObjects: [
+          {
+            name: 'cell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block', of: [{type: 'stock-ticker'}]}],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: 'c0',
+          _type: 'cell',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [
+                {_key: 's0', _type: 'span', text: 'before ', marks: []},
+                {_key: 'i0', _type: 'stock-ticker'},
+                {_key: 's1', _type: 'span', text: ' after', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <ContainerPlugin containers={[cellContainer]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-child-type="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.getAttribute('contenteditable')).toEqual('false')
+    })
+  })
+})


### PR DESCRIPTION
The container-aware rendering pipeline stripped `contentEditable` from the outer wrapper of an inline object in two places: the `defineLeaf` branch in `RenderInlineObject`, and the engine's fallback placeholder branch in `RenderElement`. Without `contenteditable="false"` on that outer wrapper, the caret could land inside the void and confuse selection.

Three pipelines × two routes per pipeline make a 2×2 matrix for inline objects:

|                       | legacy pipeline (no container) | container pipeline           |
|-----------------------|---------------------------------|------------------------------|
| **`defineLeaf` route**| `RenderInlineObject` leafConfig | `RenderInlineObject` leafConfig |
| **engine fallback**   | `RenderInlineObject` default    | `RenderElement` fallback     |

The `RenderInlineObject` leafConfig branch is shared between both pipelines, so the `defineLeaf` regression affected both. The `RenderElement` fallback branch is container-only. The legacy default route in `RenderInlineObject` (no `defineLeaf`) was already correct because it spreads the engine attributes unchanged.

This restores the behavior of the legacy default route (which `dom-structure.test.tsx` test 2 still pins): the outer wrapper element of an inline object carries `contenteditable="false"` so the browser treats it as a single uneditable unit, and any nested placeholder remains `contentEditable={false}` on its own.

### What changed

- `RenderInlineObject` no longer destructures `contentEditable` out of the attributes it hands to a `defineLeaf` render. Consumers spreading `{...attributes}` onto their outer element receive `contenteditable="false"` for inline objects in both the legacy and container pipelines.
- The engine's container fallback for an inline object without a registered `defineLeaf` now keeps `contentEditable` on the outer wrapper too. The inner placeholder span keeps its own `contentEditable={false}`.
- `dom-structure.test.tsx` test 5 (table > row > cell > text block > inline) gains `contenteditable="false"` on the outer inline-object wrapper in its pinned DOM.

### Tests

New `tests/inline-object-contenteditable.test.tsx`:

- `defineLeaf` route in the legacy pipeline - asserts the consumer's outer span has `contenteditable="false"`. Confirms the pipeline by asserting the `data-slate-spacer` variant of the void spacer is in the subtree.
- Engine fallback route in the container pipeline - asserts the engine's `[data-pt-child-type="object"]` wrapper inside a container has `contenteditable="false"`.

Both scenarios fail on `main` and pass with the fix. Verified across chromium, firefox, and webkit. Unit suite 713/713. Workspace `check:types --concurrency=1` 42/42 clean.

No changeset: `defineContainer` / `defineLeaf` / `ContainerPlugin` / `LeafPlugin` are `@alpha`, and the change is an internal DOM correction on that surface.