### PR TITLE
feat(`@portabletext/markdown`): expose editor-shape builders and defaults for code-block, table, blockquote, and list

### DIFF
--- a/.changeset/markdown-editor-shapes.md
+++ b/.changeset/markdown-editor-shapes.md
@@ -1,0 +1,18 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: expose editor-shape matcher builders and structural defaults
+
+Adds matcher helpers and exports needed to round-trip markdown through a Portable Text editor where containers like `code-block` and `table` use editor-friendly shapes (per-line text blocks, `content` field names) instead of the parser's internal shapes.
+
+New matcher helpers:
+
+- `buildCodeBlockObjectMatcher(definition)` - splits the parser's `code: string` source into an array of text blocks (one per line) under the definition's non-`language` field.
+- `buildTableObjectMatcher(definition)` - renames each `cells[i].value` to `cells[i].content`, symmetric with the other container shapes (`callout.content`, `blockquote.content`, `list-item.content`).
+
+New exports (previously internal):
+
+- `defaultBlockquoteObjectDefinition`, `defaultListObjectDefinition`, `defaultTableObjectDefinition`, `defaultCodeBlockObjectDefinition`, `buildObjectMatcher` - block-object definitions and the generic matcher builder, so consumers can register containers without redeclaring shapes.
+
+`DefaultTableRenderer` now reads `cells[i].content` first and falls back to `cells[i].value`, accepting both the editor shape and the legacy shape without a breaking change.

--- a/packages/markdown/src/default-schema.ts
+++ b/packages/markdown/src/default-schema.ts
@@ -122,11 +122,68 @@ export const defaultHtmlObjectDefinition = {
   fields: [{name: 'html', type: 'string'}],
 } as const satisfies BlockObjectDefinition
 
-const defaultTableObjectDefinition = {
+/**
+ * Default block-object definition for a `table` container with rows of
+ * cells where each cell holds a `value` array of child blocks.
+ *
+ * Add to a schema's `blockObjects` array to opt into table-as-container.
+ *
+ * @public
+ */
+export const defaultTableObjectDefinition = {
   name: 'table',
   fields: [
     {name: 'headerRows', type: 'number'},
     {name: 'rows', type: 'array'},
+  ],
+} as const satisfies BlockObjectDefinition
+
+/**
+ * Default block-object definition for the structural `list` shape produced
+ * by `markdownToPortableText` when a `types.list` matcher is provided.
+ *
+ * Add to a schema's `blockObjects` array to opt into list-as-container.
+ *
+ * @public
+ */
+export const defaultListObjectDefinition = {
+  name: 'list',
+  fields: [
+    {name: 'kind', type: 'string'},
+    {name: 'items', type: 'array'},
+  ],
+} as const satisfies BlockObjectDefinition
+
+/**
+ * Default block-object definition for the structural `blockquote` shape
+ * produced by `markdownToPortableText` when a `types.blockquote` matcher
+ * is provided.
+ *
+ * Add to a schema's `blockObjects` array to opt into blockquote-as-container.
+ *
+ * @public
+ */
+export const defaultBlockquoteObjectDefinition = {
+  name: 'blockquote',
+  fields: [{name: 'content', type: 'array'}],
+} as const satisfies BlockObjectDefinition
+
+/**
+ * Default block-object definition for an editor-shaped `code-block` where
+ * the source is split into an array of text blocks (one per line) instead
+ * of a single `code: string` field.
+ *
+ * The text-block sub-schema is intentionally narrow - no styles, decorators,
+ * annotations, lists, or inline objects - because a code line is plaintext.
+ * The wrapping container is expected to apply the monospace presentation.
+ *
+ * @public
+ */
+export const defaultCodeBlockObjectDefinition = {
+  name: 'code-block',
+  fields: [
+    {name: 'language', type: 'string'},
+    {name: 'lines', type: 'array'},
   ],
 } as const satisfies BlockObjectDefinition
 

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -54,7 +54,8 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
     _key: string
     cells: Array<{
       _key: string
-      value: Array<PortableTextBlock>
+      value?: Array<PortableTextBlock>
+      content?: Array<PortableTextBlock>
     }>
   }>
 }> = ({value, renderNode}) => {
@@ -65,10 +66,22 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
     cells: Array<{
       _type: 'cell'
       _key: string
-      value: Array<{_type: string; children?: Array<unknown>}>
+      value?: Array<{_type: string; children?: Array<unknown>}>
+      content?: Array<{_type: string; children?: Array<unknown>}>
     }>
   }>
   const lines: string[] = []
+
+  // Read the cell's child blocks from either `content` (the canonical
+  // editor-shape field, symmetric with callout/blockquote/list-item) or
+  // `value` (the historical field name). Supporting both keeps the
+  // renderer working for consumers that haven't migrated.
+  const getCellBlocks = (cell: {
+    value?: Array<{_type: string; children?: Array<unknown>}>
+    content?: Array<{_type: string; children?: Array<unknown>}>
+  }): Array<{_type: string; children?: Array<unknown>}> => {
+    return cell.content ?? cell.value ?? []
+  }
 
   // Helper to extract text from cell blocks
   const getCellText = (
@@ -91,7 +104,9 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   for (let i = 0; i < headerRows; i++) {
     const row = rows[i]
     if (row) {
-      const cellTexts = row.cells.map((cell) => getCellText(cell.value))
+      const cellTexts = row.cells.map((cell) =>
+        getCellText(getCellBlocks(cell)),
+      )
       lines.push(`| ${cellTexts.join(' | ')} |`)
     }
   }
@@ -106,7 +121,9 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   for (let i = headerRows; i < rows.length; i++) {
     const row = rows[i]
     if (row) {
-      const cellTexts = row.cells.map((cell) => getCellText(cell.value))
+      const cellTexts = row.cells.map((cell) =>
+        getCellText(getCellBlocks(cell)),
+      )
       lines.push(`| ${cellTexts.join(' | ')} |`)
     }
   }

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -45,6 +45,11 @@ export type {
   PortableTextTypeRendererOptions,
 } from './from-portable-text/types'
 export {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
+export {
+  buildCodeBlockObjectMatcher,
+  buildObjectMatcher,
+  buildTableObjectMatcher,
+} from './to-portable-text/matchers'
 export type {
   AnnotationMatcher,
   DecoratorMatcher,
@@ -52,3 +57,11 @@ export type {
   ObjectMatcher,
   StyleMatcher,
 } from './to-portable-text/matchers'
+
+export {
+  defaultBlockquoteObjectDefinition,
+  defaultCodeBlockObjectDefinition,
+  defaultListObjectDefinition,
+  defaultTableObjectDefinition,
+  defaultSchema,
+} from './default-schema'

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -7,7 +7,11 @@ import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {defaultSchema} from './default-schema'
 import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
-import {buildObjectMatcher} from './to-portable-text/matchers'
+import {
+  buildCodeBlockObjectMatcher,
+  buildObjectMatcher,
+  buildTableObjectMatcher,
+} from './to-portable-text/matchers'
 
 describe(markdownToPortableText.name, () => {
   test('empty string', () => {
@@ -5948,6 +5952,139 @@ describe(markdownToPortableText.name, () => {
           markDefs: [],
         },
       ])
+    })
+  })
+
+  describe(`code-block as container (\`types.code\` with editor shape)`, () => {
+    const codeBlockObjectDefinition = {
+      name: 'code-block',
+      fields: [
+        {name: 'language', type: 'string'},
+        {name: 'lines', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithCodeBlock = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [
+          ...defaultSchema.blockObjects,
+          codeBlockObjectDefinition,
+        ],
+      }),
+    )
+
+    test('splits fenced code source into per-line text blocks', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(
+          ['```javascript', 'const a = 1', 'const b = 2', '```'].join('\n'),
+          {
+            keyGenerator,
+            schema: schemaWithCodeBlock,
+            types: {
+              code: buildCodeBlockObjectMatcher(codeBlockObjectDefinition),
+            },
+          },
+        ),
+      ).toEqual([
+        {
+          _key: 'k4',
+          _type: 'code-block',
+          language: 'javascript',
+          lines: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {_type: 'span', _key: 'k1', text: 'const a = 1', marks: []},
+              ],
+            },
+            {
+              _type: 'block',
+              _key: 'k2',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {_type: 'span', _key: 'k3', text: 'const b = 2', marks: []},
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('omits language when the fence does not specify one', () => {
+      const keyGenerator = createTestKeyGenerator()
+      expect(
+        markdownToPortableText(['```', 'hello', '```'].join('\n'), {
+          keyGenerator,
+          schema: schemaWithCodeBlock,
+          types: {code: buildCodeBlockObjectMatcher(codeBlockObjectDefinition)},
+        }),
+      ).toEqual([
+        {
+          _key: 'k2',
+          _type: 'code-block',
+          lines: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: 'hello', marks: []}],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe(`table with editor cell shape (\`buildTableObjectMatcher\`)`, () => {
+    const tableObjectDefinition = {
+      name: 'table',
+      fields: [
+        {name: 'headerRows', type: 'number'},
+        {name: 'rows', type: 'array'},
+      ],
+    } as const satisfies BlockObjectDefinition
+
+    const schemaWithTable = compileSchema(
+      defineSchema({
+        ...defaultSchema,
+        blockObjects: [...defaultSchema.blockObjects, tableObjectDefinition],
+      }),
+    )
+
+    test('renames each cell value field to content', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const result = markdownToPortableText(
+        ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n'),
+        {
+          keyGenerator,
+          schema: schemaWithTable,
+          types: {table: buildTableObjectMatcher(tableObjectDefinition)},
+        },
+      )
+      // Pin the field-rename contract: every cell has `content`, not `value`.
+      // Iterate via cast-free type narrowing so the structural assertion
+      // doesn't carry a `value` field declaration that would mask its absence.
+      for (const block of result) {
+        if (block._type !== 'table') {
+          continue
+        }
+        const rows = (
+          block as {rows?: Array<{cells: Array<Record<string, unknown>>}>}
+        ).rows
+        for (const row of rows ?? []) {
+          for (const cell of row.cells) {
+            expect(cell).toHaveProperty('content')
+            expect(cell).not.toHaveProperty('value')
+          }
+        }
+      }
     })
   })
 })

--- a/packages/markdown/src/to-portable-text/matchers.ts
+++ b/packages/markdown/src/to-portable-text/matchers.ts
@@ -1,4 +1,5 @@
 import type {
+  PortableTextBlock,
   PortableTextObject,
   Schema,
   SchemaDefinition,
@@ -149,6 +150,13 @@ export type ObjectMatcher<
   isInline: boolean
 }) => PortableTextObject | undefined
 
+/**
+ * Builds an `ObjectMatcher` that filters the parser-emitted value down to
+ * the schema's declared fields and stamps it with the schema's `name` as
+ * `_type` plus a generated `_key`.
+ *
+ * @public
+ */
 export function buildObjectMatcher<TDefinition extends {name: string}>(
   definition: TDefinition,
 ): ObjectMatcher<ExtractValue<TDefinition>> {
@@ -190,3 +198,134 @@ export type ExtractValue<
 > = TDefinition extends {fields: ReadonlyArray<{name: infer TNames}>}
   ? Record<TNames & string, unknown>
   : Record<string, never>
+
+/**
+ * Builds an `ObjectMatcher` for an editor-shaped `code-block` that splits
+ * the parser-emitted `code: string` source into an array of text blocks
+ * (one per line) under the configured field name.
+ *
+ * Editors typically need a text-block-per-line shape so the caret can land
+ * inside, selection can span lines, and undo/redo coalesces per keystroke.
+ * The string-only shape from `buildObjectMatcher` does not support that.
+ *
+ * Pass the same `BlockObjectDefinition` that the schema declares; the
+ * helper reads its field name to know what to call the lines array.
+ *
+ * @public
+ */
+export function buildCodeBlockObjectMatcher<
+  TDefinition extends {name: string; fields: ReadonlyArray<{name: string}>},
+>(
+  definition: TDefinition,
+): ObjectMatcher<{language: string | undefined; code: string}> {
+  // The lines-shaped field is whichever field isn't `language`. For a
+  // `{language, lines}` definition that picks `lines`; for any other
+  // editor-shaped definition with a custom name (e.g. `source`), it
+  // picks that. Avoids hardcoding `lines` while keeping the API simple.
+  const linesField =
+    definition.fields.find((field) => field.name !== 'language')?.name ??
+    'lines'
+
+  return ({context, value, isInline}) => {
+    const schemaCollection = isInline
+      ? context.schema.inlineObjects
+      : context.schema.blockObjects
+
+    const schemaDefinition = schemaCollection.find(
+      (item) => item.name === definition.name,
+    )
+
+    if (!schemaDefinition) {
+      return undefined
+    }
+
+    const lines = (value.code ?? '').split('\n').map((lineText) => ({
+      _type: 'block',
+      _key: context.keyGenerator(),
+      style: 'normal',
+      children: [
+        {
+          _type: 'span',
+          _key: context.keyGenerator(),
+          text: lineText,
+          marks: [],
+        },
+      ],
+      markDefs: [],
+    }))
+
+    return {
+      _key: context.keyGenerator(),
+      _type: schemaDefinition.name,
+      ...(value.language !== undefined ? {language: value.language} : {}),
+      [linesField]: lines,
+    }
+  }
+}
+
+/**
+ * Builds an `ObjectMatcher` for an editor-shaped `table` that renames the
+ * parser-emitted `cells[i].value` field to a configurable name (typically
+ * `content`, matching what other container shapes use for their child
+ * blocks field).
+ *
+ * The renamed shape is symmetric with `callout.content`, `blockquote.content`,
+ * and `list-item.content` - useful when registering `cell` as a container in
+ * the editor.
+ *
+ * @public
+ */
+/**
+ * Builds an `ObjectMatcher` for a `table` that renames the parser-emitted
+ * `cells[i].value` field to `cells[i].content` - symmetric with the other
+ * container shapes (`callout.content`, `blockquote.content`,
+ * `list-item.content`) and useful when registering `cell` as a container
+ * in the editor.
+ *
+ * @public
+ */
+export function buildTableObjectMatcher<
+  TDefinition extends {name: string; fields: ReadonlyArray<{name: string}>},
+>(
+  definition: TDefinition,
+): ObjectMatcher<{
+  headerRows: number | undefined
+  rows: Array<{
+    _key: string
+    _type: 'row'
+    cells: Array<{
+      _type: 'cell'
+      _key: string
+      value: Array<PortableTextBlock>
+    }>
+  }>
+}> {
+  return ({context, value, isInline}) => {
+    const schemaCollection = isInline
+      ? context.schema.inlineObjects
+      : context.schema.blockObjects
+
+    const schemaDefinition = schemaCollection.find(
+      (item) => item.name === definition.name,
+    )
+
+    if (!schemaDefinition) {
+      return undefined
+    }
+
+    return {
+      _key: context.keyGenerator(),
+      _type: schemaDefinition.name,
+      headerRows: value.headerRows,
+      rows: value.rows.map((row) => ({
+        _type: 'row',
+        _key: row._key,
+        cells: row.cells.map((cell) => ({
+          _type: 'cell',
+          _key: cell._key,
+          content: cell.value,
+        })),
+      })),
+    }
+  }
+}


### PR DESCRIPTION
Adds the matcher helpers and exports needed to round-trip markdown through a Portable Text editor where containers like `code-block` and `table` use editor-friendly shapes (per-line text blocks, `content` field names) instead of the parser's internal shapes.

### Why

`@portabletext/markdown` ships container support (`types.code`, `types.table`, `types.list`, `types.blockquote`, `types.callout`), but two of the shapes the parser emits don't map directly onto what an editor wants to render:

- `types.code` receives `{language, code: string}`. An editor wants the source split into per-line text blocks so the caret can land inside, selection can span lines, and undo/redo coalesces per keystroke.
- `types.table` receives `cells[i].value`. Every other container shape names the child-blocks field `content` (`callout.content`, `blockquote.content`, `list-item.content`). Editors want the table cells to follow the same convention.

The existing `buildObjectMatcher(definition)` helper handles the simpler container shapes by filtering the parser's emission against the schema's declared fields. It can't reshape the code source or rename a nested cell field. The two new builders close that gap.

### What

**New matcher helpers** in `to-portable-text/matchers.ts`:

- `buildCodeBlockObjectMatcher(definition)` - splits the parser's `code: string` source on newlines into an array of text blocks under the definition's non-`language` field (typically `lines`).
- `buildTableObjectMatcher(definition)` - renames each `cells[i].value` to `cells[i].content`.

**New exports** from `default-schema.ts`:

- `defaultBlockquoteObjectDefinition`, `defaultListObjectDefinition`, `defaultTableObjectDefinition`, `defaultCodeBlockObjectDefinition` - previously internal block-object definitions, now exported so consumers can register containers without redeclaring shapes.
- `buildObjectMatcher` - the existing generic matcher builder, now part of the public API for the same reason.

**Non-breaking update** to `DefaultTableRenderer`:

The renderer now reads `cells[i].content` first and falls back to `cells[i].value`. Consumers using the legacy `value` shape continue to render correctly; consumers using the editor-shape via `buildTableObjectMatcher` also render correctly.

### Consumer usage

The package ships matchers (data transformation) and the structural defaults. Editor-shape renderers are simple enough to live in consumer code:

Replace `CodeBlockSchema` with the actual schema declaration; replace `MyRenderer` with the consumer's per-line render.

```ts
import {
  buildCodeBlockObjectMatcher,
  buildObjectMatcher,
  buildTableObjectMatcher,
  defaultBlockquoteObjectDefinition,
  defaultListObjectDefinition,
  markdownToPortableText,
} from '@portabletext/markdown'

const codeBlockDef = {
  name: 'code-block',
  fields: [{name: 'language', type: 'string'}, {name: 'lines', type: 'array'}],
} as const

const tableDef = {
  name: 'table',
  fields: [{name: 'headerRows', type: 'number'}, {name: 'rows', type: 'array'}],
} as const

markdownToPortableText(md, {
  schema,
  types: {
    code: buildCodeBlockObjectMatcher(codeBlockDef),
    table: buildTableObjectMatcher(tableDef),
    list: buildObjectMatcher(defaultListObjectDefinition),
    blockquote: buildObjectMatcher(defaultBlockquoteObjectDefinition),
  },
})
```

For the reverse direction (`portableTextToMarkdown`), consumers register a per-line renderer:

A consumer renderer concatenates each line block's span text with newlines and wraps in a fence with the optional language identifier.

### Tests

Two new describe blocks in `markdown-to-portable-text.test.ts`:

- `code-block as container (types.code with editor shape)` - asserts the lines-array shape and that `language` is omitted when the fence has none.
- `table with editor cell shape (buildTableObjectMatcher)` - asserts cells expose `content` and never `value`.

264/264 tests passing; `pnpm build` (pkg-utils strict) clean; workspace `pnpm check:types --concurrency=1` clean (42/42).
