### PR TITLE
refactor: un-exclude slate-fork Tier 1 utilities from the react-compiler boundary

### DIFF
--- a/packages/editor/eslint.config.js
+++ b/packages/editor/eslint.config.js
@@ -2,6 +2,25 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import {globalIgnores} from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
+// Keep in lock-step with `reactCompilerOptions.sources` in
+// `package.config.ts`. Tier 1 files are un-excluded from BOTH the
+// react-compiler boundary and the eslint react-hooks rules.
+const TIER_1_PATHS = [
+  'src/slate/path/path-equals.ts',
+  'src/slate/path/parent-path.ts',
+  'src/slate/text/text-equals.ts',
+  'src/slate/text/get-text-decorations.ts',
+  'src/slate/node/is-text-block-node.ts',
+  'src/slate/node/is-object-node.ts',
+  'src/slate/node/is-span-node.ts',
+  'src/slate/editor/is-editor.ts',
+  'src/slate/editor/start.ts',
+  'src/slate/editor/end.ts',
+  'src/slate/dom/utils/range-list.ts',
+  'src/slate/dom/utils/environment.ts',
+  'src/slate/react/utils/direction.ts',
+]
+
 export default tseslint.config([
   globalIgnores([
     'coverage',
@@ -11,6 +30,8 @@ export default tseslint.config([
     'src/slate/**',
     'src/slate-dom/**',
     'src/slate-react/**',
+    // Un-ignore Tier 1 pure utilities so react-hooks rules apply.
+    ...TIER_1_PATHS.map((path) => `!${path}`),
   ]),
   reactHooks.configs.flat.recommended,
   {

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -1,5 +1,30 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
+/**
+ * Tier 1 of the slate-fork compiler un-exclusion (see
+ * `/specs/render-pipeline-compiler-collapse.md`). These files are pure
+ * utilities - no hooks, no React, no module-level mutation - and are
+ * safe for react-compiler to memoize.
+ *
+ * Tier 2+ (hook helpers, wrappers, dispatch) un-exclude in follow-up
+ * phases.
+ */
+const TIER_1_PATHS = [
+  '/src/slate/path/path-equals.ts',
+  '/src/slate/path/parent-path.ts',
+  '/src/slate/text/text-equals.ts',
+  '/src/slate/text/get-text-decorations.ts',
+  '/src/slate/node/is-text-block-node.ts',
+  '/src/slate/node/is-object-node.ts',
+  '/src/slate/node/is-span-node.ts',
+  '/src/slate/editor/is-editor.ts',
+  '/src/slate/editor/start.ts',
+  '/src/slate/editor/end.ts',
+  '/src/slate/dom/utils/range-list.ts',
+  '/src/slate/dom/utils/environment.ts',
+  '/src/slate/react/utils/direction.ts',
+]
+
 export default defineConfig({
   define: {
     __DEV__: false,
@@ -26,7 +51,16 @@ export default defineConfig({
   babel: {reactCompiler: true},
   reactCompilerOptions: {
     target: '19',
-    sources: (filename: string) => !filename.includes('/src/slate/'),
+    // The slate-fork lives at `src/slate/`. Historically excluded
+    // wholesale; we are un-excluding it in tiers as code is audited
+    // safe for the compiler. Tier 1 = pure utilities (no hooks, no
+    // React, no module-level mutation).
+    sources: (filename: string) => {
+      if (!filename.includes('/src/slate/')) {
+        return true
+      }
+      return TIER_1_PATHS.some((path) => filename.endsWith(path))
+    },
   },
   dts: 'rolldown',
 })


### PR DESCRIPTION
## What this changes

Phase 1 of the slate-fork compiler-boundary un-exclusion plan (`/specs/render-pipeline-compiler-collapse.md`).

The `src/slate/` directory has historically been excluded from both react-compiler and the `react-hooks` ESLint rules in lock-step. Most of what lives there today is PTE-owned code that originated in the Slate fork - not foreign code that needs special handling. The exclusion is a maintenance cost without an architectural justification.

This is Phase 1: un-exclude the **pure utilities** - no hooks, no React, no module-level mutation. Safe by inspection.

## Files un-excluded

- `slate/path/path-equals.ts`
- `slate/path/parent-path.ts`
- `slate/text/text-equals.ts`
- `slate/text/get-text-decorations.ts`
- `slate/node/is-text-block-node.ts`
- `slate/node/is-object-node.ts`
- `slate/node/is-span-node.ts`
- `slate/editor/is-editor.ts`
- `slate/editor/start.ts`
- `slate/editor/end.ts`
- `slate/dom/utils/range-list.ts`
- `slate/dom/utils/environment.ts`
- `slate/react/utils/direction.ts`

The two config files (`package.config.ts` for react-compiler, `eslint.config.js` for the react-hooks rules) keep the un-exclusion list in lock-step.

## Why this is safe

These files are pure functions. The compiler may auto-memoize call results when inputs are reference-stable; the memoized results don't change reference identity behavior elsewhere in the tree. The hand-rolled `React.memo` equalities on `MemoizedElement`/`MemoizedText`/`MemoizedLeaf`/`MemoizedObjectNode` are unaffected - their gating logic and the path/text equality functions they call behave identically.

## Verification

- `pnpm check:types` clean
- `pnpm check:lint` clean (3 pre-existing warnings unrelated)
- `pnpm check:react-compiler` clean
- `pnpm build` clean
- `tests/render-count-regression.test.tsx` green:
  - 20-sibling list, type one character: 1 sibling re-render (just the changed item)
  - 100-block mass unmount: clean, no errors, editor remains responsive

The render-count regression suite is the load-bearing guard. If the compiler-managed Tier 1 outputs accidentally destabilized references that the hand-rolled equalities rely on, the sibling re-render count would jump. It stays at 1.

## What's next

Future phases (separate PRs):
- Phase 2: Tier 2 hook helpers (`use-slate-static`, `use-decorations`, etc.)
- Phase 3: the wrapper components and their hand-rolled memo equalities
- Phase 4: `useChildren` (the dispatch loop)
- Phase 5: opportunistic cleanups under the new shape

Each phase is independent and individually verifiable against the render-count regression suite.

The baseline this work measures against is captured in `/specs/render-pipeline-baseline-post-2666.md` (post-#2666 main: ~13 wrapper renders per keystroke at depth 4, ~44 at depth 6 - linear with depth, independent of sibling fan-out, thanks to the existing memo equalities).