### PR TITLE
refactor: un-exclude slate-fork Tier 2 hooks from the react-compiler boundary

### DIFF
--- a/packages/editor/eslint.config.js
+++ b/packages/editor/eslint.config.js
@@ -3,8 +3,10 @@ import {globalIgnores} from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
 // Keep in lock-step with `reactCompilerOptions.sources` in
-// `package.config.ts`. Tier 1 files are un-excluded from BOTH the
-// react-compiler boundary and the eslint react-hooks rules.
+// `package.config.ts`. These slate-fork files are un-excluded from
+// BOTH the react-compiler boundary and the eslint react-hooks rules
+// in tiers as the code is audited safe (see
+// `/specs/render-pipeline-compiler-collapse.md`).
 const TIER_1_PATHS = [
   'src/slate/path/path-equals.ts',
   'src/slate/path/parent-path.ts',
@@ -21,6 +23,19 @@ const TIER_1_PATHS = [
   'src/slate/react/utils/direction.ts',
 ]
 
+/**
+ * Tier 2 = hook utilities. Phase 2 of the un-exclusion plan.
+ */
+const TIER_2_PATHS = [
+  'src/slate/react/hooks/use-slate-static.tsx',
+  'src/slate/react/hooks/use-isomorphic-layout-effect.ts',
+  'src/slate/react/hooks/use-generic-selector.tsx',
+  'src/slate/react/hooks/use-read-only.ts',
+  'src/slate/react/hooks/use-decorations.ts',
+]
+
+const UN_IGNORED_SLATE_PATHS = [...TIER_1_PATHS, ...TIER_2_PATHS]
+
 export default tseslint.config([
   globalIgnores([
     'coverage',
@@ -31,7 +46,7 @@ export default tseslint.config([
     'src/slate-dom/**',
     'src/slate-react/**',
     // Un-ignore Tier 1 pure utilities so react-hooks rules apply.
-    ...TIER_1_PATHS.map((path) => `!${path}`),
+    ...UN_IGNORED_SLATE_PATHS.map((path) => `!${path}`),
   ]),
   reactHooks.configs.flat.recommended,
   {

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -1,13 +1,17 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
 /**
- * Tier 1 of the slate-fork compiler un-exclusion (see
- * `/specs/render-pipeline-compiler-collapse.md`). These files are pure
- * utilities - no hooks, no React, no module-level mutation - and are
- * safe for react-compiler to memoize.
+ * The slate-fork lives at `src/slate/`. Historically excluded
+ * wholesale from react-compiler; we are un-excluding it in tiers as
+ * code is audited safe for the compiler.
  *
- * Tier 2+ (hook helpers, wrappers, dispatch) un-exclude in follow-up
- * phases.
+ * - Tier 1 = pure utilities (no hooks, no React, no module-level
+ *   mutation).
+ * - Tier 2 = hook utilities (`useContext`, `useEffect`-style and
+ *   selector helpers used by the wrappers).
+ *
+ * See `/specs/render-pipeline-compiler-collapse.md`. Kept in lock-step
+ * with `eslint.config.js` (the react-hooks ignores).
  */
 const TIER_1_PATHS = [
   '/src/slate/path/path-equals.ts',
@@ -24,6 +28,21 @@ const TIER_1_PATHS = [
   '/src/slate/dom/utils/environment.ts',
   '/src/slate/react/utils/direction.ts',
 ]
+
+/**
+ * Tier 2 = hook utilities (no per-render ref mutation, no manual
+ * memoization that the compiler can't see). Phase 2 of the
+ * un-exclusion plan.
+ */
+const TIER_2_PATHS = [
+  '/src/slate/react/hooks/use-slate-static.tsx',
+  '/src/slate/react/hooks/use-isomorphic-layout-effect.ts',
+  '/src/slate/react/hooks/use-generic-selector.tsx',
+  '/src/slate/react/hooks/use-read-only.ts',
+  '/src/slate/react/hooks/use-decorations.ts',
+]
+
+const TIER_1_AND_2_PATHS = [...TIER_1_PATHS, ...TIER_2_PATHS]
 
 export default defineConfig({
   define: {
@@ -51,15 +70,11 @@ export default defineConfig({
   babel: {reactCompiler: true},
   reactCompilerOptions: {
     target: '19',
-    // The slate-fork lives at `src/slate/`. Historically excluded
-    // wholesale; we are un-excluding it in tiers as code is audited
-    // safe for the compiler. Tier 1 = pure utilities (no hooks, no
-    // React, no module-level mutation).
     sources: (filename: string) => {
       if (!filename.includes('/src/slate/')) {
         return true
       }
-      return TIER_1_PATHS.some((path) => filename.endsWith(path))
+      return TIER_1_AND_2_PATHS.some((path) => filename.endsWith(path))
     },
   },
   dts: 'rolldown',


### PR DESCRIPTION
## What this changes

Phase 2 of the slate-fork compiler-boundary un-exclusion plan (`/specs/render-pipeline-compiler-collapse.md`). Stacks on top of Phase 1 (PR #2669).

Un-excludes 5 hook utilities used by the render pipeline:

- `slate/react/hooks/use-slate-static.tsx` - `useContext` wrapper for the editor object
- `slate/react/hooks/use-isomorphic-layout-effect.ts` - SSR-safe `useLayoutEffect`
- `slate/react/hooks/use-generic-selector.tsx` - selector-with-update helper used by `useDecorations`
- `slate/react/hooks/use-read-only.ts` - `useContext` wrapper for the readOnly flag
- `slate/react/hooks/use-decorations.ts` - per-node decoration subscription

Both configs (`package.config.ts` for react-compiler, `eslint.config.js` for the react-hooks rules) un-exclude these in lock-step via shared `TIER_2_PATHS` constants composed with Tier 1.

## Why this is safe

These hooks use standard React patterns: `useContext` (`use-slate-static`, `use-read-only`), a module-level constant selecting between `useLayoutEffect` and `useEffect` (`use-isomorphic-layout-effect`), and the selector-with-equality-check pattern (`use-generic-selector`, used by `use-decorations`).

`use-generic-selector` has an explicit `eslint-disable react-hooks/exhaustive-deps` on its `useCallback` - that's intentional (the callback intentionally captures the latest ref values, not the deps closure). The compiler handles this cleanly.

Other slate-fork hooks (`use-slate-selector.tsx`, `use-slate.tsx`, `use-is-mounted.tsx`, `use-mutation-observer.ts`, `use-track-user-input.ts`, the Android input manager) stay excluded - they're tied to the `contenteditable` lifecycle in `editable.tsx`, which is out of scope for this refactor.

## Verification

- `pnpm check:types` clean
- `pnpm check:lint` clean (3 pre-existing warnings unrelated)
- `pnpm check:react-compiler` clean
- `pnpm build` clean
- `tests/render-count-regression.test.tsx` green:
  - 20-sibling list, type one character: 1 sibling re-render
  - 100-block mass unmount: clean, no errors

## What's next

Per the post-#2666 baseline (`/specs/render-pipeline-baseline-post-2666.md`), Phase 4 comes before Phase 3:

- **Phase 4** - un-exclude `useChildren` (the dispatch loop). The compiler needs to see the per-iteration path-array allocation to memoize wrapper props.
- **Phase 3** - un-exclude the wrapper components + delete the five hand-rolled `React.memo` equalities. Verify-by-breaking against the PROBE harness.
- **Phase 5** - opportunistic cleanups (ternary helper, ObjectNode fold, RenderElement signature shrink).

## PR stacking

This PR targets `refactor/compiler-tier1-utilities` (the Phase 1 branch). Once #2669 lands, this rebase-targets `main` and merges next.