### PR TITLE
refactor: un-exclude slate-fork Tier 3 wrappers from the react-compiler boundary

### DIFF
--- a/packages/editor/eslint.config.js
+++ b/packages/editor/eslint.config.js
@@ -34,7 +34,22 @@ const TIER_2_PATHS = [
   'src/slate/react/hooks/use-decorations.ts',
 ]
 
-const UN_IGNORED_SLATE_PATHS = [...TIER_1_PATHS, ...TIER_2_PATHS]
+/**
+ * Tier 3 = wrapper components rendered by `useChildren`.
+ */
+const TIER_3_PATHS = [
+  'src/slate/react/components/element.tsx',
+  'src/slate/react/components/text.tsx',
+  'src/slate/react/components/leaf.tsx',
+  'src/slate/react/components/object-node.tsx',
+  'src/slate/react/components/string.tsx',
+]
+
+const UN_IGNORED_SLATE_PATHS = [
+  ...TIER_1_PATHS,
+  ...TIER_2_PATHS,
+  ...TIER_3_PATHS,
+]
 
 export default tseslint.config([
   globalIgnores([

--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -9,6 +9,13 @@ import {defineConfig} from '@sanity/pkg-utils'
  *   mutation).
  * - Tier 2 = hook utilities (`useContext`, `useEffect`-style and
  *   selector helpers used by the wrappers).
+ * - Tier 3 = wrapper components rendered by `useChildren`. The
+ *   compiler can compile these even though `useChildren` itself
+ *   stays uncompiled: the cache stabilizes the props bundle at the
+ *   call site. Hand-rolled `React.memo` equalities are retained for
+ *   now because `useChildren` allocates fresh `path` arrays each
+ *   render; deleting the equalities is gated on a follow-up that
+ *   compiles `useChildren`.
  *
  * See `/specs/render-pipeline-compiler-collapse.md`. Kept in lock-step
  * with `eslint.config.js` (the react-hooks ignores).
@@ -42,7 +49,23 @@ const TIER_2_PATHS = [
   '/src/slate/react/hooks/use-decorations.ts',
 ]
 
-const TIER_1_AND_2_PATHS = [...TIER_1_PATHS, ...TIER_2_PATHS]
+/**
+ * Tier 3 = wrapper components rendered by `useChildren`. Phase 3 of
+ * the un-exclusion plan.
+ */
+const TIER_3_PATHS = [
+  '/src/slate/react/components/element.tsx',
+  '/src/slate/react/components/text.tsx',
+  '/src/slate/react/components/leaf.tsx',
+  '/src/slate/react/components/object-node.tsx',
+  '/src/slate/react/components/string.tsx',
+]
+
+const UN_EXCLUDED_SLATE_PATHS = [
+  ...TIER_1_PATHS,
+  ...TIER_2_PATHS,
+  ...TIER_3_PATHS,
+]
 
 export default defineConfig({
   define: {
@@ -74,7 +97,7 @@ export default defineConfig({
       if (!filename.includes('/src/slate/')) {
         return true
       }
-      return TIER_1_AND_2_PATHS.some((path) => filename.endsWith(path))
+      return UN_EXCLUDED_SLATE_PATHS.some((path) => filename.endsWith(path))
     },
   },
   dts: 'rolldown',


### PR DESCRIPTION
## What this changes

Phase 3 of the slate-fork compiler-boundary un-exclusion plan (`/specs/render-pipeline-compiler-collapse.md`). Lands after Phase 2 (PR #2670).

Un-excludes the five wrapper components rendered by `useChildren`:

- `slate/react/components/element.tsx`
- `slate/react/components/text.tsx`
- `slate/react/components/leaf.tsx`
- `slate/react/components/object-node.tsx`
- `slate/react/components/string.tsx`

Both configs (`package.config.ts` for react-compiler, `eslint.config.js` for the react-hooks rules) un-exclude these in lock-step via a new `TIER_3_PATHS` constant composed with Tier 1 + Tier 2.

## What this delivers

Two concrete things, in honest order:

**1. ESLint coverage on the wrapper bodies.** `react-hooks/exhaustive-deps` and the compiler's eslint plugin now lint these files. Future edits can't introduce missing deps or ref-during-render slip-ups without a lint failure.

**2. Compiler memoization of wrapper body work.** Each compiled wrapper has its own cache:

| Wrapper | Cache | Slot checks |
| --- | --- | --- |
| `Element` | 7 | 6 |
| `Text` | 3 | 2 |
| `Leaf` | 14 | 12 |
| `ObjectNodeComponent` | 3 | 2 |
| `TextString` | 8 | 5 |

The most useful slot, in `Element`, memoizes the props bundle handed to `useChildren`. Even though `useChildren` itself stays uncompiled, the boundary into it receives a stable props object reference when the inputs are unchanged.

## What this does NOT deliver

**No runtime perf improvement on the hot paths the render-count regression test exercises.** Sibling re-renders on `insert.text` stay at 1 (vs 1 pre-PR). The compiler-cache stabilizes intermediate values inside the wrapper bodies, but the wrappers' outer `React.memo` gate is the thing actually short-circuiting the 17-sibling fan-out - and that gate's hand-rolled `pathEquals`-based equality is doing the work.

**Hand-rolled `React.memo` equalities are retained.** They cannot be deleted yet. `useChildren` is still uncompiled and constructs fresh `path` arrays in its `renderElementComponent` callback every render (`[...parentPath, childFieldName, {_key: node._key}]`). Removing `pathEquals` from the wrapper memo equality would let the default `Object.is` gate open on every fresh path, regressing the sibling short-circuit.

Deleting the equalities is gated on a follow-up that compiles `useChildren`, which requires refactoring its `useDecorationsByChild` mutating-ref pattern (and possibly the `editor.isNodeMapDirty = false` clear-during-render). Tracked separately.

## Verification

- `pnpm check:format` clean
- `pnpm check:lint` clean
- `pnpm check:types` clean (workspace)
- `pnpm check:react-compiler` clean
- `pnpm knip` clean (only pre-existing hint output)
- `pnpm build` clean; wrapper cache slots verified in compiled `lib/index.js`
- `tests/render-count-regression.test.tsx` green (1 sibling re-render across 1 key on 20-sibling typing, mass-unmount clean)

## What's next

Per the post-#2666 baseline (`/specs/render-pipeline-baseline-post-2666.md`):

- **Follow-up A** - run the compiler bailout logger on `useChildren` to identify the exact bail reason (ref mutation in `useDecorationsByChild`, the `isNodeMapDirty` clear, or a third structural cause).
- **Follow-up B** - based on (A), reshape `splitDecorationsByChild` to take a `previous` argument and return identity-stable per-index references via `useMemo`, replacing the current ref-mutation pattern with something the compiler accepts.
- **Phase 3b** - delete the hand-rolled `React.memo` equalities. Verifiable via the existing render-count regression test (strip the equality, sibling re-renders should stay at 1 once `useChildren` is compiled and emits identity-stable paths).