### PR TITLE
feat(playground): add v7 deck sub-page

### DIFF
--- a/apps/playground/src/v7/Deck.tsx
+++ b/apps/playground/src/v7/Deck.tsx
@@ -2,6 +2,8 @@ import {
   EditorProvider,
   keyGenerator,
   PortableTextEditable,
+  useEditor,
+  useEditorSelector,
   type Editor,
   type RenderAnnotationFunction,
   type RenderDecoratorFunction,
@@ -13,9 +15,11 @@ import {
   EditorRefPlugin,
   EventListenerPlugin,
 } from '@portabletext/editor/plugins'
+import * as selectors from '@portabletext/editor/selectors'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {DeckChrome} from './deck-chrome'
 import {DeckContainerPlugins} from './deck-containers'
+import {PasteMarkdownModal} from './paste-markdown-modal'
 import {DeckNavPlugin} from './plugin.deck-nav'
 import {deckSchemaDefinition} from './schema'
 import {useShikiDecorations} from './shiki'
@@ -27,31 +31,75 @@ import {ValueInspector} from './value-inspector'
 /**
  * The v7 deck.
  *
- * One Portable Text document, N slide containers at the root, one slide
- * visible at a time. Navigation (arrow keys, click) drives a single
- * `currentSlideIndex` piece of state; the slide container's `render`
- * callback reads it from context and shows or hides itself.
+ * One Portable Text document, N `slide` containers at the root, one slide
+ * visible at a time. Slide keys are derived from the live editor value via
+ * `useEditorSelector` — when "Load markdown" replaces the value, the
+ * navigable slide set updates automatically.
  *
- * The editor is fully editable - Christian can type into a slide during
- * a presentation, which is half the point.
+ * The editor is fully editable; type into a slide during the talk.
  */
 export function Deck() {
   const editorRef = useRef<Editor | null>(null)
-  const [currentIndex, setCurrentIndex] = useState(0)
-  const [inspectorOpen, setInspectorOpen] = useState(false)
 
-  // Stable slide _keys derived from the value. We only read them once; the
-  // value is a const fixture for v1. If we ever add live "new slide" actions
-  // we'll lift this into state and update from a mutation listener.
+  return (
+    <div className="relative min-h-screen w-full overflow-hidden bg-stone-50 dark:bg-stone-950">
+      <EditorProvider
+        initialConfig={{
+          initialValue: [...deckValue],
+          schemaDefinition: deckSchemaDefinition,
+          keyGenerator,
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'error') {
+              console.error('[deck]', event)
+            }
+          }}
+        />
+        <SlidePlugin />
+        <DeckContainerPlugins />
+        <DeckBody editorRef={editorRef} />
+      </EditorProvider>
+    </div>
+  )
+}
+
+/**
+ * The deck body. Lives inside `<EditorProvider>` so it can read the live
+ * editor value via `useEditorSelector`. Owns nav state, inspector toggle,
+ * paste-modal toggle.
+ */
+function DeckBody(props: {editorRef: React.RefObject<Editor | null>}) {
+  const editor = useEditor()
+  const value = useEditorSelector(editor, selectors.getValue) ?? []
+
   const slideKeys = useMemo(
     () =>
-      deckValue
-        .map((slide) => slide._key)
-        .filter((key): key is string => typeof key === 'string'),
-    [],
+      value
+        .filter(
+          (block): block is {_type: string; _key: string} =>
+            !!block &&
+            (block as {_type: string})._type === 'slide' &&
+            typeof (block as {_key?: string})._key === 'string',
+        )
+        .map((block) => block._key),
+    [value],
   )
 
   const totalSlides = slideKeys.length
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [inspectorOpen, setInspectorOpen] = useState(false)
+  const [pasteOpen, setPasteOpen] = useState(false)
+
+  // Clamp currentIndex when the slide count changes (e.g. after loading
+  // markdown with fewer slides than the current index).
+  useEffect(() => {
+    if (currentIndex >= totalSlides && totalSlides > 0) {
+      setCurrentIndex(0)
+    }
+  }, [currentIndex, totalSlides])
 
   const goTo = useCallback(
     (index: number) => {
@@ -67,7 +115,7 @@ export function Deck() {
     [slideKeys, totalSlides],
   )
 
-  // Read initial slide from hash, listen for hash changes.
+  // Read initial slide from hash + listen for hash changes.
   useEffect(() => {
     const fromHash = () => {
       const key = window.location.hash.slice(1)
@@ -81,11 +129,8 @@ export function Deck() {
     return () => window.removeEventListener('hashchange', fromHash)
   }, [slideKeys])
 
-  // Slide navigation lives in a behavior registered via DeckNavPlugin -
-  // see plugin.deck-nav.tsx. Cmd/Ctrl + Right/Left advance the deck;
-  // Cmd/Ctrl + Up/Down jump to the first/last slide. The behavior runs
-  // inside the editor's keyboard pipeline so it doesn't fight the editor's
-  // own keydown handlers.
+  // Slide navigation lives in a behavior registered via DeckNavPlugin.
+  // Cmd/Ctrl + Right/Left advance; Cmd/Ctrl + Up/Down jump to ends.
   const navCallbacks = useMemo(
     () => ({
       onNext: () => goTo(currentIndex + 1),
@@ -103,43 +148,35 @@ export function Deck() {
 
   return (
     <SlideIndexContext.Provider value={contextValue}>
-      <div className="relative min-h-screen w-full overflow-hidden bg-stone-50 dark:bg-stone-950">
-        <EditorProvider
-          initialConfig={{
-            initialValue: [...deckValue],
-            schemaDefinition: deckSchemaDefinition,
-            keyGenerator,
-          }}
-        >
-          <EditorRefPlugin ref={editorRef} />
-          <EventListenerPlugin
-            on={(event) => {
-              if (event.type === 'error') {
-                console.error('[deck]', event)
-              }
-            }}
-          />
-          <SlidePlugin />
-          <DeckContainerPlugins />
-          <DeckNavPlugin {...navCallbacks} />
+      <DeckNavPlugin {...navCallbacks} />
 
-          <DeckEditable />
+      <DeckEditable />
 
-          <DeckChrome
-            currentIndex={currentIndex}
-            totalSlides={totalSlides}
-            inspectorOpen={inspectorOpen}
-            onPrev={() => goTo(currentIndex - 1)}
-            onNext={() => goTo(currentIndex + 1)}
-            onToggleInspector={() => setInspectorOpen((open) => !open)}
-          />
+      <DeckChrome
+        currentIndex={currentIndex}
+        totalSlides={totalSlides}
+        inspectorOpen={inspectorOpen}
+        onPrev={() => goTo(currentIndex - 1)}
+        onNext={() => goTo(currentIndex + 1)}
+        onToggleInspector={() => setInspectorOpen((open) => !open)}
+        onOpenPaste={() => setPasteOpen(true)}
+      />
 
-          <ValueInspector
-            open={inspectorOpen}
-            onClose={() => setInspectorOpen(false)}
-          />
-        </EditorProvider>
-      </div>
+      <ValueInspector
+        open={inspectorOpen}
+        onClose={() => setInspectorOpen(false)}
+      />
+
+      <PasteMarkdownModal
+        editor={props.editorRef.current}
+        open={pasteOpen}
+        onClose={() => setPasteOpen(false)}
+        onLoad={() => {
+          // Reset to the first slide of the new deck.
+          setCurrentIndex(0)
+          window.history.replaceState(null, '', window.location.pathname)
+        }}
+      />
     </SlideIndexContext.Provider>
   )
 }

--- a/apps/playground/src/v7/Deck.tsx
+++ b/apps/playground/src/v7/Deck.tsx
@@ -1,0 +1,219 @@
+import {
+  EditorProvider,
+  keyGenerator,
+  PortableTextEditable,
+  type Editor,
+  type RenderAnnotationFunction,
+  type RenderDecoratorFunction,
+  type RenderListItemFunction,
+  type RenderPlaceholderFunction,
+  type RenderStyleFunction,
+} from '@portabletext/editor'
+import {
+  EditorRefPlugin,
+  EventListenerPlugin,
+} from '@portabletext/editor/plugins'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {DeckChrome} from './deck-chrome'
+import {deckSchemaDefinition} from './schema'
+import {SlidePlugin} from './slide-container'
+import {SlideIndexContext} from './slide-nav-context'
+import {deckValue} from './slides'
+
+/**
+ * The v7 deck.
+ *
+ * One Portable Text document, N slide containers at the root, one slide
+ * visible at a time. Navigation (arrow keys, click) drives a single
+ * `currentSlideIndex` piece of state; the slide container's `render`
+ * callback reads it from context and shows or hides itself.
+ *
+ * The editor is fully editable - Christian can type into a slide during
+ * a presentation, which is half the point.
+ */
+export function Deck() {
+  const editorRef = useRef<Editor | null>(null)
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  // Stable slide _keys derived from the value. We only read them once; the
+  // value is a const fixture for v1. If we ever add live "new slide" actions
+  // we'll lift this into state and update from a mutation listener.
+  const slideKeys = useMemo(
+    () =>
+      deckValue
+        .map((slide) => slide._key)
+        .filter((key): key is string => typeof key === 'string'),
+    [],
+  )
+
+  const totalSlides = slideKeys.length
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= totalSlides) {
+        return
+      }
+      setCurrentIndex(index)
+      const hashKey = slideKeys[index]
+      if (hashKey) {
+        window.history.replaceState(null, '', `#${hashKey}`)
+      }
+    },
+    [slideKeys, totalSlides],
+  )
+
+  // Read initial slide from hash, listen for hash changes.
+  useEffect(() => {
+    const fromHash = () => {
+      const key = window.location.hash.slice(1)
+      const idx = slideKeys.indexOf(key)
+      if (idx >= 0) {
+        setCurrentIndex(idx)
+      }
+    }
+    fromHash()
+    window.addEventListener('hashchange', fromHash)
+    return () => window.removeEventListener('hashchange', fromHash)
+  }, [slideKeys])
+
+  // Arrow keys advance the deck. We capture on the document so the editor's
+  // own keydown handlers don't swallow them, but we only act when the focus
+  // is outside the editor's editable element. Inside the editable, arrow
+  // keys move the caret.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const insideEditable = target?.closest('[contenteditable="true"]')
+      if (insideEditable) {
+        return
+      }
+
+      if (
+        event.key === 'ArrowRight' ||
+        event.key === 'PageDown' ||
+        event.key === ' '
+      ) {
+        event.preventDefault()
+        goTo(currentIndex + 1)
+      } else if (event.key === 'ArrowLeft' || event.key === 'PageUp') {
+        event.preventDefault()
+        goTo(currentIndex - 1)
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        goTo(0)
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        goTo(totalSlides - 1)
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [currentIndex, goTo, totalSlides])
+
+  const contextValue = useMemo(
+    () => ({currentIndex, slideKeys}),
+    [currentIndex, slideKeys],
+  )
+
+  return (
+    <SlideIndexContext.Provider value={contextValue}>
+      <div className="min-h-screen w-full">
+        <EditorProvider
+          initialConfig={{
+            initialValue: [...deckValue],
+            schemaDefinition: deckSchemaDefinition,
+            keyGenerator,
+          }}
+        >
+          <EditorRefPlugin ref={editorRef} />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'error') {
+                console.error('[deck]', event)
+              }
+            }}
+          />
+          <SlidePlugin />
+
+          <PortableTextEditable
+            className="deck-editable focus:outline-none"
+            renderAnnotation={renderAnnotation}
+            renderDecorator={renderDecorator}
+            renderListItem={renderListItem}
+            renderPlaceholder={renderPlaceholder}
+            renderStyle={renderStyle}
+          />
+
+          <DeckChrome
+            currentIndex={currentIndex}
+            totalSlides={totalSlides}
+            onPrev={() => goTo(currentIndex - 1)}
+            onNext={() => goTo(currentIndex + 1)}
+          />
+        </EditorProvider>
+      </div>
+    </SlideIndexContext.Provider>
+  )
+}
+
+const renderDecorator: RenderDecoratorFunction = (props) => {
+  switch (props.value) {
+    case 'strong':
+      return <strong>{props.children}</strong>
+    case 'em':
+      return <em>{props.children}</em>
+    case 'code':
+      return (
+        <code className="rounded bg-stone-100 px-1.5 py-0.5 font-mono text-base text-pink-700 dark:bg-stone-800 dark:text-pink-300">
+          {props.children}
+        </code>
+      )
+    default:
+      return <>{props.children}</>
+  }
+}
+
+const renderAnnotation: RenderAnnotationFunction = (props) => {
+  if (props.schemaType.name === 'link') {
+    return (
+      <span className="underline text-blue-700 dark:text-blue-300">
+        {props.children}
+      </span>
+    )
+  }
+  return <>{props.children}</>
+}
+
+const renderListItem: RenderListItemFunction = (props) => {
+  if (props.value === 'bullet') {
+    return (
+      <span className="flex items-baseline gap-3">
+        <span aria-hidden className="text-stone-400">
+          •
+        </span>
+        <span className="flex-1">{props.children}</span>
+      </span>
+    )
+  }
+  if (props.value === 'number') {
+    return (
+      <span className="flex items-baseline gap-3">
+        <span aria-hidden className="text-stone-400 font-mono text-sm">
+          {(props.path[props.path.length - 1] as number) + 1}.
+        </span>
+        <span className="flex-1">{props.children}</span>
+      </span>
+    )
+  }
+  return <>{props.children}</>
+}
+
+const renderStyle: RenderStyleFunction = (props) => {
+  // Slides own their own style rendering via defineTextBlock. Anything that
+  // reaches this top-level handler is a fallback - just pass through.
+  return <>{props.children}</>
+}
+
+const renderPlaceholder: RenderPlaceholderFunction = () => (
+  <span className="text-stone-400">Type something…</span>
+)

--- a/apps/playground/src/v7/Deck.tsx
+++ b/apps/playground/src/v7/Deck.tsx
@@ -103,7 +103,7 @@ export function Deck() {
 
   return (
     <SlideIndexContext.Provider value={contextValue}>
-      <div className="min-h-screen w-full">
+      <div className="relative min-h-screen w-full overflow-hidden bg-stone-50 dark:bg-stone-950">
         <EditorProvider
           initialConfig={{
             initialValue: [...deckValue],
@@ -153,7 +153,7 @@ function DeckEditable() {
   const rangeDecorations = useShikiDecorations()
   return (
     <PortableTextEditable
-      className="deck-editable focus:outline-none"
+      className="deck-editable relative block h-screen w-full focus:outline-none"
       rangeDecorations={
         rangeDecorations as Parameters<
           typeof PortableTextEditable

--- a/apps/playground/src/v7/Deck.tsx
+++ b/apps/playground/src/v7/Deck.tsx
@@ -26,6 +26,7 @@ import {useShikiDecorations} from './shiki'
 import {SlidePlugin} from './slide-container'
 import {SlideIndexContext} from './slide-nav-context'
 import {deckValue} from './slides'
+import {useSwipeNavigation} from './use-swipe-navigation'
 import {ValueInspector} from './value-inspector'
 
 /**
@@ -146,11 +147,17 @@ function DeckBody(props: {editorRef: React.RefObject<Editor | null>}) {
     [currentIndex, slideKeys],
   )
 
+  // Swipe navigation - touch only, ignored inside tables / code blocks /
+  // chrome / inspector / modal (those carry data-deck-no-swipe).
+  const swipeRef = useSwipeNavigation(navCallbacks)
+
   return (
     <SlideIndexContext.Provider value={contextValue}>
       <DeckNavPlugin {...navCallbacks} />
 
-      <DeckEditable />
+      <div ref={swipeRef} className="contents">
+        <DeckEditable />
+      </div>
 
       <DeckChrome
         currentIndex={currentIndex}

--- a/apps/playground/src/v7/Deck.tsx
+++ b/apps/playground/src/v7/Deck.tsx
@@ -15,10 +15,14 @@ import {
 } from '@portabletext/editor/plugins'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {DeckChrome} from './deck-chrome'
+import {DeckContainerPlugins} from './deck-containers'
+import {DeckNavPlugin} from './plugin.deck-nav'
 import {deckSchemaDefinition} from './schema'
+import {useShikiDecorations} from './shiki'
 import {SlidePlugin} from './slide-container'
 import {SlideIndexContext} from './slide-nav-context'
 import {deckValue} from './slides'
+import {ValueInspector} from './value-inspector'
 
 /**
  * The v7 deck.
@@ -34,6 +38,7 @@ import {deckValue} from './slides'
 export function Deck() {
   const editorRef = useRef<Editor | null>(null)
   const [currentIndex, setCurrentIndex] = useState(0)
+  const [inspectorOpen, setInspectorOpen] = useState(false)
 
   // Stable slide _keys derived from the value. We only read them once; the
   // value is a const fixture for v1. If we ever add live "new slide" actions
@@ -76,39 +81,20 @@ export function Deck() {
     return () => window.removeEventListener('hashchange', fromHash)
   }, [slideKeys])
 
-  // Arrow keys advance the deck. We capture on the document so the editor's
-  // own keydown handlers don't swallow them, but we only act when the focus
-  // is outside the editor's editable element. Inside the editable, arrow
-  // keys move the caret.
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null
-      const insideEditable = target?.closest('[contenteditable="true"]')
-      if (insideEditable) {
-        return
-      }
-
-      if (
-        event.key === 'ArrowRight' ||
-        event.key === 'PageDown' ||
-        event.key === ' '
-      ) {
-        event.preventDefault()
-        goTo(currentIndex + 1)
-      } else if (event.key === 'ArrowLeft' || event.key === 'PageUp') {
-        event.preventDefault()
-        goTo(currentIndex - 1)
-      } else if (event.key === 'Home') {
-        event.preventDefault()
-        goTo(0)
-      } else if (event.key === 'End') {
-        event.preventDefault()
-        goTo(totalSlides - 1)
-      }
-    }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [currentIndex, goTo, totalSlides])
+  // Slide navigation lives in a behavior registered via DeckNavPlugin -
+  // see plugin.deck-nav.tsx. Cmd/Ctrl + Right/Left advance the deck;
+  // Cmd/Ctrl + Up/Down jump to the first/last slide. The behavior runs
+  // inside the editor's keyboard pipeline so it doesn't fight the editor's
+  // own keydown handlers.
+  const navCallbacks = useMemo(
+    () => ({
+      onNext: () => goTo(currentIndex + 1),
+      onPrev: () => goTo(currentIndex - 1),
+      onFirst: () => goTo(0),
+      onLast: () => goTo(totalSlides - 1),
+    }),
+    [currentIndex, goTo, totalSlides],
+  )
 
   const contextValue = useMemo(
     () => ({currentIndex, slideKeys}),
@@ -134,25 +120,51 @@ export function Deck() {
             }}
           />
           <SlidePlugin />
+          <DeckContainerPlugins />
+          <DeckNavPlugin {...navCallbacks} />
 
-          <PortableTextEditable
-            className="deck-editable focus:outline-none"
-            renderAnnotation={renderAnnotation}
-            renderDecorator={renderDecorator}
-            renderListItem={renderListItem}
-            renderPlaceholder={renderPlaceholder}
-            renderStyle={renderStyle}
-          />
+          <DeckEditable />
 
           <DeckChrome
             currentIndex={currentIndex}
             totalSlides={totalSlides}
+            inspectorOpen={inspectorOpen}
             onPrev={() => goTo(currentIndex - 1)}
             onNext={() => goTo(currentIndex + 1)}
+            onToggleInspector={() => setInspectorOpen((open) => !open)}
+          />
+
+          <ValueInspector
+            open={inspectorOpen}
+            onClose={() => setInspectorOpen(false)}
           />
         </EditorProvider>
       </div>
     </SlideIndexContext.Provider>
+  )
+}
+
+/**
+ * The editable surface. Pulled out as its own component so the
+ * `useShikiDecorations` hook (which calls `useEditor`) sits inside the
+ * `<EditorProvider>` tree.
+ */
+function DeckEditable() {
+  const rangeDecorations = useShikiDecorations()
+  return (
+    <PortableTextEditable
+      className="deck-editable focus:outline-none"
+      rangeDecorations={
+        rangeDecorations as Parameters<
+          typeof PortableTextEditable
+        >[0]['rangeDecorations']
+      }
+      renderAnnotation={renderAnnotation}
+      renderDecorator={renderDecorator}
+      renderListItem={renderListItem}
+      renderPlaceholder={renderPlaceholder}
+      renderStyle={renderStyle}
+    />
   )
 }
 

--- a/apps/playground/src/v7/behavior.deck-nav.ts
+++ b/apps/playground/src/v7/behavior.deck-nav.ts
@@ -1,0 +1,57 @@
+import {defineBehavior, effect} from '@portabletext/editor/behaviors'
+import type {KeyboardShortcut} from '@portabletext/keyboard-shortcuts'
+
+/**
+ * Slide-navigation behaviors for the deck.
+ *
+ * Cmd/Ctrl + Arrow drives the slide index. We model this as a real behavior
+ * (rather than a document-level keydown listener) so the editor's own
+ * keyboard handlers don't fight us for these shortcuts.
+ *
+ * Slide navigation is presentation state - not part of the document - so
+ * each behavior fires an `effect()` that calls the React setter passed in
+ * by the deck. The behavior owns turning the keystroke into an intent; the
+ * React state owns the slide index.
+ */
+
+export type DeckShortcuts = {
+  nextSlide: KeyboardShortcut
+  prevSlide: KeyboardShortcut
+  firstSlide: KeyboardShortcut
+  lastSlide: KeyboardShortcut
+}
+
+export type DeckNavCallbacks = {
+  onNext: () => void
+  onPrev: () => void
+  onFirst: () => void
+  onLast: () => void
+}
+
+export function createDeckNavBehaviors(
+  shortcuts: DeckShortcuts,
+  callbacks: DeckNavCallbacks,
+) {
+  return [
+    defineBehavior({
+      on: 'keyboard.keydown',
+      guard: ({event}) => shortcuts.nextSlide.guard(event.originEvent),
+      actions: [() => [effect(() => callbacks.onNext())]],
+    }),
+    defineBehavior({
+      on: 'keyboard.keydown',
+      guard: ({event}) => shortcuts.prevSlide.guard(event.originEvent),
+      actions: [() => [effect(() => callbacks.onPrev())]],
+    }),
+    defineBehavior({
+      on: 'keyboard.keydown',
+      guard: ({event}) => shortcuts.firstSlide.guard(event.originEvent),
+      actions: [() => [effect(() => callbacks.onFirst())]],
+    }),
+    defineBehavior({
+      on: 'keyboard.keydown',
+      guard: ({event}) => shortcuts.lastSlide.guard(event.originEvent),
+      actions: [() => [effect(() => callbacks.onLast())]],
+    }),
+  ]
+}

--- a/apps/playground/src/v7/code-highlight.tsx
+++ b/apps/playground/src/v7/code-highlight.tsx
@@ -1,0 +1,37 @@
+import type {ReactNode} from 'react'
+
+/**
+ * A code block rendered inside the deck.
+ *
+ * The lines remain editable Portable Text - this isn't an overlay or a
+ * separate editor. The styling is monospace and dark; the language label
+ * sits in the chrome above the content.
+ *
+ * Syntax highlighting (Shiki) is a follow-up. The codebase pulls Shiki in
+ * via the playground for export rendering, but driving Shiki against the
+ * editable's live text without breaking caret position needs a more careful
+ * pass than this slide deck warrants today.
+ */
+export function CodeHighlight(props: {
+  attributes: Record<string, unknown>
+  selected: boolean
+  language: string
+  children: ReactNode
+}) {
+  return (
+    <pre
+      {...(props.attributes as Record<string, string>)}
+      data-selected={props.selected ? '' : undefined}
+      data-language={props.language}
+      className="deck-code-block group relative my-5 overflow-x-auto rounded-lg border border-stone-300 bg-stone-900 px-5 py-4 font-mono text-stone-100 text-sm leading-7 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-700"
+    >
+      <span
+        contentEditable={false}
+        className="absolute top-2 right-3 select-none font-mono text-stone-500 text-xs uppercase tracking-wider"
+      >
+        {props.language}
+      </span>
+      {props.children}
+    </pre>
+  )
+}

--- a/apps/playground/src/v7/code-highlight.tsx
+++ b/apps/playground/src/v7/code-highlight.tsx
@@ -3,14 +3,10 @@ import type {ReactNode} from 'react'
 /**
  * A code block rendered inside the deck.
  *
- * The lines remain editable Portable Text - this isn't an overlay or a
- * separate editor. The styling is monospace and dark; the language label
- * sits in the chrome above the content.
- *
- * Syntax highlighting (Shiki) is a follow-up. The codebase pulls Shiki in
- * via the playground for export rendering, but driving Shiki against the
- * editable's live text without breaking caret position needs a more careful
- * pass than this slide deck warrants today.
+ * The lines remain editable Portable Text - this is not an overlay or a
+ * separate editor. Shiki syntax highlighting is wired up at the editable
+ * level via rangeDecorations; this component owns the chrome - language
+ * label, padding, the dark background, the rounded border.
  */
 export function CodeHighlight(props: {
   attributes: Record<string, unknown>
@@ -23,11 +19,12 @@ export function CodeHighlight(props: {
       {...(props.attributes as Record<string, string>)}
       data-selected={props.selected ? '' : undefined}
       data-language={props.language}
-      className="deck-code-block group relative my-5 overflow-x-auto rounded-lg border border-stone-300 bg-stone-900 px-5 py-4 font-mono text-stone-100 text-sm leading-7 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-700"
+      data-deck-no-swipe=""
+      className="deck-code-block group relative my-4 overflow-x-auto rounded-lg border border-stone-300 bg-stone-900 px-3 py-3 font-mono text-stone-100 text-xs leading-6 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg sm:my-5 sm:px-5 sm:py-4 sm:text-sm sm:leading-7 dark:border-stone-700"
     >
       <span
         contentEditable={false}
-        className="absolute top-2 right-3 select-none font-mono text-stone-500 text-xs uppercase tracking-wider"
+        className="absolute top-1.5 right-2 hidden select-none font-mono text-[10px] text-stone-500 uppercase tracking-wider sm:top-2 sm:right-3 sm:inline sm:text-xs"
       >
         {props.language}
       </span>

--- a/apps/playground/src/v7/deck-chrome.tsx
+++ b/apps/playground/src/v7/deck-chrome.tsx
@@ -1,4 +1,9 @@
-import {ChevronLeftIcon, ChevronRightIcon, CodeIcon} from 'lucide-react'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CodeIcon,
+  FileTextIcon,
+} from 'lucide-react'
 
 export function DeckChrome(props: {
   currentIndex: number
@@ -7,6 +12,7 @@ export function DeckChrome(props: {
   onPrev: () => void
   onNext: () => void
   onToggleInspector: () => void
+  onOpenPaste: () => void
 }) {
   const atStart = props.currentIndex === 0
   const atEnd = props.currentIndex === props.totalSlides - 1
@@ -21,6 +27,14 @@ export function DeckChrome(props: {
       </div>
 
       <div className="pointer-events-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={props.onOpenPaste}
+          aria-label="Load deck from markdown"
+          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+        >
+          <FileTextIcon className="size-4" />
+        </button>
         <button
           type="button"
           onClick={props.onToggleInspector}

--- a/apps/playground/src/v7/deck-chrome.tsx
+++ b/apps/playground/src/v7/deck-chrome.tsx
@@ -1,0 +1,48 @@
+import {ChevronLeftIcon, ChevronRightIcon} from 'lucide-react'
+
+export function DeckChrome(props: {
+  currentIndex: number
+  totalSlides: number
+  onPrev: () => void
+  onNext: () => void
+}) {
+  const atStart = props.currentIndex === 0
+  const atEnd = props.currentIndex === props.totalSlides - 1
+
+  return (
+    <div
+      contentEditable={false}
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex items-center justify-between gap-4 px-8 py-5"
+    >
+      <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-white/70 px-3 py-1.5 font-mono text-sm text-stone-500 backdrop-blur-md dark:bg-stone-900/70 dark:text-stone-400">
+        Portable Text v7
+      </div>
+
+      <div className="pointer-events-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={props.onPrev}
+          disabled={atStart}
+          aria-label="Previous slide"
+          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+        >
+          <ChevronLeftIcon className="size-5" />
+        </button>
+
+        <div className="rounded-full bg-white/80 px-4 py-2 font-mono text-sm text-stone-600 shadow-sm backdrop-blur-md dark:bg-stone-800/80 dark:text-stone-300">
+          {props.currentIndex + 1} / {props.totalSlides}
+        </div>
+
+        <button
+          type="button"
+          onClick={props.onNext}
+          disabled={atEnd}
+          aria-label="Next slide"
+          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+        >
+          <ChevronRightIcon className="size-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/playground/src/v7/deck-chrome.tsx
+++ b/apps/playground/src/v7/deck-chrome.tsx
@@ -1,10 +1,12 @@
-import {ChevronLeftIcon, ChevronRightIcon} from 'lucide-react'
+import {ChevronLeftIcon, ChevronRightIcon, CodeIcon} from 'lucide-react'
 
 export function DeckChrome(props: {
   currentIndex: number
   totalSlides: number
+  inspectorOpen: boolean
   onPrev: () => void
   onNext: () => void
+  onToggleInspector: () => void
 }) {
   const atStart = props.currentIndex === 0
   const atEnd = props.currentIndex === props.totalSlides - 1
@@ -19,6 +21,20 @@ export function DeckChrome(props: {
       </div>
 
       <div className="pointer-events-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={props.onToggleInspector}
+          aria-label={
+            props.inspectorOpen
+              ? 'Hide value inspector'
+              : 'Show value inspector'
+          }
+          aria-pressed={props.inspectorOpen}
+          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white aria-pressed:bg-stone-900 aria-pressed:text-white dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800 dark:aria-pressed:bg-stone-100 dark:aria-pressed:text-stone-900"
+        >
+          <CodeIcon className="size-4" />
+        </button>
+
         <button
           type="button"
           onClick={props.onPrev}

--- a/apps/playground/src/v7/deck-chrome.tsx
+++ b/apps/playground/src/v7/deck-chrome.tsx
@@ -20,20 +20,23 @@ export function DeckChrome(props: {
   return (
     <div
       contentEditable={false}
-      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex items-center justify-between gap-4 px-8 py-5"
+      data-deck-no-swipe=""
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex items-center justify-between gap-2 px-3 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:gap-4 sm:px-8 sm:py-5"
     >
-      <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-white/70 px-3 py-1.5 font-mono text-sm text-stone-500 backdrop-blur-md dark:bg-stone-900/70 dark:text-stone-400">
+      {/* Brand label - hidden on narrow viewports to save room for the
+          nav controls; reappears at sm and above. */}
+      <div className="pointer-events-auto hidden items-center gap-2 rounded-full bg-white/70 px-3 py-1.5 font-mono text-sm text-stone-500 backdrop-blur-md sm:flex dark:bg-stone-900/70 dark:text-stone-400">
         Portable Text v7
       </div>
 
-      <div className="pointer-events-auto flex items-center gap-2">
+      <div className="pointer-events-auto flex items-center gap-1.5 sm:gap-2">
         <button
           type="button"
           onClick={props.onOpenPaste}
           aria-label="Load deck from markdown"
-          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+          className="flex size-11 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white sm:size-10 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
         >
-          <FileTextIcon className="size-4" />
+          <FileTextIcon className="size-5 sm:size-4" />
         </button>
         <button
           type="button"
@@ -44,9 +47,9 @@ export function DeckChrome(props: {
               : 'Show value inspector'
           }
           aria-pressed={props.inspectorOpen}
-          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white aria-pressed:bg-stone-900 aria-pressed:text-white dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800 dark:aria-pressed:bg-stone-100 dark:aria-pressed:text-stone-900"
+          className="flex size-11 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white aria-pressed:bg-stone-900 aria-pressed:text-white sm:size-10 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800 dark:aria-pressed:bg-stone-100 dark:aria-pressed:text-stone-900"
         >
-          <CodeIcon className="size-4" />
+          <CodeIcon className="size-5 sm:size-4" />
         </button>
 
         <button
@@ -54,12 +57,12 @@ export function DeckChrome(props: {
           onClick={props.onPrev}
           disabled={atStart}
           aria-label="Previous slide"
-          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+          className="flex size-11 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 sm:size-10 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
         >
-          <ChevronLeftIcon className="size-5" />
+          <ChevronLeftIcon className="size-6 sm:size-5" />
         </button>
 
-        <div className="rounded-full bg-white/80 px-4 py-2 font-mono text-sm text-stone-600 shadow-sm backdrop-blur-md dark:bg-stone-800/80 dark:text-stone-300">
+        <div className="rounded-full bg-white/80 px-3 py-2 font-mono text-sm text-stone-600 shadow-sm backdrop-blur-md sm:px-4 dark:bg-stone-800/80 dark:text-stone-300">
           {props.currentIndex + 1} / {props.totalSlides}
         </div>
 
@@ -68,9 +71,9 @@ export function DeckChrome(props: {
           onClick={props.onNext}
           disabled={atEnd}
           aria-label="Next slide"
-          className="flex size-10 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
+          className="flex size-11 items-center justify-center rounded-full bg-white/80 text-stone-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-30 sm:size-10 dark:bg-stone-800/80 dark:text-stone-200 dark:hover:bg-stone-800"
         >
-          <ChevronRightIcon className="size-5" />
+          <ChevronRightIcon className="size-6 sm:size-5" />
         </button>
       </div>
     </div>

--- a/apps/playground/src/v7/deck-containers.tsx
+++ b/apps/playground/src/v7/deck-containers.tsx
@@ -7,7 +7,7 @@ import {
   MessageSquareWarningIcon,
   OctagonAlertIcon,
 } from 'lucide-react'
-import type {JSX, ReactNode} from 'react'
+import type {JSX} from 'react'
 import {CodeHighlight} from './code-highlight'
 
 const toneStyles: Record<
@@ -154,21 +154,14 @@ const tableContainer = defineContainer({
   render: ({attributes, children, node, selected}) => {
     const headerRows = typeof node.headerRows === 'number' ? node.headerRows : 0
     return (
-      <div
-        contentEditable={false}
-        className="my-5 overflow-x-auto rounded-lg border border-stone-300 dark:border-stone-700"
+      <table
+        {...attributes}
+        data-header-rows={headerRows}
+        data-selected={selected ? '' : undefined}
+        className="deck-table my-5 w-full border-collapse overflow-hidden rounded-lg border border-stone-300 text-base dark:border-stone-700"
       >
-        <table
-          {...(attributes as Record<string, unknown> as Record<string, string>)}
-          contentEditable
-          suppressContentEditableWarning
-          data-header-rows={headerRows}
-          data-selected={selected ? '' : undefined}
-          className="deck-table w-full border-collapse text-base"
-        >
-          <tbody>{children as ReactNode}</tbody>
-        </table>
-      </div>
+        <tbody>{children}</tbody>
+      </table>
     )
   },
   of: [
@@ -176,10 +169,7 @@ const tableContainer = defineContainer({
       type: 'row',
       childField: 'cells',
       render: ({attributes, children, selected}) => (
-        <tr
-          {...(attributes as Record<string, unknown> as Record<string, string>)}
-          data-selected={selected ? '' : undefined}
-        >
+        <tr {...attributes} data-selected={selected ? '' : undefined}>
           {children}
         </tr>
       ),
@@ -190,10 +180,7 @@ const tableContainer = defineContainer({
           childField: 'content',
           render: ({attributes, children, selected}) => (
             <td
-              {...(attributes as Record<string, unknown> as Record<
-                string,
-                string
-              >)}
+              {...attributes}
               data-selected={selected ? '' : undefined}
               className="border border-stone-300 px-3 py-2 align-top dark:border-stone-700"
             >

--- a/apps/playground/src/v7/deck-containers.tsx
+++ b/apps/playground/src/v7/deck-containers.tsx
@@ -1,0 +1,216 @@
+import {defineContainer, defineTextBlock} from '@portabletext/editor'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import {
+  AlertTriangleIcon,
+  InfoIcon,
+  LightbulbIcon,
+  MessageSquareWarningIcon,
+  OctagonAlertIcon,
+} from 'lucide-react'
+import type {JSX, ReactNode} from 'react'
+import {CodeHighlight} from './code-highlight'
+
+const toneStyles: Record<
+  string,
+  {className: string; icon: typeof InfoIcon; label: string}
+> = {
+  note: {
+    className:
+      'border-sky-400 bg-sky-50 text-sky-900 dark:bg-sky-950/40 dark:text-sky-100',
+    icon: InfoIcon,
+    label: 'Note',
+  },
+  tip: {
+    className:
+      'border-emerald-400 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100',
+    icon: LightbulbIcon,
+    label: 'Tip',
+  },
+  important: {
+    className:
+      'border-violet-400 bg-violet-50 text-violet-900 dark:bg-violet-950/40 dark:text-violet-100',
+    icon: MessageSquareWarningIcon,
+    label: 'Important',
+  },
+  warning: {
+    className:
+      'border-amber-400 bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100',
+    icon: AlertTriangleIcon,
+    label: 'Warning',
+  },
+  caution: {
+    className:
+      'border-rose-400 bg-rose-50 text-rose-900 dark:bg-rose-950/40 dark:text-rose-100',
+    icon: OctagonAlertIcon,
+    label: 'Caution',
+  },
+}
+
+function richTextBlock() {
+  return defineTextBlock({
+    type: 'block',
+    render: ({attributes, children, node}) => {
+      if (node.listItem !== undefined) {
+        return (
+          <div {...attributes} className="my-1.5">
+            {children}
+          </div>
+        )
+      }
+      switch (node.style) {
+        case 'h1':
+          return (
+            <h1
+              {...attributes}
+              className="mt-3 mb-2 font-bold text-2xl tracking-tight"
+            >
+              {children}
+            </h1>
+          )
+        case 'h2':
+          return (
+            <h2
+              {...attributes}
+              className="mt-3 mb-1 font-semibold text-xl tracking-tight"
+            >
+              {children}
+            </h2>
+          )
+        case 'h3':
+          return (
+            <h3
+              {...attributes}
+              className="mt-2 mb-1 font-semibold text-lg tracking-tight"
+            >
+              {children}
+            </h3>
+          )
+        default:
+          return (
+            <p {...attributes} className="my-1.5 leading-relaxed">
+              {children}
+            </p>
+          )
+      }
+    },
+  })
+}
+
+const calloutContainer = defineContainer({
+  type: 'callout',
+  childField: 'content',
+  render: ({attributes, children, node, selected}) => {
+    const tone = typeof node.tone === 'string' ? node.tone : 'note'
+    const style = toneStyles[tone] ?? toneStyles.note!
+    const Icon = style.icon
+    return (
+      <aside
+        {...attributes}
+        data-selected={selected ? '' : undefined}
+        className={`my-5 flex gap-3 rounded-lg border-l-4 px-5 py-4 transition-shadow data-[selected]:shadow-md ${style.className}`}
+      >
+        <span
+          contentEditable={false}
+          className="mt-1 flex shrink-0 items-center justify-center"
+        >
+          <Icon aria-hidden className="size-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div
+            contentEditable={false}
+            className="mb-1 font-mono text-xs uppercase tracking-wider opacity-70"
+          >
+            {style.label}
+          </div>
+          {children}
+        </div>
+      </aside>
+    )
+  },
+  of: [richTextBlock()],
+})
+
+const codeBlockContainer = defineContainer({
+  type: 'code-block',
+  childField: 'lines',
+  render: ({attributes, children, node, selected}) => {
+    const language =
+      typeof node.language === 'string' ? node.language : 'typescript'
+    return (
+      <CodeHighlight
+        attributes={attributes}
+        selected={selected}
+        language={language}
+      >
+        {children}
+      </CodeHighlight>
+    )
+  },
+})
+
+const tableContainer = defineContainer({
+  type: 'table',
+  childField: 'rows',
+  render: ({attributes, children, node, selected}) => {
+    const headerRows = typeof node.headerRows === 'number' ? node.headerRows : 0
+    return (
+      <div
+        contentEditable={false}
+        className="my-5 overflow-x-auto rounded-lg border border-stone-300 dark:border-stone-700"
+      >
+        <table
+          {...(attributes as Record<string, unknown> as Record<string, string>)}
+          contentEditable
+          suppressContentEditableWarning
+          data-header-rows={headerRows}
+          data-selected={selected ? '' : undefined}
+          className="deck-table w-full border-collapse text-base"
+        >
+          <tbody>{children as ReactNode}</tbody>
+        </table>
+      </div>
+    )
+  },
+  of: [
+    defineContainer({
+      type: 'row',
+      childField: 'cells',
+      render: ({attributes, children, selected}) => (
+        <tr
+          {...(attributes as Record<string, unknown> as Record<string, string>)}
+          data-selected={selected ? '' : undefined}
+        >
+          {children}
+        </tr>
+      ),
+      of: [
+        {
+          kind: 'container',
+          type: 'cell',
+          childField: 'content',
+          render: ({attributes, children, selected}) => (
+            <td
+              {...(attributes as Record<string, unknown> as Record<
+                string,
+                string
+              >)}
+              data-selected={selected ? '' : undefined}
+              className="border border-stone-300 px-3 py-2 align-top dark:border-stone-700"
+            >
+              {children}
+            </td>
+          ),
+          of: [richTextBlock()],
+        },
+      ],
+    }),
+  ],
+})
+
+export function DeckContainerPlugins(): JSX.Element {
+  return (
+    <ContainerPlugin
+      containers={[calloutContainer, codeBlockContainer, tableContainer]}
+    />
+  )
+}

--- a/apps/playground/src/v7/deck-containers.tsx
+++ b/apps/playground/src/v7/deck-containers.tsx
@@ -153,12 +153,16 @@ const tableContainer = defineContainer({
   childField: 'rows',
   render: ({attributes, children, node, selected}) => {
     const headerRows = typeof node.headerRows === 'number' ? node.headerRows : 0
+    // On narrow viewports the table renders as a scrollable block so wide
+    // technical comparisons pan horizontally instead of clipping. Resets
+    // to a normal full-width table at the sm breakpoint and above.
     return (
       <table
         {...attributes}
         data-header-rows={headerRows}
         data-selected={selected ? '' : undefined}
-        className="deck-table my-5 w-full border-collapse overflow-hidden rounded-lg border border-stone-300 text-base dark:border-stone-700"
+        data-deck-no-swipe=""
+        className="deck-table my-5 block max-w-full overflow-x-auto border-collapse rounded-lg border border-stone-300 text-sm sm:table sm:w-full sm:overflow-hidden sm:text-base dark:border-stone-700"
       >
         <tbody>{children}</tbody>
       </table>
@@ -182,7 +186,7 @@ const tableContainer = defineContainer({
             <td
               {...attributes}
               data-selected={selected ? '' : undefined}
-              className="border border-stone-300 px-3 py-2 align-top dark:border-stone-700"
+              className="border border-stone-300 px-2 py-1.5 align-top sm:px-3 sm:py-2 dark:border-stone-700"
             >
               {children}
             </td>

--- a/apps/playground/src/v7/main.tsx
+++ b/apps/playground/src/v7/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import {ThemeProvider} from '../theme-context.tsx'
+import {Deck} from './Deck.tsx'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <Deck />
+    </ThemeProvider>
+  </React.StrictMode>,
+)

--- a/apps/playground/src/v7/markdown-to-slides.ts
+++ b/apps/playground/src/v7/markdown-to-slides.ts
@@ -1,0 +1,198 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+import {
+  markdownToPortableText,
+  type ObjectMatcher,
+} from '@portabletext/markdown'
+
+/**
+ * Parse a markdown source string into deck slides.
+ *
+ * Slides are separated by horizontal rules (`---` on its own line) — the
+ * same convention Marp and Slidev use. Each chunk between rules becomes
+ * one slide; the chunk's markdown is converted to Portable Text blocks
+ * and wrapped in a `slide` container.
+ *
+ * If the source has no horizontal rules, it parses to one big slide.
+ */
+export function markdownToSlides(
+  source: string,
+  keyGenerator: () => string,
+): Array<PortableTextBlock> {
+  const chunks = splitOnHorizontalRules(source)
+  if (chunks.length === 0) {
+    return [emptySlide(keyGenerator)]
+  }
+
+  return chunks.map((chunk, index) => {
+    // The parser's default schema is permissive. We drop the deck
+    // schema arg and trust matchers to shape containers correctly;
+    // anything the deck schema does not declare is filtered when the
+    // editor validates at insert.
+    const blocks = markdownToPortableText(chunk, {
+      keyGenerator,
+      types: deckMatchers,
+    })
+
+    return {
+      _type: 'slide',
+      _key: keyGenerator(),
+      content: blocks.length > 0 ? blocks : emptySlideContent(keyGenerator),
+      // Preserve source order for stable hash links across reloads.
+      _slideIndex: index,
+    } as unknown as PortableTextBlock
+  })
+}
+
+/**
+ * Split a markdown source on horizontal-rule lines (`---` / `***` /
+ * `___` on their own line, optionally surrounded by blank lines).
+ *
+ * The rule itself is dropped — only the content between rules survives.
+ */
+function splitOnHorizontalRules(source: string): Array<string> {
+  const lines = source.split('\n')
+  const chunks: Array<string> = []
+  let current: Array<string> = []
+
+  const isRule = (line: string) => /^\s*(-{3,}|\*{3,}|_{3,})\s*$/.test(line)
+
+  for (const line of lines) {
+    if (isRule(line)) {
+      if (current.length > 0) {
+        chunks.push(current.join('\n').trim())
+      }
+      current = []
+      continue
+    }
+    current.push(line)
+  }
+
+  if (current.length > 0) {
+    const tail = current.join('\n').trim()
+    if (tail.length > 0) {
+      chunks.push(tail)
+    }
+  }
+
+  return chunks.filter((chunk) => chunk.length > 0)
+}
+
+/**
+ * Matchers for the deck schema. Lifted from pilcrow's markdown
+ * configuration — code blocks become `code-block` containers with
+ * per-line text blocks, tables become `table` containers with rich
+ * cell content, GFM alerts become `callout` containers.
+ *
+ * The deck schema has no `horizontal-rule` or `list` containers, so
+ * those parser outputs are dropped (lists stay flat as `listItem`-
+ * marked blocks, horizontal rules are consumed by the slide split
+ * before parsing).
+ */
+type AnyValue = Record<string, unknown>
+
+const codeMatcher: ObjectMatcher<AnyValue> = ({context, value, isInline}) => {
+  if (isInline) {
+    return undefined
+  }
+  const code = typeof value.code === 'string' ? value.code : ''
+  const sourceLines = code.split('\n')
+  if (sourceLines.length > 0 && sourceLines[sourceLines.length - 1] === '') {
+    sourceLines.pop()
+  }
+  const lines = sourceLines.map((text) => ({
+    _type: 'block',
+    _key: context.keyGenerator(),
+    style: 'normal',
+    children: [
+      {
+        _type: 'span',
+        _key: context.keyGenerator(),
+        text,
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  }))
+  const language =
+    typeof value.language === 'string' ? value.language : undefined
+  return {
+    _type: 'code-block',
+    _key: context.keyGenerator(),
+    ...(language ? {language} : {}),
+    lines,
+  }
+}
+
+const tableMatcher: ObjectMatcher<AnyValue> = ({context, value}) => {
+  const rows = (
+    value.rows as Array<{
+      _key: string
+      cells: Array<{_key: string; value: unknown}>
+    }>
+  ).map((row) => ({
+    _type: 'row',
+    _key: row._key,
+    cells: row.cells.map((cell) => ({
+      _type: 'cell',
+      _key: cell._key,
+      content: cell.value,
+    })),
+  }))
+  return {
+    _type: 'table',
+    _key: context.keyGenerator(),
+    ...(value.headerRows !== undefined ? {headerRows: value.headerRows} : {}),
+    rows,
+  }
+}
+
+const calloutMatcher: ObjectMatcher<AnyValue> = ({context, value}) => {
+  // GFM-alert syntax stamps every text block inside the alert with
+  // style: 'blockquote'. The callout chrome owns the visual frame; the
+  // inner blocks should render as normal prose.
+  const content = (value.content as Array<{_type: string; style?: string}>).map(
+    (block) =>
+      block._type === 'block' && block.style === 'blockquote'
+        ? {...block, style: 'normal'}
+        : block,
+  )
+  return {
+    _type: 'callout',
+    _key: context.keyGenerator(),
+    tone: value.tone,
+    content,
+  }
+}
+
+const deckMatchers = {
+  code: codeMatcher,
+  table: tableMatcher,
+  callout: calloutMatcher,
+}
+
+function emptySlide(keyGenerator: () => string): PortableTextBlock {
+  return {
+    _type: 'slide',
+    _key: keyGenerator(),
+    content: emptySlideContent(keyGenerator),
+  } as unknown as PortableTextBlock
+}
+
+function emptySlideContent(keyGenerator: () => string) {
+  return [
+    {
+      _type: 'block',
+      _key: keyGenerator(),
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          _key: keyGenerator(),
+          text: '',
+          marks: [],
+        },
+      ],
+    },
+  ]
+}

--- a/apps/playground/src/v7/paste-markdown-modal.tsx
+++ b/apps/playground/src/v7/paste-markdown-modal.tsx
@@ -1,0 +1,165 @@
+import {keyGenerator, type Editor} from '@portabletext/editor'
+import {FileTextIcon, XIcon} from 'lucide-react'
+import {useEffect, useRef, useState} from 'react'
+import {markdownToSlides} from './markdown-to-slides'
+
+/**
+ * The "paste markdown" modal.
+ *
+ * Drops a textarea over the deck. Paste a markdown source, hit Load,
+ * the deck redraws as a slideshow. Slide boundaries are horizontal
+ * rules (`---` on a line of their own). The deck stays fully editable
+ * after loading — markdown sets the initial value, the editor owns
+ * everything that happens after.
+ */
+export function PasteMarkdownModal(props: {
+  editor: Editor | null
+  open: boolean
+  onClose: () => void
+  onLoad: (slideCount: number) => void
+}) {
+  const [source, setSource] = useState(EXAMPLE_SOURCE)
+  const [error, setError] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (props.open && textareaRef.current) {
+      textareaRef.current.focus()
+      textareaRef.current.select()
+    }
+  }, [props.open])
+
+  if (!props.open) {
+    return null
+  }
+
+  const onLoad = () => {
+    if (!props.editor) {
+      setError('Editor is not ready yet.')
+      return
+    }
+    try {
+      const slides = markdownToSlides(source, keyGenerator)
+      if (slides.length === 0) {
+        setError('No slides found. Use `---` between slides.')
+        return
+      }
+      props.editor.send({type: 'update value', value: slides})
+      setError(null)
+      props.onLoad(slides.length)
+      props.onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Load markdown"
+      contentEditable={false}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-8 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          props.onClose()
+        }
+      }}
+    >
+      <div className="flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-stone-300 bg-white shadow-2xl dark:border-stone-700 dark:bg-stone-900">
+        <header className="flex items-center justify-between border-stone-200 border-b px-6 py-4 dark:border-stone-700">
+          <div>
+            <h2 className="font-semibold text-lg text-stone-900 dark:text-stone-50">
+              Load deck from markdown
+            </h2>
+            <p className="mt-0.5 text-stone-500 text-sm dark:text-stone-400">
+              Use <code className="font-mono">---</code> between slides. Tables,
+              code blocks, GFM alerts, and rich text all render through the
+              deck's containers.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={props.onClose}
+            aria-label="Close"
+            className="flex size-8 items-center justify-center rounded-md text-stone-500 hover:bg-stone-100 hover:text-stone-900 dark:hover:bg-stone-800 dark:hover:text-stone-100"
+          >
+            <XIcon className="size-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-auto px-6 py-4">
+          <textarea
+            ref={textareaRef}
+            value={source}
+            onChange={(event) => setSource(event.target.value)}
+            spellCheck={false}
+            className="block h-[50vh] w-full resize-none rounded-lg border border-stone-200 bg-stone-50 p-3 font-mono text-sm text-stone-800 focus:border-stone-400 focus:outline-none dark:border-stone-700 dark:bg-stone-950 dark:text-stone-200"
+          />
+          {error ? (
+            <p className="mt-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-rose-800 text-sm dark:border-rose-700 dark:bg-rose-950/50 dark:text-rose-200">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <footer className="flex items-center justify-end gap-3 border-stone-200 border-t bg-stone-50 px-6 py-3 dark:border-stone-700 dark:bg-stone-900/50">
+          <button
+            type="button"
+            onClick={props.onClose}
+            className="rounded-md px-4 py-2 text-stone-600 text-sm hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onLoad}
+            className="flex items-center gap-2 rounded-md bg-stone-900 px-4 py-2 font-medium text-sm text-white hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-white"
+          >
+            <FileTextIcon className="size-4" />
+            Load deck
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+const EXAMPLE_SOURCE = `# Welcome
+### A slide deck built on Portable Text v7.
+
+This deck is just one Portable Text document. Edit any slide live during the talk.
+
+Use \`---\` to add a slide.
+
+---
+
+# Tables work
+
+| Concept | Pre-v7 | v7 |
+| --- | --- | --- |
+| Path format | Numeric \`[3, 0]\` | Keyed \`[{_key:'b1'}]\` |
+| Operations | Slate-flavoured | Patch-compliant |
+| Containers | Two levels | Any depth |
+
+---
+
+# Code blocks too
+
+\`\`\`typescript
+defineBehavior({
+  on: 'keyboard.keydown',
+  guard: backspaceInEmptyCell,
+  actions: [/* compose primitives */],
+})
+\`\`\`
+
+---
+
+# Callouts
+
+> [!NOTE]
+> GitHub-style alerts render as callouts with tone and icon.
+
+> [!IMPORTANT]
+> Each slide stays editable. Type, save, share.
+`

--- a/apps/playground/src/v7/paste-markdown-modal.tsx
+++ b/apps/playground/src/v7/paste-markdown-modal.tsx
@@ -58,7 +58,8 @@ export function PasteMarkdownModal(props: {
       role="dialog"
       aria-label="Load markdown"
       contentEditable={false}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-8 backdrop-blur-sm"
+      data-deck-no-swipe=""
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 p-4 backdrop-blur-sm sm:p-8"
       onClick={(event) => {
         if (event.target === event.currentTarget) {
           props.onClose()

--- a/apps/playground/src/v7/plugin.deck-nav.tsx
+++ b/apps/playground/src/v7/plugin.deck-nav.tsx
@@ -1,0 +1,99 @@
+import {useEditor} from '@portabletext/editor'
+import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
+import {useEffect} from 'react'
+import {
+  createDeckNavBehaviors,
+  type DeckNavCallbacks,
+} from './behavior.deck-nav'
+
+/**
+ * Registers the deck's slide-navigation behaviors against the editor.
+ *
+ * Cmd/Ctrl + Right/Left advance/retreat. Cmd/Ctrl + Up/Down jump to the
+ * first/last slide. Modeled as proper editor behaviors so they participate
+ * in the keyboard shortcut pipeline (no document-level event listeners,
+ * no fighting with the editor's own keydown handlers).
+ */
+export function DeckNavPlugin(props: DeckNavCallbacks) {
+  const editor = useEditor()
+
+  useEffect(() => {
+    const behaviors = createDeckNavBehaviors(
+      {
+        nextSlide: createKeyboardShortcut({
+          default: [
+            {
+              key: 'ArrowRight',
+              meta: true,
+              ctrl: false,
+              shift: false,
+              alt: false,
+            },
+            {
+              key: 'ArrowRight',
+              meta: false,
+              ctrl: true,
+              shift: false,
+              alt: false,
+            },
+          ],
+        }),
+        prevSlide: createKeyboardShortcut({
+          default: [
+            {
+              key: 'ArrowLeft',
+              meta: true,
+              ctrl: false,
+              shift: false,
+              alt: false,
+            },
+            {
+              key: 'ArrowLeft',
+              meta: false,
+              ctrl: true,
+              shift: false,
+              alt: false,
+            },
+          ],
+        }),
+        firstSlide: createKeyboardShortcut({
+          default: [
+            {key: 'ArrowUp', meta: true, ctrl: false, shift: false, alt: false},
+            {key: 'ArrowUp', meta: false, ctrl: true, shift: false, alt: false},
+          ],
+        }),
+        lastSlide: createKeyboardShortcut({
+          default: [
+            {
+              key: 'ArrowDown',
+              meta: true,
+              ctrl: false,
+              shift: false,
+              alt: false,
+            },
+            {
+              key: 'ArrowDown',
+              meta: false,
+              ctrl: true,
+              shift: false,
+              alt: false,
+            },
+          ],
+        }),
+      },
+      props,
+    )
+
+    const unregisters = behaviors.map((behavior) =>
+      editor.registerBehavior({behavior}),
+    )
+
+    return () => {
+      for (const unregister of unregisters) {
+        unregister()
+      }
+    }
+  }, [editor, props])
+
+  return null
+}

--- a/apps/playground/src/v7/schema.ts
+++ b/apps/playground/src/v7/schema.ts
@@ -27,6 +27,7 @@ const richBlock = {
     {title: 'Heading 1', name: 'h1'},
     {title: 'Heading 2', name: 'h2'},
     {title: 'Heading 3', name: 'h3'},
+    {title: 'Blockquote', name: 'blockquote'},
   ],
 } as const
 
@@ -73,6 +74,7 @@ export const deckSchemaDefinition = defineSchema({
     {title: 'Heading 1', name: 'h1'},
     {title: 'Heading 2', name: 'h2'},
     {title: 'Heading 3', name: 'h3'},
+    {title: 'Blockquote', name: 'blockquote'},
   ],
   blockObjects: [
     {

--- a/apps/playground/src/v7/schema.ts
+++ b/apps/playground/src/v7/schema.ts
@@ -1,0 +1,79 @@
+import {defineSchema} from '@portabletext/editor'
+
+const sharedSlideBlockOf = [
+  {
+    type: 'block',
+    decorators: [
+      {title: 'Strong', name: 'strong'},
+      {title: 'Emphasis', name: 'em'},
+      {title: 'Code', name: 'code'},
+    ],
+    annotations: [
+      {
+        title: 'Link',
+        name: 'link',
+        fields: [{name: 'href', title: 'HREF', type: 'string'}],
+      },
+    ],
+    lists: [
+      {title: 'Bulleted list', name: 'bullet'},
+      {title: 'Numbered list', name: 'number'},
+    ],
+    styles: [
+      {title: 'Normal', name: 'normal'},
+      {title: 'Heading 1', name: 'h1'},
+      {title: 'Heading 2', name: 'h2'},
+      {title: 'Heading 3', name: 'h3'},
+    ],
+  },
+] as const
+
+/**
+ * Schema for the v7 deck.
+ *
+ * The deck is a single Portable Text document. Every top-level entry is a
+ * `slide` block object with a `content` array field that holds the slide's
+ * blocks. `defineContainer` (in `slide-container.tsx`) plugs into this
+ * field at render time.
+ *
+ * Containers used inside slides (code-block, table, image, hr) get added
+ * to `content.of` as we wire them up.
+ */
+export const deckSchemaDefinition = defineSchema({
+  decorators: [
+    {title: 'Strong', name: 'strong'},
+    {title: 'Emphasis', name: 'em'},
+    {title: 'Code', name: 'code'},
+  ],
+  annotations: [
+    {
+      title: 'Link',
+      name: 'link',
+      fields: [{name: 'href', title: 'HREF', type: 'string'}],
+    },
+  ],
+  lists: [
+    {title: 'Bulleted list', name: 'bullet'},
+    {title: 'Numbered list', name: 'number'},
+  ],
+  styles: [
+    {title: 'Normal', name: 'normal'},
+    {title: 'Heading 1', name: 'h1'},
+    {title: 'Heading 2', name: 'h2'},
+    {title: 'Heading 3', name: 'h3'},
+  ],
+  blockObjects: [
+    {
+      title: 'Slide',
+      name: 'slide',
+      fields: [
+        {
+          name: 'content',
+          title: 'Content',
+          type: 'array',
+          of: sharedSlideBlockOf,
+        },
+      ],
+    },
+  ],
+})

--- a/apps/playground/src/v7/schema.ts
+++ b/apps/playground/src/v7/schema.ts
@@ -1,43 +1,55 @@
 import {defineSchema} from '@portabletext/editor'
 
-const sharedSlideBlockOf = [
-  {
-    type: 'block',
-    decorators: [
-      {title: 'Strong', name: 'strong'},
-      {title: 'Emphasis', name: 'em'},
-      {title: 'Code', name: 'code'},
-    ],
-    annotations: [
-      {
-        title: 'Link',
-        name: 'link',
-        fields: [{name: 'href', title: 'HREF', type: 'string'}],
-      },
-    ],
-    lists: [
-      {title: 'Bulleted list', name: 'bullet'},
-      {title: 'Numbered list', name: 'number'},
-    ],
-    styles: [
-      {title: 'Normal', name: 'normal'},
-      {title: 'Heading 1', name: 'h1'},
-      {title: 'Heading 2', name: 'h2'},
-      {title: 'Heading 3', name: 'h3'},
-    ],
-  },
-] as const
+/**
+ * Inner schema for "rich" container content — used by callouts, fact-boxes,
+ * cells, anywhere we want full prose-formatting + lists.
+ */
+const richBlock = {
+  type: 'block',
+  decorators: [
+    {title: 'Strong', name: 'strong'},
+    {title: 'Emphasis', name: 'em'},
+    {title: 'Code', name: 'code'},
+  ],
+  annotations: [
+    {
+      title: 'Link',
+      name: 'link',
+      fields: [{name: 'href', title: 'HREF', type: 'string'}],
+    },
+  ],
+  lists: [
+    {title: 'Bulleted list', name: 'bullet'},
+    {title: 'Numbered list', name: 'number'},
+  ],
+  styles: [
+    {title: 'Normal', name: 'normal'},
+    {title: 'Heading 1', name: 'h1'},
+    {title: 'Heading 2', name: 'h2'},
+    {title: 'Heading 3', name: 'h3'},
+  ],
+} as const
+
+/**
+ * Plain code-line schema - no decorators, no annotations, no styles. Each
+ * line is one text block; the code-block container wraps them.
+ */
+const codeLineBlock = {
+  type: 'block',
+  decorators: [],
+  annotations: [],
+  styles: [],
+  lists: [],
+  inlineObjects: [],
+} as const
 
 /**
  * Schema for the v7 deck.
  *
- * The deck is a single Portable Text document. Every top-level entry is a
- * `slide` block object with a `content` array field that holds the slide's
- * blocks. `defineContainer` (in `slide-container.tsx`) plugs into this
- * field at render time.
- *
- * Containers used inside slides (code-block, table, image, hr) get added
- * to `content.of` as we wire them up.
+ * One Portable Text document, slides at the root. Each `slide` block object
+ * has a `content` array that holds the slide's blocks — rich text plus the
+ * demonstration containers (callouts, code blocks, tables) for slides that
+ * showcase those features.
  */
 export const deckSchemaDefinition = defineSchema({
   decorators: [
@@ -71,7 +83,78 @@ export const deckSchemaDefinition = defineSchema({
           name: 'content',
           title: 'Content',
           type: 'array',
-          of: sharedSlideBlockOf,
+          of: [
+            richBlock,
+            // Callout - aside with a tone (note, tip, important, warning, caution)
+            {
+              type: 'object',
+              name: 'callout',
+              fields: [
+                {name: 'tone', title: 'Tone', type: 'string'},
+                {
+                  name: 'content',
+                  title: 'Content',
+                  type: 'array',
+                  of: [richBlock],
+                },
+              ],
+            },
+            // Code block - syntax-highlighted source. Each line is one text
+            // block; the `language` field drives the Shiki tokenizer.
+            {
+              type: 'object',
+              name: 'code-block',
+              fields: [
+                {name: 'language', title: 'Language', type: 'string'},
+                {
+                  name: 'lines',
+                  title: 'Lines',
+                  type: 'array',
+                  of: [codeLineBlock],
+                },
+              ],
+            },
+            // Table - rows of cells, each cell holds rich content.
+            {
+              type: 'object',
+              name: 'table',
+              fields: [
+                {name: 'headerRows', title: 'Header rows', type: 'number'},
+                {
+                  name: 'rows',
+                  title: 'Rows',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'row',
+                      fields: [
+                        {
+                          name: 'cells',
+                          title: 'Cells',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'object',
+                              name: 'cell',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  title: 'Content',
+                                  type: 'array',
+                                  of: [richBlock],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/apps/playground/src/v7/shiki.tsx
+++ b/apps/playground/src/v7/shiki.tsx
@@ -1,0 +1,210 @@
+import type {RangeDecoration} from '@portabletext/editor'
+import {useEditor, useEditorSelector} from '@portabletext/editor'
+import {useEffect, useMemo, useRef, useState} from 'react'
+import type {BundledLanguage, BundledTheme, ThemedToken} from 'shiki/bundle/web'
+import {codeToTokens} from 'shiki/bundle/web'
+import {useTheme} from '../theme-context'
+
+/**
+ * Pure mapping from Shiki tokens to PTE `RangeDecoration` objects.
+ *
+ * Shiki emits a 2-D array of tokens (`ThemedToken[][]`), one inner array
+ * per source line. Each token has `content`, an optional `color`, and an
+ * `offset` relative to the original input. This function distributes the
+ * tokens back across the corresponding line blocks in the deck's
+ * `code-block` container so each token becomes a decoration over the
+ * matching text span.
+ *
+ * Tokens without a colour or with empty content are skipped. Tokens whose
+ * line index has no corresponding line key are dropped (parser produced
+ * extra trailing lines).
+ */
+export function tokensToDecorations(
+  tokens: ReadonlyArray<ReadonlyArray<ThemedToken>>,
+  lineKeys: ReadonlyArray<string>,
+  codeBlockKey: string,
+): Array<RangeDecoration> {
+  const decorations: Array<RangeDecoration> = []
+  for (let lineIndex = 0; lineIndex < tokens.length; lineIndex++) {
+    const lineTokens = tokens[lineIndex]
+    const lineKey = lineKeys[lineIndex]
+    if (!lineTokens || !lineKey) {
+      continue
+    }
+    let column = 0
+    for (const tok of lineTokens) {
+      const length = tok.content.length
+      const start = column
+      const end = column + length
+      column = end
+      if (length === 0 || !tok.color) {
+        continue
+      }
+      const color = tok.color
+      decorations.push({
+        component: ({children}) => <span style={{color}}>{children}</span>,
+        selection: {
+          anchor: {
+            path: [
+              {_key: codeBlockKey},
+              'lines',
+              {_key: lineKey},
+              'children',
+              0,
+            ],
+            offset: start,
+          },
+          focus: {
+            path: [
+              {_key: codeBlockKey},
+              'lines',
+              {_key: lineKey},
+              'children',
+              0,
+            ],
+            offset: end,
+          },
+        },
+      })
+    }
+  }
+  return decorations
+}
+
+type Line = {_key: string; children?: Array<{_type: string; text?: string}>}
+type CodeBlock = {
+  _key: string
+  _type: 'code-block'
+  language?: string
+  lines?: Array<Line>
+}
+type Block = {_key: string; _type: string}
+
+function isCodeBlock(block: unknown): block is CodeBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as Block)._type === 'code-block'
+  )
+}
+
+function getLineText(line: Line): string {
+  return (line.children ?? [])
+    .map((child) => (child._type === 'span' ? (child.text ?? '') : ''))
+    .join('')
+}
+
+/**
+ * Returns the current Shiki `BundledLanguage` for the given deck code-block
+ * language string. Unknown languages map to `text` (no highlighting).
+ */
+function normalizeLanguage(lang: string | undefined): BundledLanguage {
+  if (!lang || lang === 'plain' || lang === 'text') {
+    return 'text' as BundledLanguage
+  }
+  return lang as BundledLanguage
+}
+
+/**
+ * Computes Shiki decorations for every `code-block` in the current editor
+ * value. Tokenisation is async; while a fresh run is in flight the hook
+ * returns the previous decorations so the editor does not flash
+ * uncoloured.
+ *
+ * Cached per `(theme, language, source)` triple so unrelated edits don't
+ * trigger re-tokenisation. The cache is bounded at 32 entries with
+ * oldest-first eviction.
+ *
+ * Lifted from the pilcrow app verbatim - same trick, same trade-offs.
+ */
+export function useShikiDecorations(): ReadonlyArray<RangeDecoration> {
+  const {resolvedTheme} = useTheme()
+  const editor = useEditor()
+  const value = useEditorSelector(editor, (snapshot) => snapshot.context.value)
+  const [decorations, setDecorations] = useState<
+    ReadonlyArray<RangeDecoration>
+  >([])
+  const cacheRef = useRef<Map<string, Array<RangeDecoration>>>(new Map())
+
+  const codeBlocks = useMemo(() => {
+    if (!value) {
+      return [] as Array<CodeBlock>
+    }
+    const out: Array<CodeBlock> = []
+    const walk = (nodes: ReadonlyArray<unknown>) => {
+      for (const node of nodes) {
+        if (isCodeBlock(node)) {
+          out.push(node)
+          continue
+        }
+        if (node && typeof node === 'object') {
+          for (const child of Object.values(node as Record<string, unknown>)) {
+            if (Array.isArray(child)) {
+              walk(child)
+            }
+          }
+        }
+      }
+    }
+    walk(value as ReadonlyArray<unknown>)
+    return out
+  }, [value])
+
+  useEffect(() => {
+    if (codeBlocks.length === 0) {
+      setDecorations([])
+      return
+    }
+    let cancelled = false
+    const lightTheme: BundledTheme = 'github-light'
+    const darkTheme: BundledTheme = 'github-dark'
+    const activeTheme = resolvedTheme === 'dark' ? darkTheme : lightTheme
+
+    async function run() {
+      const all: Array<RangeDecoration> = []
+      for (const block of codeBlocks) {
+        const lines = block.lines ?? []
+        const lineKeys = lines.map((line) => line._key)
+        const source = lines.map(getLineText).join('\n')
+        const language = normalizeLanguage(block.language)
+        const cacheKey = `${activeTheme}\x00${language}\x00${source}`
+        const cached = cacheRef.current.get(cacheKey)
+        if (cached) {
+          all.push(...cached)
+          continue
+        }
+        try {
+          const result = await codeToTokens(source, {
+            lang: language,
+            theme: activeTheme,
+          })
+          const decorationsForBlock = tokensToDecorations(
+            result.tokens,
+            lineKeys,
+            block._key,
+          )
+          // Cap cache at 32 entries; oldest first eviction.
+          if (cacheRef.current.size >= 32) {
+            const firstKey = cacheRef.current.keys().next().value
+            if (firstKey !== undefined) {
+              cacheRef.current.delete(firstKey)
+            }
+          }
+          cacheRef.current.set(cacheKey, decorationsForBlock)
+          all.push(...decorationsForBlock)
+        } catch {
+          // Unknown language or Shiki failure - leave the block unhighlighted.
+        }
+      }
+      if (!cancelled) {
+        setDecorations(all)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [codeBlocks, resolvedTheme])
+
+  return decorations
+}

--- a/apps/playground/src/v7/shiki.tsx
+++ b/apps/playground/src/v7/shiki.tsx
@@ -19,7 +19,7 @@ import {useTheme} from '../theme-context'
  * line index has no corresponding line key are dropped (parser produced
  * extra trailing lines).
  */
-export function tokensToDecorations(
+function tokensToDecorations(
   tokens: ReadonlyArray<ReadonlyArray<ThemedToken>>,
   lineKeys: ReadonlyArray<string>,
   codeBlockKey: string,

--- a/apps/playground/src/v7/slide-container.tsx
+++ b/apps/playground/src/v7/slide-container.tsx
@@ -31,7 +31,7 @@ const slideContainer = defineContainer({
             return (
               <h1
                 {...attributes}
-                className="mt-2 mb-6 font-bold text-5xl tracking-tight text-stone-900 dark:text-stone-50"
+                className="mt-2 mb-6 font-bold text-6xl tracking-tight text-stone-900 dark:text-stone-50"
               >
                 {children}
               </h1>
@@ -49,7 +49,7 @@ const slideContainer = defineContainer({
             return (
               <h3
                 {...attributes}
-                className="mt-4 mb-2 font-semibold text-xl text-stone-800 dark:text-stone-100"
+                className="-mt-2 mb-8 font-medium text-2xl text-stone-500 dark:text-stone-400"
               >
                 {children}
               </h3>
@@ -84,13 +84,26 @@ function SlideFrame(props: {
       {...(props.attributes as Record<string, string>)}
       data-slide-index={slideIndex >= 0 ? slideIndex : undefined}
       data-active={isActive ? '' : undefined}
-      className={
+      className={[
+        'absolute inset-0 mx-auto flex flex-col justify-center px-12 py-16',
+        'mx-auto w-full max-w-4xl',
+        'transition-opacity duration-300 ease-in-out',
         isActive
-          ? 'slide-visible relative mx-auto my-0 flex min-h-[calc(100vh-4rem)] w-full max-w-4xl flex-col justify-center px-12 py-16'
-          : 'slide-hidden absolute -left-[9999px] top-0 h-0 w-0 overflow-hidden opacity-0'
-      }
+          ? 'opacity-100 pointer-events-auto z-10'
+          : 'opacity-0 pointer-events-none z-0',
+      ].join(' ')}
       aria-hidden={!isActive}
     >
+      {/* Milestone kicker - small numeric badge in the corner. */}
+      {slideIndex >= 0 ? (
+        <div
+          contentEditable={false}
+          className="absolute top-8 left-12 select-none font-mono text-stone-400 text-xs tracking-widest uppercase dark:text-stone-500"
+        >
+          {String(slideIndex + 1).padStart(2, '0')} /{' '}
+          {String(slideKeys.length).padStart(2, '0')}
+        </div>
+      ) : null}
       {props.children}
     </section>
   )

--- a/apps/playground/src/v7/slide-container.tsx
+++ b/apps/playground/src/v7/slide-container.tsx
@@ -1,0 +1,101 @@
+import {defineContainer, defineTextBlock} from '@portabletext/editor'
+import {ContainerPlugin} from '@portabletext/editor/plugins'
+import {useContext} from 'react'
+import type {JSX} from 'react'
+import {SlideIndexContext} from './slide-nav-context'
+
+const slideContainer = defineContainer({
+  type: 'slide',
+  childField: 'content',
+  render: ({attributes, children, node, path}) => {
+    return (
+      <SlideFrame attributes={attributes} slideKey={node._key} path={path}>
+        {children}
+      </SlideFrame>
+    )
+  },
+  of: [
+    defineTextBlock({
+      type: 'block',
+      render: ({attributes, children, node}) => {
+        if (node.listItem !== undefined) {
+          return (
+            <div {...attributes} className="my-1.5">
+              {children}
+            </div>
+          )
+        }
+
+        switch (node.style) {
+          case 'h1':
+            return (
+              <h1
+                {...attributes}
+                className="mt-2 mb-6 font-bold text-5xl tracking-tight text-stone-900 dark:text-stone-50"
+              >
+                {children}
+              </h1>
+            )
+          case 'h2':
+            return (
+              <h2
+                {...attributes}
+                className="mt-6 mb-3 font-semibold text-3xl tracking-tight text-stone-800 dark:text-stone-100"
+              >
+                {children}
+              </h2>
+            )
+          case 'h3':
+            return (
+              <h3
+                {...attributes}
+                className="mt-4 mb-2 font-semibold text-xl text-stone-800 dark:text-stone-100"
+              >
+                {children}
+              </h3>
+            )
+          default:
+            return (
+              <p
+                {...attributes}
+                className="my-3 text-xl leading-relaxed text-stone-700 dark:text-stone-200"
+              >
+                {children}
+              </p>
+            )
+        }
+      },
+    }),
+  ],
+})
+
+function SlideFrame(props: {
+  attributes: Record<string, unknown>
+  slideKey: string | undefined
+  path: ReadonlyArray<unknown>
+  children: React.ReactNode
+}) {
+  const {currentIndex, slideKeys} = useContext(SlideIndexContext)
+  const slideIndex = props.slideKey ? slideKeys.indexOf(props.slideKey) : -1
+  const isActive = slideIndex === currentIndex
+
+  return (
+    <section
+      {...(props.attributes as Record<string, string>)}
+      data-slide-index={slideIndex >= 0 ? slideIndex : undefined}
+      data-active={isActive ? '' : undefined}
+      className={
+        isActive
+          ? 'slide-visible relative mx-auto my-0 flex min-h-[calc(100vh-4rem)] w-full max-w-4xl flex-col justify-center px-12 py-16'
+          : 'slide-hidden absolute -left-[9999px] top-0 h-0 w-0 overflow-hidden opacity-0'
+      }
+      aria-hidden={!isActive}
+    >
+      {props.children}
+    </section>
+  )
+}
+
+export function SlidePlugin(): JSX.Element {
+  return <ContainerPlugin containers={[slideContainer]} />
+}

--- a/apps/playground/src/v7/slide-container.tsx
+++ b/apps/playground/src/v7/slide-container.tsx
@@ -31,7 +31,7 @@ const slideContainer = defineContainer({
             return (
               <h1
                 {...attributes}
-                className="mt-2 mb-6 font-bold text-6xl tracking-tight text-stone-900 dark:text-stone-50"
+                className="mt-2 mb-4 font-bold text-4xl tracking-tight text-stone-900 sm:mb-5 sm:text-5xl md:mb-6 md:text-6xl dark:text-stone-50"
               >
                 {children}
               </h1>
@@ -40,7 +40,7 @@ const slideContainer = defineContainer({
             return (
               <h2
                 {...attributes}
-                className="mt-6 mb-3 font-semibold text-3xl tracking-tight text-stone-800 dark:text-stone-100"
+                className="mt-5 mb-2 font-semibold text-xl tracking-tight text-stone-800 sm:text-2xl md:mt-6 md:mb-3 md:text-3xl dark:text-stone-100"
               >
                 {children}
               </h2>
@@ -49,7 +49,7 @@ const slideContainer = defineContainer({
             return (
               <h3
                 {...attributes}
-                className="-mt-2 mb-8 font-medium text-2xl text-stone-500 dark:text-stone-400"
+                className="-mt-1 mb-5 font-medium text-lg text-stone-500 sm:text-xl md:mb-8 md:text-2xl dark:text-stone-400"
               >
                 {children}
               </h3>
@@ -58,7 +58,7 @@ const slideContainer = defineContainer({
             return (
               <p
                 {...attributes}
-                className="my-3 text-xl leading-relaxed text-stone-700 dark:text-stone-200"
+                className="my-2 text-base leading-relaxed text-stone-700 sm:my-3 sm:text-lg md:text-xl dark:text-stone-200"
               >
                 {children}
               </p>
@@ -85,7 +85,8 @@ function SlideFrame(props: {
       data-slide-index={slideIndex >= 0 ? slideIndex : undefined}
       data-active={isActive ? '' : undefined}
       className={[
-        'absolute inset-0 mx-auto flex flex-col justify-center px-12 py-16',
+        'absolute inset-0 mx-auto flex flex-col justify-center',
+        'px-5 py-12 sm:px-8 sm:py-14 md:px-12 md:py-16',
         'mx-auto w-full max-w-4xl',
         'transition-opacity duration-300 ease-in-out',
         isActive
@@ -98,7 +99,7 @@ function SlideFrame(props: {
       {slideIndex >= 0 ? (
         <div
           contentEditable={false}
-          className="absolute top-8 left-12 select-none font-mono text-stone-400 text-xs tracking-widest uppercase dark:text-stone-500"
+          className="absolute top-5 left-5 select-none font-mono text-[10px] text-stone-400 tracking-widest uppercase sm:top-6 sm:left-8 sm:text-xs md:top-8 md:left-12 dark:text-stone-500"
         >
           {String(slideIndex + 1).padStart(2, '0')} /{' '}
           {String(slideKeys.length).padStart(2, '0')}

--- a/apps/playground/src/v7/slide-nav-context.ts
+++ b/apps/playground/src/v7/slide-nav-context.ts
@@ -1,0 +1,17 @@
+import {createContext} from 'react'
+
+/**
+ * Tracks the currently visible slide.
+ *
+ * The deck renders all slides as part of a single Portable Text document.
+ * Only one slide is visible at a time - the rest are hidden via CSS. The
+ * `currentIndex` here drives which slide gets the active styling; the
+ * `slideKeys` array lets each slide work out its own index from its `_key`.
+ */
+export const SlideIndexContext = createContext<{
+  currentIndex: number
+  slideKeys: ReadonlyArray<string>
+}>({
+  currentIndex: 0,
+  slideKeys: [],
+})

--- a/apps/playground/src/v7/slides.ts
+++ b/apps/playground/src/v7/slides.ts
@@ -1,45 +1,120 @@
 import type {PortableTextBlock} from '@portabletext/editor'
 
 /**
- * The v7 deck content - 11 milestones plus an intro and a reveal slide.
+ * The v7 deck content - the 11 architectural milestones, plus an intro,
+ * a mid-deck reveal slide, and a closing arc slide.
  *
- * Each top-level entry is a `slide` container. The container's `content`
- * field holds the slide's blocks (paragraphs, headings, lists, and
- * eventually richer containers like code blocks and tables for the slides
- * that demonstrate those features).
- *
- * Slide _keys are stable so the navigation hash can deep-link to a slide.
+ * Each top-level entry is a `slide` container. The `content` field carries
+ * a mix of text blocks, callouts, code blocks, tables, and rich-content
+ * lists - the same building blocks v7 itself enables.
  */
+
+let nextKey = 0
+function k(prefix: string) {
+  nextKey += 1
+  return `${prefix}-${nextKey.toString(36)}`
+}
 
 const span = (
   text: string,
   marks: ReadonlyArray<string> = [],
-  key = `s${Math.random().toString(36).slice(2, 8)}`,
-) => ({
+): {
+  _type: 'span'
+  _key: string
+  text: string
+  marks: ReadonlyArray<string>
+} => ({
   _type: 'span',
-  _key: key,
+  _key: k('s'),
   text,
   marks,
 })
 
-const block = (
-  options: {
-    style?: string
-    listItem?: string
-    level?: number
-    children: ReadonlyArray<ReturnType<typeof span>>
-    markDefs?: ReadonlyArray<unknown>
-  },
-  key = `b${Math.random().toString(36).slice(2, 8)}`,
-): PortableTextBlock => ({
-  _type: 'block',
-  _key: key,
-  style: options.style ?? 'normal',
-  listItem: options.listItem,
-  level: options.level,
-  markDefs: options.markDefs ?? [],
-  children: options.children,
-})
+type Span = ReturnType<typeof span>
+
+const block = (options: {
+  style?: string
+  listItem?: string
+  level?: number
+  children: ReadonlyArray<Span>
+}): PortableTextBlock =>
+  ({
+    _type: 'block',
+    _key: k('b'),
+    style: options.style ?? 'normal',
+    listItem: options.listItem,
+    level: options.level,
+    markDefs: [],
+    children: options.children,
+  }) as PortableTextBlock
+
+const para = (children: ReadonlyArray<Span>) => block({children})
+const h1 = (text: string) => block({style: 'h1', children: [span(text)]})
+const h3 = (text: string) => block({style: 'h3', children: [span(text)]})
+const bullet = (children: ReadonlyArray<Span>) =>
+  block({listItem: 'bullet', level: 1, children})
+const numbered = (children: ReadonlyArray<Span>) =>
+  block({listItem: 'number', level: 1, children})
+
+const callout = (
+  tone: 'note' | 'tip' | 'important' | 'warning' | 'caution',
+  content: ReadonlyArray<PortableTextBlock>,
+): PortableTextBlock =>
+  ({
+    _type: 'callout',
+    _key: k('c'),
+    tone,
+    content,
+  }) as unknown as PortableTextBlock
+
+const codeBlock = (
+  language: string,
+  lines: ReadonlyArray<string>,
+): PortableTextBlock =>
+  ({
+    _type: 'code-block',
+    _key: k('cb'),
+    language,
+    lines: lines.map((line) => ({
+      _type: 'block',
+      _key: k('cl'),
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          _key: k('cs'),
+          text: line,
+          marks: [],
+        },
+      ],
+    })),
+  }) as unknown as PortableTextBlock
+
+const cell = (content: ReadonlyArray<PortableTextBlock>) =>
+  ({
+    _type: 'cell',
+    _key: k('cell'),
+    content,
+  }) as const
+
+const row = (cells: ReadonlyArray<ReturnType<typeof cell>>) =>
+  ({
+    _type: 'row',
+    _key: k('row'),
+    cells,
+  }) as const
+
+const table = (
+  headerRows: number,
+  rows: ReadonlyArray<ReturnType<typeof row>>,
+): PortableTextBlock =>
+  ({
+    _type: 'table',
+    _key: k('table'),
+    headerRows,
+    rows,
+  }) as unknown as PortableTextBlock
 
 const slide = (
   key: string,
@@ -51,504 +126,429 @@ const slide = (
     content,
   }) as unknown as PortableTextBlock
 
+const cellText = (text: string) => cell([para([span(text)])])
+
 export const deckValue: ReadonlyArray<PortableTextBlock> = [
+  // -------------------------------------------------------------------
   slide('slide-intro', [
-    block({style: 'h1', children: [span('Portable Text v7')]}),
-    block({
-      style: 'h3',
-      children: [span('The architecture, told as milestones.')],
-    }),
-    block({
-      children: [
-        span(
-          'Each slide marks a turn in how the editor came to be what it is today. ',
-        ),
-        span('Press the arrow keys to advance.', ['em']),
-      ],
-    }),
+    h1('Portable Text v7'),
+    h3('The architecture, told as milestones.'),
+    para([
+      span(
+        'Each slide marks a turn in how the editor came to be what it is today. ',
+      ),
+      span('Cmd/Ctrl + Arrow to advance.', ['em']),
+    ]),
   ]),
 
+  // -------------------------------------------------------------------
   slide('slide-1', [
-    block({style: 'h1', children: [span('1. We vendored Slate')]}),
-    block({
-      style: 'h3',
-      children: [span('From a generic editor to one we own.')],
-    }),
-    block({
-      children: [
+    h1('1. We vendored Slate'),
+    h3('From a generic editor to one we own.'),
+    para([
+      span(
+        'Slate had become a liability. Generic types, upstream pace, browser quirks - every fix turned into archaeology. So we copied it into the repo. Every component, every operation, every plugin. Then we started cutting.',
+      ),
+    ]),
+    callout('note', [
+      para([
+        span('What it unlocked: ', ['strong']),
         span(
-          'Slate had become a liability. Generic types, upstream pace, browser quirks - every fix was an archaeology dig. So we copied it into the repo. Every component, every operation, every plugin. Then we started cutting.',
+          'the right to delete, the right to rename, the right to say "this is PTE" without disclaimers. Everything downstream is only possible because we stopped translating.',
         ),
-      ],
-    }),
-    block({
-      style: 'h3',
-      children: [span('What it unlocked')],
-    }),
-    block({
-      children: [
-        span('The right to delete. The right to rename. The right to say ', []),
-        span('we own that code, it is PTE', ['em']),
-        span(
-          ' without disclaimers. Everything downstream is only possible because we stopped translating.',
-        ),
-      ],
-    }),
+      ]),
+    ]),
   ]),
 
+  // -------------------------------------------------------------------
   slide('slide-2', [
-    block({
-      style: 'h1',
-      children: [span('2. Portable Text-native')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Stop pretending. The tree already was the value.')],
-    }),
-    block({
-      children: [
+    h1('2. Portable Text-native'),
+    h3('Stop pretending. The tree already was the value.'),
+    para([
+      span(
+        'The vendored Slate tree was Portable Text values in disguise. Generic ',
+      ),
+      span('Element', ['code']),
+      span(' and '),
+      span('Text', ['code']),
+      span(' became '),
+      span('PortableTextTextBlock', ['code']),
+      span(' and '),
+      span('PortableTextSpan', ['code']),
+      span(
+        '. The vocabulary aligned. Operations got renamed. Helpers got renamed.',
+      ),
+    ]),
+    callout('tip', [
+      para([
         span(
-          'The vendored Slate tree was Portable Text values in disguise: text blocks, spans, marks, markDefs, block objects. We deleted the disguise. Generic ',
+          'A consumer reading the source now sees the same words they see in the schema. No translation in the head, no translation on the wire.',
         ),
-        span('Element', ['code']),
-        span('/'),
-        span('Text', ['code']),
-        span(' became '),
-        span('PortableTextTextBlock', ['code']),
-        span('/'),
-        span('PortableTextSpan', ['code']),
-        span(
-          '. The vocabulary aligned. Operations got renamed. Helpers got renamed.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'A consumer reading the source now sees the same words they see in the schema. And the next layer - patches - became reachable, because the tree was already shaped like one.',
-        ),
-      ],
-    }),
+      ]),
+    ]),
   ]),
 
+  // -------------------------------------------------------------------
   slide('slide-3', [
-    block({
-      style: 'h1',
-      children: [span('3. Fully patch-compliant')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('The big one.')],
-    }),
-    block({
-      children: [
+    h1('3. Fully patch-compliant'),
+    h3('The big one.'),
+    para([
+      span(
+        'Pre-v7 the editor spoke Slate operations internally and translated them to Sanity patches on the way out. Translation went two ways and lost information both directions. Hundreds of lines. The source of an unreasonable share of bugs.',
+      ),
+    ]),
+    para([span('We converged the layers:')]),
+    table(1, [
+      row([
+        cellText('Operation'),
+        cellText('Sanity patch'),
+        cellText('Status'),
+      ]),
+      row([
+        cell([para([span('insert', ['code'])])]),
+        cell([para([span('insert', ['code'])])]),
+        cellText('Pass-through'),
+      ]),
+      row([
+        cell([para([span('unset', ['code'])])]),
+        cell([para([span('unset', ['code'])])]),
+        cellText('Pass-through'),
+      ]),
+      row([
+        cell([para([span('set', ['code'])])]),
+        cell([para([span('set', ['code'])])]),
+        cellText('Pass-through'),
+      ]),
+      row([
+        cell([para([span('insert.text', ['code'])])]),
+        cell([para([span('diffMatchPatch', ['code'])])]),
+        cellText('1:1 mapping'),
+      ]),
+    ]),
+    callout('important', [
+      para([
         span(
-          'Pre-v7 the editor spoke Slate operations internally and translated them to Sanity patches on the way out. Translation went two ways and lost information both directions. Hundreds of lines, the source of an unreasonable share of bugs.',
+          'We accept any patch and emit any patch. The lowest level of the editor is patch-compliant by construction.',
+          ['strong'],
         ),
-      ],
-    }),
-    block({
-      children: [
-        span('We converged the layers. ', []),
-        span('set_node', ['code']),
-        span(' died, replaced by primitive '),
-        span('set', ['code']),
-        span('/'),
-        span('unset', ['code']),
-        span(' operations that mirror Sanity patches one-to-one. '),
-        span('insert_node', ['code']),
-        span(' became '),
-        span('insert', ['code']),
-        span('. The apply layer took ownership of inverse computation.'),
-      ],
-    }),
-    block({
-      style: 'h3',
-      children: [span('The headline')],
-    }),
-    block({
-      children: [
-        span(
-          'We accept any patch and emit any patch. The lowest level of the editor is patch-compliant by construction. ',
-        ),
-        span('If you remember one milestone from this release, this is it.', [
-          'strong',
-        ]),
-      ],
-    }),
+      ]),
+      para([
+        span('If you remember one milestone from this release, this is it.'),
+      ]),
+    ]),
   ]),
 
+  // -------------------------------------------------------------------
   slide('slide-4', [
-    block({
-      style: 'h1',
-      children: [span('4. Keyed paths')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Numeric indexes out. Keys in.')],
-    }),
-    block({
-      children: [
-        span(
-          'The internal selection format was [blockIndex, childIndex, ...] - numeric, positional, fragile. Every concurrent edit invalidated every other client. We rewrote selection, operations, dirty paths, and traversal to use keyed paths natively. 1545 tests. 129 files. One PR.',
-        ),
-      ],
-    }),
-    block({
-      style: 'h3',
-      children: [span('What it unlocked')],
-    }),
-    block({
-      style: 'normal',
-      listItem: 'bullet',
-      level: 1,
-      children: [
-        span(
-          'Concurrent editing - two clients on the same _key see the same selection.',
-        ),
-      ],
-    }),
-    block({
-      style: 'normal',
-      listItem: 'bullet',
-      level: 1,
-      children: [span('Container support - paths are keyed all the way down.')],
-    }),
-    block({
-      style: 'normal',
-      listItem: 'bullet',
-      level: 1,
-      children: [span('Wire format and internal format share one path type.')],
-    }),
-    block({
-      style: 'normal',
-      listItem: 'bullet',
-      level: 1,
-      children: [
-        span('Undo through structural mutations - blocks move, keys do not.'),
-      ],
-    }),
-    block({
-      style: 'normal',
-      listItem: 'bullet',
-      level: 1,
-      children: [
-        span('Depth-agnostic by default - utils compose at any depth.'),
-      ],
-    }),
+    h1('4. Keyed paths'),
+    h3('Numeric indexes out. Keys in.'),
+    para([
+      span(
+        'The internal selection format was [blockIndex, childIndex] - numeric, positional, fragile. Every concurrent edit invalidated every other client. We rewrote selection, operations, dirty paths, and traversal to use keyed paths natively.',
+      ),
+    ]),
+    para([span('Before:')]),
+    codeBlock('json', [
+      '// Selection — indexed',
+      '{',
+      '  "anchor": {"path": [3, 0], "offset": 4},',
+      '  "focus":  {"path": [3, 0], "offset": 4}',
+      '}',
+    ]),
+    para([span('After:')]),
+    codeBlock('json', [
+      '// Selection — keyed all the way down',
+      '{',
+      '  "anchor": {"path": [{"_key":"b1"}, "children", {"_key":"s1"}], "offset": 4},',
+      '  "focus":  {"path": [{"_key":"b1"}, "children", {"_key":"s1"}], "offset": 4}',
+      '}',
+    ]),
+    bullet([
+      span(
+        'Concurrent editing — two clients on the same _key see the same selection.',
+      ),
+    ]),
+    bullet([span('Container support — paths are keyed at any depth.')]),
+    bullet([span('Wire format and internal format share one path type.')]),
+    bullet([
+      span('Undo through structural mutations — blocks move, keys do not.'),
+    ]),
   ]),
 
+  // -------------------------------------------------------------------
   slide('slide-5', [
-    block({
-      style: 'h1',
-      children: [span('5. Containers')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Nested editable structures, first-class.')],
-    }),
-    block({
-      children: [
+    h1('5. Containers'),
+    h3('Nested editable structures, first-class.'),
+    para([
+      span(
+        'Pre-v7 the editor knew two levels of depth: blocks and their children. Tables, code blocks, callouts - none of them representable. The first design was scope-grammar-based; JSONPath-style strings matching positions. It worked. We deleted it.',
+      ),
+    ]),
+    para([span('v2 is type-keyed:')]),
+    codeBlock('typescript', [
+      'const calloutContainer = defineContainer({',
+      "  type: 'callout',",
+      "  childField: 'content',",
+      '  render: ({attributes, children}) => (',
+      '    <aside {...attributes}>{children}</aside>',
+      '  ),',
+      "  of: [defineTextBlock({type: 'block', render: ...})],",
+      '})',
+    ]),
+    callout('important', [
+      para([
+        span('The locked rule: ', ['strong']),
+        span('registration is type-keyed, activation is position-gated.'),
+      ]),
+    ]),
+    para([
+      span(
+        'This slide is a slide container. The table on slide 3, the code block above, this callout - each one is a registered container in the same single Portable Text document. Tables, code blocks, callouts, fact-boxes, nested lists. Any consumer-defined nested structure works.',
+      ),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-reveal', [
+    h1('By the way…'),
+    h3('This deck is one Portable Text document.'),
+    para([
+      span(
+        'Every slide you have seen so far is a `slide` container at the root of a single PTE value. I am typing into it right now.',
+      ),
+    ]),
+    callout('tip', [
+      para([
         span(
-          'Pre-v7 the editor knew two levels of depth: blocks and their children. Tables, code blocks, callouts, lists - none of them representable as data. Consumers faked it. The first design was scope-grammar-based - JSONPath-style strings matching positions. It worked. We deleted it.',
+          'Open the value inspector (the ⟨/⟩ button in the bottom bar). Click into any slide and start typing. Watch the value update.',
         ),
-      ],
-    }),
-    block({
-      children: [
-        span('v2 is type-keyed. Register a container by its ', []),
-        span('_type', ['code']),
-        span(". Positional overrides go inside a parent's "),
-        span('of', ['code']),
-        span(' array. The locked rule: '),
-        span('registration is type-keyed, activation is position-gated.', [
+      ]),
+      para([span('It is just Portable Text.', ['em'])]),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-6', [
+    h1('6. Cascading normalization'),
+    h3('A bare type, made cursor-ready.'),
+    para([
+      span(
+        'Slate normalization assumed flat. Containers broke every assumption. We rewrote it to cascade.',
+      ),
+    ]),
+    para([span('An empty container with a missing field:')]),
+    codeBlock('typescript', [
+      "{_type: 'table'}",
+      '',
+      '// becomes…',
+      '',
+      "{_type: 'table', _key: 't1', rows: [",
+      "  {_type: 'row', _key: 'r1', cells: [",
+      "    {_type: 'cell', _key: 'c1', content: [",
+      "      {_type: 'block', _key: 'b1', children: [",
+      "        {_type: 'span', _key: 's1', text: '', marks: []}",
+      '      ]}',
+      '    ]}',
+      '  ]}',
+      ']}',
+    ]),
+    callout('note', [
+      para([
+        span(
+          'Press Backspace in an empty cell — the cell stays (it is structural). Press Backspace in the only line of a code block — the code block disappears. The complexity is internal; the surface is calm.',
+        ),
+      ]),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-7', [
+    h1('7. Depth-agnostic traversal'),
+    h3('A library of composable primitives.'),
+    para([
+      span(
+        'A hundred-plus traversal utilities existed pre-v7, most baking in path[0] or path.slice(0, 2). Each one had to be rewritten to compose primitives that work at any depth.',
+      ),
+    ]),
+    para([span('We unified the input shape:')]),
+    codeBlock('typescript', [
+      'export type TraversalSnapshot = {',
+      '  context: {',
+      '    schema: EditorSchema',
+      '    containers: ReadonlyMap<string, RegisteredContainer>',
+      '    value: PortableTextValue',
+      '    selection: EditorSelection',
+      '  }',
+      '  blockIndexMap: Map<string, number>',
+      '}',
+      '',
+      '// Satisfied by EditorSnapshot, OperationSnapshot,',
+      '// and the editor itself (via a `context` getter).',
+    ]),
+    callout('tip', [
+      para([
+        span(
+          'Behaviors written for root-level text drop into a callout, a table cell, a code block — without rewriting. Many v6 plugins migrated with zero source changes.',
+        ),
+      ]),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-8', [
+    h1('8. A cleaner DOM'),
+    h3('data-pt-path, everywhere it matters.'),
+    para([
+      span(
+        "Slate's DOM mapping had no relationship to Portable Text. data-slate-node, data-slate-leaf, data-slate-string - none of them told you which _key a node had.",
+      ),
+    ]),
+    para([span('The new mapping is direct:')]),
+    codeBlock('html', [
+      '<aside data-pt-container data-pt-path="[_key==\'k1\']">',
+      "  <p data-pt-leaf data-pt-path=\"[_key=='k1'].content[_key=='b1']\">",
+      '    <span data-pt-path="…children[_key==\'s1\']">Hello</span>',
+      '  </p>',
+      '</aside>',
+    ]),
+    para([
+      span(
+        'DOM-to-model resolution walks [data-pt-path] ancestors and parses. Open devtools on a v7 editor and you see Portable Text paths in the DOM. The mapping is no longer a translation; it is a serialization.',
+      ),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-9', [
+    h1('9. Primitive behavior events'),
+    h3('Behaviors compose the primitives the engine speaks.'),
+    para([
+      span(
+        'In v6 most behaviors raised "smart" synthetic events whose handlers contained the depth-2 assumptions. A behavior could not reach below the synthetic layer. In v7 we promoted the apply-layer primitives as ',
+      ),
+      span('@alpha', ['code']),
+      span(' behavior events:'),
+    ]),
+    codeBlock('typescript', [
+      'defineBehavior({',
+      "  on: 'keyboard.keydown',",
+      '  guard: ({event, snapshot}) => {',
+      "    if (event.originEvent.key !== 'Backspace') return false",
+      "    const cell = selectors.getFocusContainer(snapshot, {type: 'cell'})",
+      '    if (!cell || !isCellEmpty(cell)) return false',
+      '    return {cellPath: cell.path}',
+      '  },',
+      '  actions: [',
+      '    (_, {cellPath}) => [',
+      "      raise({type: 'unset', at: cellPath, paths: [['content']]}),",
+      "      raise({type: 'select', at: cellPath}),",
+      '    ],',
+      '  ],',
+      '})',
+    ]),
+    table(1, [
+      row([cellText('Event'), cellText('Sanity patch')]),
+      row([
+        cell([para([span('insert', ['code'])])]),
+        cell([para([span('insert', ['code'])])]),
+      ]),
+      row([
+        cell([para([span('unset', ['code'])])]),
+        cell([para([span('unset', ['code'])])]),
+      ]),
+      row([
+        cell([para([span('set', ['code'])])]),
+        cell([para([span('set', ['code'])])]),
+      ]),
+      row([
+        cell([para([span('insert.text', ['code'])])]),
+        cell([para([span('diffMatchPatch', ['code'])])]),
+      ]),
+      row([
+        cell([para([span('remove.text', ['code'])])]),
+        cell([para([span('diffMatchPatch', ['code'])])]),
+      ]),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-10', [
+    h1('10. Schema enforcement, symmetric'),
+    h3('Strict at every depth.'),
+    para([
+      span(
+        'Pre-v7 the editor enforced schema constraints inside containers, but accepted anything at root. Consumers wrote behaviors expecting strict enforcement; got intermittent silent drops when constraints applied below root and not at it.',
+      ),
+    ]),
+    callout('warning', [
+      para([
+        span('The asymmetry was a mistake. ', ['strong']),
+        span(
+          'v7 enforces strictly at every depth. Insert validates against the sub-schema at the target path. ',
+        ),
+        span('decorator.add', ['code']),
+        span(' filters per-block. '),
+        span('annotation.add', ['code']),
+        span(' validates the annotation type.'),
+      ]),
+    ]),
+    para([
+      span(
+        'A behavior that fires insert knows the editor will validate. A callout that only allows strong and em sees its constraints respected. The schema is the contract, top to bottom.',
+      ),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-11', [
+    h1('11. The traversal snapshot'),
+    h3('One input shape, everywhere.'),
+    para([
+      span('The type-level companion to milestone 7. '),
+      span('EditorSnapshot', ['code']),
+      span(', '),
+      span('OperationSnapshot', ['code']),
+      span(', '),
+      span('TraversalSnapshot', ['code']),
+      span(
+        ' - all share the same shape. The editor satisfies it via a context getter.',
+      ),
+    ]),
+    para([
+      span(
+        'Behaviors and selectors that read state do it the same way as the engine. 60 files migrated; the ergonomic dividend pays out forever.',
+      ),
+    ]),
+    callout('tip', [
+      para([
+        span('One mental model. ', ['strong']),
+        span('Three call sites. Zero adapters.'),
+      ]),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-arc', [
+    h1('The arc'),
+    h3('Every advanced feature traces back to four ideas.'),
+    numbered([span('We accept any patch.')]),
+    numbered([span('We emit any patch.')]),
+    numbered([span('Paths are keyed.')]),
+    numbered([span('Depth is just a parameter.')]),
+    para([
+      span(
+        'A generic positional editor became a Portable Text-native, keyed, patch-compliant, depth-agnostic, container-aware document model.',
+      ),
+    ]),
+    callout('important', [
+      para([
+        span('The headline of v7 is the architectural foundation. ', [
           'strong',
         ]),
-      ],
-    }),
-    block({
-      children: [span('Every layer of the editor learned what nesting meant.')],
-    }),
-  ]),
-
-  slide('slide-reveal', [
-    block({
-      style: 'h1',
-      children: [span('By the way')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('This deck is one Portable Text document.')],
-    }),
-    block({
-      children: [
         span(
-          'Every slide you have seen so far is a `slide` container at the root of a single PTE value. I am typing into it right now.',
+          'Markdown compliance, structured lists, tables, code blocks, callouts - those are the dividend.',
         ),
-      ],
-    }),
-    block({
-      children: [
-        span('Open the inspector. Look at the value. ', []),
-        span('It is just Portable Text.', ['em']),
-      ],
-    }),
-  ]),
-
-  slide('slide-6', [
-    block({
-      style: 'h1',
-      children: [span('6. Cascading normalization')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('A bare type, made cursor-ready.')],
-    }),
-    block({
-      children: [
-        span(
-          'Slate normalization assumed flat: blocks at root, children inside blocks, nothing deeper. Containers broke every assumption. We rewrote it to cascade.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span('An empty container with a missing field gets ', []),
-        span('[]', ['code']),
-        span(
-          ', which triggers normalization at the cells level, which inserts a default cell, which inserts a placeholder text block, which inserts an empty span. The cascade walks from a bare ',
-        ),
-        span("{_type: 'table'}", ['code']),
-        span(' to a fully cursor-ready tree.'),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'Press Backspace in an empty table cell. The cell stays - it is structural. Press Backspace in the only line of a code block. The code block disappears - its content field accepts placeholders. Complexity is internal, the surface is calm.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-7', [
-    block({
-      style: 'h1',
-      children: [span('7. Depth-agnostic traversal')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('The library of composable primitives.')],
-    }),
-    block({
-      children: [
-        span(
-          'A hundred-plus traversal utilities existed pre-v7, most baking in path[0] or path.slice(0, 2). Each one had to be rewritten to compose primitives that work at any depth.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span('We unified the input shape: ', []),
-        span('TraversalSnapshot', ['code']),
-        span(' - one structure satisfied by '),
-        span('EditorSnapshot', ['code']),
-        span(', '),
-        span('OperationSnapshot', ['code']),
-        span(', and the editor itself. One snapshot type. One mental model.'),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'Behaviors written for root-level text drop into a callout, a table cell, a code block - without rewriting. Many v6 plugins migrated with zero source changes.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-8', [
-    block({
-      style: 'h1',
-      children: [span('8. A cleaner DOM')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('data-pt-path, everywhere it matters.')],
-    }),
-    block({
-      children: [
-        span(
-          "Slate's DOM mapping had no relationship to Portable Text. data-slate-node, data-slate-leaf, data-slate-string - none of them told you which _key a node had.",
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'The new mapping is direct. Every element inside a container carries ',
-          [],
-        ),
-        span('data-pt-path', ['code']),
-        span(
-          ' - a Sanity-bracket-notation serialized keyed path. DOM-to-model resolution walks ',
-        ),
-        span('[data-pt-path]', ['code']),
-        span(' ancestors and parses. '),
-        span('data-pt-container', ['code']),
-        span(', '),
-        span('data-pt-leaf', ['code']),
-        span(', '),
-        span('data-pt-spacer', ['code']),
-        span(' describe what each element is in Portable Text terms.'),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'Open devtools on a v7 editor and you see Portable Text paths in the DOM. The mapping is no longer a translation; it is a serialization.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-9', [
-    block({
-      style: 'h1',
-      children: [span('9. Primitive behavior events')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Behaviors compose the primitives the engine speaks.')],
-    }),
-    block({
-      children: [
-        span(
-          'In v6 most behaviors raised "smart" synthetic events - insert.block, delete.block, block.set - whose handlers contained the depth-2 assumptions. A behavior could not reach below the synthetic layer.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'We promoted the apply-layer primitives as @alpha behavior events. ',
-          [],
-        ),
-        span('insert', ['code']),
-        span(', '),
-        span('unset', ['code']),
-        span(', '),
-        span('set', ['code']),
-        span(', '),
-        span('insert.text', ['code']),
-        span(', '),
-        span('remove.text', ['code']),
-        span(', '),
-        span('select', ['code']),
-        span(
-          '. Six events. One per apply-layer operation. One per Sanity patch type.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'structured-lists became the canary: 11 flat-list behaviors decompose into 4 primitives plus 9 thin behaviors. No engine changes required. The engine ships the vocabulary; consumers compose.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-10', [
-    block({
-      style: 'h1',
-      children: [span('10. Schema enforcement, symmetrical')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Strict at every depth.')],
-    }),
-    block({
-      children: [
-        span(
-          'Pre-v7 the editor enforced schema constraints inside containers but accepted anything at root. The asymmetry was a mistake - consumers wrote behaviors expecting strict enforcement, got intermittent silent drops when constraints applied below root and not at it.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'v7 enforces strictly at every depth. Insert validates against the sub-schema at the target path. decorator.add filters per-block. annotation.add validates the annotation type. The operation layer absorbs the question; behavior guards no longer gate user intent.',
-        ),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'A behavior that fires insert knows the editor will validate. A callout that only allows strong and em sees its constraints respected. The schema is the contract, top to bottom.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-11', [
-    block({
-      style: 'h1',
-      children: [span('11. The traversal snapshot')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('One input shape, everywhere.')],
-    }),
-    block({
-      children: [
-        span('The type-level companion to milestone 7. ', []),
-        span('EditorSnapshot', ['code']),
-        span(', '),
-        span('OperationSnapshot', ['code']),
-        span(', '),
-        span('TraversalSnapshot', ['code']),
-        span(' - all share the same shape. The editor satisfies it via a '),
-        span('context', ['code']),
-        span(' getter.'),
-      ],
-    }),
-    block({
-      children: [
-        span(
-          'Behaviors and selectors that read state do it the same way as the engine. 60 files migrated; the ergonomic dividend pays out forever.',
-        ),
-      ],
-    }),
-  ]),
-
-  slide('slide-arc', [
-    block({
-      style: 'h1',
-      children: [span('The arc')],
-    }),
-    block({
-      style: 'h3',
-      children: [span('Every advanced feature traces back to four ideas.')],
-    }),
-    block({
-      children: [span('We accept any patch.')],
-    }),
-    block({
-      children: [span('We emit any patch.')],
-    }),
-    block({
-      children: [span('Paths are keyed.')],
-    }),
-    block({
-      children: [span('Depth is just a parameter.')],
-    }),
-    block({
-      children: [
-        span(
-          'A generic positional editor became a Portable Text-native, keyed, patch-compliant, depth-agnostic, container-aware document model. The headline of v7 is the architectural foundation. Markdown compliance, structured lists, tables, code blocks - those are the dividend.',
-        ),
-      ],
-    }),
+      ]),
+    ]),
   ]),
 ]

--- a/apps/playground/src/v7/slides.ts
+++ b/apps/playground/src/v7/slides.ts
@@ -354,11 +354,6 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
         span('registration is type-keyed, activation is position-gated.'),
       ]),
     ]),
-    para([
-      span(
-        'This slide is a slide container. The table on slide 3, the code block above, this callout - each one is a registered container in the same Portable Text document.',
-      ),
-    ]),
   ]),
 
   // -------------------------------------------------------------------
@@ -369,7 +364,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       span('Every slide you have seen so far is a '),
       span('slide', ['code']),
       span(
-        ' container at the root of a single PTE value. I am typing into it right now.',
+        ' container at the root of a single PTE value. The table on slide 3, the code block you just saw, this callout - each one is a registered container in the same document. I am typing into it right now.',
       ),
     ]),
     callout('tip', [
@@ -443,12 +438,12 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       '// Satisfied by EditorSnapshot, OperationSnapshot,',
       '// and the editor itself (via a `context` getter).',
     ]),
-    callout('tip', [
-      para([
-        span(
-          'Behaviors written for root-level text drop into a callout, a table cell, a code block - without rewriting. Many v6 plugins migrated with zero source changes.',
-        ),
-      ]),
+    para([
+      span(
+        'Behaviors written for root-level text drop into a callout, a table cell, a code block - without rewriting. ',
+        ['strong'],
+      ),
+      span('Many v6 plugins migrated with zero source changes.'),
     ]),
   ]),
 
@@ -512,18 +507,10 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       span('. Six events, one per apply-layer operation, one per patch type.'),
     ]),
     codeBlock('typescript', [
+      '// Backspace in an empty cell: clear the cell, keep the structure.',
       'defineBehavior({',
       "  on: 'keyboard.keydown',",
-      '  guard: ({event, snapshot}) => {',
-      "    if (event.originEvent.key !== 'Backspace') return false",
-      '    const container = resolveContainerAt(',
-      '      snapshot.context.containers,',
-      '      snapshot.context.value,',
-      '      snapshot.context.selection?.focus.path ?? [],',
-      '    )',
-      "    if (container?.type !== 'cell' || !isCellEmpty(container)) return false",
-      '    return {cellPath: container.path}',
-      '  },',
+      '  guard: backspaceInEmptyCell,',
       '  actions: [',
       '    (_, {cellPath}) => [',
       "      raise({type: 'unset', at: [...cellPath, 'content']}),",

--- a/apps/playground/src/v7/slides.ts
+++ b/apps/playground/src/v7/slides.ts
@@ -1,0 +1,554 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+
+/**
+ * The v7 deck content - 11 milestones plus an intro and a reveal slide.
+ *
+ * Each top-level entry is a `slide` container. The container's `content`
+ * field holds the slide's blocks (paragraphs, headings, lists, and
+ * eventually richer containers like code blocks and tables for the slides
+ * that demonstrate those features).
+ *
+ * Slide _keys are stable so the navigation hash can deep-link to a slide.
+ */
+
+const span = (
+  text: string,
+  marks: ReadonlyArray<string> = [],
+  key = `s${Math.random().toString(36).slice(2, 8)}`,
+) => ({
+  _type: 'span',
+  _key: key,
+  text,
+  marks,
+})
+
+const block = (
+  options: {
+    style?: string
+    listItem?: string
+    level?: number
+    children: ReadonlyArray<ReturnType<typeof span>>
+    markDefs?: ReadonlyArray<unknown>
+  },
+  key = `b${Math.random().toString(36).slice(2, 8)}`,
+): PortableTextBlock => ({
+  _type: 'block',
+  _key: key,
+  style: options.style ?? 'normal',
+  listItem: options.listItem,
+  level: options.level,
+  markDefs: options.markDefs ?? [],
+  children: options.children,
+})
+
+const slide = (
+  key: string,
+  content: ReadonlyArray<PortableTextBlock>,
+): PortableTextBlock =>
+  ({
+    _type: 'slide',
+    _key: key,
+    content,
+  }) as unknown as PortableTextBlock
+
+export const deckValue: ReadonlyArray<PortableTextBlock> = [
+  slide('slide-intro', [
+    block({style: 'h1', children: [span('Portable Text v7')]}),
+    block({
+      style: 'h3',
+      children: [span('The architecture, told as milestones.')],
+    }),
+    block({
+      children: [
+        span(
+          'Each slide marks a turn in how the editor came to be what it is today. ',
+        ),
+        span('Press the arrow keys to advance.', ['em']),
+      ],
+    }),
+  ]),
+
+  slide('slide-1', [
+    block({style: 'h1', children: [span('1. We vendored Slate')]}),
+    block({
+      style: 'h3',
+      children: [span('From a generic editor to one we own.')],
+    }),
+    block({
+      children: [
+        span(
+          'Slate had become a liability. Generic types, upstream pace, browser quirks - every fix was an archaeology dig. So we copied it into the repo. Every component, every operation, every plugin. Then we started cutting.',
+        ),
+      ],
+    }),
+    block({
+      style: 'h3',
+      children: [span('What it unlocked')],
+    }),
+    block({
+      children: [
+        span('The right to delete. The right to rename. The right to say ', []),
+        span('we own that code, it is PTE', ['em']),
+        span(
+          ' without disclaimers. Everything downstream is only possible because we stopped translating.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-2', [
+    block({
+      style: 'h1',
+      children: [span('2. Portable Text-native')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Stop pretending. The tree already was the value.')],
+    }),
+    block({
+      children: [
+        span(
+          'The vendored Slate tree was Portable Text values in disguise: text blocks, spans, marks, markDefs, block objects. We deleted the disguise. Generic ',
+        ),
+        span('Element', ['code']),
+        span('/'),
+        span('Text', ['code']),
+        span(' became '),
+        span('PortableTextTextBlock', ['code']),
+        span('/'),
+        span('PortableTextSpan', ['code']),
+        span(
+          '. The vocabulary aligned. Operations got renamed. Helpers got renamed.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'A consumer reading the source now sees the same words they see in the schema. And the next layer - patches - became reachable, because the tree was already shaped like one.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-3', [
+    block({
+      style: 'h1',
+      children: [span('3. Fully patch-compliant')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('The big one.')],
+    }),
+    block({
+      children: [
+        span(
+          'Pre-v7 the editor spoke Slate operations internally and translated them to Sanity patches on the way out. Translation went two ways and lost information both directions. Hundreds of lines, the source of an unreasonable share of bugs.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span('We converged the layers. ', []),
+        span('set_node', ['code']),
+        span(' died, replaced by primitive '),
+        span('set', ['code']),
+        span('/'),
+        span('unset', ['code']),
+        span(' operations that mirror Sanity patches one-to-one. '),
+        span('insert_node', ['code']),
+        span(' became '),
+        span('insert', ['code']),
+        span('. The apply layer took ownership of inverse computation.'),
+      ],
+    }),
+    block({
+      style: 'h3',
+      children: [span('The headline')],
+    }),
+    block({
+      children: [
+        span(
+          'We accept any patch and emit any patch. The lowest level of the editor is patch-compliant by construction. ',
+        ),
+        span('If you remember one milestone from this release, this is it.', [
+          'strong',
+        ]),
+      ],
+    }),
+  ]),
+
+  slide('slide-4', [
+    block({
+      style: 'h1',
+      children: [span('4. Keyed paths')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Numeric indexes out. Keys in.')],
+    }),
+    block({
+      children: [
+        span(
+          'The internal selection format was [blockIndex, childIndex, ...] - numeric, positional, fragile. Every concurrent edit invalidated every other client. We rewrote selection, operations, dirty paths, and traversal to use keyed paths natively. 1545 tests. 129 files. One PR.',
+        ),
+      ],
+    }),
+    block({
+      style: 'h3',
+      children: [span('What it unlocked')],
+    }),
+    block({
+      style: 'normal',
+      listItem: 'bullet',
+      level: 1,
+      children: [
+        span(
+          'Concurrent editing - two clients on the same _key see the same selection.',
+        ),
+      ],
+    }),
+    block({
+      style: 'normal',
+      listItem: 'bullet',
+      level: 1,
+      children: [span('Container support - paths are keyed all the way down.')],
+    }),
+    block({
+      style: 'normal',
+      listItem: 'bullet',
+      level: 1,
+      children: [span('Wire format and internal format share one path type.')],
+    }),
+    block({
+      style: 'normal',
+      listItem: 'bullet',
+      level: 1,
+      children: [
+        span('Undo through structural mutations - blocks move, keys do not.'),
+      ],
+    }),
+    block({
+      style: 'normal',
+      listItem: 'bullet',
+      level: 1,
+      children: [
+        span('Depth-agnostic by default - utils compose at any depth.'),
+      ],
+    }),
+  ]),
+
+  slide('slide-5', [
+    block({
+      style: 'h1',
+      children: [span('5. Containers')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Nested editable structures, first-class.')],
+    }),
+    block({
+      children: [
+        span(
+          'Pre-v7 the editor knew two levels of depth: blocks and their children. Tables, code blocks, callouts, lists - none of them representable as data. Consumers faked it. The first design was scope-grammar-based - JSONPath-style strings matching positions. It worked. We deleted it.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span('v2 is type-keyed. Register a container by its ', []),
+        span('_type', ['code']),
+        span(". Positional overrides go inside a parent's "),
+        span('of', ['code']),
+        span(' array. The locked rule: '),
+        span('registration is type-keyed, activation is position-gated.', [
+          'strong',
+        ]),
+      ],
+    }),
+    block({
+      children: [span('Every layer of the editor learned what nesting meant.')],
+    }),
+  ]),
+
+  slide('slide-reveal', [
+    block({
+      style: 'h1',
+      children: [span('By the way')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('This deck is one Portable Text document.')],
+    }),
+    block({
+      children: [
+        span(
+          'Every slide you have seen so far is a `slide` container at the root of a single PTE value. I am typing into it right now.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span('Open the inspector. Look at the value. ', []),
+        span('It is just Portable Text.', ['em']),
+      ],
+    }),
+  ]),
+
+  slide('slide-6', [
+    block({
+      style: 'h1',
+      children: [span('6. Cascading normalization')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('A bare type, made cursor-ready.')],
+    }),
+    block({
+      children: [
+        span(
+          'Slate normalization assumed flat: blocks at root, children inside blocks, nothing deeper. Containers broke every assumption. We rewrote it to cascade.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span('An empty container with a missing field gets ', []),
+        span('[]', ['code']),
+        span(
+          ', which triggers normalization at the cells level, which inserts a default cell, which inserts a placeholder text block, which inserts an empty span. The cascade walks from a bare ',
+        ),
+        span("{_type: 'table'}", ['code']),
+        span(' to a fully cursor-ready tree.'),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'Press Backspace in an empty table cell. The cell stays - it is structural. Press Backspace in the only line of a code block. The code block disappears - its content field accepts placeholders. Complexity is internal, the surface is calm.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-7', [
+    block({
+      style: 'h1',
+      children: [span('7. Depth-agnostic traversal')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('The library of composable primitives.')],
+    }),
+    block({
+      children: [
+        span(
+          'A hundred-plus traversal utilities existed pre-v7, most baking in path[0] or path.slice(0, 2). Each one had to be rewritten to compose primitives that work at any depth.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span('We unified the input shape: ', []),
+        span('TraversalSnapshot', ['code']),
+        span(' - one structure satisfied by '),
+        span('EditorSnapshot', ['code']),
+        span(', '),
+        span('OperationSnapshot', ['code']),
+        span(', and the editor itself. One snapshot type. One mental model.'),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'Behaviors written for root-level text drop into a callout, a table cell, a code block - without rewriting. Many v6 plugins migrated with zero source changes.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-8', [
+    block({
+      style: 'h1',
+      children: [span('8. A cleaner DOM')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('data-pt-path, everywhere it matters.')],
+    }),
+    block({
+      children: [
+        span(
+          "Slate's DOM mapping had no relationship to Portable Text. data-slate-node, data-slate-leaf, data-slate-string - none of them told you which _key a node had.",
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'The new mapping is direct. Every element inside a container carries ',
+          [],
+        ),
+        span('data-pt-path', ['code']),
+        span(
+          ' - a Sanity-bracket-notation serialized keyed path. DOM-to-model resolution walks ',
+        ),
+        span('[data-pt-path]', ['code']),
+        span(' ancestors and parses. '),
+        span('data-pt-container', ['code']),
+        span(', '),
+        span('data-pt-leaf', ['code']),
+        span(', '),
+        span('data-pt-spacer', ['code']),
+        span(' describe what each element is in Portable Text terms.'),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'Open devtools on a v7 editor and you see Portable Text paths in the DOM. The mapping is no longer a translation; it is a serialization.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-9', [
+    block({
+      style: 'h1',
+      children: [span('9. Primitive behavior events')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Behaviors compose the primitives the engine speaks.')],
+    }),
+    block({
+      children: [
+        span(
+          'In v6 most behaviors raised "smart" synthetic events - insert.block, delete.block, block.set - whose handlers contained the depth-2 assumptions. A behavior could not reach below the synthetic layer.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'We promoted the apply-layer primitives as @alpha behavior events. ',
+          [],
+        ),
+        span('insert', ['code']),
+        span(', '),
+        span('unset', ['code']),
+        span(', '),
+        span('set', ['code']),
+        span(', '),
+        span('insert.text', ['code']),
+        span(', '),
+        span('remove.text', ['code']),
+        span(', '),
+        span('select', ['code']),
+        span(
+          '. Six events. One per apply-layer operation. One per Sanity patch type.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'structured-lists became the canary: 11 flat-list behaviors decompose into 4 primitives plus 9 thin behaviors. No engine changes required. The engine ships the vocabulary; consumers compose.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-10', [
+    block({
+      style: 'h1',
+      children: [span('10. Schema enforcement, symmetrical')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Strict at every depth.')],
+    }),
+    block({
+      children: [
+        span(
+          'Pre-v7 the editor enforced schema constraints inside containers but accepted anything at root. The asymmetry was a mistake - consumers wrote behaviors expecting strict enforcement, got intermittent silent drops when constraints applied below root and not at it.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'v7 enforces strictly at every depth. Insert validates against the sub-schema at the target path. decorator.add filters per-block. annotation.add validates the annotation type. The operation layer absorbs the question; behavior guards no longer gate user intent.',
+        ),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'A behavior that fires insert knows the editor will validate. A callout that only allows strong and em sees its constraints respected. The schema is the contract, top to bottom.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-11', [
+    block({
+      style: 'h1',
+      children: [span('11. The traversal snapshot')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('One input shape, everywhere.')],
+    }),
+    block({
+      children: [
+        span('The type-level companion to milestone 7. ', []),
+        span('EditorSnapshot', ['code']),
+        span(', '),
+        span('OperationSnapshot', ['code']),
+        span(', '),
+        span('TraversalSnapshot', ['code']),
+        span(' - all share the same shape. The editor satisfies it via a '),
+        span('context', ['code']),
+        span(' getter.'),
+      ],
+    }),
+    block({
+      children: [
+        span(
+          'Behaviors and selectors that read state do it the same way as the engine. 60 files migrated; the ergonomic dividend pays out forever.',
+        ),
+      ],
+    }),
+  ]),
+
+  slide('slide-arc', [
+    block({
+      style: 'h1',
+      children: [span('The arc')],
+    }),
+    block({
+      style: 'h3',
+      children: [span('Every advanced feature traces back to four ideas.')],
+    }),
+    block({
+      children: [span('We accept any patch.')],
+    }),
+    block({
+      children: [span('We emit any patch.')],
+    }),
+    block({
+      children: [span('Paths are keyed.')],
+    }),
+    block({
+      children: [span('Depth is just a parameter.')],
+    }),
+    block({
+      children: [
+        span(
+          'A generic positional editor became a Portable Text-native, keyed, patch-compliant, depth-agnostic, container-aware document model. The headline of v7 is the architectural foundation. Markdown compliance, structured lists, tables, code blocks - those are the dividend.',
+        ),
+      ],
+    }),
+  ]),
+]

--- a/apps/playground/src/v7/slides.ts
+++ b/apps/playground/src/v7/slides.ts
@@ -147,14 +147,31 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     h3('From a generic editor to one we own.'),
     para([
       span(
-        'Slate had become a liability. Generic types, upstream pace, browser quirks - every fix turned into archaeology. So we copied it into the repo. Every component, every operation, every plugin. Then we started cutting.',
+        'Bug reports kept turning into archaeology. "Caret skips a character on this keyboard." "Remote patch produces the wrong tree." "Undo restores wrong state." Each one bottomed out at the same question: ',
+      ),
+      span("is this our bug, or is it Slate's?", ['em']),
+      span(' PRs to upstream sat for months. The generic '),
+      span('Editor', ['code']),
+      span(', '),
+      span('Node', ['code']),
+      span(', '),
+      span('Path', ['code']),
+      span(' types were a vocabulary we paid for and never used.'),
+    ]),
+    para([
+      span(
+        'So we copied Slate into the repo. Every component, every operation, every plugin. Then we started cutting.',
       ),
     ]),
     callout('note', [
       para([
         span('What it unlocked: ', ['strong']),
+        span('the right to delete, the right to rename, the right to make '),
+        span('Path', ['code']),
+        span(' mean '),
+        span('PortableTextPath', ['code']),
         span(
-          'the right to delete, the right to rename, the right to say "this is PTE" without disclaimers. Everything downstream is only possible because we stopped translating.',
+          '. The right to say "we own that code, it\'s PTE" without disclaimers.',
         ),
       ]),
     ]),
@@ -166,7 +183,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     h3('Stop pretending. The tree already was the value.'),
     para([
       span(
-        'The vendored Slate tree was Portable Text values in disguise. Generic ',
+        'Once we owned the code, we could stop pretending. The vendored Slate tree was already Portable Text values in disguise. We deleted the disguise. Generic ',
       ),
       span('Element', ['code']),
       span(' and '),
@@ -175,14 +192,20 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       span('PortableTextTextBlock', ['code']),
       span(' and '),
       span('PortableTextSpan', ['code']),
-      span(
-        '. The vocabulary aligned. Operations got renamed. Helpers got renamed.',
-      ),
+      span('. The "Slate Editor" became '),
+      span('PortableTextSlateEditor', ['code']),
+      span(' with '),
+      span('schema', ['code']),
+      span(', '),
+      span('containers', ['code']),
+      span(', and '),
+      span('children', ['code']),
+      span(' as first-class fields.'),
     ]),
     callout('tip', [
       para([
         span(
-          'A consumer reading the source now sees the same words they see in the schema. No translation in the head, no translation on the wire.',
+          'A consumer reading the source now sees the same words they see in the schema. The type names in the source match the protocol on the wire.',
         ),
       ]),
     ]),
@@ -194,53 +217,81 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     h3('The big one.'),
     para([
       span(
-        'Pre-v7 the editor spoke Slate operations internally and translated them to Sanity patches on the way out. Translation went two ways and lost information both directions. Hundreds of lines. The source of an unreasonable share of bugs.',
+        'Pre-v7 the editor spoke Slate operations internally and translated them to Sanity patches on the way out. Translation went two ways and lost information both directions. The translation layer was the source of an unreasonable share of bugs.',
       ),
     ]),
     para([span('We converged the layers:')]),
     table(1, [
       row([
-        cellText('Operation'),
+        cellText('Behavior event'),
+        cellText('Slate operation'),
         cellText('Sanity patch'),
-        cellText('Status'),
       ]),
       row([
         cell([para([span('insert', ['code'])])]),
         cell([para([span('insert', ['code'])])]),
-        cellText('Pass-through'),
-      ]),
-      row([
-        cell([para([span('unset', ['code'])])]),
-        cell([para([span('unset', ['code'])])]),
-        cellText('Pass-through'),
-      ]),
-      row([
-        cell([para([span('set', ['code'])])]),
-        cell([para([span('set', ['code'])])]),
-        cellText('Pass-through'),
+        cell([
+          para([
+            span('insert', ['code']),
+            span(' (+ '),
+            span('setIfMissing', ['code']),
+            span(' for non-root)'),
+          ]),
+        ]),
       ]),
       row([
         cell([para([span('insert.text', ['code'])])]),
+        cell([para([span('insert_text', ['code'])])]),
         cell([para([span('diffMatchPatch', ['code'])])]),
-        cellText('1:1 mapping'),
+      ]),
+      row([
+        cell([para([span('select', ['code'])])]),
+        cell([para([span('set_selection', ['code'])])]),
+        cellText('(local; selection is not a patch)'),
       ]),
     ]),
     callout('important', [
       para([
         span(
-          'We accept any patch and emit any patch. The lowest level of the editor is patch-compliant by construction.',
+          'We accept any patch and emit any patch. The lowest level of the editor is patch-compliant by construction. ',
           ['strong'],
         ),
-      ]),
-      para([
-        span('If you remember one milestone from this release, this is it.'),
+        span('What translation remains is two files, mostly identity.'),
       ]),
     ]),
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-4', [
-    h1('4. Keyed paths'),
+  slide('slide-4-strict', [
+    h1('4. Schema enforcement, symmetric'),
+    h3('Strict at every depth.'),
+    para([
+      span(
+        'Patches gave us strict in/out. The schema gave us strict top/bottom. Pre-v7 the editor enforced constraints inside containers but accepted anything at root. Consumers wrote behaviors expecting strict enforcement and got intermittent silent drops.',
+      ),
+    ]),
+    callout('warning', [
+      para([
+        span('The asymmetry was a mistake. ', ['strong']),
+        span(
+          'v7 enforces strictly at every depth. Insert validates against the sub-schema at the target path. ',
+        ),
+        span('decorator.add', ['code']),
+        span(' filters per-block. '),
+        span('annotation.add', ['code']),
+        span(' validates the annotation type.'),
+      ]),
+    ]),
+    para([
+      span(
+        'The schema is the contract, top to bottom. A behavior that fires insert knows the editor will validate.',
+      ),
+    ]),
+  ]),
+
+  // -------------------------------------------------------------------
+  slide('slide-5-keyed', [
+    h1('5. Keyed paths'),
     h3('Numeric indexes out. Keys in.'),
     para([
       span(
@@ -249,7 +300,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     ]),
     para([span('Before:')]),
     codeBlock('json', [
-      '// Selection — indexed',
+      '// Selection - indexed',
       '{',
       '  "anchor": {"path": [3, 0], "offset": 4},',
       '  "focus":  {"path": [3, 0], "offset": 4}',
@@ -257,7 +308,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     ]),
     para([span('After:')]),
     codeBlock('json', [
-      '// Selection — keyed all the way down',
+      '// Selection - keyed all the way down',
       '{',
       '  "anchor": {"path": [{"_key":"b1"}, "children", {"_key":"s1"}], "offset": 4},',
       '  "focus":  {"path": [{"_key":"b1"}, "children", {"_key":"s1"}], "offset": 4}',
@@ -265,23 +316,25 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     ]),
     bullet([
       span(
-        'Concurrent editing — two clients on the same _key see the same selection.',
+        'Concurrent editing - two clients on the same _key see the same selection point.',
       ),
     ]),
-    bullet([span('Container support — paths are keyed at any depth.')]),
-    bullet([span('Wire format and internal format share one path type.')]),
+    bullet([span('Container support - paths are keyed at any depth.')]),
+    bullet([span('Patches and operations share one path format.')]),
     bullet([
-      span('Undo through structural mutations — blocks move, keys do not.'),
+      span(
+        'Undo works through structural mutations - blocks move, keys do not.',
+      ),
     ]),
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-5', [
-    h1('5. Containers'),
+  slide('slide-6-containers', [
+    h1('6. Containers'),
     h3('Nested editable structures, first-class.'),
     para([
       span(
-        'Pre-v7 the editor knew two levels of depth: blocks and their children. Tables, code blocks, callouts - none of them representable. The first design was scope-grammar-based; JSONPath-style strings matching positions. It worked. We deleted it.',
+        'Pre-v7 the editor knew two levels of depth: blocks and their children. Tables, code blocks, callouts - none of them representable. The first design was scope-grammar-based: JSONPath-style strings matching positions. It worked. The type-level machinery got unwieldy. We deleted it.',
       ),
     ]),
     para([span('v2 is type-keyed:')]),
@@ -303,7 +356,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     ]),
     para([
       span(
-        'This slide is a slide container. The table on slide 3, the code block above, this callout - each one is a registered container in the same single Portable Text document. Tables, code blocks, callouts, fact-boxes, nested lists. Any consumer-defined nested structure works.',
+        'This slide is a slide container. The table on slide 3, the code block above, this callout - each one is a registered container in the same Portable Text document.',
       ),
     ]),
   ]),
@@ -313,8 +366,10 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     h1('By the way…'),
     h3('This deck is one Portable Text document.'),
     para([
+      span('Every slide you have seen so far is a '),
+      span('slide', ['code']),
       span(
-        'Every slide you have seen so far is a `slide` container at the root of a single PTE value. I am typing into it right now.',
+        ' container at the root of a single PTE value. I am typing into it right now.',
       ),
     ]),
     callout('tip', [
@@ -328,19 +383,19 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-6', [
-    h1('6. Cascading normalization'),
+  slide('slide-7-cascade', [
+    h1('7. Cascading normalization'),
     h3('A bare type, made cursor-ready.'),
     para([
       span(
-        'Slate normalization assumed flat. Containers broke every assumption. We rewrote it to cascade.',
+        "Slate's normalization assumed flat - blocks at root, children inside blocks, nothing deeper. Containers broke every assumption. We rewrote it to cascade.",
       ),
     ]),
-    para([span('An empty container with a missing field:')]),
+    para([span('A bare container with no fields:')]),
     codeBlock('typescript', [
       "{_type: 'table'}",
       '',
-      '// becomes…',
+      '// becomes, in one cascade pass:',
       '',
       "{_type: 'table', _key: 't1', rows: [",
       "  {_type: 'row', _key: 'r1', cells: [",
@@ -355,19 +410,23 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     callout('note', [
       para([
         span(
-          'Press Backspace in an empty cell — the cell stays (it is structural). Press Backspace in the only line of a code block — the code block disappears. The complexity is internal; the surface is calm.',
+          'Press Backspace in an empty cell - the cell stays (it is structural). Press Backspace in the only line of a code block - the code block disappears. The complexity is internal; the surface is calm.',
         ),
       ]),
     ]),
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-7', [
-    h1('7. Depth-agnostic traversal'),
+  slide('slide-8-traversal', [
+    h1('8. Depth-agnostic traversal'),
     h3('A library of composable primitives.'),
     para([
+      span('A hundred-plus traversal utilities existed pre-v7. Most baked in '),
+      span('path[0]', ['code']),
+      span(' or '),
+      span('path.slice(0, 2)', ['code']),
       span(
-        'A hundred-plus traversal utilities existed pre-v7, most baking in path[0] or path.slice(0, 2). Each one had to be rewritten to compose primitives that work at any depth.',
+        ' as the "block path." Each one had to be rewritten to compose primitives that work at any depth.',
       ),
     ]),
     para([span('We unified the input shape:')]),
@@ -375,9 +434,8 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       'export type TraversalSnapshot = {',
       '  context: {',
       '    schema: EditorSchema',
-      '    containers: ReadonlyMap<string, RegisteredContainer>',
-      '    value: PortableTextValue',
-      '    selection: EditorSelection',
+      '    containers: Containers',
+      '    value: Array<Node>',
       '  }',
       '  blockIndexMap: Map<string, number>',
       '}',
@@ -388,28 +446,40 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     callout('tip', [
       para([
         span(
-          'Behaviors written for root-level text drop into a callout, a table cell, a code block — without rewriting. Many v6 plugins migrated with zero source changes.',
+          'Behaviors written for root-level text drop into a callout, a table cell, a code block - without rewriting. Many v6 plugins migrated with zero source changes.',
         ),
       ]),
     ]),
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-8', [
-    h1('8. A cleaner DOM'),
+  slide('slide-9-dom', [
+    h1('9. A cleaner DOM'),
     h3('data-pt-path, everywhere it matters.'),
     para([
+      span("Slate's DOM mapping had no relationship to Portable Text. "),
+      span('data-slate-node', ['code']),
+      span(', '),
+      span('data-slate-leaf', ['code']),
+      span(', '),
+      span('data-slate-string', ['code']),
       span(
-        "Slate's DOM mapping had no relationship to Portable Text. data-slate-node, data-slate-leaf, data-slate-string - none of them told you which _key a node had.",
+        ' - none of them told you which _key a node had, which path it lived at, which container it was inside.',
       ),
     ]),
     para([span('The new mapping is direct:')]),
     codeBlock('html', [
-      '<aside data-pt-container data-pt-path="[_key==\'k1\']">',
-      "  <p data-pt-leaf data-pt-path=\"[_key=='k1'].content[_key=='b1']\">",
-      '    <span data-pt-path="…children[_key==\'s1\']">Hello</span>',
+      '<td data-pt-block-type="container"',
+      "    data-pt-path=\"[_key=='slide-3'].content[_key=='table-2l'].rows[_key=='row-1g'].cells[_key=='cell-19']\">",
+      '  <p data-pt-block-type="text"',
+      "     data-pt-path=\"...cells[_key=='cell-19'].content[_key=='b-18']\">",
+      '    <span data-pt-child-type="span" data-pt-path="...content[_key==\'b-18\'].children[_key==\'s-17\']">',
+      '      <span data-pt-mark="true">',
+      '        <span data-pt-string="true">Operation</span>',
+      '      </span>',
+      '    </span>',
       '  </p>',
-      '</aside>',
+      '</td>',
     ]),
     para([
       span(
@@ -419,117 +489,61 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
   ]),
 
   // -------------------------------------------------------------------
-  slide('slide-9', [
-    h1('9. Primitive behavior events'),
+  slide('slide-10-primitives', [
+    h1('10. Primitive behavior events'),
     h3('Behaviors compose the primitives the engine speaks.'),
     para([
       span(
-        'In v6 most behaviors raised "smart" synthetic events whose handlers contained the depth-2 assumptions. A behavior could not reach below the synthetic layer. In v7 we promoted the apply-layer primitives as ',
+        'In v6 most behaviors raised "smart" synthetic events whose handlers baked in depth-2 assumptions. A behavior could not reach below the synthetic layer. In v7 the apply-layer primitives ship as ',
       ),
       span('@alpha', ['code']),
-      span(' behavior events:'),
+      span(' behavior events: '),
+      span('insert', ['code']),
+      span(', '),
+      span('insert.text', ['code']),
+      span(', '),
+      span('remove.text', ['code']),
+      span(', '),
+      span('set', ['code']),
+      span(', '),
+      span('unset', ['code']),
+      span(', '),
+      span('select', ['code']),
+      span('. Six events, one per apply-layer operation, one per patch type.'),
     ]),
     codeBlock('typescript', [
       'defineBehavior({',
       "  on: 'keyboard.keydown',",
       '  guard: ({event, snapshot}) => {',
       "    if (event.originEvent.key !== 'Backspace') return false",
-      "    const cell = selectors.getFocusContainer(snapshot, {type: 'cell'})",
-      '    if (!cell || !isCellEmpty(cell)) return false',
-      '    return {cellPath: cell.path}',
+      '    const container = resolveContainerAt(',
+      '      snapshot.context.containers,',
+      '      snapshot.context.value,',
+      '      snapshot.context.selection?.focus.path ?? [],',
+      '    )',
+      "    if (container?.type !== 'cell' || !isCellEmpty(container)) return false",
+      '    return {cellPath: container.path}',
       '  },',
       '  actions: [',
       '    (_, {cellPath}) => [',
-      "      raise({type: 'unset', at: cellPath, paths: [['content']]}),",
+      "      raise({type: 'unset', at: [...cellPath, 'content']}),",
       "      raise({type: 'select', at: cellPath}),",
       '    ],',
       '  ],',
       '})',
     ]),
-    table(1, [
-      row([cellText('Event'), cellText('Sanity patch')]),
-      row([
-        cell([para([span('insert', ['code'])])]),
-        cell([para([span('insert', ['code'])])]),
-      ]),
-      row([
-        cell([para([span('unset', ['code'])])]),
-        cell([para([span('unset', ['code'])])]),
-      ]),
-      row([
-        cell([para([span('set', ['code'])])]),
-        cell([para([span('set', ['code'])])]),
-      ]),
-      row([
-        cell([para([span('insert.text', ['code'])])]),
-        cell([para([span('diffMatchPatch', ['code'])])]),
-      ]),
-      row([
-        cell([para([span('remove.text', ['code'])])]),
-        cell([para([span('diffMatchPatch', ['code'])])]),
-      ]),
-    ]),
-  ]),
-
-  // -------------------------------------------------------------------
-  slide('slide-10', [
-    h1('10. Schema enforcement, symmetric'),
-    h3('Strict at every depth.'),
-    para([
-      span(
-        'Pre-v7 the editor enforced schema constraints inside containers, but accepted anything at root. Consumers wrote behaviors expecting strict enforcement; got intermittent silent drops when constraints applied below root and not at it.',
-      ),
-    ]),
-    callout('warning', [
+    callout('note', [
       para([
-        span('The asymmetry was a mistake. ', ['strong']),
         span(
-          'v7 enforces strictly at every depth. Insert validates against the sub-schema at the target path. ',
+          "The plugin's source becomes a thin translator between user intent and the editor's primitive vocabulary. This is what behaviors were always supposed to be.",
         ),
-        span('decorator.add', ['code']),
-        span(' filters per-block. '),
-        span('annotation.add', ['code']),
-        span(' validates the annotation type.'),
-      ]),
-    ]),
-    para([
-      span(
-        'A behavior that fires insert knows the editor will validate. A callout that only allows strong and em sees its constraints respected. The schema is the contract, top to bottom.',
-      ),
-    ]),
-  ]),
-
-  // -------------------------------------------------------------------
-  slide('slide-11', [
-    h1('11. The traversal snapshot'),
-    h3('One input shape, everywhere.'),
-    para([
-      span('The type-level companion to milestone 7. '),
-      span('EditorSnapshot', ['code']),
-      span(', '),
-      span('OperationSnapshot', ['code']),
-      span(', '),
-      span('TraversalSnapshot', ['code']),
-      span(
-        ' - all share the same shape. The editor satisfies it via a context getter.',
-      ),
-    ]),
-    para([
-      span(
-        'Behaviors and selectors that read state do it the same way as the engine. 60 files migrated; the ergonomic dividend pays out forever.',
-      ),
-    ]),
-    callout('tip', [
-      para([
-        span('One mental model. ', ['strong']),
-        span('Three call sites. Zero adapters.'),
       ]),
     ]),
   ]),
 
   // -------------------------------------------------------------------
   slide('slide-arc', [
-    h1('The arc'),
+    h1('Everything else is dividend.'),
     h3('Every advanced feature traces back to four ideas.'),
     numbered([span('We accept any patch.')]),
     numbered([span('We emit any patch.')]),
@@ -537,16 +551,16 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
     numbered([span('Depth is just a parameter.')]),
     para([
       span(
-        'A generic positional editor became a Portable Text-native, keyed, patch-compliant, depth-agnostic, container-aware document model.',
+        'A generic positional editor became a Portable Text-native, keyed, patch-compliant, depth-agnostic, container-aware document model. ',
+      ),
+      span(
+        'One snapshot shape satisfies the engine, the operations layer, the traversal utilities, and every selector consumers write.',
       ),
     ]),
     callout('important', [
       para([
-        span('The headline of v7 is the architectural foundation. ', [
-          'strong',
-        ]),
         span(
-          'Markdown compliance, structured lists, tables, code blocks, callouts - those are the dividend.',
+          'Markdown compliance, structured lists, tables, code blocks, callouts, fact-boxes, nested lists - the consumer-visible features are the dividend.',
         ),
       ]),
     ]),

--- a/apps/playground/src/v7/slides.ts
+++ b/apps/playground/src/v7/slides.ts
@@ -137,7 +137,7 @@ export const deckValue: ReadonlyArray<PortableTextBlock> = [
       span(
         'Each slide marks a turn in how the editor came to be what it is today. ',
       ),
-      span('Cmd/Ctrl + Arrow to advance.', ['em']),
+      span('Swipe or press Cmd/Ctrl + Arrow to advance.', ['em']),
     ]),
   ]),
 

--- a/apps/playground/src/v7/use-swipe-navigation.ts
+++ b/apps/playground/src/v7/use-swipe-navigation.ts
@@ -1,0 +1,105 @@
+import {useEffect, useRef} from 'react'
+
+/**
+ * Wire pointer-based swipe gestures to slide navigation.
+ *
+ * Touch and mouse-drag both work. A horizontal-dominant gesture of at
+ * least 60 CSS pixels advances or retreats one slide. Gestures starting
+ * on an element with `data-deck-no-swipe` (code blocks, tables, modals,
+ * the value inspector) are ignored so the user can pan those regions
+ * freely without triggering nav.
+ *
+ * The hook attaches to whichever element ref is returned. Add the ref to
+ * a wrapper around the deck's editable surface.
+ */
+export function useSwipeNavigation(props: {
+  onNext: () => void
+  onPrev: () => void
+}) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const onNextRef = useRef(props.onNext)
+  const onPrevRef = useRef(props.onPrev)
+
+  useEffect(() => {
+    onNextRef.current = props.onNext
+    onPrevRef.current = props.onPrev
+  }, [props.onNext, props.onPrev])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) {
+      return
+    }
+
+    let startX = 0
+    let startY = 0
+    let startTime = 0
+    let trackingPointerId: number | null = null
+    let active = false
+
+    const isPanRegion = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) {
+        return false
+      }
+      return target.closest('[data-deck-no-swipe]') !== null
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      // Touch + pen only - mouse-drag would interfere with caret placement
+      // and text selection. Desktop users have arrow keys + chrome buttons.
+      if (event.pointerType === 'mouse') {
+        return
+      }
+      if (isPanRegion(event.target)) {
+        return
+      }
+      active = true
+      startX = event.clientX
+      startY = event.clientY
+      startTime = event.timeStamp
+      trackingPointerId = event.pointerId
+    }
+
+    const onPointerUp = (event: PointerEvent) => {
+      if (!active || event.pointerId !== trackingPointerId) {
+        return
+      }
+      active = false
+      const dx = event.clientX - startX
+      const dy = event.clientY - startY
+      const absX = Math.abs(dx)
+      const absY = Math.abs(dy)
+      const elapsed = event.timeStamp - startTime
+
+      // Real swipes are fast horizontal flicks. Selections, taps, and
+      // long presses fail one of these three filters.
+      if (elapsed > 500) {
+        return
+      }
+      if (absX < 60 || absX < absY * 1.4) {
+        return
+      }
+      if (dx < 0) {
+        onNextRef.current()
+      } else {
+        onPrevRef.current()
+      }
+    }
+
+    const onPointerCancel = () => {
+      active = false
+    }
+
+    el.addEventListener('pointerdown', onPointerDown, {passive: true})
+    el.addEventListener('pointerup', onPointerUp, {passive: true})
+    el.addEventListener('pointercancel', onPointerCancel, {passive: true})
+
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('pointerup', onPointerUp)
+      el.removeEventListener('pointercancel', onPointerCancel)
+    }
+  }, [])
+
+  return ref
+}

--- a/apps/playground/src/v7/value-inspector.tsx
+++ b/apps/playground/src/v7/value-inspector.tsx
@@ -46,7 +46,8 @@ export function ValueInspector(props: {open: boolean; onClose: () => void}) {
   return (
     <aside
       contentEditable={false}
-      className="pointer-events-auto fixed inset-y-0 right-0 z-40 flex w-[28rem] flex-col border-stone-300 border-l bg-white/95 shadow-2xl backdrop-blur-md dark:border-stone-700 dark:bg-stone-900/95"
+      data-deck-no-swipe=""
+      className="pointer-events-auto fixed inset-y-0 right-0 z-40 flex w-full max-w-[28rem] flex-col border-stone-300 border-l bg-white/95 shadow-2xl backdrop-blur-md dark:border-stone-700 dark:bg-stone-900/95"
     >
       <header className="flex items-center justify-between border-stone-200 border-b px-4 py-3 dark:border-stone-700">
         <div>

--- a/apps/playground/src/v7/value-inspector.tsx
+++ b/apps/playground/src/v7/value-inspector.tsx
@@ -1,0 +1,128 @@
+import {useEditor, useEditorSelector} from '@portabletext/editor'
+import * as selectors from '@portabletext/editor/selectors'
+import {XIcon} from 'lucide-react'
+import {useMemo} from 'react'
+
+/**
+ * The "this is PTE" inspector.
+ *
+ * Renders alongside the deck and shows the live Portable Text value. The
+ * point is to demonstrate, mid-presentation, that the slideshow IS a
+ * Portable Text document - by showing its value as you type into it.
+ *
+ * Hidden by default. Toggled via the button in the chrome.
+ */
+export function ValueInspector(props: {open: boolean; onClose: () => void}) {
+  const editor = useEditor()
+  const value = useEditorSelector(editor, selectors.getValue)
+  const selection = useEditorSelector(editor, selectors.getSelection)
+
+  const renderedValue = useMemo(() => {
+    // Stringify only the currently-relevant chunk plus a top-level overview.
+    // The full deck value is ~1k lines of JSON, which buries the point.
+    if (!Array.isArray(value)) {
+      return JSON.stringify(value, null, 2)
+    }
+    const overview = value.map((slide) => {
+      if (slide && typeof slide === 'object' && '_type' in slide) {
+        const typedSlide = slide as {_type: string; _key?: string}
+        return {
+          '_type': typedSlide._type,
+          '_key': typedSlide._key,
+          // Trim content for legibility - the inspector is making a point,
+          // not exposing 4 KB of JSON per slide.
+          '…': '<content omitted>',
+        }
+      }
+      return slide
+    })
+    return JSON.stringify(overview, null, 2)
+  }, [value])
+
+  if (!props.open) {
+    return null
+  }
+
+  return (
+    <aside
+      contentEditable={false}
+      className="pointer-events-auto fixed inset-y-0 right-0 z-40 flex w-[28rem] flex-col border-stone-300 border-l bg-white/95 shadow-2xl backdrop-blur-md dark:border-stone-700 dark:bg-stone-900/95"
+    >
+      <header className="flex items-center justify-between border-stone-200 border-b px-4 py-3 dark:border-stone-700">
+        <div>
+          <h2 className="font-mono font-semibold text-sm text-stone-900 dark:text-stone-50">
+            Editor value
+          </h2>
+          <p className="mt-0.5 text-stone-500 text-xs dark:text-stone-400">
+            This is what the deck is.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={props.onClose}
+          aria-label="Close inspector"
+          className="flex size-7 items-center justify-center rounded-md text-stone-500 hover:bg-stone-100 hover:text-stone-900 dark:hover:bg-stone-800 dark:hover:text-stone-100"
+        >
+          <XIcon className="size-4" />
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-auto">
+        <pre className="px-4 py-3 font-mono text-stone-700 text-xs leading-relaxed dark:text-stone-300">
+          {renderedValue}
+        </pre>
+      </div>
+
+      <footer className="border-stone-200 border-t px-4 py-3 text-stone-500 text-xs dark:border-stone-700 dark:text-stone-400">
+        <div>
+          <span className="font-mono">selection:</span>{' '}
+          {selection ? (
+            <code className="font-mono text-stone-700 dark:text-stone-300">
+              {summarizeSelection(selection)}
+            </code>
+          ) : (
+            <em>none</em>
+          )}
+        </div>
+        <p className="mt-2 italic">
+          Type into a slide to watch the value update.
+        </p>
+      </footer>
+    </aside>
+  )
+}
+
+function summarizeSelection(selection: unknown): string {
+  if (!selection || typeof selection !== 'object') {
+    return 'none'
+  }
+  const sel = selection as {
+    anchor?: {path?: ReadonlyArray<unknown>; offset?: number}
+    focus?: {path?: ReadonlyArray<unknown>; offset?: number}
+  }
+  const a = sel.anchor
+  const f = sel.focus
+  if (!a || !f) {
+    return 'none'
+  }
+  const aPath = summarizePath(a.path)
+  const fPath = summarizePath(f.path)
+  if (aPath === fPath && a.offset === f.offset) {
+    return `${aPath} @ ${a.offset ?? 0}`
+  }
+  return `${aPath}@${a.offset ?? 0} → ${fPath}@${f.offset ?? 0}`
+}
+
+function summarizePath(path: ReadonlyArray<unknown> | undefined): string {
+  if (!path) {
+    return '?'
+  }
+  return path
+    .map((segment) => {
+      if (typeof segment === 'object' && segment && '_key' in segment) {
+        return `{${(segment as {_key: string})._key}}`
+      }
+      return String(segment)
+    })
+    .join('.')
+}

--- a/apps/playground/v7.html
+++ b/apps/playground/v7.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en" class="">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/pte.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portable Text v7</title>
+    <link rel="stylesheet" href="/src/index.css" />
+    <script>
+      ;(() => {
+        const stored = localStorage.getItem('pte-theme-mode')
+        const mode =
+          stored === 'light' || stored === 'dark' || stored === 'system'
+            ? stored
+            : 'system'
+        const isDark =
+          mode === 'dark' ||
+          (mode === 'system' &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches)
+        if (isDark) {
+          document.documentElement.classList.add('dark')
+        }
+      })()
+    </script>
+  </head>
+  <body class="bg-gray-50 dark:bg-gray-900 transition-colors">
+    <div id="root"></div>
+    <script type="module" src="/src/v7/main.tsx"></script>
+  </body>
+</html>

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -21,6 +21,14 @@ export default defineConfig({
     }),
     tailwindcss(),
   ],
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        v7: path.resolve(__dirname, 'v7.html'),
+      },
+    },
+  },
   resolve: {
     alias: {
       '@portabletext/editor': path.resolve(

--- a/knip.json
+++ b/knip.json
@@ -57,6 +57,15 @@
         "sharp"
       ]
     },
+    "apps/playground": {
+      "entry": ["index.html", "v7.html", "src/v7/main.tsx!"],
+      "ignoreDependencies": [
+        "babel-plugin-react-compiler",
+        "eslint-formatter-gha",
+        "tailwindcss-react-aria-components",
+        "sharp"
+      ]
+    },
     "examples/*": {}
   }
 }


### PR DESCRIPTION
A second entry on the playground app that presents the v7 architecture as a slideshow. The deck is one Portable Text document. Each top-level block is a `slide` container registered via the v7 Container API. The deck renders one slide at a time; the other slides stay in the document and hide via CSS, so the value remains intact and the editor remains live.

## How to try it

```
cd apps/playground
pnpm dev
# open http://localhost:5173/v7.html
```

Vercel preview builds from the existing playground deploy - `/v7.html` alongside `/`.

## What the deck contains

- 14 slides covering the 11 v7 architectural milestones, plus an intro, a mid-deck reveal, and a closing arc slide
- Container plugins exercised inside slides: **callout** (five tones with icons), **code-block** (Shiki-highlighted), **table** (rich-content cells with header rows)
- Slide 3 (patch compliance) carries an operation-to-patch table; slide 4 (keyed paths) has before/after JSON code blocks; slide 5 (containers) is itself a container with a callout and a code block inside; slide 6 (cascade) shows the bare-to-cursor-ready transformation
- The reveal slide tells the audience the deck IS a Portable Text document and points them at the value inspector

## How it's built

- `v7.html` - second HTML entry alongside playground's `index.html` (multi-entry Vite config)
- `src/v7/Deck.tsx` - the editor surface, EditorProvider, plugin wiring
- `src/v7/schema.ts` - the deck schema: slides at root, with callout / code-block / table available inside each slide's content
- `src/v7/slide-container.tsx` - the `slide` container definition. Renders only the active slide; hides the rest via CSS
- `src/v7/deck-containers.tsx` - callout / code-block / table container plugins
- `src/v7/plugin.deck-nav.tsx` + `src/v7/behavior.deck-nav.ts` - Cmd/Ctrl + Arrow as proper editor behaviors via `defineBehavior` + `createKeyboardShortcut` (the same pattern the code-editor plugin uses). The behavior's action fires an `effect()` that calls a React setter, because slide nav is presentation state, not document state
- `src/v7/shiki.tsx` - `useShikiDecorations` lifted from the pilcrow app. Walks the value for code-block instances, tokenises with Shiki against github-light/github-dark, emits range decorations
- `src/v7/value-inspector.tsx` - toggleable side panel showing the live editor value. Click into a slide, type, watch it update
- `src/v7/slides.ts` - hardcoded deck content

## Status

Draft. Working end-to-end. Visual polish, a couple more rich content passes, and a Vercel preview link are coming on this branch.