### PR TITLE
refactor: thread container context through useChildren dispatch

### DIFF
--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -149,7 +149,7 @@ type EditableProps = {
   onDOMBeforeInput?: (event: InputEvent) => void
   readOnly?: boolean
   style?: React.CSSProperties
-  renderElement?: (props: RenderElementProps) => JSX.Element
+  renderElement: (props: RenderElementProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   scrollSelectionIntoView?: (editor: DOMEditor, domRange: DOMRange) => void

--- a/packages/editor/src/slate/react/components/element.tsx
+++ b/packages/editor/src/slate/react/components/element.tsx
@@ -6,7 +6,6 @@ import React, {type JSX} from 'react'
 import {getText} from '../../../node-traversal/get-text'
 import {isInline as isInlinePath} from '../../../node-traversal/is-inline'
 import {serializePath} from '../../../paths/serialize-path'
-import {isEditableContainer} from '../../../schema/is-editable-container'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
 import type {DecoratedRange} from '../../interfaces/text'
@@ -22,26 +21,28 @@ import type {
   RenderTextProps,
 } from './editable'
 
-const defaultRenderElement = (props: RenderElementProps) => (
-  <DefaultElement {...props} />
-)
-
 /**
- * Element.
+ * Element wrapper. Receives a node that already has children (a text block
+ * or an editable container) and threads decorations + children through the
+ * `renderElement` callback.
+ *
+ * The `isContainer` flag is resolved by `useChildren` at dispatch time and
+ * passed in to avoid a second `isEditableContainer` walk here.
  */
-
 const Element = (props: {
   decorations: DecoratedRange[]
   element: PortableTextTextBlock | PortableTextObject
+  isContainer: boolean
   path: Path
-  renderElement?: (props: RenderElementProps) => JSX.Element
+  renderElement: (props: RenderElementProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
 }) => {
   const {
     decorations: parentDecorations,
     element,
-    renderElement = defaultRenderElement,
+    isContainer,
+    renderElement,
     renderLeaf,
     renderText,
   } = props
@@ -57,8 +58,6 @@ const Element = (props: {
     renderLeaf,
     renderText,
   })
-
-  const isContainer = isEditableContainer(editor, element, props.path)
 
   // Attributes that the developer must mix into the element in their
   // custom node renderer component.
@@ -94,6 +93,7 @@ const Element = (props: {
 const MemoizedElement = React.memo(Element, (prev, next) => {
   return (
     prev.element === next.element &&
+    prev.isContainer === next.isContainer &&
     pathEquals(prev.path, next.path) &&
     prev.renderElement === next.renderElement &&
     prev.renderText === next.renderText &&
@@ -101,20 +101,5 @@ const MemoizedElement = React.memo(Element, (prev, next) => {
     isElementDecorationsEqual(prev.decorations, next.decorations)
   )
 })
-
-/**
- * The default element renderer.
- */
-
-const DefaultElement = (props: RenderElementProps) => {
-  const {attributes, children} = props
-  const editor = useSlateStatic()
-  const Tag = isInlinePath(editor, props.path) ? 'span' : 'div'
-  return (
-    <Tag {...attributes} style={{position: 'relative'}}>
-      {children}
-    </Tag>
-  )
-}
 
 export default MemoizedElement

--- a/packages/editor/src/slate/react/components/object-node.tsx
+++ b/packages/editor/src/slate/react/components/object-node.tsx
@@ -1,6 +1,5 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import React, {useContext, type JSX} from 'react'
-import {ParentContainerContext} from '../../../editor/parent-container-context'
+import React, {type JSX} from 'react'
 import {serializePath} from '../../../paths/serialize-path'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -9,40 +8,27 @@ import {pathEquals} from '../../path/path-equals'
 import {useReadOnly} from '../hooks/use-read-only'
 import type {RenderElementProps} from './editable'
 
-const defaultRenderElement = (props: RenderElementProps) => {
-  const {attributes, children} = props
-  return (
-    <div {...attributes} style={{position: 'relative'}}>
-      {children}
-    </div>
-  )
-}
-
 /**
- * ObjectNode component. Renders an ObjectNode (block object or inline object)
- * through the renderElement callback.
+ * Wrapper for block or inline object nodes that have no children in the Slate
+ * model. The DOM still needs a hidden zero-width text node for caret
+ * anchoring, which is the spacer below.
  *
- * Although ObjectNodes have no children in the Slate model, the DOM must
- * contain a hidden spacer with a zero-width text node for selection anchoring.
+ * The `inContainer` flag is resolved by `useChildren` at dispatch time and
+ * passed in to avoid a `useContext(ParentContainerContext)` read here.
  */
 const ObjectNodeComponent = (props: {
   decorations: DecoratedRange[]
-  objectNode: PortableTextObject
+  inContainer: boolean
   isInline: boolean
+  objectNode: PortableTextObject
   path: Path
-  renderElement?: (props: RenderElementProps) => JSX.Element
+  renderElement: (props: RenderElementProps) => JSX.Element
 }) => {
-  const {
-    objectNode,
-    isInline,
-    path,
-    renderElement = defaultRenderElement,
-  } = props
+  const {inContainer, isInline, objectNode, path, renderElement} = props
   const dataPath = serializePath(path)
   const readOnly = useReadOnly()
-  const parentContainer = useContext(ParentContainerContext)
 
-  const attributes: RenderElementProps['attributes'] = parentContainer
+  const attributes: RenderElementProps['attributes'] = inContainer
     ? {
         'data-pt-path': dataPath,
       }
@@ -52,15 +38,13 @@ const ObjectNodeComponent = (props: {
         'data-pt-path': dataPath,
       }
 
-  if (isInline) {
-    if (!readOnly) {
-      attributes.contentEditable = false
-    }
+  if (isInline && !readOnly) {
+    attributes.contentEditable = false
   }
 
   const Tag = isInline ? 'span' : 'div'
 
-  const children = parentContainer ? (
+  const children = inContainer ? (
     <Tag
       data-pt-spacer
       style={{
@@ -108,6 +92,7 @@ const ObjectNodeComponent = (props: {
 const MemoizedObjectNode = React.memo(ObjectNodeComponent, (prev, next) => {
   return (
     prev.objectNode === next.objectNode &&
+    prev.inContainer === next.inContainer &&
     pathEquals(prev.path, next.path) &&
     prev.renderElement === next.renderElement &&
     prev.isInline === next.isInline &&

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -60,7 +60,7 @@ const useChildren = (props: {
   decorations: DecoratedRange[]
   node: Editor | Node
   path: Path
-  renderElement?: (props: RenderElementProps) => JSX.Element
+  renderElement: (props: RenderElementProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
 }): React.ReactNode => {
@@ -117,7 +117,11 @@ const useChildren = (props: {
   }
 
   const renderElementComponent = useCallback(
-    (node: PortableTextTextBlock | PortableTextObject, i: number) => {
+    (
+      node: PortableTextTextBlock | PortableTextObject,
+      i: number,
+      isContainer: boolean,
+    ) => {
       const nodePath: Path =
         parentPath.length === 0
           ? [{_key: node._key}]
@@ -127,6 +131,7 @@ const useChildren = (props: {
         <ElementComponent
           decorations={decorationsByChild[i] ?? []}
           element={node}
+          isContainer={isContainer}
           key={node._key}
           path={nodePath}
           renderElement={renderElement}
@@ -175,6 +180,11 @@ const useChildren = (props: {
     )
   }
 
+  // `inContainer` is the effective container context the dispatched
+  // children will see: either the current node's own container (when we
+  // wrap below) or the inherited parent container otherwise.
+  const inContainer = Boolean(childContainer ?? parentContainer)
+
   const renderObjectNodeComponent = (
     node: PortableTextObject,
     index: number,
@@ -187,6 +197,7 @@ const useChildren = (props: {
     return (
       <ObjectNodeComponent
         decorations={decorationsByChild[index] ?? []}
+        inContainer={inContainer}
         isInline={textBlockParent !== undefined}
         key={node._key}
         objectNode={node}
@@ -198,7 +209,7 @@ const useChildren = (props: {
 
   const elements = children.map((n: Node, i: number) => {
     if (isTextBlock({schema: editor.schema}, n)) {
-      return renderElementComponent(n, i)
+      return renderElementComponent(n, i, false)
     }
     // Fallback for text block nodes without `children`
     if (isTextBlockNode({schema: editor.schema}, n)) {
@@ -208,7 +219,7 @@ const useChildren = (props: {
       // Does `n` resolve as a container at this position?
       // (positional override in childContainer.container.of, or global)
       if (resolveContainerForNode(editor, childContainer, n)) {
-        return renderElementComponent(n, i)
+        return renderElementComponent(n, i, true)
       }
       return renderObjectNodeComponent(n, i)
     }


### PR DESCRIPTION
`Element` and `ObjectNodeComponent` each rediscover their container context inline today:

- `Element` runs `isEditableContainer(editor, element, path)` to decide between text-block and container attributes - the same walk `useChildren` already did when picking the wrapper.
- `ObjectNodeComponent` reads `ParentContainerContext` via `useContext` for the same reason, and `useChildren` already knows whether the next children sit inside a container (`childContainer ?? parentContainer`).

Push the answer down as `isContainer` / `inContainer` props from the dispatch site, drop the duplicate work, and delete the unused default `renderElement` callbacks now that `renderElement` is required all the way through the chain (`EditableProps` to `useChildren` to wrapper).

Net 42 insertions / 61 deletions across the four files. The two wrappers aren't merged: they have different hooks (`useReadOnly` vs `useSlateStatic + useDecorations + useChildren`) and conditional hook calls would violate rules-of-hooks. The dispatch in `useChildren` keeps the split clean.

### Verified

- `pnpm check:types --concurrency=1` (42/42)
- `pnpm check:lint` (24/24)
- `pnpm check:format`
- `pnpm knip`
- `pnpm exec pkg-utils build --strict` (`@portabletext/editor`)
- `tests/render-count-regression.test.tsx` (chromium, 2/2)
- `tests/dom-structure.test.tsx` (chromium, 8/8)

No changeset, refactor with no consumer-visible surface change. Render-count regression test pins the keystroke re-render count, DOM-structure tests pin the attribute shape on both text-block and container-object branches.