### PR TITLE
refactor: bundle legacy render hooks into a single prop

### DIFF
--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -128,7 +128,6 @@ export const PortableTextEditable = forwardRef<
     renderStyle,
     selection: propsSelection,
     scrollSelectionIntoView,
-    spellCheck,
     ...restProps
   } = props
 
@@ -195,10 +194,9 @@ export const PortableTextEditable = forwardRef<
         legacy={legacy}
         readOnly={readOnly}
         schema={schema}
-        spellCheck={spellCheck}
       />
     ),
-    [dropPosition, schema, readOnly, legacy, spellCheck],
+    [dropPosition, schema, readOnly, legacy],
   )
 
   const renderLeaf = useCallback(

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -177,30 +177,28 @@ export const PortableTextEditable = forwardRef<
     })
   }, [rangeDecorationsActor, rangeDecorations])
 
+  const legacy = useMemo(
+    () => ({
+      renderBlock,
+      renderChild,
+      renderListItem,
+      renderStyle,
+    }),
+    [renderBlock, renderChild, renderListItem, renderStyle],
+  )
+
   const renderElement = useCallback(
     (eProps: RenderElementProps) => (
       <RenderElement
         {...eProps}
         dropPosition={dropPosition}
+        legacy={legacy}
         readOnly={readOnly}
-        renderBlock={renderBlock}
-        renderChild={renderChild}
-        renderListItem={renderListItem}
-        renderStyle={renderStyle}
         schema={schema}
         spellCheck={spellCheck}
       />
     ),
-    [
-      dropPosition,
-      schema,
-      spellCheck,
-      readOnly,
-      renderBlock,
-      renderChild,
-      renderListItem,
-      renderStyle,
-    ],
+    [dropPosition, schema, readOnly, legacy, spellCheck],
   )
 
   const renderLeaf = useCallback(

--- a/packages/editor/src/editor/legacy-render-hooks.ts
+++ b/packages/editor/src/editor/legacy-render-hooks.ts
@@ -1,0 +1,22 @@
+import type {
+  RenderBlockFunction,
+  RenderChildFunction,
+  RenderListItemFunction,
+  RenderStyleFunction,
+} from '../types/editor'
+
+/**
+ * The legacy v6 render-callback bundle that the engine forwards to the
+ * default text-block / block-object / inline-object renderers. None of
+ * these are read by `RenderElement` itself; they are routed through to
+ * the specific component that consumes each one.
+ *
+ * When v8 retires the legacy callbacks, this type and the prop drilling
+ * around it disappear together.
+ */
+export type LegacyRenderHooks = {
+  renderBlock?: RenderBlockFunction
+  renderChild?: RenderChildFunction
+  renderListItem?: RenderListItemFunction
+  renderStyle?: RenderStyleFunction
+}

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -7,6 +7,7 @@ import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import type {BlockRenderProps, RenderBlockFunction} from '../types/editor'
 import type {EditorSchema} from './editor-schema'
+import type {LegacyRenderHooks} from './legacy-render-hooks'
 import {RenderDefaultBlockObject} from './render.default-object'
 import {DropIndicator} from './render.drop-indicator'
 import {RenderLeafConfig} from './render.leaf-config'
@@ -21,7 +22,7 @@ export function RenderBlockObject(props: {
   leafConfig?: LeafConfig
   path: Path
   readOnly: boolean
-  renderBlock?: RenderBlockFunction
+  legacy: LegacyRenderHooks
   schema: EditorSchema
 }) {
   const blockObjectRef = useRef<HTMLDivElement>(null)
@@ -69,10 +70,10 @@ export function RenderBlockObject(props: {
   }
 
   let innerContent: ReactElement
-  if (props.renderBlock && blockObjectSchemaType) {
+  if (props.legacy.renderBlock && blockObjectSchemaType) {
     innerContent = (
       <RenderBlock
-        renderBlock={props.renderBlock}
+        renderBlock={props.legacy.renderBlock}
         editorElementRef={blockObjectRef}
         focused={focused}
         path={[{_key: props.element._key}]}

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -16,14 +16,9 @@ import type {
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateStatic} from '../slate/react/hooks/use-slate-static'
-import type {
-  RenderBlockFunction,
-  RenderChildFunction,
-  RenderListItemFunction,
-  RenderStyleFunction,
-} from '../types/editor'
 import {EditorActorContext} from './editor-actor-context'
 import type {EditorSchema} from './editor-schema'
+import type {LegacyRenderHooks} from './legacy-render-hooks'
 import {ParentContainerContext} from './parent-container-context'
 import {RenderBlockObject} from './render.block-object'
 import {RenderContainer} from './render.container'
@@ -89,12 +84,9 @@ export function RenderElement(props: {
   children: ReactElement
   dropPosition?: DropPosition
   element: PortableTextTextBlock | PortableTextObject
+  legacy: LegacyRenderHooks
   path: Path
   readOnly: boolean
-  renderBlock?: RenderBlockFunction
-  renderChild?: RenderChildFunction
-  renderListItem?: RenderListItemFunction
-  renderStyle?: RenderStyleFunction
   schema: EditorSchema
   spellCheck?: boolean
 }) {
@@ -211,11 +203,9 @@ export function RenderElement(props: {
           props.path,
         )}
         element={props.element}
+        legacy={props.legacy}
         path={props.path}
         readOnly={props.readOnly}
-        renderBlock={props.renderBlock}
-        renderListItem={props.renderListItem}
-        renderStyle={props.renderStyle}
         schema={schema}
         spellCheck={props.spellCheck}
         textBlock={props.element}
@@ -246,9 +236,9 @@ export function RenderElement(props: {
         attributes={props.attributes}
         element={props.element}
         leafConfig={leafConfig}
+        legacy={props.legacy}
         path={props.path}
         readOnly={props.readOnly}
-        renderChild={props.renderChild}
         schema={schema}
       >
         {props.children}
@@ -279,9 +269,9 @@ export function RenderElement(props: {
       dropPosition={resolveElementDropPosition(props.dropPosition, props.path)}
       element={props.element}
       leafConfig={leafConfig}
+      legacy={props.legacy}
       path={props.path}
       readOnly={props.readOnly}
-      renderBlock={props.renderBlock}
       schema={schema}
     >
       {props.children}

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -88,7 +88,6 @@ export function RenderElement(props: {
   path: Path
   readOnly: boolean
   schema: EditorSchema
-  spellCheck?: boolean
 }) {
   const editorActor = useContext(EditorActorContext)
   const parentContainer = useContext(ParentContainerContext)
@@ -207,7 +206,6 @@ export function RenderElement(props: {
         path={props.path}
         readOnly={props.readOnly}
         schema={schema}
-        spellCheck={props.spellCheck}
         textBlock={props.element}
       >
         {props.children}

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -6,6 +6,7 @@ import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import type {BlockChildRenderProps, RenderChildFunction} from '../types/editor'
 import type {EditorSchema} from './editor-schema'
+import type {LegacyRenderHooks} from './legacy-render-hooks'
 import {RenderDefaultInlineObject} from './render.default-object'
 import {RenderLeafConfig} from './render.leaf-config'
 import {useIsFocusedLeaf, useIsSelectedLeaf} from './selection-state-context'
@@ -16,9 +17,9 @@ export function RenderInlineObject(props: {
   children: ReactElement
   element: PortableTextObject
   leafConfig?: LeafConfig
+  legacy: LegacyRenderHooks
   path: Path
   readOnly: boolean
-  renderChild?: RenderChildFunction
   schema: EditorSchema
 }) {
   const inlineObjectRef = useRef<HTMLElement>(null)
@@ -65,10 +66,10 @@ export function RenderInlineObject(props: {
   }
 
   let innerContent: ReactElement
-  if (props.renderChild && inlineObjectSchemaType) {
+  if (props.legacy.renderChild && inlineObjectSchemaType) {
     innerContent = (
       <RenderChild
-        renderChild={props.renderChild}
+        renderChild={props.legacy.renderChild}
         annotations={[]}
         editorElementRef={inlineObjectRef}
         selected={selected}

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -34,7 +34,6 @@ export function RenderTextBlock(props: {
   path: Path
   readOnly: boolean
   schema: EditorSchema
-  spellCheck?: boolean
   textBlock: PortableTextTextBlock
 }) {
   const blockRef = useRef<HTMLDivElement>(null)
@@ -127,7 +126,6 @@ export function RenderTextBlock(props: {
             ]
           : []),
       ].join(' ')}
-      spellCheck={props.spellCheck}
       data-block-key={props.textBlock._key}
       data-block-name={props.textBlock._type}
       data-block-type="text"

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -17,6 +17,7 @@ import type {
   RenderStyleFunction,
 } from '../types/editor'
 import type {EditorSchema} from './editor-schema'
+import type {LegacyRenderHooks} from './legacy-render-hooks'
 import {DropIndicator} from './render.drop-indicator'
 import {
   useIsFocusedContainer,
@@ -29,11 +30,9 @@ export function RenderTextBlock(props: {
   children: ReactElement
   dropPosition?: DropPosition['position']
   element: PortableTextTextBlock
+  legacy: LegacyRenderHooks
   path: Path
   readOnly: boolean
-  renderBlock?: RenderBlockFunction
-  renderListItem?: RenderListItemFunction
-  renderStyle?: RenderStyleFunction
   schema: EditorSchema
   spellCheck?: boolean
   textBlock: PortableTextTextBlock
@@ -53,7 +52,7 @@ export function RenderTextBlock(props: {
 
   let children = props.children
 
-  if (props.renderStyle && props.textBlock.style) {
+  if (props.legacy.renderStyle && props.textBlock.style) {
     const styleSchemaType =
       props.textBlock.style !== undefined
         ? subSchema.styles.find(
@@ -64,7 +63,7 @@ export function RenderTextBlock(props: {
     if (styleSchemaType) {
       children = (
         <RenderStyle
-          renderStyle={props.renderStyle}
+          renderStyle={props.legacy.renderStyle}
           block={props.textBlock}
           editorElementRef={blockRef}
           focused={focused}
@@ -83,7 +82,7 @@ export function RenderTextBlock(props: {
     }
   }
 
-  if (props.renderListItem && props.textBlock.listItem) {
+  if (props.legacy.renderListItem && props.textBlock.listItem) {
     const listItemSchemaType = subSchema.lists.find(
       (list) => list.value === props.textBlock.listItem,
     )
@@ -91,7 +90,7 @@ export function RenderTextBlock(props: {
     if (listItemSchemaType) {
       children = (
         <RenderListItem
-          renderListItem={props.renderListItem}
+          renderListItem={props.legacy.renderListItem}
           block={props.textBlock}
           editorElementRef={blockRef}
           focused={focused}
@@ -156,9 +155,9 @@ export function RenderTextBlock(props: {
     >
       {props.dropPosition === 'start' ? <DropIndicator /> : null}
       <div ref={blockRef}>
-        {props.renderBlock ? (
+        {props.legacy.renderBlock ? (
           <RenderBlock
-            renderBlock={props.renderBlock}
+            renderBlock={props.legacy.renderBlock}
             editorElementRef={blockRef}
             focused={focused}
             level={props.textBlock.level}


### PR DESCRIPTION
Two commits.

**1. `refactor: bundle legacy render hooks into a single prop`**

`RenderElement` declared four render-callback props (`renderBlock`, `renderListItem`, `renderStyle`, `renderChild`) but read none of them. The props were forwarded into `RenderTextBlock`, `RenderBlockObject`, and `RenderInlineObject`, where the actual consumers live.

Group them into one `legacy: LegacyRenderHooks` prop and forward the bundle. Each consumer destructures the field it needs at the point it needs it; the prop bag in between stops pretending to know about callbacks it never touches.

The new type lives next to the consumers in `packages/editor/src/editor/legacy-render-hooks.ts`. When the legacy callback API retires, the type and the prop disappear together.

**2. `fix: route `spellCheck` through the contenteditable shell`**

The `spellCheck` prop on `PortableTextEditable` was applied per text-block by the legacy `RenderTextBlock` default renderer, but never reached the contenteditable shell and never reached the new pipeline (`defineTextBlock` / `defineContainer` / `defineLeaf` render callbacks). Consumers passing `spellCheck={false}` with custom renderers saw spellcheck stay on.

Let the prop ride through to `SlateEditable` so it lands on the contenteditable root, where it inherits to every descendant for free. Drop the per-block application; the contenteditable parent now governs spellcheck for both pipelines.

The slate-fork shell already gates `spellCheck` with the `HAS_BEFORE_INPUT_SUPPORT` / `CAN_USE_DOM` guard, so the SSR/legacy-browser fallback is preserved.

### Verified

- `pnpm check:types --concurrency=1` (42/42)
- `pnpm check:lint` (24/24)
- `pnpm check:format`
- `pnpm exec pkg-utils build --strict` (`@portabletext/editor`)
- `tests/render-count-regression.test.tsx` (chromium, 2/2)
- `tests/dom-structure.test.tsx` (chromium, 8/8)

No changeset. The refactor is internal. The `fix:` repairs a gap in the `@alpha` new pipeline that hasn't shipped; legacy renderer behavior is preserved through CSS inheritance from the contenteditable shell.