### PR TITLE
fix: coalesce selection-state recomputes per microtask

### DIFF
--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -166,14 +166,27 @@ export function SelectionStateProvider({
       }
     }
 
+    let pendingRecompute = false
+
     const subscription = editorActor.subscribe(() => {
-      const newState = computeCurrent()
-      if (!selectionStatesEqual(stateRef.current, newState)) {
-        stateRef.current = newState
-        for (const cb of subscribersRef.current) {
-          cb()
-        }
+      // Coalesce bursts of actor updates into one selection-state
+      // recompute per microtask. The microtask drains before React's
+      // commit phase, so subscribers re-render in the same commit as
+      // the actor's state change.
+      if (pendingRecompute) {
+        return
       }
+      pendingRecompute = true
+      queueMicrotask(() => {
+        pendingRecompute = false
+        const newState = computeCurrent()
+        if (!selectionStatesEqual(stateRef.current, newState)) {
+          stateRef.current = newState
+          for (const cb of subscribersRef.current) {
+            cb()
+          }
+        }
+      })
     })
 
     return () => subscription.unsubscribe()


### PR DESCRIPTION
Bulk transactions fire one actor update per affected node. Each update was triggering a full `computeCurrent` → `selectionStatesEqual` pass on the selection-state provider, even though the selection itself remained unchanged across the burst. Inserting 1000 blocks in a single event paid for 1000 selection-state recomputes that all diffed to the same result.

This change coalesces bursts via `queueMicrotask`. The first actor update in a JS turn schedules a recompute; subsequent updates in the same turn are no-ops. The microtask drains before React's commit phase, so subscribers re-render in the same React commit as the document change — no double render per keystroke.

### Performance

Three-run medians on the `performance.test.tsx` suite (chromium, headless):

| Workload | Pre-#2666 baseline | Main (#2666) | This change |
| --- | --- | --- | --- |
| Insert 1000 blocks in empty editor | 676 ms | 902 ms | 715 ms |
| Insert 1000 blocks before existing | 600 ms | 875 ms | 619 ms |
| Insert 1000 blocks after existing | 486 ms | 596 ms | 434 ms |
| Insert 1000 tables in empty editor | 1448 ms | 2018 ms | 1501 ms |
| Insert 1000 tables before existing | 1256 ms | 2090 ms | 1281 ms |
| Insert 1000 tables after existing | 1400 ms | 2049 ms | 1254 ms |
| Set deepening nested list 30× | 54 ms | 53 ms | 54 ms |

Every bulk-insert workload either matches or beats the pre-per-slice-subscription baseline. Three of them now run faster than baseline because the coalescing also collapses redundant per-update overhead that existed before #2666.

### Correctness

The per-component re-render contract introduced by #2666 is preserved:

```
tests/render-count-regression.test.tsx
  ✓ Typing into one sibling re-renders constant work, not O(N) siblings
    Sibling re-renders after insert.text at li0 (20 siblings): 1 total across 1 keys
```

### Why microtasks, not `requestAnimationFrame`

Microtasks drain before React's commit phase, so subscribers re-render in the same React commit as the actor's own state change. With `requestAnimationFrame` the wrapper would first render with stale `focused`/`selected`, then re-render on the next frame — a double render per keystroke.
