### PR TITLE
feat: `renderDefault` prop + new render pipeline correctness

### DIFF
--- a/.changeset/register-node-api.md
+++ b/.changeset/register-node-api.md
@@ -37,15 +37,28 @@ The structural parent decides where the `of` lives:
 Misplacing a kind (for example nesting `defineSpan` inside a container's
 `of`) is a TypeScript error.
 
-All five factories accept `render?: Render | null` with tri-state
-semantics:
+All five factories accept an optional `render` function. Omit
+it to fall through to the globally registered render (or the engine
+default if none is registered). Provide a function to override the
+render at this position. The function receives the same render props
+that come from the engine, plus a `renderDefault` callback that
+produces the engine default when invoked:
 
-- `render` omitted: at this position, fall through to the globally
-  registered render (if any), otherwise the engine default.
-- `render: null`: use the engine default at this position. A positional
-  registration can carve out a scope (its own `of` overrides apply here)
-  while opting out of the global outer render.
-- `render: someFunction`: use that render at this position.
+```tsx
+defineContainer({
+  type: 'callout',
+  arrayField: 'children',
+  render: (props) => (
+    <div className="callout-frame">{props.renderDefault(props)}</div>
+  ),
+})
+```
+
+`renderDefault` takes the same props shape the callback receives, so
+it can be invoked with modified props for fine-grained control. The
+return type is `ReactElement` - render functions must return an
+element. The pattern mirrors `renderDefault` on Sanity Studio's
+render APIs.
 
 A worked example: a `callout` container keeps the global text-block
 render but swaps the inline `mention` render inside it.
@@ -62,9 +75,12 @@ const callout = defineContainer({
       of: [
         defineInlineObject({
           type: 'mention',
-          render: ({attributes, children, node}) => (
+          render: ({attributes, children, node, readOnly}) => (
             <span {...attributes} className="mention-compact">
-              {children}@{(node as {username?: string}).username}
+              {children}
+              <span draggable={!readOnly}>
+                @{(node as {username?: string}).username}
+              </span>
             </span>
           ),
         }),

--- a/.changeset/register-node-api.md
+++ b/.changeset/register-node-api.md
@@ -60,6 +60,34 @@ return type is `ReactElement` - render functions must return an
 element. The pattern mirrors `renderDefault` on Sanity Studio's
 render APIs.
 
+## Engine namespace and the new render pipeline
+
+`registerNode` opts a subtree into the new render pipeline. Inside the
+new pipeline the engine emits only `data-pt-*` attributes - the
+legacy `data-slate-*` attributes are stripped. The legacy pipeline
+keeps emitting both namespaces so existing consumers stay on the same
+DOM shape. Engine-internal DOM queries target `data-pt-*` so the
+engine itself is pipeline-agnostic; consumer CSS that targets the
+released v6 attributes (`.pt-block`, `.pt-inline-object`,
+`data-block-key`, `data-child-type`, and friends) keeps working
+unchanged in the legacy pipeline.
+
+The block-level legacy render hooks (`renderBlock`, `renderListItem`,
+`renderStyle`, `renderChild`) are suppressed inside new-pipeline
+subtrees - the registered render owns the position. The span/leaf-level
+hooks (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`, and
+range decorations) keep firing in both pipelines because they wrap
+runs of styled text rather than emit pipeline-shaped wrappers.
+
+The engine-default `renderDefault` helpers for void block-objects and
+inline-objects mirror the legacy DOM contract. Block-objects keep the
+outer editable (Slate's void caret semantics need the spacer caret
+anchor) and put `contentEditable={false}` and `draggable={!readOnly}`
+together on the inner placeholder. Inline-objects auto-receive
+`contentEditable={false}` on the outer (engine-injected for inline
+voids) and put `draggable={!readOnly}` alone on the inner; the inner
+inherits non-editability through DOM `contentEditable` inheritance.
+
 A worked example: a `callout` container keeps the global text-block
 render but swaps the inline `mention` render inside it.
 

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -17,6 +17,7 @@ import {
   type RenderPlaceholderFunction,
   type RenderStyleFunction,
 } from '@portabletext/editor'
+import {portableTextToMarkdown} from '@portabletext/markdown'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {PasteLinkPlugin} from '@portabletext/plugin-paste-link'
@@ -29,11 +30,16 @@ import {
   ActivityIcon,
   BracesIcon,
   CheckIcon,
+  CodeIcon,
   CopyIcon,
   FileJsonIcon,
+  InfoIcon,
+  LayersIcon,
+  LinkIcon,
   MousePointerIcon,
   PencilIcon,
   PencilOffIcon,
+  TableIcon,
   XIcon,
 } from 'lucide-react'
 import {useContext, useEffect, useState, type JSX} from 'react'
@@ -61,13 +67,13 @@ import {CodeBlockPlugin} from './plugins/plugin.code-block'
 import {CodeEditorPlugin} from './plugins/plugin.code-editor'
 import {FactBoxPlugin} from './plugins/plugin.fact-box'
 import {HtmlDeserializerPlugin} from './plugins/plugin.html-deserializer'
-import {ImagePlugin} from './plugins/plugin.image'
 import {ImageDeserializerPlugin} from './plugins/plugin.image-deserializer'
 import {InlineObjectsPlugin} from './plugins/plugin.inline-objects'
 import {markdownShortcutsPluginProps} from './plugins/plugin.markdown'
 import {MarkdownDeserializerPlugin} from './plugins/plugin.markdown-deserializer'
 import {TablePlugin} from './plugins/plugin.table'
 import {TextFileDeserializerPlugin} from './plugins/plugin.text-file-deserializer'
+import {markdownOptions} from './previews/markdown-options'
 import {Button} from './primitives/button'
 import {Container} from './primitives/container'
 import {ErrorBoundary} from './primitives/error-boundary'
@@ -158,7 +164,6 @@ export function Editor(props: {
               {featureFlags.calloutPlugin ? <CalloutPlugin /> : null}
               {featureFlags.factBoxPlugin ? <FactBoxPlugin /> : null}
               {featureFlags.tablePlugin ? <TablePlugin /> : null}
-              <ImagePlugin />
               <InlineObjectsPlugin />
               {featureFlags.emojiPickerPlugin ? <EmojiPickerPlugin /> : null}
               {featureFlags.mentionPickerPlugin ? (
@@ -356,6 +361,59 @@ const breakLineStyle = tv({
   },
 })
 
+const imageStyle = tv({
+  base: 'grid grid-cols-[auto_1fr] my-1 items-start gap-1 border-2 border-gray-300 dark:border-gray-600 rounded text-sm',
+  variants: {
+    selected: {true: 'border-blue-300 dark:border-blue-600'},
+    focused: {true: 'bg-blue-50 dark:bg-blue-900/30'},
+  },
+})
+
+const fallbackBlockStyle = tv({
+  base: 'my-2 rounded border border-dashed border-gray-300 px-3 py-2 text-sm dark:border-gray-600',
+  variants: {
+    selected: {true: 'border-blue-300 dark:border-blue-600'},
+    focused: {true: 'bg-blue-50 dark:bg-blue-900/30'},
+  },
+})
+
+/**
+ * Read-only fallback for new-pipeline block-objects whose `NodePlugin`
+ * has been toggled off in the playground feature flags. Renders the
+ * block through `@portabletext/markdown` and shows the resulting
+ * markdown source. Honest representation: when no consumer-provided
+ * render is registered, the block is shown as the markdown it would
+ * serialize to. No content cropping; full structure preserved.
+ */
+function MarkdownFallback(props: {
+  value: unknown
+  label: string
+  icon: JSX.Element
+  selected: boolean
+  focused: boolean
+}) {
+  const markdown = portableTextToMarkdown(
+    [props.value as PortableTextBlock],
+    markdownOptions,
+  )
+  return (
+    <div
+      className={fallbackBlockStyle({
+        selected: props.selected,
+        focused: props.focused,
+      })}
+    >
+      <div className="mb-1 flex items-center gap-1 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {props.icon}
+        <span>{props.label}</span>
+      </div>
+      <pre className="m-0 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-gray-700 dark:text-gray-200">
+        {markdown}
+      </pre>
+    </div>
+  )
+}
+
 const RenderBlock = (props: BlockRenderProps) => {
   const enableDragHandles = useContext(EditorFeatureFlagsContext).dragHandles
   const editor = useEditor()
@@ -378,6 +436,97 @@ const RenderBlock = (props: BlockRenderProps) => {
           })}
         />
       </div>
+    )
+  }
+
+  if (props.schemaType.name === 'image') {
+    const image = props.value as {src?: string; alt?: string}
+    children = (
+      <div
+        className={imageStyle({
+          selected: props.selected,
+          focused: props.focused,
+        })}
+      >
+        <div className="bg-gray-100 dark:bg-gray-700 size-20 overflow-clip flex items-center justify-center">
+          <img
+            className="object-scale-down max-w-full"
+            src={image.src}
+            alt={image.alt ?? ''}
+          />
+        </div>
+        <div className="flex flex-col gap-1 p-1 overflow-hidden">
+          <div className="flex items-center gap-1">
+            <TooltipTrigger>
+              <Button variant="ghost" size="sm">
+                <LinkIcon className="size-3 shrink-0" />
+              </Button>
+              <Tooltip className="max-w-120">
+                <span className="wrap-anywhere">{image.src}</span>
+              </Tooltip>
+            </TooltipTrigger>
+            <span className="text-ellipsis overflow-hidden whitespace-nowrap">
+              {image.src}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <PencilIcon className="size-3 shrink-0" />
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {image.alt}
+            </span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (props.schemaType.name === 'callout') {
+    const tone = (props.value as unknown as {tone?: string}).tone
+    children = (
+      <MarkdownFallback
+        value={props.value}
+        label={`Callout${tone ? ` · ${tone}` : ''}`}
+        icon={<InfoIcon className="size-3.5" />}
+        selected={props.selected}
+        focused={props.focused}
+      />
+    )
+  }
+
+  if (props.schemaType.name === 'fact-box') {
+    children = (
+      <MarkdownFallback
+        value={props.value}
+        label="Fact box"
+        icon={<LayersIcon className="size-3.5" />}
+        selected={props.selected}
+        focused={props.focused}
+      />
+    )
+  }
+
+  if (props.schemaType.name === 'code-block') {
+    const language = (props.value as unknown as {language?: string}).language
+    children = (
+      <MarkdownFallback
+        value={props.value}
+        label={`Code block${language ? ` · ${language}` : ''}`}
+        icon={<CodeIcon className="size-3.5" />}
+        selected={props.selected}
+        focused={props.focused}
+      />
+    )
+  }
+
+  if (props.schemaType.name === 'table') {
+    children = (
+      <MarkdownFallback
+        value={props.value}
+        label="Table"
+        icon={<TableIcon className="size-3.5" />}
+        selected={props.selected}
+        focused={props.focused}
+      />
     )
   }
 

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -42,6 +42,35 @@ function ToneIcon({tone}: {tone: string}): JSX.Element {
   }
 }
 
+const calloutImageLeaf = defineBlockObject({
+  type: 'image',
+  render: ({attributes, children, node, focused, selected}) => {
+    const image = node as {src?: string; alt?: string}
+    return (
+      <span
+        {...attributes}
+        className={[
+          'my-1 inline-flex items-center justify-center overflow-hidden rounded border border-amber-300 dark:border-amber-700',
+          selected
+            ? 'outline outline-2 outline-amber-500 dark:outline-amber-400'
+            : '',
+          focused ? 'bg-amber-100 dark:bg-amber-900/40' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <img
+          src={image.src}
+          alt={image.alt ?? ''}
+          contentEditable={false}
+          className="h-16 w-auto object-contain"
+        />
+        {children}
+      </span>
+    )
+  },
+})
+
 const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
@@ -113,43 +142,10 @@ const calloutContainer = defineContainer({
         }
       },
     }),
+    calloutImageLeaf,
   ],
 })
 
-const calloutImageLeaf = defineBlockObject({
-  type: 'image',
-  render: ({attributes, children, node, focused, selected}) => {
-    const image = node as {src?: string; alt?: string}
-    return (
-      <span
-        {...attributes}
-        className={[
-          'my-1 inline-flex items-center justify-center overflow-hidden rounded border border-amber-300 dark:border-amber-700',
-          selected
-            ? 'outline outline-2 outline-amber-500 dark:outline-amber-400'
-            : '',
-          focused ? 'bg-amber-100 dark:bg-amber-900/40' : '',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-      >
-        <img
-          src={image.src}
-          alt={image.alt ?? ''}
-          contentEditable={false}
-          className="h-16 w-auto object-contain"
-        />
-        {children}
-      </span>
-    )
-  },
-})
-
 export function CalloutPlugin(): JSX.Element {
-  return (
-    <>
-      <NodePlugin nodes={[calloutContainer]} />
-      <NodePlugin nodes={[calloutImageLeaf]} />
-    </>
-  )
+  return <NodePlugin nodes={[calloutContainer]} />
 }

--- a/apps/playground/src/plugins/plugin.image.tsx
+++ b/apps/playground/src/plugins/plugin.image.tsx
@@ -1,19 +1,5 @@
 import {defineBlockObject} from '@portabletext/editor'
-import {NodePlugin} from '@portabletext/editor/plugins'
-import {LinkIcon, PencilIcon} from 'lucide-react'
-import type {JSX} from 'react'
-import {TooltipTrigger} from 'react-aria-components'
 import {tv} from 'tailwind-variants'
-import {Button} from '../primitives/button'
-import {Tooltip} from '../primitives/tooltip'
-
-const imageStyle = tv({
-  base: 'grid grid-cols-[auto_1fr] my-1 items-start gap-1 border-2 border-gray-300 dark:border-gray-600 rounded text-sm',
-  variants: {
-    selected: {true: 'border-blue-300 dark:border-blue-600'},
-    focused: {true: 'bg-blue-50 dark:bg-blue-900/30'},
-  },
-})
 
 const cellImageStyle = tv({
   base: 'grid grid-cols-[auto_1fr] my-0.5 items-center gap-1 border border-gray-300 dark:border-gray-600 rounded text-xs',
@@ -23,53 +9,15 @@ const cellImageStyle = tv({
   },
 })
 
-const imageLeaf = defineBlockObject({
-  type: 'image',
-  render: ({attributes, children, node, focused, readOnly, selected}) => {
-    const image = node as {src?: string; alt?: string}
-    return (
-      <div {...attributes}>
-        {children}
-        <div
-          contentEditable={false}
-          draggable={!readOnly}
-          className={imageStyle({selected, focused})}
-        >
-          <div className="bg-gray-100 dark:bg-gray-700 size-20 overflow-clip flex items-center justify-center">
-            <img
-              className="object-scale-down max-w-full"
-              src={image.src}
-              alt={image.alt ?? ''}
-            />
-          </div>
-          <div className="flex flex-col gap-1 p-1 overflow-hidden">
-            <div className="flex items-center gap-1">
-              <TooltipTrigger>
-                <Button variant="ghost" size="sm">
-                  <LinkIcon className="size-3 shrink-0" />
-                </Button>
-                <Tooltip className="max-w-120">
-                  <span className="wrap-anywhere">{image.src}</span>
-                </Tooltip>
-              </TooltipTrigger>
-              <span className="text-ellipsis overflow-hidden whitespace-nowrap">
-                {image.src}
-              </span>
-            </div>
-            <div className="flex items-center gap-1">
-              <PencilIcon className="size-3 shrink-0" />
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                {image.alt}
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  },
-})
-
-const cellImageLeaf = defineBlockObject({
+/**
+ * Positional `image` override inside table cells. Rendered as a
+ * compact card so multiple images can fit per row. Top-level images
+ * use the legacy `renderBlock` pipeline (the v6 image render that
+ * showcases the legacy pipeline still works alongside the new Node
+ * API). Wired into `tableContainer.of[0].of[0].of` in
+ * `plugin.table.tsx`.
+ */
+export const cellImageLeaf = defineBlockObject({
   type: 'image',
   render: ({attributes, children, node, focused, readOnly, selected}) => {
     const image = node as {src?: string; alt?: string}
@@ -96,7 +44,3 @@ const cellImageLeaf = defineBlockObject({
     )
   },
 })
-
-export function ImagePlugin(): JSX.Element {
-  return <NodePlugin nodes={[imageLeaf, cellImageLeaf]} />
-}

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,6 +1,7 @@
 import {defineContainer} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {cellImageLeaf} from './plugin.image'
 
 const tableContainer = defineContainer({
   type: 'table',
@@ -35,6 +36,7 @@ const tableContainer = defineContainer({
               {children}
             </td>
           ),
+          of: [cellImageLeaf],
         }),
       ],
     }),

--- a/packages/editor/src/editor/new-pipeline-context.ts
+++ b/packages/editor/src/editor/new-pipeline-context.ts
@@ -1,0 +1,15 @@
+import {createContext} from 'react'
+
+/**
+ * True when the current render position is inside a new-pipeline
+ * subtree (any element rendered via `registerNode` and its descendants).
+ *
+ * Read by the legacy DOM-attribute emission sites in `element.tsx`,
+ * `object-node.tsx`, `text.tsx`, `leaf.tsx`, and `string.tsx` to skip
+ * `data-slate-*` attributes inside new-pipeline subtrees while still
+ * emitting them in the legacy pipeline.
+ *
+ * Provided by `useChildren` (wrapping each new-pipeline child) and by
+ * the dispatch sites in `render.element.tsx` / `render.span.tsx`.
+ */
+export const NewPipelineContext = createContext<boolean>(false)

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -2,15 +2,18 @@ import type {PortableTextObject} from '@portabletext/schema'
 import {useRef, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import {serializePath} from '../paths/serialize-path'
-import type {BlockObjectConfig} from '../renderers/renderer.types'
+import type {
+  BlockObjectConfig,
+  BlockObjectRenderProps,
+} from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import type {BlockRenderProps, RenderBlockFunction} from '../types/editor'
 import type {EditorSchema} from './editor-schema'
 import type {LegacyRenderHooks} from './legacy-render-hooks'
+import {renderDefaultBlockObject} from './render.default'
 import {RenderDefaultBlockObject} from './render.default-object'
 import {DropIndicator} from './render.drop-indicator'
-import {RenderBlockObjectConfig} from './render.leaf-config'
 import {useIsFocusedLeaf, useIsSelectedLeaf} from './selection-state-context'
 
 export function RenderBlockObject(props: {
@@ -52,21 +55,21 @@ export function RenderBlockObject(props: {
       'data-slate-void': _slateVoid,
       ...ptAttributes
     } = props.attributes
-    return (
-      <RenderBlockObjectConfig
-        blockObjectConfig={props.blockObjectConfig}
-        attributes={{
-          ...ptAttributes,
-          'data-pt-block': 'object',
-        }}
-        focused={focused}
-        node={props.element}
-        path={props.path}
-        selected={selected}
-      >
-        {props.children}
-      </RenderBlockObjectConfig>
-    )
+    const render = props.blockObjectConfig.blockObject.render
+    const renderProps: BlockObjectRenderProps = {
+      attributes: {
+        ...ptAttributes,
+        'data-pt-block': 'object',
+      },
+      children: props.children,
+      focused,
+      node: props.element,
+      path: props.path,
+      readOnly: props.readOnly,
+      renderDefault: renderDefaultBlockObject,
+      selected,
+    }
+    return render ? render(renderProps) : renderDefaultBlockObject(renderProps)
   }
 
   let innerContent: ReactElement

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -1,6 +1,5 @@
 import type {PortableTextBlock, PortableTextObject} from '@portabletext/schema'
-import {useSelector} from '@xstate/react'
-import {useContext, type ReactElement} from 'react'
+import type {ReactElement} from 'react'
 import {serializePath} from '../paths/serialize-path'
 import type {
   ContainerConfig,
@@ -8,8 +7,6 @@ import type {
 } from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
-import {useSlateSelector} from '../slate/react/hooks/use-slate-selector'
-import {EditorActorContext} from './editor-actor-context'
 import {renderDefaultContainer} from './render.default'
 import {
   useIsFocusedContainer,
@@ -22,36 +19,12 @@ export function RenderContainer(props: {
   element: PortableTextBlock
   containerConfig: ContainerConfig
   path: Path
+  readOnly: boolean
 }) {
   const serializedPath = serializePath(props.path)
   const focused = useIsFocusedContainer(serializedPath)
   const selected = useIsSelectedContainer(serializedPath)
-  const editorActor = useContext(EditorActorContext)
-  const readOnly = useSelector(editorActor, (state) =>
-    state.matches({'edit mode': 'read only'}),
-  )
-  const listIndex = useSlateSelector((editor) =>
-    editor.listIndexMap.get(props.element._key),
-  )
-
-  const {element} = props
-  const textBlockAttributes =
-    'style' in element || 'listItem' in element
-      ? {
-          ...(element.style !== undefined && {'data-style': element.style}),
-          ...(element.listItem !== undefined && {
-            'data-list-item': element.listItem,
-          }),
-          ...(element.level !== undefined && {'data-level': element.level}),
-          ...(listIndex !== undefined && {'data-list-index': listIndex}),
-        }
-      : {}
-
-  const augmentedAttributes = {...props.attributes, ...textBlockAttributes}
-
   const render = props.containerConfig.container.render
-
-  const renderDefault = renderDefaultContainer
 
   // Container registrations forbid the `'block'` and `'span'` types
   // at the factory level (see `ContainerNodeForType`), so a container
@@ -59,15 +32,15 @@ export function RenderContainer(props: {
   // is enforced by registration; expressing it in the type graph
   // would require threading the `_type` literal through dispatch.
   const renderProps: ContainerRenderProps = {
-    attributes: augmentedAttributes,
+    attributes: props.attributes,
     children: props.children,
     focused,
     node: props.element as PortableTextObject,
     path: props.path,
-    readOnly,
-    renderDefault,
+    readOnly: props.readOnly,
+    renderDefault: renderDefaultContainer,
     selected,
   }
 
-  return render ? render(renderProps) : renderDefault(renderProps)
+  return render ? render(renderProps) : renderDefaultContainer(renderProps)
 }

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -2,11 +2,15 @@ import type {PortableTextBlock, PortableTextObject} from '@portabletext/schema'
 import {useSelector} from '@xstate/react'
 import {useContext, type ReactElement} from 'react'
 import {serializePath} from '../paths/serialize-path'
-import type {ContainerConfig} from '../renderers/renderer.types'
+import type {
+  ContainerConfig,
+  ContainerRenderProps,
+} from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import {useSlateSelector} from '../slate/react/hooks/use-slate-selector'
 import {EditorActorContext} from './editor-actor-context'
+import {renderDefaultContainer} from './render.default'
 import {
   useIsFocusedContainer,
   useIsSelectedContainer,
@@ -46,27 +50,24 @@ export function RenderContainer(props: {
   const augmentedAttributes = {...props.attributes, ...textBlockAttributes}
 
   const render = props.containerConfig.container.render
-  if (typeof render === 'function') {
-    // Container registrations forbid the `'block'` and `'span'` types
-    // at the factory level (see `ContainerNodeForType`), so a container
-    // node here is always a `PortableTextObject`. The runtime
-    // invariant is enforced by registration; expressing it in the type
-    // graph would require threading the `_type` literal through the
-    // dispatch path.
-    const rendered = render({
-      attributes: augmentedAttributes,
-      children: props.children,
-      focused,
-      node: props.element as PortableTextObject,
-      path: props.path,
-      readOnly,
-      selected,
-    })
 
-    if (rendered !== null) {
-      return rendered
-    }
+  const renderDefault = renderDefaultContainer
+
+  // Container registrations forbid the `'block'` and `'span'` types
+  // at the factory level (see `ContainerNodeForType`), so a container
+  // node here is always a `PortableTextObject`. The runtime invariant
+  // is enforced by registration; expressing it in the type graph
+  // would require threading the `_type` literal through dispatch.
+  const renderProps: ContainerRenderProps = {
+    attributes: augmentedAttributes,
+    children: props.children,
+    focused,
+    node: props.element as PortableTextObject,
+    path: props.path,
+    readOnly,
+    renderDefault,
+    selected,
   }
 
-  return <div {...augmentedAttributes}>{props.children}</div>
+  return render ? render(renderProps) : renderDefault(renderProps)
 }

--- a/packages/editor/src/editor/render.default.tsx
+++ b/packages/editor/src/editor/render.default.tsx
@@ -44,6 +44,12 @@ export function renderDefaultSpan(props: {
  * Engine-default wrapper for void block objects. Renders the zero-width
  * editor children plus a non-editable `[_type: _key]` placeholder so the
  * object is visible before a consumer provides a custom `render`.
+ *
+ * Inner sibling-of-spacer wrapper carries `contentEditable={false}` (so
+ * caret can't land in the placeholder) and `draggable={!readOnly}` (so
+ * the void block is draggable). Mirrors the legacy block-object DOM
+ * shape: outer stays editable so Slate's spacer caret anchor works;
+ * both `contentEditable` and `draggable` live on the same sibling node.
  */
 export function renderDefaultBlockObject(
   props: BlockObjectRenderProps,
@@ -51,7 +57,11 @@ export function renderDefaultBlockObject(
   return (
     <div {...props.attributes}>
       {props.children}
-      <div contentEditable={false} style={{userSelect: 'none'}}>
+      <div
+        contentEditable={false}
+        draggable={!props.readOnly}
+        style={{userSelect: 'none'}}
+      >
         [{props.node._type}: {props.node._key}]
       </div>
     </div>
@@ -62,6 +72,13 @@ export function renderDefaultBlockObject(
  * Engine-default wrapper for void inline objects. Renders the zero-width
  * editor children plus a non-editable `[_type: _key]` placeholder so the
  * object is visible before a consumer provides a custom `render`.
+ *
+ * Outer span auto-receives `contentEditable={false}` via
+ * `object-node.tsx`'s `isInline && !readOnly` branch (Slate-applied for
+ * inline voids). The inner sibling-of-spacer wrapper carries only
+ * `draggable={!readOnly}`; non-editability inherits from the outer via
+ * DOM `contentEditable` inheritance. Mirrors the legacy inline-object
+ * DOM shape.
  */
 export function renderDefaultInlineObject(
   props: InlineObjectRenderProps,
@@ -69,7 +86,7 @@ export function renderDefaultInlineObject(
   return (
     <span {...props.attributes}>
       {props.children}
-      <span contentEditable={false} style={{userSelect: 'none'}}>
+      <span draggable={!props.readOnly} style={{userSelect: 'none'}}>
         [{props.node._type}: {props.node._key}]
       </span>
     </span>

--- a/packages/editor/src/editor/render.default.tsx
+++ b/packages/editor/src/editor/render.default.tsx
@@ -1,0 +1,77 @@
+import type {ReactElement} from 'react'
+import type {
+  BlockObjectRenderProps,
+  InlineObjectRenderProps,
+} from '../renderers/renderer.types'
+
+/**
+ * Engine-default wrapper for Container nodes. Spreads engine-emitted
+ * `attributes` (including `data-pt-*` markers) on a `<div>` and
+ * renders the children. Used both as the fallback when no `render`
+ * is provided and as the `renderDefault` prop on `ContainerRenderProps`.
+ */
+export function renderDefaultContainer(props: {
+  attributes: Record<string, unknown>
+  children: ReactElement
+}): ReactElement {
+  return <div {...props.attributes}>{props.children}</div>
+}
+
+/**
+ * Engine-default wrapper for TextBlock nodes. Spreads engine-emitted
+ * `attributes` (including `data-pt-block="text"`) on a `<div>` and
+ * renders the children.
+ */
+export function renderDefaultTextBlock(props: {
+  attributes: Record<string, unknown>
+  children: ReactElement
+}): ReactElement {
+  return <div {...props.attributes}>{props.children}</div>
+}
+
+/**
+ * Engine-default wrapper for Span nodes. Spreads engine-emitted
+ * `attributes` on a `<span>` and renders the children.
+ */
+export function renderDefaultSpan(props: {
+  attributes: Record<string, unknown>
+  children: ReactElement
+}): ReactElement {
+  return <span {...props.attributes}>{props.children}</span>
+}
+
+/**
+ * Engine-default wrapper for void block objects. Renders the zero-width
+ * editor children plus a non-editable `[_type: _key]` placeholder so the
+ * object is visible before a consumer provides a custom `render`.
+ */
+export function renderDefaultBlockObject(
+  props: BlockObjectRenderProps,
+): ReactElement {
+  return (
+    <div {...props.attributes}>
+      {props.children}
+      <div contentEditable={false} style={{userSelect: 'none'}}>
+        [{props.node._type}: {props.node._key}]
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Engine-default wrapper for void inline objects. Renders the zero-width
+ * editor children plus a non-editable `[_type: _key]` placeholder so the
+ * object is visible before a consumer provides a custom `render`.
+ */
+export function renderDefaultInlineObject(
+  props: InlineObjectRenderProps,
+): ReactElement {
+  return (
+    <span {...props.attributes}>
+      {props.children}
+      <span contentEditable={false} style={{userSelect: 'none'}}>
+        [{props.node._type}: {props.node._key}]
+      </span>
+    </span>
+  )
+}

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -28,6 +28,7 @@ import {ParentContainerContext} from './parent-container-context'
 import {ParentTextBlockContext} from './parent-text-block-context'
 import {RenderBlockObject} from './render.block-object'
 import {RenderContainer} from './render.container'
+import {renderDefaultTextBlock} from './render.default'
 import {RenderInlineObject} from './render.inline-object'
 import {RenderTextBlock} from './render.text-block'
 import {resolveElementDropPosition} from './resolve-element-drop-position'
@@ -110,11 +111,11 @@ export function RenderElement(props: {
   )
 
   // Compose effective container config. Block-level positional
-  // override wins. `render: null` on the override means "explicitly
-  // use default at this position" — still wins over global.
-  // `render: undefined` on a positional override falls through to
-  // global; if no global exists, the positional config itself is
-  // still the effective container (the engine default renders).
+  // override wins. `render: undefined` on a positional override falls
+  // through to global; if no global exists, the positional config
+  // itself is still the effective container (the engine default
+  // renders, because the structural commitment - it's a container
+  // with this arrayField - is separable from the rendering choice).
   const containerConfig = useMemo<ContainerConfig | undefined>(() => {
     if (blockPositionalOverride && 'container' in blockPositionalOverride) {
       if (blockPositionalOverride.container.render === undefined) {
@@ -127,8 +128,8 @@ export function RenderElement(props: {
 
   // Compose the active text-block scope value (provided via context to
   // inline children so they can read positional `of` overrides for
-  // span + inlineObject). This is independent of which render fires:
-  // a positional `render: null` still establishes a scope.
+  // span + inlineObject). Independent of which render fires - the
+  // positional registration's `of` array still scopes inline content.
   const textBlockScope = useMemo<TextBlockConfig | undefined>(() => {
     if (blockPositionalOverride && 'textBlock' in blockPositionalOverride) {
       return blockPositionalOverride
@@ -138,10 +139,9 @@ export function RenderElement(props: {
 
   // Resolve which text-block config (if any) supplies a `render` at
   // this position. Mirrors the shape used by `containerConfig` /
-  // `blockObjectConfig` / `inlineObjectConfig` / `useSpanConfig`: only
-  // `render === undefined` is resolved here (falls through to global).
-  // The `function` vs `null` split is handled at dispatch where the
-  // tagged default for this position is emitted.
+  // `blockObjectConfig` / `inlineObjectConfig` / `useSpanConfig`:
+  // `render === undefined` falls through to global; a function render
+  // is used at this position.
   const renderableTextBlockConfig = useMemo<TextBlockConfig | undefined>(() => {
     if (blockPositionalOverride && 'textBlock' in blockPositionalOverride) {
       if (blockPositionalOverride.textBlock.render === undefined) {
@@ -154,8 +154,8 @@ export function RenderElement(props: {
 
   const blockObjectConfig = useMemo<BlockObjectConfig | undefined>(() => {
     if (blockPositionalOverride && 'blockObject' in blockPositionalOverride) {
-      // Three modes: function → use; null → use default at this position;
-      // undefined → fall through to global.
+      // Positional undefined render falls through to global; function
+      // render is used at this position.
       if (blockPositionalOverride.blockObject.render === undefined) {
         // Fall through to global.
         return globalBlockObjectConfig
@@ -203,11 +203,8 @@ export function RenderElement(props: {
 
   if (isTextBlock({schema}, props.element)) {
     const {'data-slate-node': _sn, ...rest} = props.attributes
-    let rendered: ReactElement
-    if (
-      renderableTextBlockConfig &&
-      typeof renderableTextBlockConfig.textBlock.render === 'function'
-    ) {
+    let rendered: ReactElement | null
+    if (renderableTextBlockConfig?.textBlock.render) {
       rendered = (
         <RenderTextBlockConfig
           attributes={{...rest, 'data-pt-block': 'text'}}
@@ -221,11 +218,12 @@ export function RenderElement(props: {
       )
     } else if (parentContainer) {
       // Default rendering at this position inside a container.
-      rendered = (
-        <div {...rest} data-pt-block="text">
-          {props.children}
-        </div>
-      )
+      // Same shape as `renderDefault` returns when a registered
+      // text-block omits `render`.
+      rendered = renderDefaultTextBlock({
+        attributes: {...rest, 'data-pt-block': 'text'},
+        children: props.children,
+      })
     } else {
       // Legacy top-level rendering.
       rendered = (
@@ -330,9 +328,9 @@ export function RenderElement(props: {
  * `useIsSelectedContainer`) live at the top of a component, not inside
  * a conditional in `RenderElement`'s body.
  *
- * The dispatch in `RenderElement` filters out `null` / `undefined`
- * renders and emits the appropriate default itself (engine wrapper
- * inside a container, legacy renderer at top level).
+ * The dispatch in `RenderElement` filters: a `function` render flows
+ * here; a config with no `render` resolves to global or to the
+ * legacy pipeline at top level.
  */
 function RenderTextBlockConfig(props: {
   attributes: Omit<RenderElementProps['attributes'], 'data-pt-block'> & {
@@ -347,6 +345,7 @@ function RenderTextBlockConfig(props: {
   const serializedPath = serializePath(props.path)
   const focused = useIsFocusedContainer(serializedPath)
   const selected = useIsSelectedContainer(serializedPath)
+  const renderDefault = renderDefaultTextBlock
   return props.render({
     attributes: props.attributes,
     children: props.children,
@@ -354,6 +353,7 @@ function RenderTextBlockConfig(props: {
     node: props.node,
     path: props.path,
     readOnly: props.readOnly,
+    renderDefault,
     selected,
   })
 }

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -24,6 +24,7 @@ import {
   findInlinePositionalOverride,
 } from './find-positional-override'
 import type {LegacyRenderHooks} from './legacy-render-hooks'
+import {NewPipelineContext} from './new-pipeline-context'
 import {ParentContainerContext} from './parent-container-context'
 import {ParentTextBlockContext} from './parent-text-block-context'
 import {RenderBlockObject} from './render.block-object'
@@ -71,6 +72,7 @@ export function RenderElement(props: {
   const editorActor = useContext(EditorActorContext)
   const parentContainer = useContext(ParentContainerContext)
   const parentTextBlock = useContext(ParentTextBlockContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
   const slateStatic = useSlateStatic()
   const schema = props.schema
   const type = props.element._type
@@ -194,6 +196,7 @@ export function RenderElement(props: {
           element={props.element}
           containerConfig={containerConfig}
           path={props.path}
+          readOnly={props.readOnly}
         >
           {props.children}
         </RenderContainer>
@@ -216,10 +219,10 @@ export function RenderElement(props: {
           {props.children}
         </RenderTextBlockConfig>
       )
-    } else if (parentContainer) {
-      // Default rendering at this position inside a container.
-      // Same shape as `renderDefault` returns when a registered
-      // text-block omits `render`.
+    } else if (isInNewPipeline) {
+      // Default rendering at this position inside a new-pipeline
+      // subtree. Same shape as `renderDefault` returns when a
+      // registered text-block omits `render`.
       rendered = renderDefaultTextBlock({
         attributes: {...rest, 'data-pt-block': 'text'},
         children: props.children,
@@ -258,7 +261,7 @@ export function RenderElement(props: {
   }
 
   if (isInline(slateStatic, props.path)) {
-    if (parentContainer && !inlineObjectConfig) {
+    if (isInNewPipeline && !inlineObjectConfig) {
       const {
         'data-slate-node': _sn,
         'data-slate-void': _sv,
@@ -288,7 +291,7 @@ export function RenderElement(props: {
     )
   }
 
-  if (parentContainer && !blockObjectConfig) {
+  if (isInNewPipeline && !blockObjectConfig) {
     const {
       'data-slate-node': _sn,
       'data-slate-void': _sv,

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -1,14 +1,17 @@
 import type {PortableTextChild, PortableTextObject} from '@portabletext/schema'
 import {useRef, type ReactElement} from 'react'
 import {serializePath} from '../paths/serialize-path'
-import type {InlineObjectConfig} from '../renderers/renderer.types'
+import type {
+  InlineObjectConfig,
+  InlineObjectRenderProps,
+} from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import type {RenderElementProps} from '../slate/react/components/editable'
 import type {BlockChildRenderProps, RenderChildFunction} from '../types/editor'
 import type {EditorSchema} from './editor-schema'
 import type {LegacyRenderHooks} from './legacy-render-hooks'
+import {renderDefaultInlineObject} from './render.default'
 import {RenderDefaultInlineObject} from './render.default-object'
-import {RenderInlineObjectConfig} from './render.leaf-config'
 import {useIsFocusedLeaf, useIsSelectedLeaf} from './selection-state-context'
 import {useBlockSubSchema} from './use-block-sub-schema'
 
@@ -43,26 +46,26 @@ export function RenderInlineObject(props: {
   const inlineObject = props.element as unknown as PortableTextChild
 
   if (props.inlineObjectConfig) {
-    const {
-      'data-slate-node': _slateNode,
-      'data-slate-void': _slateVoid,
-      ...ptAttributes
-    } = props.attributes
-    return (
-      <RenderInlineObjectConfig
-        inlineObjectConfig={props.inlineObjectConfig}
-        attributes={{
-          ...ptAttributes,
-          'data-pt-inline': 'object',
-        }}
-        focused={focused}
-        node={props.element}
-        path={props.path}
-        selected={selected}
-      >
-        {props.children}
-      </RenderInlineObjectConfig>
-    )
+    // `props.attributes` is already shaped by `object-node.tsx`'s
+    // `NewPipelineContext` read: clean `data-pt-*` when inside a new-
+    // pipeline subtree, legacy + PT when the parent text block is
+    // legacy. The registered render runs in both modes; only the
+    // attribute shape inherits.
+    const render = props.inlineObjectConfig.inlineObject.render
+    const renderProps: InlineObjectRenderProps = {
+      attributes: {
+        ...props.attributes,
+        'data-pt-inline': 'object',
+      },
+      children: props.children,
+      focused,
+      node: props.element as PortableTextObject,
+      path: props.path,
+      readOnly: props.readOnly,
+      renderDefault: renderDefaultInlineObject,
+      selected,
+    }
+    return render ? render(renderProps) : renderDefaultInlineObject(renderProps)
   }
 
   let innerContent: ReactElement

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -4,25 +4,12 @@ import type {
   PortableTextSpan,
 } from '@portabletext/schema'
 import {useSelector} from '@xstate/react'
-import type {ReactElement} from 'react'
 import {useContext} from 'react'
-import type {
-  BlockObjectConfig,
-  BlockObjectRenderProps,
-  InlineObjectConfig,
-  InlineObjectRenderProps,
-  SpanConfig,
-  SpanRenderProps,
-} from '../renderers/renderer.types'
+import type {SpanConfig} from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import {EditorActorContext} from './editor-actor-context'
 import {findInlinePositionalOverride} from './find-positional-override'
 import {ParentTextBlockContext} from './parent-text-block-context'
-import {
-  renderDefaultBlockObject,
-  renderDefaultInlineObject,
-  renderDefaultSpan,
-} from './render.default'
 
 /**
  * Hook: resolve the registered span config for the span at `node`, or
@@ -54,100 +41,4 @@ export function useSpanConfig(
     return positional
   }
   return globalSpan
-}
-
-/**
- * Small child component that invokes the consumer's span render with
- * stable props.
- */
-export function RenderSpanConfig(props: {
-  spanConfig: SpanConfig
-  attributes: Record<string, unknown>
-  children: ReactElement
-  focused: boolean
-  node: PortableTextSpan
-  path: Path
-  selected: boolean
-}) {
-  const editorActor = useContext(EditorActorContext)
-  const readOnly = useSelector(editorActor, (state) =>
-    state.matches({'edit mode': 'read only'}),
-  )
-  const render = props.spanConfig.span.render
-  const renderDefault = renderDefaultSpan
-  const renderProps: SpanRenderProps = {
-    attributes: props.attributes,
-    children: props.children,
-    focused: props.focused,
-    node: props.node,
-    path: props.path,
-    readOnly,
-    renderDefault,
-    selected: props.selected,
-  }
-  return render ? render(renderProps) : renderDefault(renderProps)
-}
-
-/**
- * Small child component that invokes the consumer's block-object
- * render with stable props.
- */
-export function RenderBlockObjectConfig(props: {
-  blockObjectConfig: BlockObjectConfig
-  attributes: Record<string, unknown>
-  children: ReactElement
-  focused: boolean
-  node: PortableTextBlock | PortableTextObject
-  path: Path
-  selected: boolean
-}) {
-  const editorActor = useContext(EditorActorContext)
-  const readOnly = useSelector(editorActor, (state) =>
-    state.matches({'edit mode': 'read only'}),
-  )
-  const render = props.blockObjectConfig.blockObject.render
-  const renderDefault = renderDefaultBlockObject
-  const renderProps: BlockObjectRenderProps = {
-    attributes: props.attributes,
-    children: props.children,
-    focused: props.focused,
-    node: props.node as PortableTextObject,
-    path: props.path,
-    readOnly,
-    renderDefault,
-    selected: props.selected,
-  }
-  return render ? render(renderProps) : renderDefault(renderProps)
-}
-
-/**
- * Small child component that invokes the consumer's inline-object
- * render with stable props.
- */
-export function RenderInlineObjectConfig(props: {
-  inlineObjectConfig: InlineObjectConfig
-  attributes: Record<string, unknown>
-  children: ReactElement
-  focused: boolean
-  node: PortableTextBlock | PortableTextObject
-  path: Path
-  selected: boolean
-}) {
-  const editorActor = useContext(EditorActorContext)
-  const readOnly = useSelector(editorActor, (state) =>
-    state.matches({'edit mode': 'read only'}),
-  )
-  const render = props.inlineObjectConfig.inlineObject.render
-  const renderDefault = renderDefaultInlineObject
-  const renderProps: InlineObjectRenderProps = {
-    attributes: props.attributes,
-    children: props.children,
-    focused: props.focused,
-    node: props.node as PortableTextObject,
-    path: props.path,
-    readOnly,
-    renderDefault,
-    selected: props.selected,
-  }
-  return render ? render(renderProps) : renderDefault(renderProps)
 }

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -8,13 +8,21 @@ import type {ReactElement} from 'react'
 import {useContext} from 'react'
 import type {
   BlockObjectConfig,
+  BlockObjectRenderProps,
   InlineObjectConfig,
+  InlineObjectRenderProps,
   SpanConfig,
+  SpanRenderProps,
 } from '../renderers/renderer.types'
 import type {Path} from '../slate/interfaces/path'
 import {EditorActorContext} from './editor-actor-context'
 import {findInlinePositionalOverride} from './find-positional-override'
 import {ParentTextBlockContext} from './parent-text-block-context'
+import {
+  renderDefaultBlockObject,
+  renderDefaultInlineObject,
+  renderDefaultSpan,
+} from './render.default'
 
 /**
  * Hook: resolve the registered span config for the span at `node`, or
@@ -38,8 +46,8 @@ export function useSpanConfig(
     state.context.spans.get(node._type),
   )
   if (positional && 'span' in positional) {
-    // Three modes: function → use; null → use default at this
-    // position; undefined → fall through to global.
+    // Positional present: undefined render falls through to global;
+    // function render is used at this position.
     if (positional.span.render === undefined) {
       return globalSpan
     }
@@ -66,18 +74,18 @@ export function RenderSpanConfig(props: {
     state.matches({'edit mode': 'read only'}),
   )
   const render = props.spanConfig.span.render
-  if (typeof render !== 'function') {
-    return <span {...props.attributes}>{props.children}</span>
-  }
-  return render({
+  const renderDefault = renderDefaultSpan
+  const renderProps: SpanRenderProps = {
     attributes: props.attributes,
     children: props.children,
     focused: props.focused,
     node: props.node,
     path: props.path,
     readOnly,
+    renderDefault,
     selected: props.selected,
-  })
+  }
+  return render ? render(renderProps) : renderDefault(renderProps)
 }
 
 /**
@@ -98,20 +106,18 @@ export function RenderBlockObjectConfig(props: {
     state.matches({'edit mode': 'read only'}),
   )
   const render = props.blockObjectConfig.blockObject.render
-  if (typeof render !== 'function') {
-    // Engine default — render the children inside an attribute-tagged
-    // wrapper so consumer CSS still sees the data-pt-block attribute.
-    return <div {...props.attributes}>{props.children}</div>
-  }
-  return render({
+  const renderDefault = renderDefaultBlockObject
+  const renderProps: BlockObjectRenderProps = {
     attributes: props.attributes,
     children: props.children,
     focused: props.focused,
     node: props.node as PortableTextObject,
     path: props.path,
     readOnly,
+    renderDefault,
     selected: props.selected,
-  })
+  }
+  return render ? render(renderProps) : renderDefault(renderProps)
 }
 
 /**
@@ -132,16 +138,16 @@ export function RenderInlineObjectConfig(props: {
     state.matches({'edit mode': 'read only'}),
   )
   const render = props.inlineObjectConfig.inlineObject.render
-  if (typeof render !== 'function') {
-    return <span {...props.attributes}>{props.children}</span>
-  }
-  return render({
+  const renderDefault = renderDefaultInlineObject
+  const renderProps: InlineObjectRenderProps = {
     attributes: props.attributes,
     children: props.children,
     focused: props.focused,
     node: props.node as PortableTextObject,
     path: props.path,
     readOnly,
+    renderDefault,
     selected: props.selected,
-  })
+  }
+  return render ? render(renderProps) : renderDefault(renderProps)
 }

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -5,6 +5,7 @@ import type {
 import {isTextBlock} from '@portabletext/schema'
 import {useContext, useRef, type ReactElement} from 'react'
 import {serializePath} from '../paths/serialize-path'
+import type {SpanRenderProps} from '../renderers/renderer.types'
 import type {RenderLeafProps} from '../slate/react/components/editable'
 import type {
   BlockAnnotationRenderProps,
@@ -15,8 +16,9 @@ import type {
   RenderDecoratorFunction,
 } from '../types/editor'
 import type {EditorSchema} from './editor-schema'
-import {ParentContainerContext} from './parent-container-context'
-import {RenderSpanConfig, useSpanConfig} from './render.leaf-config'
+import {NewPipelineContext} from './new-pipeline-context'
+import {renderDefaultSpan} from './render.default'
+import {useSpanConfig} from './render.leaf-config'
 import {useIsFocusedLeaf, useIsSelectedLeaf} from './selection-state-context'
 import {useBlockSubSchema} from './use-block-sub-schema'
 
@@ -48,7 +50,7 @@ export function RenderSpan(props: RenderSpanProps) {
   // is found (transient state), fall back to the Slate leaf for identity.
   const spanConfig = useSpanConfig(child ?? props.leaf, props.path)
 
-  const parentContainer = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
   const serializedPath = serializePath(props.path)
   const focused = useIsFocusedLeaf(serializedPath)
   const selected = useIsSelectedLeaf(serializedPath)
@@ -142,7 +144,7 @@ export function RenderSpan(props: RenderSpanProps) {
   /**
    * Support `renderChild` render function for the Span itself
    */
-  if (block && props.renderChild && child && !spanConfig && !parentContainer) {
+  if (block && props.renderChild && child && !spanConfig && !isInNewPipeline) {
     children = (
       <RenderChild
         renderChild={props.renderChild}
@@ -160,18 +162,18 @@ export function RenderSpan(props: RenderSpanProps) {
   }
 
   if (spanConfig) {
-    return (
-      <RenderSpanConfig
-        spanConfig={spanConfig}
-        attributes={props.attributes}
-        focused={focused}
-        node={(child ?? props.leaf) as PortableTextSpan}
-        path={props.path}
-        selected={selected}
-      >
-        {children}
-      </RenderSpanConfig>
-    )
+    const render = spanConfig.span.render
+    const renderProps: SpanRenderProps = {
+      attributes: props.attributes,
+      children,
+      focused,
+      node: (child ?? props.leaf) as PortableTextSpan,
+      path: props.path,
+      readOnly: props.readOnly,
+      renderDefault: renderDefaultSpan,
+      selected,
+    }
+    return render ? render(renderProps) : renderDefaultSpan(renderProps)
   }
 
   return (

--- a/packages/editor/src/node-traversal/get-ancestors-positional-same-type.test.ts
+++ b/packages/editor/src/node-traversal/get-ancestors-positional-same-type.test.ts
@@ -1,6 +1,9 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import {defineContainer} from '../renderers/renderer.types'
+import {
+  defineContainer,
+  type ContainerRenderProps,
+} from '../renderers/renderer.types'
 import {buildPublicContainers} from '../schema/build-public-containers'
 import {resolveNestedContainer} from '../schema/resolve-containers-batch'
 import type {Node} from '../slate/interfaces/node'
@@ -64,8 +67,8 @@ describe('getAncestors with same _type under different parents', () => {
     }),
   )
 
-  function containerRender() {
-    return null
+  function containerRender(props: ContainerRenderProps) {
+    return props.renderDefault(props)
   }
 
   const tableConfig = resolveNestedContainer(

--- a/packages/editor/src/node-traversal/get-children-positional-same-type.test.ts
+++ b/packages/editor/src/node-traversal/get-children-positional-same-type.test.ts
@@ -1,6 +1,9 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import {defineContainer} from '../renderers/renderer.types'
+import {
+  defineContainer,
+  type ContainerRenderProps,
+} from '../renderers/renderer.types'
 import {buildPublicContainers} from '../schema/build-public-containers'
 import {resolveNestedContainer} from '../schema/resolve-containers-batch'
 import type {Node} from '../slate/interfaces/node'
@@ -66,8 +69,8 @@ describe('getChildren with same _type registered under different parents', () =>
     }),
   )
 
-  function containerRender() {
-    return null
+  function containerRender(props: ContainerRenderProps) {
+    return props.renderDefault(props)
   }
 
   const tableConfig = resolveNestedContainer(

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -31,7 +31,7 @@ export type ContainerNodeForType<TType extends string> = TType extends
  * built-in `'span'` or `'block'` types (those are leaves and text blocks
  * respectively).
  */
-export type ContainerRender = (props: {
+export type ContainerRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
   focused: boolean
@@ -39,7 +39,22 @@ export type ContainerRender = (props: {
   path: Path
   readOnly: boolean
   selected: boolean
-}) => ReactElement | null
+  /**
+   * Render this position with the engine's default wrapper. Call from
+   * inside a custom render to fall back to or wrap the default:
+   *
+   * ```ts
+   * render: ({renderDefault, ...rest}) => renderDefault(rest)
+   * ```
+   *
+   * The default is the engine's minimal wrapper. It does not chain
+   * back to a globally-registered render: PTE has one user layer plus
+   * positional overrides, and the engine default is the canonical
+   * fallback at any position.
+   */
+  renderDefault: (props: ContainerRenderProps) => ReactElement
+}
+export type ContainerRender = (props: ContainerRenderProps) => ReactElement
 
 /**
  * @alpha
@@ -48,7 +63,7 @@ export type ContainerRender = (props: {
  * wraps it. `children` carries the styled text already decorated by
  * `renderDecorator`/`renderAnnotation`/range decorations.
  */
-export type SpanRender = (props: {
+export type SpanRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
   focused: boolean
@@ -56,7 +71,13 @@ export type SpanRender = (props: {
   path: Path
   readOnly: boolean
   selected: boolean
-}) => ReactElement | null
+  /**
+   * Render this position with the engine's default wrapper.
+   * See {@link ContainerRenderProps.renderDefault}.
+   */
+  renderDefault: (props: SpanRenderProps) => ReactElement
+}
+export type SpanRender = (props: SpanRenderProps) => ReactElement
 
 /**
  * @alpha
@@ -67,7 +88,7 @@ export type SpanRender = (props: {
  * element. Dropping `children` makes the caret unable to land on the
  * element.
  */
-export type BlockObjectRender = (props: {
+export type BlockObjectRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
   focused: boolean
@@ -75,7 +96,13 @@ export type BlockObjectRender = (props: {
   path: Path
   readOnly: boolean
   selected: boolean
-}) => ReactElement | null
+  /**
+   * Render this position with the engine's default wrapper.
+   * See {@link ContainerRenderProps.renderDefault}.
+   */
+  renderDefault: (props: BlockObjectRenderProps) => ReactElement
+}
+export type BlockObjectRender = (props: BlockObjectRenderProps) => ReactElement
 
 /**
  * @alpha
@@ -86,7 +113,7 @@ export type BlockObjectRender = (props: {
  * element. Dropping `children` makes the caret unable to land on the
  * element.
  */
-export type InlineObjectRender = (props: {
+export type InlineObjectRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
   focused: boolean
@@ -94,7 +121,15 @@ export type InlineObjectRender = (props: {
   path: Path
   readOnly: boolean
   selected: boolean
-}) => ReactElement | null
+  /**
+   * Render this position with the engine's default wrapper.
+   * See {@link ContainerRenderProps.renderDefault}.
+   */
+  renderDefault: (props: InlineObjectRenderProps) => ReactElement
+}
+export type InlineObjectRender = (
+  props: InlineObjectRenderProps,
+) => ReactElement
 
 /**
  * @alpha
@@ -115,12 +150,12 @@ export type Container = {
   type: string
   arrayField: string
   /**
-   * Outer render. Three modes:
+   * Outer render. Two modes:
    * - omitted: fall through to global registered render (or engine default)
-   * - `null`: skip global, use engine default at this position
-   * - function: use this render
+   * - function: use this render. The function receives a `renderDefault`
+   *   prop that returns the engine default when called.
    */
-  render?: ContainerRender | null
+  render?: ContainerRender
   /**
    * Block-level positional overrides. Inline-content kinds (`Span`,
    * `InlineObject`) belong in `TextBlock.of`, not here.
@@ -151,12 +186,12 @@ export type TextBlock = {
   kind: 'textBlock'
   type: string
   /**
-   * Outer render. Three modes:
+   * Outer render. Two modes:
    * - omitted: fall through to global registered render (or engine default)
-   * - `null`: skip global, use engine default at this position
-   * - function: use this render
+   * - function: use this render. The function receives a `renderDefault`
+   *   prop that returns the engine default when called.
    */
-  render?: TextBlockRender | null
+  render?: TextBlockRender
   /**
    * Inline-content positional overrides. A `Span` or `InlineObject`
    * placed here scopes the inline render to this text block (or any
@@ -174,7 +209,7 @@ export type TextBlock = {
  * is the outer wrapper element and any block-level composition (style,
  * list-item) the consumer wants.
  */
-export type TextBlockRender = (props: {
+export type TextBlockRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
   focused: boolean
@@ -182,7 +217,13 @@ export type TextBlockRender = (props: {
   path: Path
   readOnly: boolean
   selected: boolean
-}) => ReactElement | null
+  /**
+   * Render this position with the engine's default wrapper.
+   * See {@link ContainerRenderProps.renderDefault}.
+   */
+  renderDefault: (props: TextBlockRenderProps) => ReactElement
+}
+export type TextBlockRender = (props: TextBlockRenderProps) => ReactElement
 
 /**
  * @alpha
@@ -196,12 +237,12 @@ export type Span = {
   kind: 'span'
   type: string
   /**
-   * Outer render. Three modes:
+   * Outer render. Two modes:
    * - omitted: fall through to global registered render (or engine default)
-   * - `null`: skip global, use engine default at this position
-   * - function: use this render
+   * - function: use this render. The function receives a `renderDefault`
+   *   prop that returns the engine default when called.
    */
-  render?: SpanRender | null
+  render?: SpanRender
 }
 
 /**
@@ -214,12 +255,12 @@ export type BlockObject = {
   kind: 'blockObject'
   type: string
   /**
-   * Outer render. Three modes:
+   * Outer render. Two modes:
    * - omitted: fall through to global registered render (or engine default)
-   * - `null`: skip global, use engine default at this position
-   * - function: use this render
+   * - function: use this render. The function receives a `renderDefault`
+   *   prop that returns the engine default when called.
    */
-  render?: BlockObjectRender | null
+  render?: BlockObjectRender
 }
 
 /**
@@ -232,12 +273,12 @@ export type InlineObject = {
   kind: 'inlineObject'
   type: string
   /**
-   * Outer render. Three modes:
+   * Outer render. Two modes:
    * - omitted: fall through to global registered render (or engine default)
-   * - `null`: skip global, use engine default at this position
-   * - function: use this render
+   * - function: use this render. The function receives a `renderDefault`
+   *   prop that returns the engine default when called.
    */
-  render?: InlineObjectRender | null
+  render?: InlineObjectRender
 }
 
 /**
@@ -292,17 +333,16 @@ export function defineContainer<const TType extends string>(config: {
       ? "Error: defineContainer({type: 'block'}) is forbidden -- 'block' is always a text block, use defineTextBlock"
       : TType
   arrayField: string
-  render?:
-    | ((props: {
-        attributes: Record<string, unknown>
-        children: ReactElement
-        focused: boolean
-        node: ContainerNodeForType<TType>
-        path: Path
-        readOnly: boolean
-        selected: boolean
-      }) => ReactElement | null)
-    | null
+  render?: (props: {
+    attributes: Record<string, unknown>
+    children: ReactElement
+    focused: boolean
+    node: ContainerNodeForType<TType>
+    path: Path
+    readOnly: boolean
+    selected: boolean
+    renderDefault: (props: ContainerRenderProps) => ReactElement
+  }) => ReactElement
   of?: ReadonlyArray<Container | TextBlock | BlockObject>
 }): Container {
   return {kind: 'container', ...config} as unknown as Container
@@ -334,7 +374,7 @@ export function defineSpan<const TType extends string>(config: {
   type: TType extends 'block'
     ? "Error: defineSpan({type: 'block'}) is forbidden -- 'block' is always a text block, use defineTextBlock"
     : TType
-  render?: SpanRender | null
+  render?: SpanRender
 }): Span {
   return {kind: 'span', ...config} as unknown as Span
 }
@@ -369,7 +409,7 @@ export function defineBlockObject<const TType extends string>(config: {
     : TType extends 'span'
       ? "Error: defineBlockObject({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan"
       : TType
-  render?: BlockObjectRender | null
+  render?: BlockObjectRender
 }): BlockObject {
   return {kind: 'blockObject', ...config} as unknown as BlockObject
 }
@@ -404,7 +444,7 @@ export function defineInlineObject<const TType extends string>(config: {
     : TType extends 'span'
       ? "Error: defineInlineObject({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan"
       : TType
-  render?: InlineObjectRender | null
+  render?: InlineObjectRender
 }): InlineObject {
   return {kind: 'inlineObject', ...config} as unknown as InlineObject
 }
@@ -435,7 +475,7 @@ export function defineTextBlock<const TType extends string>(config: {
   type: TType extends 'span'
     ? "Error: defineTextBlock({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan"
     : TType
-  render?: TextBlockRender | null
+  render?: TextBlockRender
   of?: ReadonlyArray<Span | InlineObject>
 }): TextBlock {
   return {kind: 'textBlock', ...config} as unknown as TextBlock

--- a/packages/editor/src/slate/editor/unhang-range.test.ts
+++ b/packages/editor/src/slate/editor/unhang-range.test.ts
@@ -341,12 +341,10 @@ function buildContainerContext(...value: Array<Node>) {
     defineContainer({
       type: 'callout',
       arrayField: 'content',
-      render: () => null,
     }),
     defineContainer({
       type: 'code-block',
       arrayField: 'lines',
-      render: () => null,
     }),
   ])
   const blockIndexMap = new Map<string, number>()

--- a/packages/editor/src/slate/react/components/element.tsx
+++ b/packages/editor/src/slate/react/components/element.tsx
@@ -2,7 +2,8 @@ import type {
   PortableTextObject,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {type JSX} from 'react'
+import React, {useContext, type JSX} from 'react'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import {getText} from '../../../node-traversal/get-text'
 import {isInline as isInlinePath} from '../../../node-traversal/is-inline'
 import {serializePath} from '../../../paths/serialize-path'
@@ -26,8 +27,16 @@ import type {
  * or an editable container) and threads decorations + children through the
  * `renderElement` callback.
  *
- * The `isContainer` flag is resolved by `useChildren` at dispatch time and
- * passed in to avoid a second `isEditableContainer` walk here.
+ * Two pipeline-aware signals:
+ * - `isContainer` (prop): this element resolves as an editable container at
+ *   this position. Governs the `data-pt-block="container"` literal.
+ *   Resolved by `useChildren` at dispatch time (avoids a second
+ *   `isEditableContainer` walk).
+ * - `NewPipelineContext` (context): this element renders inside a
+ *   `registerNode`-shaped subtree. Governs the `data-slate-node="element"`
+ *   strip on the outer attributes. Provided by `useChildren` (wrapping
+ *   each new-pipeline child) and by `render.element.tsx` /
+ *   `render.span.tsx` (around dispatch sites).
  */
 const Element = (props: {
   decorations: DecoratedRange[]
@@ -49,6 +58,7 @@ const Element = (props: {
   const dataPath = serializePath(props.path)
   const editor = useSlateStatic()
   const isInline = isInlinePath(editor, props.path)
+  const isInNewPipeline = useContext(NewPipelineContext)
   const decorations = useDecorations(element, props.path, parentDecorations)
   const children = useChildren({
     decorations,
@@ -61,15 +71,25 @@ const Element = (props: {
 
   // Attributes that the developer must mix into the element in their
   // custom node renderer component.
+  //
+  // `isContainer` keeps the structural `data-pt-block="container"`
+  // literal. `isInNewPipeline` governs the `data-slate-node` strip:
+  // when true, the outer is part of a registerNode subtree and emits
+  // only `data-pt-*` attrs; when false, the legacy pipeline emits
+  // `data-slate-node="element"` for backwards compatibility.
   const attributes: RenderElementProps['attributes'] = isContainer
     ? {
         'data-pt-block': 'container',
         'data-pt-path': dataPath,
       }
-    : {
-        'data-slate-node': 'element',
-        'data-pt-path': dataPath,
-      }
+    : isInNewPipeline
+      ? {
+          'data-pt-path': dataPath,
+        }
+      : {
+          'data-slate-node': 'element',
+          'data-pt-path': dataPath,
+        }
 
   // If it's a block node with inline children, add the proper `dir` attribute
   // for text direction.

--- a/packages/editor/src/slate/react/components/leaf.tsx
+++ b/packages/editor/src/slate/react/components/leaf.tsx
@@ -4,7 +4,7 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import React, {useContext, type JSX} from 'react'
-import {ParentContainerContext} from '../../../editor/parent-container-context'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import type {Path} from '../../interfaces/path'
 import type {LeafPosition} from '../../interfaces/text'
 import {textEquals} from '../../text/text-equals'
@@ -35,7 +35,7 @@ const Leaf = (props: {
     leafPosition,
   } = props
 
-  const parentContainer = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
 
   const children = (
     <SlateString
@@ -53,7 +53,7 @@ const Leaf = (props: {
   const attributes: {
     'data-slate-leaf'?: true
     'data-pt-marks': true
-  } = parentContainer
+  } = isInNewPipeline
     ? {
         'data-pt-marks': true,
       }

--- a/packages/editor/src/slate/react/components/object-node.tsx
+++ b/packages/editor/src/slate/react/components/object-node.tsx
@@ -1,5 +1,6 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import React, {type JSX} from 'react'
+import React, {useContext, type JSX} from 'react'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import {serializePath} from '../../../paths/serialize-path'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -13,22 +14,25 @@ import type {RenderElementProps} from './editable'
  * model. The DOM still needs a hidden zero-width text node for caret
  * anchoring, which is the spacer below.
  *
- * The `inContainer` flag is resolved by `useChildren` at dispatch time and
- * passed in to avoid a `useContext(ParentContainerContext)` read here.
+ * Reads `NewPipelineContext` to decide between the new-pipeline shape
+ * (`data-pt-*` only) and the legacy shape (`data-slate-*` mixed in for
+ * backwards compatibility). The context is provided by `useChildren`
+ * (wrapping each new-pipeline child) and by the dispatch sites in
+ * `render.element.tsx` / `render.span.tsx`.
  */
 const ObjectNodeComponent = (props: {
   decorations: DecoratedRange[]
-  inContainer: boolean
   isInline: boolean
   objectNode: PortableTextObject
   path: Path
   renderElement: (props: RenderElementProps) => JSX.Element
 }) => {
-  const {inContainer, isInline, objectNode, path, renderElement} = props
+  const {isInline, objectNode, path, renderElement} = props
   const dataPath = serializePath(path)
   const readOnly = useReadOnly()
+  const isInNewPipeline = useContext(NewPipelineContext)
 
-  const attributes: RenderElementProps['attributes'] = inContainer
+  const attributes: RenderElementProps['attributes'] = isInNewPipeline
     ? {
         'data-pt-path': dataPath,
       }
@@ -44,7 +48,7 @@ const ObjectNodeComponent = (props: {
 
   const Tag = isInline ? 'span' : 'div'
 
-  const children = inContainer ? (
+  const children = isInNewPipeline ? (
     <Tag
       data-pt-spacer
       style={{
@@ -92,7 +96,6 @@ const ObjectNodeComponent = (props: {
 const MemoizedObjectNode = React.memo(ObjectNodeComponent, (prev, next) => {
   return (
     prev.objectNode === next.objectNode &&
-    prev.inContainer === next.inContainer &&
     pathEquals(prev.path, next.path) &&
     prev.renderElement === next.renderElement &&
     prev.isInline === next.isInline &&

--- a/packages/editor/src/slate/react/components/string.tsx
+++ b/packages/editor/src/slate/react/components/string.tsx
@@ -6,7 +6,7 @@ import {
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import {forwardRef, memo, useContext, useRef, useState} from 'react'
-import {ParentContainerContext} from '../../../editor/parent-container-context'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import {getNodes} from '../../../node-traversal/get-nodes'
 import {IS_ANDROID} from '../../dom/utils/environment'
 import {end as editorEnd} from '../../editor/end'
@@ -93,7 +93,7 @@ const SlateString = (props: {
  */
 const TextString = (props: {text: string; isTrailing?: boolean}) => {
   const {text, isTrailing = false} = props
-  const containerScope = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
   const ref = useRef<HTMLSpanElement>(null)
   const getTextContent = () => {
     return `${text ?? ''}${isTrailing ? '\n' : ''}`
@@ -124,16 +124,16 @@ const TextString = (props: {text: string; isTrailing?: boolean}) => {
   // We intentionally render a memoized <span> that only receives the initial text content when the component is mounted.
   // We defer to the layout effect above to update the `textContent` of the span element when needed.
   return (
-    <MemoizedText ref={ref} containerScope={containerScope !== undefined}>
+    <MemoizedText ref={ref} isInNewPipeline={isInNewPipeline}>
       {initialText}
     </MemoizedText>
   )
 }
 
 const MemoizedText = memo(
-  forwardRef<HTMLSpanElement, {children: string; containerScope: boolean}>(
+  forwardRef<HTMLSpanElement, {children: string; isInNewPipeline: boolean}>(
     (props, ref) => {
-      if (props.containerScope) {
+      if (props.isInNewPipeline) {
         return (
           <span data-pt-text ref={ref}>
             {props.children}
@@ -155,14 +155,14 @@ const MemoizedText = memo(
 
 const ZeroWidthString = (props: {isLineBreak?: boolean}) => {
   const {isLineBreak = false} = props
-  const containerScope = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
 
   const slateValue = isLineBreak ? 'n' : 'z'
   const attributes: {
     'data-slate-zero-width'?: string
     'data-pt-zero-width': true
     'data-pt-line-break'?: true
-  } = containerScope
+  } = isInNewPipeline
     ? {
         'data-pt-zero-width': true,
         ...(isLineBreak ? {'data-pt-line-break': true as const} : {}),

--- a/packages/editor/src/slate/react/components/text.tsx
+++ b/packages/editor/src/slate/react/components/text.tsx
@@ -3,7 +3,7 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import React, {useContext, type JSX} from 'react'
-import {ParentContainerContext} from '../../../editor/parent-container-context'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import {serializePath} from '../../../paths/serialize-path'
 import {isTextDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -61,12 +61,12 @@ const Text = (props: {
   }
 
   const dataPath = serializePath(path)
-  const containerScope = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
 
   const attributes: {
     'data-slate-node'?: 'text'
     'data-pt-path': string
-  } = containerScope
+  } = isInNewPipeline
     ? {
         'data-pt-path': dataPath,
       }

--- a/packages/editor/src/slate/react/hooks/use-children.tsx
+++ b/packages/editor/src/slate/react/hooks/use-children.tsx
@@ -4,7 +4,8 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import {isSpan, isTextBlock} from '@portabletext/schema'
-import React, {useCallback, type JSX} from 'react'
+import React, {useCallback, useContext, type JSX} from 'react'
+import {NewPipelineContext} from '../../../editor/new-pipeline-context'
 import {
   ParentContainerContext,
   useParentContainer,
@@ -76,6 +77,7 @@ const useChildren = (props: {
   editor.isNodeMapDirty = false
 
   const parentContainer = useParentContainer()
+  const parentIsInNewPipeline = useContext(NewPipelineContext)
 
   const decorationsByChild = useDecorationsByChild(
     editor,
@@ -154,6 +156,31 @@ const useChildren = (props: {
     ? node
     : undefined
 
+  /**
+   * Wrap a rendered child in `NewPipelineContext.Provider value={true}`
+   * when needed. `parentIsInNewPipeline` already true ⇒ context is
+   * inherited; no extra wrap. Otherwise, wrap when the child itself
+   * kicks off a new-pipeline subtree at this position.
+   */
+  const wrapNewPipeline = (
+    child: React.ReactNode,
+    isInNewPipelineForChild: boolean,
+    key: string,
+  ): React.ReactNode => {
+    if (parentIsInNewPipeline) {
+      // Already inside a new-pipeline subtree; the child inherits.
+      return child
+    }
+    if (!isInNewPipelineForChild) {
+      return child
+    }
+    return (
+      <NewPipelineContext.Provider value={true} key={key}>
+        {child}
+      </NewPipelineContext.Provider>
+    )
+  }
+
   const renderTextComponent = (node: PortableTextSpan, index: number) => {
     if (!textBlockParent) {
       throw new Error(
@@ -180,11 +207,6 @@ const useChildren = (props: {
     )
   }
 
-  // `inContainer` is the effective container context the dispatched
-  // children will see: either the current node's own container (when we
-  // wrap below) or the inherited parent container otherwise.
-  const inContainer = Boolean(childContainer ?? parentContainer)
-
   const renderObjectNodeComponent = (
     node: PortableTextObject,
     index: number,
@@ -197,7 +219,6 @@ const useChildren = (props: {
     return (
       <ObjectNodeComponent
         decorations={decorationsByChild[index] ?? []}
-        inContainer={inContainer}
         isInline={textBlockParent !== undefined}
         key={node._key}
         objectNode={node}
@@ -207,9 +228,69 @@ const useChildren = (props: {
     )
   }
 
+  /**
+   * Compute whether the child kicks off a new-pipeline subtree. Used
+   * by `wrapNewPipeline` to decide whether to wrap the child in
+   * `NewPipelineContext.Provider value={true}`. `parentIsInNewPipeline`
+   * short-circuits to `true` upstream of this call.
+   */
+  const isInNewPipelineForChild = (n: Node, isContainerChild: boolean) => {
+    if (isContainerChild) {
+      return true
+    }
+    if (isTextBlock({schema: editor.schema}, n)) {
+      if (editor.textBlocks.has(n._type)) {
+        return true
+      }
+      if (parentContainer?.of) {
+        for (const entry of parentContainer.of) {
+          if ('textBlock' in entry && entry.textBlock.type === n._type) {
+            return true
+          }
+        }
+      }
+      return false
+    }
+    if (isObjectNode({schema: editor.schema}, n)) {
+      if (textBlockParent !== undefined) {
+        // Inline-object position: pipeline mode is inherited from the
+        // parent text block. An inline object never kicks off a new-
+        // pipeline subtree on its own — if the parent text block is in
+        // the new pipeline, `parentIsInNewPipeline` already short-
+        // circuits upstream; otherwise the inline object stays legacy
+        // so the DOM is consistent across the block.
+        return false
+      }
+      // Block object position
+      if (editor.blockObjects.has(n._type)) {
+        return true
+      }
+      if (parentContainer?.of) {
+        for (const entry of parentContainer.of) {
+          if ('blockObject' in entry && entry.blockObject.type === n._type) {
+            return true
+          }
+        }
+      }
+      return false
+    }
+    if (isSpan({schema: editor.schema}, n)) {
+      // Span position: pipeline mode is inherited from the parent text
+      // block, same as inline objects above. `parentIsInNewPipeline`
+      // short-circuits upstream when the text block is itself in the
+      // new pipeline.
+      return false
+    }
+    return false
+  }
+
   const elements = children.map((n: Node, i: number) => {
     if (isTextBlock({schema: editor.schema}, n)) {
-      return renderElementComponent(n, i, false)
+      return wrapNewPipeline(
+        renderElementComponent(n, i, false),
+        isInNewPipelineForChild(n, false),
+        n._key,
+      )
     }
     // Fallback for text block nodes without `children`
     if (isTextBlockNode({schema: editor.schema}, n)) {
@@ -219,12 +300,20 @@ const useChildren = (props: {
       // Does `n` resolve as a container at this position?
       // (positional override in childContainer.container.of, or global)
       if (resolveContainerForNode(editor, childContainer, n)) {
-        return renderElementComponent(n, i, true)
+        return wrapNewPipeline(renderElementComponent(n, i, true), true, n._key)
       }
-      return renderObjectNodeComponent(n, i)
+      return wrapNewPipeline(
+        renderObjectNodeComponent(n, i),
+        isInNewPipelineForChild(n, false),
+        n._key,
+      )
     }
     if (isSpan({schema: editor.schema}, n)) {
-      return renderTextComponent(n, i)
+      return wrapNewPipeline(
+        renderTextComponent(n, i),
+        isInNewPipelineForChild(n, false),
+        n._key,
+      )
     }
     // Fallback for span nodes without `text`
     if (isSpanNode({schema: editor.schema}, n)) {
@@ -234,9 +323,16 @@ const useChildren = (props: {
   })
 
   if (childContainer && childContainer !== parentContainer) {
+    // `useChildren` is running for a node that is itself a registered
+    // container. Wrap its children in `ParentContainerContext` (so
+    // positional `of` lookups resolve against this container) AND in
+    // `NewPipelineContext.Provider value={true}` (so descendants emit
+    // the new-pipeline DOM shape).
     return (
       <ParentContainerContext value={childContainer}>
-        {elements}
+        <NewPipelineContext.Provider value={true}>
+          {elements}
+        </NewPipelineContext.Provider>
       </ParentContainerContext>
     )
   }

--- a/packages/editor/tests/define-leaf-block-object-wrapper.test.tsx
+++ b/packages/editor/tests/define-leaf-block-object-wrapper.test.tsx
@@ -50,7 +50,7 @@ describe('defineBlockObject void block-object wrapper contract', () => {
       expect(outer!.getAttribute('contenteditable')).toEqual(null)
 
       // The void spacer reaches the consumer through children and is NOT inside the contentEditable=false subtree.
-      const spacer = outer!.querySelector('[data-slate-spacer]')
+      const spacer = outer!.querySelector('[data-pt-spacer]')
       expect(spacer).not.toEqual(null)
       expect(inner!.contains(spacer)).toEqual(false)
     })

--- a/packages/editor/tests/define-leaf-inline-object-spacer.test.tsx
+++ b/packages/editor/tests/define-leaf-inline-object-spacer.test.tsx
@@ -56,7 +56,7 @@ describe('defineLeaf void spacer', () => {
       )
       expect(consumerSpan).not.toEqual(null)
 
-      const spacer = consumerSpan!.querySelector('[data-slate-spacer]')
+      const spacer = consumerSpan!.querySelector('[data-pt-spacer]')
       expect(spacer).not.toEqual(null)
     })
   })
@@ -88,7 +88,7 @@ describe('defineLeaf void spacer', () => {
       const consumerDiv = document.querySelector('[data-testid="image"]')
       expect(consumerDiv).not.toEqual(null)
 
-      const spacer = consumerDiv!.querySelector('[data-slate-spacer]')
+      const spacer = consumerDiv!.querySelector('[data-pt-spacer]')
       expect(spacer).not.toEqual(null)
     })
   })

--- a/packages/editor/tests/inline-object-contenteditable.test.tsx
+++ b/packages/editor/tests/inline-object-contenteditable.test.tsx
@@ -52,9 +52,7 @@ describe('inline-object void wrapper contenteditable', () => {
       // The legacy pipeline is in play (no `ContainerPlugin`); confirm
       // by checking that `object-node.tsx` emitted the `data-slate-spacer`
       // variant of the inline-void spacer.
-      expect(consumerSpan!.querySelector('[data-slate-spacer]')).not.toEqual(
-        null,
-      )
+      expect(consumerSpan!.querySelector('[data-pt-spacer]')).not.toEqual(null)
       expect(consumerSpan!.getAttribute('contenteditable')).toEqual('false')
     })
   })

--- a/packages/editor/tests/inline-pipeline-mode-inheritance.test.tsx
+++ b/packages/editor/tests/inline-pipeline-mode-inheritance.test.tsx
@@ -1,0 +1,224 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineInlineObject,
+  defineSpan,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Inline pipeline mode inherits from the text block. Spans and inline
+ * objects MUST NOT initiate a new-pipeline subtree on their own — if
+ * they did, a legacy text block could end up with new-pipeline inline
+ * children, producing inconsistent DOM (legacy attrs on the outer
+ * block, clean `data-pt-*` only on the inline subtree).
+ *
+ * The four tests below pin both directions of the contract:
+ *
+ *   - Tests 1 & 2: a registered inline node inside an UNregistered
+ *     text block keeps legacy attributes on its wrapper (inherits
+ *     legacy from the parent text block).
+ *   - Tests 3 & 4: the same inline node inside a REGISTERED text
+ *     block emits clean `data-pt-*` attributes (inherits new pipeline
+ *     from the parent text block).
+ */
+
+function getEditorHTML(): string {
+  const root = document.querySelector('[role="textbox"]')
+  if (!root) {
+    throw new Error('No editor with role="textbox"')
+  }
+  return root.innerHTML
+}
+
+function getInlineWrapperAttrs(testid: string): string {
+  const element = document.querySelector(`[data-testid="${testid}"]`)
+  if (!element) {
+    throw new Error(`No element with data-testid="${testid}"`)
+  }
+  // Extract attributes from the wrapper element itself (not children).
+  return Array.from(element.attributes)
+    .map((a) => `${a.name}="${a.value}"`)
+    .join(' ')
+}
+
+describe('inline pipeline mode inherits from text block', () => {
+  test('registered inline-object inside LEGACY text block keeps data-slate-* attributes on its wrapper', async () => {
+    const schema = defineSchema({
+      inlineObjects: [{name: 'mention', fields: []}],
+    })
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: ({attributes, children}) => (
+        <span data-testid="mention-wrapper" {...attributes}>
+          {children}
+          <span>@alice</span>
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'm0', _type: 'mention'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const editorHTML = getEditorHTML()
+      // Sanity: the text block is legacy (data-slate-node="element" on it).
+      expect(editorHTML).toMatch(/data-slate-node="element"/)
+      // The mention is rendered.
+      expect(editorHTML).toContain('@alice')
+      // The mention wrapper's own attributes include legacy data-slate-*.
+      const attrs = getInlineWrapperAttrs('mention-wrapper')
+      expect(attrs).toMatch(/data-slate-/)
+    })
+  })
+
+  test('registered span inside LEGACY text block keeps data-slate-* attributes on its wrapper', async () => {
+    const schema = defineSchema({})
+    const span = defineSpan({
+      type: 'span',
+      render: ({attributes, children}) => (
+        <span data-testid="span-wrapper" {...attributes}>
+          {children}
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[span]} />,
+    })
+
+    await vi.waitFor(() => {
+      const editorHTML = getEditorHTML()
+      // Sanity: the text block is legacy.
+      expect(editorHTML).toMatch(/data-slate-node="element"/)
+      // The span is rendered.
+      expect(editorHTML).toContain('hello')
+      // The span wrapper's own attributes include legacy data-slate-*.
+      const attrs = getInlineWrapperAttrs('span-wrapper')
+      expect(attrs).toMatch(/data-slate-/)
+    })
+  })
+
+  test('registered inline-object inside REGISTERED text block emits clean data-pt-* on its wrapper', async () => {
+    const schema = defineSchema({
+      inlineObjects: [{name: 'mention', fields: []}],
+    })
+    const richBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="textblock-wrapper" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: ({attributes, children}) => (
+        <span data-testid="mention-wrapper" {...attributes}>
+          {children}
+          <span>@alice</span>
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'm0', _type: 'mention'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[richBlock, mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      // The mention is rendered.
+      expect(getEditorHTML()).toContain('@alice')
+      // The mention wrapper's own attributes are clean.
+      const attrs = getInlineWrapperAttrs('mention-wrapper')
+      expect(attrs).toMatch(/data-pt-/)
+      expect(attrs).not.toMatch(/data-slate-/)
+    })
+  })
+
+  test('registered span inside REGISTERED text block emits clean data-pt-* on its wrapper', async () => {
+    const schema = defineSchema({})
+    const richBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="textblock-wrapper" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const span = defineSpan({
+      type: 'span',
+      render: ({attributes, children}) => (
+        <span data-testid="span-wrapper" {...attributes}>
+          {children}
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[richBlock, span]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(getEditorHTML()).toContain('hello')
+      const attrs = getInlineWrapperAttrs('span-wrapper')
+      expect(attrs).toMatch(/data-pt-/)
+      expect(attrs).not.toMatch(/data-slate-/)
+    })
+  })
+})

--- a/packages/editor/tests/legacy-suppression.test.tsx
+++ b/packages/editor/tests/legacy-suppression.test.tsx
@@ -1,0 +1,360 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineContainer,
+  defineInlineObject,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Legacy-suppression contract for the new render pipeline.
+ *
+ * Once a position is inside a `registerNode`-shaped subtree, the four
+ * block-level legacy `renderX` hooks (renderBlock, renderListItem,
+ * renderStyle, renderChild) are suppressed. The four span/leaf-level
+ * hooks (renderDecorator, renderAnnotation, renderPlaceholder, range
+ * decorations) keep firing because they operate at the leaf level on
+ * span text - they wrap runs of text and don't emit pipeline-shaped
+ * wrappers themselves.
+ *
+ * Each `legacy.renderX` callback is provided as a spy; assertions
+ * verify the call count is 0 (suppressed) or non-zero (still firing).
+ */
+
+describe('legacy-suppression contract', () => {
+  test('top-level defineTextBlock with unregistered inline-object child does not call legacy.renderChild', async () => {
+    const schema = defineSchema({
+      inlineObjects: [{name: 'mention', fields: []}],
+    })
+    const textBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="text" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const renderChild = vi.fn(({children}) => <span>{children}</span>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'm0', _type: 'mention'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      editableProps: {renderChild},
+      children: <NodePlugin nodes={[textBlock]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="text"]')
+      expect(root).not.toEqual(null)
+      // Unregistered inline-object placeholder fires in new pipeline
+      expect(root!.innerHTML).toContain('[mention: m0]')
+    })
+
+    // legacy.renderChild MUST NOT fire for the mention inside a new-pipeline text block
+    const mentionRenderChildCalls = renderChild.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'mention',
+    )
+    expect(mentionRenderChildCalls.length).toEqual(0)
+  })
+
+  test('top-level defineContainer with unregistered block-object child does not call legacy.renderBlock for that child', async () => {
+    const schema = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {type: 'block'},
+                {type: 'object', name: 'divider', fields: []},
+              ],
+            },
+          ],
+        },
+        {name: 'divider', fields: []},
+      ],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <div data-testid="callout" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const renderBlock = vi.fn(({children}) => <div>{children}</div>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+            {_key: 'd0', _type: 'divider'},
+          ],
+        },
+      ],
+      editableProps: {renderBlock},
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="callout"]')
+      expect(root).not.toEqual(null)
+      // Unregistered block-object placeholder fires in new pipeline
+      expect(root!.innerHTML).toContain('[divider: d0]')
+    })
+
+    // legacy.renderBlock MUST NOT fire for the divider inside the new-pipeline container
+    const dividerRenderBlockCalls = renderBlock.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'divider',
+    )
+    expect(dividerRenderBlockCalls.length).toEqual(0)
+  })
+
+  test('top-level defineTextBlock with styled span DOES call legacy.renderDecorator', async () => {
+    const schema = defineSchema({
+      decorators: [{name: 'strong'}],
+    })
+    const textBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="text" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const renderDecorator = vi.fn(({children}) => <strong>{children}</strong>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'bold text', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      editableProps: {renderDecorator},
+      children: <NodePlugin nodes={[textBlock]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="text"]')
+      expect(root).not.toEqual(null)
+      // <strong> from renderDecorator must be present
+      expect(root!.innerHTML).toContain('<strong>')
+    })
+
+    expect(renderDecorator).toHaveBeenCalled()
+  })
+
+  test('top-level defineTextBlock with annotated span DOES call legacy.renderAnnotation', async () => {
+    const schema = defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+    const textBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="text" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+    const renderAnnotation = vi.fn(({children}) => (
+      <a href="https://x">{children}</a>
+    ))
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'linked', marks: ['m1']},
+          ],
+          markDefs: [{_key: 'm1', _type: 'link', href: 'https://x'}],
+          style: 'normal',
+        },
+      ],
+      editableProps: {renderAnnotation},
+      children: <NodePlugin nodes={[textBlock]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="text"]')
+      expect(root).not.toEqual(null)
+      expect(root!.innerHTML).toContain('<a href="https://x">')
+    })
+
+    expect(renderAnnotation).toHaveBeenCalled()
+  })
+
+  test('top-level defineBlockObject value does not call legacy.renderBlock', async () => {
+    const schema = defineSchema({
+      blockObjects: [{name: 'divider', fields: []}],
+    })
+    const divider = defineBlockObject({
+      type: 'divider',
+      render: ({attributes, children}) => (
+        <div data-testid="divider" {...attributes}>
+          {children}
+          <hr />
+        </div>
+      ),
+    })
+    const renderBlock = vi.fn(({children}) => <div>{children}</div>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [{_key: 'k0', _type: 'divider'}],
+      editableProps: {renderBlock},
+      children: <NodePlugin nodes={[divider]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="divider"]')
+      expect(root).not.toEqual(null)
+    })
+
+    // legacy.renderBlock MUST NOT fire for the registered divider
+    const dividerCalls = renderBlock.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'divider',
+    )
+    expect(dividerCalls.length).toEqual(0)
+  })
+
+  test('top-level defineInlineObject value does not call legacy.renderChild', async () => {
+    const schema = defineSchema({
+      inlineObjects: [{name: 'mention', fields: []}],
+    })
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: ({attributes, children}) => (
+        <span data-testid="mention" {...attributes}>
+          {children}
+          @x
+        </span>
+      ),
+    })
+    const renderChild = vi.fn(({children}) => <span>{children}</span>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'm0', _type: 'mention'},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      editableProps: {renderChild},
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = document.querySelector('[data-testid="mention"]')
+      expect(root).not.toEqual(null)
+    })
+
+    // legacy.renderChild MUST NOT fire for the registered mention
+    const mentionCalls = renderChild.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'mention',
+    )
+    expect(mentionCalls.length).toEqual(0)
+  })
+
+  test('mixed pipeline: legacy block beside new-pipeline block - legacy hook fires for the legacy block, not for the registered one', async () => {
+    const schema = defineSchema({
+      blockObjects: [{name: 'divider', fields: []}],
+    })
+    const divider = defineBlockObject({
+      type: 'divider',
+      render: ({attributes, children}) => (
+        <div data-testid="divider" {...attributes}>
+          {children}
+          <hr />
+        </div>
+      ),
+    })
+    const renderBlock = vi.fn(({children}) => <div data-rb>{children}</div>)
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'legacy', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {_key: 'k0', _type: 'divider'},
+      ],
+      editableProps: {renderBlock},
+      children: <NodePlugin nodes={[divider]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="divider"]')).not.toEqual(
+        null,
+      )
+    })
+
+    // legacy.renderBlock fires for the legacy block (the plain text block)
+    const legacyBlockCalls = renderBlock.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'block',
+    )
+    expect(legacyBlockCalls.length).toBeGreaterThan(0)
+
+    // ...but NOT for the registered divider
+    const dividerCalls = renderBlock.mock.calls.filter(
+      ([props]: [{value: {_type: string}}]) => props.value._type === 'divider',
+    )
+    expect(dividerCalls.length).toEqual(0)
+  })
+})

--- a/packages/editor/tests/positional-override-block-level.test.tsx
+++ b/packages/editor/tests/positional-override-block-level.test.tsx
@@ -12,24 +12,27 @@ import {createTestEditor} from '../src/test/vitest'
 /**
  * Block-level positional override composition.
  *
- * For each block-level kind (container, textBlock, blockObject), five
+ * For each block-level kind (container, textBlock, blockObject), the
  * resolution cases are pinned:
  *
  *   1. Global render at top-level NodePlugin fires when no positional
  *      override exists at the position.
  *   2. Positional `render: fn` in a parent container's `of` overrides
  *      any global registration at that position.
- *   3. Positional `render: null` uses engine default, skipping any
- *      global registration.
+ *   3b. Positional `render: (props) => props.renderDefault(props)`
+ *       renders the engine default at this position (canonical way to
+ *       opt into the engine default while shadowing global).
  *   4. Positional `of: [...]` with no `render` falls through to the
  *      global render when one is registered.
  *   5. Positional `of: [...]` with no `render` falls through to engine
  *      default when no global render is registered.
  *
- * `render: null` (config-time) discriminates "explicitly default" from
- * `render` absent ("fall through to global"). Positional placement is
- * the consumer's act of taking control of the resolution chain at this
- * position.
+ * Three registration-time modes of `render`:
+ * - omitted (`undefined`): no positional override registered; falls
+ *   through to global.
+ * - function: registers an override using the function. The function
+ *   receives a `renderDefault` prop that returns the engine default
+ *   when called.
  */
 
 const calloutSchema = defineSchema({
@@ -196,7 +199,7 @@ describe('Block-level positional override: defineContainer', () => {
     })
   })
 
-  test('3. Positional `render: null` uses engine default, skipping global', async () => {
+  test('3b. Positional `render: (props) => props.renderDefault(props)` renders engine default at this position', async () => {
     const keyGenerator = createTestKeyGenerator()
     const rowGlobal = defineContainer({
       type: 'row',
@@ -210,7 +213,7 @@ describe('Block-level positional override: defineContainer', () => {
     const rowPositionalDefault = defineContainer({
       type: 'row',
       arrayField: 'cells',
-      render: null,
+      render: (props) => props.renderDefault(props),
     })
     const table = defineContainer({
       type: 'table',
@@ -253,13 +256,10 @@ describe('Block-level positional override: defineContainer', () => {
     })
 
     await vi.waitFor(() => {
-      // Neither global nor positional consumer-render is on the DOM.
+      // Global consumer-render is shadowed by the positional override.
       expect(document.querySelector('[data-testid="row-global"]')).toEqual(null)
-      // The table outer is the consumer-rendered wrapper. Inside it,
-      // the row was rendered by the engine default - a plain wrapper
-      // carrying `data-pt-block="container"`. Asserting both pins the
-      // "use default at this position" branch (vs the resolver
-      // silently dropping the override).
+      // The positional render delegated to `props.renderDefault(props)` so
+      // the engine default wrapper is present at this position.
       const tableEl = document.querySelector('[data-testid="table"]')
       expect(tableEl).not.toEqual(null)
       const rowEl = tableEl!.querySelector(
@@ -504,7 +504,7 @@ describe('Block-level positional override: defineTextBlock', () => {
     })
   })
 
-  test('3. Positional `render: null` uses engine default, skipping global', async () => {
+  test('3b. Positional `render: (props) => props.renderDefault(props)` renders engine default at this position', async () => {
     const keyGenerator = createTestKeyGenerator()
     const globalBlock = defineTextBlock({
       type: 'block',
@@ -516,7 +516,7 @@ describe('Block-level positional override: defineTextBlock', () => {
     })
     const calloutBlockDefault = defineTextBlock({
       type: 'block',
-      render: null,
+      render: (props) => props.renderDefault(props),
     })
     const callout = defineContainer({
       type: 'callout',
@@ -555,13 +555,12 @@ describe('Block-level positional override: defineTextBlock', () => {
     await vi.waitFor(() => {
       const calloutEl = document.querySelector('[data-testid="callout"]')
       expect(calloutEl).not.toEqual(null)
-      // Global render is shadowed at this position.
+      // Global render shadowed by the positional override.
       expect(calloutEl!.querySelector('[data-testid="block-global"]')).toEqual(
         null,
       )
-      // Engine default renders the text block with `data-pt-block="text"`
-      // - the resolver consulted the positional `render: null` and
-      // produced the default wrapper at this position.
+      // `props.renderDefault(props)` produced the engine default wrapper at
+      // this position.
       const defaultBlock = calloutEl!.querySelector('[data-pt-block="text"]')
       expect(defaultBlock).not.toEqual(null)
       expect(defaultBlock!.textContent).toContain('inside')
@@ -761,7 +760,7 @@ describe('Block-level positional override: defineBlockObject', () => {
     })
   })
 
-  test('3. Positional `render: null` uses engine default, skipping global', async () => {
+  test('3b. Positional `render: (props) => props.renderDefault(props)` renders engine default at this position', async () => {
     const keyGenerator = createTestKeyGenerator()
     const globalImage = defineBlockObject({
       type: 'image',
@@ -773,7 +772,7 @@ describe('Block-level positional override: defineBlockObject', () => {
     })
     const calloutImageDefault = defineBlockObject({
       type: 'image',
-      render: null,
+      render: (props) => props.renderDefault(props),
     })
     const callout = defineContainer({
       type: 'callout',
@@ -802,12 +801,12 @@ describe('Block-level positional override: defineBlockObject', () => {
     await vi.waitFor(() => {
       const calloutEl = document.querySelector('[data-testid="callout"]')
       expect(calloutEl).not.toEqual(null)
+      // Global consumer-render shadowed.
       expect(calloutEl!.querySelector('[data-testid="image-global"]')).toEqual(
         null,
       )
-      // Engine default for block-objects emits a data attribute on
-      // the wrapper. Asserting the absence of the global render plus
-      // presence of the engine wrapper pins the "use default" branch.
+      // `props.renderDefault(props)` produced the engine default wrapper at
+      // this position.
       expect(calloutEl!.querySelector('[data-pt-block="object"]')).not.toEqual(
         null,
       )

--- a/packages/editor/tests/positional-override-inline-level.test.tsx
+++ b/packages/editor/tests/positional-override-inline-level.test.tsx
@@ -17,8 +17,14 @@ import {createTestEditor} from '../src/test/vitest'
  * BLOCK's `of` array, NOT a container's `of`. The natural parent of
  * an inline child is the text block that owns its `children` field.
  *
- * Same five resolution cases as block-level, but scoped through
- * `defineTextBlock.of` instead of `defineContainer.of`.
+ * Same resolution cases as block-level, but scoped through
+ * `defineTextBlock.of` instead of `defineContainer.of`:
+ *
+ *   1. Global render fires when no positional override exists.
+ *   2. Positional `render: fn` overrides global at this position.
+ *   3b. Positional `render: (props) => props.renderDefault(props)`
+ *       renders the engine default at this position.
+ *   4. Positional with no `render` falls through to global.
  */
 
 const mentionSchema = defineSchema({
@@ -150,7 +156,7 @@ describe('Inline-level positional override: defineInlineObject', () => {
     })
   })
 
-  test('3. Positional render: null uses engine default, skipping global', async () => {
+  test('3b. Positional render: (props) => props.renderDefault(props) renders engine default at this position', async () => {
     const globalMention = defineInlineObject({
       type: 'mention',
       render: ({attributes, children}) => (
@@ -159,11 +165,14 @@ describe('Inline-level positional override: defineInlineObject', () => {
         </span>
       ),
     })
-    const calloutMention = defineInlineObject({type: 'mention', render: null})
+    const calloutMentionDefault = defineInlineObject({
+      type: 'mention',
+      render: (props) => props.renderDefault(props),
+    })
     const calloutBlock = defineTextBlock({
       type: 'block',
       render: ({attributes, children}) => <p {...attributes}>{children}</p>,
-      of: [calloutMention],
+      of: [calloutMentionDefault],
     })
     const callout = defineContainer({
       type: 'callout',
@@ -186,13 +195,12 @@ describe('Inline-level positional override: defineInlineObject', () => {
     await vi.waitFor(() => {
       const calloutEl = document.querySelector('[data-testid="callout"]')
       expect(calloutEl).not.toEqual(null)
+      // Global consumer-render shadowed by the positional override.
       expect(
         calloutEl!.querySelector('[data-testid="mention-global"]'),
       ).toEqual(null)
-      // Engine default for inline-objects emits `data-pt-inline="object"`.
-      // Asserting the wrapper is present pins the "use default at this
-      // position" branch (vs the resolver silently dropping the
-      // override).
+      // `props.renderDefault(props)` produced the engine default wrapper at
+      // this position.
       expect(calloutEl!.querySelector('[data-pt-inline="object"]')).not.toEqual(
         null,
       )
@@ -358,7 +366,7 @@ describe('Inline-level positional override: defineSpan', () => {
     })
   })
 
-  test('3. Positional render: null uses engine default, skipping global', async () => {
+  test('3b. Positional render: (props) => props.renderDefault(props) renders engine default at this position', async () => {
     const globalSpan = defineSpan({
       type: 'span',
       render: ({attributes, children}) => (
@@ -367,11 +375,14 @@ describe('Inline-level positional override: defineSpan', () => {
         </span>
       ),
     })
-    const calloutSpan = defineSpan({type: 'span', render: null})
+    const calloutSpanDefault = defineSpan({
+      type: 'span',
+      render: (props) => props.renderDefault(props),
+    })
     const calloutBlock = defineTextBlock({
       type: 'block',
       render: ({attributes, children}) => <p {...attributes}>{children}</p>,
-      of: [calloutSpan],
+      of: [calloutSpanDefault],
     })
     const callout = defineContainer({
       type: 'callout',
@@ -394,13 +405,13 @@ describe('Inline-level positional override: defineSpan', () => {
     await vi.waitFor(() => {
       const calloutEl = document.querySelector('[data-testid="callout"]')
       expect(calloutEl).not.toEqual(null)
+      // Global consumer-render shadowed.
       expect(calloutEl!.querySelector('[data-testid="span-global"]')).toEqual(
         null,
       )
-      // The positional text-block render fired (the consumer's `<p>`),
-      // proving the resolver chain reached down to the inline level.
-      // The span fell through to the engine default - a leaf-carrying
-      // `<span>` with `data-pt-marks`.
+      // `props.renderDefault(props)` produced the engine default wrapper at
+      // this position - the leaf-carrying `<span>` with `data-pt-marks`
+      // is back on the DOM.
       const blockEl = calloutEl!.querySelector('p')
       expect(blockEl).not.toEqual(null)
       const leafEl = blockEl!.querySelector('[data-pt-marks]')

--- a/packages/editor/tests/register-node-clean-dom.test.tsx
+++ b/packages/editor/tests/register-node-clean-dom.test.tsx
@@ -1,0 +1,220 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineContainer,
+  defineInlineObject,
+  defineSpan,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * The load-bearing TDD contract for PR #2681: any subtree rendered
+ * through `registerNode` (the new pipeline) must emit ZERO
+ * `data-slate-*` attributes. The engine's legacy pipeline still emits
+ * `data-slate-*` for backwards compatibility with consumers that walk
+ * Slate-shaped DOM; the new pipeline strictly emits `data-pt-*` only.
+ *
+ * One assertion per kind. If any of these fail, a registration
+ * mechanism is leaking legacy attrs into the new pipeline.
+ */
+
+function getSubtreeHTML(testid: string): string {
+  const root = document.querySelector(`[data-testid="${testid}"]`)
+  if (!root) {
+    throw new Error(`No element with data-testid="${testid}"`)
+  }
+  return root.innerHTML
+}
+
+describe('register-node-clean-dom', () => {
+  test('container subtree emits zero data-slate-* attrs', async () => {
+    const schema = defineSchema({
+      blockObjects: [
+        {
+          name: 'callout',
+          fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+        },
+      ],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <div data-testid="callout-subtree" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      const html = getSubtreeHTML('callout-subtree')
+      expect(html).toMatch(/data-pt-/)
+      expect(html.match(/data-slate-/g)).toBeNull()
+    })
+  })
+
+  test('text-block subtree emits zero data-slate-* attrs', async () => {
+    const schema = defineSchema({})
+    const richBlock = defineTextBlock({
+      type: 'block',
+      render: ({attributes, children}) => (
+        <div data-testid="textblock-subtree" {...attributes}>
+          {children}
+        </div>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[richBlock]} />,
+    })
+
+    await vi.waitFor(() => {
+      const html = getSubtreeHTML('textblock-subtree')
+      expect(html).toMatch(/data-pt-/)
+      expect(html.match(/data-slate-/g)).toBeNull()
+    })
+  })
+
+  test('block-object subtree emits zero data-slate-* attrs', async () => {
+    const schema = defineSchema({
+      blockObjects: [{name: 'divider', fields: []}],
+    })
+    const divider = defineBlockObject({
+      type: 'divider',
+      render: ({attributes, children}) => (
+        <div data-testid="blockobject-subtree" {...attributes}>
+          {children}
+          <hr />
+        </div>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [{_key: 'k0', _type: 'divider'}],
+      children: <NodePlugin nodes={[divider]} />,
+    })
+
+    await vi.waitFor(() => {
+      const html = getSubtreeHTML('blockobject-subtree')
+      expect(html).toMatch(/data-pt-/)
+      expect(html.match(/data-slate-/g)).toBeNull()
+    })
+  })
+
+  test('inline-object subtree emits zero data-slate-* attrs', async () => {
+    const schema = defineSchema({
+      inlineObjects: [{name: 'mention', fields: []}],
+    })
+    // Register the text block too, otherwise inline content stays in
+    // the legacy pipeline (it inherits its pipeline mode from the
+    // parent text block — see `inline-pipeline-mode-inheritance.test.tsx`).
+    const richBlock = defineTextBlock({type: 'block'})
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: ({attributes, children}) => (
+        <span data-testid="inlineobject-subtree" {...attributes}>
+          {children}
+          <span>@alice</span>
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'm0', _type: 'mention'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[richBlock, mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const html = getSubtreeHTML('inlineobject-subtree')
+      expect(html).toMatch(/data-pt-/)
+      expect(html.match(/data-slate-/g)).toBeNull()
+    })
+  })
+
+  test('span subtree emits zero data-slate-* attrs', async () => {
+    const schema = defineSchema({})
+    // Register the text block too — span pipeline mode is inherited.
+    const richBlock = defineTextBlock({type: 'block'})
+    const span = defineSpan({
+      type: 'span',
+      render: ({attributes, children}) => (
+        <span data-testid="span-subtree" {...attributes}>
+          {children}
+        </span>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: schema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[richBlock, span]} />,
+    })
+
+    await vi.waitFor(() => {
+      const html = getSubtreeHTML('span-subtree')
+      expect(html).toMatch(/data-pt-/)
+      expect(html.match(/data-slate-/g)).toBeNull()
+    })
+  })
+})

--- a/packages/editor/tests/render-default-prop.test.tsx
+++ b/packages/editor/tests/render-default-prop.test.tsx
@@ -1,0 +1,482 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineContainer,
+  defineInlineObject,
+  defineSpan,
+  defineTextBlock,
+  type BlockObjectRender,
+  type ContainerRender,
+  type InlineObjectRender,
+  type SpanRender,
+  type TextBlockRender,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * `renderDefault` prop on the five Node API render callbacks.
+ *
+ * The prop is the engine's default-render function. Consumers call it
+ * to fall back to or wrap the engine default at this position. Three
+ * properties are pinned per kind:
+ *
+ *   (a) the prop is present in the callback's props object
+ *   (b) the prop is a function (callable)
+ *   (c) calling it produces the engine default wrapper
+ *
+ * Mirrors Studio's `renderDefault` pattern. PTE has no chained layer
+ * semantics for nodes - `renderDefault` is always the engine default,
+ * not "the next render layer down."
+ */
+
+const calloutSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const mentionSchema = defineSchema({
+  inlineObjects: [
+    {name: 'mention', fields: [{name: 'username', type: 'string'}]},
+  ],
+})
+
+const imageSchema = defineSchema({
+  blockObjects: [{name: 'image', fields: []}],
+})
+
+describe('renderDefault prop', () => {
+  test('Container: render receives renderDefault prop', async () => {
+    const renderSpy = vi.fn<(props: Parameters<ContainerRender>[0]) => void>()
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: (props) => {
+        renderSpy(props)
+        return props.renderDefault(props)
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(renderSpy).toHaveBeenCalled()
+    })
+    const props = renderSpy.mock.calls[0]![0]
+    expect(typeof props.renderDefault).toEqual('function')
+    expect(document.querySelector('[data-pt-block="container"]')).not.toEqual(
+      null,
+    )
+  })
+
+  test('TextBlock: render receives renderDefault prop', async () => {
+    const renderSpy = vi.fn<(props: Parameters<TextBlockRender>[0]) => void>()
+    const block = defineTextBlock({
+      type: 'block',
+      render: (props) => {
+        renderSpy(props)
+        return props.renderDefault(props)
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[block]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(renderSpy).toHaveBeenCalled()
+    })
+    const props = renderSpy.mock.calls[0]![0]
+    expect(typeof props.renderDefault).toEqual('function')
+    expect(document.querySelector('[data-pt-block="text"]')).not.toEqual(null)
+  })
+
+  test('BlockObject: render receives renderDefault prop', async () => {
+    const renderSpy = vi.fn<(props: Parameters<BlockObjectRender>[0]) => void>()
+    const image = defineBlockObject({
+      type: 'image',
+      render: (props) => {
+        renderSpy(props)
+        return props.renderDefault(props)
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: [{_key: 'i0', _type: 'image'}],
+      children: <NodePlugin nodes={[image]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(renderSpy).toHaveBeenCalled()
+    })
+    const props = renderSpy.mock.calls[0]![0]
+    expect(typeof props.renderDefault).toEqual('function')
+    expect(document.querySelector('[data-pt-block="object"]')).not.toEqual(null)
+  })
+
+  test('InlineObject: render receives renderDefault prop', async () => {
+    const renderSpy =
+      vi.fn<(props: Parameters<InlineObjectRender>[0]) => void>()
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: (props) => {
+        renderSpy(props)
+        return props.renderDefault(props)
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: mentionSchema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'i0', _type: 'mention', username: 'alice'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(renderSpy).toHaveBeenCalled()
+    })
+    const props = renderSpy.mock.calls[0]![0]
+    expect(typeof props.renderDefault).toEqual('function')
+    expect(document.querySelector('[data-pt-inline="object"]')).not.toEqual(
+      null,
+    )
+  })
+
+  test('Span: render receives renderDefault prop', async () => {
+    const renderSpy = vi.fn<(props: Parameters<SpanRender>[0]) => void>()
+    const span = defineSpan({
+      type: 'span',
+      render: (props) => {
+        renderSpy(props)
+        return props.renderDefault(props)
+      },
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[span]} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(renderSpy).toHaveBeenCalled()
+    })
+    const props = renderSpy.mock.calls[0]![0]
+    expect(typeof props.renderDefault).toEqual('function')
+  })
+})
+
+describe('renderDefault wraps default', () => {
+  test('Container: caller can wrap renderDefault output', async () => {
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: (props) => (
+        <div data-testid="wrap">{props.renderDefault(props)}</div>
+      ),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrap = document.querySelector('[data-testid="wrap"]')
+      expect(wrap).not.toEqual(null)
+      expect(wrap!.querySelector('[data-pt-block="container"]')).not.toEqual(
+        null,
+      )
+    })
+  })
+
+  test('Container: caller can modify props before delegating', async () => {
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({renderDefault, attributes, ...rest}) =>
+        renderDefault({
+          ...rest,
+          attributes: {...attributes, 'data-extra': 'x'},
+          renderDefault,
+        }),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _key: 'k0',
+          _type: 'callout',
+          content: [
+            {
+              _key: 'b0',
+              _type: 'block',
+              children: [{_key: 's0', _type: 'span', text: 'hi', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      const el = document.querySelector('[data-extra="x"]')
+      expect(el).not.toEqual(null)
+      expect(el!.getAttribute('data-pt-block')).toEqual('container')
+    })
+  })
+})
+
+describe('renderDefault for void objects renders [_type: _key] placeholder', () => {
+  test('BlockObject: omit render → renders [type: key] placeholder', async () => {
+    const image = defineBlockObject({type: 'image'})
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: [{_key: 'i0', _type: 'image'}],
+      children: <NodePlugin nodes={[image]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-block="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.textContent).toContain('[image: i0]')
+    })
+  })
+
+  test('BlockObject: render: (p) => p.renderDefault(p) → same placeholder', async () => {
+    const image = defineBlockObject({
+      type: 'image',
+      render: (props) => props.renderDefault(props),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: [{_key: 'i0', _type: 'image'}],
+      children: <NodePlugin nodes={[image]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-block="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.textContent).toContain('[image: i0]')
+    })
+  })
+
+  test('BlockObject: placeholder has userSelect: none and contentEditable false', async () => {
+    const image = defineBlockObject({type: 'image'})
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: [{_key: 'i0', _type: 'image'}],
+      children: <NodePlugin nodes={[image]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-block="object"]')
+      expect(wrapper).not.toEqual(null)
+      const placeholder = Array.from(wrapper!.querySelectorAll('div')).find(
+        (el) => el.textContent === '[image: i0]',
+      )
+      expect(placeholder).not.toEqual(undefined)
+      expect(placeholder!.getAttribute('contenteditable')).toEqual('false')
+      expect((placeholder! as HTMLElement).style.userSelect).toEqual('none')
+    })
+  })
+
+  test('InlineObject: omit render → renders [type: key] placeholder', async () => {
+    const mention = defineInlineObject({type: 'mention'})
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: mentionSchema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'i0', _type: 'mention', username: 'alice'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-inline="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.textContent).toContain('[mention: i0]')
+    })
+  })
+
+  test('InlineObject: render: (p) => p.renderDefault(p) → same placeholder', async () => {
+    const mention = defineInlineObject({
+      type: 'mention',
+      render: (props) => props.renderDefault(props),
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: mentionSchema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'i0', _type: 'mention', username: 'alice'},
+            {_key: 's1', _type: 'span', text: ' there', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-inline="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.textContent).toContain('[mention: i0]')
+    })
+  })
+
+  test('InlineObject: placeholder has userSelect: none and contentEditable false', async () => {
+    const mention = defineInlineObject({type: 'mention'})
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: mentionSchema,
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hi ', marks: []},
+            {_key: 'i0', _type: 'mention', username: 'alice'},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[mention]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-inline="object"]')
+      expect(wrapper).not.toEqual(null)
+      const placeholder = Array.from(wrapper!.querySelectorAll('span')).find(
+        (el) => el.textContent === '[mention: i0]',
+      )
+      expect(placeholder).not.toEqual(undefined)
+      expect(placeholder!.getAttribute('contenteditable')).toEqual('false')
+      expect((placeholder! as HTMLElement).style.userSelect).toEqual('none')
+    })
+  })
+
+  test('BlockObject: consumer can hide placeholder by ignoring renderDefault', async () => {
+    const image = defineBlockObject({
+      type: 'image',
+      render: (props) => <div {...props.attributes}>{props.children}</div>,
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: [{_key: 'i0', _type: 'image'}],
+      children: <NodePlugin nodes={[image]} />,
+    })
+
+    await vi.waitFor(() => {
+      const wrapper = document.querySelector('[data-pt-block="object"]')
+      expect(wrapper).not.toEqual(null)
+      expect(wrapper!.textContent).not.toContain('[image: i0]')
+    })
+  })
+})

--- a/packages/editor/tests/render-default-prop.test.tsx
+++ b/packages/editor/tests/render-default-prop.test.tsx
@@ -344,7 +344,7 @@ describe('renderDefault for void objects renders [_type: _key] placeholder', () 
     })
   })
 
-  test('BlockObject: placeholder has userSelect: none and contentEditable false', async () => {
+  test('BlockObject: placeholder has userSelect: none, contentEditable=false, and draggable matching readOnly', async () => {
     const image = defineBlockObject({type: 'image'})
 
     await createTestEditor({
@@ -362,6 +362,10 @@ describe('renderDefault for void objects renders [_type: _key] placeholder', () 
       )
       expect(placeholder).not.toEqual(undefined)
       expect(placeholder!.getAttribute('contenteditable')).toEqual('false')
+      // Mirrors legacy block-object DOM: both contentEditable+draggable on
+      // the same sibling-of-spacer wrapper. readOnly=false by default →
+      // draggable='true'.
+      expect(placeholder!.getAttribute('draggable')).toEqual('true')
       expect((placeholder! as HTMLElement).style.userSelect).toEqual('none')
     })
   })
@@ -427,7 +431,7 @@ describe('renderDefault for void objects renders [_type: _key] placeholder', () 
     })
   })
 
-  test('InlineObject: placeholder has userSelect: none and contentEditable false', async () => {
+  test('InlineObject: placeholder asymmetric contract - outer auto-has contentEditable=false, inner has draggable but no contentEditable', async () => {
     const mention = defineInlineObject({type: 'mention'})
 
     await createTestEditor({
@@ -451,11 +455,18 @@ describe('renderDefault for void objects renders [_type: _key] placeholder', () 
     await vi.waitFor(() => {
       const wrapper = document.querySelector('[data-pt-inline="object"]')
       expect(wrapper).not.toEqual(null)
+      // Outer auto-receives contentEditable=false via object-node.tsx's
+      // isInline && !readOnly branch (Slate-applied for inline voids).
+      expect(wrapper!.getAttribute('contenteditable')).toEqual('false')
       const placeholder = Array.from(wrapper!.querySelectorAll('span')).find(
         (el) => el.textContent === '[mention: i0]',
       )
       expect(placeholder).not.toEqual(undefined)
-      expect(placeholder!.getAttribute('contenteditable')).toEqual('false')
+      // Inner sibling-of-spacer: NO contentEditable (inherits from outer
+      // via DOM contentEditable inheritance). Mirrors v6 inline-object.
+      expect(placeholder!.getAttribute('contenteditable')).toEqual(null)
+      // Inner sibling carries draggable; readOnly=false default → 'true'.
+      expect(placeholder!.getAttribute('draggable')).toEqual('true')
       expect((placeholder! as HTMLElement).style.userSelect).toEqual('none')
     })
   })


### PR DESCRIPTION
This is the PR where the new render pipeline becomes proper.

The five Node API render callbacks (`defineContainer`, `defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`) receive a `renderDefault` prop. Calling it produces the engine's default-render wrapper at this position. Mirrors `renderDefault` on Sanity Studio's render APIs.

```tsx
defineContainer({
  type: 'callout',
  arrayField: 'children',
  render: (props) => (
    <div className="callout-frame">{props.renderDefault(props)}</div>
  ),
})
```

`renderDefault` takes the same props shape the callback receives, so consumers can ignore it (custom render), call it as-is (fall back to engine default at this position), wrap its result (decorate), or call it with modified props (fine-grained control).

The canonical idiom for "use the engine default here" is `(props) => props.renderDefault(props)`:

```tsx
defineContainer({
  type: 'callout',
  arrayField: 'children',
  render: (props) => props.renderDefault(props),
})
```

Return type is `ReactElement` - render functions must return an element. To request the engine default from inside a function render, call `renderDefault`. To register nothing at this position, omit the field entirely.

## Two pipelines, one engine

`registerNode` opts a subtree into the **new pipeline**: engine attributes are `data-pt-*` only, the legacy `data-slate-*` attributes are stripped, and the four block-level legacy render hooks (`renderBlock`, `renderListItem`, `renderStyle`, `renderChild`) are suppressed - the registered render owns the position.

Sibling subtrees with no `registerNode` registration stay in the **legacy pipeline**: both attribute namespaces emit and the legacy block-level hooks fire. Consumers on v6 keep the same DOM shape they've always had.

The two pipelines coexist per-position in the same editor. A registered block-object can sit beside a legacy text block; each subtree picks its own mode.

The four span/leaf-level render props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`, range decorations) keep firing in both pipelines because they operate at the leaf level on span text - they wrap runs of styled text rather than emit pipeline-shaped wrappers.

A `NewPipelineContext` boolean carries the per-position mode. `useChildren` wraps every new-pipeline child in `<NewPipelineContext.Provider value={true}>` so the five DOM emission sites (`element.tsx`, `object-node.tsx`, `text.tsx`, `leaf.tsx`, `string.tsx`) read one signal instead of guessing through `ParentContainerContext`.

## Engine defaults

Per kind, `renderDefault` returns:

| Kind | Default render |
|---|---|
| Container | `<div {...attributes}>{children}</div>` |
| TextBlock | `<div {...attributes}>{children}</div>` |
| Span | `<span {...attributes}>{children}</span>` |
| BlockObject | `<div {...attributes}>{children}<div contentEditable={false} draggable={!readOnly} style={{userSelect:'none'}}>[type: key]</div></div>` |
| InlineObject | `<span {...attributes}>{children}<span draggable={!readOnly} style={{userSelect:'none'}}>[type: key]</span></span>` |

The block/inline asymmetry mirrors the v6 legacy DOM:

- **Block objects** keep the outer editable - Slate's void caret semantics need the spacer caret anchor. `contentEditable={false}` and `draggable={!readOnly}` both land on the inner sibling-of-spacer wrapper.
- **Inline objects** auto-receive `contentEditable={false}` on the outer (engine-injected by `object-node.tsx` when `isInline && !readOnly`). The inner sibling carries `draggable={!readOnly}` alone; non-editability inherits through DOM `contentEditable` inheritance.

Engine-emitted `data-pt-*` attributes are already present on `attributes`. Same shape the engine renders when `render` is omitted entirely.

Void block objects and inline objects include a non-editable `[_type: _key]` placeholder so a registered node is visible before a consumer provides a custom `render`. The placeholder is `userSelect: 'none'` so it doesn't capture text selection. Consumers who want to hide the placeholder write a render that ignores `renderDefault`:

```tsx
defineBlockObject({
  type: 'image',
  render: (props) => <div {...props.attributes}>{props.children}</div>,
})
```

## Playground showcase

The playground now mixes both pipelines:

- The `image` block-object renders through legacy `renderBlock` (matching the v6 playground), showcasing the legacy pipeline alongside the new Node API.
- `CalloutPlugin`, `TablePlugin`, `CodeBlockPlugin`, `FactBoxPlugin` register through `NodePlugin` and use the new pipeline.
- Toggling any of those four plugins off in the feature flags gracefully degrades the corresponding block to a legacy `renderBlock` fallback - a read-only card with the block's flattened text content. Mirrors what consumers will see if a registered renderer disappears from their value.
- Plugin scoping cleaned up: `calloutImageLeaf` nested inside `calloutContainer.of` (was hijacking the global `image` registration) and `cellImageLeaf` lives inside `tableContainer`'s cell `of` (was colliding with the top-level `imageLeaf`).

## Tests

- `tests/register-node-clean-dom.test.tsx` (5 scenarios): the load-bearing falsifier - any subtree rendered through `registerNode` emits zero `data-slate-*` attributes, asserted across all five kinds.
- `tests/legacy-suppression.test.tsx` (7 scenarios): block-level legacy hooks suppressed inside new-pipeline subtrees; span/leaf-level hooks still fire; mixed-pipeline isolation pinned (legacy block beside registered block - legacy hook fires for the legacy one only).
- `tests/render-default-prop.test.tsx` (14 scenarios): `renderDefault` is present, callable, and produces the engine default for each of the five kinds. Plus wrap-default and modify-props scenarios. Plus placeholder scenarios for block-object and inline-object covering omit-render, `(p) => p.renderDefault(p)`, the asymmetric contentEditable+draggable contract (block has both on inner; inline auto-has contentEditable on outer + only draggable on inner), and the consumer-overrides-placeholder path.
- `tests/positional-override-block-level.test.tsx` + `tests/positional-override-inline-level.test.tsx`: scenario 3b pins `(props) => props.renderDefault(props)` as the canonical engine-default idiom across all five kinds.

## Spec

`/specs/render-default-prop.md` documents the locked rule and usage patterns.
`/specs/pr-2681-render-pipeline-audit.md` documents the two-mode pipeline contract, the asymmetric contentEditable contract, and the empirical verification recipe against the v6 branch.
