### PR TITLE
fix: gate `createHeadingRule` on the resolved style being present in the sub-schema

### DIFF
--- a/.changeset/heading-rule-codeblock-gate.md
+++ b/.changeset/heading-rule-codeblock-gate.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-markdown-shortcuts': patch
+---
+
+fix: gate `createHeadingRule` on the resolved style being present in the sub-schema

--- a/packages/plugin-markdown-shortcuts/src/rule.heading.ts
+++ b/packages/plugin-markdown-shortcuts/src/rule.heading.ts
@@ -52,6 +52,10 @@ export function createHeadingRule(config: {
         return false
       }
 
+      if (!subSchema.styles.some((s) => s.name === style)) {
+        return false
+      }
+
       return {match, style}
     },
     actions: [

--- a/packages/plugin-markdown-shortcuts/src/sub-schema.test.tsx
+++ b/packages/plugin-markdown-shortcuts/src/sub-schema.test.tsx
@@ -214,6 +214,100 @@ describe('Markdown shortcuts respect the sub-schema at the focus', () => {
     })
   })
 
+  test('typing `# ` when the headingStyle callback returns a style not in the sub-schema does not consume the keystroke', async () => {
+    const schemaDefinition = defineSchema({
+      styles: [{name: 'normal'}, {name: 'h1'}],
+      blockObjects: [
+        {
+          name: 'code-block',
+          fields: [
+            {
+              name: 'lines',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  decorators: [{name: 'code'}],
+                  styles: [{name: 'code'}],
+                  lists: [],
+                  annotations: [],
+                  inlineObjects: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const codeBlockContainer = defineContainer({
+      type: 'code-block',
+      arrayField: 'lines',
+      render: ({attributes, children}) => (
+        <pre data-testid="code-block" {...attributes}>
+          {children}
+        </pre>
+      ),
+    })
+
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'code-block',
+          _key: 'cb1',
+          lines: [
+            {
+              _type: 'block',
+              _key: 'l1',
+              children: [{_type: 'span', _key: 's1', text: '', marks: []}],
+              markDefs: [],
+              style: 'code',
+            },
+          ],
+        },
+      ],
+      children: (
+        <>
+          <NodePlugin nodes={[codeBlockContainer]} />
+          <MarkdownShortcutsPlugin
+            defaultStyle={({context}) => context.schema.styles[0]?.name}
+            // Buggy consumer callback: returns a style name unconditionally,
+            // even when the sub-schema at the focus does not declare it.
+            headingStyle={() => 'h1'}
+          />
+        </>
+      ),
+    })
+
+    const codeBlockElement = await vi.waitFor(() => {
+      const element = document.querySelector('[data-testid="code-block"]')
+      expect(element).not.toEqual(null)
+      return element!
+    })
+
+    await userEvent.click(codeBlockElement)
+    await userEvent.keyboard('# ')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'code-block',
+          _key: 'cb1',
+          lines: [
+            {
+              _type: 'block',
+              _key: 'l1',
+              children: [{_type: 'span', _key: 's1', text: '# ', marks: []}],
+              markDefs: [],
+              style: 'code',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
   test('typing a markdown link when no link annotation is declared does not consume the keystroke or move the caret', async () => {
     const schemaDefinition = defineSchema({
       decorators: [{name: 'strong'}],


### PR DESCRIPTION
The heading input rule for the markdown shortcuts plugin fires whenever `/^#+ /` matches at the start of the focus block, including in sub-schemas that do not declare any of the styles the consumer's `headingStyle` callback returns. The rule already bails when the callback returns `undefined`, but a buggy callback that returns a style name unconditionally - rather than guarding on whether it is in `context.schema.styles` - would cause the rule's actions to dispatch a `block.set` for an unknown style, swallowing the keystroke.

The rule now self-gates: after resolving the style via the callback, it checks that the style exists in the sub-schema at the focus. If not, the guard returns `false` and the input rule does nothing.

A new scenario in `sub-schema.test.tsx` pins the contract by using a deliberately buggy `headingStyle` callback that returns `'h1'` unconditionally inside a code-block sub-schema whose styles are `[{name: 'code'}]`. Typing `# ` now leaves the text as `"# "` instead of being consumed.
