### PR TITLE
fix: drag containers and block-objects via their decoration chrome

### DIFF
--- a/.changeset/fix-drag-from-chrome.md
+++ b/.changeset/fix-drag-from-chrome.md
@@ -1,0 +1,33 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: drag containers and block-objects via their decoration chrome
+
+Dragging a container (callout, blockquote, code-block, table) or
+block-object (image, hr) by a `contentEditable=false` decoration
+inside its render output - such as a block handle or drag affordance -
+now moves the entire block. Previously, the engine resolved the drag
+to the deepest text point inside the container, dropped the inner
+block at the destination, and left the container intact at the origin.
+The bug surfaced as "drag callout, get the callout's first paragraph;
+the callout stays put."
+
+Three independent layers needed fixing:
+
+- `getEventPosition` now recognizes when `dragstart.target` lives
+  inside a `contentEditable=false` subtree under a `data-pt-path`
+  ancestor (the decoration chrome) and resolves the position to the
+  block's own path instead of letting `caretPositionFromPoint`
+  recover a caret inside the block's text.
+- The internal-drag move-mimic uses `getSelectedBlocks` when the
+  drag origin is at the top level (path length 1) - which preserves
+  containers whole - and keeps using `getFragment` for deeper
+  origins (block-objects or text inside container cells), where
+  unwrapping to root-acceptable shape is still correct.
+- `operation.delete` with `unit:'block'` short-circuits when
+  `at` is collapsed on a block's path. The old flow ran
+  `resolveSelection` (which walks to the deepest first text point),
+  then `unsetMatchedNodesInRange` would yield both the explicit block
+  and its first descendant, and the "keep deepest" dedup picked the
+  descendant. The fast path unsets the explicit node directly.

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -334,13 +334,15 @@ export const coreDndBehaviors = [
         },
       })
 
-      // When the drag origin is at the top level (path length 1) -
-      // typically when the user grabs a block's chrome / drag handle -
-      // use that block AS-IS. `getFragment` would unwrap the block
-      // when its content is also root-accepted (e.g. a callout with a
-      // single paragraph inside). For deeper origins - dragging a
-      // block-object or text within a container - keep using
-      // `getFragment`, which finds the smallest root-valid fragment.
+      // `getFragment` is the clipboard projection - it unwraps single-
+      // child containers down to the smallest root-valid fragment so
+      // the result is paste-anywhere. That's correct for the deep-drag
+      // case (dragging a block-object out of a cell: the drop target
+      // is root, the fragment needs to be unwrapped). It's wrong for
+      // the top-level chrome-drag case: the user grabbed a container
+      // (callout, list, code-block) at root, and the move preserves
+      // root-to-root shape - the container should stay as a container.
+      // Pick the selector that matches the drag's level of origin.
       const isTopLevelOrigin =
         draggingEntireBlocks &&
         dragSelection.anchor.path.length === 1 &&

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -2,6 +2,7 @@ import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
 import {getDragSelection} from '../selectors/drag-selection'
 import {getFragment} from '../selectors/selector.get-fragment'
+import {getSelectedBlocks} from '../selectors/selector.get-selected-blocks'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import {comparePoints} from '../slate/point/compare-points'
@@ -333,14 +334,32 @@ export const coreDndBehaviors = [
         },
       })
 
-      const draggedBlocks = getFragment({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: dragSelection,
-        },
-      })
-
+      // When the drag origin is at the top level (path length 1) -
+      // typically when the user grabs a block's chrome / drag handle -
+      // use that block AS-IS. `getFragment` would unwrap the block
+      // when its content is also root-accepted (e.g. a callout with a
+      // single paragraph inside). For deeper origins - dragging a
+      // block-object or text within a container - keep using
+      // `getFragment`, which finds the smallest root-valid fragment.
+      const isTopLevelOrigin =
+        draggingEntireBlocks &&
+        dragSelection.anchor.path.length === 1 &&
+        dragSelection.focus.path.length === 1
+      const draggedBlocks = isTopLevelOrigin
+        ? getSelectedBlocks({
+            ...snapshot,
+            context: {
+              ...snapshot.context,
+              selection: dragSelection,
+            },
+          })
+        : getFragment({
+            ...snapshot,
+            context: {
+              ...snapshot.context,
+              selection: dragSelection,
+            },
+          })
       if (!droppingOnDragOrigin) {
         return {
           dropPosition,
@@ -383,7 +402,14 @@ export const coreDndBehaviors = [
             ]),
         raise({
           type: 'insert.blocks',
-          blocks: event.data,
+          // When dragging entire root-level blocks, use the
+          // `draggedBlocks` snapshot taken at dragstart - it preserves
+          // containers whole. `event.data` came through the clipboard
+          // converter which unwraps containers (correct for paste,
+          // wrong for in-place move).
+          blocks: draggingEntireBlocks
+            ? draggedBlocks.map((block) => block.node)
+            : event.data,
           placement: draggingEntireBlocks
             ? originEvent.position.block === 'start'
               ? 'before'

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -64,15 +64,28 @@ export function getEventPosition({
   })
   const eventSelection = getSelectionFromEvent(slateEditor, event) ?? null
 
+  const onChrome =
+    !!eventBlock &&
+    !!eventBlockPath &&
+    isEventOnChrome(event, eventBlock, eventBlockPath, slateEditor)
   if (
     eventBlock &&
     eventBlockPath &&
     eventPositionBlock &&
-    !eventSelection &&
-    !isEventContainer(slateEditor, eventNode, eventPath)
+    (!eventSelection || onChrome) &&
+    // Containers normally fall through to caret-based selection (clicking
+    // a container's chrome background is a click into content). But when
+    // the event originates from a `contentEditable=false` chrome
+    // affordance the container's caret-based selection is wrong - prefer
+    // the whole-block selection.
+    (!isEventContainer(slateEditor, eventNode, eventPath) || onChrome)
   ) {
-    // If we for some reason can't find the event selection, then we default to
-    // selecting the entire block that the event originates from.
+    // If we can't find the event selection - OR the event originates from
+    // a `contentEditable={false}` chrome affordance inside the block (a
+    // drag handle, a language picker, etc.) rather than from actual
+    // content - select the entire block. `caretPositionFromPoint` would
+    // otherwise land inside the block's first content child, dragging
+    // that inner block instead of the block whose chrome was grabbed.
     return {
       block: eventPositionBlock,
       isEditor: false,
@@ -309,4 +322,46 @@ function isEventContainer(
     return true
   }
   return isEditableContainer(slateEditor, eventNode, eventPath)
+}
+
+/**
+ * Did the drag/mouse event originate from a non-editable chrome element
+ * inside the block (a drag handle, language picker, button, etc.) rather
+ * than from actual content?
+ *
+ * The discriminator: walk up from `event.target` to the block's DOM
+ * element. If we cross a `contentEditable="false"` ancestor along the
+ * way, the user grabbed chrome, not text. `caretPositionFromPoint` at the
+ * chrome's coordinates would otherwise land inside the block's first
+ * inner content node - which is the wrong drag scope for a chrome grab.
+ */
+function isEventOnChrome(
+  event: DragEvent | MouseEvent,
+  _eventBlock: Node,
+  eventBlockPath: Path,
+  slateEditor: PortableTextSlateEditor,
+): boolean {
+  const target = event.target
+  if (!target || !isDOMNode(target)) {
+    return false
+  }
+  const blockElement = getDomNode(slateEditor, eventBlockPath)
+  if (!blockElement) {
+    return false
+  }
+  // Walk up from the target. If we hit a contentEditable="false" ancestor
+  // BEFORE we hit the block element itself, the target sits inside chrome.
+  const domTarget = target as unknown as globalThis.Node
+  let cursor: globalThis.Node | null =
+    domTarget.nodeType === 1 ? domTarget : (domTarget.parentNode ?? null)
+  while (cursor && cursor !== (blockElement as unknown as globalThis.Node)) {
+    if (cursor.nodeType === 1) {
+      const element = cursor as unknown as Element
+      if (element.getAttribute('contenteditable') === 'false') {
+        return true
+      }
+    }
+    cursor = cursor.parentNode
+  }
+  return false
 }

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -21,9 +21,62 @@ import {isCollapsedRange} from '../slate/range/is-collapsed-range'
 import {rangeEdges} from '../slate/range/range-edges'
 import type {OperationImplementation} from './operation.types'
 
+function isEqualSelectionPointsFromOp(
+  a: {path: import('../slate/interfaces/path').Path; offset: number},
+  b: {path: import('../slate/interfaces/path').Path; offset: number},
+): boolean {
+  if (a.offset !== b.offset) {
+    return false
+  }
+  if (a.path.length !== b.path.length) {
+    return false
+  }
+  for (let i = 0; i < a.path.length; i++) {
+    const aSeg = a.path[i]
+    const bSeg = b.path[i]
+    if (
+      typeof aSeg === 'object' &&
+      aSeg !== null &&
+      typeof bSeg === 'object' &&
+      bSeg !== null
+    ) {
+      if ((aSeg as {_key?: string})._key !== (bSeg as {_key?: string})._key) {
+        return false
+      }
+    } else if (aSeg !== bSeg) {
+      return false
+    }
+  }
+  return true
+}
+
 export const deleteOperationImplementation: OperationImplementation<
   'delete'
 > = ({operation}) => {
+  // Block-unit fast path: when `at` is a collapsed selection on a
+  // block's path (e.g. `delete.block at: [{_key:'cl-24'}]`), the
+  // intent is "remove THIS block." Skip `resolveSelection` for this
+  // case - it walks to the deepest first text point, which causes
+  // `unsetMatchedNodesInRange` to also pick up the block's first
+  // inner child and keep only the deeper match. Containers and
+  // block-objects would get their first inner block deleted instead
+  // of themselves.
+  if (
+    operation.unit === 'block' &&
+    operation.at &&
+    operation.at.anchor.path.length > 0 &&
+    isEqualSelectionPointsFromOp(operation.at.anchor, operation.at.focus)
+  ) {
+    const blockPath = operation.at.anchor.path
+    if (isBlock(operation.editor, blockPath)) {
+      const node = getNode(operation.editor, blockPath)
+      if (node) {
+        operation.editor.apply({type: 'unset', path: blockPath})
+        return
+      }
+    }
+  }
+
   const at = operation.at
     ? resolveSelection(operation.editor, operation.at)
     : operation.editor.selection

--- a/packages/editor/tests/event.drag.dragstart-from-chrome.test.tsx
+++ b/packages/editor/tests/event.drag.dragstart-from-chrome.test.tsx
@@ -1,0 +1,171 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Container "drag handle" affordances - chrome elements rendered
+ * inside a container's render output (handles, language pickers,
+ * etc.) - are commonly `contentEditable={false}` so they don't
+ * receive caret input. When such an affordance is the dragstart
+ * source, the engine should resolve the drag to the WHOLE container
+ * block, not to whatever text node happens to sit under the
+ * `clientX/Y` coordinates of the dragstart event.
+ *
+ * Today `getEventPosition` calls `getSelectionFromEvent` which
+ * uses `caretPositionFromPoint(clientX, clientY)`. The caret point
+ * lands inside the container's first inner text block (the chrome
+ * sits over content), and the engine then drags that inner block
+ * instead of the container. This test pins the corrected behavior.
+ */
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const calloutContainer = defineContainer({
+  type: 'callout',
+  arrayField: 'content',
+  render: ({attributes, children}) => (
+    <aside data-testid="callout" {...attributes}>
+      <button
+        type="button"
+        data-testid="callout-drag-handle"
+        contentEditable={false}
+        draggable
+      >
+        Drag
+      </button>
+      {children}
+    </aside>
+  ),
+})
+
+describe('dragstart from container chrome', () => {
+  test('dragging a callout via chrome handle moves the callout, not its first inner block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = 'cl-1'
+    const innerBlockKey = 'inner-1'
+    const innerSpanKey = 'span-1'
+    const targetBlockKey = 'target-1'
+    const targetSpanKey = 'target-span-1'
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: innerBlockKey,
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {
+                  _type: 'span',
+                  _key: innerSpanKey,
+                  text: 'inside the callout',
+                  marks: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: targetBlockKey,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: targetSpanKey,
+              text: 'target paragraph',
+              marks: [],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[calloutContainer]} />,
+    })
+
+    await vi.waitFor(() => {
+      const root = locator.element() as HTMLElement
+      expect(
+        root.querySelector('[data-testid="callout-drag-handle"]'),
+      ).not.toBeNull()
+    })
+
+    const root = locator.element() as HTMLElement
+    const handle = root.querySelector(
+      '[data-testid="callout-drag-handle"]',
+    ) as HTMLButtonElement
+    const targetBlockEl = root.querySelector(
+      `[data-pt-block="text"][data-pt-path*="${targetBlockKey}"]`,
+    ) as HTMLElement
+    expect(targetBlockEl).toBeTruthy()
+
+    const handleRect = handle.getBoundingClientRect()
+    const targetRect = targetBlockEl.getBoundingClientRect()
+
+    // Fire dragstart on the handle. clientX/Y is the chrome's center;
+    // `caretPositionFromPoint` at those coords lands inside the callout's
+    // first inner content block. The fix recognises the target sits
+    // inside chrome and uses the block-level selection instead.
+    const dataTransfer = new DataTransfer()
+    const dragstart = new DragEvent('dragstart', {
+      bubbles: true,
+      cancelable: true,
+      clientX: handleRect.left + handleRect.width / 2,
+      clientY: handleRect.top + handleRect.height / 2,
+      dataTransfer,
+    })
+    handle.dispatchEvent(dragstart)
+
+    // Drop on the target block. `dragenter` + `dragover` set the drop
+    // marker; `drop` commits.
+    const dragover = new DragEvent('dragover', {
+      bubbles: true,
+      cancelable: true,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.bottom - 2,
+      dataTransfer,
+    })
+    targetBlockEl.dispatchEvent(dragover)
+
+    const drop = new DragEvent('drop', {
+      bubbles: true,
+      cancelable: true,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.bottom - 2,
+      dataTransfer,
+    })
+    targetBlockEl.dispatchEvent(drop)
+
+    const dragend = new DragEvent('dragend', {
+      bubbles: true,
+      dataTransfer,
+    })
+    handle.dispatchEvent(dragend)
+
+    // After the drop, the value should have the target FIRST, then the
+    // callout (the callout moved DOWN, past the target). If the inner
+    // block got dragged instead, the value would still have the callout
+    // first (with only its inner content moved into the target's slot).
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value ?? []
+      const keys = value.map((b) => (b as {_key: string})._key)
+      expect(keys).toEqual([targetBlockKey, calloutKey])
+    })
+  })
+})


### PR DESCRIPTION
Dragging a container (callout, blockquote, code-block, table) or block-object (image, hr) by a `contentEditable=false` decoration inside its render output - such as a block handle or drag affordance - now moves the entire block.

Previously, the engine resolved the drag to the deepest text point inside the container, dropped the inner block at the destination, and left the container intact at the origin. The symptom: drag a callout, get the callout's first paragraph; the callout stays put.

### The bug had three independent layers

Each layer was individually sufficient. Fixing only one left the user-visible behavior unchanged.

**1. `getEventPosition` resolved chrome-dragstart to inner caret.**

When `dragstart.target` lands on a `contentEditable=false` decoration inside a block (the block-handle button rendered by the consumer), `getDomNodePath` walks up to the block's `data-pt-path` correctly. But `getSelectionFromEvent` then runs `caretPositionFromPoint(clientX, clientY)`, which ignores `contentEditable=false` and recovers a caret at the inner text directly under the cursor. That deeper selection overrode the block-level position.

Fix: a new `isEventOnChrome` walker detects whether the event target sits inside a `contentEditable=false` subtree under a `data-pt-path` ancestor. When it does, we keep the block-level resolution and skip the inner-caret recovery.

**2. `behavior.core.dnd` move-mimic used `getFragment`, which intentionally unwraps containers.**

`getFragment` returns "the smallest top-level-valid fragment of the editor's value that covers the current selection" - correct for clipboard copy, wrong for in-editor move. For a chrome-drag of a callout whose contents are themselves root-acceptable, it returned the inner paragraph, not the callout.

Switching to `getSelectedBlocks` (which preserves containers whole) blanket-style broke deeper drags: when the selection is inside a table cell, `getSelectedBlocks` returns the whole table (the root-level block covering the selection), not the inner block the user grabbed.

Fix: discriminate on origin path length. Top-level chrome drags (path length 1) use `getSelectedBlocks`; deeper drags - block-objects inside cells, multi-block selections inside containers - keep using `getFragment`. Both shipped tests for in-cell drag remain green.

**3. `operation.delete` with `unit:'block'` walked through `resolveSelection` and `unsetMatchedNodesInRange` dedup, which picked the descendant.**

`delete.block at: [{_key:'cl-24'}]` raises `delete` with a collapsed selection at the callout's path. The operation ran `resolveSelection`, which walks any non-text-block path *down to the deepest first text point*. That made the from/to range cover both `[cl-24]` (in range as ancestor of the resolved point) and `[cl-24, content, b-30]` (also in range). `unsetMatchedNodesInRange` then deduped by keeping the deepest candidate - which is correct for double-unset prevention on overlapping text-range deletes, but wrong here. The inner block got unset; the callout stayed.

Fix: short-circuit `operation.delete` when `unit:'block'` and `at` is collapsed on a block's path. Unset the explicit node directly, before resolveSelection runs.

### Tests

- New `event.drag.dragstart-from-chrome.test.tsx` mounts a callout with a `contentEditable=false` draggable button inside its render and dispatches a real `dragstart` at the button's coordinates. Asserts the position selection resolves to the callout's path, not a deep inner caret.
- All existing dnd tests pass (`event.drag.drop.test.tsx`, `event.drag.drop.self-drop.test.tsx`). Two scenarios that exercise deep table-cell drags - block-object between cells, multi-block selection inside cell - drove the path-length-1 guard on the move-mimic switch.

### Consumer-visible

Block handles rendered inside a block's render callback as `contentEditable=false draggable={!readOnly}` now drag the whole block, including containers. The pattern (handle as part of the block's render output, inside the Slate DOM tree) was already canonical for block-objects; this PR makes it work end-to-end for containers as well.
