### PR TITLE
fix: `move.block` guards against moving a block onto its own path

### DIFF
--- a/.changeset/move-block-same-path.md
+++ b/.changeset/move-block-same-path.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: `move.block` guards against moving a block onto its own path

--- a/packages/editor/src/operations/operation.move.block.ts
+++ b/packages/editor/src/operations/operation.move.block.ts
@@ -25,6 +25,17 @@ export const moveBlockOperationImplementation: OperationImplementation<
     )
   }
 
+  // Moving a block onto its own resolved path is a no-op. Without this
+  // guard the implementation unsets the source then tries to insert at
+  // a path that no longer points at anything (the index has shifted by
+  // one), eating the block. Consumers reaching for the raw `move.block`
+  // event with caller-supplied keys can land in this shape easily; the
+  // high-level `move.block up`/`down` events bail earlier when there
+  // is no neighbouring sibling.
+  if (originEntry.node._key === destinationEntry.node._key) {
+    return
+  }
+
   // Determine movement direction within the shared sibling array. Only
   // supports moves at the same level today (root → root or within the
   // same container field). Cross-level moves would need the behavior to

--- a/packages/editor/tests/event.move.block.test.tsx
+++ b/packages/editor/tests/event.move.block.test.tsx
@@ -138,3 +138,28 @@ describe('event.move.block up', () => {
     })
   })
 })
+
+describe('event.move.block', () => {
+  test('Scenario: Moving a block to its own position is a no-op', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [image, foo, bar],
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [{name: 'image'}],
+      }),
+    })
+
+    // Moving a block onto its own path should leave the value unchanged.
+    // Today this silently unsets the source then inserts at a path that
+    // no longer resolves, eating the block.
+    editor.send({
+      type: 'move.block',
+      at: [{_key: image._key}],
+      to: [{_key: image._key}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([image, foo, bar])
+    })
+  })
+})


### PR DESCRIPTION
The `move.block` operation handler unsets the source block, then inserts the same node before or after the destination path. When the destination resolves to the same block as the source, the `unset` shifts the surrounding indices and the follow-up `insert` lands at a path that no longer points at the intended slot. The block is eaten and the surrounding value silently loses an entry.

The high-level `move.block up` / `move.block down` events do not hit this shape because they guard via `getSibling`, which returns `undefined` at the boundary and bails. Consumers reaching for the raw `move.block` event with caller-supplied origin and destination keys (custom drag-and-drop plugins, behaviors that compose the event from arbitrary path inputs) have no such guard - a drop on the same block was data loss.

## Reproduction

```ts
editor.send({
  type: 'move.block',
  at: [{_key: 'k1'}],
  to: [{_key: 'k1'}],
})

// Before: value is now [k2, k3] (k1 is gone)
// After:  value is unchanged [k1, k2, k3]
```

## Fix

Early return from `moveBlockOperationImplementation` when origin and destination resolve to the same block.

A single failing scenario in `tests/event.move.block.test.tsx` covers the case. Reverting the guard drops it back to red across all three browsers (chromium / firefox / webkit).
