### PR TITLE
fix: backspace before a container lands the caret at the end of the container's content

### DIFF
--- a/.changeset/backspace-before-container-end-point.md
+++ b/.changeset/backspace-before-container-end-point.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: backspace before a container lands the caret at the end of the container's content, not at its start

--- a/packages/editor/src/behaviors/behavior.core.block-objects.ts
+++ b/packages/editor/src/behaviors/behavior.core.block-objects.ts
@@ -1,4 +1,6 @@
+import {isSpan} from '@portabletext/schema'
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
+import {getLeaf} from '../node-traversal/get-leaf'
 import {getSibling} from '../node-traversal/get-sibling'
 import {getFocusBlockObject} from '../selectors/selector.get-focus-block-object'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
@@ -244,13 +246,26 @@ const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
       isEmptyTextBlock(snapshot.context, focusedTextBlock.node) &&
       !isTextBlockNode(snapshot.context, previousSibling.node)
     ) {
-      return {focusedTextBlock, previousSibling}
+      // Land the caret at the END of the previous sibling's deepest leaf.
+      // A span leaf gets the end of its text, anything else (void block-object,
+      // inline-object) gets focused at its own path.
+      const leaf = getLeaf(snapshot, previousSibling.path, {edge: 'end'})
+      const previousEndPoint = leaf
+        ? {
+            path: leaf.path,
+            offset: isSpan(snapshot.context, leaf.node)
+              ? leaf.node.text.length
+              : 0,
+          }
+        : {path: previousSibling.path, offset: 0}
+
+      return {focusedTextBlock, previousEndPoint}
     }
 
     return false
   },
   actions: [
-    (_, {focusedTextBlock, previousSibling}) => [
+    (_, {focusedTextBlock, previousEndPoint}) => [
       raise({
         type: 'delete.block',
         at: focusedTextBlock.path,
@@ -258,8 +273,8 @@ const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
       raise({
         type: 'select',
         at: {
-          anchor: {path: previousSibling.path, offset: 0},
-          focus: {path: previousSibling.path, offset: 0},
+          anchor: previousEndPoint,
+          focus: previousEndPoint,
         },
       }),
     ],

--- a/packages/editor/tests/backspace-before-container.test.tsx
+++ b/packages/editor/tests/backspace-before-container.test.tsx
@@ -1,0 +1,395 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+/**
+ * Backspace at the start of an empty text block that follows a container
+ * should delete the empty text block and place the caret at the END of the
+ * container's last text content, not at the START of the container.
+ *
+ * Before this fix, the caret landed at `{path: container.path, offset: 0}`,
+ * which renders as a caret at the container's leading edge. The fix is to
+ * compute the end point of the container's last text-block leaf.
+ */
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {name: 'image'},
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [{type: 'block'}, {type: 'image'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const containers = [
+  defineContainer({
+    type: 'callout',
+    arrayField: 'content',
+  }),
+  defineContainer({
+    type: 'table',
+    arrayField: 'rows',
+  }),
+  defineContainer({
+    type: 'row',
+    arrayField: 'cells',
+  }),
+  defineContainer({
+    type: 'cell',
+    arrayField: 'content',
+  }),
+]
+
+describe('Backspace before container', () => {
+  test('Backspace at start of empty text block after callout lands at end of callout content', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: 'foo', marks: []}],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Caret should be at end of "foo", inside the callout.
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['CALLOUT:', '  B: foo|'].join('\n'),
+      )
+    })
+  })
+
+  test('Backspace at start of empty text block after callout with multi-block content lands at end of last block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'cb0',
+              children: [{_type: 'span', _key: 'cs0', text: 'foo', marks: []}],
+            },
+            {
+              _type: 'block',
+              _key: 'cb1',
+              children: [{_type: 'span', _key: 'cs1', text: 'bar', marks: []}],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Caret should be at end of "bar" (last text block in callout).
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['CALLOUT:', '  B: foo', '  B: bar|'].join('\n'),
+      )
+    })
+  })
+
+  test('Backspace at start of empty text block after table lands at end of last cell content', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'ce0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'tb0',
+                      children: [
+                        {_type: 'span', _key: 'ts0', text: 'foo', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'ce1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'tb1',
+                      children: [
+                        {_type: 'span', _key: 'ts1', text: 'bar', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Caret should be at end of "bar" (last cell's last text block).
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        [
+          'TABLE:',
+          '  ROW:',
+          '    CELL:',
+          '      B: foo',
+          '    CELL:',
+          '      B: bar|',
+        ].join('\n'),
+      )
+    })
+  })
+
+  test('Backspace at start of empty text block after void block-object focuses the block-object', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {_type: 'image', _key: 'i0'},
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Selection should focus the void image.
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('^{IMAGE}|')
+    })
+  })
+
+  test('Backspace at start of empty text block after table whose last cell ends in an image focuses the image', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'ce0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'tb0',
+                      children: [
+                        {_type: 'span', _key: 'ts0', text: 'foo', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'ce1',
+                  content: [{_type: 'image', _key: 'ti0'}],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Caret should focus the image inside the last cell.
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        [
+          'TABLE:',
+          '  ROW:',
+          '    CELL:',
+          '      B: foo',
+          '    CELL:',
+          '      ^{IMAGE}|',
+        ].join('\n'),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Backspace at the start of an empty text block that follows a container used to land the caret at `{path: container.path, offset: 0}` - the container's leading edge, rendered visually as a caret at the container's start. That's a disorienting jump backwards across the container boundary.

The caret now lands at the **end** of the container's deepest text leaf - the end of the container's last line - matching what a user expects when crossing a container boundary backwards.

For void block-objects (image, hr) the behaviour is unchanged: the leaf is the object itself, and the caret continues to land at the object's path with offset 0.

### Implementation

`deletingEmptyTextBlockAfterBlockObject` in `behavior.core.block-objects.ts` now uses `getLeaf(snapshot, previousSibling.path, {edge: 'end'})` to find the deepest leaf node inside the previous sibling. If that leaf is a span, the caret lands at `{path: leaf.path, offset: leaf.node.text.length}`. Otherwise (void object, empty container) it falls back to the old `{path: previousSibling.path, offset: 0}`.

### Tests

`packages/editor/tests/backspace-before-container.test.tsx` adds three falsifying scenarios:

- empty text block after a single-block callout - caret lands at end of the only line
- empty text block after a multi-block callout - caret lands at end of the **last** line
- empty text block after a table (`table` > `row` > `cell` > `block`) - caret lands at end of the last cell's last text block

All three failed against `main` and pass with this fix. No existing test in `event.delete.backward`, `event.delete`, `event.delete.matrix`, `delete-empty-container`, or `cross-container-range-delete` regressed.