### PR TITLE
fix: `DefaultTableRenderer` always emits a valid GFM table

### DIFF
--- a/.changeset/default-table-renderer-valid-gfm.md
+++ b/.changeset/default-table-renderer-valid-gfm.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: `DefaultTableRenderer` always emits a valid GFM table
+
+The first row is always rendered as the header, followed by the delimiter row, followed by the remaining rows as body. The `headerRows` field on the Portable Text table is ignored on serialization so that the emitted Markdown round-trips through any GFM parser. Tables with no rows render as an empty string.

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -45,6 +45,13 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
 }
 
 /**
+ * Renders a Portable Text table block-object back to Markdown. Because
+ * GFM allows exactly one header row, the first row is always emitted as
+ * the header, followed by the delimiter row, followed by the remaining
+ * rows as body rows. The PT `headerRows` field is informational on the
+ * Portable Text side and is ignored on the way out so that the emitted
+ * Markdown is always a valid GFM table.
+ *
  * @public
  */
 export const DefaultTableRenderer: PortableTextTypeRenderer<{
@@ -58,7 +65,6 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
     }>
   }>
 }> = ({value, renderNode}) => {
-  const headerRows = value.headerRows || 0
   const rows = value.rows as Array<{
     _key: string
     _type: 'row'
@@ -68,7 +74,12 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
       value: Array<{_type: string; children?: Array<unknown>}>
     }>
   }>
-  const lines: string[] = []
+
+  const headerRow = rows.at(0)
+
+  if (!headerRow) {
+    return ''
+  }
 
   // Helper to extract text from cell blocks
   const getCellText = (
@@ -87,24 +98,19 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
       .trim()
   }
 
-  // Add header rows
-  for (let i = 0; i < headerRows; i++) {
-    const row = rows[i]
-    if (row) {
-      const cellTexts = row.cells.map((cell) => getCellText(cell.value))
-      lines.push(`| ${cellTexts.join(' | ')} |`)
-    }
-  }
+  const lines: string[] = []
 
-  // Add separator line if there are headers
-  if (headerRows > 0 && rows[0]) {
-    const separators = rows[0].cells.map(() => ' --- ')
-    lines.push(`|${separators.join('|')}|`)
-  }
+  // First row is the header
+  const headerCells = headerRow.cells.map((cell) => getCellText(cell.value))
+  lines.push(`| ${headerCells.join(' | ')} |`)
 
-  // Add body rows
-  for (let i = headerRows; i < rows.length; i++) {
-    const row = rows[i]
+  // Delimiter row, sized to the header
+  const separators = headerRow.cells.map(() => ' --- ')
+  lines.push(`|${separators.join('|')}|`)
+
+  // Remaining rows are the body
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows.at(i)
     if (row) {
       const cellTexts = row.cells.map((cell) => getCellText(cell.value))
       lines.push(`| ${cellTexts.join(' | ')} |`)

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1410,6 +1410,406 @@ describe(portableTextToMarkdown.name, () => {
         ).toBe(markdownOut)
       })
     })
+
+    describe('table without designated header row', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 3',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 4',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('headerRows undefined promotes the first row to header', () => {
+        const markdownOut = [
+          '| Cell 1 | Cell 2 |',
+          '| --- | --- |',
+          '| Cell 3 | Cell 4 |',
+        ].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+
+      test('headerRows 0 promotes the first row to header', () => {
+        const table = portableText.at(0)
+        if (!table) {
+          throw new Error('expected a table block')
+        }
+        const withZeroHeaderRows = [{...table, headerRows: 0}]
+        const markdownOut = [
+          '| Cell 1 | Cell 2 |',
+          '| --- | --- |',
+          '| Cell 3 | Cell 4 |',
+        ].join('\n')
+
+        expect(
+          portableTextToMarkdown(withZeroHeaderRows, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
+
+    describe('table with multiple header rows', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          headerRows: 2,
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Subheader 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Subheader 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('only the first row becomes the header, the rest are body rows', () => {
+        const markdownOut = [
+          '| Header 1 | Header 2 |',
+          '| --- | --- |',
+          '| Subheader 1 | Subheader 2 |',
+          '| Cell 1 | Cell 2 |',
+        ].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
+
+    describe('table with no rows', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [],
+        },
+      ]
+
+      test('emits nothing', () => {
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe('')
+      })
+    })
+
+    describe('table with a single row', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Cell 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('emits header + delimiter, no body', () => {
+        const markdownOut = ['| Cell 1 | Cell 2 |', '| --- | --- |'].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
   })
 
   describe('callouts', () => {


### PR DESCRIPTION
`DefaultTableRenderer` emits Markdown that isn't a valid GFM table when the Portable Text table doesn't have exactly one designated header row:

- `headerRows` undefined or `0`: no header row is emitted, no delimiter line is emitted. A GFM parser treats the output as a sequence of paragraphs with literal pipe characters, not a table.
- `headerRows` greater than `1`: multiple lines are emitted before the delimiter, but GFM allows exactly one header row, so only the last of those is treated as the header by a parser and the rest are silently demoted to body rows under it.

Both cases mean a round-trip through `markdownToPortableText` after `portableTextToMarkdown` drops the structure.

This change ignores `headerRows` on serialization and always renders the first row as the header, the delimiter line sized to it, and every remaining row as body. Tables with no rows render as the empty string. The `headerRows` field on the Portable Text value is unchanged; it stays available to consumers that want to track header-row intent on the PT side.