### PR TITLE
fix: `DefaultTableRenderer` widens asymmetric tables to fit the widest row

### DIFF
--- a/.changeset/default-table-renderer-asymmetric-rows.md
+++ b/.changeset/default-table-renderer-asymmetric-rows.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: `DefaultTableRenderer` widens asymmetric tables to fit the widest row
+
+When rows had different cell counts the delimiter row was sized to the header, so a GFM parser silently dropped cells from any body row that was wider than the header. The renderer now sizes the delimiter to the widest row and pads narrower rows with empty cells so all data survives the round-trip.

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -52,6 +52,10 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
  * Portable Text side and is ignored on the way out so that the emitted
  * Markdown is always a valid GFM table.
  *
+ * Asymmetric tables (rows of varying cell counts) are widened to match
+ * the row with the most cells. Narrower rows are padded with empty cells
+ * so a GFM parser doesn't silently drop the extra cells in wider rows.
+ *
  * @public
  */
 export const DefaultTableRenderer: PortableTextTypeRenderer<{
@@ -100,20 +104,35 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
 
   const lines: string[] = []
 
-  // First row is the header
-  const headerCells = headerRow.cells.map((cell) => getCellText(cell.value))
-  lines.push(`| ${headerCells.join(' | ')} |`)
+  // GFM requires every row to have the same number of cells as the header row
+  // and the delimiter row. Parsers silently drop excess cells from body rows
+  // that are wider than the header, so we widen the table to the widest row
+  // and pad narrower rows with empty cells to keep all data visible.
+  const columnCount = rows.reduce(
+    (max, row) => Math.max(max, row.cells.length),
+    0,
+  )
 
-  // Delimiter row, sized to the header
-  const separators = headerRow.cells.map(() => ' --- ')
+  const renderRow = (cells: typeof headerRow.cells): string => {
+    const texts = cells.map((cell) => getCellText(cell.value))
+    while (texts.length < columnCount) {
+      texts.push('')
+    }
+    return `| ${texts.join(' | ')} |`
+  }
+
+  // First row is the header, padded to the table's column count
+  lines.push(renderRow(headerRow.cells))
+
+  // Delimiter row, sized to the column count
+  const separators = Array.from({length: columnCount}, () => ' --- ')
   lines.push(`|${separators.join('|')}|`)
 
   // Remaining rows are the body
   for (let i = 1; i < rows.length; i++) {
     const row = rows.at(i)
     if (row) {
-      const cellTexts = row.cells.map((cell) => getCellText(cell.value))
-      lines.push(`| ${cellTexts.join(' | ')} |`)
+      lines.push(renderRow(row.cells))
     }
   }
 

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1810,6 +1810,246 @@ describe(portableTextToMarkdown.name, () => {
         ).toBe(markdownOut)
       })
     })
+
+    describe('asymmetric table with a wider body row', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Body 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Body 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Body 3',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('the header row is padded so no body cells are dropped', () => {
+        const markdownOut = [
+          '| Header 1 |  |  |',
+          '| --- | --- | --- |',
+          '| Body 1 | Body 2 | Body 3 |',
+        ].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
+
+    describe('asymmetric table with a wider header row', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header 3',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Body 1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('the body row is padded so it lines up under the header', () => {
+        const markdownOut = [
+          '| Header 1 | Header 2 | Header 3 |',
+          '| --- | --- | --- |',
+          '| Body 1 |  |  |',
+        ].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
   })
 
   describe('callouts', () => {


### PR DESCRIPTION
When a Portable Text table has rows of varying cell counts, the delimiter row used to be sized to the header. A GFM parser sizes the table to the header + delimiter, so any body row wider than the header had its extra cells silently dropped (per GFM §4.10 "the excess is ignored"). A body row narrower than the header rendered fine because parsers pad narrow rows with empty cells.

This change sizes the delimiter to the widest row in the table and pads narrower rows with empty cells, so every cell from the source Portable Text survives the round-trip through `markdownToPortableText`.