### PR TITLE
fix: `DefaultTableRenderer` escapes characters that would break a GFM table row

### DIFF
--- a/.changeset/default-table-renderer-escape-cell-content.md
+++ b/.changeset/default-table-renderer-escape-cell-content.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: `DefaultTableRenderer` escapes characters that would break a GFM table row
+
+A `|` in a cell's text used to end the cell, causing all cells to the right to shift. A `\n` inside a multi-line block-object (such as a code block) used to end the row, causing all cells after the first line break to be lost. The renderer now escapes literal pipes as `\|` and replaces newlines with `<br>` so every cell in the source Portable Text survives the round-trip through `markdownToPortableText`.

--- a/packages/markdown/src/escape.test.ts
+++ b/packages/markdown/src/escape.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, test} from 'vitest'
 import {
   escapeImageAndLinkText,
   escapeImageAndLinkTitle,
+  escapeTableCell,
   unescapeImageAndLinkText,
 } from './escape'
 
@@ -56,5 +57,37 @@ describe(escapeImageAndLinkTitle.name, () => {
 
   test('leaves other characters unchanged', () => {
     expect(escapeImageAndLinkTitle('Hello World!')).toBe('Hello World!')
+  })
+})
+
+describe(escapeTableCell.name, () => {
+  test('escapes literal pipe', () => {
+    expect(escapeTableCell('a | b')).toBe('a \\| b')
+  })
+
+  test('escapes multiple pipes', () => {
+    expect(escapeTableCell('a | b | c')).toBe('a \\| b \\| c')
+  })
+
+  test('replaces newlines with <br>', () => {
+    expect(escapeTableCell('line 1\nline 2')).toBe('line 1<br>line 2')
+  })
+
+  test('leaves already-escaped pipes intact', () => {
+    expect(escapeTableCell('a \\| b')).toBe('a \\| b')
+  })
+
+  test('leaves backslashes alone', () => {
+    expect(escapeTableCell('a\\b')).toBe('a\\b')
+  })
+
+  test('preserves link-text escapes alongside pipe escaping', () => {
+    expect(
+      escapeTableCell('[link \\[with brackets\\]](https://example.com)'),
+    ).toBe('[link \\[with brackets\\]](https://example.com)')
+  })
+
+  test('leaves plain text unchanged', () => {
+    expect(escapeTableCell('hello world')).toBe('hello world')
   })
 })

--- a/packages/markdown/src/escape.ts
+++ b/packages/markdown/src/escape.ts
@@ -18,3 +18,21 @@ export function unescapeImageAndLinkText(text: string): string {
 export function escapeImageAndLinkTitle(text: string): string {
   return text.replace(/([\\"])/g, '\\$1')
 }
+
+/**
+ * Escapes characters that have special meaning at the row level of a GFM
+ * table cell.
+ *
+ * A literal `|` ends the cell, so unescaped pipes are replaced with `\|`.
+ * Newlines end the row, so they are replaced with `<br>` to keep the
+ * visible line break inside the cell. Already-escaped pipes (`\|`) are
+ * left intact so that escapes introduced by mark renderers survive the
+ * pass.
+ *
+ * Backslashes are intentionally not escaped here so that other escapes
+ * already in the rendered cell (such as `\[` and `\]` in link text) are
+ * not double-escaped.
+ */
+export function escapeTableCell(text: string): string {
+  return text.replace(/(?<!\\)\|/g, '\\|').replace(/\n/g, '<br>')
+}

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -1,5 +1,9 @@
 import type {PortableTextBlock, TypedObject} from '@portabletext/types'
-import {escapeImageAndLinkText, escapeImageAndLinkTitle} from '../../escape'
+import {
+  escapeImageAndLinkText,
+  escapeImageAndLinkTitle,
+  escapeTableCell,
+} from '../../escape'
 import type {PortableTextTypeRenderer} from '../types'
 
 /**
@@ -114,7 +118,7 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   )
 
   const renderRow = (cells: typeof headerRow.cells): string => {
-    const texts = cells.map((cell) => getCellText(cell.value))
+    const texts = cells.map((cell) => escapeTableCell(getCellText(cell.value)))
     while (texts.length < columnCount) {
       texts.push('')
     }

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -2050,6 +2050,149 @@ describe(portableTextToMarkdown.name, () => {
         ).toBe(markdownOut)
       })
     })
+
+    describe('table with a pipe in cell text', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'a | b',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'c',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('escapes the pipe so it stays inside the cell', () => {
+        const markdownOut = ['| a \\| b | c |', '| --- | --- |'].join('\n')
+
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(markdownOut)
+      })
+    })
+
+    describe('table with a multi-line block-object in a cell', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'code',
+                      _key: keyGenerator(),
+                      language: 'js',
+                      code: 'const x = 1\nconst y = 2',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('replaces newlines with <br> so the row stays intact', () => {
+        const result = portableTextToMarkdown(portableText, {
+          types: {
+            table: DefaultTableRenderer,
+            code: DefaultCodeBlockRenderer,
+          },
+        })
+
+        expect(result).toBe(
+          [
+            '| Header |',
+            '| --- |',
+            '| ```js<br>const x = 1<br>const y = 2<br>``` |',
+          ].join('\n'),
+        )
+      })
+    })
   })
 
   describe('callouts', () => {


### PR DESCRIPTION
`DefaultTableRenderer` used to pass cell content into the row unescaped, so two characters that have special meaning at the row level corrupted the table on round-trip through `markdownToPortableText`:

- A literal `|` in cell text ended the cell. `a | b` in one PT cell parsed as two cells, shifting every subsequent cell to the right.
- A `\n` in a cell ended the row. A multi-line block-object (code block, multi-paragraph block) inside a cell dropped every cell that came after the first line break.

This change introduces an `escapeTableCell` helper that escapes literal pipes as `\|` and replaces newlines with `<br>`. The helper is applied to the rendered cell text inside `DefaultTableRenderer` so escapes already produced by mark renderers (such as `\[` and `\]` in link text, or pipes inside an `\|`) are not double-escaped. Backslashes are intentionally not touched for the same reason - escaping them would corrupt every mark-rendered escape sequence already in the cell.

Hard breaks between spans inside a single cell are not in scope for this change. They collapse to no visible break (existing behavior) rather than corrupting the row, so they are a fidelity issue rather than a validity issue. A consumer that needs the break preserved can render it as `<br>` via the pluggable mark renderer.