### PR TITLE
fix: dedupe `'selection'` emissions by semantic equality

### DIFF
--- a/.changeset/dedupe-selection-emissions.md
+++ b/.changeset/dedupe-selection-emissions.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: dedupe `'selection'` emissions by semantic equality
+
+`'selection'` events could fire twice in a row with the same anchor, focus, and direction when an internal selection reference changed without the caret actually moving (for example after applying a remote patch on the span the caret is inside). Consumers wiring `'selection'` to focus state would race against their own caret-driven UI. The guard now compares the selection by value.

--- a/packages/editor/src/editor/relay-machine.ts
+++ b/packages/editor/src/editor/relay-machine.ts
@@ -3,6 +3,7 @@ import type {PortableTextBlock} from '@portabletext/schema'
 import type {FocusEvent} from 'react'
 import {assign, emit, setup, type ActorRefFrom} from 'xstate'
 import type {EditorSelection, InvalidValueResolution} from '../types/editor'
+import {isEqualSelections} from '../utils/util.is-equal-selections'
 
 /**
  * @public
@@ -128,7 +129,8 @@ export const relayMachine = setup({
         ],
       },
       {
-        guard: ({context, event}) => context.prevSelection !== event.selection,
+        guard: ({context, event}) =>
+          !isEqualSelections(context.prevSelection, event.selection),
         actions: [
           assign({
             prevSelection: ({event}) => event.selection,

--- a/packages/editor/tests/selection-emit-dedup.test.tsx
+++ b/packages/editor/tests/selection-emit-dedup.test.tsx
@@ -1,0 +1,129 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {EventListenerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('selection emission dedup', () => {
+  test('a remote patch that re-spreads the selection range does not emit a duplicate selection', async () => {
+    const onSelection = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_type: 'span', _key: 'k1', text: 'foo bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const selectionInsideText = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 7},
+      backward: false,
+    }
+    const updatedValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_type: 'span', _key: 'k1', text: 'foo BAZ', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'selection') {
+              onSelection(event.selection)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({type: 'select', at: selectionInsideText})
+
+    await vi.waitFor(() => {
+      expect(onSelection).toHaveBeenLastCalledWith(selectionInsideText)
+    })
+
+    // A remote patch that mutates the span's text triggers Slate's
+    // apply-operation selection re-spread, which produces an EditorSelection
+    // with a fresh reference but the same semantic value.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: 'foo BAZ',
+          origin: 'remote',
+        },
+      ],
+      snapshot: initialValue,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(updatedValue)
+    })
+
+    expect(onSelection).toHaveBeenCalledTimes(1)
+  })
+
+  test('a genuine selection move still emits a selection', async () => {
+    const onSelection = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_type: 'span', _key: 'k1', text: 'foo bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const startOfText = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      backward: false,
+    }
+    const insideText = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 7},
+      backward: false,
+    }
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'selection') {
+              onSelection(event.selection)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({type: 'select', at: startOfText})
+
+    await vi.waitFor(() => {
+      expect(onSelection).toHaveBeenLastCalledWith(startOfText)
+    })
+
+    editor.send({type: 'select', at: insideText})
+
+    await vi.waitFor(() => {
+      expect(onSelection).toHaveBeenLastCalledWith(insideText)
+    })
+
+    expect(onSelection).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
The relay machine compared each incoming selection to the previous one by reference. That worked while an upstream cache in the `updateSelection` Slate plugin guaranteed the same `EditorSelection` object reference would flow through every `onChange` cycle that hadn't actually moved the caret. When that cache was dropped (so the editor passes its raw `editor.selection` through), the guard started letting semantically identical selections emit twice whenever Slate produced a fresh `Range` reference - for example after applying a remote patch on the span the caret is inside, or after a blur followed by a focus restoration around a toolbar action.

Consumers wiring `'selection'` to focus state could then race against their own caret-driven UI: a popover, dialog, or focus path computed from the first emission was clobbered by the second. Sanity Studio's `Annotations.spec.tsx :9` failed in v7 because of exactly this race - patched the installed PTE lib in a Studio sandbox with the semantic check inline, test went FAIL to PASS.

The guard now compares anchor, focus, and direction with `isEqualSelections`. Selections that genuinely change still emit; the `lastEventWasFocused` branch is unchanged so a `'focused'` event still releases the next selection unconditionally for re-sync.

## What to review

- `packages/editor/src/editor/relay-machine.ts` - the three-line guard change.
- `packages/editor/tests/selection-emit-dedup.test.tsx` - public-API tests using `EventListenerPlugin` and `editor.send`:
  - **scenario 1 (falsifier)**: a remote `'patches'` event sets a span's text. Slate's `apply-operation` re-spreads `editor.selection` (fresh ref, same semantic value). Broken main emits a phantom 'selection'; fixed dedups it.
  - **scenario 2 (regression guard)**: a genuine `editor.send({type: 'select', at: ...})` to a different position still produces an emission.