### PR TITLE
feat: support per-column alignment on tables

### DIFF
--- a/.changeset/table-alignment.md
+++ b/.changeset/table-alignment.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: support per-column alignment on tables
+
+The default `table` block-object now carries an optional `alignment` field that mirrors GFM's per-column alignment markers. `markdownToPortableText` reads the colons on the delimiter row (`:---`, `:---:`, `---:`) and writes them to `alignment` as an array of `'left' | 'center' | 'right' | null`, indexed by column. `portableTextToMarkdown` does the inverse: a `null` (or missing) entry emits `---`, otherwise the entry decides which colons surround the dashes. Tables without alignment round-trip unchanged - the `alignment` field is omitted on the way in and skipped on the way out.

--- a/packages/markdown/src/default-schema.ts
+++ b/packages/markdown/src/default-schema.ts
@@ -126,6 +126,7 @@ const defaultTableObjectDefinition = {
   name: 'table',
   fields: [
     {name: 'headerRows', type: 'number'},
+    {name: 'alignment', type: 'array'},
     {name: 'rows', type: 'array'},
   ],
 } as const satisfies BlockObjectDefinition

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -65,6 +65,7 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
 export const DefaultTableRenderer: PortableTextTypeRenderer<{
   _type: 'table'
   headerRows: number | undefined
+  alignment: Array<'left' | 'center' | 'right' | null> | undefined
   rows: Array<{
     _key: string
     cells: Array<{
@@ -82,6 +83,7 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
       value: Array<{_type: string; children?: Array<unknown>}>
     }>
   }>
+  const alignment = value.alignment
 
   const headerRow = rows.at(0)
 
@@ -128,8 +130,21 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   // First row is the header, padded to the table's column count
   lines.push(renderRow(headerRow.cells))
 
-  // Delimiter row, sized to the column count
-  const separators = Array.from({length: columnCount}, () => ' --- ')
+  // Delimiter row, sized to the column count. Each cell's colons encode the
+  // column's alignment as defined by `value.alignment[columnIndex]`.
+  const separators = Array.from({length: columnCount}, (_, index) => {
+    const align = alignment?.at(index)
+    if (align === 'left') {
+      return ' :--- '
+    }
+    if (align === 'center') {
+      return ' :---: '
+    }
+    if (align === 'right') {
+      return ' ---: '
+    }
+    return ' --- '
+  })
   lines.push(`|${separators.join('|')}|`)
 
   // Remaining rows are the body

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -3336,6 +3336,7 @@ describe(markdownToPortableText.name, () => {
       name: 'table',
       fields: [
         {name: 'headerRows', type: 'number'},
+        {name: 'alignment', type: 'array'},
         {name: 'rows', type: 'array'},
       ],
     } as const satisfies BlockObjectDefinition
@@ -4590,6 +4591,58 @@ describe(markdownToPortableText.name, () => {
           markDefs: [],
         },
       ])
+    })
+
+    test('table with column alignment', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '| L | C | R | D |',
+        '| :--- | :---: | ---: | --- |',
+        '| 1 | 2 | 3 | 4 |',
+      ].join('\n')
+
+      const result = markdownToPortableText(
+        markdown,
+        getTableTestOptions(keyGenerator),
+      )
+      expect((result.at(0) as {alignment?: unknown}).alignment).toEqual([
+        'left',
+        'center',
+        'right',
+        null,
+      ])
+    })
+
+    test('table with one aligned column among unaligned columns', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '| A | B | C |',
+        '| --- | --- | ---: |',
+        '| 1 | 2 | 3 |',
+      ].join('\n')
+
+      const result = markdownToPortableText(
+        markdown,
+        getTableTestOptions(keyGenerator),
+      )
+      expect((result.at(0) as {alignment?: unknown}).alignment).toEqual([
+        null,
+        null,
+        'right',
+      ])
+    })
+
+    test('table with no alignment omits the alignment field', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n')
+
+      const result = markdownToPortableText(
+        markdown,
+        getTableTestOptions(keyGenerator),
+      )
+      expect(result.at(0) as Record<string, unknown>).not.toHaveProperty(
+        'alignment',
+      )
     })
   })
 

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -2193,6 +2193,296 @@ describe(portableTextToMarkdown.name, () => {
         )
       })
     })
+
+    describe('table with column alignment', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          alignment: ['left', 'center', 'right', null],
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'L',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'C',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'R',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'D',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: '1',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: '2',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: '3',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: '4',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('encodes column alignment as colons on the delimiter row', () => {
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(
+          [
+            '| L | C | R | D |',
+            '| :--- | :---: | ---: | --- |',
+            '| 1 | 2 | 3 | 4 |',
+          ].join('\n'),
+        )
+      })
+    })
+
+    describe('table with only one aligned column', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          alignment: [null, null, 'right'],
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'A',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'B',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'C',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('emits `---` for unaligned columns and `---:` for the right-aligned column', () => {
+        expect(
+          portableTextToMarkdown(portableText, {
+            types: {
+              table: DefaultTableRenderer,
+            },
+          }),
+        ).toBe(['| A | B | C |', '| --- | --- | ---: |'].join('\n'))
+      })
+    })
   })
 
   describe('callouts', () => {

--- a/packages/markdown/src/to-portable-text/extract-alignment.test.ts
+++ b/packages/markdown/src/to-portable-text/extract-alignment.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, test} from 'vitest'
+import {extractAlignmentFromStyleAttr} from './markdown-to-portable-text'
+
+describe(extractAlignmentFromStyleAttr.name, () => {
+  test('returns `left` for `text-align:left`', () => {
+    expect(extractAlignmentFromStyleAttr('text-align:left')).toBe('left')
+  })
+
+  test('returns `center` for `text-align:center`', () => {
+    expect(extractAlignmentFromStyleAttr('text-align:center')).toBe('center')
+  })
+
+  test('returns `right` for `text-align:right`', () => {
+    expect(extractAlignmentFromStyleAttr('text-align:right')).toBe('right')
+  })
+
+  test('returns `null` for `null`', () => {
+    expect(extractAlignmentFromStyleAttr(null)).toBeNull()
+  })
+
+  test('returns `null` for the empty string', () => {
+    expect(extractAlignmentFromStyleAttr('')).toBeNull()
+  })
+
+  test('returns `null` for a `style` value without `text-align`', () => {
+    expect(extractAlignmentFromStyleAttr('background-color:red')).toBeNull()
+  })
+
+  test('tolerates whitespace around the colon', () => {
+    expect(extractAlignmentFromStyleAttr('text-align : center')).toBe('center')
+  })
+
+  test('reads `text-align` alongside other declarations', () => {
+    expect(
+      extractAlignmentFromStyleAttr(
+        'background-color:red;text-align:right;color:blue',
+      ),
+    ).toBe('right')
+  })
+
+  test('returns `null` for unknown `text-align` keywords', () => {
+    expect(extractAlignmentFromStyleAttr('text-align:justify')).toBeNull()
+  })
+})

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -78,6 +78,7 @@ type Options = {
     html?: ObjectMatcher<{html: string}>
     table?: ObjectMatcher<{
       headerRows: number | undefined
+      alignment: Array<'left' | 'center' | 'right' | null> | undefined
       rows: Array<{
         _key: string
         _type: 'row'
@@ -185,6 +186,23 @@ const defaultOptions = {
     callout: buildObjectMatcher(defaultCalloutObjectDefinition),
   },
 } as const satisfies Options
+
+/**
+ * Reads GFM column alignment from a markdown-it cell token's `style`
+ * attribute. Tolerates other CSS declarations sharing the value.
+ */
+export function extractAlignmentFromStyleAttr(
+  styleAttr: string | null,
+): 'left' | 'center' | 'right' | null {
+  if (!styleAttr) {
+    return null
+  }
+  const match = styleAttr.match(/text-align\s*:\s*(left|center|right)/)
+  if (!match) {
+    return null
+  }
+  return match[1] as 'left' | 'center' | 'right'
+}
 
 /**
  * Flattens a table structure by lifting all blocks from all cells.
@@ -344,6 +362,7 @@ export function markdownToPortableText(
       }>
     }>
     headerRows: number
+    alignment: Array<'left' | 'center' | 'right' | null>
   } | null = null
   let currentTableRow: Array<{
     _type: 'cell'
@@ -1099,7 +1118,7 @@ export function markdownToPortableText(
       // Tables
       case 'table_open':
         flushBlock()
-        currentTable = {rows: [], headerRows: 0}
+        currentTable = {rows: [], headerRows: 0, alignment: []}
         break
 
       case 'table_close': {
@@ -1109,6 +1128,7 @@ export function markdownToPortableText(
 
         // Only create table object if table type is defined
         if (consolidatedOptions.types.table) {
+          const hasAlignment = currentTable.alignment.some((a) => a !== null)
           const tableObject = consolidatedOptions.types.table({
             context: {
               schema: consolidatedOptions.schema,
@@ -1120,6 +1140,7 @@ export function markdownToPortableText(
                 currentTable.headerRows > 0
                   ? currentTable.headerRows
                   : undefined,
+              alignment: hasAlignment ? currentTable.alignment : undefined,
             },
             isInline: false,
           })
@@ -1175,6 +1196,14 @@ export function markdownToPortableText(
 
       case 'th_open':
       case 'td_open': {
+        // Alignment is per-column, set on every cell of that column. Read
+        // from the header so each column contributes exactly one entry.
+        if (currentTable && inTableHead && token.type === 'th_open') {
+          currentTable.alignment.push(
+            extractAlignmentFromStyleAttr(token.attrGet('style')),
+          )
+        }
+
         // Start a new block for the table cell
         const style = consolidatedOptions.block.normal({
           context: {schema: consolidatedOptions.schema},


### PR DESCRIPTION
GFM tables encode per-column alignment on the delimiter row using colons. `:---` is left-aligned, `:---:` is center-aligned, `---:` is right-aligned, and a bare `---` leaves the column with no alignment specified. The default table block-object had no representation for this, so any alignment in source markdown was dropped on parse and any aligned table assembled in Portable Text was emitted without colons.

This change adds an optional `alignment` field to the default `table` schema: `Array<'left' | 'center' | 'right' | null>` indexed by column. The shape mirrors GFM exactly - column-scoped (not cell-scoped, because GFM has no per-cell alignment), positional (the index is the column), `null` for columns without an alignment marker so positional indexing stays stable across sparse alignment. Tables without any aligned columns omit the field entirely.

`markdownToPortableText` reads the colons by inspecting the `style="text-align:..."` attribute that `markdown-it` puts on each header cell, and emits the array only if at least one column has alignment. `portableTextToMarkdown` does the inverse in `DefaultTableRenderer`: a `null` or missing entry emits `---`, the alignment values emit the matching colon pattern. Tables that don't carry an `alignment` field round-trip identically to before.

Sample round-trip:

```
| L    | C      | R    | D   |
| :--- | :---:  | ---: | --- |
| 1    | 2      | 3    | 4   |
```

```ts
{
  _type: 'table',
  alignment: ['left', 'center', 'right', null],
  rows: [
    {_type: 'row', cells: [/* L, C, R, D */]},
    {_type: 'row', cells: [/* 1, 2, 3, 4 */]},
  ],
}
```

Five new tests cover both directions: full alignment array round-trip, sparse alignment (one aligned column among unaligned), and the no-alignment case that proves the field is omitted when no column is aligned.