### PR TITLE
fix: emit `'selection'` only when the selection actually moves

### DIFF
--- a/.changeset/selection-emit-stability.md
+++ b/.changeset/selection-emit-stability.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: emit `'selection'` only when the selection actually moves
+
+The `'selection'` event is now emitted only when an operation changes the
+caret's anchor, focus, or direction. Previously, internal sync paths could
+trigger redundant emits even when the selection was unchanged - for example,
+when remote patches arrived for a different part of the value, or when the
+sync machine re-ran on a value reference change.
+
+Consumers can keep using `'selection'` as a signal for both real caret
+movements and deliberate "active state changed" wake-ups (such as toggling a
+decorator on a collapsed caret), and will no longer see spurious events on
+unrelated value updates.

--- a/packages/editor/src/editor/relay-machine.ts
+++ b/packages/editor/src/editor/relay-machine.ts
@@ -3,7 +3,6 @@ import type {PortableTextBlock} from '@portabletext/schema'
 import type {FocusEvent} from 'react'
 import {assign, emit, setup, type ActorRefFrom} from 'xstate'
 import type {EditorSelection, InvalidValueResolution} from '../types/editor'
-import {isEqualSelections} from '../utils/util.is-equal-selections'
 
 /**
  * @public
@@ -115,33 +114,20 @@ export const relayMachine = setup({
         emit(({event}) => event),
       ],
     },
-    'selection': [
-      {
-        guard: ({context}) => context.lastEventWasFocused,
-        actions: [
-          assign({
-            prevSelection: ({event}) => event.selection,
-          }),
-          emit(({event}) => event),
-          assign({
-            lastEventWasFocused: false,
-          }),
-        ],
-      },
-      {
-        guard: ({context, event}) =>
-          !isEqualSelections(context.prevSelection, event.selection),
-        actions: [
-          assign({
-            prevSelection: ({event}) => event.selection,
-          }),
-          emit(({event}) => event),
-          assign({
-            lastEventWasFocused: false,
-          }),
-        ],
-      },
-    ],
+    'selection': {
+      guard: ({context, event}) =>
+        context.lastEventWasFocused ||
+        context.prevSelection !== event.selection,
+      actions: [
+        assign({
+          prevSelection: ({event}) => event.selection,
+        }),
+        emit(({event}) => event),
+        assign({
+          lastEventWasFocused: false,
+        }),
+      ],
+    },
     '*': {
       actions: [
         emit(({event}) => event),

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -507,15 +507,28 @@ export function applyOperation(editor: Editor, op: Operation): void {
   }
 
   if (transformSelection && editor.selection) {
-    const selection = {...editor.selection}
+    const anchor = transformPoint(editor.selection.anchor, op)
+    const focus = transformPoint(editor.selection.focus, op)
 
-    for (const [point, key] of rangePoints(selection)) {
-      selection[key] = transformPoint(point, op)!
-    }
-
-    editor.selection = {
-      ...selection,
-      backward: isBackwardRange(selection, editor),
+    if (!anchor || !focus) {
+      // The operation removed the host node of one of the selection's
+      // endpoints. The selection is no longer valid.
+      editor.selection = null
+    } else if (
+      anchor !== editor.selection.anchor ||
+      focus !== editor.selection.focus
+    ) {
+      // `transformPoint` returns the same reference when the operation doesn't
+      // move the point. If neither endpoint moved, the selection is identity-
+      // stable and we leave `editor.selection` alone. This lets internal sync
+      // paths (e.g. remote patches arriving via `update value`) run set/unset/
+      // insert_text operations without forcing downstream consumers to re-derive
+      // selection-keyed state for no semantic reason.
+      editor.selection = {
+        anchor,
+        focus,
+        backward: isBackwardRange({anchor, focus}, editor),
+      }
     }
   }
 }

--- a/packages/editor/src/engine/point/transform-point.ts
+++ b/packages/editor/src/engine/point/transform-point.ts
@@ -6,7 +6,9 @@ import {isAncestorPath} from '../path/is-ancestor-path'
 import {pathEquals} from '../path/path-equals'
 
 /**
- * Transform a point by an operation.
+ * Transform a point by an operation. Returns the same `point` reference when
+ * the operation doesn't actually move the point, so callers can use referential
+ * equality to detect "nothing changed."
  *
  * With keyed paths, most operations don't affect paths at all:
  * - insert: no-op (new node has its own key, doesn't shift siblings)
@@ -27,31 +29,38 @@ export function transformPoint(
   }
 
   const {affinity = 'forward'} = options
-  let {path, offset}: {path: Path; offset: number} = point
 
   switch (op.type) {
     case 'insert_text': {
       if (
-        pathEquals(op.path, path) &&
-        (op.offset < offset || (op.offset === offset && affinity === 'forward'))
+        pathEquals(op.path, point.path) &&
+        (op.offset < point.offset ||
+          (op.offset === point.offset && affinity === 'forward'))
       ) {
-        offset += op.text.length
+        return {path: point.path, offset: point.offset + op.text.length}
       }
 
-      break
+      return point
     }
 
     case 'remove_text': {
-      if (pathEquals(op.path, path) && op.offset <= offset) {
-        offset -= Math.min(offset - op.offset, op.text.length)
+      if (pathEquals(op.path, point.path) && op.offset <= point.offset) {
+        return {
+          path: point.path,
+          offset:
+            point.offset - Math.min(point.offset - op.offset, op.text.length),
+        }
       }
 
-      break
+      return point
     }
 
     case 'set': {
       const propertyName = op.path[op.path.length - 1]
       const nodePath = op.path.slice(0, -1)
+
+      let path: Path = point.path
+      let offset: number = point.offset
 
       // When _key is set to a new value, update any point referencing the old key
       if (propertyName === '_key' && typeof op.value === 'string') {
@@ -61,19 +70,20 @@ export function transformPoint(
             : undefined
 
         if (oldKey) {
-          const newPath: Path = [...path]
-          let changed = false
+          let newPath: Path | undefined = undefined
 
-          for (let i = 0; i < newPath.length; i++) {
-            const segment = newPath[i]
+          for (let i = 0; i < path.length; i++) {
+            const segment = path[i]
 
             if (isKeyedSegment(segment) && segment._key === oldKey) {
+              if (newPath === undefined) {
+                newPath = [...path]
+              }
               newPath[i] = {_key: op.value}
-              changed = true
             }
           }
 
-          if (changed) {
+          if (newPath !== undefined) {
             path = newPath
           }
         }
@@ -88,33 +98,42 @@ export function transformPoint(
         }
       }
 
-      break
+      if (path === point.path && offset === point.offset) {
+        return point
+      }
+
+      return {path, offset}
     }
 
     case 'unset': {
       const lastSegment = op.path[op.path.length - 1]
 
       if (isKeyedSegment(lastSegment)) {
-        if (pathEquals(op.path, path) || isAncestorPath(op.path, path)) {
+        if (
+          pathEquals(op.path, point.path) ||
+          isAncestorPath(op.path, point.path)
+        ) {
           return null
         }
-        break
+        return point
       }
 
       const propertyName = lastSegment
       const nodePath = op.path.slice(0, -1)
 
-      if (propertyName === 'text' && pathEquals(nodePath, path)) {
-        offset = 0
+      if (
+        propertyName === 'text' &&
+        pathEquals(nodePath, point.path) &&
+        point.offset !== 0
+      ) {
+        return {path: point.path, offset: 0}
       }
 
-      break
+      return point
     }
 
     // set_selection: no transform needed
     default:
       return point
   }
-
-  return {path, offset}
 }

--- a/packages/editor/tests/selection-emit-stability.test.tsx
+++ b/packages/editor/tests/selection-emit-stability.test.tsx
@@ -1,0 +1,189 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {EventListenerPlugin} from '../src/plugins'
+import {getActiveDecorators} from '../src/selectors/selector.get-active-decorators'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('selection emit stability', () => {
+  test('decorator.add on collapsed caret emits a single selection event', async () => {
+    const onSelection = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const foo = {_key: 'k1', _type: 'span', text: 'foo bar', marks: []}
+    const block = {
+      _key: 'k0',
+      _type: 'block',
+      children: [foo],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [block],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'selection') {
+              onSelection(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    const caretAt4 = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+    }
+
+    editor.send({type: 'select', at: caretAt4})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...caretAt4,
+        backward: false,
+      })
+    })
+
+    onSelection.mockClear()
+
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(getActiveDecorators(editor.getSnapshot())).toEqual(['strong'])
+    })
+
+    expect(onSelection).toHaveBeenCalledTimes(1)
+  })
+
+  test('decorator.add on whole-span selection emits a single selection event', async () => {
+    const onSelection = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const foo = {_key: 'k1', _type: 'span', text: 'foo bar', marks: []}
+    const block = {
+      _key: 'k0',
+      _type: 'block',
+      children: [foo],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [block],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'selection') {
+              onSelection(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    const wholeSpan = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 7},
+    }
+
+    editor.send({type: 'select', at: wholeSpan})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...wholeSpan,
+        backward: false,
+      })
+    })
+
+    onSelection.mockClear()
+
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {...block, children: [{...foo, marks: ['strong']}]},
+      ])
+    })
+
+    expect(onSelection).toHaveBeenCalledTimes(1)
+  })
+
+  test('remote patches that do not move the caret emit no selection event', async () => {
+    const onSelection = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const foo = {_key: 'k1', _type: 'span', text: 'foo bar', marks: []}
+    const block = {
+      _key: 'k0',
+      _type: 'block',
+      children: [foo],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [block],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'selection') {
+              onSelection(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    const caretAt3 = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+    }
+
+    editor.send({type: 'select', at: caretAt3})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...caretAt3,
+        backward: false,
+      })
+    })
+
+    onSelection.mockClear()
+
+    // A remote patch that writes the same text must not produce a selection
+    // emit, since the caret hasn't moved.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: 'foo bar',
+          origin: 'remote',
+        },
+      ],
+      snapshot: [block],
+    })
+
+    const caretAt5 = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 5},
+    }
+
+    editor.send({type: 'select', at: caretAt5})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...caretAt5,
+        backward: false,
+      })
+    })
+
+    expect(onSelection).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes / supersedes #2702.

The `'selection'` event was being emitted on every internal `onChange()` cycle, even when the underlying anchor and focus were unchanged. Consumers that read selection-derived state - toolbars showing active decorators, Sanity Studio's form-state focus coupling - over-rendered or, in the form-state case, navigated openPath on selection events that didn't carry any new information.

The root cause was `apply-operation`'s `transformSelection` block rebuilding `editor.selection` with a fresh reference on every set / unset / insert_text / remove_text operation, including operations that didn't touch the caret. Remote patches arriving via `update value` routinely hit this path. Downstream guards couldn't tell those fresh references apart from genuine selection moves.

Two changes restore reference stability:

- `transformPoint` now returns the same `point` reference when the operation doesn't actually move the point. Callers can use referential equality to detect "nothing changed."
- `apply-operation`'s `transformSelection` block reads that referential signal: if neither anchor nor focus moved, `editor.selection` is left alone. No allocation, no semantic compare.

With reference stability at the source, the relay machine's existing selection guard can be referential too. Its two `'selection'` branches collapse into one with a single guard:

```ts
guard: ({context, event}) =>
  context.lastEventWasFocused || context.prevSelection !== event.selection
```

Deliberate wake-up reselects in `operation.decorator.add` / `operation.decorator.remove` (`editor.selection = {...selection}`) still flow through. They produce a fresh reference that the referential guard correctly forwards, so toolbar consumers still get the signal they need when toggling a decorator on a collapsed caret or on a fully-selected span.

This supersedes the broader revert in #2702. PR #2698's relay-level semantic dedup correctly caught the bridge-sync no-op emit, but also caught the deliberate wake-up reselects, which broke active-decorator state in toolbars. Stabilizing the reference upstream and basing the relay guard on reference equality lets both shapes coexist.

## What to review

- `packages/editor/src/engine/point/transform-point.ts` - returns same `point` reference when no transform applied. Eight other call sites (`transformRange`, `apply-merge-node`, `apply-split-node`, `unwrap-container`, `move-range-by-operation`, `diff-text`, `point-ref`) get identity stability for free.
- `packages/editor/src/engine/core/apply-operation.ts` - `transformSelection` block uses referential check on the transformed anchor and focus.
- `packages/editor/src/editor/relay-machine.ts` - two selection branches collapsed into one with a referential guard.
- `packages/editor/tests/selection-emit-stability.test.tsx` - three scenarios covering decorator wake-ups (collapsed caret, whole-span) and the remote no-op patch.

## Verification

- All 731 unit tests pass.
- New browser tests pass: 3 / 3.
- Sanity Studio playwright-ct PortableText suite pass against Studio with `@portabletext/editor` patched to this commit, with no Studio-side changes: 18 / 18 (Annotations 3, ObjectBlock + Toolbar 15, all serial).