### PR TITLE
chore: scaffold `@portabletext/plugin-table` skeleton

### DIFF
--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -1,0 +1,23 @@
+# Table Plugin
+
+> 📊 Table support for the Portable Text Editor
+
+**Status:** skeleton package, private. Not yet published to npm.
+
+This package will host the schema, container registrations, and behaviors for first-class tables in the Portable Text Editor. The goal is to support tables across standalone PTE, Sanity Studio, and Sanity Canvas with a single shared core.
+
+## Planned API
+
+```tsx
+import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
+import {TablePlugin} from '@portabletext/plugin-table'
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <PortableTextEditable />
+      <TablePlugin />
+    </EditorProvider>
+  )
+}
+```

--- a/packages/plugin-table/eslint.config.js
+++ b/packages/plugin-table/eslint.config.js
@@ -1,0 +1,19 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import {globalIgnores} from 'eslint/config'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config([
+  globalIgnores(['dist', '*.test.tsx']),
+  reactHooks.configs.flat.recommended,
+  {
+    files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {'react-hooks/exhaustive-deps': 'error'},
+  },
+])

--- a/packages/plugin-table/package.config.ts
+++ b/packages/plugin-table/package.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  babel: {reactCompiler: true},
+  reactCompilerOptions: {target: '19'},
+})

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@portabletext/plugin-table",
+  "version": "0.0.0",
+  "private": true,
+  "description": "📊 Table support for the Portable Text Editor",
+  "keywords": [
+    "portabletext",
+    "plugin",
+    "table"
+  ],
+  "homepage": "https://portabletext.org",
+  "bugs": {
+    "url": "https://github.com/portabletext/editor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/portabletext/editor.git",
+    "directory": "packages/plugin-table"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg-utils build --strict --check --clean",
+    "check:lint": "biome lint .",
+    "check:react-compiler": "eslint .",
+    "check:types": "tsc",
+    "check:types:watch": "tsc --watch",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "pkg-utils watch",
+    "lint:fix": "biome lint --write .",
+    "prepublishOnly": "turbo run build"
+  },
+  "devDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "@sanity/tsconfig": "^2.1.0",
+    "@types/react": "^19.2.14",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "react": "^19.2.5",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0"
+  },
+  "peerDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "react": "^19.2"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/plugin-table/src/index.ts
+++ b/packages/plugin-table/src/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin.table'

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -1,0 +1,22 @@
+import {useEditor} from '@portabletext/editor'
+import {useEffect} from 'react'
+
+/**
+ * Skeleton placeholder for the table plugin.
+ *
+ * This component currently registers no behaviors and renders nothing. It
+ * exists so that consumers can wire `<TablePlugin />` into their editor today
+ * and pick up real functionality as the package grows.
+ *
+ * @alpha
+ */
+export function TablePlugin() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    // Reserved for behavior registration once the table API takes shape.
+    void editor
+  }, [editor])
+
+  return null
+}

--- a/packages/plugin-table/tsconfig.dist.json
+++ b/packages/plugin-table/tsconfig.dist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-table/tsconfig.json
+++ b/packages/plugin-table/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["**/*.ts", "**/*.tsx", "src/index.ts"],
+  "exclude": ["dist", "./node_modules"]
+}

--- a/packages/plugin-table/tsconfig.settings.json
+++ b/packages/plugin-table/tsconfig.settings.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1031,6 +1031,36 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4)
 
+  packages/plugin-table:
+    devDependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../editor
+      '@sanity/tsconfig':
+        specifier: ^2.1.0
+        version: 2.1.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+
   packages/plugin-typeahead-picker:
     dependencies:
       '@portabletext/keyboard-shortcuts':
@@ -9678,7 +9708,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -9755,7 +9785,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -9764,7 +9794,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -9830,7 +9860,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.3
+      semver: 7.8.0
 
   '@changesets/get-github-info@0.7.0':
     dependencies:
@@ -13042,7 +13072,7 @@ snapshots:
 
   '@sanity/parse-package-json@2.0.0':
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@sanity/pkg-utils@10.2.1(@types/babel__core@7.20.5)(@types/node@20.19.25)(babel-plugin-react-compiler@1.0.0)(debug@4.4.3)(oxc-resolver@11.19.1)(typescript@5.9.3)':
     dependencies:
@@ -14258,7 +14288,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       pathe: 2.0.3
 
   ast-types@0.16.1:
@@ -14896,11 +14926,11 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       eslint: 9.39.1(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -14930,7 +14960,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -17388,7 +17418,7 @@ snapshots:
   rolldown-plugin-dts@0.18.1(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.52)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
@@ -17405,7 +17435,7 @@ snapshots:
   rolldown-plugin-dts@0.18.3(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.54)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 3.0.0
@@ -18567,9 +18597,9 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.1.13
+      zod: 4.4.3
 
   zod-validation-error@5.0.0(zod@4.1.13):
     dependencies:


### PR DESCRIPTION
Private skeleton package for first-class table support in the Portable Text Editor. The package will host the schema, container registrations, and behaviors for tables across standalone PTE, Sanity Studio, and Sanity Canvas.

Mirrors the `plugin-one-line` package shape: pkg-utils build, biome lint, eslint react-compiler check, strictest tsconfig. Marked `private: true` so it does not publish.

Exports a `TablePlugin` React component as an `@alpha` no-op placeholder so consumers can wire it in today and pick up real functionality as the API grows.

```tsx
import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
import {TablePlugin} from '@portabletext/plugin-table'

function App() {
  return (
    <EditorProvider initialConfig={{schemaDefinition}}>
      <PortableTextEditable />
      <TablePlugin />
    </EditorProvider>
  )
}
```

## Layout

```
packages/plugin-table/
├── package.json           // private: true, no version publishing
├── package.config.ts      // pkg-utils + react-compiler
├── eslint.config.js
├── tsconfig.{json,settings,dist}.json
├── README.md
└── src/
    ├── index.ts
    └── plugin.table.tsx   // export function TablePlugin() { return null }
```

## Checks

- `check:format`, `check:lint`, `check:types`, `check:knip`, `build` — all green locally.
- No changeset (private package).