### PR TITLE
fix: seed positional context at `collectDescendantPaths` entry points

### DIFF
--- a/.changeset/normalize-descendant-containers.md
+++ b/.changeset/normalize-descendant-containers.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: seed positional context at `collectDescendantPaths` entry points

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -3,7 +3,9 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Operation} from '../engine/interfaces/operation'
 import type {Path} from '../engine/interfaces/path'
+import {parentPath} from '../engine/path/parent-path'
 import {pathLevels} from '../engine/path/path-levels'
+import {resolveContainerAt} from '../schema/resolve-container-at'
 import type {
   Containers,
   RegisteredContainer,
@@ -110,7 +112,17 @@ export function getDirtyPaths(
             const childNode = child as Node
             const childPath: Path = [{_key: childNode._key}]
             levels.push(childPath)
-            collectDescendantPaths(context, childNode, childPath, levels)
+            // Seed the walker with the child's own registration so it
+            // can recurse into the child's container fields. At root,
+            // a child is registered globally if at all.
+            const childRegistration = context.containers.get(childNode._type)
+            collectDescendantPaths(
+              context,
+              childNode,
+              childPath,
+              levels,
+              childRegistration,
+            )
           }
         }
         return levels
@@ -130,7 +142,23 @@ export function getDirtyPaths(
           !Array.isArray(op.value)
         ) {
           const valueNode = op.value as Node
-          collectDescendantPaths(context, valueNode, op.path, levels)
+          // The replacement node's own registration scopes descent. Resolve
+          // positionally via its path so nested-only registrations are
+          // recognized.
+          const valueRegistration = resolveContainerAt(
+            context.containers,
+            context.value,
+            op.path,
+          )
+          collectDescendantPaths(
+            context,
+            valueNode,
+            op.path,
+            levels,
+            valueRegistration && 'field' in valueRegistration
+              ? valueRegistration
+              : undefined,
+          )
         }
         return levels
       }
@@ -152,6 +180,17 @@ export function getDirtyPaths(
         const arrayFieldName = getChildFieldName(context, nodePath)
 
         if (arrayFieldName === propertyName) {
+          // Each child's parent is the node at nodePath. Resolve
+          // positionally so nested-only registrations are recognized.
+          const parentRegistration = resolveContainerAt(
+            context.containers,
+            context.value,
+            nodePath,
+          )
+          const seed =
+            parentRegistration && 'field' in parentRegistration
+              ? parentRegistration
+              : undefined
           for (let i = 0; i < op.value.length; i++) {
             const child = op.value[i]
 
@@ -170,7 +209,7 @@ export function getDirtyPaths(
               {_key: childNode._key},
             ]
             levels.push(childPath)
-            collectDescendantPaths(context, childNode, childPath, levels)
+            collectDescendantPaths(context, childNode, childPath, levels, seed)
           }
         }
       }
@@ -265,8 +304,23 @@ export function getDirtyPaths(
       // Use index-based child paths to avoid dedup collisions when
       // children have duplicate keys (pre-normalization). Walk all
       // child array fields via the schema so container descendants
-      // are also dirtied.
-      collectDescendantPaths(context, node, nodePath, levels)
+      // are also dirtied. Seed the walker with the inserted node's
+      // parent registration resolved positionally - flat type-keyed
+      // lookup misses nested-only registrations.
+      const parentRegistration = resolveContainerAt(
+        context.containers,
+        context.value,
+        parentPath(nodePath),
+      )
+      collectDescendantPaths(
+        context,
+        node,
+        nodePath,
+        levels,
+        parentRegistration && 'field' in parentRegistration
+          ? parentRegistration
+          : undefined,
+      )
 
       return levels
     }

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -2177,4 +2177,561 @@ describe('container normalization', () => {
       ])
     })
   })
+  test('partial nested subtree inserted via patches normalizes leaves to placeholder blocks', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={tableContainers} />,
+    })
+
+    // Insert a partially-formed table: rows + cells are scaffolded, but each
+    // cell's `content` field is missing entirely. Normalization should walk
+    // descendants of the insertion and fill each cell's content with a
+    // placeholder block.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}],
+          position: 'after',
+          items: [
+            {
+              _type: 'table',
+              _key: 'table-0',
+              rows: [
+                {
+                  _type: 'row',
+                  _key: 'row-0',
+                  cells: [
+                    {_type: 'cell', _key: 'cell-0'},
+                    {_type: 'cell', _key: 'cell-1'},
+                  ],
+                },
+              ],
+            },
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: 'table-0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k6',
+                      children: [
+                        {_type: 'span', _key: 'k7', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k4',
+                      children: [
+                        {_type: 'span', _key: 'k5', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('partial nested subtree inserted via insert.block event normalizes leaves to placeholder blocks', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={tableContainers} />,
+    })
+
+    // Same shape as the patches test above, but inserted via the
+    // `insert.block` event instead. The contract for normalization should not
+    // depend on the origin of the operation.
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'table',
+        _key: 'table-0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'row-0',
+            cells: [
+              {_type: 'cell', _key: 'cell-0'},
+              {_type: 'cell', _key: 'cell-1'},
+            ],
+          },
+        ],
+      },
+      placement: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'table',
+          _key: 'table-0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k6',
+                      children: [
+                        {_type: 'span', _key: 'k7', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k4',
+                      children: [
+                        {_type: 'span', _key: 'k5', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('partial row inserted into existing table via patches normalizes cell content', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={tableContainers} />,
+    })
+
+    // Insert a partial row directly into the table's `rows` field via a
+    // remote patch. The row's only cell has no `content` field at all;
+    // normalization should fill it.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: tableKey}, 'rows', {_key: 'row-0'}],
+          position: 'after',
+          items: [
+            {
+              _type: 'row',
+              _key: 'row-1',
+              cells: [{_type: 'cell', _key: 'cell-1'}],
+            },
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'row-1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k3',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 'k4', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('partial row inserted into existing table via insert.block normalizes cell content', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={tableContainers} />,
+    })
+
+    // Same shape but via insert.block targeting the reference row's path.
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'row',
+        _key: 'row-1',
+        cells: [{_type: 'cell', _key: 'cell-1'}],
+      },
+      placement: 'after',
+      at: {
+        anchor: {path: [{_key: tableKey}, 'rows', {_key: 'row-0'}], offset: 0},
+        focus: {path: [{_key: tableKey}, 'rows', {_key: 'row-0'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'row-1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k3',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 'k4', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('partial row inserted at nested path with nested-\`of\` registration normalizes cell content', async () => {
+    // Mirrors plugin-table's exact setup: single top-level container with
+    // nested-`of` children, partial row inserted at a NESTED path.
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+
+    const nestedTableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      render: ({children}) => <>{children}</>,
+      of: [
+        defineContainer({
+          type: 'row',
+          arrayField: 'cells',
+          render: ({children}) => <>{children}</>,
+          of: [
+            defineContainer({
+              type: 'cell',
+              arrayField: 'content',
+              render: ({children}) => <>{children}</>,
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[nestedTableContainer]} />,
+    })
+
+    editor.send({
+      type: 'insert.block',
+      block: {
+        _type: 'row',
+        _key: 'row-1',
+        cells: [{_type: 'cell', _key: 'cell-1'}],
+      },
+      placement: 'after',
+      at: {
+        anchor: {path: [{_key: tableKey}, 'rows', {_key: 'row-0'}], offset: 0},
+        focus: {path: [{_key: tableKey}, 'rows', {_key: 'row-0'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: tableKey,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'row-0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'row-1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cell-1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'k3',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 'k4', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Inserting a partial subtree into a registered container left descendant container fields unnormalized. Cells inside a freshly inserted row, for instance, kept no `content` field even though `content` is itself a registered container that should auto-fill with a placeholder text block.

The gap surfaces when registrations are nested only inside a parent's `of` and never declared at the top level:

```tsx
defineContainer({
  type: 'table',
  arrayField: 'rows',
  of: [
    defineContainer({
      type: 'row',
      arrayField: 'cells',
      of: [
        defineContainer({type: 'cell', arrayField: 'content'}),
      ],
    }),
  ],
})
```

With this shape, the public `containers` map only holds an entry for `table` - `row` and `cell` resolve via the parent's `of` chain during descent.

### Cause

`getDirtyPaths.collectDescendantPaths` resolves nested containers via the parent's `of` chain when threading positional context through recursion. The recursion is correct; the four top-level entry points (one in `case 'insert'`, three in `case 'set'`) did not seed the walker with the parent context. The first descent step fell back to the flat `containers` map - which omits same-`_type` entries that are registered only positionally inside another container's `of`.

Without that first step finding the registration, the walker bailed out and emitted no descendant paths. Normalization then never visited the cells inside the inserted row, so their `content` fields stayed unfilled.

### Fix

Each entry point now resolves the relevant parent registration via `resolveContainerAt` (which is itself positional-aware) and passes it as the walker's `parent` seed. The walker's existing recursion threads it from there.

### Commits

- `test` adds five scenarios pinning partial-subtree normalization across operation origins (`patches` events from external mutators, `insert.block` events from behaviors) and across registration shapes (flat top-level entries vs nested-`of` chains).
- `fix` seeds positional context at each of the four `collectDescendantPaths` entry points.