### PR TITLE
fix: Backspace no longer triggers `history.undo` after typing past an auto-decorated pair

### DIFF
--- a/.changeset/character-pair-decorator-selection-listener.md
+++ b/.changeset/character-pair-decorator-selection-listener.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/plugin-character-pair-decorator": patch
+---
+
+fix: Backspace no longer triggers `history.undo` after typing past an auto-decorated pair

--- a/packages/plugin-character-pair-decorator/package.json
+++ b/packages/plugin-character-pair-decorator/package.json
@@ -49,7 +49,9 @@
     "test:browser:firefox": "vitest run --project \"browser (firefox)\"",
     "test:browser:firefox:watch": "vitest watch --project \"browser (firefox)\"",
     "test:browser:webkit": "vitest run --project \"browser (webkit)\"",
-    "test:browser:webkit:watch": "vitest watch --project \"browser (webkit)\""
+    "test:browser:webkit:watch": "vitest watch --project \"browser (webkit)\"",
+    "test:unit": "vitest run --project unit",
+    "test:unit:watch": "vitest watch --project unit"
   },
   "dependencies": {
     "@xstate/react": "^6.1.0",
@@ -58,6 +60,7 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@portabletext/schema": "workspace:*",
     "@sanity/tsconfig": "^2.1.0",
     "@types/react": "^19.2.14",
     "@vitejs/plugin-react": "^5.2.0",
@@ -66,6 +69,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "racejar": "workspace:*",
     "react": "^19.2.5",
     "typescript": "catalog:",
     "typescript-eslint": "^8.48.0",

--- a/packages/plugin-character-pair-decorator/src/backspace.feature
+++ b/packages/plugin-character-pair-decorator/src/backspace.feature
@@ -1,0 +1,13 @@
+Feature: Backspace after auto-decoration
+
+  Background:
+    Given a global keymap
+
+  Scenario: Backspace after typing past an auto-decorated pair deletes one character
+    Given the text ""
+    When "`code`" is typed
+    Then the text is "code"
+    When " hello" is typed
+    Then the text is "code, hello"
+    When "{Backspace}" is pressed
+    Then the text is "code, hell"

--- a/packages/plugin-character-pair-decorator/src/backspace.test.tsx
+++ b/packages/plugin-character-pair-decorator/src/backspace.test.tsx
@@ -1,0 +1,36 @@
+import {parameterTypes} from '@portabletext/editor/test'
+import {
+  createTestEditor,
+  stepDefinitions,
+  type Context,
+} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {Before} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import backspaceFeature from './backspace.feature?raw'
+import {CharacterPairDecoratorPlugin} from './plugin.character-pair-decorator'
+
+Feature({
+  hooks: [
+    Before(async (context: Context) => {
+      const {editor, locator} = await createTestEditor({
+        children: (
+          <CharacterPairDecoratorPlugin
+            decorator={() => 'code'}
+            pair={{char: '`', amount: 1}}
+          />
+        ),
+        schemaDefinition: defineSchema({
+          decorators: [{name: 'code'}, {name: 'strong'}],
+          annotations: [{name: 'link'}],
+        }),
+      })
+
+      context.locator = locator
+      context.editor = editor
+    }),
+  ],
+  featureText: backspaceFeature,
+  stepDefinitions,
+  parameterTypes,
+})

--- a/packages/plugin-character-pair-decorator/src/global.d.ts
+++ b/packages/plugin-character-pair-decorator/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.feature?raw' {
+  const content: string
+  export default content
+}

--- a/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
+++ b/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
@@ -1,11 +1,6 @@
 import type {BlockOffset, Editor, EditorContext} from '@portabletext/editor'
 import {useEditor} from '@portabletext/editor'
-import {
-  defineBehavior,
-  effect,
-  forward,
-  raise,
-} from '@portabletext/editor/behaviors'
+import {defineBehavior, effect, raise} from '@portabletext/editor/behaviors'
 import * as utils from '@portabletext/editor/utils'
 import {useActorRef} from '@xstate/react'
 import {isDeepEqual} from 'remeda'
@@ -99,49 +94,34 @@ const selectionListenerCallback: CallbackLogicFunction<
   DecoratorPairEvent,
   {editor: Editor}
 > = ({sendBack, input}) => {
-  const unregister = input.editor.registerBehavior({
-    behavior: defineBehavior({
-      on: 'select',
-      guard: ({snapshot, event}) => {
-        if (!event.at) {
-          return {blockOffsets: undefined}
-        }
+  // Listen for the emitted 'selection' event which fires after ANY cursor
+  // movement (typing, clicking, pasting, etc.) - not just explicit 'select'
+  // behavior events.
+  const subscription = input.editor.on('selection', (event) => {
+    if (!event.selection) {
+      sendBack({type: 'selection', blockOffsets: undefined})
+      return
+    }
 
-        const anchor = utils.spanSelectionPointToBlockOffset({
-          snapshot,
-          selectionPoint: event.at.anchor,
-        })
-        const focus = utils.spanSelectionPointToBlockOffset({
-          snapshot,
-          selectionPoint: event.at.focus,
-        })
+    const snapshot = input.editor.getSnapshot()
+    const anchor = utils.spanSelectionPointToBlockOffset({
+      snapshot,
+      selectionPoint: event.selection.anchor,
+    })
+    const focus = utils.spanSelectionPointToBlockOffset({
+      snapshot,
+      selectionPoint: event.selection.focus,
+    })
 
-        if (!anchor || !focus) {
-          return {blockOffsets: undefined}
-        }
+    if (!anchor || !focus) {
+      sendBack({type: 'selection', blockOffsets: undefined})
+      return
+    }
 
-        return {
-          blockOffsets: {
-            anchor,
-            focus,
-          },
-        }
-      },
-      actions: [
-        ({event}, {blockOffsets}) => [
-          {
-            type: 'effect',
-            effect: () => {
-              sendBack({type: 'selection', blockOffsets})
-            },
-          },
-          forward(event),
-        ],
-      ],
-    }),
+    sendBack({type: 'selection', blockOffsets: {anchor, focus}})
   })
 
-  return unregister
+  return () => subscription.unsubscribe()
 }
 
 const deleteBackwardListenerCallback: CallbackLogicFunction<

--- a/packages/plugin-character-pair-decorator/vitest.config.ts
+++ b/packages/plugin-character-pair-decorator/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   test: {
     projects: [
       {
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+      {
         plugins: [
           react({
             babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
@@ -13,6 +19,7 @@ export default defineConfig({
         ],
         test: {
           name: 'browser',
+          include: ['src/**/*.test.tsx'],
           browser: {
             enabled: true,
             headless: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@portabletext/schema':
+        specifier: workspace:*
+        version: link:../schema
       '@sanity/tsconfig':
         specifier: ^2.1.0
         version: 2.1.0
@@ -684,6 +687,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      racejar:
+        specifier: workspace:*
+        version: link:../racejar
       react:
         specifier: ^19.2.5
         version: 19.2.5


### PR DESCRIPTION
After `CharacterPairDecoratorPlugin` auto-decorates a pair, the next `Backspace` would undo the entire typing burst instead of deleting one character. Now Backspace deletes one character as expected.

## Why

The plugin's state machine enters a `decorator added` state immediately after auto-decoration and is supposed to leave it on the next caret movement. Detection used `defineBehavior({on: 'select'})`, which only fires for explicit `select` behavior events. Typing raises `insert.text`, which moves the caret via the apply layer without raising a `select` event — so the machine stayed in `decorator added` forever during typing, and any later Backspace routed to `history.undo`.

`plugin-input-rule` already uses the right pattern: `input.editor.on('selection', ...)` — the engine-emitted `selection` event fires whenever `editor.selection` changes, regardless of which behavior event drove the change. This PR ports that pattern.

## Shape

- Replace `defineBehavior({on: 'select', ...})` with `input.editor.on('selection', ...)` in `selectionListenerCallback`
- Drop the now-unused `forward` import
- Add a vitest project split (`unit` for `*.test.ts`, `browser` for `*.test.tsx`) mirroring `plugin-paste-link`, and wire `test:unit` + `test:unit:watch` scripts
- Add a racejar/gherkin browser test pinning the contract

## TDD

Test commit fails RED on `origin/main` (Backspace undoes the typing burst → text is `"code, "` instead of `"code, hell"`). Fix commit makes it green.

## Sibling

Same fix shipped against `editor-v6.x` via #2713.