### PR TITLE
fix: stop `useEditorSelector` from triggering `Maximum update depth exceeded`

### DIFF
--- a/.changeset/use-editor-selector-stable-snapshot.md
+++ b/.changeset/use-editor-selector-stable-snapshot.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stop `useEditorSelector` from triggering `Maximum update depth exceeded`

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -136,11 +136,11 @@ export const PortableTextEditable = forwardRef<
 
   const editorActor = useContext(EditorActorContext)
   const relayActor = useContext(RelayActorContext)
-  const schema = editorActor.getSnapshot().context.schema
+  const editorEngine = useEngine()
+  const schema = editorEngine.schema
   const readOnly = useSelector(editorActor, (s) =>
     s.matches({'edit mode': 'read only'}),
   )
-  const editorEngine = useEngine()
   const validateSelectionActor = useActorRef(validateSelectionMachine, {
     input: {
       editorEngine,
@@ -351,7 +351,7 @@ export const PortableTextEditable = forwardRef<
         event.stopPropagation()
         event.preventDefault()
 
-        const selection = editorActor.getSnapshot().context.selection
+        const selection = editorEngine.selection
         const position = selection ? {selection} : undefined
 
         if (!position) {
@@ -407,7 +407,7 @@ export const PortableTextEditable = forwardRef<
                 'No result from custom paste handler, pasting normally',
               )
 
-              const selection = editorActor.getSnapshot().context.selection
+              const selection = editorEngine.selection
               const position = selection ? {selection} : undefined
 
               if (!position) {
@@ -433,9 +433,8 @@ export const PortableTextEditable = forwardRef<
                 behaviorEvent: {
                   type: 'insert.blocks',
                   blocks: parseBlocks({
-                    keyGenerator:
-                      editorActor.getSnapshot().context.keyGenerator,
-                    schema: editorActor.getSnapshot().context.schema,
+                    keyGenerator: editorEngine.keyGenerator,
+                    schema: editorEngine.schema,
                     blocks: result.insert,
                     options: {
                       normalize: false,
@@ -467,7 +466,7 @@ export const PortableTextEditable = forwardRef<
         event.preventDefault()
         event.stopPropagation()
 
-        const selection = editorActor.getSnapshot().context.selection
+        const selection = editorEngine.selection
         const position = selection ? {selection} : undefined
 
         if (!position) {
@@ -506,17 +505,14 @@ export const PortableTextEditable = forwardRef<
         if (
           !editorEngine.selection &&
           editorEngine.children.length === 1 &&
-          isEmptyTextBlock(
-            editorActor.getSnapshot().context,
-            editorEngine.children.at(0),
-          )
+          isEmptyTextBlock(editorEngine, editorEngine.children.at(0))
         ) {
           editorEngine.select(start(editorEngine, []))
           editorEngine.onChange()
         }
       }
     },
-    [editorActor, onFocus, relayActor, editorEngine],
+    [onFocus, relayActor, editorEngine],
   )
 
   const handleClick = useCallback(

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -35,7 +35,6 @@ import type {
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {Path} from '../types/paths'
 import type {EditorActor} from './editor-machine'
-import {getEditorSnapshot} from './editor-selector'
 
 export function createEditableAPI(
   editor: PortableTextEditorEngine,
@@ -85,20 +84,14 @@ export function createEditableAPI(
       })
     },
     isMarkActive: (mark: string): boolean => {
-      const snapshot = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshot = editor.snapshot
 
       const activeDecorators = getActiveDecorators(snapshot)
 
       return activeDecorators.includes(mark)
     },
     marks: (): string[] => {
-      const snapshot = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshot = editor.snapshot
 
       const activeAnnotations = getActiveAnnotationsMarks(snapshot)
       const activeDecorators = getActiveDecorators(snapshot)
@@ -212,7 +205,7 @@ export function createEditableAPI(
       }
     },
     isVoid: (element: PortableTextBlock | PortableTextChild): boolean => {
-      const schema = editorActor.getSnapshot().context.schema
+      const schema = editor.schema
       return ![schema.block.name, schema.span.name].includes(element._type)
     },
     findByPath: (
@@ -288,18 +281,12 @@ export function createEditableAPI(
     isAnnotationActive: (
       annotationType: PortableTextObject['_type'],
     ): boolean => {
-      const snapshot = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshot = editor.snapshot
 
       return isActiveAnnotation(annotationType)(snapshot)
     },
     addAnnotation: (type, value) => {
-      const snapshotBefore = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshotBefore = editor.snapshot
       const selectedValueBefore = getSelectedValue(snapshotBefore)
       const focusSpanBefore = getFocusSpan(snapshotBefore)
       const markDefsBefore = selectedValueBefore.flatMap((block) => {
@@ -319,10 +306,7 @@ export function createEditableAPI(
         editor,
       })
 
-      const snapshotAfter = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshotAfter = editor.snapshot
 
       const selectedValueAfter = getSelectedValue(snapshotAfter)
       const focusBlockAfter = getFocusBlock(snapshotAfter)
@@ -432,10 +416,7 @@ export function createEditableAPI(
       })
     },
     getFragment: () => {
-      const snapshot = getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editor,
-      })
+      const snapshot = editor.snapshot
 
       return getFragment(snapshot).map((entry) => entry.node)
     },

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -4,9 +4,9 @@ import {withDOM} from '../engine/dom/plugin/with-dom'
 import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block'
 import {debug} from '../internal-utils/debug'
-import {buildPublicContainers} from '../schema/build-public-containers'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
+import {getEditorSnapshot} from './editor-selector'
 import type {RelayActor} from './relay-machine'
 
 type EditorEngineConfig = {
@@ -25,7 +25,9 @@ export function createEditorEngine(
   const placeholderBlock = createPlaceholderBlock({
     context: {
       schema: context.schema,
-      containers: buildPublicContainers(context.containers),
+      // No containers registered at engine-init time. NodePlugin
+      // registrations run later, after the engine is attached.
+      containers: new Map(),
       value: [],
       keyGenerator: context.keyGenerator,
     },
@@ -36,6 +38,8 @@ export function createEditorEngine(
 
   editor.schema = context.schema
   editor.keyGenerator = context.keyGenerator
+  editor.converters = context.initialConverters
+  editor.readOnly = context.initialReadOnly
   editor.containers = new Map()
   editor.publicContainers = new Map()
   editor.blockObjects = new Map()
@@ -79,6 +83,25 @@ export function createEditorEngine(
       listIndexMap: editorEngine.listIndexMap,
     },
   )
+
+  // Initialize the stored snapshot synchronously so the engine satisfies the
+  // `Subscribable<EditorSnapshot>` contract from first read. Refreshed on
+  // every editor-actor notification below.
+  editorEngine.snapshot = getEditorSnapshot({
+    editorEngineInstance: editorEngine,
+  })
+
+  config.subscriptions.push(() => {
+    const subscription = config.editorActor.subscribe(() => {
+      editorEngine.snapshot = getEditorSnapshot({
+        editorEngineInstance: editorEngine,
+      })
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  })
 
   return editorEngine
 }

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -13,7 +13,6 @@ import {createEditorEngine} from './create-editor-engine'
 import {createEditorDom} from './editor-dom'
 import type {EditorActor} from './editor-machine'
 import {editorMachine, rerouteExternalBehaviorEvent} from './editor-machine'
-import {getEditorSnapshot} from './editor-selector'
 import {mutationMachine, type MutationActor} from './mutation-machine'
 import {relayMachine, type RelayActor} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
@@ -52,11 +51,7 @@ export function createInternalEditor(config: EditorConfig): {
 
   const editor: Editor = {
     dom: createEditorDom((event) => editorActor.send(event), editorEngine),
-    getSnapshot: () =>
-      getEditorSnapshot({
-        editorActorSnapshot: editorActor.getSnapshot(),
-        editorEngineInstance: editorEngine,
-      }),
+    getSnapshot: () => editorEngine.snapshot,
     registerBehavior: (behaviorConfig) => {
       const priority = createEditorPriority({
         name: 'custom',

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -21,25 +21,16 @@ import {normalize} from '../engine/editor/normalize'
 import {debug} from '../internal-utils/debug'
 import type {EventPosition} from '../internal-utils/event-position'
 import {sortByPriority} from '../priority/priority.sort'
-import type {
-  BlockObjectConfig,
-  InlineObjectConfig,
-  RegistrableNode,
-  SpanConfig,
-  TextBlockConfig,
-} from '../renderers/renderer.types'
-import {buildPublicContainers} from '../schema/build-public-containers'
-import {
-  resolveNestedContainer,
-  resolveTextBlockConfig,
-  type ResolvedContainers,
-} from '../schema/resolve-containers'
+import type {RegistrableNode} from '../renderers/renderer.types'
 import type {NamespaceEvent, OmitFromUnion} from '../type-utils'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {pathsOverlap} from '../utils/util.paths-overlap'
 import type {EditorSchema} from './editor-schema'
-import {isTypeAlreadyRegistered} from './registration-helpers'
+import {
+  registerNodeOnEngine,
+  unregisterNodeOnEngine,
+} from './register-node-on-engine'
 import type {
   EditorEmittedEvent,
   MutationEvent,
@@ -196,18 +187,13 @@ export const editorMachine = setup({
     context: {} as {
       behaviors: Set<BehaviorConfig>
       behaviorsSorted: boolean
-      blockObjects: Map<string, BlockObjectConfig>
-      containers: ResolvedContainers
-      converters: Array<Converter>
-      inlineObjects: Map<string, InlineObjectConfig>
-      spans: Map<string, SpanConfig>
-      textBlocks: Map<string, TextBlockConfig>
+      initialConverters: Array<Converter>
       keyGenerator: () => string
       pendingEvents: Array<InternalPatchEvent | MutationEvent>
       pendingIncomingPatchesEvents: Array<PatchesEvent>
+      pendingRegistrations: Array<RegistrableNode>
       schema: EditorSchema
       initialReadOnly: boolean
-      selection: EditorSelection
       initialValue: Array<PortableTextBlock> | undefined
       internalDrag?: {
         origin: Pick<EventPosition, 'selection'>
@@ -251,145 +237,46 @@ export const editorMachine = setup({
           : context.editorEngine
       },
     }),
-    'register': assign(({context, event}) => {
+    'register': ({context, event}) => {
       assertEvent(event, 'register')
-      const node = event.node
-      if (node.kind === 'container') {
-        if (isTypeAlreadyRegistered(context, 'container', node.type)) {
-          return {}
-        }
-        const containerConfig = resolveNestedContainer(context.schema, node)
-        if (!containerConfig) {
-          // resolveNestedContainer has already warned with chain context.
-          return {}
-        }
-        const containers = new Map(context.containers)
-        containers.set(node.type, containerConfig)
-        if (context.editorEngine) {
-          context.editorEngine.containers = containers
-          context.editorEngine.publicContainers =
-            buildPublicContainers(containers)
-          normalize(context.editorEngine, {force: true})
-          context.editorEngine.onChange()
-        }
-        return {containers}
+      if (!context.editorEngine) {
+        // Engine isn't attached yet (a child plugin's useEffect ran
+        // before EditorProvider's). Buffer the registration; it will
+        // be drained by `attach maps to editor engine` once the engine
+        // is attached.
+        context.pendingRegistrations.push(event.node)
+        return
       }
-      if (node.kind === 'textBlock') {
-        if (isTypeAlreadyRegistered(context, 'textBlock', node.type)) {
-          return {}
-        }
-        const textBlocks = new Map(context.textBlocks)
-        textBlocks.set(node.type, resolveTextBlockConfig(node))
-        if (context.editorEngine) {
-          context.editorEngine.textBlocks = textBlocks
-          context.editorEngine.onChange()
-        }
-        return {textBlocks}
-      }
-      if (node.kind === 'span') {
-        if (isTypeAlreadyRegistered(context, 'span', node.type)) {
-          return {}
-        }
-        const spans = new Map(context.spans)
-        spans.set(node.type, {span: node})
-        if (context.editorEngine) {
-          context.editorEngine.spans = spans
-          context.editorEngine.onChange()
-        }
-        return {spans}
-      }
-      if (node.kind === 'blockObject') {
-        if (isTypeAlreadyRegistered(context, 'blockObject', node.type)) {
-          return {}
-        }
-        const blockObjects = new Map(context.blockObjects)
-        blockObjects.set(node.type, {blockObject: node})
-        if (context.editorEngine) {
-          context.editorEngine.blockObjects = blockObjects
-          context.editorEngine.onChange()
-        }
-        return {blockObjects}
-      }
-      // inlineObject
-      if (isTypeAlreadyRegistered(context, 'inlineObject', node.type)) {
-        return {}
-      }
-      const inlineObjects = new Map(context.inlineObjects)
-      inlineObjects.set(node.type, {inlineObject: node})
-      if (context.editorEngine) {
-        context.editorEngine.inlineObjects = inlineObjects
-        context.editorEngine.onChange()
-      }
-      return {inlineObjects}
-    }),
-    'unregister': assign(({context, event}) => {
+      registerNodeOnEngine(context.editorEngine, event.node)
+    },
+    'unregister': ({context, event}) => {
       assertEvent(event, 'unregister')
-      const node = event.node
-      if (node.kind === 'container') {
-        const containers = new Map(context.containers)
-        containers.delete(node.type)
-        if (context.editorEngine) {
-          context.editorEngine.containers = containers
-          context.editorEngine.publicContainers =
-            buildPublicContainers(containers)
-          normalize(context.editorEngine, {force: true})
-          context.editorEngine.onChange()
+      if (!context.editorEngine) {
+        // Engine isn't attached yet; drop any matching pending
+        // registration (cleanup path on unmount-before-attach).
+        const index = context.pendingRegistrations.indexOf(event.node)
+        if (index >= 0) {
+          context.pendingRegistrations.splice(index, 1)
         }
-        return {containers}
+        return
       }
-      if (node.kind === 'textBlock') {
-        const textBlocks = new Map(context.textBlocks)
-        textBlocks.delete(node.type)
-        if (context.editorEngine) {
-          context.editorEngine.textBlocks = textBlocks
-          context.editorEngine.onChange()
-        }
-        return {textBlocks}
-      }
-      if (node.kind === 'span') {
-        const spans = new Map(context.spans)
-        spans.delete(node.type)
-        if (context.editorEngine) {
-          context.editorEngine.spans = spans
-          context.editorEngine.onChange()
-        }
-        return {spans}
-      }
-      if (node.kind === 'blockObject') {
-        const blockObjects = new Map(context.blockObjects)
-        blockObjects.delete(node.type)
-        if (context.editorEngine) {
-          context.editorEngine.blockObjects = blockObjects
-          context.editorEngine.onChange()
-        }
-        return {blockObjects}
-      }
-      // inlineObject
-      const inlineObjects = new Map(context.inlineObjects)
-      inlineObjects.delete(node.type)
-      if (context.editorEngine) {
-        context.editorEngine.inlineObjects = inlineObjects
-        context.editorEngine.onChange()
-      }
-      return {inlineObjects}
-    }),
+      unregisterNodeOnEngine(context.editorEngine, event.node)
+    },
     'attach maps to editor engine': ({context}) => {
-      // After the editor engine is constructed, mirror the actor's
-      // registration maps onto it and trigger a force-normalize so any
-      // rules that depend on the maps (e.g. unwrap-on-empty) run against
-      // the freshly attached editor.
-      if (context.editorEngine) {
-        context.editorEngine.containers = context.containers
-        context.editorEngine.publicContainers = buildPublicContainers(
-          context.containers,
-        )
-        context.editorEngine.blockObjects = context.blockObjects
-        context.editorEngine.inlineObjects = context.inlineObjects
-        context.editorEngine.spans = context.spans
-        context.editorEngine.textBlocks = context.textBlocks
-        normalize(context.editorEngine, {force: true})
-        context.editorEngine.onChange()
+      // After the editor engine is constructed, drain any registrations
+      // that arrived from child components' useEffects (which fire
+      // before EditorProvider's). Each drained registration mutates
+      // the engine and triggers normalize+onChange.
+      if (!context.editorEngine) {
+        return
       }
+      const engine = context.editorEngine
+      for (const node of context.pendingRegistrations) {
+        registerNodeOnEngine(engine, node)
+      }
+      context.pendingRegistrations.length = 0
+      normalize(engine, {force: true})
+      engine.onChange()
     },
     'emit patch event': emit(({event}) => {
       assertEvent(event, 'internal.patch')
@@ -399,8 +286,20 @@ export const editorMachine = setup({
       assertEvent(event, 'mutation')
       return event
     }),
-    'emit read only': emit({type: 'read only'}),
-    'emit editable': emit({type: 'editable'}),
+    'emit read only': enqueueActions(({context, enqueue}) => {
+      if (context.editorEngine) {
+        context.editorEngine.readOnly = true
+        context.editorEngine.onChange()
+      }
+      enqueue.emit({type: 'read only'})
+    }),
+    'emit editable': enqueueActions(({context, enqueue}) => {
+      if (context.editorEngine) {
+        context.editorEngine.readOnly = false
+        context.editorEngine.onChange()
+      }
+      enqueue.emit({type: 'editable'})
+    }),
     'defer event': assign({
       pendingEvents: ({context, event}) => {
         assertEvent(event, ['internal.patch', 'mutation'])
@@ -510,10 +409,10 @@ export const editorMachine = setup({
           remainingEventBehaviors: behaviors,
           event: event.behaviorEvent,
           editor: event.editor,
-          converters: context.converters,
-          keyGenerator: context.keyGenerator,
-          schema: context.schema,
-          readOnly: self.getSnapshot().matches({'edit mode': 'read only'}),
+          converters: event.editor.converters,
+          keyGenerator: event.editor.keyGenerator,
+          schema: event.editor.schema,
+          readOnly: event.editor.readOnly,
           nativeEvent: event.nativeEvent,
           sendBack: (eventSentBack) => {
             if (eventSentBack.type === 'set drag ghost') {
@@ -566,17 +465,12 @@ export const editorMachine = setup({
   context: ({input}) => ({
     behaviors: new Set(coreBehaviorsConfig),
     behaviorsSorted: false,
-    containers: new Map(),
-    blockObjects: new Map(),
-    inlineObjects: new Map(),
-    spans: new Map(),
-    textBlocks: new Map(),
-    converters: input.converters ?? [],
+    initialConverters: input.converters ?? [],
     keyGenerator: input.keyGenerator,
     pendingEvents: [],
     pendingIncomingPatchesEvents: [],
+    pendingRegistrations: [],
     schema: input.schema,
-    selection: null,
     initialReadOnly: input.readOnly ?? false,
     initialValue: input.initialValue,
   }),
@@ -593,10 +487,7 @@ export const editorMachine = setup({
       actions: ['unregister'],
     },
     'update selection': {
-      actions: [
-        assign({selection: ({event}) => event.selection}),
-        emit(({event}) => ({...event, type: 'selection'})),
-      ],
+      actions: [emit(({event}) => ({...event, type: 'selection'}))],
     },
     'set drag ghost': {
       actions: assign({dragGhost: ({event}) => event.ghost}),

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -2,7 +2,6 @@ import {useSelector} from '@xstate/react'
 import type {AnyActorRef} from 'xstate'
 import type {Editor} from '../editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
-import type {EditorActor} from './editor-machine'
 import type {EditorSnapshot} from './editor-snapshot'
 
 function defaultCompare<T>(a: T, b: T) {
@@ -55,20 +54,18 @@ export function useEditorSelector<TSelected>(
 }
 
 export function getEditorSnapshot({
-  editorActorSnapshot,
   editorEngineInstance,
 }: {
-  editorActorSnapshot: ReturnType<EditorActor['getSnapshot']>
   editorEngineInstance: PortableTextEditorEngine
 }): EditorSnapshot {
   return {
     blockIndexMap: editorEngineInstance.blockIndexMap,
     context: {
       containers: editorEngineInstance.publicContainers,
-      converters: editorActorSnapshot.context.converters,
-      keyGenerator: editorActorSnapshot.context.keyGenerator,
-      readOnly: editorActorSnapshot.matches({'edit mode': 'read only'}),
-      schema: editorActorSnapshot.context.schema,
+      converters: editorEngineInstance.converters,
+      keyGenerator: editorEngineInstance.keyGenerator,
+      readOnly: editorEngineInstance.readOnly,
+      schema: editorEngineInstance.schema,
       selection: editorEngineInstance.selection,
       value: editorEngineInstance.children,
     },

--- a/packages/editor/src/editor/register-node-on-engine.ts
+++ b/packages/editor/src/editor/register-node-on-engine.ts
@@ -1,0 +1,126 @@
+import {normalize} from '../engine/editor/normalize'
+import type {RegistrableNode} from '../renderers/renderer.types'
+import {buildPublicContainers} from '../schema/build-public-containers'
+import {
+  resolveNestedContainer,
+  resolveTextBlockConfig,
+} from '../schema/resolve-containers'
+import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {isTypeAlreadyRegistered} from './registration-helpers'
+
+/**
+ * Mutate the engine's registration maps for a single `RegistrableNode`.
+ * Used by the editor machine's `register` action and by the drain step
+ * for registrations that arrived before the engine was attached.
+ *
+ * For containers, force-normalizes the editor so existing nodes of the
+ * registered `_type` pick up the container shape (e.g. `rows: []`).
+ *
+ * No-op when the type is already registered as an exclusive kind.
+ */
+export function registerNodeOnEngine(
+  engine: PortableTextEditorEngine,
+  node: RegistrableNode,
+): void {
+  if (node.kind === 'container') {
+    if (isTypeAlreadyRegistered(engine, 'container', node.type)) {
+      return
+    }
+    const containerConfig = resolveNestedContainer(engine.schema, node)
+    if (!containerConfig) {
+      // resolveNestedContainer has already warned with chain context.
+      return
+    }
+    const containers = new Map(engine.containers)
+    containers.set(node.type, containerConfig)
+    engine.containers = containers
+    engine.publicContainers = buildPublicContainers(containers)
+    normalize(engine, {force: true})
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'textBlock') {
+    if (isTypeAlreadyRegistered(engine, 'textBlock', node.type)) {
+      return
+    }
+    const textBlocks = new Map(engine.textBlocks)
+    textBlocks.set(node.type, resolveTextBlockConfig(node))
+    engine.textBlocks = textBlocks
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'span') {
+    if (isTypeAlreadyRegistered(engine, 'span', node.type)) {
+      return
+    }
+    const spans = new Map(engine.spans)
+    spans.set(node.type, {span: node})
+    engine.spans = spans
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'blockObject') {
+    if (isTypeAlreadyRegistered(engine, 'blockObject', node.type)) {
+      return
+    }
+    const blockObjects = new Map(engine.blockObjects)
+    blockObjects.set(node.type, {blockObject: node})
+    engine.blockObjects = blockObjects
+    engine.onChange()
+    return
+  }
+  // inlineObject
+  if (isTypeAlreadyRegistered(engine, 'inlineObject', node.type)) {
+    return
+  }
+  const inlineObjects = new Map(engine.inlineObjects)
+  inlineObjects.set(node.type, {inlineObject: node})
+  engine.inlineObjects = inlineObjects
+  engine.onChange()
+}
+
+/**
+ * Mutate the engine's registration maps to remove a registered node.
+ * Reverse of {@link registerNodeOnEngine}; used by the editor machine's
+ * `unregister` action.
+ */
+export function unregisterNodeOnEngine(
+  engine: PortableTextEditorEngine,
+  node: RegistrableNode,
+): void {
+  if (node.kind === 'container') {
+    const containers = new Map(engine.containers)
+    containers.delete(node.type)
+    engine.containers = containers
+    engine.publicContainers = buildPublicContainers(containers)
+    normalize(engine, {force: true})
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'textBlock') {
+    const textBlocks = new Map(engine.textBlocks)
+    textBlocks.delete(node.type)
+    engine.textBlocks = textBlocks
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'span') {
+    const spans = new Map(engine.spans)
+    spans.delete(node.type)
+    engine.spans = spans
+    engine.onChange()
+    return
+  }
+  if (node.kind === 'blockObject') {
+    const blockObjects = new Map(engine.blockObjects)
+    blockObjects.delete(node.type)
+    engine.blockObjects = blockObjects
+    engine.onChange()
+    return
+  }
+  // inlineObject
+  const inlineObjects = new Map(engine.inlineObjects)
+  inlineObjects.delete(node.type)
+  engine.inlineObjects = inlineObjects
+  engine.onChange()
+}

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -3,11 +3,11 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import {isTextBlock} from '@portabletext/schema'
-import {useSelector} from '@xstate/react'
-import {useContext, useMemo, type ReactElement} from 'react'
+import {useCallback, useContext, useMemo, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
+import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import {isInline} from '../node-traversal/is-inline'
 import {serializePath} from '../paths/serialize-path'
@@ -17,7 +17,6 @@ import type {
   InlineObjectConfig,
   TextBlockConfig,
 } from '../renderers/renderer.types'
-import {EditorActorContext} from './editor-actor-context'
 import type {EditorSchema} from './editor-schema'
 import {
   findBlockPositionalOverride,
@@ -45,10 +44,10 @@ import {
  * re-renders unless one of the slots actually changes.
  */
 function tupleRefEqual<T extends readonly unknown[]>(
-  previous: T,
+  previous: T | null,
   next: T,
 ): boolean {
-  if (previous.length !== next.length) {
+  if (previous === null || previous.length !== next.length) {
     return false
   }
   for (let i = 0; i < previous.length; i++) {
@@ -69,7 +68,6 @@ export function RenderElement(props: {
   readOnly: boolean
   schema: EditorSchema
 }) {
-  const editorActor = useContext(EditorActorContext)
   const parentContainer = useContext(ParentContainerContext)
   const parentTextBlock = useContext(ParentTextBlockContext)
   const isInNewPipeline = useContext(NewPipelineContext)
@@ -100,15 +98,17 @@ export function RenderElement(props: {
     globalBlockObjectConfig,
     globalInlineObjectConfig,
     textBlockConfig,
-  ] = useSelector(
-    editorActor,
-    (state) =>
-      [
-        state.context.containers.get(type),
-        state.context.blockObjects.get(type),
-        state.context.inlineObjects.get(type),
-        state.context.textBlocks.get(type),
-      ] as const,
+  ] = useEngineSelector(
+    useCallback(
+      (engine) =>
+        [
+          engine.containers.get(type),
+          engine.blockObjects.get(type),
+          engine.inlineObjects.get(type),
+          engine.textBlocks.get(type),
+        ] as const,
+      [type],
+    ),
     tupleRefEqual,
   )
 

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -3,11 +3,10 @@ import type {
   PortableTextObject,
   PortableTextSpan,
 } from '@portabletext/schema'
-import {useSelector} from '@xstate/react'
-import {useContext} from 'react'
+import {useCallback, useContext} from 'react'
 import type {Path} from '../engine/interfaces/path'
+import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
 import type {SpanConfig} from '../renderers/renderer.types'
-import {EditorActorContext} from './editor-actor-context'
 import {findInlinePositionalOverride} from './find-positional-override'
 import {ParentTextBlockContext} from './parent-text-block-context'
 
@@ -15,8 +14,8 @@ import {ParentTextBlockContext} from './parent-text-block-context'
  * Hook: resolve the registered span config for the span at `node`, or
  * `undefined` if none matches.
  *
- * Subscribes to the editor actor's `spans` map so the component
- * re-renders when spans register/unregister.
+ * Subscribes to the engine's `spans` map so the component re-renders
+ * when spans register/unregister.
  *
  * One-hop type-keyed dispatch. Positional (in-parent) overrides via
  * `defineContainer`'s `of` array are resolved one level up by the
@@ -26,11 +25,10 @@ export function useSpanConfig(
   node: PortableTextBlock | PortableTextSpan | PortableTextObject,
   _path: Path,
 ): SpanConfig | undefined {
-  const editorActor = useContext(EditorActorContext)
   const parentTextBlock = useContext(ParentTextBlockContext)
   const positional = findInlinePositionalOverride(parentTextBlock, node._type)
-  const globalSpan = useSelector(editorActor, (state) =>
-    state.context.spans.get(node._type),
+  const globalSpan = useEngineSelector(
+    useCallback((engine) => engine.spans.get(node._type), [node._type]),
   )
   if (positional && 'span' in positional) {
     // Positional present: undefined render falls through to global;

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -10,7 +10,6 @@ import {
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {EditorActorContext} from './editor-actor-context'
-import {getEditorSnapshot} from './editor-selector'
 import {getSelectionState, type SelectionState} from './get-selection-state'
 
 const emptySet = new Set<string>()
@@ -109,11 +108,7 @@ export function SelectionStateProvider({
   // (handled in the subscription effect below).
   const computeCurrent = useMemo(
     () => () => {
-      const actorSnapshot = editorActor.getSnapshot()
-      const snapshot = getEditorSnapshot({
-        editorActorSnapshot: actorSnapshot,
-        editorEngineInstance: editorEngine,
-      })
+      const snapshot = editorEngine.snapshot
       const selection = snapshot.context.selection
         ? {
             anchorPath: snapshot.context.selection.anchor.path,
@@ -135,7 +130,7 @@ export function SelectionStateProvider({
         selection,
       )
     },
-    [editorActor, editorEngine],
+    [editorEngine],
   )
 
   // Seed the initial snapshot exactly once via `useState`'s lazy

--- a/packages/editor/src/editor/usePortableTextEditorSelection.tsx
+++ b/packages/editor/src/editor/usePortableTextEditorSelection.tsx
@@ -1,4 +1,5 @@
 import {startTransition, useContext, useEffect, useState} from 'react'
+import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import type {EditorSelection} from '../types/editor'
 import {EditorActorContext} from './editor-actor-context'
 
@@ -9,8 +10,9 @@ import {EditorActorContext} from './editor-actor-context'
  */
 export const usePortableTextEditorSelection = (): EditorSelection => {
   const editorActor = useContext(EditorActorContext)
+  const editorEngine = useEngineStatic()
   const [selection, setSelection] = useState<EditorSelection>(
-    editorActor.getSnapshot().context.selection,
+    editorEngine.selection,
   )
 
   useEffect(() => {

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -1,6 +1,8 @@
 import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
+import type {Converter} from '../converters/converter.types'
 import type {EditorSchema} from '../editor/editor-schema'
+import type {EditorSnapshot} from '../editor/editor-snapshot'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
 import type {DOMEditor} from '../engine/dom/plugin/dom-editor'
 import type {Operation as EngineOperation} from '../engine/interfaces/operation'
@@ -35,6 +37,8 @@ export interface PortableTextEditorEngine extends DOMEditor {
 
   schema: EditorSchema
   keyGenerator: () => string
+  converters: Array<Converter>
+  readOnly: boolean
   containers: ResolvedContainers
   /**
    * Narrow {@link Containers} projection of `containers`, exposed on the
@@ -74,4 +78,15 @@ export interface PortableTextEditorEngine extends DOMEditor {
   isRedoing: boolean
   isUndoing: boolean
   withHistory: boolean
+
+  /**
+   * The current {@link EditorSnapshot}. Reassigned (new object reference)
+   * whenever the editor's observable state changes, and only then. Reads
+   * are reference-stable between mutations, which lets
+   * `useSyncExternalStore` short-circuit before invoking selectors.
+   *
+   * `editor.getSnapshot()` returns this property. Internal callers can
+   * also read it directly to avoid building snapshots ad-hoc.
+   */
+  snapshot: EditorSnapshot
 }

--- a/packages/editor/tests/use-editor-selector-regression.test.tsx
+++ b/packages/editor/tests/use-editor-selector-regression.test.tsx
@@ -1,0 +1,133 @@
+import {StrictMode, useEffect} from 'react'
+import {expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  useEditor,
+  useEditorSelector,
+  type EditorSnapshot,
+} from '../src'
+import {
+  getActiveAnnotations,
+  getFragment,
+  getSelectedValue,
+} from '../src/selectors'
+
+const schema = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  styles: [{name: 'normal'}, {name: 'h1'}],
+  lists: [{name: 'bullet'}],
+})
+
+function Probe({selector}: {selector: (s: EditorSnapshot) => unknown}) {
+  const editor = useEditor()
+  // Reading the selected value drives the test; the variable is intentionally
+  // unused. We only care that the instrumented selector got invoked.
+  useEditorSelector(editor, selector)
+  return null
+}
+
+function FocusInitialBlock() {
+  const editor = useEditor()
+  useEffect(() => {
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+      },
+    })
+  }, [editor])
+  return null
+}
+
+/**
+ * Counts how many times `selector` is invoked across React's render cycle for a
+ * single editor mount. With a stable upstream snapshot, `useSyncExternalStore`
+ * memoizes and the selector is invoked a small, bounded number of times. With
+ * an unstable upstream snapshot (the v7 regression), the selector is invoked
+ * on every external store notification AND on every uncached `getSnapshot()`
+ * read, producing dozens to hundreds of invocations and tripping React's
+ * `Maximum update depth exceeded` guard.
+ */
+async function countSelectorInvocations(
+  baseSelector: (s: EditorSnapshot) => unknown,
+): Promise<number> {
+  let count = 0
+  const instrumented = (s: EditorSnapshot) => {
+    count++
+    return baseSelector(s)
+  }
+  // Suppress React's noisy `getSnapshot should be cached` warning + maximum
+  // update depth error; we measure the invocation count directly.
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    render(
+      <StrictMode>
+        <EditorProvider
+          initialConfig={{
+            schemaDefinition: schema,
+            initialValue: [
+              {
+                _type: 'block',
+                _key: 'b1',
+                children: [{_type: 'span', _key: 's1', text: 'hello'}],
+              },
+            ],
+          }}
+        >
+          <PortableTextEditable />
+          <FocusInitialBlock />
+          <Probe selector={instrumented} />
+        </EditorProvider>
+      </StrictMode>,
+    )
+    // Focus the editor so selectors that early-return on null selection
+    // (e.g. getFocusBlock) actually exercise the regression.
+    const editable = document.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement | null
+    editable?.focus()
+    await new Promise((r) => setTimeout(r, 300))
+    return count
+  } finally {
+    errorSpy.mockRestore()
+  }
+}
+
+// Selectors that build fresh refs each call: every call must produce a fresh
+// `[]`/`{}` because the snapshot they read from is a fresh object each tick.
+// With a stable upstream snapshot, useSyncExternalStore short-circuits before
+// invoking the selector, so the call count stays bounded (single-digit on
+// mount; small for each commit).
+//
+// Note: `getFocusBlock` is also unstable (returns fresh `{node, path}`) but
+// stays bounded in this harness because the editor's selection deduplication
+// (apply-operation.ts transformSelection ref-stability) keeps the upstream
+// snapshot stable across re-renders once the initial selection settles. The
+// same selector under a noisier consumer (toolbar, popover) loops in Studio.
+const UNSTABLE_SELECTORS = [
+  {name: 'getActiveAnnotations', selector: getActiveAnnotations},
+  {name: 'getSelectedValue', selector: getSelectedValue},
+  {name: 'getFragment', selector: getFragment},
+] as const
+
+// Reasonable upper bound: even StrictMode double-render + a handful of
+// external-store notifications during mount/focus settles well under 50 calls.
+// The regression produces ~175 before React bails.
+const BOUND = 50
+
+for (const {name, selector} of UNSTABLE_SELECTORS) {
+  test(`${name} - selector invoked a bounded number of times`, async () => {
+    const calls = await countSelectorInvocations(selector)
+    expect(calls).toBeLessThan(BOUND)
+  })
+}
+
+test('control: reading a stable context field stays bounded', async () => {
+  const calls = await countSelectorInvocations((s) => s.context.value)
+  expect(calls).toBeLessThan(BOUND)
+})


### PR DESCRIPTION
`editor.getSnapshot()` was building a fresh `EditorSnapshot` on every call, violating the `Subscribable<EditorSnapshot>` contract that `useSyncExternalStore` relies on. Selectors that derive fresh arrays or objects — `getActiveAnnotations`, `getFocusBlock`, `getSelectedValue`, `getFragment`, and others — were re-invoked on every external-store read and returned fresh references each time, which triggers React's `Maximum update depth exceeded` in StrictMode. Studio's toolbar and annotation popover surface this most reliably.

## The fix

The snapshot is now stored on the editor engine. After every actor notification the engine refreshes its stored snapshot, so reads between notifications return the same reference. `editor.getSnapshot()` collapses to returning the stored snapshot.

## Falsifier

`packages/editor/tests/use-editor-selector-regression.test.tsx` instruments each affected selector and asserts a bounded invocation count per mount. Pre-fix the three derived-array selectors invoked ~175 times before React bailed; post-fix all stay well under the bound.

## Follow-up

The more principled cleanup — collapsing data ownership so the engine is the sole owner of `schema`, `converters`, `keyGenerator`, `selection` and the registration Maps, rather than mirroring them on the actor's xstate context — is left for a follow-up. That reshape disturbs the api-extractor chunk graph and breaks downstream plugin builds (TS2742) on its own; it deserves a separate PR with focused investigation.