### PR TITLE
refactor: store editor state on snapshot

### DIFF
--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -44,7 +44,7 @@ function isDropTargetingDragOrigin(
     return true
   }
 
-  const root = {children: snapshot.context.value}
+  const root = {value: snapshot.context.value}
   const [startA, endA] = rangeEdges(dropSelection, root)
   const [startB, endB] = rangeEdges(dragOriginSelection, root)
 

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -126,7 +126,7 @@ export function performEvent({
       }
 
       performOperation({
-        snapshot: editor,
+        snapshot: editor.snapshot,
         operation: {
           ...event,
           editor,
@@ -367,7 +367,7 @@ export function performEvent({
       }
 
       performOperation({
-        snapshot: editor,
+        snapshot: editor.snapshot,
         operation: {
           ...event,
           editor,

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -137,7 +137,7 @@ export const PortableTextEditable = forwardRef<
   const editorActor = useContext(EditorActorContext)
   const relayActor = useContext(RelayActorContext)
   const editorEngine = useEngine()
-  const schema = editorEngine.schema
+  const schema = editorEngine.snapshot.context.schema
   const readOnly = useSelector(editorActor, (s) =>
     s.matches({'edit mode': 'read only'}),
   )
@@ -309,7 +309,7 @@ export const PortableTextEditable = forwardRef<
         event.stopPropagation()
         event.preventDefault()
 
-        const selection = editorEngine.selection ?? undefined
+        const selection = editorEngine.snapshot.context.selection ?? undefined
         const position = selection ? {selection} : undefined
 
         if (!position) {
@@ -351,7 +351,7 @@ export const PortableTextEditable = forwardRef<
         event.stopPropagation()
         event.preventDefault()
 
-        const selection = editorEngine.selection
+        const selection = editorEngine.snapshot.context.selection
         const position = selection ? {selection} : undefined
 
         if (!position) {
@@ -379,8 +379,8 @@ export const PortableTextEditable = forwardRef<
   // Handle incoming pasting events in the editor
   const handlePaste = useCallback(
     (event: ClipboardEvent<HTMLDivElement>): Promise<void> | void => {
-      const value = editorEngine.children
-      const ptRange = editorEngine.selection
+      const value = editorEngine.snapshot.context.value
+      const ptRange = editorEngine.snapshot.context.selection
       const path = ptRange?.focus.path || []
       const onPasteResult = onPaste?.({
         event,
@@ -389,7 +389,7 @@ export const PortableTextEditable = forwardRef<
         schemaTypes: portableTextEditor.schemaTypes,
       })
 
-      if (onPasteResult || !editorEngine.selection) {
+      if (onPasteResult || !editorEngine.snapshot.context.selection) {
         event.preventDefault()
 
         // Resolve it as promise (can be either async promise or sync return value)
@@ -407,7 +407,7 @@ export const PortableTextEditable = forwardRef<
                 'No result from custom paste handler, pasting normally',
               )
 
-              const selection = editorEngine.selection
+              const selection = editorEngine.snapshot.context.selection
               const position = selection ? {selection} : undefined
 
               if (!position) {
@@ -433,8 +433,8 @@ export const PortableTextEditable = forwardRef<
                 behaviorEvent: {
                   type: 'insert.blocks',
                   blocks: parseBlocks({
-                    keyGenerator: editorEngine.keyGenerator,
-                    schema: editorEngine.schema,
+                    keyGenerator: editorEngine.snapshot.context.keyGenerator,
+                    schema: editorEngine.snapshot.context.schema,
                     blocks: result.insert,
                     options: {
                       normalize: false,
@@ -466,7 +466,7 @@ export const PortableTextEditable = forwardRef<
         event.preventDefault()
         event.stopPropagation()
 
-        const selection = editorEngine.selection
+        const selection = editorEngine.snapshot.context.selection
         const position = selection ? {selection} : undefined
 
         if (!position) {
@@ -503,9 +503,12 @@ export const PortableTextEditable = forwardRef<
         relayActor.send({type: 'focused', event})
 
         if (
-          !editorEngine.selection &&
-          editorEngine.children.length === 1 &&
-          isEmptyTextBlock(editorEngine, editorEngine.children.at(0))
+          !editorEngine.snapshot.context.selection &&
+          editorEngine.snapshot.context.value.length === 1 &&
+          isEmptyTextBlock(
+            editorEngine.snapshot.context,
+            editorEngine.snapshot.context.value.at(0),
+          )
         ) {
           editorEngine.select(start(editorEngine, []))
           editorEngine.onChange()

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -127,25 +127,29 @@ export function createEditableAPI(
       })
     },
     focusBlock: (): PortableTextBlock | undefined => {
-      if (!editor.selection) {
+      if (!editor.snapshot.context.selection) {
         return undefined
       }
 
-      const focusPath = editor.selection.focus.path
+      const focusPath = editor.snapshot.context.selection.focus.path
 
       return (
-        getBlock(editor, focusPath)?.node ??
-        getBlock(editor, parentPath(focusPath))?.node
+        getBlock(editor.snapshot, focusPath)?.node ??
+        getBlock(editor.snapshot, parentPath(focusPath))?.node
       )
     },
     focusChild: (): PortableTextChild | undefined => {
-      if (!editor.selection) {
+      if (!editor.snapshot.context.selection) {
         return undefined
       }
 
-      const leaf = getLeaf(editor, editor.selection.focus.path, {edge: 'start'})
+      const leaf = getLeaf(
+        editor.snapshot,
+        editor.snapshot.context.selection.focus.path,
+        {edge: 'start'},
+      )
 
-      if (!leaf || isBlock(editor, leaf.path)) {
+      if (!leaf || isBlock(editor.snapshot, leaf.path)) {
         return undefined
       }
 
@@ -167,7 +171,7 @@ export function createEditableAPI(
         editor,
       })
 
-      return editor.selection?.focus.path ?? []
+      return editor.snapshot.context.selection?.focus.path ?? []
     },
     insertBlock: <TSchemaType extends {name: string}>(
       type: TSchemaType,
@@ -186,7 +190,7 @@ export function createEditableAPI(
         editor,
       })
 
-      return editor.selection?.focus.path ?? []
+      return editor.snapshot.context.selection?.focus.path ?? []
     },
     hasBlockStyle: (style: string): boolean => {
       try {
@@ -205,7 +209,7 @@ export function createEditableAPI(
       }
     },
     isVoid: (element: PortableTextBlock | PortableTextChild): boolean => {
-      const schema = editor.schema
+      const schema = editor.snapshot.context.schema
       return ![schema.block.name, schema.span.name].includes(element._type)
     },
     findByPath: (
@@ -214,7 +218,7 @@ export function createEditableAPI(
       PortableTextBlock | PortableTextChild | undefined,
       Path | undefined,
     ] => {
-      const result = getNode(editor, path as InternalPath)
+      const result = getNode(editor.snapshot, path as InternalPath)
 
       if (!result) {
         return [undefined, undefined]
@@ -228,7 +232,7 @@ export function createEditableAPI(
       let node: Node | undefined
       try {
         const entry = Array.from(
-          getNodes(editor, {
+          getNodes(editor.snapshot, {
             match: (n) => n._key === element._key,
           }),
         )[0]
@@ -242,29 +246,38 @@ export function createEditableAPI(
       return node
     },
     activeAnnotations: (): PortableTextObject[] => {
-      if (!editor.selection || editor.selection.focus.path.length < 2) {
+      if (
+        !editor.snapshot.context.selection ||
+        editor.snapshot.context.selection.focus.path.length < 2
+      ) {
         return []
       }
       try {
         const activeAnnotations: PortableTextObject[] = []
-        const spans = getNodes(editor, {
-          from: rangeStart(editor.selection, editor).path,
-          to: rangeEnd(editor.selection, editor).path,
+        const spans = getNodes(editor.snapshot, {
+          from: rangeStart(
+            editor.snapshot.context.selection,
+            editor.snapshot.context,
+          ).path,
+          to: rangeEnd(
+            editor.snapshot.context.selection,
+            editor.snapshot.context,
+          ).path,
           match: (node) =>
-            isSpan({schema: editor.schema}, node) &&
+            isSpan({schema: editor.snapshot.context.schema}, node) &&
             node.marks !== undefined &&
             Array.isArray(node.marks) &&
             node.marks.length > 0,
         })
         for (const {node: span, path: spanPath} of spans) {
-          const blockEntry = getTextBlock(editor, parentPath(spanPath))
+          const blockEntry = getTextBlock(editor.snapshot, parentPath(spanPath))
           if (!blockEntry) {
             continue
           }
           const block = blockEntry.node
           block.markDefs?.forEach((def) => {
             if (
-              isSpan({schema: editor.schema}, span) &&
+              isSpan({schema: editor.snapshot.context.schema}, span) &&
               span.marks &&
               Array.isArray(span.marks) &&
               span.marks.includes(def._key)
@@ -395,16 +408,22 @@ export function createEditableAPI(
       })
     },
     getSelection: (): EditorSelection | null => {
-      return editor.selection
+      return editor.snapshot.context.selection
     },
     getValue: () => {
-      return editor.children
+      return editor.snapshot.context.value
     },
     isCollapsedSelection: () => {
-      return !!editor.selection && isCollapsedRange(editor.selection)
+      return (
+        !!editor.snapshot.context.selection &&
+        isCollapsedRange(editor.snapshot.context.selection)
+      )
     },
     isExpandedSelection: () => {
-      return !!editor.selection && isExpandedRange(editor.selection)
+      return (
+        !!editor.snapshot.context.selection &&
+        isExpandedRange(editor.snapshot.context.selection)
+      )
     },
     insertBreak: () => {
       editorActor.send({
@@ -428,7 +447,7 @@ export function createEditableAPI(
         return false
       }
 
-      return rangeIncludes(selectionA, selectionB, editor)
+      return rangeIncludes(selectionA, selectionB, editor.snapshot.context)
     },
   }
 

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -6,7 +6,6 @@ import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block
 import {debug} from '../internal-utils/debug'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
-import {getEditorSnapshot} from './editor-selector'
 import type {RelayActor} from './relay-machine'
 
 type EditorEngineConfig = {
@@ -36,27 +35,37 @@ export function createEditorEngine(
 
   const editor = createEditor()
 
-  editor.schema = context.schema
-  editor.keyGenerator = context.keyGenerator
-  editor.converters = context.initialConverters
-  editor.readOnly = context.initialReadOnly
+  // The engine's observable state lives on `editor.snapshot`. The
+  // wrapping snapshot and context objects are reassigned (new
+  // identity) when the editor settles; inner mutable values
+  // (selection, value, etc) are mutated in place by operations.
+  editor.snapshot = {
+    blockIndexMap: new Map<string, number>(),
+    context: {
+      containers: new Map(),
+      converters: context.initialConverters,
+      keyGenerator: context.keyGenerator,
+      readOnly: context.initialReadOnly,
+      schema: context.schema,
+      selection: null,
+      value: [placeholderBlock],
+    },
+    decoratorState: {},
+  }
+
   editor.containers = new Map()
-  editor.publicContainers = new Map()
   editor.blockObjects = new Map()
   editor.inlineObjects = new Map()
   editor.spans = new Map()
   editor.textBlocks = new Map()
 
   editor.decoratedRanges = []
-  editor.decoratorState = {}
-  editor.blockIndexMap = new Map<string, number>()
+  editor.blockIndexMap = editor.snapshot.blockIndexMap
   editor.history = {undos: [], redos: []}
 
   editor.listIndexMap = new Map<string, number>()
   editor.remotePatches = []
   editor.undoStepId = undefined
-
-  editor.children = [placeholderBlock]
 
   editor.isDeferringMutations = false
   editor.isNormalizingNode = false
@@ -76,7 +85,7 @@ export function createEditorEngine(
   buildIndexMaps(
     {
       schema: context.schema,
-      value: editorEngine.children,
+      value: editorEngine.snapshot.context.value,
     },
     {
       blockIndexMap: editorEngine.blockIndexMap,
@@ -84,18 +93,17 @@ export function createEditorEngine(
     },
   )
 
-  // Initialize the stored snapshot synchronously so the engine satisfies the
-  // `Subscribable<EditorSnapshot>` contract from first read. Refreshed on
-  // every editor-actor notification below.
-  editorEngine.snapshot = getEditorSnapshot({
-    editorEngineInstance: editorEngine,
-  })
-
+  // Each editor-actor notification flips the snapshot wrapper
+  // identity so `useSyncExternalStore` re-evaluates selectors. The
+  // inner state (selection, value, decoratorState) is read directly
+  // from `editor.snapshot.context` and mutated in place by
+  // operations; cross-mutation reads stay reference-stable.
   config.subscriptions.push(() => {
     const subscription = config.editorActor.subscribe(() => {
-      editorEngine.snapshot = getEditorSnapshot({
-        editorEngineInstance: editorEngine,
-      })
+      editorEngine.snapshot = {
+        ...editorEngine.snapshot,
+        context: {...editorEngine.snapshot.context},
+      }
     })
 
     return () => {

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -236,7 +236,7 @@ function createActors(config: {
           config.editorActor.send({
             ...event,
             type: 'internal.patch',
-            value: config.editorEngine.children,
+            value: config.editorEngine.snapshot.context.value,
           })
           break
 

--- a/packages/editor/src/editor/editor-dom.ts
+++ b/packages/editor/src/editor/editor-dom.ts
@@ -80,11 +80,14 @@ function getChildNodes(
   }
 
   try {
-    const [start, end] = rangeEdges(snapshot.context.selection, editorEngine)
+    const [start, end] = rangeEdges(
+      snapshot.context.selection,
+      editorEngine.snapshot.context,
+    )
     const childEntries: Array<{node: unknown; path: Path}> = []
     let buffered: {node: unknown; path: Path} | undefined
 
-    for (const entry of getNodes(editorEngine, {
+    for (const entry of getNodes(editorEngine.snapshot, {
       from: start.path,
       to: end.path,
     })) {

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -288,14 +288,14 @@ export const editorMachine = setup({
     }),
     'emit read only': enqueueActions(({context, enqueue}) => {
       if (context.editorEngine) {
-        context.editorEngine.readOnly = true
+        context.editorEngine.snapshot.context.readOnly = true
         context.editorEngine.onChange()
       }
       enqueue.emit({type: 'read only'})
     }),
     'emit editable': enqueueActions(({context, enqueue}) => {
       if (context.editorEngine) {
-        context.editorEngine.readOnly = false
+        context.editorEngine.snapshot.context.readOnly = false
         context.editorEngine.onChange()
       }
       enqueue.emit({type: 'editable'})
@@ -374,7 +374,7 @@ export const editorMachine = setup({
       }
 
       try {
-        const currentSelection = editorEngine.selection
+        const currentSelection = editorEngine.snapshot.context.selection
 
         DOMEditor.focus(editorEngine)
 
@@ -382,7 +382,8 @@ export const editorMachine = setup({
           editorEngine.select(currentSelection)
 
           // Tell the engine to use this selection for DOM sync
-          editorEngine.pendingSelection = editorEngine.selection
+          editorEngine.pendingSelection =
+            editorEngine.snapshot.context.selection
 
           // Trigger the DOM sync
           editorEngine.onChange()
@@ -409,10 +410,10 @@ export const editorMachine = setup({
           remainingEventBehaviors: behaviors,
           event: event.behaviorEvent,
           editor: event.editor,
-          converters: event.editor.converters,
-          keyGenerator: event.editor.keyGenerator,
-          schema: event.editor.schema,
-          readOnly: event.editor.readOnly,
+          converters: event.editor.snapshot.context.converters,
+          keyGenerator: event.editor.snapshot.context.keyGenerator,
+          schema: event.editor.snapshot.context.schema,
+          readOnly: event.editor.snapshot.context.readOnly,
           nativeEvent: event.nativeEvent,
           sendBack: (eventSentBack) => {
             if (eventSentBack.type === 'set drag ghost') {

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -1,7 +1,6 @@
 import {useSelector} from '@xstate/react'
 import type {AnyActorRef} from 'xstate'
 import type {Editor} from '../editor'
-import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorSnapshot} from './editor-snapshot'
 
 function defaultCompare<T>(a: T, b: T) {
@@ -51,24 +50,4 @@ export function useEditorSelector<TSelected>(
     selector,
     compare,
   )
-}
-
-export function getEditorSnapshot({
-  editorEngineInstance,
-}: {
-  editorEngineInstance: PortableTextEditorEngine
-}): EditorSnapshot {
-  return {
-    blockIndexMap: editorEngineInstance.blockIndexMap,
-    context: {
-      containers: editorEngineInstance.publicContainers,
-      converters: editorEngineInstance.converters,
-      keyGenerator: editorEngineInstance.keyGenerator,
-      readOnly: editorEngineInstance.readOnly,
-      schema: editorEngineInstance.schema,
-      selection: editorEngineInstance.selection,
-      value: editorEngineInstance.children,
-    },
-    decoratorState: editorEngineInstance.decoratorState,
-  }
 }

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -62,21 +62,21 @@ export function createEditorSnapshot({
   readOnly: boolean
   schema: EditorSchema
 }) {
-  const selection = editor.selection
+  const selection = editor.snapshot.context.selection
 
   const context = {
-    containers: editor.publicContainers,
+    containers: editor.snapshot.context.containers,
     converters,
     keyGenerator,
     readOnly,
     schema,
     selection,
-    value: editor.children,
+    value: editor.snapshot.context.value,
   } satisfies EditorContext
 
   return {
     blockIndexMap: editor.blockIndexMap,
     context,
-    decoratorState: editor.decoratorState,
+    decoratorState: editor.snapshot.decoratorState,
   } satisfies EditorSnapshot
 }

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -323,9 +323,9 @@ function createDecorate(
 ) {
   return function decorate([node, path]: NodeEntry): Array<Range> {
     const defaultStyle = schema.styles.at(0)?.name
-    const firstBlock = editorEngine.children[0]
+    const firstBlock = editorEngine.snapshot.context.value[0]
     const editorOnlyContainsEmptyParagraph =
-      editorEngine.children.length === 1 &&
+      editorEngine.snapshot.context.value.length === 1 &&
       firstBlock &&
       isEmptyTextBlock({schema}, firstBlock) &&
       (!firstBlock.style || firstBlock.style === defaultStyle) &&
@@ -353,7 +353,7 @@ function createDecorate(
     }
 
     if (
-      !isTextBlock({schema: editorEngine.schema}, node) ||
+      !isTextBlock({schema: editorEngine.snapshot.context.schema}, node) ||
       node.children.length === 0
     ) {
       return []
@@ -364,7 +364,7 @@ function createDecorate(
       if (isCollapsedRange(decoratedRange)) {
         // Collapsed ranges should only be decorated if they are on a block child level.
         const anchorBlock = getEnclosingBlock(
-          editorEngine,
+          editorEngine.snapshot,
           decoratedRange.anchor.path,
         )
         const anchorChildSegment = decoratedRange.anchor.path.at(-1)
@@ -388,8 +388,8 @@ function createDecorate(
             anchor: {path, offset: 0},
             focus: {path, offset: 0},
           },
-          editorEngine,
-        ) || rangeIncludes(decoratedRange, path, editorEngine)
+          editorEngine.snapshot.context,
+        ) || rangeIncludes(decoratedRange, path, editorEngine.snapshot.context)
       )
     })
   }

--- a/packages/editor/src/editor/register-node-on-engine.ts
+++ b/packages/editor/src/editor/register-node-on-engine.ts
@@ -26,7 +26,10 @@ export function registerNodeOnEngine(
     if (isTypeAlreadyRegistered(engine, 'container', node.type)) {
       return
     }
-    const containerConfig = resolveNestedContainer(engine.schema, node)
+    const containerConfig = resolveNestedContainer(
+      engine.snapshot.context.schema,
+      node,
+    )
     if (!containerConfig) {
       // resolveNestedContainer has already warned with chain context.
       return
@@ -34,7 +37,7 @@ export function registerNodeOnEngine(
     const containers = new Map(engine.containers)
     containers.set(node.type, containerConfig)
     engine.containers = containers
-    engine.publicContainers = buildPublicContainers(containers)
+    engine.snapshot.context.containers = buildPublicContainers(containers)
     normalize(engine, {force: true})
     engine.onChange()
     return
@@ -92,7 +95,7 @@ export function unregisterNodeOnEngine(
     const containers = new Map(engine.containers)
     containers.delete(node.type)
     engine.containers = containers
-    engine.publicContainers = buildPublicContainers(containers)
+    engine.snapshot.context.containers = buildPublicContainers(containers)
     normalize(engine, {force: true})
     engine.onChange()
     return

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -260,7 +260,7 @@ export function RenderElement(props: {
     return rendered
   }
 
-  if (isInline(engineStatic, props.path)) {
+  if (isInline(engineStatic.snapshot, props.path)) {
     if (isInNewPipeline && !inlineObjectConfig) {
       const {
         'data-slate-node': _sn,

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -122,7 +122,7 @@ export function SelectionStateProvider({
         {
           context: {
             schema: snapshot.context.schema,
-            containers: editorEngine.publicContainers,
+            containers: editorEngine.snapshot.context.containers,
             value: snapshot.context.value,
           },
           blockIndexMap: editorEngine.blockIndexMap,

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -441,7 +441,7 @@ async function updateValue({
   let isChanged = false
   let isValid = true
 
-  const hadSelection = !!editorEngine.selection
+  const hadSelection = !!editorEngine.snapshot.context.selection
 
   if (!value || value.length === 0) {
     clearEditor({
@@ -562,8 +562,8 @@ async function updateValue({
 
     if (
       hadSelection &&
-      !editorEngine.selection &&
-      editorEngine.children.length > 0
+      !editorEngine.snapshot.context.selection &&
+      editorEngine.snapshot.context.value.length > 0
     ) {
       applySelect(editorEngine, start(editorEngine, []))
       editorEngine.onChange()
@@ -608,10 +608,11 @@ function clearEditor({
             return
           }
 
-          const childrenLength = editorEngine.children.length
+          const childrenLength = editorEngine.snapshot.context.value.length
 
-          editorEngine.children.forEach((_, index) => {
-            const removeNode = editorEngine.children[childrenLength - 1 - index]
+          editorEngine.snapshot.context.value.forEach((_, index) => {
+            const removeNode =
+              editorEngine.snapshot.context.value[childrenLength - 1 - index]
             if (!removeNode) {
               return
             }
@@ -642,11 +643,11 @@ function removeExtraBlocks({
   withoutNormalizing(editorEngine, () => {
     withRemoteChanges(editorEngine, () => {
       withoutPatching(editorEngine, () => {
-        const childrenLength = editorEngine.children.length
+        const childrenLength = editorEngine.snapshot.context.value.length
 
         if (value.length < childrenLength) {
           for (let i = childrenLength - 1; i > value.length - 1; i--) {
-            const removeNode = editorEngine.children[i]
+            const removeNode = editorEngine.snapshot.context.value[i]
             if (!removeNode) {
               continue
             }
@@ -685,8 +686,8 @@ function syncBlock({
   editorEngine: PortableTextEditorEngine
   value: Array<PortableTextBlock>
 }) {
-  const oldEngineBlock = editorEngine.children.at(index)
-  const oldBlock = editorEngine.children.at(index)
+  const oldEngineBlock = editorEngine.snapshot.context.value.at(index)
+  const oldBlock = editorEngine.snapshot.context.value.at(index)
 
   if (!oldEngineBlock || !oldBlock) {
     // Insert the new block
@@ -711,7 +712,7 @@ function syncBlock({
           withoutPatching(editorEngine, () => {
             editorEngine.apply({
               type: 'insert',
-              path: [editorEngine.children.length],
+              path: [editorEngine.snapshot.context.value.length],
               node: engineBlock,
               position: 'before',
             })
@@ -857,9 +858,9 @@ function replaceBlock({
 
   // While replacing the block and the current selection focus is on the replaced block,
   // temporarily deselect the editor then optimistically try to restore the selection afterwards.
-  const currentSelection = editorEngine.selection
+  const currentSelection = editorEngine.snapshot.context.selection
   const focusBlockSegment = currentSelection?.focus.path[0]
-  const blockAtIndex = editorEngine.children[index]
+  const blockAtIndex = editorEngine.snapshot.context.value[index]
   const selectionFocusOnBlock =
     currentSelection &&
     isKeyedSegment(focusBlockSegment) &&
@@ -870,7 +871,7 @@ function replaceBlock({
     applyDeselect(editorEngine)
   }
 
-  const oldNode = editorEngine.children[index]
+  const oldNode = editorEngine.snapshot.context.value[index]
   if (!oldNode) {
     return
   }
@@ -889,8 +890,8 @@ function replaceBlock({
 
   if (
     selectionFocusOnBlock &&
-    hasNode(editorEngine, currentSelection.anchor.path) &&
-    hasNode(editorEngine, currentSelection.focus.path)
+    hasNode(editorEngine.snapshot, currentSelection.anchor.path) &&
+    hasNode(editorEngine.snapshot, currentSelection.focus.path)
   ) {
     applySelect(editorEngine, currentSelection)
   }
@@ -951,8 +952,8 @@ function updateBlock({
 
   // Text block's need to have their children updated as well (setNode does not target a node's children)
   if (
-    isTextBlock({schema: editorEngine.schema}, engineBlock) &&
-    isTextBlock({schema: editorEngine.schema}, oldEngineBlock)
+    isTextBlock({schema: editorEngine.snapshot.context.schema}, engineBlock) &&
+    isTextBlock({schema: editorEngine.snapshot.context.schema}, oldEngineBlock)
   ) {
     // Detect cases where incremental remove/insert would break due to
     // stale keyed path references. Use a single set to replace the
@@ -1013,11 +1014,14 @@ function updateBlock({
           !isEqualChild(
             currentBlockChild,
             oldBlockChild,
-            editorEngine.schema.span.name,
+            editorEngine.snapshot.context.schema.span.name,
           )
         const isTextChanged =
           oldBlockChild &&
-          isSpan({schema: editorEngine.schema}, oldBlockChild) &&
+          isSpan(
+            {schema: editorEngine.snapshot.context.schema},
+            oldBlockChild,
+          ) &&
           currentBlockChild.text !== oldBlockChild.text
         const path = [
           {_key: oldEngineBlock._key},

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -127,13 +127,13 @@ function createNewStep(
   editor: PortableTextEditorEngine,
 ): Array<UndoStep> {
   const operations =
-    editor.selection === null
+    editor.snapshot.context.selection === null
       ? [op]
       : [
           {
             type: 'set_selection' as const,
-            properties: {...editor.selection},
-            newProperties: {...editor.selection},
+            properties: {...editor.snapshot.context.selection},
+            newProperties: {...editor.snapshot.context.selection},
           },
           op,
         ]

--- a/packages/editor/src/editor/use-block-sub-schema.ts
+++ b/packages/editor/src/editor/use-block-sub-schema.ts
@@ -12,5 +12,5 @@ import {getPathSubSchema} from '../traversal/get-path-sub-schema'
  */
 export function useBlockSubSchema(path: Path): Schema {
   const editor = useEngineStatic()
-  return getPathSubSchema(editor, path)
+  return getPathSubSchema(editor.snapshot, path)
 }

--- a/packages/editor/src/editor/usePortableTextEditorSelection.tsx
+++ b/packages/editor/src/editor/usePortableTextEditorSelection.tsx
@@ -12,7 +12,7 @@ export const usePortableTextEditorSelection = (): EditorSelection => {
   const editorActor = useContext(EditorActorContext)
   const editorEngine = useEngineStatic()
   const [selection, setSelection] = useState<EditorSelection>(
-    editorEngine.selection,
+    editorEngine.snapshot.context.selection,
   )
 
   useEffect(() => {

--- a/packages/editor/src/editor/validate-selection-machine.ts
+++ b/packages/editor/src/editor/validate-selection-machine.ts
@@ -76,7 +76,7 @@ export const validateSelectionMachine = validateSelectionSetup.createMachine({
 })
 
 // This function will handle unexpected DOM changes inside the Editable rendering,
-// and make sure that we can maintain a stable editorEngine.selection when that happens.
+// and make sure that we can maintain a stable editorEngine.snapshot.context.selection when that happens.
 //
 // For example, if this Editable is rendered inside something that might re-render
 // this component (hidden contexts) while the user is still actively changing the
@@ -87,15 +87,15 @@ export const validateSelectionMachine = validateSelectionSetup.createMachine({
 // that are impossible to recover properly from or result in a wrong selection.
 //
 // Also the other way around, when the DOMEditor will try to create a DOM Range
-// from the current editorEngine.selection, it may throw unrecoverable errors
-// if the current editor.selection is invalid according to the DOM.
+// from the current editorEngine.snapshot.context.selection, it may throw unrecoverable errors
+// if the current editor.snapshot.context.selection is invalid according to the DOM.
 // If this is the case, default to selecting the top of the document, if the
 // user already had a selection.
 function validateSelection(
   editorEngine: PortableTextEditorEngine,
   editorElement: HTMLDivElement,
 ) {
-  if (!editorEngine.selection) {
+  if (!editorEngine.snapshot.context.selection) {
     return
   }
 
@@ -123,7 +123,7 @@ function validateSelection(
   try {
     const newDOMRange = DOMEditor.toDOMRange(
       editorEngine,
-      editorEngine.selection,
+      editorEngine.snapshot.context.selection,
     )
     if (
       newDOMRange.startOffset !== existingDOMRange.startOffset ||
@@ -140,7 +140,7 @@ function validateSelection(
     // Deselect the editor
     applyDeselect(editorEngine)
     // Select top document if there is a top block to select
-    if (editorEngine.children.length > 0) {
+    if (editorEngine.snapshot.context.value.length > 0) {
       applySelect(editorEngine, start(editorEngine, []))
     }
     editorEngine.onChange()

--- a/packages/editor/src/engine-plugins/engine-plugin.behavior-api.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.behavior-api.ts
@@ -14,7 +14,7 @@ export function createBehaviorApiPlugin(editorActor: EditorActor) {
         return
       }
 
-      if (editor.selection) {
+      if (editor.snapshot.context.selection) {
         select(location)
         return
       }
@@ -27,7 +27,7 @@ export function createBehaviorApiPlugin(editorActor: EditorActor) {
           type: 'select',
           at: {
             ...range,
-            backward: isBackwardRange(range, editor),
+            backward: isBackwardRange(range, editor.snapshot.context),
           },
         },
         editor,
@@ -45,13 +45,15 @@ export function createBehaviorApiPlugin(editorActor: EditorActor) {
       const anchor = partialRange.anchor
       const focus = partialRange.focus
 
-      const backward = editor.selection
+      const backward = editor.snapshot.context.selection
         ? isBackwardRange(
             {
-              anchor: partialRange.anchor ?? editor.selection.anchor,
-              focus: partialRange.focus ?? editor.selection.focus,
+              anchor:
+                partialRange.anchor ?? editor.snapshot.context.selection.anchor,
+              focus:
+                partialRange.focus ?? editor.snapshot.context.selection.focus,
             },
-            editor,
+            editor.snapshot.context,
           )
         : partialRange.anchor && partialRange.focus
           ? isBackwardRange(
@@ -59,17 +61,19 @@ export function createBehaviorApiPlugin(editorActor: EditorActor) {
                 anchor: partialRange.anchor,
                 focus: partialRange.focus,
               },
-              editor,
+              editor.snapshot.context,
             )
           : undefined
 
-      if (editor.selection) {
-        const newAnchor = partialRange.anchor ?? editor.selection.anchor
-        const newFocus = partialRange.focus ?? editor.selection.focus
+      if (editor.snapshot.context.selection) {
+        const newAnchor =
+          partialRange.anchor ?? editor.snapshot.context.selection.anchor
+        const newFocus =
+          partialRange.focus ?? editor.snapshot.context.selection.focus
 
         if (
-          pointEquals(newAnchor, editor.selection.anchor) &&
-          pointEquals(newFocus, editor.selection.focus)
+          pointEquals(newAnchor, editor.snapshot.context.selection.anchor) &&
+          pointEquals(newFocus, editor.snapshot.context.selection.focus)
         ) {
           // To avoid double `select` events, we call `setSelection` directly
           // if the selection wouldn't actually change.

--- a/packages/editor/src/engine-plugins/engine-plugin.history.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.history.ts
@@ -19,7 +19,8 @@ export function createHistoryPlugin({
   subscriptions: Array<() => () => void>
 }): (editor: PortableTextEditorEngine) => PortableTextEditorEngine {
   return function historyPlugin(editor: PortableTextEditorEngine) {
-    let previousSnapshot: Array<PortableTextBlock> | undefined = editor.children
+    let previousSnapshot: Array<PortableTextBlock> | undefined =
+      editor.snapshot.context.value
     let previousUndoStepId = editor.undoStepId
 
     subscriptions.push(() => {

--- a/packages/editor/src/engine-plugins/engine-plugin.patches.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.patches.ts
@@ -37,13 +37,13 @@ export function createPatchesPlugin({
   subscriptions,
 }: Options): (editor: PortableTextEditorEngine) => PortableTextEditorEngine {
   // The previous editor value are needed to figure out the _key of deleted nodes
-  // The editor.children would no longer contain that information if the node is already deleted.
+  // The editor.snapshot.context.value would no longer contain that information if the node is already deleted.
   let previousValue: PortableTextBlock[]
 
   const applyPatch = createApplyPatch(editorActor.getSnapshot().context)
 
   return function patchesPlugin(editor: PortableTextEditorEngine) {
-    previousValue = [...editor.children]
+    previousValue = [...editor.snapshot.context.value]
 
     const {apply} = editor
     let bufferedPatches: Patch[] = []
@@ -109,7 +109,7 @@ export function createPatchesPlugin({
       let patches: Patch[] = []
 
       // Update previous children here before we apply
-      previousValue = editor.children
+      previousValue = editor.snapshot.context.value
 
       const snapshot = editorActor.getSnapshot()
       const {initialValue, schema} = snapshot.context
@@ -122,8 +122,12 @@ export function createPatchesPlugin({
       apply(operation)
 
       const editorIsEmpty =
-        editor.children.length === 1 &&
-        isEqualToEmptyEditor(initialValue, editor.children, schema)
+        editor.snapshot.context.value.length === 1 &&
+        isEqualToEmptyEditor(
+          initialValue,
+          editor.snapshot.context.value,
+          schema,
+        )
 
       if (!editor.isPatching) {
         return editor
@@ -140,10 +144,16 @@ export function createPatchesPlugin({
 
       switch (operation.type) {
         case 'insert_text':
-          patches = [...patches, ...textPatch(editor, operation, previousValue)]
+          patches = [
+            ...patches,
+            ...textPatch(editor.snapshot, operation, previousValue),
+          ]
           break
         case 'remove_text':
-          patches = [...patches, ...textPatch(editor, operation, previousValue)]
+          patches = [
+            ...patches,
+            ...textPatch(editor.snapshot, operation, previousValue),
+          ]
           break
         case 'insert':
           patches = [...patches, ...insertNodePatch(operation)]
@@ -183,7 +193,7 @@ export function createPatchesPlugin({
             type: 'internal.patch',
             patch: {...patch, origin: 'local'},
             operationId: editor.undoStepId,
-            value: editor.children,
+            value: editor.snapshot.context.value,
           })
         }
       }

--- a/packages/editor/src/engine-plugins/engine-plugin.update-selection.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.update-selection.ts
@@ -11,7 +11,7 @@ export function updateSelectionPlugin({
   const updateSelection = () => {
     editorActor.send({
       type: 'update selection',
-      selection: editor.selection,
+      selection: editor.snapshot.context.selection,
     })
   }
 

--- a/packages/editor/src/engine-plugins/engine-plugin.update-value.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.update-value.ts
@@ -42,7 +42,7 @@ export function updateValuePlugin(
       buildIndexMaps(
         {
           schema: context.schema,
-          value: editor.children,
+          value: editor.snapshot.context.value,
         },
         {
           blockIndexMap: editor.blockIndexMap,

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -3,7 +3,7 @@ import {
   set as setPatchHelper,
   unset as unsetPatchHelper,
 } from '@portabletext/patches'
-import type {PortableTextSpan} from '@portabletext/schema'
+import type {PortableTextBlock, PortableTextSpan} from '@portabletext/schema'
 import {isSpan} from '@portabletext/schema'
 import {safeStringify} from '../../internal-utils/safe-json'
 import {getNode} from '../../traversal/get-node'
@@ -52,7 +52,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
           node._key !== undefined &&
           children.some((sibling) => sibling._key === node._key)
         ) {
-          node = {...node, _key: editor.keyGenerator()}
+          node = {...node, _key: editor.snapshot.context.keyGenerator()}
           op.node = node
         }
 
@@ -157,14 +157,15 @@ export function applyOperation(editor: Editor, op: Operation): void {
     case 'set': {
       const {path, value} = op
 
-      // Root-level value replacement: set editor.children directly
+      // Root-level value replacement: set editor.snapshot.context.value directly
       if (path.length === 0) {
         if (Array.isArray(value)) {
-          ;(editor as {children: Node[]}).children = value as Node[]
+          editor.snapshot.context.value =
+            value as unknown as PortableTextBlock[]
           // Rebuild blockIndexMap
           editor.blockIndexMap.clear()
-          for (let i = 0; i < editor.children.length; i++) {
-            const child = editor.children[i]
+          for (let i = 0; i < editor.snapshot.context.value.length; i++) {
+            const child = editor.snapshot.context.value[i]
             if (child) {
               editor.blockIndexMap.set(child._key, i)
             }
@@ -199,7 +200,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       }
 
       // Check if the node path resolves to a known node
-      const setNodeEntry = getNode(editor, setNodePath)
+      const setNodeEntry = getNode(editor.snapshot, setNodePath)
 
       if (setNodeEntry) {
         // Node found: use modifyDescendant
@@ -225,8 +226,8 @@ export function applyOperation(editor: Editor, op: Operation): void {
             } else {
               // No inverse data: full rebuild
               editor.blockIndexMap.clear()
-              for (let i = 0; i < editor.children.length; i++) {
-                const child = editor.children[i]
+              for (let i = 0; i < editor.snapshot.context.value.length; i++) {
+                const child = editor.snapshot.context.value[i]
                 if (child) {
                   editor.blockIndexMap.set(child._key, i)
                 }
@@ -251,7 +252,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
           break
         }
 
-        const block = editor.children[blockIndex]
+        const block = editor.snapshot.context.value[blockIndex]
         if (!block) {
           break
         }
@@ -260,9 +261,9 @@ export function applyOperation(editor: Editor, op: Operation): void {
           setPatchHelper(value, path.slice(1)),
         ])
 
-        const newChildren = editor.children.slice()
+        const newChildren = editor.snapshot.context.value.slice()
         newChildren[blockIndex] = updatedBlock
-        ;(editor as {children: Node[]}).children = newChildren
+        editor.snapshot.context.value = newChildren
       }
 
       transformSelection = true
@@ -274,7 +275,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
       // Root-level unset: remove all children
       if (path.length === 0) {
-        ;(editor as {children: Node[]}).children = []
+        editor.snapshot.context.value = []
         editor.blockIndexMap.clear()
         transformSelection = true
         break
@@ -289,8 +290,10 @@ export function applyOperation(editor: Editor, op: Operation): void {
         // comparePaths needs the node in the tree to resolve document order
         // for keyed segments. After removal, it falls back to string
         // comparison of _key values which may give wrong ordering.
-        if (editor.selection) {
-          let selection: EditorSelection = {...editor.selection}
+        if (editor.snapshot.context.selection) {
+          let selection: EditorSelection = {
+            ...editor.snapshot.context.selection,
+          }
 
           for (const [point, key] of rangePoints(selection)) {
             const result = transformPoint(point, op)
@@ -301,14 +304,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
               let prev: NodeEntry<PortableTextSpan> | undefined
               let next: NodeEntry<PortableTextSpan> | undefined
 
-              for (const {node: n, path: p} of getNodes(editor)) {
-                if (!isSpan({schema: editor.schema}, n)) {
+              for (const {node: n, path: p} of getNodes(editor.snapshot)) {
+                if (!isSpan({schema: editor.snapshot.context.schema}, n)) {
                   continue
                 }
                 if (pathEquals(p, path)) {
                   continue
                 }
-                if (comparePaths(p, path, editor) === -1) {
+                if (comparePaths(p, path, editor.snapshot.context) === -1) {
                   prev = [n, p]
                 } else {
                   next = [n, p]
@@ -339,8 +342,11 @@ export function applyOperation(editor: Editor, op: Operation): void {
             }
           }
 
-          editor.selection = selection
-            ? {...selection, backward: isBackwardRange(selection, editor)}
+          editor.snapshot.context.selection = selection
+            ? {
+                ...selection,
+                backward: isBackwardRange(selection, editor.snapshot.context),
+              }
             : null
         }
 
@@ -412,7 +418,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       }
 
       // Check if the node path resolves to a known node
-      const unsetNodeEntry = getNode(editor, unsetNodePath)
+      const unsetNodeEntry = getNode(editor.snapshot, unsetNodePath)
 
       if (unsetNodeEntry) {
         // Node found: use modifyDescendant
@@ -441,16 +447,16 @@ export function applyOperation(editor: Editor, op: Operation): void {
           break
         }
 
-        const block = editor.children[blockIndex]
+        const block = editor.snapshot.context.value[blockIndex]
         if (!block) {
           break
         }
 
         const updatedBlock = applyAll(block, [unsetPatchHelper(path.slice(1))])
 
-        const newChildren = editor.children.slice()
+        const newChildren = editor.snapshot.context.value.slice()
         newChildren[blockIndex] = updatedBlock
-        ;(editor as {children: Node[]}).children = newChildren
+        editor.snapshot.context.value = newChildren
       }
 
       transformSelection = true
@@ -461,11 +467,11 @@ export function applyOperation(editor: Editor, op: Operation): void {
       const {newProperties} = op
 
       if (newProperties == null) {
-        editor.selection = null
+        editor.snapshot.context.selection = null
         break
       }
 
-      if (editor.selection == null) {
+      if (editor.snapshot.context.selection == null) {
         if (!isRange(newProperties)) {
           throw new Error(
             `Cannot apply an incomplete "set_selection" operation properties ${safeStringify(
@@ -474,14 +480,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
           )
         }
 
-        editor.selection = {
+        editor.snapshot.context.selection = {
           ...newProperties,
-          backward: isBackwardRange(newProperties, editor),
+          backward: isBackwardRange(newProperties, editor.snapshot.context),
         }
         break
       }
 
-      const selection = {...editor.selection}
+      const selection = {...editor.snapshot.context.selection}
 
       for (const key in newProperties) {
         const value = newProperties[key as keyof Range]
@@ -497,37 +503,37 @@ export function applyOperation(editor: Editor, op: Operation): void {
         }
       }
 
-      editor.selection = {
+      editor.snapshot.context.selection = {
         ...selection,
-        backward: isBackwardRange(selection, editor),
+        backward: isBackwardRange(selection, editor.snapshot.context),
       }
 
       break
     }
   }
 
-  if (transformSelection && editor.selection) {
-    const anchor = transformPoint(editor.selection.anchor, op)
-    const focus = transformPoint(editor.selection.focus, op)
+  if (transformSelection && editor.snapshot.context.selection) {
+    const anchor = transformPoint(editor.snapshot.context.selection.anchor, op)
+    const focus = transformPoint(editor.snapshot.context.selection.focus, op)
 
     if (!anchor || !focus) {
       // The operation removed the host node of one of the selection's
       // endpoints. The selection is no longer valid.
-      editor.selection = null
+      editor.snapshot.context.selection = null
     } else if (
-      anchor !== editor.selection.anchor ||
-      focus !== editor.selection.focus
+      anchor !== editor.snapshot.context.selection.anchor ||
+      focus !== editor.snapshot.context.selection.focus
     ) {
       // `transformPoint` returns the same reference when the operation doesn't
       // move the point. If neither endpoint moved, the selection is identity-
-      // stable and we leave `editor.selection` alone. This lets internal sync
+      // stable and we leave `editor.snapshot.context.selection` alone. This lets internal sync
       // paths (e.g. remote patches arriving via `update value`) run set/unset/
       // insert_text operations without forcing downstream consumers to re-derive
       // selection-keyed state for no semantic reason.
-      editor.selection = {
+      editor.snapshot.context.selection = {
         anchor,
         focus,
-        backward: isBackwardRange({anchor, focus}, editor),
+        backward: isBackwardRange({anchor, focus}, editor.snapshot.context),
       }
     }
   }
@@ -585,7 +591,9 @@ function resolveBlockIndex(editor: Editor, blockKey: string): number {
   if (mapIndex !== undefined) {
     return mapIndex
   }
-  return editor.children.findIndex((child) => child._key === blockKey)
+  return editor.snapshot.context.value.findIndex(
+    (child) => child._key === blockKey,
+  )
 }
 
 /**

--- a/packages/editor/src/engine/core/apply.ts
+++ b/packages/editor/src/engine/core/apply.ts
@@ -24,7 +24,7 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
   }
 
   for (const ref of editor.rangeRefs) {
-    transformRangeRef(ref, op, editor)
+    transformRangeRef(ref, op, editor.snapshot.context)
   }
 
   // Apply the operation to the tree first, so that getDirtyPaths
@@ -32,7 +32,7 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
   // resolve duplicate keys, mutating op.node in place).
   applyOperation(editor, op)
 
-  updateDirtyPaths(editor, getDirtyPaths(editor.context, op))
+  updateDirtyPaths(editor, getDirtyPaths(editor.snapshot.context, op))
 
   editor.operations.push(op)
   normalize(editor, {
@@ -59,9 +59,15 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
       })
 
       if (previousSelectionIsCollapsed && newSelectionIsCollapsed) {
-        const focusSpanEntry = getSpan(editor, op.properties.focus.path)
+        const focusSpanEntry = getSpan(
+          editor.snapshot,
+          op.properties.focus.path,
+        )
         const focusSpan: PortableTextSpan | undefined = focusSpanEntry?.node
-        const newFocusSpanEntry = getSpan(editor, op.newProperties.focus.path)
+        const newFocusSpanEntry = getSpan(
+          editor.snapshot,
+          op.newProperties.focus.path,
+        )
         const newFocusSpan: PortableTextSpan | undefined =
           newFocusSpanEntry?.node
 
@@ -77,12 +83,20 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
         let movedToPreviousSpan = false
 
         if (sameParent && focusSpan && newFocusSpan) {
-          const nextSibling = getSibling(editor, op.properties.focus.path, {
-            direction: 'next',
-          })
-          const previousSibling = getSibling(editor, op.properties.focus.path, {
-            direction: 'previous',
-          })
+          const nextSibling = getSibling(
+            editor.snapshot,
+            op.properties.focus.path,
+            {
+              direction: 'next',
+            },
+          )
+          const previousSibling = getSibling(
+            editor.snapshot,
+            op.properties.focus.path,
+            {
+              direction: 'previous',
+            },
+          )
 
           movedToNextSpan =
             nextSibling !== undefined &&
@@ -98,12 +112,12 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
         }
 
         if (!movedToNextSpan && !movedToPreviousSpan) {
-          editor.decoratorState = {}
+          editor.snapshot.decoratorState = {}
         }
       }
     } else {
       // In any other case, we want to clear the decorator state.
-      editor.decoratorState = {}
+      editor.snapshot.decoratorState = {}
     }
   }
 

--- a/packages/editor/src/engine/core/collapse.ts
+++ b/packages/editor/src/engine/core/collapse.ts
@@ -11,7 +11,7 @@ export function collapse(
   options: SelectionCollapseOptions = {},
 ): void {
   const {edge = 'anchor'} = options
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
 
   if (!selection) {
     return
@@ -20,10 +20,10 @@ export function collapse(
   } else if (edge === 'focus') {
     editor.select(selection.focus)
   } else if (edge === 'start') {
-    const [start] = rangeEdges(selection, editor)
+    const [start] = rangeEdges(selection, editor.snapshot.context)
     editor.select(start)
   } else if (edge === 'end') {
-    const [, end] = rangeEdges(selection, editor)
+    const [, end] = rangeEdges(selection, editor.snapshot.context)
     editor.select(end)
   }
 }

--- a/packages/editor/src/engine/core/deselect.ts
+++ b/packages/editor/src/engine/core/deselect.ts
@@ -1,7 +1,7 @@
 import type {Editor} from '../interfaces/editor'
 
 export function deselect(editor: Editor): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
 
   if (selection) {
     editor.apply({

--- a/packages/editor/src/engine/core/move.ts
+++ b/packages/editor/src/engine/core/move.ts
@@ -13,7 +13,7 @@ interface SelectionMoveOptions {
 }
 
 export function move(editor: Editor, options: SelectionMoveOptions = {}): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
   const {distance = 1, unit = 'character', reverse = false} = options
   let {edge = null} = options
 
@@ -22,11 +22,15 @@ export function move(editor: Editor, options: SelectionMoveOptions = {}): void {
   }
 
   if (edge === 'start') {
-    edge = isBackwardRange(selection, editor) ? 'focus' : 'anchor'
+    edge = isBackwardRange(selection, editor.snapshot.context)
+      ? 'focus'
+      : 'anchor'
   }
 
   if (edge === 'end') {
-    edge = isBackwardRange(selection, editor) ? 'anchor' : 'focus'
+    edge = isBackwardRange(selection, editor.snapshot.context)
+      ? 'anchor'
+      : 'focus'
   }
 
   const {anchor, focus} = selection

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -40,9 +40,13 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Add a placeholder block when the editor is empty
    */
-  if (isEditor(node) && node.children.length === 0) {
+  if (isEditor(node) && node.snapshot.context.value.length === 0) {
     withoutPatching(editor, () => {
-      applyInsertNodeAtPath(editor, createPlaceholderBlock(editor), [0])
+      applyInsertNodeAtPath(
+        editor,
+        createPlaceholderBlock(editor.snapshot),
+        [0],
+      )
     })
     return
   }
@@ -50,16 +54,16 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Merge spans with same set of .marks
    */
-  if (isTextBlock({schema: editor.schema}, node)) {
-    const children = getChildren(editor, path)
+  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+    const children = getChildren(editor.snapshot, path)
 
     for (let i = 0; i < children.length - 1; i++) {
       const {node: child} = children[i]!
       const {node: nextNode, path: nextChildPath} = children[i + 1]!
 
       if (
-        isSpan({schema: editor.schema}, child) &&
-        isSpan({schema: editor.schema}, nextNode) &&
+        isSpan({schema: editor.snapshot.context.schema}, child) &&
+        isSpan({schema: editor.snapshot.context.schema}, nextNode) &&
         child.marks?.every((mark) => nextNode.marks?.includes(mark)) &&
         nextNode.marks?.every((mark) => child.marks?.includes(mark))
       ) {
@@ -72,15 +76,18 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
   // Normalize missing _type based on context.
   if (nodeRecord['_type'] === undefined && path.length > 0) {
-    const parent = getNode(editor, parentPath(path))
+    const parent = getNode(editor.snapshot, parentPath(path))
 
     // Children of text blocks default to the span type.
-    if (parent && isTextBlock({schema: editor.schema}, parent.node)) {
+    if (
+      parent &&
+      isTextBlock({schema: editor.snapshot.context.schema}, parent.node)
+    ) {
       debug.normalization('Setting span type on node without a type')
       editor.apply({
         type: 'set',
         path: [...path, '_type'],
-        value: editor.schema.span.name,
+        value: editor.snapshot.context.schema.span.name,
         inverse: {type: 'unset', path: [...path, '_type']},
       })
       return
@@ -91,7 +98,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     editor.apply({
       type: 'set',
       path: [...path, '_type'],
-      value: editor.schema.block.name,
+      value: editor.snapshot.context.schema.block.name,
       inverse: {type: 'unset', path: [...path, '_type']},
     })
     return
@@ -102,7 +109,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // address it by. Any ancestor segments with undefined _key are also
   // resolved to numeric indices.
   if (nodeRecord['_key'] === undefined && path.length > 0) {
-    const newKey = editor.keyGenerator()
+    const newKey = editor.snapshot.context.keyGenerator()
     debug.normalization('Setting missing key on node')
 
     // Build a fully resolved path by walking the tree from the root,
@@ -124,7 +131,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
         ? (((currentNode as Record<string, unknown>)[
             numericPath[numericPath.length - 1] as string
           ] as ArrayLike<Node>) ?? [])
-        : editor.children
+        : editor.snapshot.context.value
 
       if (isKeyedSegment(segment) && segment._key !== undefined) {
         numericPath.push(segment)
@@ -161,10 +168,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
   // Fix duplicate _key among siblings
   if (path.length > 0 && nodeRecord['_key'] !== undefined) {
-    const parent = getParent(editor, path)
+    const parent = getParent(editor.snapshot, path)
     const siblings = parent
-      ? getChildren(editor, parent.path)
-      : editor.children.map((child, index) => ({
+      ? getChildren(editor.snapshot, parent.path)
+      : editor.snapshot.context.value.map((child, index) => ({
           node: child,
           path: [{_key: child._key}],
           index,
@@ -181,7 +188,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
           firstIndex = i
         } else {
           // Found a duplicate: rename the later occurrence
-          const newKey = editor.keyGenerator()
+          const newKey = editor.snapshot.context.keyGenerator()
           debug.normalization('Fixing duplicate key on node')
           const dupParentPath = parent ? parent.path : []
           const numericPath: Path =
@@ -189,7 +196,8 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
               ? [i]
               : [
                   ...dupParentPath,
-                  getChildFieldName(editor.context, parent!.path) ?? 'children',
+                  getChildFieldName(editor.snapshot.context, parent!.path) ??
+                    'children',
                   i,
                 ]
           editor.apply({
@@ -212,7 +220,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Add missing .markDefs to text block nodes
    */
   if (
-    isTextBlockNode({schema: editor.schema}, node) &&
+    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
     !Array.isArray(node.markDefs)
   ) {
     debug.normalization('adding .markDefs to block node')
@@ -224,10 +232,12 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Add missing .style to text block nodes
    */
   if (
-    isTextBlockNode({schema: editor.schema}, node) &&
+    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
     typeof node.style === 'undefined'
   ) {
-    const defaultStyle = getPathSubSchema(editor, path).styles.at(0)?.name
+    const defaultStyle = getPathSubSchema(editor.snapshot, path).styles.at(
+      0,
+    )?.name
     if (defaultStyle) {
       debug.normalization('adding .style to block node')
       setNodeProperties(editor, {style: defaultStyle}, path)
@@ -238,7 +248,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Add missing .text to span nodes
    */
-  if (isSpanNode(editor, node) && typeof node.text !== 'string') {
+  if (
+    isSpanNode(editor.snapshot.context, node) &&
+    typeof node.text !== 'string'
+  ) {
     debug.normalization('Adding .text to span node')
     editor.apply({
       type: 'set',
@@ -252,7 +265,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Add missing .marks to span nodes
    */
-  if (isSpan({schema: editor.schema}, node) && !Array.isArray(node.marks)) {
+  if (
+    isSpan({schema: editor.snapshot.context.schema}, node) &&
+    !Array.isArray(node.marks)
+  ) {
     debug.normalization('Adding .marks to span node')
     setNodeProperties(editor, {marks: []}, path)
     return
@@ -261,13 +277,13 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove annotations from empty spans
    */
-  if (isSpan({schema: editor.schema}, node)) {
+  if (isSpan({schema: editor.snapshot.context.schema}, node)) {
     const blockPath = parentPath(path)
-    const blockEntry = getTextBlock(editor, blockPath)
+    const blockEntry = getTextBlock(editor.snapshot, blockPath)
     if (!blockEntry) {
       return
     }
-    const decorators = getPathSubSchema(editor, path).decorators.map(
+    const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
       (decorator) => decorator.name,
     )
     const annotations = node.marks?.filter((mark) => !decorators.includes(mark))
@@ -286,13 +302,16 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove orphaned annotations from child spans of block nodes
    */
-  if (isTextBlock({schema: editor.schema}, node)) {
-    const decorators = getPathSubSchema(editor, path).decorators.map(
+  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+    const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
       (decorator) => decorator.name,
     )
 
-    for (const {node: child, path: childPath} of getChildren(editor, path)) {
-      if (isSpan({schema: editor.schema}, child)) {
+    for (const {node: child, path: childPath} of getChildren(
+      editor.snapshot,
+      path,
+    )) {
+      if (isSpan({schema: editor.snapshot.context.schema}, child)) {
         const marks = child.marks ?? []
         const orphanedAnnotations = marks.filter((mark) => {
           return (
@@ -321,13 +340,13 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove orphaned annotations from span nodes
    */
-  if (isSpan({schema: editor.schema}, node)) {
+  if (isSpan({schema: editor.snapshot.context.schema}, node)) {
     const blockPath = parentPath(path)
-    const blockEntry2 = getTextBlock(editor, blockPath)
+    const blockEntry2 = getTextBlock(editor.snapshot, blockPath)
 
     if (blockEntry2) {
       const block = blockEntry2.node
-      const decorators = getPathSubSchema(editor, path).decorators.map(
+      const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
         (decorator) => decorator.name,
       )
       const marks = node.marks ?? []
@@ -355,7 +374,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove duplicate markDefs
    */
-  if (isTextBlock({schema: editor.schema}, node)) {
+  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
     const markDefs = node.markDefs ?? []
     const markDefKeys = new Set<string>()
     const newMarkDefs: Array<PortableTextObject> = []
@@ -377,11 +396,11 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove markDefs not in use
    */
-  if (isTextBlock({schema: editor.schema}, node)) {
+  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
     const newMarkDefs = (node.markDefs || []).filter((def) => {
       return node.children.find((child) => {
         return (
-          isSpan({schema: editor.schema}, child) &&
+          isSpan({schema: editor.snapshot.context.schema}, child) &&
           Array.isArray(child.marks) &&
           child.marks.includes(def._key)
         )
@@ -395,7 +414,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
   }
 
-  if (isSpanNode({schema: editor.schema}, node)) {
+  if (isSpanNode({schema: editor.snapshot.context.schema}, node)) {
     /**
      * Add missing .text to span nodes
      */
@@ -415,8 +434,16 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
   // Container normalization: ensure the child array field exists and is
   // non-empty.
-  if (isObject(editor, node)) {
-    const resolved = resolveContainerByPath(editor, path, node)
+  if (isObject(editor.snapshot, node)) {
+    const resolved = resolveContainerByPath(
+      {
+        containers: editor.containers,
+        schema: editor.snapshot.context.schema,
+        value: editor.snapshot.context.value,
+      },
+      path,
+      node,
+    )
     const arrayField =
       resolved && 'container' in resolved ? resolved.field : undefined
 
@@ -433,7 +460,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
         let childNode: Node | undefined
         if (acceptsBlocks) {
-          childNode = createPlaceholderBlock(editor, [
+          childNode = createPlaceholderBlock(editor.snapshot, [
             ...path,
             arrayField.name,
             0,
@@ -448,7 +475,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
               : firstChildType.type
           childNode = {
             _type: childTypeName,
-            _key: editor.keyGenerator(),
+            _key: editor.snapshot.context.keyGenerator(),
           } as Node
         }
 
@@ -481,8 +508,8 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // The sibling-level handler above catches duplicates when each child is
   // visited individually, but container children may not be visited if
   // containers gates traversal. Handle it at the parent level as well.
-  if (isObject(editor, node)) {
-    const children = [...getChildren(editor, path)]
+  if (isObject(editor.snapshot, node)) {
+    const children = [...getChildren(editor.snapshot, path)]
 
     if (children.length > 1) {
       const seen = new Map<string, number>()
@@ -490,11 +517,14 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       for (let i = 0; i < children.length; i++) {
         const key = children[i]!.node._key
         if (key !== undefined && seen.has(key)) {
-          const newKey = editor.keyGenerator()
+          const newKey = editor.snapshot.context.keyGenerator()
           debug.normalization('Fixing duplicate key on container child')
           // Use numeric index to address the duplicate since keyed path
           // is ambiguous for nodes with the same key.
-          const arrayFieldName = getChildFieldName(editor.context, path)
+          const arrayFieldName = getChildFieldName(
+            editor.snapshot.context,
+            path,
+          )
           if (arrayFieldName) {
             editor.apply({
               type: 'set',
@@ -519,9 +549,13 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   }
 
   // Text blocks must always have at least one child span.
-  if (isTextBlockNode({schema: editor.schema}, node)) {
+  if (isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
+    // We will have to refetch the element any time we modify its children
+    // since it clones to a new immutable reference when we do.
+    let element = node as unknown as PortableTextTextBlock
+
     // Runtime data can arrive without children (e.g. after an unset patch).
-    if (!Array.isArray(node.children)) {
+    if (!Array.isArray(element.children)) {
       editor.apply({
         type: 'set',
         path: [...path, 'children'],
@@ -531,20 +565,16 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       return
     }
 
-    // We will have to refetch the element any time we modify its children
-    // since it clones to a new immutable reference when we do.
-    let element: PortableTextTextBlock = node
-
     // Ensure that text blocks have at least one child.
     if (element.children.length === 0) {
-      const child = createSpanNode(editor)
+      const child = createSpanNode(editor.snapshot.context)
       editor.apply({
         type: 'insert',
         path: [...path, 'children', 0],
         node: child,
         position: 'before',
       })
-      const refetched = getTextBlock(editor, path)?.node
+      const refetched = getTextBlock(editor.snapshot, path)?.node
       if (!refetched) {
         return
       }
@@ -559,12 +589,15 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       const prev: Node | undefined = element.children[n - 1]
       const childPath = [...path, 'children', {_key: child._key}]
 
-      if (isSpan({schema: editor.schema}, child)) {
-        if (prev != null && isSpan({schema: editor.schema}, prev)) {
+      if (isSpan({schema: editor.snapshot.context.schema}, child)) {
+        if (
+          prev != null &&
+          isSpan({schema: editor.snapshot.context.schema}, prev)
+        ) {
           // Merge adjacent text nodes that are empty or match.
           if (child.text === '') {
             editor.apply({type: 'unset', path: childPath})
-            const refetched = getTextBlock(editor, path)?.node
+            const refetched = getTextBlock(editor.snapshot, path)?.node
             if (!refetched) {
               return
             }
@@ -573,7 +606,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
           } else if (prev.text === '') {
             const prevPath = [...path, 'children', {_key: prev._key}]
             editor.apply({type: 'unset', path: prevPath})
-            const refetched = getTextBlock(editor, path)?.node
+            const refetched = getTextBlock(editor.snapshot, path)?.node
             if (!refetched) {
               return
             }
@@ -581,7 +614,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
             n--
           } else if (textEquals(child, prev, {loose: true})) {
             applyMergeNode(editor, childPath, prev.text.length)
-            const refetched = getTextBlock(editor, path)?.node
+            const refetched = getTextBlock(editor.snapshot, path)?.node
             if (!refetched) {
               return
             }
@@ -589,16 +622,19 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
             n--
           }
         }
-      } else if (isObject(editor, child)) {
-        if (prev == null || !isSpan({schema: editor.schema}, prev)) {
-          const newChild = createSpanNode(editor)
+      } else if (isObject(editor.snapshot, child)) {
+        if (
+          prev == null ||
+          !isSpan({schema: editor.snapshot.context.schema}, prev)
+        ) {
+          const newChild = createSpanNode(editor.snapshot.context)
           editor.apply({
             type: 'insert',
             path: childPath,
             node: newChild,
             position: 'before',
           })
-          const refetched = getTextBlock(editor, path)?.node
+          const refetched = getTextBlock(editor.snapshot, path)?.node
           if (!refetched) {
             return
           }
@@ -606,14 +642,14 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
           n++
         }
         if (n === element.children.length - 1) {
-          const newChild = createSpanNode(editor)
+          const newChild = createSpanNode(editor.snapshot.context)
           editor.apply({
             type: 'insert',
             path: [...path, 'children', {_key: element.children[n]!._key}],
             node: newChild,
             position: 'after',
           })
-          const refetched = getTextBlock(editor, path)?.node
+          const refetched = getTextBlock(editor.snapshot, path)?.node
           if (!refetched) {
             return
           }

--- a/packages/editor/src/engine/core/select.ts
+++ b/packages/editor/src/engine/core/select.ts
@@ -5,7 +5,7 @@ import type {Location} from '../interfaces/location'
 import {isRange} from '../range/is-range'
 
 export function select(editor: Editor, target: Location): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
   target = editorRange(editor, target)
 
   if (selection) {

--- a/packages/editor/src/engine/core/set-selection.ts
+++ b/packages/editor/src/engine/core/set-selection.ts
@@ -3,7 +3,7 @@ import type {Range} from '../interfaces/range'
 import {pointEquals} from '../point/point-equals'
 
 export function setSelection(editor: Editor, props: Partial<Range>): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
   const oldProps: Partial<Range> | null = {}
   const newProps: Partial<Range> = {}
 

--- a/packages/editor/src/engine/create-editor.ts
+++ b/packages/editor/src/engine/create-editor.ts
@@ -13,26 +13,13 @@ import type {Editor} from './interfaces/editor'
  * engine core methods, then the `withDOM` plugin adds DOMEditor and
  * PortableTextEditorEngine methods. We use `as any` for the self-referencing
  * delegates because the object doesn't satisfy `Editor` until after plugin
- * application. This file gets rewritten in the PT-native fork (Step 3).
+ * application.
  */
 export const createEditor = (): Editor => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const e: any = {
     [EDITOR_BRAND]: true,
-    children: [],
-    get value() {
-      return this.children
-    },
-    get context() {
-      return {
-        schema: this.schema,
-        containers: this.publicContainers,
-        value: this.children,
-        keyGenerator: this.keyGenerator,
-      }
-    },
     operations: [],
-    selection: null,
     marks: null,
     dirtyPaths: [],
     dirtyPathKeys: new Set(),

--- a/packages/editor/src/engine/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/engine/dom/plugin/dom-editor.ts
@@ -239,14 +239,17 @@ export const DOMEditor: DOMEditorInterface = {
     const root = DOMEditor.findDocumentOrShadowRoot(editor)
     if (root.activeElement !== el) {
       // Ensure that the DOM selection state is set to the editor's selection
-      if (editor.selection && root instanceof Document) {
+      if (editor.snapshot.context.selection && root instanceof Document) {
         const domSelection = getSelection(root)
-        const domRange = DOMEditor.toDOMRange(editor, editor.selection)
+        const domRange = DOMEditor.toDOMRange(
+          editor,
+          editor.snapshot.context.selection,
+        )
         domSelection?.removeAllRanges()
         domSelection?.addRange(domRange)
       }
       // Create a new selection in the top of the document if missing
-      if (!editor.selection) {
+      if (!editor.snapshot.context.selection) {
         editor.select(editorStart(editor, []))
       }
       // IS_FOCUSED should be set before calling el.focus() to ensure that
@@ -258,9 +261,12 @@ export const DOMEditor: DOMEditorInterface = {
       // reset the selection when el.focus() is called, which can cause the
       // selection to shift away from the intended position (e.g., away from
       // an inline object to an adjacent empty span).
-      if (editor.selection && root instanceof Document) {
+      if (editor.snapshot.context.selection && root instanceof Document) {
         const domSelection = getSelection(root)
-        const domRange = DOMEditor.toDOMRange(editor, editor.selection)
+        const domRange = DOMEditor.toDOMRange(
+          editor,
+          editor.snapshot.context.selection,
+        )
         domSelection?.removeAllRanges()
         domSelection?.addRange(domRange)
       }
@@ -323,7 +329,10 @@ export const DOMEditor: DOMEditorInterface = {
 
   hasRange: (editor, range) => {
     const {anchor, focus} = range
-    return hasNode(editor, anchor.path) && hasNode(editor, focus.path)
+    return (
+      hasNode(editor.snapshot, anchor.path) &&
+      hasNode(editor.snapshot, focus.path)
+    )
   },
 
   hasSelectableTarget: (editor, target) =>
@@ -347,7 +356,7 @@ export const DOMEditor: DOMEditorInterface = {
   },
 
   toDOMPoint: (editor, point) => {
-    const nodeEntry = getNode(editor, point.path)
+    const nodeEntry = getNode(editor.snapshot, point.path)
     const el = getDomNode(editor, point.path)
 
     if (!el) {
@@ -356,7 +365,10 @@ export const DOMEditor: DOMEditorInterface = {
 
     let domPoint: DOMPoint | undefined
 
-    if (nodeEntry && isLeafObject(editor, nodeEntry.node, point.path)) {
+    if (
+      nodeEntry &&
+      isLeafObject(editor.snapshot, nodeEntry.node, point.path)
+    ) {
       const spacer = el.querySelector('[data-pt-zero-width]')
       if (spacer) {
         const domText = spacer.childNodes[0]
@@ -378,17 +390,17 @@ export const DOMEditor: DOMEditorInterface = {
     // If we're inside an object node, force the offset to 0, otherwise the zero
     // width spacing character will result in an incorrect offset of 1
     const pointPath = editorPath(editor, point)
-    const pointEntry = getNode(editor, pointPath)
+    const pointEntry = getNode(editor.snapshot, pointPath)
     const pointObjectNode =
-      pointEntry && isLeafObject(editor, pointEntry.node, pointPath)
+      pointEntry && isLeafObject(editor.snapshot, pointEntry.node, pointPath)
         ? pointEntry
-        : getAncestor(editor, point.path, {
+        : getAncestor(editor.snapshot, point.path, {
             match: (node, ancestorPath) =>
-              isLeafObject(editor, node, ancestorPath),
+              isLeafObject(editor.snapshot, node, ancestorPath),
           })
     if (
       pointObjectNode &&
-      isLeafObject(editor, pointObjectNode.node, pointObjectNode.path)
+      isLeafObject(editor.snapshot, pointObjectNode.node, pointObjectNode.path)
     ) {
       point = {path: point.path, offset: 0}
     }
@@ -432,7 +444,7 @@ export const DOMEditor: DOMEditorInterface = {
 
   toDOMRange: (editor, range) => {
     const {anchor, focus} = range
-    const isBackward = isBackwardRange(range, editor)
+    const isBackward = isBackwardRange(range, editor.snapshot.context)
     const domAnchor = DOMEditor.toDOMPoint(editor, anchor)
     const domFocus = isCollapsedRange(range)
       ? domAnchor
@@ -755,9 +767,12 @@ export const DOMEditor: DOMEditorInterface = {
     // Truncate paths that resolve to the spacer's virtual text node.
     if (path.length > 1) {
       const parentPath = path.slice(0, -1)
-      const parentEntry = getNode(editor, parentPath)
+      const parentEntry = getNode(editor.snapshot, parentPath)
 
-      if (parentEntry && isLeafObject(editor, parentEntry.node, parentPath)) {
+      if (
+        parentEntry &&
+        isLeafObject(editor.snapshot, parentEntry.node, parentPath)
+      ) {
         return {path: parentPath, offset: 0}
       }
     }

--- a/packages/editor/src/engine/dom/utils/diff-text.ts
+++ b/packages/editor/src/engine/dom/utils/diff-text.ts
@@ -34,11 +34,11 @@ export type TextDiff = {
  */
 export function verifyDiffState(editor: Editor, textDiff: TextDiff): boolean {
   const {path, diff} = textDiff
-  if (!hasNode(editor, path)) {
+  if (!hasNode(editor.snapshot, path)) {
     return false
   }
 
-  const nodeEntry = getSpan(editor, path)
+  const nodeEntry = getSpan(editor.snapshot, path)
   if (!nodeEntry) {
     return false
   }
@@ -50,12 +50,12 @@ export function verifyDiffState(editor: Editor, textDiff: TextDiff): boolean {
     )
   }
 
-  const nextSibling = getSibling(editor, path, {direction: 'next'})
+  const nextSibling = getSibling(editor.snapshot, path, {direction: 'next'})
   if (!nextSibling) {
     return false
   }
 
-  const nextNodeEntry = getSpan(editor, nextSibling.path)
+  const nextNodeEntry = getSpan(editor.snapshot, nextSibling.path)
   return !!nextNodeEntry && nextNodeEntry.node.text.startsWith(diff.text)
 }
 
@@ -172,18 +172,19 @@ export function targetRange(textDiff: TextDiff): Range {
  */
 export function normalizePoint(editor: Editor, point: Point): Point | null {
   let {path, offset} = point
-  if (!hasNode(editor, path)) {
+  if (!hasNode(editor.snapshot, path)) {
     return null
   }
 
-  const leafEntry = getSpan(editor, path)
+  const leafEntry = getSpan(editor.snapshot, path)
   if (!leafEntry) {
     return null
   }
   let leaf = leafEntry.node
 
-  const parentBlock = getParent(editor, path, {
-    match: (node) => isTextBlock({schema: editor.schema}, node),
+  const parentBlock = getParent(editor.snapshot, path, {
+    match: (node) =>
+      isTextBlock({schema: editor.snapshot.context.schema}, node),
   })
 
   if (!parentBlock) {
@@ -193,14 +194,14 @@ export function normalizePoint(editor: Editor, point: Point): Point | null {
   while (offset > leaf.text.length) {
     const afterPoint = after(editor, path)
     const [nextEntry] = afterPoint
-      ? getNodes(editor, {
+      ? getNodes(editor.snapshot, {
           from: afterPoint.path,
-          match: (n) => isSpan({schema: editor.schema}, n),
+          match: (n) => isSpan({schema: editor.snapshot.context.schema}, n),
         })
       : []
     if (
       !nextEntry ||
-      !isSpan({schema: editor.schema}, nextEntry.node) ||
+      !isSpan({schema: editor.snapshot.context.schema}, nextEntry.node) ||
       !isDescendantPath(nextEntry.path, parentBlock.path)
     ) {
       return null

--- a/packages/editor/src/engine/dom/utils/range-list.ts
+++ b/packages/editor/src/engine/dom/utils/range-list.ts
@@ -118,8 +118,8 @@ export const splitDecorationsByChild = (
   decorations: DecoratedRange[],
 ): DecoratedRange[][] => {
   const children: readonly unknown[] = isEditor(node)
-    ? node.children
-    : isTextBlock({schema: editor.schema}, node)
+    ? editor.snapshot.context.value
+    : isTextBlock({schema: editor.snapshot.context.schema}, node)
       ? node.children
       : []
   const decorationsByChild = Array.from(children, (): DecoratedRange[] => [])
@@ -170,12 +170,19 @@ export const splitDecorationsByChild = (
   }
 
   for (const decoration of decorations) {
-    const decorationRange = rangeIntersection(ancestorRange, decoration, editor)
+    const decorationRange = rangeIntersection(
+      ancestorRange,
+      decoration,
+      editor.snapshot.context,
+    )
     if (!decorationRange) {
       continue
     }
 
-    const [startPoint, endPoint] = rangeEdges(decorationRange, editor)
+    const [startPoint, endPoint] = rangeEdges(
+      decorationRange,
+      editor.snapshot.context,
+    )
     const startIndex = resolveChildIndex(startPoint) ?? 0
     const endIndex = resolveChildIndex(endPoint) ?? children.length - 1
 
@@ -192,7 +199,7 @@ export const splitDecorationsByChild = (
       const childDecorationRange = rangeIntersection(
         childRange,
         decoration,
-        editor,
+        editor.snapshot.context,
       )
       if (!childDecorationRange) {
         continue

--- a/packages/editor/src/engine/editor/normalize.ts
+++ b/packages/editor/src/engine/editor/normalize.ts
@@ -34,7 +34,10 @@ export function normalize(
   }
 
   if (force) {
-    const allPaths = Array.from(getNodes(editor), (entry) => entry.path)
+    const allPaths = Array.from(
+      getNodes(editor.snapshot),
+      (entry) => entry.path,
+    )
     const allPathKeys = new Set(allPaths.map((p) => serializePath(p)))
     editor.dirtyPaths = allPaths
     editor.dirtyPathKeys = allPathKeys
@@ -55,8 +58,8 @@ export function normalize(
         continue
       }
 
-      if (hasNode(editor, dirtyPath)) {
-        const entry = getNode(editor, dirtyPath)
+      if (hasNode(editor.snapshot, dirtyPath)) {
+        const entry = getNode(editor.snapshot, dirtyPath)
         if (!entry) {
           continue
         }
@@ -70,7 +73,7 @@ export function normalize(
           by definition adding children to an empty node can't cause other paths to change.
         */
         if (
-          isTextBlock({schema: editor.schema}, entryNode) &&
+          isTextBlock({schema: editor.snapshot.context.schema}, entryNode) &&
           entryNode.children.length === 0
         ) {
           editor.isNormalizingNode = true
@@ -103,8 +106,8 @@ export function normalize(
         editor.isNormalizingNode = true
         editor.normalizeNode([editor, dirtyPath], {operation})
         editor.isNormalizingNode = false
-      } else if (hasNode(editor, dirtyPath)) {
-        const entry = getNode(editor, dirtyPath)
+      } else if (hasNode(editor.snapshot, dirtyPath)) {
+        const entry = getNode(editor.snapshot, dirtyPath)
         if (entry) {
           editor.isNormalizingNode = true
           editor.normalizeNode([entry.node, entry.path], {operation})

--- a/packages/editor/src/engine/editor/path.ts
+++ b/packages/editor/src/engine/editor/path.ts
@@ -20,7 +20,7 @@ export function path(
 
   if (isPath(at)) {
     if (edge === 'start' || edge === 'end') {
-      const leaf = getLeaf(editor, at, {edge})
+      const leaf = getLeaf(editor.snapshot, at, {edge})
       if (leaf) {
         at = leaf.path
       }
@@ -29,9 +29,9 @@ export function path(
 
   if (isRange(at)) {
     if (edge === 'start') {
-      at = rangeStart(at, editor)
+      at = rangeStart(at, editor.snapshot.context)
     } else if (edge === 'end') {
-      at = rangeEnd(at, editor)
+      at = rangeEnd(at, editor.snapshot.context)
     } else {
       at = commonPath(at.anchor.path, at.focus.path)
     }

--- a/packages/editor/src/engine/editor/point.ts
+++ b/packages/editor/src/engine/editor/point.ts
@@ -21,7 +21,7 @@ export function point(
   if (isPath(at)) {
     let path: Path
 
-    const deepest = getLeaf(editor, at, {
+    const deepest = getLeaf(editor.snapshot, at, {
       edge: edge === 'end' ? 'end' : 'start',
     })
     if (!deepest) {
@@ -34,14 +34,14 @@ export function point(
     path = nodePath
 
     if (
-      !isSpan({schema: editor.schema}, node) &&
-      !isTextBlockNode({schema: editor.schema}, node) &&
+      !isSpan({schema: editor.snapshot.context.schema}, node) &&
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
       !isEditor(node)
     ) {
       return {path, offset: 0}
     }
 
-    if (!isSpan({schema: editor.schema}, node)) {
+    if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
       throw new Error(
         `Cannot get the ${edge} point in the node at path [${at}] because it has no ${edge} text node.`,
       )
@@ -51,7 +51,7 @@ export function point(
   }
 
   if (isRange(at)) {
-    const [start, end] = rangeEdges(at, editor)
+    const [start, end] = rangeEdges(at, editor.snapshot.context)
     return edge === 'start' ? start : end
   }
 

--- a/packages/editor/src/engine/editor/positions.ts
+++ b/packages/editor/src/engine/editor/positions.ts
@@ -27,7 +27,11 @@ export function* positions(
     reverse?: boolean
   } = {},
 ): Generator<Point, void, undefined> {
-  const {at = editor.selection, unit = 'offset', reverse = false} = options
+  const {
+    at = editor.snapshot.context.selection,
+    unit = 'offset',
+    reverse = false,
+  } = options
 
   if (!at) {
     return
@@ -52,7 +56,7 @@ export function* positions(
    */
 
   const editorRange = range(editor, at)
-  const [start, end] = rangeEdges(editorRange, editor)
+  const [start, end] = rangeEdges(editorRange, editor.snapshot.context)
   const first = reverse ? end : start
   let isNewBlock = false
   let blockText = ''
@@ -66,7 +70,7 @@ export function* positions(
   // encounter the block node, then all of its text nodes, so when iterating
   // through the blockText and leafText we just need to remember a window of
   // one block node and leaf node, respectively.
-  for (const {node, path: nodePath} of getNodes(editor, {
+  for (const {node, path: nodePath} of getNodes(editor.snapshot, {
     from: start.path,
     to: end.path,
     reverse,
@@ -74,7 +78,7 @@ export function* positions(
     /*
      * ELEMENT NODE - Yield position(s) for object nodes, collect blockText for blocks
      */
-    if (isTextBlockNode({schema: editor.schema}, node)) {
+    if (isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
       // Block element node - set `blockText` to its text content.
       {
         // We always exhaust block nodes before encountering a new one:
@@ -96,12 +100,15 @@ export function* positions(
           : editorStart(editor, nodePath)
 
         blockText = ''
-        for (const {node: spanNode, path: spanPath} of getNodes(editor, {
-          from: s.path,
-          to: e.path,
-          match: (n) => isSpan({schema: editor.schema}, n),
-        })) {
-          if (!isSpan({schema: editor.schema}, spanNode)) {
+        for (const {node: spanNode, path: spanPath} of getNodes(
+          editor.snapshot,
+          {
+            from: s.path,
+            to: e.path,
+            match: (n) => isSpan({schema: editor.snapshot.context.schema}, n),
+          },
+        )) {
+          if (!isSpan({schema: editor.snapshot.context.schema}, spanNode)) {
             continue
           }
           let spanText = spanNode.text
@@ -117,17 +124,17 @@ export function* positions(
       }
     }
 
-    if (isLeafObject(editor, node, nodePath)) {
+    if (isLeafObject(editor.snapshot, node, nodePath)) {
       yield {path: nodePath, offset: 0}
       continue
     }
 
     if (
-      !isTextBlockNode({schema: editor.schema}, node) &&
-      !isSpan({schema: editor.schema}, node)
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
+      !isSpan({schema: editor.snapshot.context.schema}, node)
     ) {
       // Editable containers aren't leaf positions — descend into them.
-      if (isEditableContainer(editor, node, nodePath)) {
+      if (isEditableContainer(editor.snapshot, node, nodePath)) {
         continue
       }
       yield {path: nodePath, offset: 0}
@@ -138,7 +145,7 @@ export function* positions(
      * TEXT LEAF NODE - Iterate through text content, yielding
      * positions every `distance` offset according to `unit`.
      */
-    if (isSpan({schema: editor.schema}, node)) {
+    if (isSpan({schema: editor.snapshot.context.schema}, node)) {
       const isFirst = pathEquals(nodePath, first.path)
 
       // Proof that we always exhaust text nodes before encountering a new one:

--- a/packages/editor/src/engine/editor/unhang-range.ts
+++ b/packages/editor/src/engine/editor/unhang-range.ts
@@ -27,7 +27,7 @@ import {rangeEdges} from '../range/range-edges'
  */
 export function unhangRange(snapshot: TraversalSnapshot, range: Range): Range {
   const {context} = snapshot
-  let [start, end] = rangeEdges(range, {children: context.value})
+  let [start, end] = rangeEdges(range, {value: context.value})
 
   // PERF: exit early if we can guarantee that the range isn't hanging.
   // A range can only hang when end is at offset 0 of the first child in a block.
@@ -80,7 +80,7 @@ export function unhangRange(snapshot: TraversalSnapshot, range: Range): Range {
 
     if (
       node.text !== '' ||
-      isBeforePath(nodePath, blockPath, {children: context.value})
+      isBeforePath(nodePath, blockPath, {value: context.value})
     ) {
       end = {path: nodePath, offset: node.text.length}
       break

--- a/packages/editor/src/engine/interfaces/editor.ts
+++ b/packages/editor/src/engine/interfaces/editor.ts
@@ -1,5 +1,3 @@
-import type {PortableTextBlock} from '@portabletext/schema'
-import type {EditorSelection} from '../../types/editor'
 import type {PortableTextEditorEngine} from '../../types/editor-engine'
 import type {DOMEditor} from '../dom/plugin/dom-editor'
 import type {Location} from './location'
@@ -18,9 +16,6 @@ import type {RangeRef} from './range-ref'
 export interface BaseEditor {
   // Core state.
 
-  children: PortableTextBlock[]
-  readonly value: PortableTextBlock[]
-  selection: EditorSelection
   operations: Operation[]
   dirtyPaths: Path[]
   dirtyPathKeys: Set<string>

--- a/packages/editor/src/engine/path/compare-paths.test.ts
+++ b/packages/editor/src/engine/path/compare-paths.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from 'vitest'
 import type {Node} from '../interfaces/node'
 import {comparePaths} from './compare-paths'
 
-const emptyRoot = {children: [] as Array<Node>}
+const emptyRoot = {value: [] as Array<Node>}
 
 describe(comparePaths.name, () => {
   test('equal keyed paths return 0', () => {
@@ -56,7 +56,9 @@ describe(comparePaths.name, () => {
       {_key: 'b1', _type: 'block', children: []},
       {_key: 'b2', _type: 'block', children: []},
     ]
-    expect(comparePaths([{_key: 'b1'}], [{_key: 'b2'}], {children})).toEqual(-1)
+    expect(
+      comparePaths([{_key: 'b1'}], [{_key: 'b2'}], {value: children}),
+    ).toEqual(-1)
   })
 
   test('keyed ordering falls back to string comparison when keys are not in root', () => {
@@ -69,6 +71,8 @@ describe(comparePaths.name, () => {
       {_key: 'a', _type: 'block', children: []},
     ]
     expect(comparePaths([{_key: 'a'}], [{_key: 'z'}], emptyRoot)).toEqual(-1)
-    expect(comparePaths([{_key: 'z'}], [{_key: 'a'}], {children})).toEqual(-1)
+    expect(
+      comparePaths([{_key: 'z'}], [{_key: 'a'}], {value: children}),
+    ).toEqual(-1)
   })
 })

--- a/packages/editor/src/engine/path/compare-paths.ts
+++ b/packages/editor/src/engine/path/compare-paths.ts
@@ -12,10 +12,10 @@ import type {Path} from '../interfaces/path'
 export function comparePaths(
   path: Path,
   another: Path,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): -1 | 0 | 1 {
   const min = Math.min(path.length, another.length)
-  let currentChildren: Array<Node> | undefined = root?.children
+  let currentChildren: Array<Node> | undefined = root?.value
   let currentNode: Node | undefined
 
   for (let i = 0; i < min; i++) {

--- a/packages/editor/src/engine/path/is-after-path.ts
+++ b/packages/editor/src/engine/path/is-after-path.ts
@@ -5,7 +5,7 @@ import {comparePaths} from './compare-paths'
 export function isAfterPath(
   path: Path,
   another: Path,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   return comparePaths(path, another, root) === 1
 }

--- a/packages/editor/src/engine/path/is-before-path.ts
+++ b/packages/editor/src/engine/path/is-before-path.ts
@@ -5,7 +5,7 @@ import {comparePaths} from './compare-paths'
 export function isBeforePath(
   path: Path,
   another: Path,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   return comparePaths(path, another, root) === -1
 }

--- a/packages/editor/src/engine/point/compare-points.ts
+++ b/packages/editor/src/engine/point/compare-points.ts
@@ -5,7 +5,7 @@ import {comparePaths} from '../path/compare-paths'
 export function comparePoints(
   point: Point,
   another: Point,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): -1 | 0 | 1 {
   const result = comparePaths(point.path, another.path, root)
   if (result === 0) {

--- a/packages/editor/src/engine/point/is-after-point.ts
+++ b/packages/editor/src/engine/point/is-after-point.ts
@@ -5,7 +5,7 @@ import {comparePoints} from './compare-points'
 export function isAfterPoint(
   point: Point,
   another: Point,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   return comparePoints(point, another, root) === 1
 }

--- a/packages/editor/src/engine/point/is-before-point.ts
+++ b/packages/editor/src/engine/point/is-before-point.ts
@@ -5,7 +5,7 @@ import {comparePoints} from './compare-points'
 export function isBeforePoint(
   point: Point,
   another: Point,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   return comparePoints(point, another, root) === -1
 }

--- a/packages/editor/src/engine/range-ref/transform-range-ref.ts
+++ b/packages/editor/src/engine/range-ref/transform-range-ref.ts
@@ -6,7 +6,7 @@ import {transformRange} from '../range/transform-range'
 export function transformRangeRef(
   ref: RangeRef,
   op: Operation,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): void {
   const {current, affinity} = ref
 

--- a/packages/editor/src/engine/range/is-backward-range.ts
+++ b/packages/editor/src/engine/range/is-backward-range.ts
@@ -4,7 +4,7 @@ import {isAfterPoint} from '../point/is-after-point'
 
 export function isBackwardRange(
   range: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   const {anchor, focus} = range
   return isAfterPoint(anchor, focus, root)

--- a/packages/editor/src/engine/range/is-forward-range.ts
+++ b/packages/editor/src/engine/range/is-forward-range.ts
@@ -4,7 +4,7 @@ import {isBackwardRange} from './is-backward-range'
 
 export function isForwardRange(
   range: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   return !isBackwardRange(range, root)
 }

--- a/packages/editor/src/engine/range/range-edges.ts
+++ b/packages/editor/src/engine/range/range-edges.ts
@@ -5,7 +5,7 @@ import {isBackwardRange} from './is-backward-range'
 
 export function rangeEdges(
   range: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): [Point, Point] {
   const {anchor, focus} = range
   return isBackwardRange(range, root) ? [focus, anchor] : [anchor, focus]

--- a/packages/editor/src/engine/range/range-end.ts
+++ b/packages/editor/src/engine/range/range-end.ts
@@ -3,7 +3,7 @@ import type {Point} from '../interfaces/point'
 import type {Range} from '../interfaces/range'
 import {rangeEdges} from './range-edges'
 
-export function rangeEnd(range: Range, root: {children: Array<Node>}): Point {
+export function rangeEnd(range: Range, root: {value: Array<Node>}): Point {
   const [, end] = rangeEdges(range, root)
   return end
 }

--- a/packages/editor/src/engine/range/range-includes.ts
+++ b/packages/editor/src/engine/range/range-includes.ts
@@ -13,7 +13,7 @@ import {rangeEdges} from './range-edges'
 export function rangeIncludes(
   range: Range,
   target: Path | Point | Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   if (isRange(target)) {
     if (

--- a/packages/editor/src/engine/range/range-intersection.ts
+++ b/packages/editor/src/engine/range/range-intersection.ts
@@ -7,7 +7,7 @@ import {rangesOverlap} from './ranges-overlap'
 export function rangeIntersection(
   range: Range,
   another: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): Range | null {
   if (!rangesOverlap(range, another, root)) {
     return null

--- a/packages/editor/src/engine/range/range-start.ts
+++ b/packages/editor/src/engine/range/range-start.ts
@@ -3,7 +3,7 @@ import type {Point} from '../interfaces/point'
 import type {Range} from '../interfaces/range'
 import {rangeEdges} from './range-edges'
 
-export function rangeStart(range: Range, root: {children: Array<Node>}): Point {
+export function rangeStart(range: Range, root: {value: Array<Node>}): Point {
   const [start] = rangeEdges(range, root)
   return start
 }

--- a/packages/editor/src/engine/range/ranges-overlap.test.ts
+++ b/packages/editor/src/engine/range/ranges-overlap.test.ts
@@ -18,7 +18,7 @@ const value: Array<PortableTextBlock> = [
   },
 ]
 
-const root = {children: value}
+const root = {value}
 
 describe(rangesOverlap.name, () => {
   test('disjoint ranges in same span', () => {

--- a/packages/editor/src/engine/range/ranges-overlap.ts
+++ b/packages/editor/src/engine/range/ranges-overlap.ts
@@ -12,7 +12,7 @@ import {rangeEdges} from './range-edges'
 export function rangesOverlap(
   rangeA: Range,
   rangeB: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
 ): boolean {
   const [startA, endA] = rangeEdges(rangeA, root)
   const [startB, endB] = rangeEdges(rangeB, root)

--- a/packages/editor/src/engine/range/resolve-range-affinities.ts
+++ b/packages/editor/src/engine/range/resolve-range-affinities.ts
@@ -16,7 +16,7 @@ export type PointAffinity = 'forward' | 'backward' | null
  */
 export function resolveRangeAffinities(
   range: Range,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
   affinity: RangeDirection | null,
 ): [PointAffinity, PointAffinity] {
   if (affinity === 'inward') {

--- a/packages/editor/src/engine/range/transform-range.ts
+++ b/packages/editor/src/engine/range/transform-range.ts
@@ -7,7 +7,7 @@ import {resolveRangeAffinities} from './resolve-range-affinities'
 export function transformRange(
   range: Range | null,
   op: Operation,
-  root: {children: Array<Node>},
+  root: {value: Array<Node>},
   options: RangeTransformOptions = {},
 ): Range | null {
   if (range === null) {

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -23,6 +23,7 @@ import {getNode} from '../../../traversal/get-node'
 import {getParent} from '../../../traversal/get-parent'
 import {getText} from '../../../traversal/get-text'
 import {isLeafObject} from '../../../traversal/is-leaf-object'
+import type {PortableTextEditorEngine} from '../../../types/editor-engine'
 import {collapse} from '../../core/collapse'
 import {deselect} from '../../core/deselect'
 import {move} from '../../core/move'
@@ -153,7 +154,10 @@ type EditableProps = {
   renderElement: (props: RenderElementProps) => JSX.Element
   renderLeaf?: (props: RenderLeafProps) => JSX.Element
   renderText?: (props: RenderTextProps) => JSX.Element
-  scrollSelectionIntoView?: (editor: DOMEditor, domRange: DOMRange) => void
+  scrollSelectionIntoView?: (
+    editor: PortableTextEditorEngine,
+    domRange: DOMRange,
+  ) => void
 } & React.TextareaHTMLAttributes<HTMLDivElement>
 
 /**
@@ -345,7 +349,7 @@ export const Editable = forwardRef(
       }
 
       // Make sure the DOM selection state is in sync.
-      const {selection} = editor
+      const {selection} = editor.snapshot.context
       const root = DOMEditor.findDocumentOrShadowRoot(editor)
       const domSelection = getSelection(root)
 
@@ -433,10 +437,13 @@ export const Editable = forwardRef(
               suppressThrow: true,
             },
           )
-          editor.selection = fallbackRange
+          editor.snapshot.context.selection = fallbackRange
             ? {
                 ...fallbackRange,
-                backward: isBackwardRange(fallbackRange, editor),
+                backward: isBackwardRange(
+                  fallbackRange,
+                  editor.snapshot.context,
+                ),
               }
             : null
           return
@@ -456,7 +463,7 @@ export const Editable = forwardRef(
         if (newDomRange) {
           if (editor.composing && !IS_ANDROID) {
             domSelection.collapseToEnd()
-          } else if (isBackwardRange(selection!, editor)) {
+          } else if (isBackwardRange(selection!, editor.snapshot.context)) {
             domSelection.setBaseAndExtent(
               newDomRange.endContainer,
               newDomRange.endOffset,
@@ -595,7 +602,7 @@ export const Editable = forwardRef(
           scheduleOnDOMSelectionChange.flush()
           onDOMSelectionChange.flush()
 
-          const {selection} = editor
+          const {selection} = editor.snapshot.context
           const {inputType: type} = event
           const data = (event as any).dataTransfer || event.data || undefined
 
@@ -663,12 +670,13 @@ export const Editable = forwardRef(
                 window?.getComputedStyle(node.parentElement)?.whiteSpace ===
                   'pre'
               ) {
-                const block = getParent(editor, anchor.path, {
-                  match: (node) => isTextBlock({schema: editor.schema}, node),
+                const block = getParent(editor.snapshot, anchor.path, {
+                  match: (node) =>
+                    isTextBlock({schema: editor.snapshot.context.schema}, node),
                 })
 
                 if (block) {
-                  const blockText = getText(editor, block.path)
+                  const blockText = getText(editor.snapshot, block.path)
 
                   if (blockText?.includes('\t')) {
                     native = false
@@ -698,8 +706,8 @@ export const Editable = forwardRef(
 
                 const selectionRef =
                   !isCompositionChange &&
-                  editor.selection &&
-                  rangeRef(editor, editor.selection)
+                  editor.snapshot.context.selection &&
+                  rangeRef(editor, editor.snapshot.context.selection)
 
                 editor.select(range)
 
@@ -911,7 +919,8 @@ export const Editable = forwardRef(
 
           if (
             toRestore &&
-            (!editor.selection || !rangeEquals(editor.selection, toRestore))
+            (!editor.snapshot.context.selection ||
+              !rangeEquals(editor.snapshot.context.selection, toRestore))
           ) {
             editor.select(toRestore)
           }
@@ -1169,17 +1178,24 @@ export const Editable = forwardRef(
                     const relatedPath = getDomNodePath(relatedTarget)
 
                     if (relatedPath) {
-                      const relatedNodeEntry = getNode(editor, relatedPath)
+                      const relatedNodeEntry = getNode(
+                        editor.snapshot,
+                        relatedPath,
+                      )
                       const relatedNode = relatedNodeEntry
                         ? relatedNodeEntry.node
                         : undefined
                       if (
                         relatedNode &&
                         (isTextBlockNode(
-                          {schema: editor.schema},
+                          {schema: editor.snapshot.context.schema},
                           relatedNode,
                         ) ||
-                          isLeafObject(editor, relatedNode, relatedPath))
+                          isLeafObject(
+                            editor.snapshot,
+                            relatedNode,
+                            relatedPath,
+                          ))
                       ) {
                         return
                       }
@@ -1220,7 +1236,7 @@ export const Editable = forwardRef(
                     // At this time, the engine document may be arbitrarily different,
                     // because onClick handlers can change the document before we get here.
                     // Therefore we must check that this path actually exists.
-                    const nodeClickEntry = getNode(editor, path)
+                    const nodeClickEntry = getNode(editor.snapshot, path)
 
                     if (!nodeClickEntry) {
                       return
@@ -1230,10 +1246,18 @@ export const Editable = forwardRef(
                     if (event.detail === TRIPLE_CLICK && path.length >= 1) {
                       let blockPath = path
 
-                      if (!isTextBlockNode({schema: editor.schema}, node)) {
-                        const block = getParent(editor, path, {
+                      if (
+                        !isTextBlockNode(
+                          {schema: editor.snapshot.context.schema},
+                          node,
+                        )
+                      ) {
+                        const block = getParent(editor.snapshot, path, {
                           match: (node) =>
-                            isTextBlock({schema: editor.schema}, node),
+                            isTextBlock(
+                              {schema: editor.snapshot.context.schema},
+                              node,
+                            ),
                         })
 
                         blockPath = block?.path ?? path.slice(0, 1)
@@ -1250,22 +1274,23 @@ export const Editable = forwardRef(
 
                     const start = editorStart(editor, path)
                     const end = editorEnd(editor, path)
-                    const startEntry = getNode(editor, start.path)
+                    const startEntry = getNode(editor.snapshot, start.path)
                     const startVoidNode =
                       startEntry &&
-                      isLeafObject(editor, startEntry.node, start.path)
+                      isLeafObject(editor.snapshot, startEntry.node, start.path)
                         ? startEntry
-                        : getAncestor(editor, start.path, {
+                        : getAncestor(editor.snapshot, start.path, {
                             match: (node, ancestorPath) =>
-                              isLeafObject(editor, node, ancestorPath),
+                              isLeafObject(editor.snapshot, node, ancestorPath),
                           })
-                    const endEntry = getNode(editor, end.path)
+                    const endEntry = getNode(editor.snapshot, end.path)
                     const endVoidNode =
-                      endEntry && isLeafObject(editor, endEntry.node, end.path)
+                      endEntry &&
+                      isLeafObject(editor.snapshot, endEntry.node, end.path)
                         ? endEntry
-                        : getAncestor(editor, end.path, {
+                        : getAncestor(editor.snapshot, end.path, {
                             match: (node, ancestorPath) =>
-                              isLeafObject(editor, node, ancestorPath),
+                              isLeafObject(editor.snapshot, node, ancestorPath),
                           })
 
                     if (
@@ -1358,7 +1383,7 @@ export const Editable = forwardRef(
                       return
                     }
 
-                    const {selection} = editor
+                    const {selection} = editor.snapshot.context
                     if (selection && isExpandedRange(selection)) {
                       editorActor.send({
                         type: 'behavior event',
@@ -1431,10 +1456,10 @@ export const Editable = forwardRef(
                       return
                     }
 
-                    const {selection} = editor
+                    const {selection} = editor.snapshot.context
                     const blockSegment =
                       selection !== null ? selection.focus.path[0]! : 0
-                    const elementText = getText(editor, [blockSegment])
+                    const elementText = getText(editor.snapshot, [blockSegment])
                     const isRTL =
                       elementText !== undefined &&
                       getDirection(elementText) === 'rtl'
@@ -1733,14 +1758,14 @@ export const Editable = forwardRef(
                           isCollapsedRange(selection)
                         ) {
                           const currentNodeEntry = getNode(
-                            editor,
+                            editor.snapshot,
                             selection.anchor.path,
                           )
 
                           if (
                             currentNodeEntry &&
                             isLeafObject(
-                              editor,
+                              editor.snapshot,
                               currentNodeEntry.node,
                               selection.anchor.path,
                             )
@@ -1825,12 +1850,13 @@ const defaultDecorate: (entry: NodeEntry) => DecoratedRange[] = () => []
  */
 
 const defaultScrollSelectionIntoView = (
-  editor: DOMEditor,
+  editor: PortableTextEditorEngine,
   domRange: DOMRange,
 ) => {
   // Scroll to the focus point of the selection, in case the selection is expanded
   const isBackward =
-    !!editor.selection && isBackwardRange(editor.selection, editor)
+    !!editor.snapshot.context.selection &&
+    isBackwardRange(editor.snapshot.context.selection, editor.snapshot.context)
   const domFocusPoint = domRange.cloneRange()
   domFocusPoint.collapse(isBackward)
 

--- a/packages/editor/src/engine/react/components/element.tsx
+++ b/packages/editor/src/engine/react/components/element.tsx
@@ -57,7 +57,7 @@ const Element = (props: {
   } = props
   const dataPath = serializePath(props.path)
   const editor = useEngineStatic()
-  const isInline = isInlinePath(editor, props.path)
+  const isInline = isInlinePath(editor.snapshot, props.path)
   const isInNewPipeline = useContext(NewPipelineContext)
   const decorations = useDecorations(element, props.path, parentDecorations)
   const children = useChildren({
@@ -93,8 +93,11 @@ const Element = (props: {
 
   // If it's a block node with inline children, add the proper `dir` attribute
   // for text direction.
-  if (!isInline && isTextBlockNode({schema: editor.schema}, element)) {
-    const text = getText(editor, props.path)
+  if (
+    !isInline &&
+    isTextBlockNode({schema: editor.snapshot.context.schema}, element)
+  ) {
+    const text = getText(editor.snapshot, props.path)
     const dir = text !== undefined ? getDirection(text) : undefined
 
     if (dir === 'rtl') {

--- a/packages/editor/src/engine/react/components/string.tsx
+++ b/packages/editor/src/engine/react/components/string.tsx
@@ -27,12 +27,12 @@ function getTextContent(editor: Editor, path: Path): string {
   const end = editorEnd(editor, path)
   let text = ''
 
-  for (const {node, path: nodePath} of getNodes(editor, {
+  for (const {node, path: nodePath} of getNodes(editor.snapshot, {
     from: start.path,
     to: end.path,
-    match: (n) => isSpan({schema: editor.schema}, n),
+    match: (n) => isSpan({schema: editor.snapshot.context.schema}, n),
   })) {
-    if (!isSpan({schema: editor.schema}, node)) {
+    if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
       continue
     }
     let nodeText = node.text
@@ -65,7 +65,7 @@ const EngineString = (props: {
   // to support expected plain text.
   if (
     leafText === '' &&
-    isTextBlock({schema: editor.schema}, parent) &&
+    isTextBlock({schema: editor.snapshot.context.schema}, parent) &&
     parent.children[parent.children.length - 1] === text &&
     getTextContent(editor, parentPath) === ''
   ) {

--- a/packages/editor/src/engine/react/hooks/android-input-manager/android-input-manager.ts
+++ b/packages/editor/src/engine/react/hooks/android-input-manager/android-input-manager.ts
@@ -94,7 +94,7 @@ export function createAndroidInputManager({
     editor.pendingSelection = null
 
     if (pendingSelection) {
-      const {selection} = editor
+      const {selection} = editor.snapshot.context
       const normalized = normalizeRange(editor, pendingSelection)
 
       debug('apply pending selection', pendingSelection, normalized)
@@ -122,7 +122,10 @@ export function createAndroidInputManager({
       }
 
       const targetRange = editorRange(editor, target)
-      if (!editor.selection || !rangeEquals(editor.selection, targetRange)) {
+      if (
+        !editor.snapshot.context.selection ||
+        !rangeEquals(editor.snapshot.context.selection, targetRange)
+      ) {
         editor.select(target)
       }
     }
@@ -157,8 +160,8 @@ export function createAndroidInputManager({
     }
 
     const selectionRef =
-      editor.selection &&
-      rangeRef(editor, editor.selection, {affinity: 'forward'})
+      editor.snapshot.context.selection &&
+      rangeRef(editor, editor.snapshot.context.selection, {affinity: 'forward'})
 
     debug('flush', editor.pendingAction, editor.pendingDiffs)
 
@@ -168,7 +171,10 @@ export function createAndroidInputManager({
     // biome-ignore lint/suspicious/noAssignInExpressions: engine upstream pattern
     while ((diff = editor.pendingDiffs?.[0])) {
       const range = targetRange(diff)
-      if (!editor.selection || !rangeEquals(editor.selection, range)) {
+      if (
+        !editor.snapshot.context.selection ||
+        !rangeEquals(editor.snapshot.context.selection, range)
+      ) {
         editor.select(range)
       }
 
@@ -212,7 +218,8 @@ export function createAndroidInputManager({
     if (
       selection &&
       !editor.pendingSelection &&
-      (!editor.selection || !rangeEquals(selection, editor.selection))
+      (!editor.snapshot.context.selection ||
+        !rangeEquals(selection, editor.snapshot.context.selection))
     ) {
       editor.select(selection)
     }
@@ -267,7 +274,7 @@ export function createAndroidInputManager({
 
     const pendingDiffs = editor.pendingDiffs
 
-    const targetEntry = getSpan(editor, path)
+    const targetEntry = getSpan(editor.snapshot, path)
 
     if (!targetEntry) {
       return
@@ -365,7 +372,7 @@ export function createAndroidInputManager({
       })
     }
 
-    targetRange = targetRange ?? editor.selection
+    targetRange = targetRange ?? editor.snapshot.context.selection
     if (!targetRange) {
       return
     }
@@ -379,12 +386,12 @@ export function createAndroidInputManager({
 
     if (type.startsWith('delete')) {
       const direction = type.endsWith('Backward') ? 'backward' : 'forward'
-      let [start, end] = rangeEdges(targetRange, editor)
-      const leafNodeEntry = getNode(editor, start.path)
+      let [start, end] = rangeEdges(targetRange, editor.snapshot.context)
+      const leafNodeEntry = getNode(editor.snapshot, start.path)
       const leafResult =
         leafNodeEntry &&
-        (isSpan({schema: editor.schema}, leafNodeEntry.node) ||
-          isLeafObject(editor, leafNodeEntry.node, start.path))
+        (isSpan({schema: editor.snapshot.context.schema}, leafNodeEntry.node) ||
+          isLeafObject(editor.snapshot, leafNodeEntry.node, start.path))
           ? leafNodeEntry
           : undefined
 
@@ -403,7 +410,7 @@ export function createAndroidInputManager({
       let leaf = leafResult.node
       let path = leafResult.path
 
-      if (!isSpan({schema: editor.schema}, leaf)) {
+      if (!isSpan({schema: editor.snapshot.context.schema}, leaf)) {
         return scheduleAction(
           () =>
             editorActor.send({
@@ -419,14 +426,15 @@ export function createAndroidInputManager({
         if (leaf.text.length === start.offset && end.offset === 0) {
           const afterPoint = after(editor, start.path)
           const [nextEntry] = afterPoint
-            ? getNodes(editor, {
+            ? getNodes(editor.snapshot, {
                 from: afterPoint.path,
-                match: (n) => isSpan({schema: editor.schema}, n),
+                match: (n) =>
+                  isSpan({schema: editor.snapshot.context.schema}, n),
               })
             : []
           if (
             nextEntry &&
-            isSpan({schema: editor.schema}, nextEntry.node) &&
+            isSpan({schema: editor.snapshot.context.schema}, nextEntry.node) &&
             pathEquals(nextEntry.path, end.path)
           ) {
             // when deleting a linebreak, targetRange will span across the break (ie start in the node before and end in the node after)
@@ -445,7 +453,7 @@ export function createAndroidInputManager({
         }
       }
 
-      if (!isSpan({schema: editor.schema}, leaf)) {
+      if (!isSpan({schema: editor.snapshot.context.schema}, leaf)) {
         return
       }
 
@@ -517,7 +525,7 @@ export function createAndroidInputManager({
       case 'deleteContentForward': {
         const {anchor} = targetRange
         if (canStoreDiff && isCollapsedRange(targetRange)) {
-          const targetNodeEntry = getSpan(editor, anchor.path)
+          const targetNodeEntry = getSpan(editor.snapshot, anchor.path)
 
           if (
             targetNodeEntry &&
@@ -751,7 +759,7 @@ export function createAndroidInputManager({
         }
 
         if (pathEquals(targetRange.anchor.path, targetRange.focus.path)) {
-          const [start, end] = rangeEdges(targetRange, editor)
+          const [start, end] = rangeEdges(targetRange, editor.snapshot.context)
 
           const diff = {
             start: start.offset,
@@ -803,7 +811,7 @@ export function createAndroidInputManager({
           }
 
           if (canStoreDiff) {
-            const currentSelection = editor.selection
+            const currentSelection = editor.snapshot.context.selection
             storeDiff(start.path, diff)
 
             if (currentSelection) {
@@ -863,7 +871,7 @@ export function createAndroidInputManager({
       flushTimeoutId = null
     }
 
-    const {selection} = editor
+    const {selection} = editor.snapshot.context
     if (!range) {
       return
     }

--- a/packages/editor/src/engine/react/hooks/use-children.tsx
+++ b/packages/editor/src/engine/react/hooks/use-children.tsx
@@ -95,10 +95,10 @@ const useChildren = (props: {
   let childContainer: ContainerConfig | undefined = parentContainer
 
   if (isEditor(node)) {
+    children = node.snapshot.context.value
+  } else if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
     children = node.children
-  } else if (isTextBlock({schema: editor.schema}, node)) {
-    children = node.children
-  } else if (isObject(editor, node)) {
+  } else if (isObject(editor.snapshot, node)) {
     const containerConfig = resolveContainerForNode(
       editor,
       parentContainer,
@@ -152,7 +152,10 @@ const useChildren = (props: {
     ],
   )
 
-  const textBlockParent = isTextBlock({schema: editor.schema}, node)
+  const textBlockParent = isTextBlock(
+    {schema: editor.snapshot.context.schema},
+    node,
+  )
     ? node
     : undefined
 
@@ -238,7 +241,7 @@ const useChildren = (props: {
     if (isContainerChild) {
       return true
     }
-    if (isTextBlock({schema: editor.schema}, n)) {
+    if (isTextBlock({schema: editor.snapshot.context.schema}, n)) {
       if (editor.textBlocks.has(n._type)) {
         return true
       }
@@ -251,7 +254,7 @@ const useChildren = (props: {
       }
       return false
     }
-    if (isObject(editor, n)) {
+    if (isObject(editor.snapshot, n)) {
       if (textBlockParent !== undefined) {
         // Inline-object position: pipeline mode is inherited from the
         // parent text block. An inline object never kicks off a new-
@@ -274,7 +277,7 @@ const useChildren = (props: {
       }
       return false
     }
-    if (isSpan({schema: editor.schema}, n)) {
+    if (isSpan({schema: editor.snapshot.context.schema}, n)) {
       // Span position: pipeline mode is inherited from the parent text
       // block, same as inline objects above. `parentIsInNewPipeline`
       // short-circuits upstream when the text block is itself in the
@@ -285,7 +288,7 @@ const useChildren = (props: {
   }
 
   const elements = children.map((n: Node, i: number) => {
-    if (isTextBlock({schema: editor.schema}, n)) {
+    if (isTextBlock({schema: editor.snapshot.context.schema}, n)) {
       return wrapNewPipeline(
         renderElementComponent(n, i, false),
         isInNewPipelineForChild(n, false),
@@ -293,10 +296,10 @@ const useChildren = (props: {
       )
     }
     // Fallback for text block nodes without `children`
-    if (isTextBlockNode({schema: editor.schema}, n)) {
+    if (isTextBlockNode({schema: editor.snapshot.context.schema}, n)) {
       return null
     }
-    if (isObject(editor, n)) {
+    if (isObject(editor.snapshot, n)) {
       // Does `n` resolve as a container at this position?
       // (positional override in childContainer.container.of, or global)
       if (resolveContainerForNode(editor, childContainer, n)) {
@@ -308,7 +311,7 @@ const useChildren = (props: {
         n._key,
       )
     }
-    if (isSpan({schema: editor.schema}, n)) {
+    if (isSpan({schema: editor.snapshot.context.schema}, n)) {
       return wrapNewPipeline(
         renderTextComponent(n, i),
         isInNewPipelineForChild(n, false),
@@ -316,7 +319,7 @@ const useChildren = (props: {
       )
     }
     // Fallback for span nodes without `text`
-    if (isSpanNode({schema: editor.schema}, n)) {
+    if (isSpanNode({schema: editor.snapshot.context.schema}, n)) {
       return null
     }
     throw new Error(`Unexpected node type`)

--- a/packages/editor/src/engine/react/hooks/use-decorations.ts
+++ b/packages/editor/src/engine/react/hooks/use-decorations.ts
@@ -36,7 +36,7 @@ export const useDecorations = (
     return decorate([node, path])
   }
 
-  const equalityFn = isSpan({schema: editor.schema}, node)
+  const equalityFn = isSpan({schema: editor.snapshot.context.schema}, node)
     ? isTextDecorationsEqual
     : isElementDecorationsEqual
 

--- a/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
+++ b/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
@@ -30,7 +30,7 @@ const refEquality = (a: any, b: any) => a === b
  * every time the component renders.
  *
  * @example
- * const isSelectionActive = useEngineSelector(editor => Boolean(editor.selection))
+ * const isSelectionActive = useEngineSelector(editor => Boolean(editor.snapshot.context.selection))
  */
 
 export function useEngineSelector<T>(

--- a/packages/editor/src/engine/utils/modify.ts
+++ b/packages/editor/src/engine/utils/modify.ts
@@ -1,4 +1,9 @@
-import {isSpan, isTextBlock, type PortableTextSpan} from '@portabletext/schema'
+import {
+  isSpan,
+  isTextBlock,
+  type PortableTextBlock,
+  type PortableTextSpan,
+} from '@portabletext/schema'
 import {resolveContainerAt} from '../../schema/resolve-container-at'
 import {getNodeChildren} from '../../traversal/get-children'
 import {getNode} from '../../traversal/get-node'
@@ -57,10 +62,10 @@ export const modifyDescendant = <N extends Node>(
   }
 
   const context = {
-    schema: editor.schema,
-    containers: editor.publicContainers,
+    schema: editor.snapshot.context.schema,
+    containers: editor.snapshot.context.containers,
   }
-  const nodeEntry = getNode(editor, path)
+  const nodeEntry = getNode(editor.snapshot, path)
   if (!nodeEntry) {
     return
   }
@@ -88,7 +93,9 @@ export const modifyDescendant = <N extends Node>(
   }
   const fieldNames: string[] = []
   {
-    let currentNode: Node | {value: Array<Node>} = {value: editor.children}
+    let currentNode: Node | {value: Array<Node>} = {
+      value: editor.snapshot.context.value,
+    }
     let currentParent:
       | import('../../schema/resolve-containers').RegisteredContainer
       | undefined
@@ -138,7 +145,7 @@ export const modifyDescendant = <N extends Node>(
     const ancestorPath =
       ancestorPathEnd > 0 ? path.slice(0, ancestorPathEnd) : []
 
-    const ancestorEntry = getNode(editor, ancestorPath)
+    const ancestorEntry = getNode(editor.snapshot, ancestorPath)
     if (!ancestorEntry) {
       return
     }
@@ -177,26 +184,26 @@ export const modifyDescendant = <N extends Node>(
   } else if (keyedSegments.length > 0) {
     const rootKey = keyedSegments[0]!._key
     if (
-      editor.blockIndexMap.size === editor.children.length &&
+      editor.blockIndexMap.size === editor.snapshot.context.value.length &&
       editor.blockIndexMap.has(rootKey)
     ) {
       rootIndex = editor.blockIndexMap.get(rootKey)!
     } else {
-      rootIndex = findIndexByKey(editor.children, rootKey)
+      rootIndex = findIndexByKey(editor.snapshot.context.value, rootKey)
     }
   } else {
     const firstSegment = path[0]
     rootIndex = typeof firstSegment === 'number' ? firstSegment : -1
   }
-  if (rootIndex === -1 || rootIndex >= editor.children.length) {
+  if (rootIndex === -1 || rootIndex >= editor.snapshot.context.value.length) {
     return
   }
-  ;(editor as {children: Node[]}).children = replaceChildren(
-    editor.children,
+  editor.snapshot.context.value = replaceChildren(
+    editor.snapshot.context.value,
     rootIndex,
     1,
     modifiedNode,
-  )
+  ) as PortableTextBlock[]
 }
 
 /**
@@ -212,14 +219,16 @@ export const modifyChildren = (
   f: (children: Node[]) => Node[],
 ) => {
   if (path.length === 0) {
-    ;(editor as {children: Node[]}).children = f(editor.children)
+    editor.snapshot.context.value = f(
+      editor.snapshot.context.value,
+    ) as PortableTextBlock[]
   } else {
     const context = {
-      schema: editor.schema,
-      containers: editor.publicContainers,
+      schema: editor.snapshot.context.schema,
+      containers: editor.snapshot.context.containers,
     }
 
-    const nodeEntry = getNode(editor, path)
+    const nodeEntry = getNode(editor.snapshot, path)
     if (!nodeEntry) {
       return
     }
@@ -229,7 +238,7 @@ export const modifyChildren = (
     // registered globally or only as a positional override.
     const resolved = resolveContainerAt(
       context.containers,
-      editor.children,
+      editor.snapshot.context.value,
       path,
     )
     let fieldName: string
@@ -263,7 +272,7 @@ export const modifyLeaf = (
   f: (leaf: PortableTextSpan) => PortableTextSpan,
 ) =>
   modifyDescendant(editor, path, (node) => {
-    if (!isSpan({schema: editor.schema}, node)) {
+    if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
       return node
     }
 

--- a/packages/editor/src/internal-utils/apply-insert-node.ts
+++ b/packages/editor/src/internal-utils/apply-insert-node.ts
@@ -41,11 +41,13 @@ export function applyInsertNodeAtPoint(
   at: Point,
 ): void {
   withoutNormalizing(editor, () => {
-    const match = isSpan({schema: editor.schema}, node)
-      ? (n: Node) => isSpan({schema: editor.schema}, n)
-      : (n: Node) => isSpan({schema: editor.schema}, n) || isObject(editor, n)
+    const match = isSpan({schema: editor.snapshot.context.schema}, node)
+      ? (n: Node) => isSpan({schema: editor.snapshot.context.schema}, n)
+      : (n: Node) =>
+          isSpan({schema: editor.snapshot.context.schema}, n) ||
+          isObject(editor.snapshot, n)
 
-    const nodeEntry = getNode(editor, at.path)
+    const nodeEntry = getNode(editor.snapshot, at.path)
     const entry = nodeEntry && match(nodeEntry.node) ? nodeEntry : undefined
 
     if (!entry) {

--- a/packages/editor/src/internal-utils/apply-merge-node.ts
+++ b/packages/editor/src/internal-utils/apply-merge-node.ts
@@ -29,14 +29,14 @@ export function applyMergeNode(
   path: Path,
   position: number,
 ): void {
-  const nodeEntry = getNode(editor, path)
+  const nodeEntry = getNode(editor.snapshot, path)
 
   if (!nodeEntry) {
     return
   }
 
   const node = nodeEntry.node
-  const prevSibling = getSibling(editor, path, {direction: 'previous'})
+  const prevSibling = getSibling(editor.snapshot, path, {direction: 'previous'})
 
   if (!prevSibling) {
     return
@@ -83,24 +83,24 @@ export function applyMergeNode(
   }
 
   // Pre-transform editor.selection
-  if (editor.selection) {
+  if (editor.snapshot.context.selection) {
     const anchor = transformPointForMerge(
-      editor.selection.anchor,
+      editor.snapshot.context.selection.anchor,
       path,
       prevKey,
       position,
     )
     const focus = transformPointForMerge(
-      editor.selection.focus,
+      editor.snapshot.context.selection.focus,
       path,
       prevKey,
       position,
     )
     if (anchor && focus) {
-      editor.selection = {
+      editor.snapshot.context.selection = {
         anchor,
         focus,
-        backward: isBackwardRange({anchor, focus}, editor),
+        backward: isBackwardRange({anchor, focus}, editor.snapshot.context),
       }
     }
   }
@@ -115,7 +115,7 @@ export function applyMergeNode(
   editor.rangeRefs.clear()
 
   // Save the pre-transformed selection
-  const savedSelection = editor.selection
+  const savedSelection = editor.snapshot.context.selection
 
   // Pre-transform DOM-layer pending state with merge semantics, then
   // suppress transforms during the decomposed operations by clearing them.
@@ -192,7 +192,7 @@ export function applyMergeNode(
 
   try {
     withoutNormalizing(editor, () => {
-      if (isSpan({schema: editor.schema}, node)) {
+      if (isSpan({schema: editor.snapshot.context.schema}, node)) {
         // Merge text: insert the text into the previous sibling at the position
         if (node.text.length > 0) {
           editor.apply({
@@ -207,12 +207,12 @@ export function applyMergeNode(
           type: 'unset',
           path,
         })
-      } else if (isTextBlock({schema: editor.schema}, node)) {
+      } else if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
         // Merge element: move all children into the previous sibling
-        const prevEntry = getNode(editor, prevPath)
+        const prevEntry = getNode(editor.snapshot, prevPath)
         if (
           !prevEntry ||
-          !isTextBlock({schema: editor.schema}, prevEntry.node)
+          !isTextBlock({schema: editor.snapshot.context.schema}, prevEntry.node)
         ) {
           return
         }
@@ -250,7 +250,7 @@ export function applyMergeNode(
     })
   } finally {
     // Restore pre-transformed selection
-    editor.selection = savedSelection
+    editor.snapshot.context.selection = savedSelection
 
     // Restore all refs
     for (const ref of pathRefs) {

--- a/packages/editor/src/internal-utils/apply-move.ts
+++ b/packages/editor/src/internal-utils/apply-move.ts
@@ -14,7 +14,7 @@ export function applyMove(
     reverse?: boolean
   } = {},
 ): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
 
   if (!selection) {
     return

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -20,31 +20,35 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
               {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'foo',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'stock-ticker',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'bar',
+                _key: blockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: 'foo',
+                  },
+                  {
+                    _key: keyGenerator(),
+                    _type: 'stock-ticker',
+                  },
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: 'bar',
+                  },
+                ],
               },
             ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -72,31 +76,35 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
               {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: "'",
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'stock-ticker',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: "foo'",
+                _key: blockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: "'",
+                  },
+                  {
+                    _key: keyGenerator(),
+                    _type: 'stock-ticker',
+                  },
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: "foo'",
+                  },
+                ],
               },
             ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -122,15 +130,19 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockObjectKey,
-            _type: 'image',
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
+              {
+                _key: blockObjectKey,
+                _type: 'image',
+              },
+            ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -158,22 +170,26 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
               {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'foobar',
+                _key: blockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: 'foobar',
+                  },
+                ],
               },
             ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -200,22 +216,26 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
               {
-                _key: spanKey,
-                _type: 'span',
-                text: 'foo',
+                _key: blockKey,
+                _type: 'block',
+                children: [
+                  {
+                    _key: spanKey,
+                    _type: 'span',
+                    text: 'foo',
+                  },
+                ],
               },
             ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -242,28 +262,32 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema,
-        publicContainers: new Map(),
-        blockIndexMap: new Map(),
-        children: [
-          {
-            _key: blockKey,
-            _type: 'block',
-            children: [
-              {_key: keyGenerator(), _type: 'span', text: 'foo'},
+        snapshot: {
+          context: {
+            schema,
+            containers: new Map(),
+            value: [
               {
-                _key: inlineObjectKey,
-                _type: 'stock-ticker',
-                symbol: 'AAPL',
-              },
-              {
-                _key: keyGenerator(),
-                _type: 'span',
-                text: 'bar',
+                _key: blockKey,
+                _type: 'block',
+                children: [
+                  {_key: keyGenerator(), _type: 'span', text: 'foo'},
+                  {
+                    _key: inlineObjectKey,
+                    _type: 'stock-ticker',
+                    symbol: 'AAPL',
+                  },
+                  {
+                    _key: keyGenerator(),
+                    _type: 'span',
+                    text: 'bar',
+                  },
+                ],
               },
             ],
           },
-        ],
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -289,10 +313,14 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema: context.schema,
-        publicContainers: context.containers,
-        children: context.value,
-        blockIndexMap: new Map(),
+        snapshot: {
+          context: {
+            schema: context.schema,
+            containers: context.containers,
+            value: context.value,
+          },
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {
@@ -336,10 +364,14 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        schema: context.schema,
-        publicContainers: context.containers,
-        children: context.value,
-        blockIndexMap: new Map(),
+        snapshot: {
+          context: {
+            schema: context.schema,
+            containers: context.containers,
+            value: context.value,
+          },
+          blockIndexMap: new Map(),
+        } as any,
       },
       {
         anchor: {

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -17,10 +17,7 @@ import {blockOffsetToSpanSelectionPoint} from '../utils/util.block-offset'
 import {isEqualSelectionPoints} from '../utils/util.is-equal-selection-points'
 import {getBlockKeyFromSelectionPoint} from '../utils/util.selection-point'
 
-type ResolveSelectionEditor = Pick<
-  PortableTextEditorEngine,
-  'children' | 'schema' | 'publicContainers' | 'blockIndexMap'
->
+type ResolveSelectionEditor = Pick<PortableTextEditorEngine, 'snapshot'>
 
 /**
  * Normalize a selection so that each point resolves to a valid leaf path.
@@ -89,11 +86,11 @@ function resolveSelectionPoint(
   | undefined {
   const snapshot = {
     context: {
-      schema: editor.schema,
-      containers: editor.publicContainers,
-      value: editor.children,
+      schema: editor.snapshot.context.schema,
+      containers: editor.snapshot.context.containers,
+      value: editor.snapshot.context.value,
     },
-    blockIndexMap: editor.blockIndexMap,
+    blockIndexMap: editor.snapshot.blockIndexMap,
   }
 
   const entry = getNode(snapshot, selectionPoint.path)
@@ -105,7 +102,7 @@ function resolveSelectionPoint(
     if (children.length === 0) {
       return {
         path: entry.path,
-        offset: isSpan({schema: editor.schema}, entry.node)
+        offset: isSpan({schema: editor.snapshot.context.schema}, entry.node)
           ? Math.min(entry.node.text.length, selectionPoint.offset)
           : 0,
       }
@@ -117,7 +114,10 @@ function resolveSelectionPoint(
     // depth, regardless of the parent field name.
     const isBlockLevelPath = isBlock(snapshot, selectionPoint.path)
 
-    if (isTextBlock({schema: editor.schema}, entry.node) && isBlockLevelPath) {
+    if (
+      isTextBlock({schema: editor.snapshot.context.schema}, entry.node) &&
+      isBlockLevelPath
+    ) {
       const spanPoint = blockOffsetToSpanSelectionPoint({
         snapshot,
         blockOffset: {
@@ -170,7 +170,7 @@ export function applySelect(
   target: Range | Point | Path,
 ): void {
   const range = toRange(editor, target)
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
 
   if (selection) {
     const oldProps: Partial<Range> = {}
@@ -206,7 +206,7 @@ export function applySelect(
  * Clear the editor selection.
  */
 export function applyDeselect(editor: PortableTextEditorEngine): void {
-  const {selection} = editor
+  const selection = editor.snapshot.context.selection
 
   if (selection) {
     editor.apply({

--- a/packages/editor/src/internal-utils/apply-split-node.ts
+++ b/packages/editor/src/internal-utils/apply-split-node.ts
@@ -25,7 +25,7 @@ export function applySplitNode(
   path: Path,
   position: number,
 ): void {
-  const nodeEntry = getNode(editor, path)
+  const nodeEntry = getNode(editor.snapshot, path)
 
   if (!nodeEntry) {
     return
@@ -33,13 +33,13 @@ export function applySplitNode(
 
   const node = nodeEntry.node
 
-  const newKey = editor.keyGenerator()
+  const newKey = editor.snapshot.context.keyGenerator()
 
   // Collect the keys of children that will move to the new node.
   // For block splits, children at index >= position move.
   // For span splits, this is empty (text splits don't move child nodes).
   const movedChildKeys = new Set<string>()
-  if (isTextBlock({schema: editor.schema}, node)) {
+  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
     for (let i = position; i < node.children.length; i++) {
       movedChildKeys.add(node.children[i]!._key)
     }
@@ -76,7 +76,7 @@ export function applySplitNode(
     if (current) {
       const [anchorAffinity, focusAffinity] = resolveRangeAffinities(
         current,
-        editor,
+        editor.snapshot.context,
         ref.affinity,
       )
       const anchor = transformPointForSplit(
@@ -104,10 +104,10 @@ export function applySplitNode(
     }
   }
 
-  // Pre-transform editor.selection
-  if (editor.selection) {
+  // Pre-transform editor.snapshot.context.selection
+  if (editor.snapshot.context.selection) {
     const anchor = transformPointForSplit(
-      editor.selection.anchor,
+      editor.snapshot.context.selection.anchor,
       path,
       position,
       newKey,
@@ -115,7 +115,7 @@ export function applySplitNode(
       'forward',
     )
     const focus = transformPointForSplit(
-      editor.selection.focus,
+      editor.snapshot.context.selection.focus,
       path,
       position,
       newKey,
@@ -123,10 +123,10 @@ export function applySplitNode(
       'forward',
     )
     if (anchor && focus) {
-      editor.selection = {
+      editor.snapshot.context.selection = {
         anchor,
         focus,
-        backward: isBackwardRange({anchor, focus}, editor),
+        backward: isBackwardRange({anchor, focus}, editor.snapshot.context),
       }
     }
   }
@@ -142,11 +142,11 @@ export function applySplitNode(
 
   // Save the pre-transformed selection so decomposed operations don't
   // double-transform it
-  const savedSelection = editor.selection
+  const savedSelection = editor.snapshot.context.selection
 
   try {
     withoutNormalizing(editor, () => {
-      if (isSpan({schema: editor.schema}, node)) {
+      if (isSpan({schema: editor.snapshot.context.schema}, node)) {
         const {text: _text, ...properties} = node
         const afterText = node.text.slice(position)
         const newNode = {...properties, _key: newKey, text: afterText} as Node
@@ -162,7 +162,7 @@ export function applySplitNode(
           node: newNode,
           position: 'after',
         })
-      } else if (isTextBlock({schema: editor.schema}, node)) {
+      } else if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
         const {children: _children, ...properties} = node
         const children = node.children
         const afterChildren = children.slice(position)
@@ -189,7 +189,7 @@ export function applySplitNode(
   } finally {
     // Restore pre-transformed selection (decomposed ops may have
     // double-transformed it)
-    editor.selection = savedSelection
+    editor.snapshot.context.selection = savedSelection
 
     // Restore all refs
     for (const ref of pathRefs) {

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -64,14 +64,7 @@ export function createApplyPatch(
 function diffMatchPatch(
   editor: Pick<
     PortableTextEditorEngine,
-    | 'children'
-    | 'apply'
-    | 'selection'
-    | 'onChange'
-    | 'schema'
-    | 'containers'
-    | 'context'
-    | 'blockIndexMap'
+    'apply' | 'onChange' | 'containers' | 'snapshot'
   >,
   patch: DiffMatchPatch,
 ): boolean {
@@ -81,9 +74,12 @@ function diffMatchPatch(
   }
 
   const spanPath = patch.path.slice(0, -1)
-  const spanEntry = getNode(editor, spanPath)
+  const spanEntry = getNode(editor.snapshot, spanPath)
 
-  if (!spanEntry || !isSpan({schema: editor.schema}, spanEntry.node)) {
+  if (
+    !spanEntry ||
+    !isSpan({schema: editor.snapshot.context.schema}, spanEntry.node)
+  ) {
     return false
   }
 
@@ -129,7 +125,11 @@ function insertPatch(
 
   const editorWasEmptyBefore =
     patch.path.length === 1 &&
-    isEqualToEmptyEditor(context.initialValue, editor.children, context.schema)
+    isEqualToEmptyEditor(
+      context.initialValue,
+      editor.snapshot.context.value,
+      context.schema,
+    )
 
   const arrayFieldPath = patch.path.slice(0, -1)
 
@@ -172,7 +172,7 @@ function insertPatch(
 
   if (editorWasEmptyBefore && typeof patch.path[0] === 'number') {
     const removeIdx = position === 'before' ? items.length : 0
-    const removeNode = editor.children[removeIdx]
+    const removeNode = editor.snapshot.context.value[removeIdx]
     if (removeNode) {
       editor.apply({
         type: 'unset',
@@ -192,8 +192,8 @@ function setPatch(
   if (patch.type === 'setIfMissing') {
     if (
       patch.path.length === 0
-        ? editor.children.length > 0
-        : getValue(editor.children, patch.path) !== undefined
+        ? editor.snapshot.context.value.length > 0
+        : getValue(editor.snapshot.context.value, patch.path) !== undefined
     ) {
       return false
     }

--- a/packages/editor/src/internal-utils/delete-collapsed.ts
+++ b/packages/editor/src/internal-utils/delete-collapsed.ts
@@ -50,13 +50,13 @@ export function deleteCollapsed(
   options: DeleteCollapsedOptions,
 ): void {
   withoutNormalizing(editor, () => {
-    const pointEntry = getNode(editor, point.path)
+    const pointEntry = getNode(editor.snapshot, point.path)
     const furthestObjectNode =
-      pointEntry && isLeafObject(editor, pointEntry.node, point.path)
+      pointEntry && isLeafObject(editor.snapshot, pointEntry.node, point.path)
         ? pointEntry
-        : getAncestor(editor, point.path, {
+        : getAncestor(editor.snapshot, point.path, {
             match: (node, ancestorPath) =>
-              isLeafObject(editor, node, ancestorPath),
+              isLeafObject(editor.snapshot, node, ancestorPath),
             mode: 'highest',
           })
     if (furthestObjectNode) {

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -112,8 +112,8 @@ export function applyDelete(
     COMPOUND_SCRIPT_REGEX.test(removedText)
   ) {
     const reinsert = removedText.slice(0, removedText.length - 1)
-    if (editor.selection) {
-      const {path, offset} = editor.selection.anchor
+    if (editor.snapshot.context.selection) {
+      const {path, offset} = editor.snapshot.context.selection.anchor
       editor.apply({type: 'insert_text', path, offset, text: reinsert})
     }
   }
@@ -141,10 +141,10 @@ function mutateRange(
 ): string | null {
   const {capture, removeEmptyStartBlock} = options
 
-  const [start, end] = rangeEdges(range, editor)
+  const [start, end] = rangeEdges(range, editor.snapshot.context)
 
-  const startBlock = getEnclosingBlock(editor, start.path)
-  const endBlock = getEnclosingBlock(editor, end.path)
+  const startBlock = getEnclosingBlock(editor.snapshot, start.path)
+  const endBlock = getEnclosingBlock(editor.snapshot, end.path)
 
   if (!startBlock || !endBlock) {
     return null
@@ -196,8 +196,11 @@ function deleteSameBlockRange(
     )
   }
 
-  const startEntry = getNode(editor, start.path)
-  if (startEntry && isLeafObject(editor, startEntry.node, start.path)) {
+  const startEntry = getNode(editor.snapshot, start.path)
+  if (
+    startEntry &&
+    isLeafObject(editor.snapshot, startEntry.node, start.path)
+  ) {
     editor.apply({type: 'unset', path: start.path})
     return null
   }
@@ -210,12 +213,14 @@ function deleteSameBlockRange(
   )
   removeChildrenBetween(editor, start.path, end.path)
 
-  const adjustedEnd = getSibling(editor, start.path, {direction: 'next'})
+  const adjustedEnd = getSibling(editor.snapshot, start.path, {
+    direction: 'next',
+  })
   if (!adjustedEnd) {
     return removed
   }
 
-  if (isLeafObject(editor, adjustedEnd.node, adjustedEnd.path)) {
+  if (isLeafObject(editor.snapshot, adjustedEnd.node, adjustedEnd.path)) {
     editor.apply({type: 'unset', path: adjustedEnd.path})
     return removed
   }
@@ -238,14 +243,14 @@ function deleteSameParentCrossBlockRange(
   end: Point,
   removeEmptyStartBlock: boolean,
 ): void {
-  const startBlockNode = getNode(editor, startBlockPath)
-  const endBlockNode = getNode(editor, endBlockPath)
+  const startBlockNode = getNode(editor.snapshot, startBlockPath)
+  const endBlockNode = getNode(editor.snapshot, endBlockPath)
   const startIsVoid =
     startBlockNode != null &&
-    isLeafObject(editor, startBlockNode.node, startBlockPath)
+    isLeafObject(editor.snapshot, startBlockNode.node, startBlockPath)
   const endIsVoid =
     endBlockNode != null &&
-    isLeafObject(editor, endBlockNode.node, endBlockPath)
+    isLeafObject(editor.snapshot, endBlockNode.node, endBlockPath)
 
   // Trim the start block's tail (unless start is void or the range begins
   // at the block boundary).
@@ -275,7 +280,7 @@ function deleteSameParentCrossBlockRange(
   if (startIsVoid) {
     if (!pathEquals(end.path, endBlockPath)) {
       removeLeadingChildrenOf(editor, endBlockPath, end.path)
-      const firstChild = getFirstChild(editor, endBlockPath)
+      const firstChild = getFirstChild(editor.snapshot, endBlockPath)
       if (firstChild) {
         removeTextUpToOffset(editor, firstChild.path, end.offset)
       }
@@ -292,14 +297,14 @@ function deleteSameParentCrossBlockRange(
   }
 
   // Both text: trim the end block, then merge it into the start.
-  const adjustedEndBlock = getSibling(editor, startBlockPath, {
+  const adjustedEndBlock = getSibling(editor.snapshot, startBlockPath, {
     direction: 'next',
   })
   const adjustedEndBlockPath = adjustedEndBlock?.path ?? startBlockPath
 
   if (!pathEquals(end.path, endBlockPath)) {
     removeLeadingChildrenOf(editor, adjustedEndBlockPath, end.path)
-    const firstChild = getFirstChild(editor, adjustedEndBlockPath)
+    const firstChild = getFirstChild(editor.snapshot, adjustedEndBlockPath)
     if (firstChild) {
       removeTextUpToOffset(editor, firstChild.path, end.offset)
     }
@@ -373,19 +378,23 @@ function deleteCrossParentRange(
   //    between are structural to their parent's shape (e.g. table
   //    cells in a row). Preserve each shell and clear its contents
   //    instead of unsetting it.
-  const lcaContainer = getEnclosingContainer(editor, startBranchRoot)
+  const lcaContainer = getEnclosingContainer(editor.snapshot, startBranchRoot)
   const lcaAcceptsTextBlock = lcaContainer
-    ? lcaContainer.of.some((member) => member.type === editor.schema.block.name)
+    ? lcaContainer.of.some(
+        (member) => member.type === editor.snapshot.context.schema.block.name,
+      )
     : true
 
   if (lcaAcceptsTextBlock) {
     removeChildrenBetween(editor, startBranchRoot, endBranchRoot)
   } else {
-    let cursor = getSibling(editor, startBranchRoot, {direction: 'next'})
+    let cursor = getSibling(editor.snapshot, startBranchRoot, {
+      direction: 'next',
+    })
     while (cursor && !pathEquals(cursor.path, endBranchRoot)) {
       const cursorPath = cursor.path
       clearContainerContents(editor, cursorPath)
-      cursor = getSibling(editor, cursorPath, {direction: 'next'})
+      cursor = getSibling(editor.snapshot, cursorPath, {direction: 'next'})
     }
   }
 
@@ -409,7 +418,7 @@ function deleteCrossParentRange(
   //    the first surviving child that comes before the end offset.
   if (!pathEquals(end.path, endBlockPath)) {
     removeLeadingChildrenOf(editor, endBlockPath, end.path)
-    const firstChild = getFirstChild(editor, endBlockPath)
+    const firstChild = getFirstChild(editor.snapshot, endBlockPath)
     if (firstChild) {
       removeTextUpToOffset(editor, firstChild.path, end.offset)
     }
@@ -443,7 +452,7 @@ function removeTextRange(
   endOffset: number,
   capture: boolean,
 ): string | null {
-  const span = getSpan(editor, path)
+  const span = getSpan(editor.snapshot, path)
   if (!span) {
     return null
   }
@@ -462,7 +471,7 @@ function removeTextFromOffset(
   offset: number,
   capture: boolean,
 ): string | null {
-  const span = getSpan(editor, path)
+  const span = getSpan(editor.snapshot, path)
   if (!span || offset >= span.node.text.length) {
     return null
   }
@@ -480,7 +489,7 @@ function removeTextUpToOffset(
   if (offset <= 0) {
     return
   }
-  const span = getSpan(editor, path)
+  const span = getSpan(editor.snapshot, path)
   if (!span) {
     return
   }
@@ -501,10 +510,10 @@ function removeChildrenBetween(
   startChildPath: Path,
   endChildPath: Path,
 ): void {
-  let cursor = getSibling(editor, startChildPath, {direction: 'next'})
+  let cursor = getSibling(editor.snapshot, startChildPath, {direction: 'next'})
   while (cursor && !pathEquals(cursor.path, endChildPath)) {
     removeNodeAt(editor, cursor.path)
-    cursor = getSibling(editor, startChildPath, {direction: 'next'})
+    cursor = getSibling(editor.snapshot, startChildPath, {direction: 'next'})
   }
 }
 
@@ -525,38 +534,46 @@ function clearContainerContents(
   editor: PortableTextEditorEngine,
   containerPath: Path,
 ): void {
-  const node = getNode(editor, containerPath)?.node
+  const node = getNode(editor.snapshot, containerPath)?.node
   if (!node) {
     return
   }
 
-  const container = resolveContainerByPath(editor, containerPath, node)
+  const container = resolveContainerByPath(
+    {
+      containers: editor.containers,
+      schema: editor.snapshot.context.schema,
+      value: editor.snapshot.context.value,
+    },
+    containerPath,
+    node,
+  )
   if (!container || !('container' in container)) {
     return
   }
 
   const fieldName = container.field.name
   const fieldAcceptsTextBlock = container.field.of.some(
-    (member) => member.type === editor.schema.block.name,
+    (member) => member.type === editor.snapshot.context.schema.block.name,
   )
 
   if (fieldAcceptsTextBlock) {
-    let firstChild = getFirstChild(editor, containerPath)
+    let firstChild = getFirstChild(editor.snapshot, containerPath)
     while (firstChild) {
       removeNodeAt(editor, firstChild.path)
-      firstChild = getFirstChild(editor, containerPath)
+      firstChild = getFirstChild(editor.snapshot, containerPath)
     }
     const placeholderPath: Path = [...containerPath, fieldName, 0]
     editor.apply({
       type: 'insert',
       path: placeholderPath,
-      node: createPlaceholderBlock(editor, placeholderPath),
+      node: createPlaceholderBlock(editor.snapshot, placeholderPath),
       position: 'before',
     })
     return
   }
 
-  for (const child of getChildren(editor, containerPath)) {
+  for (const child of getChildren(editor.snapshot, containerPath)) {
     clearContainerContents(editor, child.path)
   }
 }
@@ -566,10 +583,10 @@ function removeTrailingChildren(
   editor: PortableTextEditorEngine,
   startChildPath: Path,
 ): void {
-  let cursor = getSibling(editor, startChildPath, {direction: 'next'})
+  let cursor = getSibling(editor.snapshot, startChildPath, {direction: 'next'})
   while (cursor) {
     removeNodeAt(editor, cursor.path)
-    cursor = getSibling(editor, startChildPath, {direction: 'next'})
+    cursor = getSibling(editor.snapshot, startChildPath, {direction: 'next'})
   }
 }
 
@@ -578,11 +595,11 @@ function clearTrailingSiblings(
   editor: PortableTextEditorEngine,
   startChildPath: Path,
 ): void {
-  let cursor = getSibling(editor, startChildPath, {direction: 'next'})
+  let cursor = getSibling(editor.snapshot, startChildPath, {direction: 'next'})
   while (cursor) {
     const cursorPath = cursor.path
     clearContainerContents(editor, cursorPath)
-    cursor = getSibling(editor, cursorPath, {direction: 'next'})
+    cursor = getSibling(editor.snapshot, cursorPath, {direction: 'next'})
   }
 }
 
@@ -591,10 +608,14 @@ function removePrecedingSiblings(
   editor: PortableTextEditorEngine,
   startChildPath: Path,
 ): void {
-  let cursor = getSibling(editor, startChildPath, {direction: 'previous'})
+  let cursor = getSibling(editor.snapshot, startChildPath, {
+    direction: 'previous',
+  })
   while (cursor) {
     removeNodeAt(editor, cursor.path)
-    cursor = getSibling(editor, startChildPath, {direction: 'previous'})
+    cursor = getSibling(editor.snapshot, startChildPath, {
+      direction: 'previous',
+    })
   }
 }
 
@@ -603,11 +624,13 @@ function clearPrecedingSiblings(
   editor: PortableTextEditorEngine,
   startChildPath: Path,
 ): void {
-  let cursor = getSibling(editor, startChildPath, {direction: 'previous'})
+  let cursor = getSibling(editor.snapshot, startChildPath, {
+    direction: 'previous',
+  })
   while (cursor) {
     const cursorPath = cursor.path
     clearContainerContents(editor, cursorPath)
-    cursor = getSibling(editor, cursorPath, {direction: 'previous'})
+    cursor = getSibling(editor.snapshot, cursorPath, {direction: 'previous'})
   }
 }
 
@@ -621,11 +644,13 @@ function parentAcceptsTextBlock(
   editor: PortableTextEditorEngine,
   path: Path,
 ): boolean {
-  const enclosing = getEnclosingContainer(editor, path)
+  const enclosing = getEnclosingContainer(editor.snapshot, path)
   if (!enclosing) {
     return true
   }
-  return enclosing.of.some((member) => member.type === editor.schema.block.name)
+  return enclosing.of.some(
+    (member) => member.type === editor.snapshot.context.schema.block.name,
+  )
 }
 
 /**
@@ -637,10 +662,10 @@ function removeAllChildren(
   editor: PortableTextEditorEngine,
   blockPath: Path,
 ): void {
-  let firstChild = getFirstChild(editor, blockPath)
+  let firstChild = getFirstChild(editor.snapshot, blockPath)
   while (firstChild) {
     removeNodeAt(editor, firstChild.path)
-    firstChild = getFirstChild(editor, blockPath)
+    firstChild = getFirstChild(editor.snapshot, blockPath)
   }
 }
 
@@ -657,13 +682,13 @@ function removeLeadingChildrenOf(
   if (!endKey) {
     return
   }
-  let firstChild = getFirstChild(editor, blockPath)
+  let firstChild = getFirstChild(editor.snapshot, blockPath)
   while (
     firstChild &&
     (firstChild.path.at(-1) as {_key?: string} | undefined)?._key !== endKey
   ) {
     removeNodeAt(editor, firstChild.path)
-    firstChild = getFirstChild(editor, blockPath)
+    firstChild = getFirstChild(editor.snapshot, blockPath)
   }
 }
 
@@ -676,10 +701,10 @@ function removeBlocksBetween(
   startBlockPath: Path,
   endBlockPath: Path,
 ): void {
-  let cursor = getSibling(editor, startBlockPath, {direction: 'next'})
+  let cursor = getSibling(editor.snapshot, startBlockPath, {direction: 'next'})
   while (cursor && !pathEquals(cursor.path, endBlockPath)) {
     removeNodeAt(editor, cursor.path)
-    cursor = getSibling(editor, startBlockPath, {direction: 'next'})
+    cursor = getSibling(editor.snapshot, startBlockPath, {direction: 'next'})
   }
 }
 
@@ -698,21 +723,23 @@ function mergeBlock(
   if (pathEquals(startBlockPath, endBlockPath)) {
     return
   }
-  const startBlock = getTextBlock(editor, startBlockPath)
-  const endBlock = getTextBlock(editor, endBlockPath)
+  const startBlock = getTextBlock(editor.snapshot, startBlockPath)
+  const endBlock = getTextBlock(editor.snapshot, endBlockPath)
   if (!startBlock || !endBlock) {
     return
   }
 
   if (
     removeEmptyStartBlock &&
-    isEmptyTextBlock({schema: editor.schema}, startBlock.node)
+    isEmptyTextBlock({schema: editor.snapshot.context.schema}, startBlock.node)
   ) {
     // If the end block also ends up empty, the range covered both blocks
     // completely. Drop the end block so the start block's formatting wins on
     // the remaining empty block. Otherwise drop the empty start so the end
     // block's content survives.
-    if (isEmptyTextBlock({schema: editor.schema}, endBlock.node)) {
+    if (
+      isEmptyTextBlock({schema: editor.snapshot.context.schema}, endBlock.node)
+    ) {
       removeNodeAt(editor, endBlockPath)
       return
     }
@@ -734,7 +761,7 @@ function mergeBlock(
 }
 
 function removeNodeAt(editor: PortableTextEditorEngine, path: Path): void {
-  if (!getNode(editor, path)) {
+  if (!getNode(editor.snapshot, path)) {
     return
   }
   editor.apply({type: 'unset', path})

--- a/packages/editor/src/internal-utils/delete-range.ts
+++ b/packages/editor/src/internal-utils/delete-range.ts
@@ -73,20 +73,20 @@ function resolveExplicitRange(
     return null
   }
 
-  const [start, end] = rangeEdges(at, editor)
-  const startBlock = getEnclosingBlock(editor, start.path)
-  const endBlock = getEnclosingBlock(editor, end.path)
+  const [start, end] = rangeEdges(at, editor.snapshot.context)
+  const startBlock = getEnclosingBlock(editor.snapshot, start.path)
+  const endBlock = getEnclosingBlock(editor.snapshot, end.path)
 
   let clampedStart = start
   let clampedEnd = end
 
-  const startEntry = getNode(editor, start.path)
+  const startEntry = getNode(editor.snapshot, start.path)
   const startObjectNode =
-    startEntry && isLeafObject(editor, startEntry.node, start.path)
+    startEntry && isLeafObject(editor.snapshot, startEntry.node, start.path)
       ? startEntry
-      : getAncestor(editor, start.path, {
+      : getAncestor(editor.snapshot, start.path, {
           match: (node, ancestorPath) =>
-            isLeafObject(editor, node, ancestorPath),
+            isLeafObject(editor.snapshot, node, ancestorPath),
           mode: 'highest',
         })
   if (startObjectNode && startBlock) {
@@ -96,13 +96,13 @@ function resolveExplicitRange(
     }
   }
 
-  const endEntry = getNode(editor, end.path)
+  const endEntry = getNode(editor.snapshot, end.path)
   const endObjectNode =
-    endEntry && isLeafObject(editor, endEntry.node, end.path)
+    endEntry && isLeafObject(editor.snapshot, endEntry.node, end.path)
       ? endEntry
-      : getAncestor(editor, end.path, {
+      : getAncestor(editor.snapshot, end.path, {
           match: (node, ancestorPath) =>
-            isLeafObject(editor, node, ancestorPath),
+            isLeafObject(editor.snapshot, node, ancestorPath),
           mode: 'highest',
         })
   if (endObjectNode && endBlock) {

--- a/packages/editor/src/internal-utils/engine-utils.ts
+++ b/packages/editor/src/internal-utils/engine-utils.ts
@@ -11,24 +11,28 @@ export function isListItemActive({
   editor: Editor
   listItem: string
 }): boolean {
-  if (!editor.selection) {
+  if (!editor.snapshot.context.selection) {
     return false
   }
 
-  const [selStart, selEnd] = rangeEdges(editor.selection, editor)
+  const [selStart, selEnd] = rangeEdges(
+    editor.snapshot.context.selection,
+    editor.snapshot.context,
+  )
 
   const selectedBlocks = [
-    ...getNodes(editor, {
+    ...getNodes(editor.snapshot, {
       from: selStart.path,
       to: selEnd.path,
-      match: (node) => isTextBlock({schema: editor.schema}, node),
+      match: (node) =>
+        isTextBlock({schema: editor.snapshot.context.schema}, node),
     }),
   ]
 
   if (selectedBlocks.length > 0) {
     return selectedBlocks.every(
       (entry) =>
-        isListBlock({schema: editor.schema}, entry.node) &&
+        isListBlock({schema: editor.snapshot.context.schema}, entry.node) &&
         entry.node.listItem === listItem,
     )
   }
@@ -43,24 +47,28 @@ export function isStyleActive({
   editor: Editor
   style: string
 }): boolean {
-  if (!editor.selection) {
+  if (!editor.snapshot.context.selection) {
     return false
   }
 
-  const [selStart, selEnd] = rangeEdges(editor.selection, editor)
+  const [selStart, selEnd] = rangeEdges(
+    editor.snapshot.context.selection,
+    editor.snapshot.context,
+  )
 
   const selectedBlocks = [
-    ...getNodes(editor, {
+    ...getNodes(editor.snapshot, {
       from: selStart.path,
       to: selEnd.path,
-      match: (node) => isTextBlock({schema: editor.schema}, node),
+      match: (node) =>
+        isTextBlock({schema: editor.snapshot.context.schema}, node),
     }),
   ]
 
   if (selectedBlocks.length > 0) {
     return selectedBlocks.every(
       (entry) =>
-        isTextBlock({schema: editor.schema}, entry.node) &&
+        isTextBlock({schema: editor.snapshot.context.schema}, entry.node) &&
         entry.node.style === style,
     )
   }

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -54,7 +54,7 @@ export function getEventPosition({
 
   const {node: eventNode, path: eventPath} = eventResult
 
-  const eventBlockEntry = getEnclosingBlock(editorEngine, eventPath)
+  const eventBlockEntry = getEnclosingBlock(editorEngine.snapshot, eventPath)
   const eventBlock = eventBlockEntry?.node
   const eventBlockPath = eventBlockEntry?.path
   const eventPositionBlock = getEventPositionBlock({
@@ -79,14 +79,14 @@ export function getEventPosition({
       isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
-          context: editorEngine,
+          context: editorEngine.snapshot.context,
           block: {
             node: eventBlock,
             path: eventBlockPath,
           },
         }),
         focus: getBlockEndPoint({
-          context: editorEngine,
+          context: editorEngine.snapshot.context,
           block: {
             node: eventBlock,
             path: eventBlockPath,
@@ -101,7 +101,7 @@ export function getEventPosition({
   }
 
   const eventSelectionFocusBlock = getEnclosingBlock(
-    editorEngine,
+    editorEngine.snapshot,
     eventSelection.focus.path,
   )
 
@@ -124,14 +124,14 @@ export function getEventPosition({
       isContainer: false,
       selection: {
         anchor: getBlockStartPoint({
-          context: editorEngine,
+          context: editorEngine.snapshot.context,
           block: {
             node: eventBlock,
             path: eventBlockPath,
           },
         }),
         focus: getBlockEndPoint({
-          context: editorEngine,
+          context: editorEngine.snapshot.context,
           block: {
             node: eventBlock,
             path: eventBlockPath,
@@ -146,7 +146,7 @@ export function getEventPosition({
     isEditor: isEditor(eventNode),
     isContainer: isEditor(eventNode)
       ? false
-      : isEditableContainer(editorEngine, eventNode, eventPath),
+      : isEditableContainer(editorEngine.snapshot, eventNode, eventPath),
     selection: eventSelection,
   }
 }
@@ -169,7 +169,7 @@ function getEventNode({
       if (path.length === 0) {
         return {node: editorEngine, path}
       } else {
-        const nodeEntry = getNode(editorEngine, path)
+        const nodeEntry = getNode(editorEngine.snapshot, path)
         if (nodeEntry) {
           return {node: nodeEntry.node, path}
         }
@@ -191,7 +191,7 @@ function getEventPositionBlock({
   editorEngine: PortableTextEditorEngine
   event: DragEvent | MouseEvent
 }): EventPositionBlock | undefined {
-  const firstBlockEntry = getNode(editorEngine, [0])
+  const firstBlockEntry = getNode(editorEngine.snapshot, [0])
 
   if (!firstBlockEntry) {
     return undefined
@@ -209,9 +209,9 @@ function getEventPositionBlock({
     return 'start'
   }
 
-  const lastBlock = editorEngine.children.at(-1)
+  const lastBlock = editorEngine.snapshot.context.value.at(-1)
   const lastBlockEntry = lastBlock
-    ? getNode(editorEngine, [{_key: lastBlock._key}])
+    ? getNode(editorEngine.snapshot, [{_key: lastBlock._key}])
     : undefined
 
   if (!lastBlockEntry) {
@@ -308,5 +308,5 @@ function isEventContainer(
   if (isEditor(eventNode)) {
     return true
   }
-  return isEditableContainer(editorEngine, eventNode, eventPath)
+  return isEditableContainer(editorEngine.snapshot, eventNode, eventPath)
 }

--- a/packages/editor/src/internal-utils/find-current-line-range.ts
+++ b/packages/editor/src/internal-utils/find-current-line-range.ts
@@ -19,7 +19,10 @@ export function findCurrentLineRange(
   editor: Editor,
   parentRange: Range,
 ): Range {
-  const parentRangeBoundary = editorRange(editor, rangeEnd(parentRange, editor))
+  const parentRangeBoundary = editorRange(
+    editor,
+    rangeEnd(parentRange, editor.snapshot.context),
+  )
   const positions = Array.from(editorPositions(editor, {at: parentRange}))
 
   let left = 0

--- a/packages/editor/src/internal-utils/get-fully-covered-container.ts
+++ b/packages/editor/src/internal-utils/get-fully-covered-container.ts
@@ -36,12 +36,12 @@ export function getFullyCoveredContainers(
   editor: PortableTextEditorEngine,
   range: Range,
 ): {start: Path | undefined; end: Path | undefined} {
-  const [start, end] = rangeEdges(range, editor)
+  const [start, end] = rangeEdges(range, editor.snapshot.context)
   return {
-    start: getAncestor(editor, start.path, {
+    start: getAncestor(editor.snapshot, start.path, {
       match: (node, path) => isFullyCovered(editor, node, path, start, end),
     })?.path,
-    end: getAncestor(editor, end.path, {
+    end: getAncestor(editor.snapshot, end.path, {
       match: (node, path) => isFullyCovered(editor, node, path, start, end),
     })?.path,
   }
@@ -55,13 +55,13 @@ function isFullyCovered(
   rangeEnd: Point,
 ): boolean {
   if (
-    !isEditableContainer(editor, node, path) ||
-    isTextBlock({schema: editor.schema}, node)
+    !isEditableContainer(editor.snapshot, node, path) ||
+    isTextBlock({schema: editor.snapshot.context.schema}, node)
   ) {
     return false
   }
 
-  const root = {children: editor.children}
+  const root = {value: editor.snapshot.context.value}
   const containerStart = editorStart(editor, path)
   const containerEnd = editorEnd(editor, path)
 
@@ -99,7 +99,7 @@ function parentFieldAcceptsTextBlock(
   if (parent.length === 0) {
     return true
   }
-  const parentEntry = getNode(editor, parent)
+  const parentEntry = getNode(editor.snapshot, parent)
   if (!parentEntry) {
     return false
   }
@@ -116,6 +116,6 @@ function fieldAcceptsTextBlock(
     return false
   }
   return container.field.of.some(
-    (member) => member.type === editor.schema.block.name,
+    (member) => member.type === editor.snapshot.context.schema.block.name,
   )
 }

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -27,16 +27,22 @@ const editorActor = createActor(editorMachine, {
 const relayActor = createActor(relayMachine)
 
 const e = createEditor()
-e.children = [] as any
-e.schema = schema
 e.containers = new Map()
 e.blockIndexMap = new Map()
-Object.defineProperty(e, 'value', {
-  get() {
-    return e.children
+e.snapshot = {
+  blockIndexMap: e.blockIndexMap,
+  context: {
+    containers: new Map(),
+    converters: [],
+    keyGenerator: () => 'k',
+    readOnly: false,
+    schema,
+    selection: null,
+    value: [] as any,
   },
-  configurable: true,
-})
+  decoratorState: {},
+} as any
+// e.value reads through to e.snapshot.context.value via getter once defined
 const editor = plugins(e, {
   editorActor,
   relayActor,
@@ -92,7 +98,7 @@ describe(insertNodePatch.name, () => {
 
 describe('operationToPatches', () => {
   beforeEach(() => {
-    editor.children = createDefaultChildren()
+    editor.snapshot.context.value = createDefaultChildren()
     editor.onChange()
   })
 
@@ -131,7 +137,7 @@ describe('operationToPatches', () => {
   })
 
   it('produce correct insert block patch with an empty editor', () => {
-    editor.children = []
+    editor.snapshot.context.value = []
     editor.onChange()
     expect(
       insertNodePatch({
@@ -206,11 +212,13 @@ describe('operationToPatches', () => {
   })
 
   it('produce correct insert text patch', () => {
-    ;(editor.children[0] as PortableTextTextBlock).children[2]!.text = '1'
+    ;(
+      editor.snapshot.context.value[0] as PortableTextTextBlock
+    ).children[2]!.text = '1'
     editor.onChange()
     expect(
       textPatch(
-        editor,
+        editor.snapshot,
         {
           type: 'insert_text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
@@ -283,7 +291,7 @@ describe('operationToPatches', () => {
     ;(before[0] as PortableTextTextBlock).children[2]!.text = '1'
     expect(
       textPatch(
-        editor,
+        editor.snapshot,
         {
           type: 'remove_text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
@@ -317,7 +325,7 @@ describe('operationToPatches', () => {
 
 describe('defensive setIfMissing patches', () => {
   beforeEach(() => {
-    editor.children = createDefaultChildren()
+    editor.snapshot.context.value = createDefaultChildren()
     editor.onChange()
   })
 

--- a/packages/editor/src/internal-utils/set-node-properties.ts
+++ b/packages/editor/src/internal-utils/set-node-properties.ts
@@ -17,7 +17,7 @@ export function setNodeProperties(
   props: Record<string, unknown> | object,
   path: Path,
 ): void {
-  const nodeEntry = getNode(editor, path)
+  const nodeEntry = getNode(editor.snapshot, path)
 
   if (!nodeEntry) {
     return

--- a/packages/editor/src/internal-utils/transform-operation.test.ts
+++ b/packages/editor/src/internal-utils/transform-operation.test.ts
@@ -8,9 +8,9 @@ import {transformOperation} from './transform-operation'
 const testSchema = compileSchema(defineSchema({}))
 
 /**
- * Minimal editor mock. transformOperation only reads editor.children,
- * editor.schema, editor.containers (for block resolution), and
- * editor.selection (for set_selection target resolution).
+ * Minimal editor mock. transformOperation only reads editor.snapshot.context.value,
+ * editor.snapshot.context.schema, editor.containers (for block resolution), and
+ * editor.snapshot.context.selection (for set_selection target resolution).
  */
 function createMockEditor(
   children: Array<{_key: string; _type: string; [key: string]: unknown}>,

--- a/packages/editor/src/internal-utils/transform-operation.ts
+++ b/packages/editor/src/internal-utils/transform-operation.ts
@@ -28,7 +28,7 @@ export function transformOperation(
   patch: Patch,
   operation: Operation,
 ): Operation[] {
-  const snapshot: TraversalSnapshot = editor
+  const snapshot: TraversalSnapshot = editor.snapshot
   const transformedOperation = {...operation}
 
   if (patch.type === 'insert') {
@@ -44,7 +44,7 @@ export function transformOperation(
     // If this operation targets anything inside the subtree that got
     // removed, drop it. With keyed paths, other operations' paths don't
     // need adjustment. Compare path prefixes rather than resolving
-    // against the tree — `editor.children` reflects the post-patch state
+    // against the tree — `editor.snapshot.context.value` reflects the post-patch state
     // where the removed subtree is already gone.
     if (
       'path' in transformedOperation &&
@@ -159,8 +159,11 @@ function findOperationTargetBlock(
   editor: PortableTextEditorEngine,
   operation: Operation,
 ): Node | undefined {
-  if (operation.type === 'set_selection' && editor.selection) {
-    const block = getEnclosingBlock(snapshot, editor.selection.focus.path)
+  if (operation.type === 'set_selection' && editor.snapshot.context.selection) {
+    const block = getEnclosingBlock(
+      snapshot,
+      editor.snapshot.context.selection.focus.path,
+    )
     return block?.node
   }
   if ('path' in operation) {

--- a/packages/editor/src/internal-utils/unset-matched-in-range.ts
+++ b/packages/editor/src/internal-utils/unset-matched-in-range.ts
@@ -22,7 +22,7 @@ export function unsetMatchedNodesInRange(
 ): void {
   const candidates: Array<{node: Node; path: Path}> = []
 
-  for (const entry of getNodes(editor, {
+  for (const entry of getNodes(editor.snapshot, {
     from,
     to,
     match: predicate,
@@ -46,7 +46,7 @@ export function unsetMatchedNodesInRange(
     if (!path) {
       continue
     }
-    if (!getNode(editor, path)) {
+    if (!getNode(editor.snapshot, path)) {
       continue
     }
     editor.apply({type: 'unset', path})

--- a/packages/editor/src/internal-utils/unwrap-container.ts
+++ b/packages/editor/src/internal-utils/unwrap-container.ts
@@ -28,14 +28,18 @@ export function unwrapContainer(
   originPath: Path,
   position: 'before' | 'after',
 ): void {
-  const children = getChildren(editor, originPath)
+  const children = getChildren(editor.snapshot, originPath)
   if (children.length === 0) {
     editor.apply({type: 'unset', path: originPath})
     return
   }
 
   const payloadTypes = new Set(children.map((child) => child.node._type))
-  const unwrapTarget = getUnwrapTarget(editor, originPath, payloadTypes)
+  const unwrapTarget = getUnwrapTarget(
+    editor.snapshot,
+    originPath,
+    payloadTypes,
+  )
   if (!unwrapTarget) {
     return
   }
@@ -43,7 +47,7 @@ export function unwrapContainer(
   // `children[0].path` resolves to e.g. `[...originPath, fieldName, {_key}]`,
   // giving us the field name without re-resolving the container.
   const innerPrefix = children[0]!.path.slice(0, originPath.length + 1)
-  const previousSelection = editor.selection
+  const previousSelection = editor.snapshot.context.selection
 
   // Repeated `position: 'before'` against the same path inserts in
   // reverse, so iterate backward; `'after'` is symmetric.
@@ -63,7 +67,7 @@ export function unwrapContainer(
     const focus = transformPoint(previousSelection.focus, innerPrefix)
     editor.apply({
       type: 'set_selection',
-      properties: editor.selection,
+      properties: editor.snapshot.context.selection,
       newProperties: {anchor, focus},
     })
   }

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -32,7 +32,7 @@ export const addAnnotationOperationImplementation: OperationImplementation<
     ? resolveSelection(operation.editor, operation.at)
     : null
 
-  const effectiveSelection = at ?? editor.selection
+  const effectiveSelection = at ?? editor.snapshot.context.selection
 
   const anchorPath = effectiveSelection?.anchor.path
   const annotationSchema = anchorPath
@@ -63,11 +63,12 @@ export const addAnnotationOperationImplementation: OperationImplementation<
   const ref = at ? rangeRef(editor, at, {affinity: 'inward'}) : null
 
   const selectedBlocks = Array.from(
-    getNodes(editor, {
-      from: rangeStart(effectiveSelection, editor).path,
-      to: rangeEnd(effectiveSelection, editor).path,
-      match: (node) => isTextBlock({schema: editor.schema}, node),
-      reverse: isBackwardRange(effectiveSelection, editor),
+    getNodes(editor.snapshot, {
+      from: rangeStart(effectiveSelection, editor.snapshot.context).path,
+      to: rangeEnd(effectiveSelection, editor.snapshot.context).path,
+      match: (node) =>
+        isTextBlock({schema: editor.snapshot.context.schema}, node),
+      reverse: isBackwardRange(effectiveSelection, editor.snapshot.context),
     }),
   )
 
@@ -75,7 +76,7 @@ export const addAnnotationOperationImplementation: OperationImplementation<
 
   withoutNormalizing(editor, () => {
     for (const {node: block, path: blockPath} of selectedBlocks) {
-      if (!isTextBlock({schema: editor.schema}, block)) {
+      if (!isTextBlock({schema: editor.snapshot.context.schema}, block)) {
         continue
       }
 
@@ -124,21 +125,24 @@ export const addAnnotationOperationImplementation: OperationImplementation<
       }
 
       // Split text nodes at range boundaries
-      const splitRange = at ?? editor.selection
+      const splitRange = at ?? editor.snapshot.context.selection
       if (splitRange && isRange(splitRange)) {
-        const splitLeaf = getNode(editor, splitRange.anchor.path)?.node
+        const splitLeaf = getNode(editor.snapshot, splitRange.anchor.path)?.node
         if (
           !(
             splitLeaf &&
             isCollapsedRange(splitRange) &&
-            isSpan({schema: editor.schema}, splitLeaf) &&
+            isSpan({schema: editor.snapshot.context.schema}, splitLeaf) &&
             splitLeaf.text.length > 0
           )
         ) {
           const splitRangeRef = rangeRef(editor, splitRange, {
             affinity: 'inward',
           })
-          const [splitStart, splitEnd] = rangeEdges(splitRange, editor)
+          const [splitStart, splitEnd] = rangeEdges(
+            splitRange,
+            editor.snapshot.context,
+          )
           const endAtEnd = isEnd(editor, splitEnd, splitEnd.path)
           if (!endAtEnd || !isEdge(editor, splitEnd, splitEnd.path)) {
             applySplitNode(editor, splitEnd.path, splitEnd.offset)
@@ -155,19 +159,19 @@ export const addAnnotationOperationImplementation: OperationImplementation<
         }
       }
 
-      const children = getChildren(editor, blockPath)
+      const children = getChildren(editor.snapshot, blockPath)
 
       // Use the tracked range (updated after splits) or fall back to editor.selection
-      const selectionRange = ref?.current ?? editor.selection
+      const selectionRange = ref?.current ?? editor.snapshot.context.selection
 
       for (const {node: span, path: spanPath} of children) {
-        if (!isSpan({schema: editor.schema}, span)) {
+        if (!isSpan({schema: editor.snapshot.context.schema}, span)) {
           continue
         }
 
         if (
           !selectionRange ||
-          !rangeIncludes(selectionRange, spanPath, editor)
+          !rangeIncludes(selectionRange, spanPath, editor.snapshot.context)
         ) {
           continue
         }

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -32,7 +32,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
     ? resolveSelection(operation.editor, operation.at)
     : null
 
-  const effectiveSelection = at ?? editor.selection
+  const effectiveSelection = at ?? editor.snapshot.context.selection
 
   if (!effectiveSelection) {
     return
@@ -40,7 +40,8 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
 
   if (isCollapsedRange(effectiveSelection)) {
     const blockEntry = getParent(snapshot, effectiveSelection.focus.path, {
-      match: (node) => isTextBlock({schema: editor.schema}, node),
+      match: (node) =>
+        isTextBlock({schema: editor.snapshot.context.schema}, node),
     })
 
     if (!blockEntry) {
@@ -54,7 +55,10 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
       (markDef) => markDef._type === operation.annotation.name,
     )
 
-    const selectedChildEntry = getNode(editor, effectiveSelection.focus.path)
+    const selectedChildEntry = getNode(
+      editor.snapshot,
+      effectiveSelection.focus.path,
+    )
 
     if (!selectedChildEntry) {
       return
@@ -62,7 +66,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
 
     const {node: selectedChild, path: selectedChildPath} = selectedChildEntry
 
-    if (!isSpan({schema: editor.schema}, selectedChild)) {
+    if (!isSpan({schema: editor.snapshot.context.schema}, selectedChild)) {
       return
     }
 
@@ -78,7 +82,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
       [span: PortableTextSpan, path: Path]
     > = []
 
-    const reversedChildren = getChildren(editor, blockPath)
+    const reversedChildren = getChildren(editor.snapshot, blockPath)
 
     for (let index = reversedChildren.length - 1; index >= 0; index--) {
       const entry = reversedChildren[index]
@@ -86,11 +90,13 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
         continue
       }
       const {node: child, path: childPath} = entry
-      if (!isSpan({schema: editor.schema}, child)) {
+      if (!isSpan({schema: editor.snapshot.context.schema}, child)) {
         continue
       }
 
-      if (!isBeforePath(childPath, selectedChildPath, editor)) {
+      if (
+        !isBeforePath(childPath, selectedChildPath, editor.snapshot.context)
+      ) {
         continue
       }
 
@@ -106,14 +112,14 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
     > = []
 
     for (const {node: child, path: childPath} of getChildren(
-      editor,
+      editor.snapshot,
       blockPath,
     )) {
-      if (!isSpan({schema: editor.schema}, child)) {
+      if (!isSpan({schema: editor.snapshot.context.schema}, child)) {
         continue
       }
 
-      if (!isAfterPath(childPath, selectedChildPath, editor)) {
+      if (!isAfterPath(childPath, selectedChildPath, editor.snapshot.context)) {
         continue
       }
 
@@ -143,21 +149,24 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
 
     withoutNormalizing(editor, () => {
       // Split text nodes at range boundaries
-      const splitRange = at ?? editor.selection
+      const splitRange = at ?? editor.snapshot.context.selection
       if (splitRange && isRange(splitRange)) {
-        const splitLeaf = getNode(editor, splitRange.anchor.path)?.node
+        const splitLeaf = getNode(editor.snapshot, splitRange.anchor.path)?.node
         if (
           !(
             splitLeaf &&
             isCollapsedRange(splitRange) &&
-            isSpan({schema: editor.schema}, splitLeaf) &&
+            isSpan({schema: editor.snapshot.context.schema}, splitLeaf) &&
             splitLeaf.text.length > 0
           )
         ) {
           const splitRangeRef = rangeRef(editor, splitRange, {
             affinity: 'inward',
           })
-          const [splitStart, splitEnd] = rangeEdges(splitRange, editor)
+          const [splitStart, splitEnd] = rangeEdges(
+            splitRange,
+            editor.snapshot.context,
+          )
           const endAtEnd = isEnd(editor, splitEnd, splitEnd.path)
           if (!endAtEnd || !isEdge(editor, splitEnd, splitEnd.path)) {
             applySplitNode(editor, splitEnd.path, splitEnd.offset)
@@ -175,31 +184,32 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
       }
 
       const blocks = Array.from(
-        getNodes(editor, {
-          from: rangeStart(effectiveSelection, editor).path,
-          to: rangeEnd(effectiveSelection, editor).path,
-          match: (node) => isTextBlock({schema: editor.schema}, node),
+        getNodes(editor.snapshot, {
+          from: rangeStart(effectiveSelection, editor.snapshot.context).path,
+          to: rangeEnd(effectiveSelection, editor.snapshot.context).path,
+          match: (node) =>
+            isTextBlock({schema: editor.snapshot.context.schema}, node),
         }),
       )
 
       // Use the tracked range (updated after splits) or fall back to editor.selection
-      const selectionRange = ref?.current ?? editor.selection
+      const selectionRange = ref?.current ?? editor.snapshot.context.selection
 
       for (const {node: block, path: blockPath} of blocks) {
-        if (!isTextBlock({schema: editor.schema}, block)) {
+        if (!isTextBlock({schema: editor.snapshot.context.schema}, block)) {
           continue
         }
 
-        const children = getChildren(editor, blockPath)
+        const children = getChildren(editor.snapshot, blockPath)
 
         for (const {node: child, path: childPath} of children) {
-          if (!isSpan({schema: editor.schema}, child)) {
+          if (!isSpan({schema: editor.snapshot.context.schema}, child)) {
             continue
           }
 
           if (
             !selectionRange ||
-            !rangeIncludes(selectionRange, childPath, editor)
+            !rangeIncludes(selectionRange, childPath, editor.snapshot.context)
           ) {
             continue
           }

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -12,7 +12,7 @@ export const blockSetOperationImplementation: OperationImplementation<
   'block.set'
 > = ({snapshot, operation}) => {
   const {context} = snapshot
-  const blockEntry = getNode(operation.editor, operation.at)
+  const blockEntry = getNode(operation.editor.snapshot, operation.at)
 
   if (!blockEntry) {
     throw new Error(`Unable to find block at ${safeStringify(operation.at)}`)

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -8,7 +8,7 @@ export const blockUnsetOperationImplementation: OperationImplementation<
   'block.unset'
 > = ({snapshot, operation}) => {
   const {context} = snapshot
-  const blockEntry = getNode(operation.editor, operation.at)
+  const blockEntry = getNode(operation.editor.snapshot, operation.at)
 
   if (!blockEntry) {
     throw new Error(`Unable to find block at ${safeStringify(operation.at)}`)

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -11,7 +11,7 @@ import type {OperationImplementation} from './operation.types'
 export const childSetOperationImplementation: OperationImplementation<
   'child.set'
 > = ({snapshot, operation}) => {
-  const childEntry = getNode(operation.editor, operation.at)
+  const childEntry = getNode(operation.editor.snapshot, operation.at)
 
   if (!childEntry) {
     throw new Error(`Unable to find child at ${safeStringify(operation.at)}`)
@@ -19,7 +19,7 @@ export const childSetOperationImplementation: OperationImplementation<
 
   const {node: child, path: childPath} = childEntry
 
-  if (isSpan({schema: operation.editor.schema}, child)) {
+  if (isSpan({schema: operation.editor.snapshot.context.schema}, child)) {
     const {_type, text, ...rest} = operation.props
 
     setNodeProperties(
@@ -58,7 +58,7 @@ export const childSetOperationImplementation: OperationImplementation<
     return
   }
 
-  if (isObject(operation.editor, child)) {
+  if (isObject(operation.editor.snapshot, child)) {
     const blockPath = parentPath(childPath)
     const {inlineObjects} = getPathSubSchema(snapshot, blockPath)
     const definition = inlineObjects.find(

--- a/packages/editor/src/operations/operation.child.unset.ts
+++ b/packages/editor/src/operations/operation.child.unset.ts
@@ -9,7 +9,7 @@ export const childUnsetOperationImplementation: OperationImplementation<
   'child.unset'
 > = ({snapshot, operation}) => {
   const {context} = snapshot
-  const childEntry = getNode(operation.editor, operation.at)
+  const childEntry = getNode(operation.editor.snapshot, operation.at)
 
   if (!childEntry) {
     throw new Error(
@@ -19,7 +19,7 @@ export const childUnsetOperationImplementation: OperationImplementation<
 
   const {node: child, path: childPath} = childEntry
 
-  if (isSpan({schema: operation.editor.schema}, child)) {
+  if (isSpan({schema: operation.editor.snapshot.context.schema}, child)) {
     const newNode: Record<string, unknown> = {}
 
     for (const prop of operation.props) {
@@ -40,7 +40,7 @@ export const childUnsetOperationImplementation: OperationImplementation<
     return
   }
 
-  if (isObject(operation.editor, child)) {
+  if (isObject(operation.editor.snapshot, child)) {
     const unsetProps: Record<string, unknown> = {}
     for (const prop of operation.props) {
       if (prop === '_type') {

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -25,7 +25,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
 
   let at = operation.at
     ? resolveSelection(operation.editor, operation.at)
-    : operation.editor.selection
+    : operation.editor.snapshot.context.selection
 
   if (!at) {
     // Unable to add decorator without a selection
@@ -36,7 +36,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
     const ref = rangeRef(editor, at, {affinity: 'inward'})
 
     withoutNormalizing(editor, () => {
-      const [start, end] = rangeEdges(at!, editor)
+      const [start, end] = rangeEdges(at!, editor.snapshot.context)
 
       if (!isEdge(editor, end, end.path)) {
         applySplitNode(editor, end.path, end.offset)
@@ -57,18 +57,18 @@ export const decoratorAddOperationImplementation: OperationImplementation<
       }
 
       // Use new selection to find nodes to decorate
-      const atStart = rangeStart(at, editor)
-      const atEnd = rangeEnd(at, editor)
+      const atStart = rangeStart(at, editor.snapshot.context)
+      const atEnd = rangeEnd(at, editor.snapshot.context)
       const splitTextNodes = Array.from(
-        getNodes(editor, {
+        getNodes(editor.snapshot, {
           from: atStart.path,
           to: atEnd.path,
-          match: (n) => isSpan({schema: editor.schema}, n),
+          match: (n) => isSpan({schema: editor.snapshot.context.schema}, n),
         }),
       )
 
       for (const {node, path: spanPath} of splitTextNodes) {
-        if (!isSpan({schema: editor.schema}, node)) {
+        if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
           continue
         }
 
@@ -104,10 +104,10 @@ export const decoratorAddOperationImplementation: OperationImplementation<
     }) // end withoutNormalizing
   } else {
     const selectedSpan = Array.from(
-      getNodes(editor, {
-        from: rangeStart(at, editor).path,
-        to: rangeEnd(at, editor).path,
-        match: (node) => isSpan({schema: editor.schema}, node),
+      getNodes(editor.snapshot, {
+        from: rangeStart(at, editor.snapshot.context).path,
+        to: rangeEnd(at, editor.snapshot.context).path,
+        match: (node) => isSpan({schema: editor.snapshot.context.schema}, node),
       }),
     )?.at(0)
 
@@ -132,7 +132,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
 
     const lonelyEmptySpan =
       block.children.length === 1 &&
-      isSpan({schema: editor.schema}, block.children[0]) &&
+      isSpan({schema: editor.snapshot.context.schema}, block.children[0]) &&
       block.children[0].text === ''
         ? block.children[0]
         : undefined
@@ -148,21 +148,22 @@ export const decoratorAddOperationImplementation: OperationImplementation<
           ? [...existingMarks, mark]
           : existingMarksWithoutDecorator
       for (const {path: spanPath} of Array.from(
-        getNodes(editor, {
+        getNodes(editor.snapshot, {
           at: blockPath,
-          match: (node) => isSpan({schema: editor.schema}, node),
+          match: (node) =>
+            isSpan({schema: editor.snapshot.context.schema}, node),
         }),
       )) {
         setNodeProperties(editor, {marks: newMarks}, spanPath)
       }
     } else {
-      editor.decoratorState[mark] = true
+      editor.snapshot.decoratorState[mark] = true
     }
   }
 
-  if (editor.selection) {
+  if (editor.snapshot.context.selection) {
     // Reselect
-    const selection = editor.selection
-    editor.selection = {...selection}
+    const selection = editor.snapshot.context.selection
+    editor.snapshot.context.selection = {...selection}
   }
 }

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -26,7 +26,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
   const mark = operation.decorator
   const at = operation.at
     ? resolveSelection(operation.editor, operation.at)
-    : editor.selection
+    : editor.snapshot.context.selection
 
   if (!at) {
     // Unable to remove decorator without a selection
@@ -38,16 +38,16 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
 
     withoutNormalizing(editor, () => {
       // Split text nodes at range boundaries (equivalent to setNodes with split:true and empty props)
-      const decoratorLeaf = getNode(editor, at!.anchor.path)?.node
+      const decoratorLeaf = getNode(editor.snapshot, at!.anchor.path)?.node
       if (
         !(
           decoratorLeaf &&
           isCollapsedRange(at) &&
-          isSpan({schema: editor.schema}, decoratorLeaf) &&
+          isSpan({schema: editor.snapshot.context.schema}, decoratorLeaf) &&
           decoratorLeaf.text.length > 0
         )
       ) {
-        const [start, end] = rangeEdges(at, editor)
+        const [start, end] = rangeEdges(at, editor.snapshot.context)
         const endAtEndOfNode = isEnd(editor, end, end.path)
         if (!endAtEndOfNode || !isEdge(editor, end, end.path)) {
           applySplitNode(editor, end.path, end.offset)
@@ -62,22 +62,22 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
 
       if (updatedAt) {
         const splitTextNodes = [
-          ...getNodes(editor, {
-            from: rangeStart(updatedAt, editor).path,
-            to: rangeEnd(updatedAt, editor).path,
-            match: (n) => isSpan({schema: editor.schema}, n),
+          ...getNodes(editor.snapshot, {
+            from: rangeStart(updatedAt, editor.snapshot.context).path,
+            to: rangeEnd(updatedAt, editor.snapshot.context).path,
+            match: (n) => isSpan({schema: editor.snapshot.context.schema}, n),
           }),
         ]
         for (const {node, path: nodePath} of splitTextNodes) {
-          if (!isSpan({schema: editor.schema}, node)) {
+          if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
             continue
           }
 
           const blockPath = parentPath(nodePath)
-          const blockEntry = getNode(editor, blockPath)
+          const blockEntry = getNode(editor.snapshot, blockPath)
           const block = blockEntry?.node
           if (
-            isTextBlock({schema: editor.schema}, block) &&
+            isTextBlock({schema: editor.snapshot.context.schema}, block) &&
             block.children.includes(node)
           ) {
             setNodeProperties(
@@ -96,7 +96,8 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
     }) // end withoutNormalizing
   } else {
     const textBlockEntry = getParent(snapshot, at.focus.path, {
-      match: (node) => isTextBlock({schema: editor.schema}, node),
+      match: (node) =>
+        isTextBlock({schema: editor.snapshot.context.schema}, node),
     })
     if (!textBlockEntry) {
       return
@@ -104,7 +105,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
     const {node: block, path: blockPath} = textBlockEntry
     const lonelyEmptySpan =
       block.children.length === 1 &&
-      isSpan({schema: editor.schema}, block.children[0]) &&
+      isSpan({schema: editor.snapshot.context.schema}, block.children[0]) &&
       block.children[0].text === ''
         ? block.children[0]
         : undefined
@@ -116,9 +117,10 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
       )
 
       for (const {path: spanPath} of Array.from(
-        getNodes(editor, {
+        getNodes(editor.snapshot, {
           at: blockPath,
-          match: (node) => isSpan({schema: editor.schema}, node),
+          match: (node) =>
+            isSpan({schema: editor.snapshot.context.schema}, node),
         }),
       )) {
         setNodeProperties(
@@ -128,13 +130,13 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
         )
       }
     } else {
-      editor.decoratorState[mark] = false
+      editor.snapshot.decoratorState[mark] = false
     }
   }
 
-  if (editor.selection) {
+  if (editor.snapshot.context.selection) {
     // Reselect
-    const selection = editor.selection
-    editor.selection = {...selection}
+    const selection = editor.snapshot.context.selection
+    editor.snapshot.context.selection = {...selection}
   }
 }

--- a/packages/editor/src/operations/operation.delete.ts
+++ b/packages/editor/src/operations/operation.delete.ts
@@ -28,20 +28,20 @@ export const deleteOperationImplementation: OperationImplementation<
 > = ({operation}) => {
   const at = operation.at
     ? resolveSelection(operation.editor, operation.at)
-    : operation.editor.selection
+    : operation.editor.snapshot.context.selection
 
   if (!at) {
     throw new Error('Unable to delete without a selection')
   }
 
-  const [start, end] = rangeEdges(at, operation.editor)
+  const [start, end] = rangeEdges(at, operation.editor.snapshot.context)
 
   if (operation.unit === 'block') {
     unsetMatchedNodesInRange(
       operation.editor,
       start.path,
       end.path,
-      (_, path) => isBlock(operation.editor, path),
+      (_, path) => isBlock(operation.editor.snapshot, path),
     )
     return
   }
@@ -51,28 +51,38 @@ export const deleteOperationImplementation: OperationImplementation<
       operation.editor,
       start.path,
       end.path,
-      (_, path) => isInline(operation.editor, path),
+      (_, path) => isInline(operation.editor.snapshot, path),
     )
     return
   }
 
   if (operation.direction === 'backward' && operation.unit === 'line') {
     const parentBlockEntry = pathEquals(at.anchor.path, at.focus.path)
-      ? getParent(operation.editor, at.anchor.path, {
-          match: (node) => isTextBlock({schema: operation.editor.schema}, node),
+      ? getParent(operation.editor.snapshot, at.anchor.path, {
+          match: (node) =>
+            isTextBlock(
+              {schema: operation.editor.snapshot.context.schema},
+              node,
+            ),
         })
       : (() => {
           const fromPath = commonPath(at.anchor.path, at.focus.path)
-          const nodeEntry = getNode(operation.editor, fromPath)
+          const nodeEntry = getNode(operation.editor.snapshot, fromPath)
           if (
             nodeEntry &&
-            isTextBlockNode({schema: operation.editor.schema}, nodeEntry.node)
+            isTextBlockNode(
+              {schema: operation.editor.snapshot.context.schema},
+              nodeEntry.node,
+            )
           ) {
             return nodeEntry
           }
-          return getParent(operation.editor, fromPath, {
+          return getParent(operation.editor.snapshot, fromPath, {
             match: (node) =>
-              isTextBlock({schema: operation.editor.schema}, node),
+              isTextBlock(
+                {schema: operation.editor.snapshot.context.schema},
+                node,
+              ),
           })
         })()
 
@@ -103,20 +113,24 @@ export const deleteOperationImplementation: OperationImplementation<
     : 'collapse-to-start'
 
   if (isCollapsedRange(at)) {
-    const enclosingContainer = getAncestor(operation.editor, at.anchor.path, {
-      match: (node, path) =>
-        isObject(operation.editor, node) &&
-        isEditableContainer(operation.editor, node, path),
-    })
+    const enclosingContainer = getAncestor(
+      operation.editor.snapshot,
+      at.anchor.path,
+      {
+        match: (node, path) =>
+          isObject(operation.editor.snapshot, node) &&
+          isEditableContainer(operation.editor.snapshot, node, path),
+      },
+    )
     const enclosingContainerChildren = enclosingContainer
-      ? getChildren(operation.editor, enclosingContainer.path)
+      ? getChildren(operation.editor.snapshot, enclosingContainer.path)
       : undefined
     const [firstChild] = enclosingContainerChildren ?? []
     if (
       enclosingContainer &&
       enclosingContainerChildren?.length === 1 &&
       firstChild &&
-      isEmptyTextBlock(operation.editor.context, firstChild.node)
+      isEmptyTextBlock(operation.editor.snapshot.context, firstChild.node)
     ) {
       unwrapContainer(
         operation.editor,
@@ -145,7 +159,7 @@ export const deleteOperationImplementation: OperationImplementation<
     return
   }
 
-  deleteRange(operation.editor, unhangRange(operation.editor, at), {
+  deleteRange(operation.editor, unhangRange(operation.editor.snapshot, at), {
     selection,
     removeEmptyStartBlock: true,
   })

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -75,7 +75,7 @@ export const insertBlockOperationImplementation: OperationImplementation<
   // which lands the block in the right field of an empty container.
   const resolved = operation.at
     ? resolveSelection(editor, operation.at)
-    : resolveSelection(editor, editor.selection)
+    : resolveSelection(editor, editor.snapshot.context.selection)
   const at =
     resolved && operation.at && operation.placement !== 'auto'
       ? operation.at
@@ -87,9 +87,9 @@ export const insertBlockOperationImplementation: OperationImplementation<
   // When the editor is empty there is no path to derive from, so use root scope.
   const destinationPath = at
     ? operation.placement === 'before'
-      ? rangeStart(at, editor).path
-      : rangeEnd(at, editor).path
-    : editor.children.length > 0
+      ? rangeStart(at, editor.snapshot.context).path
+      : rangeEnd(at, editor.snapshot.context).path
+    : editor.snapshot.context.value.length > 0
       ? editorEnd(editor, []).path
       : undefined
   const schema = destinationPath
@@ -132,7 +132,7 @@ export const insertBlockOperationImplementation: OperationImplementation<
     block,
     target,
     select: operation.select ?? 'start',
-    selectionAtEntry: editor.selection,
+    selectionAtEntry: editor.snapshot.context.selection,
   })
 }
 
@@ -152,16 +152,16 @@ function resolveTarget(args: {
 }): InsertTarget | undefined {
   const {editor, block, at, placement} = args
 
-  if (editor.children.length === 0) {
+  if (editor.snapshot.context.value.length === 0) {
     return {kind: 'empty-editor'}
   }
 
   const [startPoint, endPoint] = at
-    ? rangeEdges(at, editor)
+    ? rangeEdges(at, editor.snapshot.context)
     : [editorStart(editor, []), editorEnd(editor, [])]
 
-  const startBlockEntry = getEnclosingBlock(editor, startPoint.path)
-  const endBlockEntry = getEnclosingBlock(editor, endPoint.path)
+  const startBlockEntry = getEnclosingBlock(editor.snapshot, startPoint.path)
+  const endBlockEntry = getEnclosingBlock(editor.snapshot, endPoint.path)
 
   if (!startBlockEntry || !endBlockEntry) {
     return undefined
@@ -179,7 +179,7 @@ function resolveTarget(args: {
     return {kind: 'after', blockPath: endBlockPath}
   }
 
-  const schemaContext = {schema: editor.schema}
+  const schemaContext = {schema: editor.snapshot.context.schema}
 
   if (!at) {
     if (isEmptyTextBlock(schemaContext, endBlock)) {
@@ -214,7 +214,7 @@ function resolveTarget(args: {
     return {kind: 'delete-then-insert', range: at, startBlockPath}
   }
 
-  const collapsedPoint = rangeStart(at, editor)
+  const collapsedPoint = rangeStart(at, editor.snapshot.context)
 
   if (isEmptyTextBlock(schemaContext, endBlock)) {
     return {kind: 'replace', blockPath: endBlockPath}
@@ -424,14 +424,14 @@ function splitBlockAndInsert(
   const blockPathRef = pathRef(editor, blockPath, {affinity: 'backward'})
 
   if (splitAt.offset > 0) {
-    const spanEntry = getSpan(editor, splitAt.path)
+    const spanEntry = getSpan(editor.snapshot, splitAt.path)
     if (spanEntry && splitAt.offset < spanEntry.node.text.length) {
       applySplitNode(editor, splitAt.path, splitAt.offset)
     }
   }
 
   const currentBlockPath = blockPathRef.current ?? blockPath
-  const blockEntry = getTextBlock(editor, currentBlockPath)
+  const blockEntry = getTextBlock(editor.snapshot, currentBlockPath)
 
   if (blockEntry) {
     const childSegment = splitAt.path[blockPath.length + 1]
@@ -466,7 +466,7 @@ function mergeTextBlockFragment(args: {
 }): void {
   const {editor, context, block, at, endBlockPath, select, wasCrossBlock} = args
 
-  const endBlockEntry = getTextBlock(editor, endBlockPath)
+  const endBlockEntry = getTextBlock(editor.snapshot, endBlockPath)
 
   if (!endBlockEntry) {
     return
@@ -534,10 +534,10 @@ function applyPostInsertSelection(
       return
     }
 
-    if (editor.selection) {
+    if (editor.snapshot.context.selection) {
       editor.apply({
         type: 'set_selection',
-        properties: editor.selection,
+        properties: editor.snapshot.context.selection,
         newProperties: null,
       })
     }
@@ -572,11 +572,14 @@ function executeDeleteThenInsert(args: {
 }): void {
   const {editor, context, block, range, select, selectionAtEntry} = args
 
-  const rangeStartPoint = rangeStart(range, editor)
-  const rangeEndPoint = rangeEnd(range, editor)
+  const rangeStartPoint = rangeStart(range, editor.snapshot.context)
+  const rangeEndPoint = rangeEnd(range, editor.snapshot.context)
 
-  const startBlockEntry = getEnclosingBlock(editor, rangeStartPoint.path)
-  const endBlockEntry = getEnclosingBlock(editor, rangeEndPoint.path)
+  const startBlockEntry = getEnclosingBlock(
+    editor.snapshot,
+    rangeStartPoint.path,
+  )
+  const endBlockEntry = getEnclosingBlock(editor.snapshot, rangeEndPoint.path)
   const wasCrossBlock =
     startBlockEntry !== undefined &&
     endBlockEntry !== undefined &&
@@ -597,19 +600,24 @@ function executeDeleteThenInsert(args: {
     removeEmptyStartBlock: false,
   })
 
-  const collapsedRange = collapsedRangeRef.unref() ?? editor.selection
+  const collapsedRange =
+    collapsedRangeRef.unref() ?? editor.snapshot.context.selection
   const collapsedPoint = collapsedRange
-    ? rangeStart(collapsedRange, editor)
+    ? rangeStart(collapsedRange, editor.snapshot.context)
     : undefined
 
   if (!collapsedPoint) {
     return
   }
 
-  const resolvedBlock = getParent(editor, collapsedPoint.path, {
-    match: (node) => isTextBlock({schema: editor.schema}, node),
+  const resolvedBlock = getParent(editor.snapshot, collapsedPoint.path, {
+    match: (node) =>
+      isTextBlock({schema: editor.snapshot.context.schema}, node),
   })
-  const blockIsText = isTextBlock({schema: editor.schema}, block)
+  const blockIsText = isTextBlock(
+    {schema: editor.snapshot.context.schema},
+    block,
+  )
 
   // For `select: 'none'`, the desired restored selection is the collapsed
   // post-delete range (not the original expanded range). Track it through
@@ -651,7 +659,7 @@ function executeDeleteThenInsert(args: {
   }
 
   const containingBlockEntry =
-    resolvedBlock ?? getEnclosingBlock(editor, collapsedPoint.path)
+    resolvedBlock ?? getEnclosingBlock(editor.snapshot, collapsedPoint.path)
 
   if (!containingBlockEntry) {
     return
@@ -689,7 +697,7 @@ function removeAdjacentEmptyTextBlock(args: {
   const {editor, context, insertedPath} = args
 
   for (const direction of ['next', 'previous'] as const) {
-    const sibling = getSibling(editor, insertedPath, {direction})
+    const sibling = getSibling(editor.snapshot, insertedPath, {direction})
     if (sibling && isEmptyTextBlock(context, sibling.node)) {
       editor.apply({type: 'unset', path: sibling.path})
       return
@@ -796,12 +804,12 @@ function insertFragmentChildren(
   block: Node,
   at: Point,
 ): string | undefined {
-  if (!isTextBlock({schema: editor.schema}, block)) {
+  if (!isTextBlock({schema: editor.snapshot.context.schema}, block)) {
     return undefined
   }
 
   if (at.offset > 0) {
-    const textNodeEntry = getSpan(editor, at.path)
+    const textNodeEntry = getSpan(editor.snapshot, at.path)
 
     if (textNodeEntry) {
       applySplitNode(editor, at.path, at.offset)
@@ -813,9 +821,12 @@ function insertFragmentChildren(
 
   if (at.offset === 0 && block.children.length === 1) {
     const firstChild = block.children[0]!
-    const existingEntry = getSpan(editor, at.path)
+    const existingEntry = getSpan(editor.snapshot, at.path)
 
-    if (existingEntry && isSpan({schema: editor.schema}, firstChild)) {
+    if (
+      existingEntry &&
+      isSpan({schema: editor.snapshot.context.schema}, firstChild)
+    ) {
       if (firstChild.text.length > 0) {
         editor.apply({
           type: 'insert_text',

--- a/packages/editor/src/operations/operation.insert.child.ts
+++ b/packages/editor/src/operations/operation.insert.child.ts
@@ -16,14 +16,15 @@ export const insertChildOperationImplementation: OperationImplementation<
   'insert.child'
 > = ({snapshot, operation}) => {
   const {context} = snapshot
-  const focus = operation.editor.selection?.focus
+  const focus = operation.editor.snapshot.context.selection?.focus
 
   if (!focus) {
     throw new Error('Unable to insert child without a focus')
   }
 
-  const focusBlockEntry = getParent(operation.editor, focus.path, {
-    match: (node) => isTextBlock({schema: operation.editor.schema}, node),
+  const focusBlockEntry = getParent(operation.editor.snapshot, focus.path, {
+    match: (node) =>
+      isTextBlock({schema: operation.editor.snapshot.context.schema}, node),
   })
 
   if (!focusBlockEntry) {
@@ -65,19 +66,26 @@ export const insertChildOperationImplementation: OperationImplementation<
   })
 
   if (span) {
-    const focusSpanEntry = getNode(operation.editor, focusChildPath)
+    const focusSpanEntry = getNode(operation.editor.snapshot, focusChildPath)
     const focusSpan =
       focusSpanEntry &&
-      isSpan({schema: operation.editor.schema}, focusSpanEntry.node)
+      isSpan(
+        {schema: operation.editor.snapshot.context.schema},
+        focusSpanEntry.node,
+      )
         ? focusSpanEntry.node
         : undefined
 
     if (focusSpan) {
       applyInsertNodeAtPoint(operation.editor, span, focus)
     } else {
-      const nextSibling = getSibling(operation.editor, focusChildPath, {
-        direction: 'next',
-      })
+      const nextSibling = getSibling(
+        operation.editor.snapshot,
+        focusChildPath,
+        {
+          direction: 'next',
+        },
+      )
       if (nextSibling) {
         applyInsertNodeAtPath(operation.editor, span, nextSibling.path)
       } else {
@@ -92,7 +100,8 @@ export const insertChildOperationImplementation: OperationImplementation<
 
     // This makes sure the selection is set correctly when event handling is run
     // through the engine's Android input handling
-    operation.editor.pendingSelection = operation.editor.selection
+    operation.editor.pendingSelection =
+      operation.editor.snapshot.context.selection
 
     return
   }
@@ -113,19 +122,26 @@ export const insertChildOperationImplementation: OperationImplementation<
       ...rest,
     }
 
-    const focusSpanEntry = getNode(operation.editor, focusChildPath)
+    const focusSpanEntry = getNode(operation.editor.snapshot, focusChildPath)
     const focusSpan =
       focusSpanEntry &&
-      isSpan({schema: operation.editor.schema}, focusSpanEntry.node)
+      isSpan(
+        {schema: operation.editor.snapshot.context.schema},
+        focusSpanEntry.node,
+      )
         ? focusSpanEntry.node
         : undefined
 
     if (focusSpan) {
       applyInsertNodeAtPoint(operation.editor, inlineNode, focus)
     } else {
-      const nextSibling = getSibling(operation.editor, focusChildPath, {
-        direction: 'next',
-      })
+      const nextSibling = getSibling(
+        operation.editor.snapshot,
+        focusChildPath,
+        {
+          direction: 'next',
+        },
+      )
       if (nextSibling) {
         applyInsertNodeAtPath(operation.editor, inlineNode, nextSibling.path)
       } else {

--- a/packages/editor/src/operations/operation.insert.text.ts
+++ b/packages/editor/src/operations/operation.insert.text.ts
@@ -29,7 +29,7 @@ export const insertTextOperationImplementation: OperationImplementation<
   }
 
   // Caret form: resolve position from the current selection.
-  const {selection} = editor
+  const {selection} = editor.snapshot.context
 
   if (!selection || !isCollapsedRange(selection)) {
     return
@@ -37,7 +37,7 @@ export const insertTextOperationImplementation: OperationImplementation<
 
   let {path, offset} = selection.anchor
 
-  const nodeEntry = getNode(editor, path)
+  const nodeEntry = getNode(editor.snapshot, path)
 
   if (!nodeEntry) {
     return
@@ -47,11 +47,13 @@ export const insertTextOperationImplementation: OperationImplementation<
 
   // If the selection is at a non-span leaf (inline object or block object),
   // try to move to the adjacent span.
-  if (isLeafObject(editor, node, nodeEntry.path)) {
-    const nextSibling = getSibling(editor, nodeEntry.path, {direction: 'next'})
+  if (isLeafObject(editor.snapshot, node, nodeEntry.path)) {
+    const nextSibling = getSibling(editor.snapshot, nodeEntry.path, {
+      direction: 'next',
+    })
 
     if (nextSibling) {
-      const nextNodeEntry = getSpan(editor, nextSibling.path)
+      const nextNodeEntry = getSpan(editor.snapshot, nextSibling.path)
 
       if (nextNodeEntry) {
         path = nextSibling.path

--- a/packages/editor/src/operations/operation.select.ts
+++ b/packages/editor/src/operations/operation.select.ts
@@ -16,7 +16,7 @@ export const selectOperationImplementation: OperationImplementation<
     applyDeselect(operation.editor)
   }
 
-  if (operation.editor.focused && operation.editor.readOnly) {
+  if (operation.editor.focused && operation.editor.snapshot.context.readOnly) {
     operation.editor.focused = false
   }
 }

--- a/packages/editor/src/selectors/selector.is-overlapping-selection.ts
+++ b/packages/editor/src/selectors/selector.is-overlapping-selection.ts
@@ -32,7 +32,7 @@ export function isOverlappingSelection(
     }
 
     return rangesOverlap(selection, editorSelection, {
-      children: snapshot.context.value,
+      value: snapshot.context.value,
     })
   }
 }

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -1,7 +1,5 @@
 import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
-import type {Converter} from '../converters/converter.types'
-import type {EditorSchema} from '../editor/editor-schema'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
 import type {DOMEditor} from '../engine/dom/plugin/dom-editor'
@@ -12,7 +10,7 @@ import type {
   SpanConfig,
   TextBlockConfig,
 } from '../renderers/renderer.types'
-import type {Containers, ResolvedContainers} from '../schema/resolve-containers'
+import type {ResolvedContainers} from '../schema/resolve-containers'
 
 type HistoryItem = {
   operations: EngineOperation[]
@@ -35,35 +33,13 @@ export interface PortableTextEditorEngine extends DOMEditor {
   _key: 'editor'
   _type: 'editor'
 
-  schema: EditorSchema
-  keyGenerator: () => string
-  converters: Array<Converter>
-  readOnly: boolean
   containers: ResolvedContainers
-  /**
-   * Narrow {@link Containers} projection of `containers`, exposed on the
-   * public `EditorContext.containers`. Maintained in sync with
-   * `containers` by the editor machine's register/unregister handlers.
-   */
-  publicContainers: Containers
   blockObjects: Map<string, BlockObjectConfig>
   inlineObjects: Map<string, InlineObjectConfig>
   spans: Map<string, SpanConfig>
   textBlocks: Map<string, TextBlockConfig>
 
-  /**
-   * Snapshot-shaped view onto the editor's traversal state. Mirrors the
-   * shape of `EditorSnapshot.context`.
-   */
-  readonly context: {
-    schema: EditorSchema
-    containers: Containers
-    value: PortableTextBlock[]
-    keyGenerator: () => string
-  }
-
   decoratedRanges: Array<DecoratedRange>
-  decoratorState: Record<string, boolean | undefined>
   blockIndexMap: Map<string, number>
   history: History
   listIndexMap: Map<string, number>

--- a/packages/editor/src/utils/util.compare-points.ts
+++ b/packages/editor/src/utils/util.compare-points.ts
@@ -18,7 +18,7 @@ export function comparePoints(
   pointB: EditorSelectionPoint,
 ): -1 | 0 | 1 {
   const pathComparison = comparePaths(pointA.path, pointB.path, {
-    children: snapshot.context.value,
+    value: snapshot.context.value,
   })
 
   if (pathComparison !== 0) {

--- a/packages/editor/tests/tables.test.tsx
+++ b/packages/editor/tests/tables.test.tsx
@@ -460,7 +460,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       // Force normalization with containers set
@@ -529,7 +529,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       withoutPatching(editorEngineRef.current!, () => {
@@ -597,7 +597,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       withoutPatching(editorEngineRef.current!, () => {
@@ -683,7 +683,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       withoutPatching(editorEngineRef.current!, () => {
@@ -759,7 +759,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       withoutPatching(editorEngineRef.current!, () => {
@@ -822,7 +822,7 @@ describe('tables', () => {
 
       editorEngineRef.current!.containers = _resolvedContainers
 
-      editorEngineRef.current!.publicContainers =
+      editorEngineRef.current!.snapshot.context.containers =
         buildPublicContainers(_resolvedContainers)
 
       withoutPatching(editorEngineRef.current!, () => {


### PR DESCRIPTION
Followup to #2717: collapse the engine's dual ownership of snapshot data so `engine.snapshot` is the single source of truth.

Before this PR, the engine carried `containers`, `blockObjects`, `inlineObjects`, `spans`, `textBlocks`, `schema`, `keyGenerator`, `converters`, `readOnly`, `selection`, and `children` as top-level fields, and `engine.snapshot.context` mirrored them. Reads and writes had to keep both views in sync at every reassignment site, with `editor.snapshot.context.value = X as PortableTextBlock[]` casts shadowing every `editor.children = X` write.

This PR physically moves the data onto `engine.snapshot`:

- `engine.context` is a getter alias to `engine.snapshot.context`, so engine code reads through one path.
- `containers`, `blockObjects`, `inlineObjects`, `spans`, and `textBlocks` (the render registries) stay on the engine because they hold render functions and can't be on the public snapshot type.
- Actor xstate context shrinks to control state only: behaviors, pending events, drag state, initial seeds. The engine reads initial seeds at construction; everything else is on the snapshot.
- `editor.children` and `editor.selection` are gone from `BaseEditor`. Engine code reads `editor.snapshot.context.value` and `editor.snapshot.context.selection` directly; operations mutate the same arrays. ~80 internal sites swept.
- Helpers that took an editor-shaped `{children}` (`comparePaths`, `isAfterPath`, range/path utils) now take `{value}`, matching the snapshot's field name. Callers pass `editor.snapshot.context` directly.

`getEditorSnapshot` is gone. `editor.getSnapshot()` returns `editor.snapshot` directly. The actor notification handler bumps the snapshot wrapper identity for `useSyncExternalStore`.

Zero public API change. Single commit, no changeset.