### PR TITLE
refactor: remove `isBlockPath`

### DIFF
--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -2,7 +2,7 @@ import {isTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getParent} from '../traversal/get-parent'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
-import {isBlockPath} from '../types/paths'
+import {getBlock} from '../traversal/is-block'
 import {blockOffsetToSpanSelectionPoint} from '../utils/util.block-offset'
 import {isSelectionExpanded} from '../utils/util.is-selection-expanded'
 import {getFocusSpan} from './selector.get-focus-span'
@@ -38,7 +38,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
 
   let selection = snapshot.context.selection
 
-  if (isBlockPath(selection.anchor.path)) {
+  if (getBlock(snapshot, selection.anchor.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
       snapshot,
       blockOffset: {
@@ -56,7 +56,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
       : selection
   }
 
-  if (isBlockPath(selection.focus.path)) {
+  if (getBlock(snapshot, selection.focus.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
       snapshot,
       blockOffset: {

--- a/packages/editor/src/types/paths.ts
+++ b/packages/editor/src/types/paths.ts
@@ -36,25 +36,6 @@ export type Path = PathSegment[]
 export type BlockPath = Path
 
 /**
- * @public
- */
-export function isBlockPath(path: Path): path is BlockPath {
-  const firstSegment = path.at(0)
-
-  return (
-    path.length === 1 &&
-    firstSegment !== undefined &&
-    isRecord(firstSegment) &&
-    '_key' in firstSegment &&
-    typeof firstSegment._key === 'string'
-  )
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && (typeof value === 'object' || typeof value === 'function')
-}
-
-/**
  * A path to an annotation markDef on a block.
  *
  * @public


### PR DESCRIPTION
Superseded by #2727 — same change but framed as a `fix:` after Christian flagged that the shallow-depth assumption is an actual user-visible bug, not a refactor.