### PR TITLE
fix: `getMarkState` returns marks for selections inside containers

### DIFF
--- a/.changeset/fix-mark-state-in-containers.md
+++ b/.changeset/fix-mark-state-in-containers.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: `getMarkState` returns marks for selections inside containers

--- a/packages/editor/src/selectors/selector.get-mark-state.test.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.test.ts
@@ -2,6 +2,7 @@ import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {resolveTestbedContainers} from '../traversal/node-traversal-testbed'
 import {getMarkState} from './selector.get-mark-state'
 
 describe(getMarkState.name, () => {
@@ -320,6 +321,72 @@ describe(getMarkState.name, () => {
       state: 'changed',
       marks: [],
       previousMarks: [linkKey],
+    })
+  })
+
+  test('Scenario: Caret on a block-rooted selection inside a container', () => {
+    const schema = compileSchema(
+      defineSchema({
+        decorators: [{name: 'strong'}],
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'block',
+                    decorators: [{name: 'strong'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const containers = resolveTestbedContainers(schema, [
+      {kind: 'container', type: 'callout', arrayField: 'content'},
+    ])
+
+    const snapshot = createTestSnapshot({
+      context: {
+        schema,
+        containers,
+        value: [
+          {
+            _type: 'callout',
+            _key: 'c1',
+            content: [
+              {
+                _type: 'block',
+                _key: 'b1',
+                children: [
+                  {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+                ],
+              },
+            ],
+          },
+        ],
+        selection: {
+          anchor: {
+            path: [{_key: 'c1'}, 'content', {_key: 'b1'}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: 'c1'}, 'content', {_key: 'b1'}],
+            offset: 3,
+          },
+          backward: false,
+        },
+      },
+    })
+
+    expect(getMarkState(snapshot)).toEqual({
+      state: 'unchanged',
+      marks: ['strong'],
     })
   })
 })

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -2,7 +2,7 @@ import {isTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getParent} from '../traversal/get-parent'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
-import {isBlockPath} from '../types/paths'
+import {getBlock} from '../traversal/is-block'
 import {blockOffsetToSpanSelectionPoint} from '../utils/util.block-offset'
 import {isSelectionExpanded} from '../utils/util.is-selection-expanded'
 import {getFocusSpan} from './selector.get-focus-span'
@@ -38,7 +38,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
 
   let selection = snapshot.context.selection
 
-  if (isBlockPath(selection.anchor.path)) {
+  if (getBlock(snapshot, selection.anchor.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
       snapshot,
       blockOffset: {
@@ -56,7 +56,7 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
       : selection
   }
 
-  if (isBlockPath(selection.focus.path)) {
+  if (getBlock(snapshot, selection.focus.path)) {
     const spanSelectionPoint = blockOffsetToSpanSelectionPoint({
       snapshot,
       blockOffset: {

--- a/packages/editor/src/types/paths.ts
+++ b/packages/editor/src/types/paths.ts
@@ -36,25 +36,6 @@ export type Path = PathSegment[]
 export type BlockPath = Path
 
 /**
- * @public
- */
-export function isBlockPath(path: Path): path is BlockPath {
-  const firstSegment = path.at(0)
-
-  return (
-    path.length === 1 &&
-    firstSegment !== undefined &&
-    isRecord(firstSegment) &&
-    '_key' in firstSegment &&
-    typeof firstSegment._key === 'string'
-  )
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && (typeof value === 'object' || typeof value === 'function')
-}
-
-/**
  * A path to an annotation markDef on a block.
  *
  * @public


### PR DESCRIPTION
`getMarkState` checked whether the selection point was at a block boundary using `isBlockPath`, which only returned true when `path.length === 1`. Inside a container — e.g. a text block nested under `table.rows[].cells[].content[]` — the path is deeper, the check fell through, and the block-offset never got converted to a span-offset. `getFocusSpan` then couldn't resolve, and `getMarkState` returned `undefined`.

Replaced with `getBlock(snapshot, path)` from `@portabletext/editor/traversal`, which answers the same question at any depth.

The added test exercises a caret on a block-rooted selection inside a callout container and asserts the marks come through.