### PR TITLE
fix: capture inverse data for locally-applied set and unset operations so they can be undone

### DIFF
--- a/.changeset/inverse-data-set-unset.md
+++ b/.changeset/inverse-data-set-unset.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: capture inverse data for locally-applied `set` and `unset` operations so they can be undone

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -5,6 +5,7 @@ import {
 } from '@portabletext/patches'
 import type {PortableTextBlock, PortableTextSpan} from '@portabletext/schema'
 import {isSpan} from '@portabletext/schema'
+import {getValue} from '../../internal-utils/get-value'
 import {safeStringify} from '../../internal-utils/safe-json'
 import {getNode} from '../../traversal/get-node'
 import {getNodes} from '../../traversal/get-nodes'
@@ -157,6 +158,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
     case 'set': {
       const {path, value} = op
 
+      if (!op.inverse && !editor.isProcessingRemoteChanges) {
+        const previousValue = getValue(editor.snapshot.context.value, path)
+        op.inverse =
+          previousValue === undefined
+            ? {type: 'unset', path}
+            : {type: 'set', path, value: previousValue}
+      }
+
       // Root-level value replacement: set editor.snapshot.context.value directly
       if (path.length === 0) {
         if (Array.isArray(value)) {
@@ -275,6 +284,13 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
       // Root-level unset: remove all children
       if (path.length === 0) {
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          op.inverse = {
+            type: 'set',
+            path,
+            value: editor.snapshot.context.value,
+          }
+        }
         editor.snapshot.context.value = []
         editor.blockIndexMap.clear()
         transformSelection = true
@@ -415,6 +431,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
       if (unsetPropertyPath.length === 0 || unsetNodePath.length === 0) {
         break
+      }
+
+      if (!op.inverse && !editor.isProcessingRemoteChanges) {
+        const previousValue = getValue(editor.snapshot.context.value, path)
+        if (previousValue === undefined) {
+          break
+        }
+        op.inverse = {type: 'set', path, value: previousValue}
       }
 
       // Check if the node path resolves to a known node

--- a/packages/editor/tests/event.set.test.tsx
+++ b/packages/editor/tests/event.set.test.tsx
@@ -36,4 +36,307 @@ describe('event.set', () => {
       ])
     })
   })
+
+  test('Scenario: undo a set on a block property', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        styles: [{name: 'normal'}, {name: 'h1'}],
+      }),
+      initialValue,
+    })
+
+    editor.send({type: 'set', at: [{_key: 'b0'}, 'style'], value: 'h1'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'h1',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo a set that creates a new block property', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue,
+    })
+
+    editor.send({type: 'set', at: [{_key: 'b0'}, 'listItem'], value: 'bullet'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          listItem: 'bullet',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo a set on a markDef property', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: ['m0']}],
+        markDefs: [{_key: 'm0', _type: 'link', href: 'https://a.com'}],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'set',
+      at: [{_key: 'b0'}, 'markDefs', {_key: 'm0'}, 'href'],
+      value: 'https://b.com',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: ['m0']}],
+          markDefs: [{_key: 'm0', _type: 'link', href: 'https://b.com'}],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo a full-block replacement', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'set',
+      at: [{_key: 'b0'}],
+      value: {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's1', _type: 'span', text: 'NEW', marks: []}],
+        markDefs: [],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's1', _type: 'span', text: 'NEW', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo a root-level value replacement', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const replacement = [
+      {
+        _key: 'b1',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's1', _type: 'span', text: 'NEW', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    editor.send({type: 'set', at: [], value: replacement})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(replacement)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test("Scenario: undo a set of a container's children array to []", async () => {
+    const initialValue = [
+      {
+        _key: 't0',
+        _type: 'table',
+        rows: [
+          {
+            _key: 'r0',
+            _type: 'row',
+            cells: [
+              {
+                _key: 'c0',
+                _type: 'cell',
+                content: [
+                  {
+                    _key: 'b0',
+                    _type: 'block',
+                    style: 'normal',
+                    children: [
+                      {_key: 's0', _type: 'span', text: 'foo', marks: []},
+                    ],
+                    markDefs: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'set',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells'],
+      value: [],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 't0',
+          _type: 'table',
+          rows: [{_key: 'r0', _type: 'row', cells: []}],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
 })

--- a/packages/editor/tests/event.unset.test.tsx
+++ b/packages/editor/tests/event.unset.test.tsx
@@ -1,6 +1,8 @@
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema} from '../src'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('event.unset', () => {
@@ -77,6 +79,435 @@ describe('event.unset', () => {
           markDefs: [],
         },
       ])
+    })
+  })
+
+  test('Scenario: undo an unset of a property on a block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        listItem: 'bullet',
+        level: 1,
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        styles: [{name: 'normal'}],
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue,
+    })
+
+    editor.send({type: 'unset', at: [{_key: 'b0'}, 'level']})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          listItem: 'bullet',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo an unset that removes a node from an array', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [
+          {_key: 's0', _type: 'span', text: 'foo', marks: []},
+          {_key: 's1', _type: 'span', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'unset',
+      at: [{_key: 'b0'}, 'children', {_key: 's1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo an unset of a nested property', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [
+          {
+            _key: 's0',
+            _type: 'span',
+            text: 'foo',
+            marks: ['m0'],
+          },
+        ],
+        markDefs: [{_key: 'm0', _type: 'link', href: 'https://example.com'}],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'unset',
+      at: [{_key: 'b0'}, 'markDefs', {_key: 'm0'}, 'href'],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: ['m0']}],
+          markDefs: [{_key: 'm0', _type: 'link'}],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test("Scenario: undo an unset of a container's children array clears + restores", async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [
+      {
+        _key: 't0',
+        _type: 'table',
+        rows: [
+          {
+            _key: 'r0',
+            _type: 'row',
+            cells: [
+              {
+                _key: 'c0',
+                _type: 'cell',
+                content: [
+                  {
+                    _key: 'b0',
+                    _type: 'block',
+                    style: 'normal',
+                    children: [
+                      {_key: 's0', _type: 'span', text: 'foo', marks: []},
+                    ],
+                    markDefs: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue,
+    })
+
+    editor.send({
+      type: 'unset',
+      at: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+        'content',
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 't0',
+          _type: 'table',
+          rows: [
+            {
+              _key: 'r0',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'c0',
+                  _type: 'cell',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test("Scenario: undo an unset of a container's children array works with containers registered", async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue = [
+      {
+        _key: 't0',
+        _type: 'table',
+        rows: [
+          {
+            _key: 'r0',
+            _type: 'row',
+            cells: [
+              {
+                _key: 'c0',
+                _type: 'cell',
+                content: [
+                  {
+                    _key: 'b0',
+                    _type: 'block',
+                    style: 'normal',
+                    children: [
+                      {_key: 's0', _type: 'span', text: 'foo', marks: []},
+                    ],
+                    markDefs: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      render: ({children}) => <>{children}</>,
+      of: [
+        defineContainer({
+          type: 'row',
+          arrayField: 'cells',
+          render: ({children}) => <>{children}</>,
+          of: [
+            defineContainer({
+              type: 'cell',
+              arrayField: 'content',
+              render: ({children}) => <>{children}</>,
+            }),
+          ],
+        }),
+      ],
+    })
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue,
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    editor.send({
+      type: 'unset',
+      at: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+        'content',
+      ],
+    })
+
+    // Normalization repopulates the cell with a single empty text block.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 't0',
+          _type: 'table',
+          rows: [
+            {
+              _key: 'r0',
+              _type: 'row',
+              cells: [
+                {
+                  _key: 'c0',
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: 'k2',
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_key: 'k3', _type: 'span', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: undo an unset at the root level', async () => {
+    const initialValue = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        style: 'normal',
+        children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    editor.send({type: 'unset', at: []})
+
+    // Normalization re-emits an empty block after the root unset. Wait for the
+    // event chain to settle before triggering undo.
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })
   })
 })


### PR DESCRIPTION
Local `set` and `unset` operations whose `op.inverse` field never got populated would throw `Cannot invert <op> operation without inverse data` on `history.undo`. The `history.undo` plugin catches that throw and clears the entire undo stack as a side effect — so a single botched undo would wipe everything before it.

This was the case for:

- `set` on the root value (`at: []`)
- `set` on a full block (`at: [{_key:'b0'}]`)
- `set` on a block property (`at: [{_key:'b0'}, 'style']`) — both for existing-property changes and new-property creates
- `set` on a markDef property (`at: [{_key:'b0'}, 'markDefs', {_key:'m0'}, 'href']`)
- `set` on the markDefs / else fallback path (block resolved by key, node not found)
- `unset` on the root value (`at: []`)
- `unset` on a block property (`at: [{_key:'b0'}, 'style']`)
- `unset` on a nested property (`at: [{_key:'b0'}, 'markDefs', {_key:'m0'}, 'href']`)
- `unset` of a container's children array (`at: [{_key:'b0'}, 'cells']`) — both with and without container registration

`set` and `unset` of a keyed/numeric array member already populate their own richer inverse (with `node`, `position`, `value` for `unset`) and are unchanged.

The fix lifts inverse capture to a single preamble at the top of each case in `apply-operation.ts`. Before mutating, read `getValue(snapshot.value, path)`; assign `op.inverse = {type: 'set', path, value: previousValue}` when the value exists, or `{type: 'unset', path}` when it doesn't (so undoing a property-create unsets it cleanly). The `unset` preamble skips keyed/numeric tails — the node-removal branch below still populates its own inverse.

Falsifying tests for every branch in `event.set.test.tsx` and `event.unset.test.tsx`. Each scenario applies the op, asserts post-state, then asserts that `history.undo` restores the initial value.