### PR TITLE
docs: tell consumers to stabilize `BehaviorPlugin`'s `behaviors` array

### DIFF
--- a/packages/editor/src/plugins/plugin.behavior.tsx
+++ b/packages/editor/src/plugins/plugin.behavior.tsx
@@ -4,6 +4,13 @@ import {useEditor} from '../editor/use-editor'
 
 /**
  * @beta
+ *
+ * Plugin component that registers a list of `Behavior`s with the editor.
+ *
+ * Stabilize the `behaviors` array (a module-level constant or `useMemo`)
+ * to avoid a full unregister/re-register cycle on every parent render: a
+ * new array reference per render triggers the registration effect to
+ * re-run.
  */
 export function BehaviorPlugin(props: {behaviors: Array<Behavior>}) {
   const editor = useEditor()


### PR DESCRIPTION
From end-user feedback: a consumer hit a real footgun passing a fresh array literal as `BehaviorPlugin`'s `behaviors` prop. The registration effect re-ran on every parent render — unregistering then re-registering every behavior — and because `editor.registerBehavior` mints a fresh priority cookie per call, this also rebuilt the priority-sorted behavior list inside the actor on each render.

`NodePlugin` already documents the same requirement for its `nodes` prop:

> Stabilize the `nodes` array (a module-level constant or `useMemo`) to avoid a full unregister/re-register cycle on every parent render: a new array reference per render triggers the registration effect to re-run.

`BehaviorPlugin` had the identical effect dependency but no warning. This matches the convention.