### PR TITLE
test: add a container Enter escape scenario for a list inside a container

### DIFF
--- a/packages/editor/tests/container-enter-escape.test.tsx
+++ b/packages/editor/tests/container-enter-escape.test.tsx
@@ -25,6 +25,28 @@ const codeBlockContainer = defineContainer({
   ),
 })
 
+const calloutSchema = defineSchema({
+  lists: [{name: 'bullet'}, {name: 'number'}],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+      ],
+    },
+  ],
+})
+
+const calloutContainer = defineContainer({
+  type: 'callout',
+  arrayField: 'content',
+  render: ({children}) => <>{children}</>,
+})
+
 describe('container Enter escape', () => {
   test('Scenario: Enter on empty last line with empty previous sibling escapes to editor root', async () => {
     const keyGenerator = createTestKeyGenerator()
@@ -237,6 +259,138 @@ describe('container Enter escape', () => {
               style: 'normal',
             },
           ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Enter on empty trailing list item clears the list marker before container-escape kicks in', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const item1Key = keyGenerator()
+    const span1Key = keyGenerator()
+    const item2Key = keyGenerator()
+    const span2Key = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: item1Key,
+              children: [
+                {_type: 'span', _key: span1Key, text: 'First item', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'bullet',
+              level: 1,
+            },
+            {
+              _type: 'block',
+              _key: item2Key,
+              children: [{_type: 'span', _key: span2Key, text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'bullet',
+              level: 1,
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[calloutContainer]} />,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: item2Key},
+            'children',
+            {_key: span2Key},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: item2Key},
+            'children',
+            {_key: span2Key},
+          ],
+          offset: 0,
+        },
+      },
+    })
+
+    editor.send({type: 'insert.break'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: item1Key,
+              children: [
+                {_type: 'span', _key: span1Key, text: 'First item', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'bullet',
+              level: 1,
+            },
+            {
+              _type: 'block',
+              _key: item2Key,
+              children: [{_type: 'span', _key: span2Key, text: '', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'insert.break'})
+    editor.send({type: 'insert.break'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: calloutKey,
+          content: [
+            {
+              _type: 'block',
+              _key: item1Key,
+              children: [
+                {_type: 'span', _key: span1Key, text: 'First item', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+              listItem: 'bullet',
+              level: 1,
+            },
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'k9',
+          children: [{_type: 'span', _key: 'k10', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
         },
       ])
     })


### PR DESCRIPTION
Captures the existing canonical 3-Enter sequence for escaping a list inside a container as a regression test:

1. Enter on the empty trailing list item — `clearListOnEnter` clears the marker, the item becomes an empty plain paragraph still inside the container.
2. Enter again — focus is an empty plain block with a non-empty bullet sibling above, neither `breakingOutOfContainer` (needs previous-empty) nor `clearListOnEnter` (needs a list item) match, the default `insert.break` inserts a fresh empty paragraph after.
3. Enter once more — focus and previous are both empty trailing paragraphs, `breakingOutOfContainer` matches and escapes, landing a fresh block after the container with the original list item intact.

The scenario lives alongside the two existing `container Enter escape` scenarios as a third sibling.