### PR TITLE
feat: catch-all '*' registration for blockObject, inlineObject, textBlock, span

### DIFF
--- a/.changeset/catch-all-registration.md
+++ b/.changeset/catch-all-registration.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: catch-all node registration via `'*'` for `defineBlockObject`, `defineInlineObject`, `defineTextBlock`, and `defineSpan`
+
+Pass `type: '*'` to register a render callback that handles any `_type` that has no specific registration. A single `defineBlockObject({type: '*', render})` plays the role of the legacy `renderBlock` callback; `defineTextBlock({type: '*', render})` plays the same role for text blocks; `defineInlineObject({type: '*', render})` and `defineSpan({type: '*', render})` mirror `renderChild`.
+
+Resolution order (most specific wins):
+
+1. Positional registration for the exact `_type` (inside a container's `of`)
+2. Positional `'*'` (inside a container's `of`)
+3. Global registration for the exact `_type`
+4. Global `'*'`
+5. Engine default
+
+`defineContainer` does not accept `'*'` — a container is a structural commitment that the editor needs to know about up front. Trying to do so is a compile-time error.

--- a/packages/editor/src/editor/find-positional-override.ts
+++ b/packages/editor/src/editor/find-positional-override.ts
@@ -18,7 +18,7 @@ export function findBlockPositionalOverride(
   if (!parentConfig?.of) {
     return undefined
   }
-  return parentConfig.of.find((entry) => {
+  const specific = parentConfig.of.find((entry) => {
     if ('container' in entry) {
       return entry.container.type === type
     }
@@ -26,6 +26,19 @@ export function findBlockPositionalOverride(
       return entry.textBlock.type === type
     }
     return entry.blockObject.type === type
+  })
+  if (specific) {
+    return specific
+  }
+  // Catch-all fallback. Containers are not eligible for `'*'`.
+  return parentConfig.of.find((entry) => {
+    if ('container' in entry) {
+      return false
+    }
+    if ('textBlock' in entry) {
+      return entry.textBlock.type === '*'
+    }
+    return entry.blockObject.type === '*'
   })
 }
 
@@ -41,10 +54,19 @@ export function findInlinePositionalOverride(
   if (!parentTextBlock?.of) {
     return undefined
   }
-  return parentTextBlock.of.find((entry) => {
+  const specific = parentTextBlock.of.find((entry) => {
     if ('span' in entry) {
       return entry.span.type === type
     }
     return entry.inlineObject.type === type
+  })
+  if (specific) {
+    return specific
+  }
+  return parentTextBlock.of.find((entry) => {
+    if ('span' in entry) {
+      return entry.span.type === '*'
+    }
+    return entry.inlineObject.type === '*'
   })
 }

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -36,27 +36,7 @@ import {
   useIsFocusedContainer,
   useIsSelectedContainer,
 } from './selection-state-context'
-
-/**
- * Reference-equality comparator for fixed-length tuples. Each slot is
- * compared via `Object.is`; the tuple is considered equal when every
- * slot's reference is unchanged. Lets a multi-slot `useSelector` skip
- * re-renders unless one of the slots actually changes.
- */
-function tupleRefEqual<T extends readonly unknown[]>(
-  previous: T | null,
-  next: T,
-): boolean {
-  if (previous === null || previous.length !== next.length) {
-    return false
-  }
-  for (let i = 0; i < previous.length; i++) {
-    if (!Object.is(previous[i], next[i])) {
-      return false
-    }
-  }
-  return true
-}
+import {tupleRefEqual} from './tuple-ref-equal'
 
 export function RenderElement(props: {
   attributes: RenderElementProps['attributes']
@@ -96,16 +76,22 @@ export function RenderElement(props: {
   const [
     globalContainerConfig,
     globalBlockObjectConfig,
+    globalBlockObjectCatchAll,
     globalInlineObjectConfig,
+    globalInlineObjectCatchAll,
     textBlockConfig,
+    textBlockCatchAll,
   ] = useEngineSelector(
     useCallback(
       (engine) =>
         [
           engine.containers.get(type),
           engine.blockObjects.get(type),
+          engine.blockObjects.get('*'),
           engine.inlineObjects.get(type),
+          engine.inlineObjects.get('*'),
           engine.textBlocks.get(type),
+          engine.textBlocks.get('*'),
         ] as const,
       [type],
     ),
@@ -136,8 +122,8 @@ export function RenderElement(props: {
     if (blockPositionalOverride && 'textBlock' in blockPositionalOverride) {
       return blockPositionalOverride
     }
-    return textBlockConfig
-  }, [blockPositionalOverride, textBlockConfig])
+    return textBlockConfig ?? textBlockCatchAll
+  }, [blockPositionalOverride, textBlockConfig, textBlockCatchAll])
 
   // Resolve which text-block config (if any) supplies a `render` at
   // this position. Mirrors the shape used by `containerConfig` /
@@ -147,28 +133,32 @@ export function RenderElement(props: {
   const renderableTextBlockConfig = useMemo<TextBlockConfig | undefined>(() => {
     if (blockPositionalOverride && 'textBlock' in blockPositionalOverride) {
       if (blockPositionalOverride.textBlock.render === undefined) {
-        return textBlockConfig
+        return textBlockConfig ?? textBlockCatchAll
       }
       return blockPositionalOverride
     }
-    return textBlockConfig
-  }, [blockPositionalOverride, textBlockConfig])
+    return textBlockConfig ?? textBlockCatchAll
+  }, [blockPositionalOverride, textBlockConfig, textBlockCatchAll])
 
   const blockObjectConfig = useMemo<BlockObjectConfig | undefined>(() => {
     if (blockPositionalOverride && 'blockObject' in blockPositionalOverride) {
       // Positional undefined render falls through to global; function
       // render is used at this position.
       if (blockPositionalOverride.blockObject.render === undefined) {
-        // Fall through to global.
-        return globalBlockObjectConfig
+        return globalBlockObjectConfig ?? globalBlockObjectCatchAll
       }
       return blockPositionalOverride
     }
     if (containerConfig) {
       return undefined
     }
-    return globalBlockObjectConfig
-  }, [blockPositionalOverride, globalBlockObjectConfig, containerConfig])
+    return globalBlockObjectConfig ?? globalBlockObjectCatchAll
+  }, [
+    blockPositionalOverride,
+    globalBlockObjectConfig,
+    globalBlockObjectCatchAll,
+    containerConfig,
+  ])
 
   // Inline-object positional override comes from the parent TEXT
   // BLOCK's `of`, not the parent container's.
@@ -178,15 +168,20 @@ export function RenderElement(props: {
       'inlineObject' in inlinePositionalOverride
     ) {
       if (inlinePositionalOverride.inlineObject.render === undefined) {
-        return globalInlineObjectConfig
+        return globalInlineObjectConfig ?? globalInlineObjectCatchAll
       }
       return inlinePositionalOverride
     }
     if (containerConfig) {
       return undefined
     }
-    return globalInlineObjectConfig
-  }, [inlinePositionalOverride, globalInlineObjectConfig, containerConfig])
+    return globalInlineObjectConfig ?? globalInlineObjectCatchAll
+  }, [
+    inlinePositionalOverride,
+    globalInlineObjectConfig,
+    globalInlineObjectCatchAll,
+    containerConfig,
+  ])
 
   if (containerConfig) {
     return (

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -9,6 +9,7 @@ import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
 import type {SpanConfig} from '../renderers/renderer.types'
 import {findInlinePositionalOverride} from './find-positional-override'
 import {ParentTextBlockContext} from './parent-text-block-context'
+import {tupleRefEqual} from './tuple-ref-equal'
 
 /**
  * Hook: resolve the registered span config for the span at `node`, or
@@ -27,16 +28,21 @@ export function useSpanConfig(
 ): SpanConfig | undefined {
   const parentTextBlock = useContext(ParentTextBlockContext)
   const positional = findInlinePositionalOverride(parentTextBlock, node._type)
-  const globalSpan = useEngineSelector(
-    useCallback((engine) => engine.spans.get(node._type), [node._type]),
+  const [globalSpan, globalSpanCatchAll] = useEngineSelector(
+    useCallback(
+      (engine) =>
+        [engine.spans.get(node._type), engine.spans.get('*')] as const,
+      [node._type],
+    ),
+    tupleRefEqual,
   )
   if (positional && 'span' in positional) {
     // Positional present: undefined render falls through to global;
     // function render is used at this position.
     if (positional.span.render === undefined) {
-      return globalSpan
+      return globalSpan ?? globalSpanCatchAll
     }
     return positional
   }
-  return globalSpan
+  return globalSpan ?? globalSpanCatchAll
 }

--- a/packages/editor/src/editor/tuple-ref-equal.ts
+++ b/packages/editor/src/editor/tuple-ref-equal.ts
@@ -1,0 +1,20 @@
+/**
+ * Reference-equality comparator for fixed-length tuples. Each slot is
+ * compared via `Object.is`; the tuple is considered equal when every
+ * slot's reference is unchanged. Lets a multi-slot `useSelector` skip
+ * re-renders unless one of the slots actually changes.
+ */
+export function tupleRefEqual<T extends readonly unknown[]>(
+  previous: T | null,
+  next: T,
+): boolean {
+  if (previous === null || previous.length !== next.length) {
+    return false
+  }
+  for (let i = 0; i < previous.length; i++) {
+    if (!Object.is(previous[i], next[i])) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/editor/src/engine/react/hooks/use-children.tsx
+++ b/packages/editor/src/engine/react/hooks/use-children.tsx
@@ -242,7 +242,7 @@ const useChildren = (props: {
       return true
     }
     if (isTextBlock({schema: editor.snapshot.context.schema}, n)) {
-      if (editor.textBlocks.has(n._type)) {
+      if (editor.textBlocks.has(n._type) || editor.textBlocks.has('*')) {
         return true
       }
       if (parentContainer?.of) {
@@ -265,7 +265,7 @@ const useChildren = (props: {
         return false
       }
       // Block object position
-      if (editor.blockObjects.has(n._type)) {
+      if (editor.blockObjects.has(n._type) || editor.blockObjects.has('*')) {
         return true
       }
       if (parentContainer?.of) {

--- a/packages/editor/src/renderers/renderer.types.test-d.ts
+++ b/packages/editor/src/renderers/renderer.types.test-d.ts
@@ -1,0 +1,28 @@
+import {describe, expectTypeOf, test} from 'vitest'
+import type {defineContainer} from './renderer.types'
+
+describe('defineContainer type guards', () => {
+  test("forbids type: '*'", () => {
+    expectTypeOf<
+      Parameters<typeof defineContainer<'*'>>[0]['type']
+    >().toEqualTypeOf<"Error: defineContainer({type: '*'}) is forbidden -- containers cannot be registered by wildcard">()
+  })
+
+  test("forbids type: 'span'", () => {
+    expectTypeOf<
+      Parameters<typeof defineContainer<'span'>>[0]['type']
+    >().toEqualTypeOf<"Error: defineContainer({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan">()
+  })
+
+  test("forbids type: 'block'", () => {
+    expectTypeOf<
+      Parameters<typeof defineContainer<'block'>>[0]['type']
+    >().toEqualTypeOf<"Error: defineContainer({type: 'block'}) is forbidden -- 'block' is always a text block, use defineTextBlock">()
+  })
+
+  test('accepts other string literal types', () => {
+    expectTypeOf<
+      Parameters<typeof defineContainer<'callout'>>[0]['type']
+    >().toEqualTypeOf<'callout'>()
+  })
+})

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -331,7 +331,9 @@ export function defineContainer<const TType extends string>(config: {
     ? "Error: defineContainer({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan"
     : TType extends 'block'
       ? "Error: defineContainer({type: 'block'}) is forbidden -- 'block' is always a text block, use defineTextBlock"
-      : TType
+      : TType extends '*'
+        ? "Error: defineContainer({type: '*'}) is forbidden -- containers cannot be registered by wildcard"
+        : TType
   arrayField: string
   render?: (props: {
     attributes: Record<string, unknown>

--- a/packages/editor/tests/catch-all-registration.test.tsx
+++ b/packages/editor/tests/catch-all-registration.test.tsx
@@ -1,0 +1,668 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineContainer,
+  defineInlineObject,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const calloutSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {
+          name: 'content',
+          type: 'array',
+          of: [{type: 'block'}, {type: 'image'}, {type: 'video'}],
+        },
+      ],
+    },
+    {name: 'image'},
+    {name: 'video'},
+  ],
+})
+
+const mentionSchema = defineSchema({
+  inlineObjects: [{name: 'mention'}, {name: 'emoji'}],
+})
+
+describe('catch-all registration: global blockObject', () => {
+  test('blockObject catch-all catches an unregistered top-level block-object type', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [{_type: 'image', _key: 'k0'}],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div
+                  data-testid={`fallback-${node._type}`}
+                  data-fallback="block"
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const fallback = document.querySelector('[data-testid="fallback-image"]')
+      expect(fallback).not.toEqual(null)
+      expect(fallback!.getAttribute('data-fallback')).toEqual('block')
+    })
+  })
+
+  test('specific-type registration wins over blockObject catch-all', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {_type: 'image', _key: 'k0'},
+        {_type: 'video', _key: 'k1'},
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineBlockObject({
+              type: 'image',
+              render: ({attributes, children}) => (
+                <div data-testid="specific-image" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div data-testid={`fallback-${node._type}`} {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="specific-image"]'),
+      ).not.toEqual(null)
+      expect(
+        document.querySelector('[data-testid="fallback-video"]'),
+      ).not.toEqual(null)
+      expect(document.querySelector('[data-testid="fallback-image"]')).toEqual(
+        null,
+      )
+    })
+  })
+
+  test('blockObject catch-all catches unregistered types inside a registered container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div data-testid={`fallback-${node._type}`} {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      const fallback = callout!.querySelector('[data-testid="fallback-image"]')
+      expect(fallback).not.toEqual(null)
+    })
+  })
+})
+
+describe('catch-all registration: global inlineObject', () => {
+  test('inlineObject catch-all catches an unregistered inline-object type', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: mentionSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 's0', text: 'Hi ', marks: []},
+            {_type: 'mention', _key: 'm0'},
+            {_type: 'span', _key: 's1', text: '!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: 'block',
+              render: ({attributes, children}) => (
+                <p data-testid="text-block" {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
+            defineInlineObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <span
+                  data-testid={`fallback-inline-${node._type}`}
+                  {...attributes}
+                >
+                  {children}
+                </span>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const fallback = document.querySelector(
+        '[data-testid="fallback-inline-mention"]',
+      )
+      expect(fallback).not.toEqual(null)
+    })
+  })
+})
+
+describe('catch-all registration: global textBlock', () => {
+  test('textBlock catch-all renders text blocks inside a container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b0',
+              children: [{_type: 'span', _key: 's0', text: 'hello', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <p data-testid={`fallback-text-${node._type}`} {...attributes}>
+                  {children}
+                </p>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      const fallback = callout!.querySelector(
+        '[data-testid="fallback-text-block"]',
+      )
+      expect(fallback).not.toEqual(null)
+      expect(fallback!.textContent).toContain('hello')
+    })
+  })
+})
+
+describe('catch-all registration: positional', () => {
+  test('positional catch-all inside a container catches unregistered child types', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: '*',
+                  render: ({attributes, children, node}) => (
+                    <div
+                      data-testid={`positional-${node._type}`}
+                      {...attributes}
+                    >
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      const positional = callout!.querySelector(
+        '[data-testid="positional-image"]',
+      )
+      expect(positional).not.toEqual(null)
+    })
+  })
+
+  test('positional catch-all beats global specific-type registration', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: '*',
+                  render: ({attributes, children, node}) => (
+                    <div
+                      data-testid={`positional-${node._type}`}
+                      {...attributes}
+                    >
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+            defineBlockObject({
+              type: 'image',
+              render: ({attributes, children}) => (
+                <div data-testid="global-image" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-image"]'),
+      ).not.toEqual(null)
+      expect(callout!.querySelector('[data-testid="global-image"]')).toEqual(
+        null,
+      )
+    })
+  })
+
+  test('positional specific-type beats positional catch-all', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {_type: 'image', _key: 'i0'},
+            {_type: 'video', _key: 'v0'},
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: 'image',
+                  render: ({attributes, children}) => (
+                    <div
+                      data-testid="positional-image-specific"
+                      {...attributes}
+                    >
+                      {children}
+                    </div>
+                  ),
+                }),
+                defineBlockObject({
+                  type: '*',
+                  render: ({attributes, children, node}) => (
+                    <div
+                      data-testid={`positional-fallback-${node._type}`}
+                      {...attributes}
+                    >
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-image-specific"]'),
+      ).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-fallback-video"]'),
+      ).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-fallback-image"]'),
+      ).toEqual(null)
+    })
+  })
+})
+
+describe('catch-all registration: cross-rung precedence', () => {
+  test('positional specific beats global catch-all for the same type', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: 'image',
+                  render: ({attributes, children}) => (
+                    <div data-testid="positional-image" {...attributes}>
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div
+                  data-testid={`global-catch-all-${node._type}`}
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-image"]'),
+      ).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="global-catch-all-image"]'),
+      ).toEqual(null)
+    })
+  })
+
+  test('positional specific beats global specific for the same type', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: 'image',
+                  render: ({attributes, children}) => (
+                    <div data-testid="positional-image" {...attributes}>
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+            defineBlockObject({
+              type: 'image',
+              render: ({attributes, children}) => (
+                <div data-testid="global-image" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-image"]'),
+      ).not.toEqual(null)
+      expect(callout!.querySelector('[data-testid="global-image"]')).toEqual(
+        null,
+      )
+    })
+  })
+
+  test('all four rungs present: positional specific wins', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutSchema,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [{_type: 'image', _key: 'i0'}],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'callout',
+              arrayField: 'content',
+              render: ({attributes, children}) => (
+                <div data-testid="callout" {...attributes}>
+                  {children}
+                </div>
+              ),
+              of: [
+                defineBlockObject({
+                  type: 'image',
+                  render: ({attributes, children}) => (
+                    <div data-testid="positional-image" {...attributes}>
+                      {children}
+                    </div>
+                  ),
+                }),
+                defineBlockObject({
+                  type: '*',
+                  render: ({attributes, children, node}) => (
+                    <div
+                      data-testid={`positional-catch-all-${node._type}`}
+                      {...attributes}
+                    >
+                      {children}
+                    </div>
+                  ),
+                }),
+              ],
+            }),
+            defineBlockObject({
+              type: 'image',
+              render: ({attributes, children}) => (
+                <div data-testid="global-image" {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div
+                  data-testid={`global-catch-all-${node._type}`}
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const callout = document.querySelector('[data-testid="callout"]')
+      expect(callout).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-image"]'),
+      ).not.toEqual(null)
+      expect(
+        callout!.querySelector('[data-testid="positional-catch-all-image"]'),
+      ).toEqual(null)
+      expect(callout!.querySelector('[data-testid="global-image"]')).toEqual(
+        null,
+      )
+      expect(
+        callout!.querySelector('[data-testid="global-catch-all-image"]'),
+      ).toEqual(null)
+    })
+  })
+})


### PR DESCRIPTION
Registers a fallback renderer for any unregistered `_type` via `type: '*'` on `defineBlockObject`, `defineInlineObject`, `defineTextBlock`, or `defineSpan`.

Resolution order (highest priority first):

1. Positional `of` registration for this `_type`
2. Positional `of` registration for `'*'`
3. Engine global registration for this `_type`
4. Engine global registration for `'*'`
5. Engine default

`defineContainer` does not accept `'*'` — wildcarding structural commitments would change editing semantics unpredictably.

Eight TDD scenarios in `tests/catch-all-registration.test.tsx` pin the contract.