### PR TITLE
fix: skip no-op operations from history capture

### DIFF
--- a/.changeset/skip-no-op-history-capture.md
+++ b/.changeset/skip-no-op-history-capture.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: skip no-op operations from history capture

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -1,6 +1,6 @@
 import type {Operation} from '../engine/interfaces/operation'
+import type {Range} from '../engine/interfaces/range'
 import {pathEquals} from '../engine/path/path-equals'
-import type {PortableTextEditorEngine} from '../types/editor-engine'
 
 type UndoStep = {
   operations: Array<Operation>
@@ -10,30 +10,35 @@ type UndoStep = {
 export function createUndoSteps({
   steps,
   op,
-  editor,
   currentUndoStepId,
   previousUndoStepId,
+  operationsInProgress,
+  isNormalizingNode,
+  selectionBeforeApply,
 }: {
   steps: Array<UndoStep>
   op: Operation
-  editor: PortableTextEditorEngine
   currentUndoStepId: string | undefined
   previousUndoStepId: string | undefined
+  /** Snapshots of pre-apply editor state — volatile during apply. */
+  operationsInProgress: boolean
+  isNormalizingNode: boolean
+  selectionBeforeApply: Range | null
 }): Array<UndoStep> {
   const lastStep = steps.at(-1)
 
   if (!lastStep) {
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
-  if (editor.operations.length > 0) {
-    // The editor has operations in progress
+  if (operationsInProgress) {
+    // The editor had operations in progress when apply started.
 
-    if (currentUndoStepId === previousUndoStepId || editor.isNormalizingNode) {
+    if (currentUndoStepId === previousUndoStepId || isNormalizingNode) {
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
   if (
@@ -84,7 +89,7 @@ export function createUndoSteps({
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
-    return createNewStep(steps, op, editor)
+    return createNewStep(steps, op, selectionBeforeApply)
   }
 
   // Handle case when both IDs are defined but different (e.g., consecutive
@@ -118,22 +123,22 @@ export function createUndoSteps({
     }
   }
 
-  return createNewStep(steps, op, editor)
+  return createNewStep(steps, op, selectionBeforeApply)
 }
 
 function createNewStep(
   steps: Array<UndoStep>,
   op: Operation,
-  editor: PortableTextEditorEngine,
+  selectionBeforeApply: Range | null,
 ): Array<UndoStep> {
   const operations =
-    editor.snapshot.context.selection === null
+    selectionBeforeApply === null
       ? [op]
       : [
           {
             type: 'set_selection' as const,
-            properties: {...editor.snapshot.context.selection},
-            newProperties: {...editor.snapshot.context.selection},
+            properties: {...selectionBeforeApply},
+            newProperties: {...selectionBeforeApply},
           },
           op,
         ]

--- a/packages/editor/src/engine-plugins/engine-plugin.history.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.history.ts
@@ -99,6 +99,24 @@ export function createHistoryPlugin({
         return
       }
 
+      // Snapshot pre-apply state — these fields are all volatile during apply.
+      const operationsInProgress = editor.operations.length > 0
+      const isNormalizingNode = editor.isNormalizingNode
+      const selectionBeforeApply = editor.snapshot.context.selection
+
+      apply(op)
+
+      const isNoOp =
+        ((op.type === 'set' || op.type === 'unset' || op.type === 'insert') &&
+          !op.inverse) ||
+        ((op.type === 'insert_text' || op.type === 'remove_text') &&
+          op.text.length === 0)
+
+      if (isNoOp) {
+        previousUndoStepId = currentUndoStepId
+        return
+      }
+
       if (op.type !== 'set_selection') {
         // Clear the redo steps if any actual changes are made
         if (editor.history.redos.length > 0) {
@@ -109,9 +127,11 @@ export function createHistoryPlugin({
       editor.history.undos = createUndoSteps({
         steps: editor.history.undos,
         op,
-        editor,
         currentUndoStepId,
         previousUndoStepId,
+        operationsInProgress,
+        isNormalizingNode,
+        selectionBeforeApply,
       })
 
       // Make sure we don't exceed the maximum number of undo steps we want
@@ -121,8 +141,6 @@ export function createHistoryPlugin({
       }
 
       previousUndoStepId = currentUndoStepId
-
-      apply(op)
     }
 
     return editor

--- a/packages/editor/tests/no-op-history-skip.test.tsx
+++ b/packages/editor/tests/no-op-history-skip.test.tsx
@@ -1,0 +1,107 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {InternalEditorEngineRefPlugin} from '../src/plugins/plugin.internal.editor-engine-ref'
+import {createTestEditor} from '../src/test/vitest'
+import type {PortableTextEditorEngine} from '../src/types/editor-engine'
+
+describe('no-op operations are not recorded to history', () => {
+  test('Scenario: unset of an undefined property does not pollute history', async () => {
+    const engineRef = React.createRef<PortableTextEditorEngine>()
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        styles: [{name: 'normal'}],
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      children: <InternalEditorEngineRefPlugin ref={engineRef} />,
+    })
+
+    editor.send({type: 'insert.text', text: ' bar'})
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+
+    editor.send({type: 'unset', at: [{_key: 'b0'}, 'level']})
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+  })
+
+  test('Scenario: insert_text with empty text does not pollute history', async () => {
+    const engineRef = React.createRef<PortableTextEditorEngine>()
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({styles: [{name: 'normal'}]}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      children: <InternalEditorEngineRefPlugin ref={engineRef} />,
+    })
+
+    editor.send({type: 'insert.text', text: ' bar'})
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+
+    editor.send({type: 'insert.text', text: ''})
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+  })
+
+  test('Scenario: remove_text with empty text does not pollute history', async () => {
+    const engineRef = React.createRef<PortableTextEditorEngine>()
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({styles: [{name: 'normal'}]}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      children: <InternalEditorEngineRefPlugin ref={engineRef} />,
+    })
+
+    editor.send({type: 'insert.text', text: ' bar'})
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+
+    editor.send({
+      type: 'remove.text',
+      at: [{_key: 'b0'}, 'children', {_key: 's0'}],
+      offset: 0,
+      text: '',
+    })
+
+    await vi.waitFor(() => {
+      expect(engineRef.current!.history.undos).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
The history plugin invokes `createUndoSteps` before `apply(op)` runs, so every op gets recorded to history regardless of whether it mutated state. Two failure modes:

1. **Crash class.** When `unset` or `insert` breaks early in apply without populating `op.inverse`, the next `history.undo` throws while computing the inverse. The catch in `operation.history.undo.ts` then silently wipes the entire undo stack. Concrete trigger: `unset` of a property that wasn't set — apply checks `previousValue === undefined` and breaks, but the no-op is already on the stack.

2. **Pollution class.** `insert_text` and `remove_text` with empty text reach apply, break early, and leave behind structurally-invertible-but-still-no-op steps. They don't crash undo but they split a user-perceived single edit across multiple `history.undo` calls.

The fix reorders the history plugin's `editor.apply` override to run `apply(op)` first, then gate recording on:

- `set` / `unset` / `insert` without `op.inverse` — apply broke early.
- `insert_text` / `remove_text` with `op.text.length === 0` — known no-op shape.

`set_selection` flows through unconditionally because consecutive selections are intentionally merged into the previous step.

Reordering moves `apply(op)` ahead of `createUndoSteps`. Three editor fields that `createUndoSteps` previously read directly are volatile during apply — `editor.operations.length`, `editor.isNormalizingNode`, and `editor.snapshot.context.selection` — so they're now snapshotted pre-apply and passed in as explicit params. The selection-restore stored in each undo step needed the pre-apply selection in particular; without that capture, undo would restore the caret to where it ended up *after* the op instead of where it started.

Followup to #2735, which closed the inverse-capture gap for field-property `unset`. That PR fixed the per-op crash; this one keeps no-ops out of history in the first place.

## Tests

`tests/no-op-history-skip.test.tsx` — three scenarios, each puts a real mutation on the stack, then a no-op of the relevant shape, then asserts that one `history.undo` restores the initial value:

1. `unset` of an undefined property (the crash class).
2. `insert.text` with empty string (currently filtered upstream — kept as a regression invariant).
3. `remove.text` with empty string (the pollution class).

Scenarios 1 and 3 fail on `main` and pass with the gate; scenario 2 passes either way today.

The full history-touching test suite (`event.history.{undo,redo}`, `event.set`, `event.unset`, `event.split`, `event.block.set`, `event.move.block.selection`, `behavior-api`, `history.preserving-keys`, `placeholder-block`, `undo-merge-blocks`, `undo-redo-collaboration`) stays green.
