### PR TITLE
refactor: drop dead blockIndexMap fallback in apply-operation's set _key-rename branch

### DIFF
--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -219,28 +219,22 @@ export function applyOperation(editor: Editor, op: Operation): void {
             return {...node, [propertyName]: value} as typeof node
           })
 
-          // Update blockIndexMap when _key changes on a root-level block
-          if (propertyName === '_key' && setNodePath.length === 1) {
-            if (op.inverse) {
-              const oldKey =
-                op.inverse.type === 'set' ? op.inverse.value : undefined
-              const newKey = value
-              if (typeof oldKey === 'string' && typeof newKey === 'string') {
-                const blockIndex = editor.blockIndexMap.get(oldKey)
-                if (blockIndex !== undefined) {
-                  editor.blockIndexMap.delete(oldKey)
-                  editor.blockIndexMap.set(newKey, blockIndex)
-                }
-              }
-            } else {
-              // No inverse data: full rebuild
-              editor.blockIndexMap.clear()
-              for (let i = 0; i < editor.snapshot.context.value.length; i++) {
-                const child = editor.snapshot.context.value[i]
-                if (child) {
-                  editor.blockIndexMap.set(child._key, i)
-                }
-              }
+          // Update blockIndexMap when _key changes on a root-level block.
+          // The preamble above guarantees op.inverse is populated; if it's a
+          // 'set' (existing key being renamed), the surgical delete+set keeps
+          // the map consistent. A 'unset' inverse means the node didn't have
+          // a _key before — no map entry to migrate, nothing to do.
+          if (
+            propertyName === '_key' &&
+            setNodePath.length === 1 &&
+            op.inverse?.type === 'set' &&
+            typeof op.inverse.value === 'string' &&
+            typeof value === 'string'
+          ) {
+            const blockIndex = editor.blockIndexMap.get(op.inverse.value)
+            if (blockIndex !== undefined) {
+              editor.blockIndexMap.delete(op.inverse.value)
+              editor.blockIndexMap.set(value, blockIndex)
             }
           }
         } else {


### PR DESCRIPTION
Followup to #2735. The `case 'set'` preamble now guarantees `op.inverse` is populated for every locally-applied `set`, which makes two pieces of plumbing in the `_key`-rename branch dead:

- The `else` block that did a full `blockIndexMap` rebuild as a fallback when inverse data was missing. Inverse is never missing here, so the rebuild never runs.
- The `if (op.inverse) { … } else { … }` outer guard around the surgical delete/set. No more `else` to guard.
- The `op.inverse.type === 'set' ? op.inverse.value : undefined` ternary plus the subsequent `typeof oldKey === 'string'` runtime check that handled the case where the unwrap returned undefined.

Collapsed to a single condition that reads `op.inverse?.type === 'set'` directly, narrows `op.inverse.value` to string via `typeof`, and does the surgical map update. If the inverse is a `'unset'` (which happens when the node didn't have a `_key` before — there's no map entry to migrate), nothing to do.

No behavior change. `event.set.test.tsx` + `event.unset.test.tsx` (15) green; unit suite (757) green.