### PR TITLE
test: `toTextspec` handles containers registered positionally via parent `of`

### DIFF
--- a/packages/editor/test-utils/to-textspec.test.ts
+++ b/packages/editor/test-utils/to-textspec.test.ts
@@ -454,3 +454,174 @@ describe(toTextspec.name, () => {
     )
   })
 })
+
+describe('toTextspec(): nested-`of` container registration', () => {
+  // Plugin-table-shaped registration: a single top-level container that
+  // declares its children positionally inside `of`, not as separate
+  // top-level registrations.
+  const nestedTableContainers: Containers = resolveContainers(schema, [
+    {
+      type: 'table',
+      arrayField: 'rows',
+      of: [
+        {
+          kind: 'container',
+          type: 'tableRow',
+          arrayField: 'cells',
+          of: [
+            {
+              kind: 'container',
+              type: 'tableCell',
+              arrayField: 'content',
+            },
+          ],
+        },
+      ],
+    },
+  ])
+
+  test('nested table with single cell recurses into positionally-registered row + cell', () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c0',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b0',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's0', text: 'hello', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    expect(
+      toTextspec({
+        schema,
+        value,
+        selection: null,
+        containers: nestedTableContainers,
+      }),
+    ).toBe('TABLE:\n  TABLEROW:\n    TABLECELL:\n      B: hello')
+  })
+
+  test('nested 2x2 table recurses through positional registrations', () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'tableRow',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c00',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b00',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's00', text: 'a', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'tableCell',
+                _key: 'c01',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b01',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's01', text: 'b', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'tableRow',
+            _key: 'r1',
+            cells: [
+              {
+                _type: 'tableCell',
+                _key: 'c10',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b10',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's10', text: 'c', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'tableCell',
+                _key: 'c11',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'b11',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's11', text: 'd', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Array<PortableTextBlock>
+    expect(
+      toTextspec({
+        schema,
+        value,
+        selection: null,
+        containers: nestedTableContainers,
+      }),
+    ).toBe(
+      [
+        'TABLE:',
+        '  TABLEROW:',
+        '    TABLECELL:',
+        '      B: a',
+        '    TABLECELL:',
+        '      B: b',
+        '  TABLEROW:',
+        '    TABLECELL:',
+        '      B: c',
+        '    TABLECELL:',
+        '      B: d',
+      ].join('\n'),
+    )
+  })
+})

--- a/packages/editor/test-utils/to-textspec.ts
+++ b/packages/editor/test-utils/to-textspec.ts
@@ -14,7 +14,10 @@ import type {
   TextBlock,
   Selection as TextspecSelection,
 } from '@textspec/notation'
-import type {Containers} from '../src/schema/resolve-containers'
+import type {
+  Containers,
+  RegisteredContainer,
+} from '../src/schema/resolve-containers'
 import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
 /**
@@ -351,18 +354,20 @@ function convertBlockToTextspec(
   containers: Containers,
   annotationKeys: Map<string, string> | undefined,
   block: PortableTextBlock,
+  parent?: RegisteredContainer,
 ): Block {
   if (isTextBlock({schema}, block)) {
     return convertTextBlock(schema, block, annotationKeys)
   }
 
-  if (containers.has(block._type)) {
+  const resolved = resolveChildContainer(containers, parent, block._type)
+  if (resolved) {
     return convertContainerBlock(
       schema,
       containers,
       annotationKeys,
       block,
-      block._type,
+      resolved,
     )
   }
 
@@ -373,23 +378,35 @@ function convertBlockToTextspec(
   }
 }
 
+/**
+ * Resolve which {@link RegisteredContainer} applies to a child of type
+ * `childType` under `parent`. Positional override (parent.of) wins;
+ * otherwise fall back to the top-level `containers` map. Returns
+ * undefined when the type is not registered at this position.
+ */
+function resolveChildContainer(
+  containers: Containers,
+  parent: RegisteredContainer | undefined,
+  childType: string,
+): RegisteredContainer | undefined {
+  if (parent?.of) {
+    for (const entry of parent.of) {
+      if (entry.type === childType && entry.kind === 'container') {
+        return entry
+      }
+    }
+  }
+  return containers.get(childType)
+}
+
 function convertContainerBlock(
   schema: Schema,
   containers: Containers,
   annotationKeys: Map<string, string> | undefined,
   block: Record<string, unknown>,
-  containerType: string,
+  parent: RegisteredContainer,
 ): ContainerBlock {
-  const containerField = containers.get(containerType)?.field
-
-  if (!containerField) {
-    return {
-      kind: 'containerBlock',
-      type:
-        typeof block['_type'] === 'string' ? block['_type'].toUpperCase() : '',
-      children: [],
-    }
-  }
+  const containerField = parent.field
 
   const fieldValue = block[containerField.name]
   const children: Array<Block> = []
@@ -406,15 +423,20 @@ function convertContainerBlock(
         typeof item._type === 'string'
       ) {
         const typedItem = item as Record<string, unknown>
+        const childContainer = resolveChildContainer(
+          containers,
+          parent,
+          item._type,
+        )
 
-        if (containers.has(item._type)) {
+        if (childContainer) {
           children.push(
             convertContainerBlock(
               schema,
               containers,
               annotationKeys,
               typedItem,
-              item._type,
+              childContainer,
             ),
           )
         } else {


### PR DESCRIPTION
Previously `toTextspec` recursed through container children by looking each child's `_type` up in the top-level `containers` map. Containers registered positionally inside a parent's `of` array — rather than as separate top-level entries — missed that lookup and rendered as bare block objects, so a `defineContainer({type:'table', of: [row, cell]})` registration printed as

```
TABLE:
  {ROW}
  {ROW}
```

instead of recursing into rows and cells.

Resolve children through the parent's `of` first, then fall back to the top-level map — mirroring `resolveContainerAt`'s positional-override rule. Flat top-level registrations keep working unchanged.

The two falsifying tests cover a 1-cell and a 2×2 table registered as a single nested-`of` chain; both produce the same notation that the existing flat-registration tests produce.

`fromTextspec` has the same flaw and will get the same treatment in a follow-up — `@portabletext/plugin-table`'s assertions only need the serialize direction right now.