### PR TITLE
fix: merge consecutive text operations across forward-only behavior undo step boundary

### DIFF
--- a/.changeset/merge-text-ops-across-undo-step-id-mismatch.md
+++ b/.changeset/merge-text-ops-across-undo-step-id-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: merge consecutive text operations across forward-only behavior undo step boundary

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -123,6 +123,23 @@ export function createUndoSteps({
     }
   }
 
+  // Asymmetric on purpose — the reverse direction (current defined, previous
+  // undefined) signals an intentional undo step boundary and stays unmerged.
+  if (currentUndoStepId === undefined && previousUndoStepId !== undefined) {
+    const lastOp = lastStep.operations.at(-1)
+
+    if (
+      lastOp &&
+      op.type === 'insert_text' &&
+      lastOp.type === 'insert_text' &&
+      op.offset === lastOp.offset + lastOp.text.length &&
+      pathEquals(op.path, lastOp.path) &&
+      op.text !== ' '
+    ) {
+      return mergeIntoLastStep(steps, lastStep, op)
+    }
+  }
+
   return createNewStep(steps, op, selectionBeforeApply)
 }
 

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -938,4 +938,33 @@ describe('event.history.undo', () => {
       expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })
   })
+
+  test('Scenario: forward-only behavior merges consecutive typing into one undo step', async () => {
+    const {editor, locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'a',
+              actions: [({event}) => [forward(event)]],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.type(locator, 'a')
+    await userEvent.type(locator, 'b')
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: ab|')
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
 })


### PR DESCRIPTION
When a forward-only behavior intercepts one keystroke and the next keystroke has no matching behavior, the two ops land in separate undo steps even though the user perceives them as continuous typing. The intercepted keystroke gets an `undoStepId` from the `mode === 'send' && !isNativeBehaviorEvent` branch in `perform-event.ts`; the next keystroke flows through the native input path with `undoStepId` undefined. The `createUndoSteps` merge heuristic has branches for both-undefined and both-defined-different, but no branch for the current-undefined / previous-defined mismatch — so the merge skips and each keystroke becomes its own step.

The fix adds the symmetric merge branch for that case. The reverse direction (current defined, previous undefined) intentionally stays unmerged: a behavior claiming an event with an `undoStepId` signals an intentional undo step boundary, like input rules replacing `->` with `→`.

Picks up the work from #2334 — the underlying gap still existed after the renames in #2700 and the `createUndoSteps` reorder in #2739.

## Tests

`tests/event.history.undo.test.tsx` — a forward-only behavior on `insert.text` with `text === 'a'`, then `userEvent.type` 'a' followed by 'b'. With the merge gap, one `history.undo` only pops the 'b' step, leaving "a"; with the symmetric branch, one undo restores the empty initial value. Fails on `main`, passes here.
