### PR TITLE
feat: `withSnapshot` action for declaring a data dependency on a fresh editor snapshot inside a single action set

### DIFF
--- a/.changeset/with-snapshot-action.md
+++ b/.changeset/with-snapshot-action.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: `withSnapshot` action for declaring a data dependency on a fresh editor snapshot inside a single action set

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -4,6 +4,9 @@ import type {EditorSchema} from '../editor/editor-schema'
 import {createEditorSnapshot} from '../editor/editor-snapshot'
 import {withPerformingBehaviorOperation} from '../engine-plugins/engine-plugin.performing-behavior-operation'
 import {withoutNormalizingConditional} from '../engine-plugins/engine-plugin.without-normalizing-conditional'
+import {isNormalizing} from '../engine/editor/is-normalizing'
+import {normalize} from '../engine/editor/normalize'
+import {setNormalizing} from '../engine/editor/set-normalizing'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
 import {performOperation} from '../operations/operation.perform'
@@ -253,95 +256,145 @@ export function performEvent({
       }
 
       const actionTypes = actions.map((action) => action.type)
-      const uniqueActionTypes = new Set(actionTypes)
+      // `with-snapshot` actions are group-transparent: they participate in
+      // the surrounding deferred-normalization group without breaking it.
+      // The flush inside each `with-snapshot` happens explicitly when it
+      // runs, so the surrounding actions still benefit from grouped
+      // normalization.
+      const groupingActionTypes = new Set(
+        actionTypes.filter((type) => type !== 'with-snapshot'),
+      )
 
-      // The set of actions are all `raise` actions
+      // The set of actions are all `raise` actions (ignoring `with-snapshot`)
       const raiseGroup =
         actionTypes.length > 1 &&
-        uniqueActionTypes.size === 1 &&
-        uniqueActionTypes.has('raise')
+        groupingActionTypes.size === 1 &&
+        groupingActionTypes.has('raise')
 
-      // The set of actions are all `execute` actions
+      // The set of actions are all `execute` actions (ignoring `with-snapshot`)
       const executeGroup =
         actionTypes.length > 1 &&
-        uniqueActionTypes.size === 1 &&
-        uniqueActionTypes.has('execute')
+        groupingActionTypes.size === 1 &&
+        groupingActionTypes.has('execute')
+
+      const dispatchAction = (
+        action: BehaviorAction,
+        withinWithSnapshot: boolean,
+      ): void => {
+        if (action.type === 'effect') {
+          try {
+            action.effect({
+              send: sendBack,
+            })
+          } catch (error) {
+            console.error(
+              new Error(
+                `Executing effect as a result of "${event.type}" failed due to: ${error instanceof Error ? error.message : error}`,
+              ),
+            )
+          }
+
+          return
+        }
+
+        if (action.type === 'forward') {
+          const remainingEventBehaviors = eventBehaviors.slice(
+            eventBehaviorIndex + 1,
+          )
+
+          performEvent({
+            mode: mode === 'execute' ? 'execute' : 'forward',
+            behaviors,
+            remainingEventBehaviors,
+            event: action.event,
+            editor,
+            converters,
+            keyGenerator,
+            readOnly,
+            schema,
+            nativeEvent,
+            sendBack,
+          })
+
+          return
+        }
+
+        if (action.type === 'raise') {
+          performEvent({
+            mode: mode === 'execute' ? 'execute' : 'raise',
+            behaviors,
+            remainingEventBehaviors:
+              mode === 'execute' ? remainingEventBehaviors : behaviors,
+            event: action.event,
+            editor,
+            converters,
+            keyGenerator,
+            readOnly,
+            schema,
+            nativeEvent,
+            sendBack,
+          })
+
+          return
+        }
+
+        if (action.type === 'with-snapshot') {
+          if (withinWithSnapshot) {
+            throw new Error(
+              '`withSnapshot` cannot be nested inside another `withSnapshot`-derived action stream.',
+            )
+          }
+
+          // Flush deferred normalization so the callback sees fresh state.
+          // The outer `withoutNormalizingConditional` may have flipped
+          // `editor.normalizing` off to defer per-op normalization; we
+          // temporarily flip it back on, drain the dirty paths, and restore.
+          const wasNormalizing = isNormalizing(editor)
+          setNormalizing(editor, true)
+          normalize(editor)
+          setNormalizing(editor, wasNormalizing)
+
+          const freshSnapshot = createEditorSnapshot({
+            converters,
+            editor,
+            keyGenerator,
+            readOnly,
+            schema,
+          })
+          const nextActions = action.fn({
+            snapshot: freshSnapshot,
+            event,
+            dom: createEditorDom(sendBack, editor),
+          })
+
+          for (const nextAction of nextActions) {
+            dispatchAction(nextAction, true)
+          }
+
+          return
+        }
+
+        performEvent({
+          mode: 'execute',
+          behaviors,
+          remainingEventBehaviors: [],
+          event: action.event,
+          editor,
+          converters,
+          keyGenerator,
+          readOnly,
+          schema,
+          nativeEvent: undefined,
+          sendBack,
+        })
+      }
 
       withoutNormalizingConditional(
         editor,
         () => raiseGroup || executeGroup,
         () => {
           for (const action of actions) {
-            if (action.type === 'effect') {
-              try {
-                action.effect({
-                  send: sendBack,
-                })
-              } catch (error) {
-                console.error(
-                  new Error(
-                    `Executing effect as a result of "${event.type}" failed due to: ${error instanceof Error ? error.message : error}`,
-                  ),
-                )
-              }
-
-              continue
-            }
-
-            if (action.type === 'forward') {
-              const remainingEventBehaviors = eventBehaviors.slice(
-                eventBehaviorIndex + 1,
-              )
-
-              performEvent({
-                mode: mode === 'execute' ? 'execute' : 'forward',
-                behaviors,
-                remainingEventBehaviors,
-                event: action.event,
-                editor,
-                converters,
-                keyGenerator,
-                readOnly,
-                schema,
-                nativeEvent,
-                sendBack,
-              })
-
-              continue
-            }
-
-            if (action.type === 'raise') {
-              performEvent({
-                mode: mode === 'execute' ? 'execute' : 'raise',
-                behaviors,
-                remainingEventBehaviors:
-                  mode === 'execute' ? remainingEventBehaviors : behaviors,
-                event: action.event,
-                editor,
-                converters,
-                keyGenerator,
-                readOnly,
-                schema,
-                nativeEvent,
-                sendBack,
-              })
-
-              continue
-            }
-
-            performEvent({
-              mode: 'execute',
-              behaviors,
-              remainingEventBehaviors: [],
-              event: action.event,
-              editor,
-              converters,
-              keyGenerator,
-              readOnly,
-              schema,
-              nativeEvent: undefined,
-              sendBack,
-            })
+            dispatchAction(action, false)
           }
         },
       )

--- a/packages/editor/src/behaviors/behavior.types.action.ts
+++ b/packages/editor/src/behaviors/behavior.types.action.ts
@@ -52,6 +52,17 @@ export type BehaviorAction =
         send: (event: ExternalBehaviorEvent) => void
       }) => void
     }
+  | {
+      type: 'with-snapshot'
+      fn: (payload: {
+        snapshot: EditorSnapshot
+        event:
+          | SyntheticBehaviorEvent
+          | NativeBehaviorEvent
+          | CustomBehaviorEvent
+        dom: EditorDom
+      }) => Array<BehaviorAction>
+    }
 
 /**
  * Directly executes an event, bypassing all Behavior matching.
@@ -204,6 +215,53 @@ export function effect(
   effect: PickFromUnion<BehaviorAction, 'type', 'effect'>['effect'],
 ): PickFromUnion<BehaviorAction, 'type', 'effect'> {
   return {type: 'effect', effect}
+}
+
+/**
+ * Declares a data dependency on the post-normalization editor snapshot.
+ *
+ * Use `withSnapshot` inside an actions array when later actions need to read
+ * editor state that earlier actions are about to mutate. The engine flushes
+ * any deferred normalization before invoking `fn`, re-derives a fresh
+ * snapshot, and splices the returned actions into the stream.
+ *
+ * `withSnapshot` inherits the surrounding undo intent — it does not introduce
+ * or suppress a new undo step. Whatever `editor.undoStepId` is at the point
+ * the spliced actions execute, they execute under it.
+ *
+ * Nesting `withSnapshot` inside another `withSnapshot`-derived action stream
+ * is not supported in v1 and throws at runtime.
+ *
+ * @example
+ * ```ts
+ * defineBehavior({
+ *   on: 'delete',
+ *   guard: ({snapshot}) => getTableSelection(snapshot) ?? false,
+ *   actions: [
+ *     ({snapshot}, tableSelection) => [
+ *       // 1. Clear every cell in the rectangular selection.
+ *       ...unsetCellActions(snapshot, tableSelection),
+ *       // 2. Position the caret in the top-left cell. The engine flushes
+ *       //    normalization first, so `select.block` resolves against the
+ *       //    freshly-minted empty leaves.
+ *       withSnapshot(({snapshot}) => [
+ *         raise({
+ *           type: 'select.block',
+ *           at: topLeftCellPath(tableSelection),
+ *           select: 'start',
+ *         }),
+ *       ]),
+ *     ],
+ *   ],
+ * })
+ * ```
+ *
+ * @beta
+ */
+export function withSnapshot(
+  fn: PickFromUnion<BehaviorAction, 'type', 'with-snapshot'>['fn'],
+): PickFromUnion<BehaviorAction, 'type', 'with-snapshot'> {
+  return {type: 'with-snapshot', fn}
 }
 
 /**

--- a/packages/editor/src/behaviors/index.ts
+++ b/packages/editor/src/behaviors/index.ts
@@ -3,6 +3,7 @@ export {
   execute,
   forward,
   raise,
+  withSnapshot,
   type BehaviorAction,
   type BehaviorActionSet,
 } from './behavior.types.action'

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -8,6 +8,7 @@ import {
   execute,
   forward,
   raise,
+  withSnapshot,
 } from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
@@ -1024,5 +1025,91 @@ describe('Behavior API', () => {
         )
       })
     })
+  })
+
+  test('Scenario: `withSnapshot` provides fresh editor state inside a single action set', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's0', text: 'hello', marks: []}],
+        },
+      ],
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.clear-and-recenter',
+              actions: [
+                () => [
+                  raise({
+                    type: 'unset',
+                    at: [{_key: 'b0'}, 'children', {_key: 's0'}],
+                  }),
+                  withSnapshot(() => [
+                    raise({
+                      type: 'select.block',
+                      at: [{_key: 'b0'}],
+                      select: 'start',
+                    }),
+                  ]),
+                ],
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({type: 'custom.clear-and-recenter'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
+
+  test('Scenario: `withSnapshot` cannot be nested', async () => {
+    let innerInvoked = false
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.nest',
+              actions: [
+                () => [
+                  withSnapshot(() => [
+                    withSnapshot(() => {
+                      innerInvoked = true
+                      return []
+                    }),
+                  ]),
+                ],
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    editor.send({type: 'custom.nest'})
+
+    await vi.waitFor(() => {
+      expect(
+        consoleError.mock.calls.some((call) =>
+          String(call[0]).includes('`withSnapshot` cannot be nested'),
+        ),
+      ).toBe(true)
+    })
+
+    expect(innerInvoked).toBe(false)
+
+    consoleError.mockRestore()
   })
 })


### PR DESCRIPTION
A behavior can need a corrective action — e.g. landing the caret somewhere — that reads editor state which earlier actions in the same set are about to mutate. With the existing primitives, the corrective action runs against the same snapshot the guard saw: the leaf it tries to land on is the same leaf the unsets are about to destroy, and after `transformPoint` truncates the selection during normalization, the caret ends up parked on a non-leaf container path.

Splitting into two action sets gives fresh snapshots, but rotates `undoStepId` — one keystroke produces two undo steps. Acceptable for `auto-close-brackets` (the bracket pairs are correctly separate undo units), unacceptable for a multi-cell delete that should feel like one edit.

This PR introduces `withSnapshot` to declare that dependency explicitly inside a single actions array:

```ts
defineBehavior({
  on: 'delete',
  guard: ({snapshot}) => getTableSelection(snapshot) ?? false,
  actions: [
    ({snapshot}, tableSelection) => [
      ...unsetCellActions(snapshot, tableSelection),
      withSnapshot(({snapshot}) => [
        raise({
          type: 'select.block',
          at: topLeftCellPath(tableSelection),
          select: 'start',
        }),
      ]),
    ],
  ],
})
```

`withSnapshot(fn)` returns an action that the engine processes by flushing any deferred normalization, re-deriving a fresh snapshot, invoking `fn`, and splicing the returned actions into the surrounding stream.

The framing matters: `withSnapshot` is a data-dependency declaration, not a control marker. `fn`'s payload IS the semantic content — actions computed against fresh state. The normalization flush is the engine implementing that dependency, not API surface.

### Contract

- **Group-transparent.** `withSnapshot` actions are excluded from the same-type grouping that defers normalization across a set of `raise` or `execute` actions. `[raise, raise, raise, withSnapshot(...)]` still defers normalization across the raises, and `withSnapshot` flushes when it runs. Without this, the mere presence of `withSnapshot` in an actions array would break the group check structurally and disable the deferral.
- **Inherits undo intent.** Does not introduce or suppress `undoStepId` rotation. Whatever `editor.undoStepId` is when the spliced actions execute, they execute under it.
- **Nesting throws.** `withSnapshot` inside another `withSnapshot`-derived action stream throws at the engine site. Cheap to allow later if a real use case appears; expensive to deprecate once shipped with ambiguous semantics.

### Tests

Two scenarios in `behavior-api.test.tsx`:

1. **Fresh snapshot after deferred normalization.** A custom event raises an `unset` then a `withSnapshot`-wrapped `select.block`. Without the flush, `resolveSelection` descends to the about-to-be-unset span, `transformPoint` truncates the selection back to the block path, and `toTextspec` renders `B: ` (no marker). With the flush, the select callback sees the freshly-minted empty leaf and lands at it: `B: |`. Verified the test fails on a flush-skipped engine.
2. **Nesting throws.** A nested `withSnapshot` triggers the engine throw; the inner callback never runs.