### PR TITLE
fix: merge `set_selection` from a follow-up action set into the previous undo step

### DIFF
--- a/.changeset/merge-set-selection-across-undo-steps.md
+++ b/.changeset/merge-set-selection-across-undo-steps.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: merge `set_selection` from a follow-up action set into the previous undo step

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -38,6 +38,14 @@ export function createUndoSteps({
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
+    // A `set_selection` op that lands in a different undo step than the
+    // ongoing operations belongs with the preceding mutating op
+    // (a corrective `select` from a follow-up action set, or a
+    // selection rotation between behavior phases).
+    if (op.type === 'set_selection') {
+      return mergeIntoLastStep(steps, lastStep, op)
+    }
+
     return createNewStep(steps, op, selectionBeforeApply)
   }
 

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -967,4 +967,52 @@ describe('event.history.undo', () => {
       expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
+
+  test('Scenario: `set_selection` op in a follow-up action set merges into the previous step', async () => {
+    // A behavior with two action sets: set 1 mutates the value (raise
+    // `insert.text`), set 2 emits a corrective `set_selection`. The two
+    // sets get different undo step ids by design. The selection op in
+    // set 2 should merge into set 1's step so one undo press reverts
+    // the whole event.
+    const {editor, locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.two-sets',
+              actions: [
+                () => [raise({type: 'insert.text', text: 'xy'})],
+                ({snapshot}) => {
+                  const focusBlock = getFocusBlock(snapshot)
+                  if (!focusBlock) {
+                    return []
+                  }
+                  return [
+                    raise({
+                      type: 'select.block',
+                      at: focusBlock.path,
+                      select: 'start',
+                    }),
+                  ]
+                },
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({type: 'custom.two-sets'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |xy')
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
+    })
+  })
 })

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -969,11 +969,16 @@ describe('event.history.undo', () => {
   })
 
   test('Scenario: `set_selection` op in a follow-up action set merges into the previous step', async () => {
-    // A behavior with two action sets: set 1 mutates the value (raise
-    // `insert.text`), set 2 emits a corrective `set_selection`. The two
-    // sets get different undo step ids by design. The selection op in
-    // set 2 should merge into set 1's step so one undo press reverts
-    // the whole event.
+    // A behavior with two action sets:
+    //   set 1: raise `insert.text 'xy'` - mutates the value, caret ends at end
+    //   set 2: raise `select.block ... select: 'start'` - moves the caret
+    //          back to the start so the user can re-read what was inserted
+    //
+    // The two sets get different undo step ids by design. Without the
+    // `set_selection` merge, the first `history.undo` press would only
+    // undo set 2's caret move (caret jumps back to end of 'xy') and
+    // leave the text mutation in place. A second press would then revert
+    // the text. With the merge, one press reverts the whole event.
     const {editor, locator} = await createTestEditor({
       children: (
         <BehaviorPlugin


### PR DESCRIPTION
A behavior with multiple action sets gets a fresh `undoStepId` between sets so that each set's mutations form their own undo group. That's the right default — `auto-close-brackets` relies on it to keep the inserted pair separable from later edits.

But when a later set's only effect is a corrective selection — landing the caret inside a freshly normalized block, say — the resulting `set_selection` op gets recorded as its own undo step. One keystroke produces two undo steps, and the first `history.undo` press restores the cursor without touching the value. The user then has to undo a second time to actually revert the edit.

The existing `set_selection`-merge heuristic in `createUndoSteps` already handles the analogous case when no operations are in progress:

```ts
if (
  op.type === 'set_selection' &&
  currentUndoStepId !== undefined &&
  previousUndoStepId !== undefined &&
  previousUndoStepId !== currentUndoStepId
) {
  return mergeIntoLastStep(steps, lastStep, op)
}
```

This PR extends the `operationsInProgress` branch with the same rule. When a `set_selection` op arrives under a different `undoStepId` than the ongoing operations, merge it into the previous step rather than creating a new one.

### Test

One new scenario in `event.history.undo.test.tsx`: a behavior raises `insert.text` in set 1 and a corrective `select.block` in set 2. Before this PR the first `history.undo` press only reverts the selection (`B: xy|` stays `B: xy|`). After this PR the first press reverts the whole event back to the original empty block.

Verified by removing the new heuristic branch: test FAILS with `Received: "B: xy|"` instead of expected `"B: |"`. All 13 history-touching test files (109 tests) green with the fix in place.