### PR TITLE
feat: export defineX render-prop types

### DIFF
--- a/.changeset/export-render-prop-types.md
+++ b/.changeset/export-render-prop-types.md
@@ -1,0 +1,14 @@
+---
+"@portabletext/editor": minor
+---
+
+feat: export `defineX` render-prop types
+
+Add public re-exports for the prop and render-function types of the
+`defineContainer` / `defineTextBlock` / `defineSpan` /
+`defineBlockObject` / `defineInlineObject` factories:
+`ContainerRenderProps`, `ContainerRender`, `TextBlockRenderProps`,
+`TextBlockRender`, `SpanRenderProps`, `SpanRender`,
+`BlockObjectRenderProps`, `BlockObjectRender`, `InlineObjectRenderProps`,
+`InlineObjectRender`. Consumers writing custom node renders no longer
+need to derive these via `Parameters<NonNullable<...>>` inference.

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -50,11 +50,21 @@ export {
   defineSpan,
   defineTextBlock,
   type BlockObject,
+  type BlockObjectRender,
+  type BlockObjectRenderProps,
   type Container,
+  type ContainerRender,
+  type ContainerRenderProps,
   type InlineObject,
+  type InlineObjectRender,
+  type InlineObjectRenderProps,
   type RegistrableNode,
   type Span,
+  type SpanRender,
+  type SpanRenderProps,
   type TextBlock,
+  type TextBlockRender,
+  type TextBlockRenderProps,
 } from './renderers/renderer.types'
 export {resolveContainerAt} from './schema/resolve-containers'
 export type {

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -54,6 +54,9 @@ export type ContainerRenderProps = {
    */
   renderDefault: (props: ContainerRenderProps) => ReactElement
 }
+/**
+ * @alpha
+ */
 export type ContainerRender = (props: ContainerRenderProps) => ReactElement
 
 /**
@@ -77,6 +80,9 @@ export type SpanRenderProps = {
    */
   renderDefault: (props: SpanRenderProps) => ReactElement
 }
+/**
+ * @alpha
+ */
 export type SpanRender = (props: SpanRenderProps) => ReactElement
 
 /**
@@ -102,6 +108,9 @@ export type BlockObjectRenderProps = {
    */
   renderDefault: (props: BlockObjectRenderProps) => ReactElement
 }
+/**
+ * @alpha
+ */
 export type BlockObjectRender = (props: BlockObjectRenderProps) => ReactElement
 
 /**
@@ -127,6 +136,9 @@ export type InlineObjectRenderProps = {
    */
   renderDefault: (props: InlineObjectRenderProps) => ReactElement
 }
+/**
+ * @alpha
+ */
 export type InlineObjectRender = (
   props: InlineObjectRenderProps,
 ) => ReactElement
@@ -223,6 +235,9 @@ export type TextBlockRenderProps = {
    */
   renderDefault: (props: TextBlockRenderProps) => ReactElement
 }
+/**
+ * @alpha
+ */
 export type TextBlockRender = (props: TextBlockRenderProps) => ReactElement
 
 /**


### PR DESCRIPTION
Add public re-exports for the prop and render-function types of the `defineContainer` / `defineTextBlock` / `defineSpan` / `defineBlockObject` / `defineInlineObject` factories.

The factories themselves are already exported, but their associated prop and render-function types are not. Consumers writing custom node renders currently have to derive them via `Parameters<NonNullable<Parameters<typeof defineBlockObject>[0]['render']>>[0]` inference. This PR exposes them directly:

- `ContainerRenderProps`, `ContainerRender`
- `TextBlockRenderProps`, `TextBlockRender`
- `SpanRenderProps`, `SpanRender`
- `BlockObjectRenderProps`, `BlockObjectRender`
- `InlineObjectRenderProps`, `InlineObjectRender`

All tagged `@alpha`, matching the factories they belong to.