### PR TITLE
fix: allow catch-all defineX({type: '*'}) registrations across kinds

### DIFF
--- a/.changeset/catchall-cross-kind.md
+++ b/.changeset/catchall-cross-kind.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: allow catch-all `defineX({type: '*'})` registrations across kinds
+
+A `defineTextBlock({type: '*'})` registration no longer blocks subsequent `defineBlockObject({type: '*'})` and `defineInlineObject({type: '*'})` registrations. The `'*'` sentinel is a kind-specific catch-all and is not subject to the cross-kind exclusivity that applies to real `_type` identifiers.

--- a/packages/editor/src/editor/registration-helpers.ts
+++ b/packages/editor/src/editor/registration-helpers.ts
@@ -71,6 +71,12 @@ export function isTypeAlreadyRegistered(
     return true
   }
 
+  // The '*' sentinel is a kind-specific catch-all, not a real `_type`,
+  // so cross-kind exclusivity does not apply.
+  if (type === '*') {
+    return false
+  }
+
   // Cross-kind exclusivity. blockObject and inlineObject can co-exist
   // with each other but not with container/textBlock/span. The
   // exclusive kinds (container/textBlock/span) are mutually exclusive

--- a/packages/editor/tests/catch-all-registration.test.tsx
+++ b/packages/editor/tests/catch-all-registration.test.tsx
@@ -666,3 +666,74 @@ describe('catch-all registration: cross-rung precedence', () => {
     })
   })
 })
+
+const objectAndInlineSchema = defineSchema({
+  blockObjects: [{name: 'callout'}],
+  inlineObjects: [{name: 'mention'}],
+})
+
+describe("catch-all registration: cross-kind coexistence at '*'", () => {
+  test('textBlock, blockObject, and inlineObject catch-alls all register and dispatch', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: objectAndInlineSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          children: [
+            {_type: 'span', _key: 's0', text: 'Before '},
+            {_type: 'mention', _key: 'm0'},
+            {_type: 'span', _key: 's1', text: ' after'},
+          ],
+          markDefs: [],
+        },
+        {_type: 'callout', _key: 'c0'},
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div data-testid={`tb-${node._type}`} {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div data-testid={`bo-${node._type}`} {...attributes}>
+                  {children}
+                </div>
+              ),
+            }),
+            defineInlineObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <span data-testid={`io-${node._type}`} {...attributes}>
+                  {children}
+                </span>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="tb-block"]')).not.toEqual(
+        null,
+      )
+      expect(document.querySelector('[data-testid="bo-callout"]')).not.toEqual(
+        null,
+      )
+      expect(document.querySelector('[data-testid="io-mention"]')).not.toEqual(
+        null,
+      )
+    })
+  })
+})


### PR DESCRIPTION
A `defineTextBlock({type: '*'})` registration was blocking subsequent `defineBlockObject({type: '*'})` and `defineInlineObject({type: '*'})` registrations because `textBlock` is in the cross-kind exclusivity set.

The `'*'` sentinel is a kind-specific catch-all (matches any node of its kind that has no specific `_type` registration), not a real `_type` identifier. Cross-kind exclusivity (which protects against the same `_type` being claimed by multiple kinds) does not apply to it.

Registering all three of `defineTextBlock({type: '*'})`, `defineBlockObject({type: '*'})`, and `defineInlineObject({type: '*'})` is the canonical pattern for consumers that want a single set of render callbacks to handle every text-block, block-object, and inline-object in the value.

The same-kind duplicate check still rejects an accidental re-registration of the same catch-all within one kind.