### PR TITLE
feat: expose dropPosition and listIndex on text-block and block-object render-props

### DIFF
--- a/.changeset/expose-drop-position-and-list-index.md
+++ b/.changeset/expose-drop-position-and-list-index.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: expose `dropPosition` and `listIndex` on text-block and block-object render-props
+
+`defineTextBlock` and `defineBlockObject` now receive engine-derived signals that aren't available on the value:
+
+- `dropPosition: 'start' | 'end' | undefined` — set mid-drag when this block is the current drop target. Consumers using a custom `render` can show their own drop affordance (or delegate via `renderDefault`).
+- `listIndex: number | undefined` on `TextBlockRenderProps` — 1-based running index of a list-item within its visible list run (level-aware, resets across non-list interrupts). Now resolves correctly for list-items inside containers; each container is its own list-counter scope.
+
+`defineBlockObject` and `defineInlineObject` render-props also receive `draggable` on `attributes` so browser drag-and-drop works without the consumer having to opt in manually.

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -60,8 +60,10 @@ export function RenderBlockObject(props: {
       attributes: {
         ...ptAttributes,
         'data-pt-block': 'object',
+        'draggable': !props.readOnly,
       },
       children: props.children,
+      dropPosition: props.dropPosition,
       focused,
       node: props.element,
       path: props.path,

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -206,6 +206,10 @@ export function RenderElement(props: {
       rendered = (
         <RenderTextBlockConfig
           attributes={{...rest, 'data-pt-block': 'text'}}
+          dropPosition={resolveElementDropPosition(
+            props.dropPosition,
+            props.path,
+          )}
           render={renderableTextBlockConfig.textBlock.render}
           node={props.element}
           path={props.path}
@@ -335,6 +339,7 @@ function RenderTextBlockConfig(props: {
     'data-pt-block': 'text'
   }
   children: ReactElement
+  dropPosition?: DropPosition['position']
   node: PortableTextTextBlock
   path: Path
   readOnly: boolean
@@ -343,11 +348,16 @@ function RenderTextBlockConfig(props: {
   const serializedPath = serializePath(props.path)
   const focused = useIsFocusedContainer(serializedPath)
   const selected = useIsSelectedContainer(serializedPath)
+  const listIndex = useEngineSelector((editor) =>
+    editor.listIndexMap.get(props.node._key),
+  )
   const renderDefault = renderDefaultTextBlock
   return props.render({
     attributes: props.attributes,
     children: props.children,
+    dropPosition: props.dropPosition,
     focused,
+    listIndex,
     node: props.node,
     path: props.path,
     readOnly: props.readOnly,

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -56,6 +56,7 @@ export function RenderInlineObject(props: {
       attributes: {
         ...props.attributes,
         'data-pt-inline': 'object',
+        'draggable': !props.readOnly,
       },
       children: props.children,
       focused,

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -4,6 +4,7 @@ import type {
   PortableTextTextBlock,
 } from '@portabletext/schema'
 import type {ReactElement} from 'react'
+import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import type {Path} from '../engine/interfaces/path'
 import type {ChildArrayField} from '../schema/resolve-containers'
 
@@ -97,6 +98,15 @@ export type SpanRender = (props: SpanRenderProps) => ReactElement
 export type BlockObjectRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
+  /**
+   * Set to `'start'` or `'end'` while the editor is mid-drag and a
+   * drop above or below this block is the current target. `undefined`
+   * otherwise. The engine-default render shows a drop indicator at
+   * this position; consumers using a custom render must render their
+   * own affordance (or delegate via `renderDefault`) for drop targets
+   * to be visible.
+   */
+  dropPosition?: DropPosition['position']
   focused: boolean
   node: PortableTextObject
   path: Path
@@ -224,7 +234,22 @@ export type TextBlock = {
 export type TextBlockRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
+  /**
+   * Set to `'start'` or `'end'` while the editor is mid-drag and a
+   * drop above or below this block is the current target. `undefined`
+   * otherwise. The engine-default render shows a drop indicator at
+   * this position; consumers using a custom render must render their
+   * own affordance (or delegate via `renderDefault`) for drop targets
+   * to be visible.
+   */
+  dropPosition?: DropPosition['position']
   focused: boolean
+  /**
+   * For list-item text blocks, the 1-based running index of this item
+   * within its visible list run (accounts for the level and resets
+   * across non-list interrupts). `undefined` for non-list blocks.
+   */
+  listIndex?: number
   node: PortableTextTextBlock
   path: Path
   readOnly: boolean

--- a/packages/editor/tests/render-props-draggable.test.tsx
+++ b/packages/editor/tests/render-props-draggable.test.tsx
@@ -1,0 +1,89 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineInlineObject,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('draggable', () => {
+  test('BlockObjectRenderProps.attributes.draggable is true', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({blockObjects: [{name: 'image'}]}),
+      initialValue: [{_type: 'image', _key: 'k0'}],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-draggable={String(attributes['draggable'])}
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      expect(k0?.getAttribute('data-draggable')).toEqual('true')
+      expect(k0?.getAttribute('draggable')).toEqual('true')
+    })
+  })
+
+  test('InlineObjectRenderProps.attributes.draggable is true', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({inlineObjects: [{name: 'mention'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 's0', text: 'hello ', marks: []},
+            {_type: 'mention', _key: 'm0'},
+            {_type: 'span', _key: 's1', text: ' world', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineInlineObject({
+              type: '*',
+              render: ({attributes, children, node}) => (
+                <span
+                  data-testid={`inline-${node._key}`}
+                  data-draggable={String(attributes['draggable'])}
+                  {...attributes}
+                >
+                  {children}
+                </span>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const m0 = document.querySelector('[data-testid="inline-m0"]')
+      expect(m0?.getAttribute('data-draggable')).toEqual('true')
+      expect(m0?.getAttribute('draggable')).toEqual('true')
+    })
+  })
+})

--- a/packages/editor/tests/render-props-drop-position-list-index.test-d.ts
+++ b/packages/editor/tests/render-props-drop-position-list-index.test-d.ts
@@ -1,0 +1,39 @@
+import {expectTypeOf, test} from 'vitest'
+import {
+  defineBlockObject,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+
+test('TextBlockRenderProps exposes optional listIndex: number', () => {
+  defineTextBlock({
+    type: '*',
+    render: (props) => {
+      expectTypeOf(props.listIndex).toEqualTypeOf<number | undefined>()
+      return props.renderDefault(props)
+    },
+  })
+})
+
+test('TextBlockRenderProps exposes optional dropPosition', () => {
+  defineTextBlock({
+    type: '*',
+    render: (props) => {
+      expectTypeOf(props.dropPosition).toEqualTypeOf<
+        'start' | 'end' | undefined
+      >()
+      return props.renderDefault(props)
+    },
+  })
+})
+
+test('BlockObjectRenderProps exposes optional dropPosition', () => {
+  defineBlockObject({
+    type: '*',
+    render: (props) => {
+      expectTypeOf(props.dropPosition).toEqualTypeOf<
+        'start' | 'end' | undefined
+      >()
+      return props.renderDefault(props)
+    },
+  })
+})

--- a/packages/editor/tests/render-props-drop-position.test.tsx
+++ b/packages/editor/tests/render-props-drop-position.test.tsx
@@ -1,0 +1,87 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('dropPosition', () => {
+  test('BlockObjectRenderProps.dropPosition is undefined when not mid-drag', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({blockObjects: [{name: 'image'}]}),
+      initialValue: [{_type: 'image', _key: 'k0'}],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineBlockObject({
+              type: '*',
+              render: ({attributes, children, dropPosition, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-drop-position={
+                    dropPosition === undefined ? 'none' : dropPosition
+                  }
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      expect(k0?.getAttribute('data-drop-position')).toEqual('none')
+    })
+  })
+
+  test('TextBlockRenderProps.dropPosition is undefined when not mid-drag', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, dropPosition, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-drop-position={
+                    dropPosition === undefined ? 'none' : dropPosition
+                  }
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      expect(k0?.getAttribute('data-drop-position')).toEqual('none')
+    })
+  })
+})

--- a/packages/editor/tests/render-props-list-index.test.tsx
+++ b/packages/editor/tests/render-props-list-index.test.tsx
@@ -1,0 +1,252 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const listSchema = defineSchema({
+  lists: [{name: 'number'}, {name: 'bullet'}],
+})
+
+describe('listIndex', () => {
+  test('catch-all defineTextBlock receives listIndex for list-item blocks', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: listSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          listItem: 'number',
+          level: 1,
+          children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k1',
+          listItem: 'number',
+          level: 1,
+          children: [{_type: 'span', _key: 's1', text: 'two', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          listItem: 'number',
+          level: 1,
+          children: [{_type: 'span', _key: 's2', text: 'three', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, listIndex, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-list-index={listIndex}
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      const k1 = document.querySelector('[data-testid="block-k1"]')
+      const k2 = document.querySelector('[data-testid="block-k2"]')
+      expect(k0?.getAttribute('data-list-index')).toEqual('1')
+      expect(k1?.getAttribute('data-list-index')).toEqual('2')
+      expect(k2?.getAttribute('data-list-index')).toEqual('3')
+    })
+  })
+
+  test('listIndex is undefined for non-list-item blocks', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: listSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 's0', text: 'plain', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, listIndex, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-list-index={
+                    listIndex === undefined ? 'none' : String(listIndex)
+                  }
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      expect(k0?.getAttribute('data-list-index')).toEqual('none')
+    })
+  })
+
+  test('listIndex resets across non-list interrupts', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: listSchema,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          listItem: 'number',
+          level: 1,
+          children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k1',
+          children: [{_type: 'span', _key: 's1', text: 'plain', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          listItem: 'number',
+          level: 1,
+          children: [{_type: 'span', _key: 's2', text: 'one again', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, listIndex, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-list-index={
+                    listIndex === undefined ? 'none' : String(listIndex)
+                  }
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      const k1 = document.querySelector('[data-testid="block-k1"]')
+      const k2 = document.querySelector('[data-testid="block-k2"]')
+      expect(k0?.getAttribute('data-list-index')).toEqual('1')
+      expect(k1?.getAttribute('data-list-index')).toEqual('none')
+      expect(k2?.getAttribute('data-list-index')).toEqual('1')
+    })
+  })
+
+  test('listIndex is undefined for list-items inside a container', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        lists: [{name: 'number'}, {name: 'bullet'}],
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c0',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              listItem: 'number',
+              level: 1,
+              children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              _key: 'k1',
+              listItem: 'number',
+              level: 1,
+              children: [{_type: 'span', _key: 's1', text: 'two', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({type: 'callout', arrayField: 'content'}),
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children, listIndex, node}) => (
+                <div
+                  data-testid={`block-${node._key}`}
+                  data-list-index={
+                    listIndex === undefined ? 'none' : String(listIndex)
+                  }
+                  {...attributes}
+                >
+                  {children}
+                </div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      const k0 = document.querySelector('[data-testid="block-k0"]')
+      const k1 = document.querySelector('[data-testid="block-k1"]')
+      expect(k0?.getAttribute('data-list-index')).toEqual('none')
+      expect(k1?.getAttribute('data-list-index')).toEqual('none')
+    })
+  })
+})


### PR DESCRIPTION
`defineTextBlock` and `defineBlockObject` now receive two engine-derived signals that aren't available on the value, letting catch-all consumers recreate the legacy drop indicator and numbered-list affordances:

- **`dropPosition: 'start' | 'end' | undefined`** on both `TextBlockRenderProps` and `BlockObjectRenderProps`. Set mid-drag when this block is the current drop target. Consumers using a custom `render` can show their own drop affordance, or delegate via `renderDefault`.
- **`listIndex: number | undefined`** on `TextBlockRenderProps`. The 1-based running index of a list-item within its visible list run — level-aware, resets across non-list interrupts. Engine already computes it (`editor.listIndexMap`); now exposed.

Both fields are optional in the consumer's destructure (catch-all consumers that don't care simply omit them).

Generic — applies to anyone using `defineTextBlock({type: '*'})` / `defineBlockObject({type: '*'})` or a positional override in a container's `of` array.