### PR TITLE
fix: apply `insertReplacementText` at the correct position inside iframes

### DIFF
--- a/.changeset/grammarly-replacement-in-iframe.md
+++ b/.changeset/grammarly-replacement-in-iframe.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: apply `insertReplacementText` at the correct position inside iframes
+
+Accepting a suggestion from a browser extension like Grammarly now replaces the targeted word, even when the editor is mounted inside an iframe.

--- a/packages/editor/src/slate/react/components/editable.tsx
+++ b/packages/editor/src/slate/react/components/editable.tsx
@@ -708,13 +708,33 @@ export const Editable = forwardRef(
           ) {
             const [targetRange] = (event as any).getTargetRanges()
 
-            if (targetRange) {
-              const range = ReactEditor.toSlateRange(editor, targetRange, {
+            // The target ranges tell us where the input should be applied.
+            // Synthetic `beforeinput` events dispatched by browser extensions
+            // like Grammarly carry no target ranges; they set the DOM selection
+            // to the affected range instead. The `onDOMSelectionChange` flush
+            // above normally syncs `editor.selection` to that DOM selection, but
+            // inside an iframe it can't: accepting an extension suggestion moves
+            // focus off the editable, so the flush bails on its focus check and
+            // `editor.selection` stays stale. Fall back to the DOM selection so
+            // the input isn't applied at the wrong place.
+            const domSelection = getSelection(
+              ReactEditor.findDocumentOrShadowRoot(editor),
+            )
+            const inputTarget =
+              targetRange ??
+              (domSelection && domSelection.rangeCount > 0
+                ? domSelection
+                : undefined)
+
+            if (inputTarget) {
+              const range = ReactEditor.toSlateRange(editor, inputTarget, {
                 exactMatch: false,
-                suppressThrow: false,
+                // The DOM selection fallback is not guaranteed to be a valid
+                // Slate range, so don't throw on it.
+                suppressThrow: !targetRange,
               })
 
-              if (!selection || !rangeEquals(selection, range)) {
+              if (range && (!selection || !rangeEquals(selection, range))) {
                 native = false
 
                 const selectionRef =

--- a/packages/editor/tests/event.input.replacement-text.test.tsx
+++ b/packages/editor/tests/event.input.replacement-text.test.tsx
@@ -1,0 +1,85 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {createTestEditor} from '../src/test/vitest'
+import {getSelectionAfterText} from '../test-utils/text-selection'
+
+describe('insertReplacementText', () => {
+  test('Scenario: applied at the DOM selection when the event has no target ranges', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: spanKey,
+              text: 'wat is the problem',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    // Move the editor selection to the end of the text, away from the word
+    // that will be replaced. This is the stale selection that a browser
+    // extension's replacement must not be applied at.
+    const staleSelection = getSelectionAfterText(
+      editor.getSnapshot().context,
+      'wat is the problem',
+    )
+    editor.send({type: 'select', at: staleSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual(staleSelection)
+    })
+
+    const editableElement = locator.element()
+    const textNode = editableElement.querySelector(
+      '[data-slate-string]',
+    )?.firstChild
+
+    if (!textNode) {
+      throw new Error('Could not find the editable text node')
+    }
+
+    // Browser extensions like Grammarly set the DOM selection on the word to
+    // replace and then dispatch a synthetic `insertReplacementText` event with
+    // no target ranges. Both steps happen synchronously here so the editor's
+    // own `selectionchange` sync doesn't run in between, mimicking how that
+    // sync bails inside an iframe when focus moves to the extension's UI.
+    const domSelection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(textNode, 0)
+    range.setEnd(textNode, 3)
+    domSelection?.removeAllRanges()
+    domSelection?.addRange(range)
+
+    editableElement.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertReplacementText',
+        data: 'What',
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'What is the problem',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Accepting a suggestion from a browser extension like Grammarly dispatches a synthetic `insertReplacementText` `beforeinput` event that carries no target ranges, relying instead on the DOM selection the extension sets on the word to replace. Inside an iframe, accepting the suggestion moves focus off the editable, so `onDOMSelectionChange` bails on its focus check and `editor.selection` stays stale -- the replacement was then applied at the stale selection instead of on top of the word.

Fall back to the DOM selection in `onDOMBeforeInput` when a `beforeinput` event has no target ranges, for any input type.