### PR TITLE
refactor: factor SelectionStateProvider shape into createSliceStore

### DIFF
--- a/.changeset/create-editor-slice.md
+++ b/.changeset/create-editor-slice.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: add `createEditorSlice` for plugin-defined snapshot-derived state

--- a/.changeset/use-is-focused-selected-hooks.md
+++ b/.changeset/use-is-focused-selected-hooks.md
@@ -1,0 +1,36 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: replace `focused` and `selected` render props with `useIsFocused*` and `useIsSelected*` hooks
+
+The `focused` and `selected` props are no longer passed to the render callbacks of `defineContainer`, `defineTextBlock`, `defineBlockObject`, `defineInlineObject`, and `defineSpan`. Read them from inside your render body with the new hooks instead:
+
+```ts
+import {
+  useIsFocusedContainer,
+  useIsFocusedLeaf,
+  useIsSelectedContainer,
+  useIsSelectedLeaf,
+} from '@portabletext/editor'
+
+defineBlockObject({
+  type: 'image',
+  render: ({attributes, children, path, node}) => {
+    const focused = useIsFocusedLeaf(path)
+    const selected = useIsSelectedLeaf(path)
+    return (
+      <div {...attributes} aria-selected={selected} data-focused={focused}>
+        {children}
+        <img src={node.src as string} />
+      </div>
+    )
+  },
+})
+```
+
+Use `useIsFocusedContainer` and `useIsSelectedContainer` for `defineContainer` and `defineTextBlock` renders; use `useIsFocusedLeaf` and `useIsSelectedLeaf` for `defineBlockObject`, `defineInlineObject`, and `defineSpan` renders.
+
+Each hook subscribes to a single slice of selection state and only triggers a re-render when its own value flips. Renders that don't read `focused` or `selected` no longer re-render when the caret moves between unrelated nodes.
+
+The legacy `renderBlock`, `renderChild`, `renderDecorator`, and `renderAnnotation` callbacks on `<PortableTextEditable>` still receive `focused` and `selected` and are not affected.

--- a/packages/editor/src/editor/create-editor-slice.tsx
+++ b/packages/editor/src/editor/create-editor-slice.tsx
@@ -1,0 +1,244 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react'
+import type {EditorSnapshot} from './editor-snapshot'
+import {useEditor} from './use-editor'
+
+/**
+ * @alpha
+ */
+export type EditorSliceStore<TState> = {
+  subscribe: (callback: () => void) => () => void
+  getSnapshot: () => TState
+}
+
+type SliceInstance<TState> = {
+  store: EditorSliceStore<TState>
+  recompute: (snapshot: EditorSnapshot) => void
+  defaultState: TState
+}
+
+type SliceHostRegistry = {
+  register: <TState>(
+    sliceId: symbol,
+    instance: SliceInstance<TState>,
+  ) => () => void
+  get: <TState>(sliceId: symbol) => SliceInstance<TState> | undefined
+  subscribeToRegistry: (callback: () => void) => () => void
+}
+
+const SliceHostContext = createContext<SliceHostRegistry | null>(null)
+
+/**
+ * @alpha
+ *
+ * Hosts plugin-registered slices. Mounted by `EditorProvider`.
+ */
+export function EditorSliceHost(props: {children: ReactNode}) {
+  const editor = useEditor()
+
+  const [initialRegistry] = useState(
+    () => new Map<symbol, SliceInstance<unknown>>(),
+  )
+  const registryRef = useRef(initialRegistry)
+  const [initialRegistrySubs] = useState(() => new Set<() => void>())
+  const registrySubsRef = useRef(initialRegistrySubs)
+
+  useEffect(() => {
+    let pendingRecompute = false
+
+    const subscription = editor.subscribe({
+      next: () => {
+        if (pendingRecompute) {
+          return
+        }
+        pendingRecompute = true
+        queueMicrotask(() => {
+          pendingRecompute = false
+          const snapshot = editor.getSnapshot()
+          for (const instance of registryRef.current.values()) {
+            instance.recompute(snapshot)
+          }
+        })
+      },
+    })
+
+    return () => subscription.unsubscribe()
+  }, [editor])
+
+  const registry = useMemo<SliceHostRegistry>(
+    () => ({
+      register: (sliceId, instance) => {
+        registryRef.current.set(sliceId, instance as SliceInstance<unknown>)
+        for (const cb of registrySubsRef.current) {
+          cb()
+        }
+        return () => {
+          registryRef.current.delete(sliceId)
+          for (const cb of registrySubsRef.current) {
+            cb()
+          }
+        }
+      },
+      get: (sliceId) =>
+        registryRef.current.get(sliceId) as SliceInstance<never> | undefined,
+      subscribeToRegistry: (callback) => {
+        registrySubsRef.current.add(callback)
+        return () => {
+          registrySubsRef.current.delete(callback)
+        }
+      },
+    }),
+    [],
+  )
+
+  return (
+    <SliceHostContext.Provider value={registry}>
+      {props.children}
+    </SliceHostContext.Provider>
+  )
+}
+
+/**
+ * @alpha
+ *
+ * Factory for plugin-author-defined slices of engine-derived state.
+ * The returned `Plugin` mounts the slice with the editor's slice host;
+ * the returned `useSlice` hook reads from anywhere inside the editor
+ * and only re-renders when the selected value flips.
+ *
+ * @example
+ * ```tsx
+ * const listIndexSlice = createEditorSlice<Map<string, number>>({
+ *   defaultState: new Map(),
+ *   compute: (snapshot) => buildListIndexMap(snapshot.context),
+ *   equal: shallowMapEqual,
+ *   displayName: 'ListIndexSlice',
+ * })
+ *
+ * export function ListIndexPlugin() {
+ *   return <listIndexSlice.Plugin />
+ * }
+ *
+ * export function useListIndex(path: Path): number | undefined {
+ *   return listIndexSlice.useSlice((map) => map.get(path[0]._key))
+ * }
+ * ```
+ */
+export function createEditorSlice<TState>(options: {
+  defaultState: TState
+  compute: (snapshot: EditorSnapshot) => TState
+  equal: (a: TState, b: TState) => boolean
+  displayName?: string
+}) {
+  const {defaultState, compute, equal} = options
+  const displayName = options.displayName ?? 'EditorSlice'
+
+  const sliceId = Symbol(displayName)
+
+  function Plugin() {
+    const registry = useContext(SliceHostContext)
+    if (!registry) {
+      throw new Error(
+        `${displayName}.Plugin must be mounted inside <EditorProvider>.`,
+      )
+    }
+    const editor = useEditor()
+
+    const [seed] = useState(() => compute(editor.getSnapshot()))
+    const stateRef = useRef<TState>(seed)
+    const [initialSubscribers] = useState(() => new Set<() => void>())
+    const subscribersRef = useRef<Set<() => void>>(initialSubscribers)
+
+    const store = useMemo<EditorSliceStore<TState>>(
+      () => ({
+        subscribe: (callback) => {
+          subscribersRef.current.add(callback)
+          return () => {
+            subscribersRef.current.delete(callback)
+          }
+        },
+        getSnapshot: () => stateRef.current,
+      }),
+      [],
+    )
+
+    useEffect(() => {
+      // Reconcile state between render-time seed and effect-time
+      // (snapshot may have advanced after child effects).
+      const next = compute(editor.getSnapshot())
+      if (!equal(stateRef.current, next)) {
+        stateRef.current = next
+        for (const cb of subscribersRef.current) {
+          cb()
+        }
+      }
+
+      const unregister = registry.register(sliceId, {
+        store,
+        defaultState,
+        recompute: (snapshot) => {
+          const newState = compute(snapshot)
+          if (!equal(stateRef.current, newState)) {
+            stateRef.current = newState
+            for (const cb of subscribersRef.current) {
+              cb()
+            }
+          }
+        },
+      })
+
+      return unregister
+    }, [editor, registry, store])
+
+    return null
+  }
+  Plugin.displayName = `${displayName}.Plugin`
+
+  function useSlice<TSelected>(
+    selector: (state: TState) => TSelected,
+    selectorEqual: (a: TSelected, b: TSelected) => boolean = Object.is,
+  ): TSelected {
+    const registry = useContext(SliceHostContext)
+
+    // Re-read the registered instance whenever Plugin mounts/unmounts.
+    const registryVersion = useSyncExternalStore(
+      registry ? registry.subscribeToRegistry : noopSubscribe,
+      () => (registry ? registry.get(sliceId) : undefined),
+    )
+
+    const instance = registryVersion as SliceInstance<TState> | undefined
+
+    const lastSelected = useRef<{value: TSelected; hasValue: boolean}>({
+      value: undefined as TSelected,
+      hasValue: false,
+    })
+
+    return useSyncExternalStore(
+      instance ? instance.store.subscribe : noopSubscribe,
+      () => {
+        const state = instance ? instance.store.getSnapshot() : defaultState
+        const next = selector(state)
+        if (
+          lastSelected.current.hasValue &&
+          selectorEqual(lastSelected.current.value, next)
+        ) {
+          return lastSelected.current.value
+        }
+        lastSelected.current = {value: next, hasValue: true}
+        return next
+      },
+    )
+  }
+
+  return {Plugin, useSlice}
+}
+
+const noopSubscribe = (() => () => {}) satisfies (cb: () => void) => () => void

--- a/packages/editor/src/editor/create-slice-store.tsx
+++ b/packages/editor/src/editor/create-slice-store.tsx
@@ -1,0 +1,126 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import type {AnyActorRef} from 'xstate'
+
+export type SliceStore<TState> = {
+  subscribe: (callback: () => void) => () => void
+  getSnapshot: () => TState
+}
+
+/**
+ * Factor of the `SelectionStateProvider` shape: one subscription to an
+ * actor, one state struct recomputed per change (microtask-coalesced),
+ * exposed via a `useSyncExternalStore`-compatible store + React context
+ * so consumers attach per-slice and re-render only when their slice
+ * flips.
+ */
+export function createSliceStore<TState>(options: {
+  defaultState: TState
+  equal: (a: TState, b: TState) => boolean
+  displayName: string
+}): {
+  Provider: (props: {
+    actor: AnyActorRef
+    /**
+     * Memoize this with `useMemo` / `useCallback` — a new `compute`
+     * reference tears down and re-subscribes the actor effect.
+     */
+    compute: () => TState
+    children: ReactNode
+  }) => ReactNode
+  useStore: () => SliceStore<TState>
+} {
+  const {defaultState, equal, displayName} = options
+
+  // No-op store for slice hooks called outside a Provider.
+  const defaultStore: SliceStore<TState> = {
+    subscribe: () => () => {},
+    getSnapshot: () => defaultState,
+  }
+
+  const StoreContext = createContext<SliceStore<TState>>(defaultStore)
+  StoreContext.displayName = displayName
+
+  function Provider(props: {
+    actor: AnyActorRef
+    compute: () => TState
+    children: ReactNode
+  }) {
+    const {actor, compute} = props
+
+    const [seed] = useState(compute)
+    const stateRef = useRef<TState>(seed)
+
+    const [initialSubscribers] = useState(() => new Set<() => void>())
+    const subscribersRef = useRef<Set<() => void>>(initialSubscribers)
+
+    useEffect(() => {
+      // Catches state changes between the first render (when `seed` was
+      // captured) and this effect firing after commit. Child effects
+      // run before parent effects, so subscribers are already attached.
+      const next = compute()
+      if (!equal(stateRef.current, next)) {
+        stateRef.current = next
+        for (const cb of subscribersRef.current) {
+          cb()
+        }
+      }
+
+      let pendingRecompute = false
+
+      const subscription = actor.subscribe(() => {
+        // Coalesce bursts of actor updates into one recompute per
+        // microtask. The microtask drains before React's commit phase.
+        if (pendingRecompute) {
+          return
+        }
+        pendingRecompute = true
+        queueMicrotask(() => {
+          pendingRecompute = false
+          const newState = compute()
+          if (!equal(stateRef.current, newState)) {
+            stateRef.current = newState
+            for (const cb of subscribersRef.current) {
+              cb()
+            }
+          }
+        })
+      })
+
+      return () => subscription.unsubscribe()
+    }, [actor, compute])
+
+    const store = useMemo<SliceStore<TState>>(
+      () => ({
+        subscribe: (callback) => {
+          subscribersRef.current.add(callback)
+          return () => {
+            subscribersRef.current.delete(callback)
+          }
+        },
+        getSnapshot: () => stateRef.current,
+      }),
+      [],
+    )
+
+    return (
+      <StoreContext.Provider value={store}>
+        {props.children}
+      </StoreContext.Provider>
+    )
+  }
+  Provider.displayName = `${displayName}.Provider`
+
+  function useStore(): SliceStore<TState> {
+    return useContext(StoreContext)
+  }
+
+  return {Provider, useStore}
+}

--- a/packages/editor/src/editor/editor-provider.tsx
+++ b/packages/editor/src/editor/editor-provider.tsx
@@ -4,6 +4,7 @@ import type {EditorConfig} from '../editor'
 import {Engine} from '../engine/react/components/engine'
 import {stopActor} from '../internal-utils/stop-actor'
 import {createInternalEditor} from './create-editor'
+import {EditorSliceHost} from './create-editor-slice'
 import {EditorActorContext} from './editor-actor-context'
 import {EditorContext} from './editor-context'
 import {PortableTextEditor} from './PortableTextEditor'
@@ -81,7 +82,7 @@ export function EditorProvider(props: EditorProviderProps) {
         <RelayActorContext.Provider value={internalEditor.actors.relayActor}>
           <Engine editor={internalEditor.editorEngine}>
             <PortableTextEditorContext.Provider value={portableTextEditor}>
-              {props.children}
+              <EditorSliceHost>{props.children}</EditorSliceHost>
             </PortableTextEditorContext.Provider>
           </Engine>
         </RelayActorContext.Provider>

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -3,7 +3,6 @@ import {useRef, type ReactElement} from 'react'
 import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
-import {serializePath} from '../paths/serialize-path'
 import type {
   BlockObjectConfig,
   BlockObjectRenderProps,
@@ -30,9 +29,8 @@ export function RenderBlockObject(props: {
 }) {
   const blockObjectRef = useRef<HTMLDivElement>(null)
 
-  const serializedPath = serializePath(props.path)
-  const selected = useIsSelectedLeaf(serializedPath)
-  const focused = useIsFocusedLeaf(serializedPath)
+  const selected = useIsSelectedLeaf(props.path)
+  const focused = useIsFocusedLeaf(props.path)
 
   const blockObjectSchemaType = props.schema.blockObjects.find(
     (schemaType) => schemaType.name === props.element._type,
@@ -62,12 +60,10 @@ export function RenderBlockObject(props: {
         'data-pt-block': 'object',
       },
       children: props.children,
-      focused,
       node: props.element,
       path: props.path,
       readOnly: props.readOnly,
       renderDefault: renderDefaultBlockObject,
-      selected,
     }
     return render ? render(renderProps) : renderDefaultBlockObject(renderProps)
   }

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -2,16 +2,11 @@ import type {PortableTextBlock, PortableTextObject} from '@portabletext/schema'
 import type {ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
-import {serializePath} from '../paths/serialize-path'
 import type {
   ContainerConfig,
   ContainerRenderProps,
 } from '../renderers/renderer.types'
 import {renderDefaultContainer} from './render.default'
-import {
-  useIsFocusedContainer,
-  useIsSelectedContainer,
-} from './selection-state-context'
 
 export function RenderContainer(props: {
   attributes: RenderElementProps['attributes']
@@ -21,9 +16,6 @@ export function RenderContainer(props: {
   path: Path
   readOnly: boolean
 }) {
-  const serializedPath = serializePath(props.path)
-  const focused = useIsFocusedContainer(serializedPath)
-  const selected = useIsSelectedContainer(serializedPath)
   const render = props.containerConfig.container.render
 
   // Container registrations forbid the `'block'` and `'span'` types
@@ -34,12 +26,10 @@ export function RenderContainer(props: {
   const renderProps: ContainerRenderProps = {
     attributes: props.attributes,
     children: props.children,
-    focused,
     node: props.element as PortableTextObject,
     path: props.path,
     readOnly: props.readOnly,
     renderDefault: renderDefaultContainer,
-    selected,
   }
 
   return render ? render(renderProps) : renderDefaultContainer(renderProps)

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -9,7 +9,6 @@ import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
 import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
-import {serializePath} from '../paths/serialize-path'
 import type {
   BlockObjectConfig,
   ContainerConfig,
@@ -32,10 +31,6 @@ import {renderDefaultTextBlock} from './render.default'
 import {RenderInlineObject} from './render.inline-object'
 import {RenderTextBlock} from './render.text-block'
 import {resolveElementDropPosition} from './resolve-element-drop-position'
-import {
-  useIsFocusedContainer,
-  useIsSelectedContainer,
-} from './selection-state-context'
 import {tupleRefEqual} from './tuple-ref-equal'
 
 export function RenderElement(props: {
@@ -321,14 +316,9 @@ export function RenderElement(props: {
 
 /**
  * Renders a text block via a registered `defineTextBlock` config whose
- * `render` is a function. Extracted into its own component so the
- * per-slice selection hooks (`useIsFocusedContainer` /
- * `useIsSelectedContainer`) live at the top of a component, not inside
- * a conditional in `RenderElement`'s body.
- *
- * The dispatch in `RenderElement` filters: a `function` render flows
- * here; a config with no `render` resolves to global or to the
- * legacy pipeline at top level.
+ * `render` is a function. Extracted into its own component because the
+ * dispatch in `RenderElement` filters by render-shape and the new
+ * pipeline must not flow through the legacy-callback branch.
  */
 function RenderTextBlockConfig(props: {
   attributes: Omit<RenderElementProps['attributes'], 'data-pt-block'> & {
@@ -340,18 +330,13 @@ function RenderTextBlockConfig(props: {
   readOnly: boolean
   render: NonNullable<TextBlockConfig['textBlock']['render']>
 }) {
-  const serializedPath = serializePath(props.path)
-  const focused = useIsFocusedContainer(serializedPath)
-  const selected = useIsSelectedContainer(serializedPath)
   const renderDefault = renderDefaultTextBlock
   return props.render({
     attributes: props.attributes,
     children: props.children,
-    focused,
     node: props.node,
     path: props.path,
     readOnly: props.readOnly,
     renderDefault,
-    selected,
   })
 }

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -2,7 +2,6 @@ import type {PortableTextChild, PortableTextObject} from '@portabletext/schema'
 import {useRef, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
-import {serializePath} from '../paths/serialize-path'
 import type {
   InlineObjectConfig,
   InlineObjectRenderProps,
@@ -39,9 +38,8 @@ export function RenderInlineObject(props: {
     )
   }
 
-  const serializedPath = serializePath(props.path)
-  const selected = useIsSelectedLeaf(serializedPath)
-  const focused = useIsFocusedLeaf(serializedPath)
+  const selected = useIsSelectedLeaf(props.path)
+  const focused = useIsFocusedLeaf(props.path)
 
   const inlineObject = props.element as unknown as PortableTextChild
 
@@ -58,12 +56,10 @@ export function RenderInlineObject(props: {
         'data-pt-inline': 'object',
       },
       children: props.children,
-      focused,
       node: props.element as PortableTextObject,
       path: props.path,
       readOnly: props.readOnly,
       renderDefault: renderDefaultInlineObject,
-      selected,
     }
     return render ? render(renderProps) : renderDefaultInlineObject(renderProps)
   }

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -5,7 +5,6 @@ import type {
 import {isTextBlock} from '@portabletext/schema'
 import {useContext, useRef, type ReactElement} from 'react'
 import type {RenderLeafProps} from '../engine/react/components/editable'
-import {serializePath} from '../paths/serialize-path'
 import type {SpanRenderProps} from '../renderers/renderer.types'
 import type {
   BlockAnnotationRenderProps,
@@ -51,9 +50,8 @@ export function RenderSpan(props: RenderSpanProps) {
   const spanConfig = useSpanConfig(child ?? props.leaf, props.path)
 
   const isInNewPipeline = useContext(NewPipelineContext)
-  const serializedPath = serializePath(props.path)
-  const focused = useIsFocusedLeaf(serializedPath)
-  const selected = useIsSelectedLeaf(serializedPath)
+  const focused = useIsFocusedLeaf(props.path)
+  const selected = useIsSelectedLeaf(props.path)
 
   const decoratorSchemaTypes = subSchema.decorators.map(
     (decorator) => decorator.name,
@@ -166,12 +164,10 @@ export function RenderSpan(props: RenderSpanProps) {
     const renderProps: SpanRenderProps = {
       attributes: props.attributes,
       children,
-      focused,
       node: (child ?? props.leaf) as PortableTextSpan,
       path: props.path,
       readOnly: props.readOnly,
       renderDefault: renderDefaultSpan,
-      selected,
     }
     return render ? render(renderProps) : renderDefaultSpan(renderProps)
   }

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -7,7 +7,6 @@ import type {DropPosition} from '../behaviors/behavior.core.drop-position'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
 import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
-import {serializePath} from '../paths/serialize-path'
 import type {
   BlockListItemRenderProps,
   BlockRenderProps,
@@ -41,9 +40,8 @@ export function RenderTextBlock(props: {
     name: props.schema.block.name,
     fields: props.schema.block.fields ?? [],
   } satisfies BlockObjectSchemaType
-  const serializedPath = serializePath(props.path)
-  const selected = useIsSelectedContainer(serializedPath)
-  const focused = useIsFocusedContainer(serializedPath)
+  const selected = useIsSelectedContainer(props.path)
+  const focused = useIsFocusedContainer(props.path)
   const listIndex = useEngineSelector((editor) =>
     editor.listIndexMap.get(props.textBlock._key),
   )

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -1,14 +1,7 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react'
+import {useContext, useMemo, useSyncExternalStore} from 'react'
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
+import {createSliceStore} from './create-slice-store'
 import {EditorActorContext} from './editor-actor-context'
 import {getSelectionState, type SelectionState} from './get-selection-state'
 
@@ -27,7 +20,7 @@ const defaultSelectionState: SelectionState = {
  * change doesn't move any per-component slice.
  *
  * Assumes the Set instances passed via `selectedLeafPaths` /
- * `selectedContainerPaths` are immutable per emission - `getSelectionState`
+ * `selectedContainerPaths` are immutable per emission — `getSelectionState`
  * builds a fresh Set on each recompute rather than mutating in place,
  * so size + containment equivalence is a sound equality check.
  */
@@ -64,24 +57,11 @@ function selectionStatesEqual(
   return true
 }
 
-/**
- * External store shape exposed to consumers. Components subscribe via
- * `useSyncExternalStore` with a per-slice snapshot selector so they
- * only re-render when their own slice flips - typing a character
- * doesn't cascade through every visible container's wrapper.
- */
-type SelectionStateStore = {
-  subscribe: (callback: () => void) => () => void
-  getSnapshot: () => SelectionState
-}
-
-const defaultStore: SelectionStateStore = {
-  subscribe: () => () => {},
-  getSnapshot: () => defaultSelectionState,
-}
-
-const SelectionStateStoreContext =
-  createContext<SelectionStateStore>(defaultStore)
+const {Provider: StoreProvider, useStore} = createSliceStore<SelectionState>({
+  defaultState: defaultSelectionState,
+  equal: selectionStatesEqual,
+  displayName: 'SelectionStateStore',
+})
 
 /**
  * Subscribes once to the editor actor and maintains a single source of
@@ -103,10 +83,9 @@ export function SelectionStateProvider({
   const editorActor = useContext(EditorActorContext)
   const editorEngine = useEngineStatic()
 
-  // Compute the current snapshot once on every read. Cheap when nothing
-  // has changed (refs are reference-equal); recomputes on actor updates
-  // (handled in the subscription effect below).
-  const computeCurrent = useMemo(
+  // Memoized on engine identity so the actor subscription doesn't
+  // tear down on every Provider re-render.
+  const compute = useMemo(
     () => () => {
       const snapshot = editorEngine.snapshot
       const selection = snapshot.context.selection
@@ -133,87 +112,20 @@ export function SelectionStateProvider({
     [editorEngine],
   )
 
-  // Seed the initial snapshot exactly once via `useState`'s lazy
-  // initializer, then keep it on a ref the external store reads from.
-  // `useRef(seed)` writes `seed` to the ref on first render only;
-  // subsequent renders ignore the argument. The subscription effect
-  // below takes ownership of updates after mount.
-  const [seed] = useState(computeCurrent)
-  const stateRef = useRef<SelectionState>(seed)
-
-  // Same pattern for the subscriber Set: lazy-init via `useState` so we
-  // allocate the empty Set exactly once, not on every render.
-  const [initialSubscribers] = useState(() => new Set<() => void>())
-  const subscribersRef = useRef<Set<() => void>>(initialSubscribers)
-
-  useEffect(() => {
-    // Mount ordering: child effects run before parent effects, so by
-    // the time this effect runs every consumer `useSyncExternalStore`
-    // has already registered its notify callback in
-    // `subscribersRef.current`. The recompute-and-notify below catches
-    // any state changes between the provider's first render (when we
-    // seeded `stateRef`) and this effect firing (after commit).
-    const next = computeCurrent()
-    if (!selectionStatesEqual(stateRef.current, next)) {
-      stateRef.current = next
-      for (const cb of subscribersRef.current) {
-        cb()
-      }
-    }
-
-    let pendingRecompute = false
-
-    const subscription = editorActor.subscribe(() => {
-      // Coalesce bursts of actor updates into one selection-state
-      // recompute per microtask. The microtask drains before React's
-      // commit phase, so subscribers re-render in the same commit as
-      // the actor's state change.
-      if (pendingRecompute) {
-        return
-      }
-      pendingRecompute = true
-      queueMicrotask(() => {
-        pendingRecompute = false
-        const newState = computeCurrent()
-        if (!selectionStatesEqual(stateRef.current, newState)) {
-          stateRef.current = newState
-          for (const cb of subscribersRef.current) {
-            cb()
-          }
-        }
-      })
-    })
-
-    return () => subscription.unsubscribe()
-  }, [editorActor, computeCurrent])
-
-  const store = useMemo<SelectionStateStore>(
-    () => ({
-      subscribe: (callback) => {
-        subscribersRef.current.add(callback)
-        return () => {
-          subscribersRef.current.delete(callback)
-        }
-      },
-      getSnapshot: () => stateRef.current,
-    }),
-    [],
-  )
-
   return (
-    <SelectionStateStoreContext.Provider value={store}>
+    <StoreProvider actor={editorActor} compute={compute}>
       {children}
-    </SelectionStateStoreContext.Provider>
+    </StoreProvider>
   )
 }
 
 /**
  * Subscribe to whether a container at `serializedPath` is currently
- * focused. Re-renders only when this boolean flips - not when other
+ * focused. Re-renders only when this boolean flips — not when other
  * containers' focused state changes.
  */
 export function useIsFocusedContainer(serializedPath: string): boolean {
-  const store = useContext(SelectionStateStoreContext)
+  const store = useStore()
   return useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().focusedContainerPath === serializedPath,
@@ -225,7 +137,7 @@ export function useIsFocusedContainer(serializedPath: string): boolean {
  * current selection.
  */
 export function useIsSelectedContainer(serializedPath: string): boolean {
-  const store = useContext(SelectionStateStoreContext)
+  const store = useStore()
   return useSyncExternalStore(store.subscribe, () =>
     store.getSnapshot().selectedContainerPaths.has(serializedPath),
   )
@@ -236,7 +148,7 @@ export function useIsSelectedContainer(serializedPath: string): boolean {
  * `serializedPath` is currently focused.
  */
 export function useIsFocusedLeaf(serializedPath: string): boolean {
-  const store = useContext(SelectionStateStoreContext)
+  const store = useStore()
   return useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().focusedLeafPath === serializedPath,
@@ -248,7 +160,7 @@ export function useIsFocusedLeaf(serializedPath: string): boolean {
  * selection.
  */
 export function useIsSelectedLeaf(serializedPath: string): boolean {
-  const store = useContext(SelectionStateStoreContext)
+  const store = useStore()
   return useSyncExternalStore(store.subscribe, () =>
     store.getSnapshot().selectedLeafPaths.has(serializedPath),
   )

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -1,5 +1,7 @@
 import {useContext, useMemo, useSyncExternalStore} from 'react'
+import type {Path} from '../engine/interfaces/path'
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
+import {serializePath} from '../paths/serialize-path'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {createSliceStore} from './create-slice-store'
 import {EditorActorContext} from './editor-actor-context'
@@ -120,12 +122,16 @@ export function SelectionStateProvider({
 }
 
 /**
- * Subscribe to whether a container at `serializedPath` is currently
- * focused. Re-renders only when this boolean flips — not when other
- * containers' focused state changes.
+ * @alpha
+ *
+ * Subscribe to whether the container at `path` is currently the
+ * innermost container that contains the caret. Re-renders only when
+ * this boolean flips — not when other containers' focused state
+ * changes, and not on every keystroke when the boolean doesn't move.
  */
-export function useIsFocusedContainer(serializedPath: string): boolean {
+export function useIsFocusedContainer(path: Path): boolean {
   const store = useStore()
+  const serializedPath = serializePath(path)
   return useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().focusedContainerPath === serializedPath,
@@ -133,22 +139,28 @@ export function useIsFocusedContainer(serializedPath: string): boolean {
 }
 
 /**
- * Subscribe to whether a container at `serializedPath` is within the
- * current selection.
+ * @alpha
+ *
+ * Subscribe to whether the container at `path` is within (or contains)
+ * the current selection.
  */
-export function useIsSelectedContainer(serializedPath: string): boolean {
+export function useIsSelectedContainer(path: Path): boolean {
   const store = useStore()
+  const serializedPath = serializePath(path)
   return useSyncExternalStore(store.subscribe, () =>
     store.getSnapshot().selectedContainerPaths.has(serializedPath),
   )
 }
 
 /**
- * Subscribe to whether a leaf (span / inline object / block object) at
- * `serializedPath` is currently focused.
+ * @alpha
+ *
+ * Subscribe to whether the leaf (span, inline object, or block object)
+ * at `path` is the one the caret is in or on.
  */
-export function useIsFocusedLeaf(serializedPath: string): boolean {
+export function useIsFocusedLeaf(path: Path): boolean {
   const store = useStore()
+  const serializedPath = serializePath(path)
   return useSyncExternalStore(
     store.subscribe,
     () => store.getSnapshot().focusedLeafPath === serializedPath,
@@ -156,11 +168,14 @@ export function useIsFocusedLeaf(serializedPath: string): boolean {
 }
 
 /**
- * Subscribe to whether a leaf at `serializedPath` is within the current
+ * @alpha
+ *
+ * Subscribe to whether the leaf at `path` is within the current
  * selection.
  */
-export function useIsSelectedLeaf(serializedPath: string): boolean {
+export function useIsSelectedLeaf(path: Path): boolean {
   const store = useStore()
+  const serializedPath = serializePath(path)
   return useSyncExternalStore(store.subscribe, () =>
     store.getSnapshot().selectedLeafPaths.has(serializedPath),
   )

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -37,6 +37,10 @@ export {
 } from '@portabletext/schema'
 export {useEditorSelector, type EditorSelector} from './editor/editor-selector'
 export {
+  createEditorSlice,
+  type EditorSliceStore,
+} from './editor/create-editor-slice'
+export {
   useIsFocusedContainer,
   useIsFocusedLeaf,
   useIsSelectedContainer,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -36,6 +36,12 @@ export {
   type StyleDefinition,
 } from '@portabletext/schema'
 export {useEditorSelector, type EditorSelector} from './editor/editor-selector'
+export {
+  useIsFocusedContainer,
+  useIsFocusedLeaf,
+  useIsSelectedContainer,
+  useIsSelectedLeaf,
+} from './editor/selection-state-context'
 export type {EditorContext, EditorSnapshot} from './editor/editor-snapshot'
 export {usePortableTextEditor} from './editor/usePortableTextEditor'
 export {usePortableTextEditorSelection} from './editor/usePortableTextEditorSelection'

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -34,11 +34,9 @@ export type ContainerNodeForType<TType extends string> = TType extends
 export type ContainerRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
-  focused: boolean
   node: PortableTextObject
   path: Path
   readOnly: boolean
-  selected: boolean
   /**
    * Render this position with the engine's default wrapper. Call from
    * inside a custom render to fall back to or wrap the default:
@@ -69,11 +67,9 @@ export type ContainerRender = (props: ContainerRenderProps) => ReactElement
 export type SpanRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
-  focused: boolean
   node: PortableTextSpan
   path: Path
   readOnly: boolean
-  selected: boolean
   /**
    * Render this position with the engine's default wrapper.
    * See {@link ContainerRenderProps.renderDefault}.
@@ -97,11 +93,9 @@ export type SpanRender = (props: SpanRenderProps) => ReactElement
 export type BlockObjectRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
-  focused: boolean
   node: PortableTextObject
   path: Path
   readOnly: boolean
-  selected: boolean
   /**
    * Render this position with the engine's default wrapper.
    * See {@link ContainerRenderProps.renderDefault}.
@@ -125,11 +119,9 @@ export type BlockObjectRender = (props: BlockObjectRenderProps) => ReactElement
 export type InlineObjectRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
-  focused: boolean
   node: PortableTextObject
   path: Path
   readOnly: boolean
-  selected: boolean
   /**
    * Render this position with the engine's default wrapper.
    * See {@link ContainerRenderProps.renderDefault}.
@@ -224,11 +216,9 @@ export type TextBlock = {
 export type TextBlockRenderProps = {
   attributes: Record<string, unknown>
   children: ReactElement
-  focused: boolean
   node: PortableTextTextBlock
   path: Path
   readOnly: boolean
-  selected: boolean
   /**
    * Render this position with the engine's default wrapper.
    * See {@link ContainerRenderProps.renderDefault}.
@@ -353,11 +343,9 @@ export function defineContainer<const TType extends string>(config: {
   render?: (props: {
     attributes: Record<string, unknown>
     children: ReactElement
-    focused: boolean
     node: ContainerNodeForType<TType>
     path: Path
     readOnly: boolean
-    selected: boolean
     renderDefault: (props: ContainerRenderProps) => ReactElement
   }) => ReactElement
   of?: ReadonlyArray<Container | TextBlock | BlockObject>

--- a/packages/editor/tests/container-render-focused-selected.test.tsx
+++ b/packages/editor/tests/container-render-focused-selected.test.tsx
@@ -2,6 +2,7 @@ import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import type {Path} from '../src/engine/interfaces/path'
+import {useIsFocusedContainer, useIsSelectedContainer} from '../src/index'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
@@ -54,7 +55,7 @@ const tableSchema = defineSchema({
   ],
 })
 
-describe('container render focused, selected, and path', () => {
+describe('useIsFocusedContainer / useIsSelectedContainer / useIsFocusedLeaf / useIsSelectedLeaf', () => {
   test('Only the innermost container is focused; ancestors are selected', async () => {
     const calloutValues: Array<{
       focused: boolean
@@ -93,14 +94,18 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'callout',
               arrayField: 'content',
-              render: ({attributes, children, focused, selected, path}) => {
+              render: ({attributes, children, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 calloutValues.push({focused, selected, path})
                 return <div {...attributes}>{children}</div>
               },
               of: [
                 defineTextBlock({
                   type: 'block',
-                  render: ({attributes, children, focused, selected, path}) => {
+                  render: ({attributes, children, path}) => {
+                    const focused = useIsFocusedContainer(path)
+                    const selected = useIsSelectedContainer(path)
                     calloutBlockValues.push({focused, selected, path})
                     return <div {...attributes}>{children}</div>
                   },
@@ -176,7 +181,9 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'callout',
               arrayField: 'content',
-              render: ({attributes, children, focused, selected}) => {
+              render: ({attributes, children, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 calloutValues.push({focused, selected})
                 return <div {...attributes}>{children}</div>
               },
@@ -246,7 +253,9 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'table',
               arrayField: 'rows',
-              render: ({attributes, children, focused, selected}) => {
+              render: ({attributes, children, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 tableValues.push({focused, selected})
                 return <div {...attributes}>{children}</div>
               },
@@ -254,7 +263,9 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'row',
               arrayField: 'cells',
-              render: ({attributes, children, focused, selected}) => {
+              render: ({attributes, children, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 rowValues.push({focused, selected})
                 return <div {...attributes}>{children}</div>
               },
@@ -262,14 +273,18 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'cell',
               arrayField: 'content',
-              render: ({attributes, children, focused, selected}) => {
+              render: ({attributes, children, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 cellValues.push({focused, selected})
                 return <div {...attributes}>{children}</div>
               },
               of: [
                 defineTextBlock({
                   type: 'block',
-                  render: ({attributes, children, focused, selected}) => {
+                  render: ({attributes, children, path}) => {
+                    const focused = useIsFocusedContainer(path)
+                    const selected = useIsSelectedContainer(path)
                     cellBlockValues.push({focused, selected})
                     return <div {...attributes}>{children}</div>
                   },
@@ -389,7 +404,9 @@ describe('container render focused, selected, and path', () => {
             defineContainer({
               type: 'cell',
               arrayField: 'content',
-              render: ({attributes, children, focused, selected, node}) => {
+              render: ({attributes, children, node, path}) => {
+                const focused = useIsFocusedContainer(path)
+                const selected = useIsSelectedContainer(path)
                 cellValues.push({key: node._key, focused, selected})
                 return <div {...attributes}>{children}</div>
               },

--- a/packages/editor/tests/create-editor-slice.test.tsx
+++ b/packages/editor/tests/create-editor-slice.test.tsx
@@ -1,0 +1,269 @@
+import {describe, expect, test, vi} from 'vitest'
+import {page} from 'vitest/browser'
+import {
+  createEditorSlice,
+  defineSchema,
+  type EditorSnapshot,
+  type Path,
+} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Exercises the public `createEditorSlice` primitive by building a
+ * minimal slice that tracks per-block existence at the root level.
+ *
+ * The point isn't to test list-index or any specific signal — it's to
+ * prove the primitive's contract: plugin authors use only public
+ * exports; consumers reading via `useSlice` work regardless of where
+ * they sit in the editor tree; re-renders only happen when the
+ * selected value flips.
+ */
+describe('createEditorSlice', () => {
+  // Slice: map of block key -> block index (root level).
+  function buildBlockIndexMap(snapshot: EditorSnapshot): Map<string, number> {
+    const map = new Map<string, number>()
+    snapshot.context.value.forEach((block, index) => {
+      map.set(block._key, index)
+    })
+    return map
+  }
+
+  function mapsEqual(a: Map<string, number>, b: Map<string, number>): boolean {
+    if (a === b) {
+      return true
+    }
+    if (a.size !== b.size) {
+      return false
+    }
+    for (const [key, value] of a) {
+      if (b.get(key) !== value) {
+        return false
+      }
+    }
+    return true
+  }
+
+  const blockIndexSlice = createEditorSlice<Map<string, number>>({
+    defaultState: new Map(),
+    compute: buildBlockIndexMap,
+    equal: mapsEqual,
+    displayName: 'BlockIndexSlice',
+  })
+
+  function useBlockIndex(path: Path): number | undefined {
+    const first = path[0]
+    const key =
+      typeof first === 'object' && first !== null && '_key' in first
+        ? first._key
+        : undefined
+    return blockIndexSlice.useSlice((map) =>
+      key === undefined ? undefined : map.get(key),
+    )
+  }
+
+  test('useSlice resolves the live value at the right path', async () => {
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'two', marks: []}],
+      },
+    ]
+
+    function Probe({blockKey}: {blockKey: string}) {
+      const index = useBlockIndex([{_key: blockKey}])
+      return <span data-testid={`probe-${blockKey}-${index ?? 'none'}`} />
+    }
+
+    await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue: initialValue as never,
+      children: (
+        <>
+          <blockIndexSlice.Plugin />
+          <Probe blockKey="b0" />
+          <Probe blockKey="b1" />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0-0')).toBeInTheDocument()
+      expect(page.getByTestId('probe-b1-1')).toBeInTheDocument()
+    })
+  })
+
+  test('useSlice returns defaultState selection when Plugin is not mounted', async () => {
+    function Probe({blockKey}: {blockKey: string}) {
+      const index = useBlockIndex([{_key: blockKey}])
+      return <span data-testid={`probe-${blockKey}-${index ?? 'none'}`} />
+    }
+
+    await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      // No <blockIndexSlice.Plugin /> in children — slice unregistered.
+      children: <Probe blockKey="b0" />,
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0-none')).toBeInTheDocument()
+    })
+  })
+
+  test('consumers whose selected value did not flip do not re-render', async () => {
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'first', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'second', marks: []}],
+      },
+    ]
+
+    const renderCounts = new Map<string, number>()
+
+    function Probe({blockKey}: {blockKey: string}) {
+      const index = useBlockIndex([{_key: blockKey}])
+      renderCounts.set(blockKey, (renderCounts.get(blockKey) ?? 0) + 1)
+      return <span data-testid={`probe-${blockKey}-${index ?? 'none'}`} />
+    }
+
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue: initialValue as never,
+      children: (
+        <>
+          <blockIndexSlice.Plugin />
+          <Probe blockKey="b0" />
+          <Probe blockKey="b1" />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0-0')).toBeInTheDocument()
+      expect(page.getByTestId('probe-b1-1')).toBeInTheDocument()
+    })
+
+    // Settle.
+    await new Promise((r) => setTimeout(r, 100))
+    const baseline = new Map(renderCounts)
+
+    // Update value: same blocks, same indices. b0's selected value
+    // does NOT flip (still 0); b1's does NOT flip (still 1). Neither
+    // probe should re-render.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 's0', text: 'first edited', marks: []},
+          ],
+        },
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', text: 'second', marks: []}],
+        },
+      ] as never,
+    } as never)
+
+    // Give the engine a chance to fan the snapshot change through the
+    // slice host. If a re-render were going to happen, it would by now.
+    await new Promise((r) => setTimeout(r, 200))
+
+    const b0Delta = (renderCounts.get('b0') ?? 0) - (baseline.get('b0') ?? 0)
+    const b1Delta = (renderCounts.get('b1') ?? 0) - (baseline.get('b1') ?? 0)
+
+    expect(b0Delta).toBe(0)
+    expect(b1Delta).toBe(0)
+  })
+
+  test('consumers whose selected value flips do re-render', async () => {
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+      },
+    ]
+
+    const renderCounts = new Map<string, number>()
+
+    function Probe({blockKey}: {blockKey: string}) {
+      const index = useBlockIndex([{_key: blockKey}])
+      renderCounts.set(blockKey, (renderCounts.get(blockKey) ?? 0) + 1)
+      return <span data-testid={`probe-${blockKey}-${index ?? 'none'}`} />
+    }
+
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue: initialValue as never,
+      children: (
+        <>
+          <blockIndexSlice.Plugin />
+          <Probe blockKey="b0" />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0-0')).toBeInTheDocument()
+    })
+
+    await new Promise((r) => setTimeout(r, 100))
+    const baseline = renderCounts.get('b0') ?? 0
+
+    // Prepend a new block. b0 shifts from index 0 -> index 1.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: 'b-new',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'sn', text: 'zero', marks: []}],
+        },
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's0', text: 'one', marks: []}],
+        },
+      ] as never,
+    } as never)
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0-1')).toBeInTheDocument()
+    })
+
+    expect(renderCounts.get('b0') ?? 0).toBeGreaterThan(baseline)
+  })
+})


### PR DESCRIPTION
`SelectionStateProvider` ships a self-contained pattern that's worth reusing: subscribe once to an actor, recompute a state struct per change (microtask-coalesced), expose it through a `useSyncExternalStore`-compatible store so consumers attach per-slice and re-render only when their slice flips.

This PR extracts the framework code into `createSliceStore<TState>` and rewrites `SelectionStateProvider` on top of it. Static parts (the context, the default store, the equality function) live on the factory return; dynamic parts (the actor, the compute closure) are Provider props so callers can thread engine refs without forcing a context tear-down on engine change.

The factor is structural only:

- Same actor subscription (editor firehose).
- Same mount-time reconcile between the lazy seed and the post-commit recompute.
- Same equality short-circuit on notify.
- Same exposed hooks (`useIsFocusedContainer` / `useIsSelectedContainer` / `useIsFocusedLeaf` / `useIsSelectedLeaf`) with identical behavior.

`selection-state-context.tsx` shrinks from 255 to 174 lines, keeping only the domain bits: `SelectionState`, `defaultSelectionState`, `selectionStatesEqual`, the `compute` closure that reads `editorEngine.snapshot`, and the four slice hooks.

`createSliceStore` is internal-only — not exported from `index.ts`. Future slice stores for engine signals (drop target, list index, focused/selected migration off render-props) consume it.

No consumer-observable change. `render-count-regression`'s "Typing into one sibling re-renders constant work, not O(N) siblings" still passes — the per-slice fan-out cost shape is what the factor is preserving.