### PR TITLE
refactor: key `listIndexMap` by serialized path

### DIFF
--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -45,7 +45,7 @@ export function RenderTextBlock(props: {
   const selected = useIsSelectedContainer(serializedPath)
   const focused = useIsFocusedContainer(serializedPath)
   const listIndex = useEngineSelector((editor) =>
-    editor.listIndexMap.get(props.textBlock._key),
+    editor.listIndexMap.get(serializedPath),
   )
   const subSchema = useBlockSubSchema(props.path)
 

--- a/packages/editor/src/internal-utils/build-index-maps.test.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.test.ts
@@ -65,7 +65,7 @@ describe(buildIndexMaps.name, () => {
       {blockIndexMap, listIndexMap},
     )
     expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
-    expect(listIndexMap).toEqual(new Map([['k0', 1]]))
+    expect(listIndexMap).toEqual(new Map([['[_key=="k0"]', 1]]))
   })
 
   /**
@@ -77,7 +77,7 @@ describe(buildIndexMaps.name, () => {
       {blockIndexMap, listIndexMap},
     )
     expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
-    expect(listIndexMap).toEqual(new Map([['k0', 1]]))
+    expect(listIndexMap).toEqual(new Map([['[_key=="k0"]', 1]]))
   })
 
   /**
@@ -112,10 +112,10 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 2],
-        ['k3', 1],
-        ['k4', 2],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
       ]),
     )
   })
@@ -152,10 +152,10 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 2],
-        ['k3', 1],
-        ['k4', 2],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
       ]),
     )
   })
@@ -186,9 +186,9 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 1],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
       ]),
     )
   })
@@ -212,9 +212,9 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 2],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
       ]),
     )
   })
@@ -242,11 +242,11 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 2],
-        ['k2', 1],
-        ['k3', 1],
-        ['k4', 1],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 1],
       ]),
     )
   })
@@ -276,12 +276,12 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 2],
-        ['k2', 1],
-        ['k3', 1],
-        ['k4', 1],
-        ['k5', 1],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 1],
+        ['[_key=="k5"]', 1],
       ]),
     )
   })
@@ -315,10 +315,10 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 2],
-        ['k3', 2],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k3"]', 2],
       ]),
     )
   })
@@ -349,9 +349,9 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 1],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
       ]),
     )
   })
@@ -400,15 +400,15 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 1],
-        ['k3', 1],
-        ['k4', 2],
-        ['k5', 1],
-        ['k6', 1],
-        ['k7', 2],
-        ['k8', 3],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
+        ['[_key=="k5"]', 1],
+        ['[_key=="k6"]', 1],
+        ['[_key=="k7"]', 2],
+        ['[_key=="k8"]', 3],
       ]),
     )
   })
@@ -432,9 +432,9 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k2', 2],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
       ]),
     )
   })
@@ -458,9 +458,9 @@ describe(buildIndexMaps.name, () => {
     )
     expect(listIndexMap).toEqual(
       new Map([
-        ['k0', 1],
-        ['k1', 1],
-        ['k3', 1],
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k3"]', 1],
       ]),
     )
   })

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -1,5 +1,6 @@
 import type {EditorContext} from '../editor/editor-snapshot'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
+import {serializePath} from '../paths/serialize-path'
 
 // Maps for each list type, keeping track of the current list count for each
 // level.
@@ -63,7 +64,7 @@ export function buildIndexMaps(
       levelIndexMap.set(block.level, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
-      listIndexMap.set(block._key, listIndex)
+      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
 
       previousListItem = {
         listItem: block.listItem,
@@ -85,7 +86,7 @@ export function buildIndexMaps(
       levelIndexMap.set(block.level, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
-      listIndexMap.set(block._key, listIndex)
+      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
 
       previousListItem = {
         listItem: block.listItem,
@@ -121,7 +122,7 @@ export function buildIndexMaps(
     levelIndexMap.set(block.level, levelCounter + 1)
     levelIndexMaps.set(block.listItem, levelIndexMap)
 
-    listIndexMap.set(block._key, levelCounter + 1)
+    listIndexMap.set(serializePath([{_key: block._key}]), levelCounter + 1)
 
     previousListItem = {
       listItem: block.listItem,


### PR DESCRIPTION
The `listIndexMap` now stores entries keyed by the serialized path of the block, not the bare `_key`. No consumer behavior changes — the sole reader (`RenderTextBlock`) reads via the serialized path it already computes for selection-state lookups.

This brings the storage shape in line with how it'll be consumed once list-index moves onto the slice-store pattern, where keys need to discriminate the same `_key` appearing in different ancestor scopes.