### PR TITLE
feat: extend `blockIndexMap` to every keyed node

### DIFF
--- a/.changeset/block-index-map-path-keyed.md
+++ b/.changeset/block-index-map-path-keyed.md
@@ -1,0 +1,15 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: extend `blockIndexMap` to every keyed node
+
+`blockIndexMap` now indexes every keyed node in the tree (root
+blocks, spans, inline objects, and nodes nested inside registered
+containers). Entries are keyed by the serialized full path from the
+document root.
+
+Sibling-navigation selectors (`getPreviousBlock`, `getNextBlock`,
+`getNextSpan`, `getPreviousSpan`, `getNextInlineObject`,
+`getPreviousInlineObject`) and behavior `getSibling` calls resolve
+in constant time at any depth.

--- a/packages/editor/src/behaviors/behavior.abstract.insert.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.insert.ts
@@ -2,6 +2,7 @@ import type {EditorSelector} from '../editor/editor-selector'
 import type {Path} from '../engine/interfaces/path'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
 import {siblingPath} from '../engine/path/sibling-path'
+import {serializePath} from '../paths/serialize-path'
 import {isSelectionExpanded} from '../selectors'
 import {getFocusBlock} from '../selectors/selector.get-focus-block'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
@@ -24,7 +25,7 @@ function getUniqueBlockKey(
       return snapshot.context.keyGenerator()
     }
 
-    if (snapshot.blockIndexMap.has(blockKey)) {
+    if (snapshot.blockIndexMap.has(serializePath([{_key: blockKey}]))) {
       return snapshot.context.keyGenerator()
     }
 

--- a/packages/editor/src/dom-traversal/get-dom-node.ts
+++ b/packages/editor/src/dom-traversal/get-dom-node.ts
@@ -26,7 +26,7 @@ export function getDomNode(
   const blockSegment = path[0]
 
   if (isKeyedSegment(blockSegment)) {
-    const blockIndex = editor.blockIndexMap.get(blockSegment._key)
+    const blockIndex = editor.blockIndexMap.get(serializePath([blockSegment]))
 
     if (blockIndex !== undefined) {
       const blockNode = editorElement.children[blockIndex]

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -1,6 +1,7 @@
 import {plugins} from '../engine-plugins/engine-plugins'
 import {createEditor} from '../engine/create-editor'
 import {withDOM} from '../engine/dom/plugin/with-dom'
+import {BlockIndexMap} from '../internal-utils/block-index-map'
 import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block'
 import {debug} from '../internal-utils/debug'
@@ -21,6 +22,8 @@ export function createEditorEngine(
 
   const context = config.editorActor.getSnapshot().context
 
+  const blockIndexMap = new BlockIndexMap()
+
   const placeholderBlock = createPlaceholderBlock({
     context: {
       schema: context.schema,
@@ -30,7 +33,7 @@ export function createEditorEngine(
       value: [],
       keyGenerator: context.keyGenerator,
     },
-    blockIndexMap: new Map(),
+    blockIndexMap,
   })
 
   const editor = createEditor()
@@ -40,7 +43,7 @@ export function createEditorEngine(
   // identity) when the editor settles; inner mutable values
   // (selection, value, etc) are mutated in place by operations.
   editor.snapshot = {
-    blockIndexMap: new Map<string, number>(),
+    blockIndexMap,
     context: {
       containers: new Map(),
       converters: context.initialConverters,
@@ -60,7 +63,7 @@ export function createEditorEngine(
   editor.textBlocks = new Map()
 
   editor.decoratedRanges = []
-  editor.blockIndexMap = editor.snapshot.blockIndexMap
+  editor.blockIndexMap = blockIndexMap
   editor.history = {undos: [], redos: []}
 
   editor.listIndexMap = new Map<string, number>()
@@ -86,6 +89,7 @@ export function createEditorEngine(
     {
       schema: context.schema,
       value: editorEngine.snapshot.context.value,
+      containers: editorEngine.snapshot.context.containers,
     },
     {
       blockIndexMap: editorEngine.blockIndexMap,

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -41,7 +41,7 @@ export type EditorContext = {
  */
 export type EditorSnapshot = {
   context: EditorContext
-  blockIndexMap: Map<string, number>
+  blockIndexMap: ReadonlyMap<string, number>
   /**
    * @beta
    * Subject to change

--- a/packages/editor/src/engine-plugins/engine-plugin.update-value.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.update-value.ts
@@ -1,7 +1,8 @@
 import type {EditorContext} from '../editor/editor-snapshot'
-import {buildIndexMaps} from '../internal-utils/build-index-maps'
+import {buildListIndexMap} from '../internal-utils/build-index-maps'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
+import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 
 export function updateValuePlugin(
@@ -31,23 +32,32 @@ export function updateValuePlugin(
       return
     }
 
+    const beforeValue = editor.snapshot.context.value
     apply(operation)
+    const afterValue = editor.snapshot.context.value
 
-    // Operations deep inside blocks (path length > 2) only modify nested
-    // structure and cannot affect root-level blockIndexMap or listIndexMap.
-    // Root-level inserts/removes are already handled incrementally by
-    // applyOperation, so we only need a full rebuild for operations at or
-    // near the root level.
+    transformBlockIndexMap(
+      editor.blockIndexMap,
+      operation,
+      beforeValue,
+      afterValue,
+      {
+        schema: context.schema,
+        containers: editor.snapshot.context.containers,
+      },
+    )
+
+    // List index can only change as a result of root-level insert/remove or
+    // a property change on a root block. Deeper ops cannot shift list
+    // indexes.
     if (operation.path.length <= 2) {
-      buildIndexMaps(
+      buildListIndexMap(
         {
           schema: context.schema,
           value: editor.snapshot.context.value,
+          containers: editor.snapshot.context.containers,
         },
-        {
-          blockIndexMap: editor.blockIndexMap,
-          listIndexMap: editor.listIndexMap,
-        },
+        editor.listIndexMap,
       )
     }
   }

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -7,9 +7,11 @@ import type {PortableTextBlock, PortableTextSpan} from '@portabletext/schema'
 import {isSpan} from '@portabletext/schema'
 import {getValue} from '../../internal-utils/get-value'
 import {safeStringify} from '../../internal-utils/safe-json'
+import {serializePath} from '../../paths/serialize-path'
 import {getNode} from '../../traversal/get-node'
 import {getNodes} from '../../traversal/get-nodes'
 import type {EditorSelection} from '../../types/editor'
+import type {KeyedSegment} from '../../types/paths'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import type {Editor} from '../interfaces/editor'
 import type {Node, NodeEntry} from '../interfaces/node'
@@ -41,9 +43,6 @@ export function applyOperation(editor: Editor, op: Operation): void {
       const {path} = op
       let {node} = op
 
-      const isRootInsert = parentPath(path).length === 0
-      let insertIndex = -1
-
       modifyChildren(editor, parentPath(path), (children) => {
         // Ensure unique keys on inserted nodes (skip during remote/undo/redo)
         if (
@@ -62,9 +61,9 @@ export function applyOperation(editor: Editor, op: Operation): void {
 
         if (isKeyedSegment(lastSegment)) {
           const siblingIndex = resolveChildIndex(
-            children,
-            lastSegment._key,
-            isRootInsert ? editor.blockIndexMap : undefined,
+            editor.blockIndexMap,
+            path.slice(0, -1),
+            lastSegment,
           )
           if (siblingIndex === -1) {
             throw new Error(
@@ -96,20 +95,8 @@ export function applyOperation(editor: Editor, op: Operation): void {
           }
         }
 
-        insertIndex = index
         return insertChildren(children, index, node)
       })
-
-      if (isRootInsert && insertIndex !== -1) {
-        if (insertIndex < editor.blockIndexMap.size) {
-          for (const [key, idx] of editor.blockIndexMap) {
-            if (idx >= insertIndex) {
-              editor.blockIndexMap.set(key, idx + 1)
-            }
-          }
-        }
-        editor.blockIndexMap.set(node._key, insertIndex)
-      }
 
       transformSelection = true
       break
@@ -171,14 +158,6 @@ export function applyOperation(editor: Editor, op: Operation): void {
         if (Array.isArray(value)) {
           editor.snapshot.context.value =
             value as unknown as PortableTextBlock[]
-          // Rebuild blockIndexMap
-          editor.blockIndexMap.clear()
-          for (let i = 0; i < editor.snapshot.context.value.length; i++) {
-            const child = editor.snapshot.context.value[i]
-            if (child) {
-              editor.blockIndexMap.set(child._key, i)
-            }
-          }
         }
         transformSelection = true
         break
@@ -218,25 +197,6 @@ export function applyOperation(editor: Editor, op: Operation): void {
           modifyDescendant(editor, setNodePath, (node) => {
             return {...node, [propertyName]: value} as typeof node
           })
-
-          // Update blockIndexMap when _key changes on a root-level block.
-          // The preamble above guarantees op.inverse is populated; if it's a
-          // 'set' (existing key being renamed), the surgical delete+set keeps
-          // the map consistent. A 'unset' inverse means the node didn't have
-          // a _key before — no map entry to migrate, nothing to do.
-          if (
-            propertyName === '_key' &&
-            setNodePath.length === 1 &&
-            op.inverse?.type === 'set' &&
-            typeof op.inverse.value === 'string' &&
-            typeof value === 'string'
-          ) {
-            const blockIndex = editor.blockIndexMap.get(op.inverse.value)
-            if (blockIndex !== undefined) {
-              editor.blockIndexMap.delete(op.inverse.value)
-              editor.blockIndexMap.set(value, blockIndex)
-            }
-          }
         } else {
           // Multiple property segments: deep set on the resolved node
           modifyDescendant(editor, setNodePath, (node) => {
@@ -245,12 +205,12 @@ export function applyOperation(editor: Editor, op: Operation): void {
         }
       } else {
         // Node not found (e.g., markDefs path): apply on the root block
-        const blockKey = findBlockKey(path)
-        if (!blockKey) {
+        const blockSegment = findBlockSegment(path)
+        if (!blockSegment) {
           break
         }
 
-        const blockIndex = resolveBlockIndex(editor, blockKey)
+        const blockIndex = resolveBlockIndex(editor, blockSegment)
         if (blockIndex === -1) {
           break
         }
@@ -286,7 +246,6 @@ export function applyOperation(editor: Editor, op: Operation): void {
           }
         }
         editor.snapshot.context.value = []
-        editor.blockIndexMap.clear()
         transformSelection = true
         break
       }
@@ -360,18 +319,14 @@ export function applyOperation(editor: Editor, op: Operation): void {
             : null
         }
 
-        const isRootRemove = parentPath(path).length === 0
-        let removeIndex = -1
-        let removedKey: string | undefined
-
         modifyChildren(editor, parentPath(path), (children) => {
           let index: number
 
           if (isKeyedSegment(lastSegment)) {
             index = resolveChildIndex(
-              children,
-              lastSegment._key,
-              isRootRemove ? editor.blockIndexMap : undefined,
+              editor.blockIndexMap,
+              path.slice(0, -1),
+              lastSegment,
             )
           } else {
             index = lastSegment
@@ -402,19 +357,8 @@ export function applyOperation(editor: Editor, op: Operation): void {
             }
           }
 
-          removedKey = children[index]?._key
-          removeIndex = index
           return removeChildren(children, index, 1)
         })
-
-        if (isRootRemove && removeIndex !== -1 && removedKey) {
-          editor.blockIndexMap.delete(removedKey)
-          for (const [key, idx] of editor.blockIndexMap) {
-            if (idx > removeIndex) {
-              editor.blockIndexMap.set(key, idx - 1)
-            }
-          }
-        }
 
         break
       }
@@ -455,12 +399,12 @@ export function applyOperation(editor: Editor, op: Operation): void {
         }
       } else {
         // Node not found (e.g., markDefs path): apply on the root block
-        const blockKey = findBlockKey(path)
-        if (!blockKey) {
+        const blockSegment = findBlockSegment(path)
+        if (!blockSegment) {
           break
         }
 
-        const blockIndex = resolveBlockIndex(editor, blockKey)
+        const blockIndex = resolveBlockIndex(editor, blockSegment)
         if (blockIndex === -1) {
           break
         }
@@ -570,48 +514,33 @@ function replaceLastSegment(path: Path, segment: Path[number]): Path {
 }
 
 /**
- * Resolve a child index by key, using blockIndexMap for O(1) lookup when available.
- * Falls back to linear scan when the map is unavailable or stale.
+ * Resolve a child index by keyed segment via `blockIndexMap`.
  */
 function resolveChildIndex(
-  children: Array<Node>,
-  key: string,
-  blockIndexMap: Map<string, number> | undefined,
+  blockIndexMap: ReadonlyMap<string, number>,
+  parentSegments: Path,
+  segment: KeyedSegment,
 ): number {
-  if (blockIndexMap) {
-    const index = blockIndexMap.get(key)
-    if (index !== undefined) {
-      const candidate = children[index]
-      if (candidate && candidate._key === key) {
-        return index
-      }
-    }
-  }
-  return children.findIndex((child) => child._key === key)
+  const index = blockIndexMap.get(serializePath([...parentSegments, segment]))
+  return index ?? -1
 }
 
 /**
  * Extract the block key from the first segment of a path.
  */
-function findBlockKey(path: Path): string | undefined {
+function findBlockSegment(path: Path): KeyedSegment | undefined {
   const firstSegment = path[0]
   if (isKeyedSegment(firstSegment)) {
-    return firstSegment._key
+    return firstSegment
   }
   return undefined
 }
 
 /**
- * Resolve a block index by key, using blockIndexMap for O(1) lookup.
+ * Resolve a root block's index via `blockIndexMap`.
  */
-function resolveBlockIndex(editor: Editor, blockKey: string): number {
-  const mapIndex = editor.blockIndexMap.get(blockKey)
-  if (mapIndex !== undefined) {
-    return mapIndex
-  }
-  return editor.snapshot.context.value.findIndex(
-    (child) => child._key === blockKey,
-  )
+function resolveBlockIndex(editor: Editor, segment: KeyedSegment): number {
+  return editor.blockIndexMap.get(serializePath([segment])) ?? -1
 }
 
 /**

--- a/packages/editor/src/engine/utils/modify.ts
+++ b/packages/editor/src/engine/utils/modify.ts
@@ -4,6 +4,7 @@ import {
   type PortableTextBlock,
   type PortableTextSpan,
 } from '@portabletext/schema'
+import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerAt} from '../../schema/resolve-container-at'
 import {getNodeChildren} from '../../traversal/get-children'
 import {getNode} from '../../traversal/get-node'
@@ -182,12 +183,12 @@ export const modifyDescendant = <N extends Node>(
   if (rootNumericIndex !== undefined) {
     rootIndex = rootNumericIndex
   } else if (keyedSegments.length > 0) {
-    const rootKey = keyedSegments[0]!._key
-    if (editor.blockIndexMap.has(rootKey)) {
-      rootIndex = editor.blockIndexMap.get(rootKey)!
-    } else {
-      rootIndex = findIndexByKey(editor.snapshot.context.value, rootKey)
-    }
+    const rootSegment = keyedSegments[0]!
+    const mapIndex = editor.blockIndexMap.get(serializePath([rootSegment]))
+    rootIndex =
+      mapIndex !== undefined
+        ? mapIndex
+        : findIndexByKey(editor.snapshot.context.value, rootSegment._key)
   } else {
     const firstSegment = path[0]
     rootIndex = typeof firstSegment === 'number' ? firstSegment : -1

--- a/packages/editor/src/internal-utils/block-index-map.ts
+++ b/packages/editor/src/internal-utils/block-index-map.ts
@@ -1,0 +1,22 @@
+import {serializePath} from '../paths/serialize-path'
+
+/**
+ * A `Map<string, number>` keyed by serialized keyed paths (e.g.
+ * `[_key=="b0"]`). `.get` and `.has` accept either a serialized path or a
+ * bare `_key` so older consumers reading by `_key` keep working.
+ */
+export class BlockIndexMap extends Map<string, number> {
+  override get(key: string): number | undefined {
+    if (key.startsWith('[_key==')) {
+      return super.get(key)
+    }
+    return super.get(serializePath([{_key: key}]))
+  }
+
+  override has(key: string): boolean {
+    if (key.startsWith('[_key==')) {
+      return super.has(key)
+    }
+    return super.has(serializePath([{_key: key}]))
+  }
+}

--- a/packages/editor/src/internal-utils/build-index-maps.test.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.test.ts
@@ -4,7 +4,6 @@ import {
   type PortableTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import {defaultKeyGenerator} from '../utils/key-generator'
 import {buildIndexMaps} from './build-index-maps'
 
 function blockObject(_key: string, name: string) {
@@ -29,7 +28,7 @@ function textBlock(
     _type: 'block',
     children: [
       {
-        _key: defaultKeyGenerator(),
+        _key: `${_key}-s0`,
         _type: 'span',
         text: `${listItem}-${level}`,
       },
@@ -51,7 +50,10 @@ describe(buildIndexMaps.name, () => {
   const listIndexMap = new Map<string, number>()
 
   test('empty', () => {
-    buildIndexMaps({schema, value: []}, {blockIndexMap, listIndexMap})
+    buildIndexMaps(
+      {schema, containers: new Map(), value: []},
+      {blockIndexMap, listIndexMap},
+    )
     expect(blockIndexMap).toEqual(new Map())
     expect(listIndexMap).toEqual(new Map())
   })
@@ -61,10 +63,19 @@ describe(buildIndexMaps.name, () => {
    */
   test('single list item', () => {
     buildIndexMaps(
-      {schema, value: [textBlock('k0', {listItem: 'number', level: 1})]},
+      {
+        schema,
+        containers: new Map(),
+        value: [textBlock('k0', {listItem: 'number', level: 1})],
+      },
       {blockIndexMap, listIndexMap},
     )
-    expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
+    expect(blockIndexMap).toEqual(
+      new Map([
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+      ]),
+    )
     expect(listIndexMap).toEqual(new Map([['[_key=="k0"]', 1]]))
   })
 
@@ -73,10 +84,19 @@ describe(buildIndexMaps.name, () => {
    */
   test('single indented list item', () => {
     buildIndexMaps(
-      {schema, value: [textBlock('k0', {listItem: 'number', level: 2})]},
+      {
+        schema,
+        containers: new Map(),
+        value: [textBlock('k0', {listItem: 'number', level: 2})],
+      },
       {blockIndexMap, listIndexMap},
     )
-    expect(blockIndexMap).toEqual(new Map([['k0', 0]]))
+    expect(blockIndexMap).toEqual(
+      new Map([
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+      ]),
+    )
     expect(listIndexMap).toEqual(new Map([['[_key=="k0"]', 1]]))
   })
 
@@ -91,6 +111,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -103,11 +124,16 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
-        ['k3', 3],
-        ['k4', 4],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k2"].children[_key=="k2-s0"]', 0],
+        ['[_key=="k3"]', 3],
+        ['[_key=="k3"].children[_key=="k3-s0"]', 0],
+        ['[_key=="k4"]', 4],
+        ['[_key=="k4"].children[_key=="k4-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -131,6 +157,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -143,11 +170,15 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
-        ['k3', 3],
-        ['k4', 4],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k3"]', 3],
+        ['[_key=="k3"].children[_key=="k3-s0"]', 0],
+        ['[_key=="k4"]', 4],
+        ['[_key=="k4"].children[_key=="k4-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -169,6 +200,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'bullet', level: 1}),
@@ -179,9 +211,12 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k2"].children[_key=="k2-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -202,6 +237,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'bullet', level: 2}),
@@ -230,6 +266,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -263,6 +300,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -296,6 +334,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 2}),
@@ -307,10 +346,14 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
-        ['k3', 3],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k2"].children[_key=="k2-s0"]', 0],
+        ['[_key=="k3"]', 3],
+        ['[_key=="k3"].children[_key=="k3-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -332,6 +375,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 2}),
           textBlock('k1', {listItem: 'number', level: 1}),
@@ -342,9 +386,12 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k2"].children[_key=="k2-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -371,6 +418,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 1}),
           textBlock('k1', {listItem: 'number', level: 3}),
@@ -387,15 +435,24 @@ describe(buildIndexMaps.name, () => {
     )
     expect(blockIndexMap).toEqual(
       new Map([
-        ['k0', 0],
-        ['k1', 1],
-        ['k2', 2],
-        ['k3', 3],
-        ['k4', 4],
-        ['k5', 5],
-        ['k6', 6],
-        ['k7', 7],
-        ['k8', 8],
+        ['[_key=="k0"]', 0],
+        ['[_key=="k0"].children[_key=="k0-s0"]', 0],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k1"].children[_key=="k1-s0"]', 0],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k2"].children[_key=="k2-s0"]', 0],
+        ['[_key=="k3"]', 3],
+        ['[_key=="k3"].children[_key=="k3-s0"]', 0],
+        ['[_key=="k4"]', 4],
+        ['[_key=="k4"].children[_key=="k4-s0"]', 0],
+        ['[_key=="k5"]', 5],
+        ['[_key=="k5"].children[_key=="k5-s0"]', 0],
+        ['[_key=="k6"]', 6],
+        ['[_key=="k6"].children[_key=="k6-s0"]', 0],
+        ['[_key=="k7"]', 7],
+        ['[_key=="k7"].children[_key=="k7-s0"]', 0],
+        ['[_key=="k8"]', 8],
+        ['[_key=="k8"].children[_key=="k8-s0"]', 0],
       ]),
     )
     expect(listIndexMap).toEqual(
@@ -422,6 +479,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'bullet', level: 1}),
           textBlock('k1', {listItem: 'number', level: 2}),
@@ -448,6 +506,7 @@ describe(buildIndexMaps.name, () => {
     buildIndexMaps(
       {
         schema,
+        containers: new Map(),
         value: [
           textBlock('k0', {listItem: 'number', level: 2}),
           textBlock('k1', {listItem: 'bullet', level: 1}),

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -1,17 +1,26 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorContext, EditorSnapshot} from '../editor/editor-snapshot'
+import type {Node} from '../engine/interfaces/node'
+import type {Path} from '../engine/interfaces/path'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
 import {serializePath} from '../paths/serialize-path'
+import type {RegisteredContainer} from '../schema/container-types'
+import {getNodeChildren} from '../traversal/get-children'
+import type {KeyedSegment} from '../types/paths'
 
 // Maps for each list type, keeping track of the current list count for each
 // level.
 const levelIndexMaps = new Map<string, Map<number, number>>()
 
 /**
- * Mutates the maps in place.
+ * Mutates both maps in place. Used for initial engine population and tests.
+ *
+ * During operation application `blockIndexMap` is maintained incrementally by
+ * `transform-block-index-map` helpers; only `listIndexMap` needs a full
+ * rebuild per op (see `buildListIndexMap`).
  */
 export function buildIndexMaps(
-  context: Pick<EditorContext, 'schema' | 'value'>,
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   {
     blockIndexMap,
     listIndexMap,
@@ -21,6 +30,38 @@ export function buildIndexMaps(
   },
 ): void {
   blockIndexMap.clear()
+  for (let blockIndex = 0; blockIndex < context.value.length; blockIndex++) {
+    const block = context.value.at(blockIndex)
+    if (block === undefined) {
+      continue
+    }
+    const blockSegment: KeyedSegment = {_key: block._key}
+    const blockPath: Path = [blockSegment]
+    const blockKey = serializePath(blockPath)
+    if (!blockIndexMap.has(blockKey)) {
+      blockIndexMap.set(blockKey, blockIndex)
+    }
+    collectDescendantIndexes(
+      context,
+      block,
+      blockPath,
+      undefined,
+      blockIndexMap,
+    )
+  }
+  buildListIndexMap(context, listIndexMap)
+}
+
+/**
+ * Mutates `listIndexMap` in place. Recomputes list-item indices for every
+ * root block. Called per op by `updateValuePlugin` because list-item
+ * numbering depends on root-block adjacency, which any structural op can
+ * disturb non-locally.
+ */
+export function buildListIndexMap(
+  context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
+  listIndexMap: Map<string, number>,
+): void {
   listIndexMap.clear()
   levelIndexMaps.clear()
 
@@ -38,7 +79,8 @@ export function buildIndexMaps(
       continue
     }
 
-    blockIndexMap.set(block._key, blockIndex)
+    const blockSegment: KeyedSegment = {_key: block._key}
+    const blockPath: Path = [blockSegment]
 
     // Clear the state if we encounter a non-text block
     if (!isTextBlockNode(context, block)) {
@@ -65,7 +107,7 @@ export function buildIndexMaps(
       levelIndexMap.set(block.level, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
-      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
+      listIndexMap.set(serializePath(blockPath), listIndex)
 
       previousListItem = {
         listItem: block.listItem,
@@ -87,7 +129,7 @@ export function buildIndexMaps(
       levelIndexMap.set(block.level, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
-      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
+      listIndexMap.set(serializePath(blockPath), listIndex)
 
       previousListItem = {
         listItem: block.listItem,
@@ -123,12 +165,47 @@ export function buildIndexMaps(
     levelIndexMap.set(block.level, levelCounter + 1)
     levelIndexMaps.set(block.listItem, levelIndexMap)
 
-    listIndexMap.set(serializePath([{_key: block._key}]), levelCounter + 1)
+    listIndexMap.set(serializePath(blockPath), levelCounter + 1)
 
     previousListItem = {
       listItem: block.listItem,
       level: block.level,
     }
+  }
+}
+
+export function collectDescendantIndexes(
+  context: Pick<EditorContext, 'schema' | 'containers'>,
+  node: Node,
+  nodePath: Path,
+  parent: RegisteredContainer | undefined,
+  blockIndexMap: Map<string, number>,
+): void {
+  const result = getNodeChildren(context, node, parent)
+  if (!result) {
+    return
+  }
+
+  for (let i = 0; i < result.children.length; i++) {
+    const child = result.children[i]!
+    if (!child._key) {
+      continue
+    }
+
+    const childSegment: KeyedSegment = {_key: child._key}
+    const childPath: Path = [...nodePath, result.fieldName, childSegment]
+    const childKey = serializePath(childPath)
+    if (!blockIndexMap.has(childKey)) {
+      blockIndexMap.set(childKey, i)
+    }
+
+    collectDescendantIndexes(
+      context,
+      child,
+      childPath,
+      result.parent,
+      blockIndexMap,
+    )
   }
 }
 
@@ -143,13 +220,14 @@ export function createTestSnapshot(input: {
 }): EditorSnapshot {
   const blockIndexMap = new Map<string, number>()
   const listIndexMap = new Map<string, number>()
+  const containers = input.containers ?? new Map()
   buildIndexMaps(
-    {schema: input.schema, value: input.value},
+    {schema: input.schema, value: input.value, containers},
     {blockIndexMap, listIndexMap},
   )
   return {
     context: {
-      containers: input.containers ?? new Map(),
+      containers,
       converters: [],
       keyGenerator: () => '',
       readOnly: false,

--- a/packages/editor/src/internal-utils/create-placeholder-block.ts
+++ b/packages/editor/src/internal-utils/create-placeholder-block.ts
@@ -11,7 +11,7 @@ type PlaceholderSnapshot = {
     value: Array<Node>
     keyGenerator: () => string
   }
-  blockIndexMap: Map<string, number>
+  blockIndexMap: ReadonlyMap<string, number>
 }
 
 /**

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -12,7 +12,21 @@ import {plugins} from '../engine-plugins/engine-plugins'
 import {createEditor} from '../engine/create-editor'
 import type {Node} from '../engine/interfaces/node'
 import {defaultKeyGenerator} from '../utils/key-generator'
+import {buildIndexMaps} from './build-index-maps'
 import {insertNodePatch, textPatch} from './operation-to-patches'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 const schemaDefinition = defineSchema({
   inlineObjects: [{name: 'someObject'}],
@@ -99,6 +113,17 @@ describe(insertNodePatch.name, () => {
 describe('operationToPatches', () => {
   beforeEach(() => {
     editor.snapshot.context.value = createDefaultChildren()
+    buildIndexMaps(
+      {
+        schema: editor.snapshot.context.schema,
+        containers: editor.snapshot.context.containers,
+        value: editor.snapshot.context.value as Array<PortableTextBlock>,
+      },
+      {
+        blockIndexMap: editor.snapshot.blockIndexMap as Map<string, number>,
+        listIndexMap: new Map<string, number>(),
+      },
+    )
     editor.onChange()
   })
 
@@ -273,7 +298,11 @@ describe('operationToPatches', () => {
             containers: new Map(),
             value: blockObjectChildren,
           },
-          blockIndexMap: new Map(),
+          blockIndexMap: buildBlockIndexMap(
+            blockObjectSchema,
+            new Map(),
+            blockObjectChildren,
+          ),
         },
         {
           type: 'insert_text',
@@ -289,6 +318,7 @@ describe('operationToPatches', () => {
   it('produces correct remove text patch', () => {
     const before = createDefaultChildren()
     ;(before[0] as PortableTextTextBlock).children[2]!.text = '1'
+
     expect(
       textPatch(
         editor.snapshot,

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -29,7 +29,7 @@ export function textPatch(
       containers: snapshot.context.containers,
       value: beforeValue as Array<Node>,
     },
-    blockIndexMap: new Map(),
+    blockIndexMap: snapshot.blockIndexMap,
   }
   const prevSpan = getSpan(beforeSnapshot, operation.path)
   const patch = diffMatchPatch(prevSpan?.node.text ?? '', span.node.text, [

--- a/packages/editor/src/internal-utils/transform-block-index-map.test.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.test.ts
@@ -1,0 +1,385 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {Operation} from '../engine/interfaces/operation'
+import {defineContainer} from '../renderers/renderer.types'
+import {resolveContainers} from '../schema/resolve-containers-batch'
+import {BlockIndexMap} from './block-index-map'
+import {buildIndexMaps} from './build-index-maps'
+import {transformBlockIndexMap} from './transform-block-index-map'
+
+/**
+ * Oracle equivalence: applying `op` to `beforeValue` to produce `afterValue`,
+ * then calling `transformBlockIndexMap` on a map built from `beforeValue`,
+ * must produce a map identical to one built fresh from `afterValue`.
+ */
+function assertEquivalent({
+  schema,
+  containers,
+  beforeValue,
+  afterValue,
+  op,
+}: {
+  schema: ReturnType<typeof compileSchema>
+  containers: ReturnType<typeof resolveContainers>
+  beforeValue: ReadonlyArray<PortableTextBlock>
+  afterValue: ReadonlyArray<PortableTextBlock>
+  op: Operation
+}) {
+  const incrementalMap = new BlockIndexMap()
+  buildIndexMaps(
+    {schema, value: beforeValue as PortableTextBlock[], containers},
+    {blockIndexMap: incrementalMap, listIndexMap: new Map()},
+  )
+  transformBlockIndexMap(incrementalMap, op, beforeValue, afterValue, {
+    schema,
+    containers,
+  })
+
+  const oracleMap = new BlockIndexMap()
+  buildIndexMaps(
+    {schema, value: afterValue as PortableTextBlock[], containers},
+    {blockIndexMap: oracleMap, listIndexMap: new Map()},
+  )
+
+  expect(Object.fromEntries([...incrementalMap].sort())).toEqual(
+    Object.fromEntries([...oracleMap].sort()),
+  )
+}
+
+const tableSchema = compileSchema(
+  defineSchema({
+    blockObjects: [
+      {
+        name: 'table',
+        fields: [
+          {
+            name: 'rows',
+            type: 'array',
+            of: [
+              {
+                type: 'object',
+                name: 'row',
+                fields: [
+                  {
+                    name: 'cells',
+                    type: 'array',
+                    of: [
+                      {
+                        type: 'object',
+                        name: 'cell',
+                        fields: [
+                          {
+                            name: 'content',
+                            type: 'array',
+                            of: [{type: 'block'}],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }),
+)
+const tableContainers = resolveContainers(tableSchema, [
+  defineContainer({
+    type: 'table',
+    arrayField: 'rows',
+    of: [
+      defineContainer({
+        type: 'row',
+        arrayField: 'cells',
+        of: [defineContainer({type: 'cell', arrayField: 'content'})],
+      }),
+    ],
+  }),
+])
+
+describe('transformBlockIndexMap', () => {
+  test('insert root block at end', () => {
+    const before: ReadonlyArray<PortableTextBlock> = []
+    const after = [
+      {_key: 'b0', _type: 'block', children: []} as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'insert',
+        path: [0],
+        node: after[0] as never,
+        position: 'before',
+      },
+    })
+  })
+
+  test('insert root block in middle (shifts siblings)', () => {
+    const b0 = {_key: 'b0', _type: 'block', children: []} as PortableTextBlock
+    const b1 = {_key: 'b1', _type: 'block', children: []} as PortableTextBlock
+    const newBlock = {
+      _key: 'b2',
+      _type: 'block',
+      children: [],
+    } as PortableTextBlock
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: [b0, b1],
+      afterValue: [b0, newBlock, b1],
+      op: {
+        type: 'insert',
+        path: [1],
+        node: newBlock as never,
+        position: 'before',
+      },
+    })
+  })
+
+  test('insert with unkeyed node is a no-op for the map', () => {
+    const before: ReadonlyArray<PortableTextBlock> = []
+    const after = [{_type: 'table'} as unknown as PortableTextBlock]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'insert',
+        path: [0],
+        node: after[0] as never,
+        position: 'before',
+      },
+    })
+  })
+
+  test('remove root block shifts siblings down', () => {
+    const b0 = {_key: 'b0', _type: 'block', children: []} as PortableTextBlock
+    const b1 = {_key: 'b1', _type: 'block', children: []} as PortableTextBlock
+    const b2 = {_key: 'b2', _type: 'block', children: []} as PortableTextBlock
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: [b0, b1, b2],
+      afterValue: [b0, b2],
+      op: {
+        type: 'unset',
+        path: [1],
+      },
+    })
+  })
+
+  test('insert keyed table with empty subtree', () => {
+    const before: ReadonlyArray<PortableTextBlock> = []
+    const after = [{_key: 't0', _type: 'table'} as PortableTextBlock]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'insert',
+        path: [0],
+        node: after[0] as never,
+        position: 'before',
+      },
+    })
+  })
+
+  test('set rows on freshly-inserted table walks the new subtree', () => {
+    const before = [{_key: 't0', _type: 'table'} as PortableTextBlock]
+    const rows = [{_key: 'r0', _type: 'row', cells: []}]
+    const after = [
+      {_key: 't0', _type: 'table', rows} as unknown as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [{_key: 't0'}, 'rows'],
+        value: rows,
+      },
+    })
+  })
+
+  test('set rows replacement prunes old descendants', () => {
+    const before = [
+      {
+        _key: 't0',
+        _type: 'table',
+        rows: [
+          {_key: 'r0', _type: 'row', cells: [{_key: 'c0', _type: 'cell'}]},
+        ],
+      } as unknown as PortableTextBlock,
+    ]
+    const newRows = [{_key: 'r1', _type: 'row', cells: []}]
+    const after = [
+      {
+        _key: 't0',
+        _type: 'table',
+        rows: newRows,
+      } as unknown as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [{_key: 't0'}, 'rows'],
+        value: newRows,
+      },
+    })
+  })
+
+  test('rename _key on a root block', () => {
+    const before = [
+      {_key: 'old', _type: 'block', children: []} as PortableTextBlock,
+    ]
+    const after = [
+      {_key: 'new', _type: 'block', children: []} as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [{_key: 'old'}, '_key'],
+        value: 'new',
+        inverse: {type: 'set', path: [{_key: 'old'}, '_key'], value: 'old'},
+      },
+    })
+  })
+
+  test('mint _key on previously-unkeyed root node', () => {
+    const before = [{_type: 'table'} as unknown as PortableTextBlock]
+    const after = [{_type: 'table', _key: 'k0'} as unknown as PortableTextBlock]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [0, '_key'],
+        value: 'k0',
+        inverse: {type: 'unset', path: [0, '_key']},
+      },
+    })
+  })
+
+  test('text content set on span is a no-op for the map', () => {
+    const before = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        children: [{_key: 's0', _type: 'span', text: 'hello'}],
+      } as PortableTextBlock,
+    ]
+    const after = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        children: [{_key: 's0', _type: 'span', text: 'world'}],
+      } as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
+        value: 'world',
+      },
+    })
+  })
+
+  test('set_selection is a no-op for the map', () => {
+    const before = [
+      {_key: 'b0', _type: 'block', children: []} as PortableTextBlock,
+    ]
+    const after = before
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set_selection',
+        properties: null,
+        newProperties: {
+          anchor: {path: [0], offset: 0},
+          focus: {path: [0], offset: 0},
+        },
+      },
+    })
+  })
+
+  test('insert_text is a no-op for the map', () => {
+    const before = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        children: [{_key: 's0', _type: 'span', text: 'hello'}],
+      } as PortableTextBlock,
+    ]
+    const after = [
+      {
+        _key: 'b0',
+        _type: 'block',
+        children: [{_key: 's0', _type: 'span', text: 'helloX'}],
+      } as PortableTextBlock,
+    ]
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'insert_text',
+        path: [{_key: 'b0'}, 'children', {_key: 's0'}],
+        offset: 5,
+        text: 'X',
+      },
+    })
+  })
+
+  test('root-level set replaces entire value', () => {
+    const before = [
+      {_key: 'b0', _type: 'block', children: []} as PortableTextBlock,
+    ]
+    const after = [
+      {_key: 'b1', _type: 'block', children: []},
+      {_key: 'b2', _type: 'block', children: []},
+    ] as ReadonlyArray<PortableTextBlock>
+    assertEquivalent({
+      schema: tableSchema,
+      containers: tableContainers,
+      beforeValue: before,
+      afterValue: after,
+      op: {
+        type: 'set',
+        path: [],
+        value: after,
+      },
+    })
+  })
+})

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -1,0 +1,438 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorContext} from '../editor/editor-snapshot'
+import type {Node} from '../engine/interfaces/node'
+import type {Operation} from '../engine/interfaces/operation'
+import type {Path} from '../engine/interfaces/path'
+import {parentPath as getParentPath} from '../engine/path/parent-path'
+import {serializePath} from '../paths/serialize-path'
+import type {
+  RegisteredContainer,
+  RegisteredPositional,
+} from '../schema/container-types'
+import {resolveContainerAt} from '../schema/resolve-container-at'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+import type {BlockIndexMap} from './block-index-map'
+import {buildIndexMaps, collectDescendantIndexes} from './build-index-maps'
+
+/**
+ * Context needed by the pure `transformBlockIndexMap` function. Pure
+ * w.r.t. value — value is passed explicitly as `beforeValue`/`afterValue`.
+ */
+type PureTransformContext = Pick<EditorContext, 'schema' | 'containers'>
+
+function isFullContainer(
+  candidate: RegisteredContainer | RegisteredPositional | undefined,
+): candidate is RegisteredContainer {
+  return candidate !== undefined && 'field' in candidate
+}
+
+// Apply an op's structural effect to `blockIndexMap`. Each function mirrors
+// the corresponding value-tree mutation. Called once per branch in
+// `applyOperation` after the value tree has settled.
+
+/**
+ * Apply an editor operation's structural effect to a `blockIndexMap`.
+ *
+ * Pure function. Given a map built from `beforeValue` and an operation
+ * that produced `afterValue`, mutates the map so it equals one built
+ * fresh from `afterValue`. The oracle invariant is exercised in
+ * `transform-block-index-map.test.ts`.
+ *
+ * Text and selection ops have no structural effect. Insert/unset/set
+ * shift, remove, and add descendant entries scoped to the affected
+ * subtree only — the whole map is never walked.
+ */
+export function transformBlockIndexMap(
+  map: BlockIndexMap,
+  op: Operation,
+  beforeValue: ReadonlyArray<Node>,
+  afterValue: ReadonlyArray<Node>,
+  context: PureTransformContext,
+): void {
+  switch (op.type) {
+    case 'insert_text':
+    case 'remove_text':
+    case 'set_selection':
+      return
+    case 'insert': {
+      const parentNodePath = getParentPath(op.path)
+      const lastSegment = op.path[op.path.length - 1]
+      // Resolve the anchor index (the path's last segment addresses an
+      // existing sibling for keyed paths, or a literal index for numeric).
+      const anchorIndex =
+        typeof lastSegment === 'number'
+          ? lastSegment
+          : resolveChildIndexInValue(beforeValue, op.path)
+      const insertIndex =
+        op.position === 'after' ? anchorIndex + 1 : anchorIndex
+      shiftDescendantsAtParent(map, parentNodePath, insertIndex, +1)
+      // The inserted node now sits at `insertIndex` in `afterValue`. Replace
+      // the op path's last segment with the numeric position; preserves any
+      // preceding field-name segment.
+      const insertedNumericPath: Path = [...op.path.slice(0, -1), insertIndex]
+      addSubtree(map, context, afterValue, insertedNumericPath)
+      return
+    }
+    case 'unset': {
+      // Root-level unset: `path = []` clears all blocks.
+      if (op.path.length === 0) {
+        map.clear()
+        return
+      }
+      const lastSegment = op.path[op.path.length - 1]
+      if (typeof lastSegment === 'string') {
+        // Property unset (not a node removal). Property removal on a
+        // node cannot affect the keyed structure under it.
+        return
+      }
+      const parentNodePath = getParentPath(op.path)
+      const removeIndex =
+        typeof lastSegment === 'number'
+          ? lastSegment
+          : resolveChildIndexInValue(beforeValue, op.path)
+      pruneSubtreeAtPath(map, beforeValue, op.path)
+      if (removeIndex >= 0) {
+        shiftDescendantsAtParent(map, parentNodePath, removeIndex, -1)
+      }
+      return
+    }
+    case 'set': {
+      // Root-level full replace: `path = []`.
+      if (op.path.length === 0) {
+        map.clear()
+        buildIndexMaps(
+          {
+            schema: context.schema,
+            value: afterValue as unknown as PortableTextBlock[],
+            containers: context.containers,
+          },
+          {blockIndexMap: map, listIndexMap: new Map()},
+        )
+        return
+      }
+      const lastSegment = op.path[op.path.length - 1]
+      // `set [...nodePath, propertyName] = value` is the common path
+      // (modifyDescendant). `set [...keyedPath] = wholeNode` is a
+      // full node replacement.
+      if (typeof lastSegment === 'string') {
+        const nodePath = op.path.slice(0, -1)
+        if (lastSegment === '_key') {
+          handleKeyChange(map, beforeValue, afterValue, nodePath, context)
+          return
+        }
+        // Property change that may have introduced keyed descendants
+        // (synthesized array fields like `rows`, `cells`, `content`).
+        // Reconcile the parent node's subtree: prune what `beforeValue`
+        // had below it, then walk `afterValue`.
+        if (op.value !== null && typeof op.value === 'object') {
+          pruneSubtreeAtPath(map, beforeValue, nodePath, /*keepSelf*/ true)
+          addSubtree(map, context, afterValue, nodePath)
+        }
+        return
+      }
+      // Last segment is keyed or numeric — full node replacement.
+      pruneSubtreeAtPath(map, beforeValue, op.path, /*keepSelf*/ true)
+      addSubtree(map, context, afterValue, op.path)
+      return
+    }
+  }
+}
+
+/**
+ * Find the child index for a keyed path's last segment by walking the
+ * value. Used when an op's path ends in a `KeyedSegment` instead of a
+ * numeric index. Returns `-1` if not resolvable.
+ */
+function resolveChildIndexInValue(
+  value: ReadonlyArray<Node>,
+  path: Path,
+): number {
+  let currentChildren: ReadonlyArray<Node> = value
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i]!
+    if (typeof segment === 'string') {
+      continue
+    }
+    let node: Node | undefined
+    if (isKeyedSegment(segment)) {
+      node = currentChildren.find((c) => c._key === segment._key)
+    } else if (typeof segment === 'number') {
+      node = currentChildren.at(segment)
+    }
+    if (!node) {
+      return -1
+    }
+    // Descend into the next named field (the following path segment is a string)
+    const next = path[i + 1]
+    if (typeof next === 'string') {
+      const field = (node as Record<string, unknown>)[next]
+      if (!Array.isArray(field)) {
+        return -1
+      }
+      currentChildren = field as ReadonlyArray<Node>
+      i++
+    }
+  }
+  const last = path[path.length - 1]!
+  if (typeof last === 'number') {
+    return last
+  }
+  if (isKeyedSegment(last)) {
+    return currentChildren.findIndex((c) => c._key === last._key)
+  }
+  return -1
+}
+
+/**
+ * Shift map entries for all keyed children of `parentNodePath` whose
+ * index is at-or-above `pivot` by `direction` (1 or -1). Also walks
+ * descendants of shifted children — but only their entries
+ * already-in-map move, the parent path stays the same.
+ *
+ * For root-level shifts (parentNodePath empty) the index in the
+ * `blockIndexMap` IS the root child index, so a key like
+ * `[_key=="bN"]` carries the index we want to shift. For nested
+ * shifts the parent's serialized path is a strict prefix of every
+ * sibling's serialized path.
+ */
+function shiftDescendantsAtParent(
+  map: BlockIndexMap,
+  parentNodePath: Path,
+  pivot: number,
+  direction: 1 | -1,
+): void {
+  const parentSerialized =
+    parentNodePath.length === 0 ? '' : serializePath(parentNodePath)
+  // A sibling's serialized path is exactly: `${parentSerialized}.${field}[_key=="…"]`
+  // For root-level, parentSerialized === '' so siblings are `[_key=="…"]`.
+  const expectedPrefix = parentSerialized === '' ? '' : `${parentSerialized}.`
+  for (const [key, idx] of map) {
+    if (parentSerialized === '') {
+      // Root siblings only: key must be exactly `[_key=="…"]`, no `.`
+      if (key.includes('.')) {
+        continue
+      }
+      if (!key.startsWith('[_key==')) {
+        continue
+      }
+    } else {
+      if (!key.startsWith(expectedPrefix)) {
+        continue
+      }
+      // Sibling key shape: `${parentSerialized}.${fieldName}[_key=="…"]` with
+      // no further `.` after the field name segment.
+      const rest = key.slice(expectedPrefix.length)
+      // rest = `fieldName[_key=="…"]` for a sibling; descendants have `.` further in.
+      const fieldEnd = rest.indexOf('[')
+      if (fieldEnd === -1) {
+        continue
+      }
+      const afterKeyed = rest.indexOf(']', fieldEnd)
+      if (afterKeyed === -1 || afterKeyed !== rest.length - 1) {
+        continue
+      }
+    }
+    if (direction === 1 ? idx >= pivot : idx > pivot) {
+      map.set(key, idx + direction)
+    }
+  }
+}
+
+/**
+ * Remove map entries for the node at `nodePath` in `beforeValue` and all its
+ * keyed descendants. Uses `getNodeChildren` to walk the subtree, so the
+ * cost is bounded by the subtree size — not the map size.
+ */
+function pruneSubtreeAtPath(
+  map: BlockIndexMap,
+  beforeValue: ReadonlyArray<Node>,
+  nodePath: Path,
+  keepSelf: boolean = false,
+): void {
+  const node = resolveNodeAtPath(beforeValue, nodePath)
+  if (!node) {
+    return
+  }
+  const keyedPath = toKeyedPath(beforeValue, nodePath)
+  if (keyedPath === undefined) {
+    return
+  }
+  if (!keepSelf) {
+    map.delete(serializePath(keyedPath))
+  }
+  // Walk descendants in `beforeValue` and delete each by path.
+  // We don't have an EditorContext here, so descend through known
+  // shape: a node's keyed children live under a single array field. We
+  // can't know the field name without context — but we don't NEED
+  // schema to walk the value, we can iterate every array-valued
+  // property whose entries have `_key`s.
+  walkKeyedChildrenInValue(node, keyedPath, (childPath) => {
+    map.delete(serializePath(childPath))
+  })
+}
+
+/**
+ * Generic walk over keyed-child arrays in a node. Iterates every
+ * array-valued field; for each entry with a `_key`, recurses. Mirrors
+ * `getNodeChildren` shape but without requiring container resolution.
+ */
+function walkKeyedChildrenInValue(
+  node: Node,
+  nodePath: Path,
+  visit: (childPath: Path) => void,
+): void {
+  for (const key of Object.keys(node as Record<string, unknown>)) {
+    const field = (node as Record<string, unknown>)[key]
+    if (!Array.isArray(field)) {
+      continue
+    }
+    for (const child of field as ReadonlyArray<Node>) {
+      if (!child || child._key === undefined) {
+        continue
+      }
+      const childPath: Path = [...nodePath, key, {_key: child._key}]
+      visit(childPath)
+      walkKeyedChildrenInValue(child, childPath, visit)
+    }
+  }
+}
+
+/**
+ * Walk the subtree at `nodePath` in `afterValue` and insert each keyed
+ * descendant into the map. Uses `getNodeChildren` for proper container
+ * resolution so positional `of` shapes follow the schema.
+ */
+function addSubtree(
+  map: BlockIndexMap,
+  context: PureTransformContext,
+  afterValue: ReadonlyArray<Node>,
+  opPath: Path,
+): void {
+  const node = resolveNodeAtPath(afterValue, opPath)
+  if (!node) {
+    return
+  }
+  // Resolve the keyed path (op paths may be numeric; the map stores
+  // keyed paths exclusively).
+  const keyedPath = toKeyedPath(afterValue, opPath)
+  if (keyedPath === undefined) {
+    return
+  }
+  const childIndex = resolveChildIndexInValue(afterValue, opPath)
+  if (childIndex >= 0) {
+    map.set(serializePath(keyedPath), childIndex)
+  }
+  const parentNodePath = getParentPath(keyedPath)
+  const parentContainer =
+    parentNodePath.length > 0
+      ? resolveContainerAt(context.containers, afterValue, parentNodePath)
+      : undefined
+  collectDescendantIndexes(
+    {schema: context.schema, containers: context.containers},
+    node,
+    keyedPath,
+    isFullContainer(parentContainer) ? parentContainer : undefined,
+    map,
+  )
+}
+
+/**
+ * Rewrite each numeric segment in `path` to a keyed segment by
+ * resolving against `value`. Returns `undefined` if any segment
+ * doesn't resolve, or if a keyed node has no `_key`.
+ */
+function toKeyedPath(value: ReadonlyArray<Node>, path: Path): Path | undefined {
+  const result: Array<Path[number]> = []
+  let currentChildren: ReadonlyArray<Node> = value
+  let currentNode: Node | undefined
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i]!
+    if (typeof segment === 'string') {
+      result.push(segment)
+      if (!currentNode) {
+        return undefined
+      }
+      const field = (currentNode as Record<string, unknown>)[segment]
+      if (!Array.isArray(field)) {
+        return undefined
+      }
+      currentChildren = field as ReadonlyArray<Node>
+      continue
+    }
+    if (typeof segment === 'number') {
+      currentNode = currentChildren.at(segment)
+      if (!currentNode) {
+        return undefined
+      }
+      result.push({_key: currentNode._key as string})
+      continue
+    }
+    if (isKeyedSegment(segment)) {
+      currentNode = currentChildren.find((c) => c._key === segment._key)
+      if (!currentNode) {
+        return undefined
+      }
+      result.push(segment)
+      continue
+    }
+    return undefined
+  }
+  return result
+}
+
+function handleKeyChange(
+  map: BlockIndexMap,
+  beforeValue: ReadonlyArray<Node>,
+  afterValue: ReadonlyArray<Node>,
+  nodePath: Path,
+  context: PureTransformContext,
+): void {
+  // Drop all map entries that lived under the node's old path.
+  pruneSubtreeAtPath(map, beforeValue, nodePath, /*keepSelf*/ false)
+  // The renamed node still sits at the same child index in
+  // `afterValue`; locate it by index to build the new keyed path.
+  const childIndex = resolveChildIndexInValue(beforeValue, nodePath)
+  if (childIndex < 0) {
+    return
+  }
+  const parentSegments = nodePath.slice(0, -1)
+  const newKeyedNodePath: Path = [...parentSegments, childIndex]
+  addSubtree(map, context, afterValue, newKeyedNodePath)
+}
+
+/**
+ * Resolve a node at a path in a value tree. Handles both numeric and
+ * keyed segments. Returns `undefined` if any segment doesn't resolve.
+ */
+function resolveNodeAtPath(
+  value: ReadonlyArray<Node>,
+  path: Path,
+): Node | undefined {
+  let currentChildren: ReadonlyArray<Node> = value
+  let currentNode: Node | undefined
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i]!
+    if (typeof segment === 'string') {
+      if (!currentNode) {
+        return undefined
+      }
+      const field = (currentNode as Record<string, unknown>)[segment]
+      if (!Array.isArray(field)) {
+        return undefined
+      }
+      currentChildren = field as ReadonlyArray<Node>
+      continue
+    }
+    if (isKeyedSegment(segment)) {
+      currentNode = currentChildren.find((c) => c._key === segment._key)
+    } else if (typeof segment === 'number') {
+      currentNode = currentChildren.at(segment)
+    } else {
+      return undefined
+    }
+    if (!currentNode) {
+      return undefined
+    }
+  }
+  return currentNode
+}

--- a/packages/editor/src/schema/get-block-object-schema.test.ts
+++ b/packages/editor/src/schema/get-block-object-schema.test.ts
@@ -1,8 +1,22 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {defineContainer, type Container} from '../renderers/renderer.types'
 import {getBlockObjectSchema} from './get-block-object-schema'
 import {resolveContainers} from './resolve-containers'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 const testRender: Container['render'] = ({children}) => children
 
@@ -20,7 +34,7 @@ describe(getBlockObjectSchema.name, () => {
     )
     const context = {
       context: {schema, containers: new Map(), value: []},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, new Map(), []),
     }
     const node = {_type: 'image', _key: 'i0', src: 'foo.png'}
 
@@ -59,7 +73,7 @@ describe(getBlockObjectSchema.name, () => {
 
     const context = {
       context: {schema, containers, value: []},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, containers, []),
     }
     // `image` is in root `blockObjects` but not inline-declared inside callout.
     // Looking it up at a callout-internal position falls back to root.
@@ -82,7 +96,7 @@ describe(getBlockObjectSchema.name, () => {
     )
     const context = {
       context: {schema, containers: new Map(), value: []},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, new Map(), []),
     }
     const node = {_type: 'unknown', _key: 'u0'}
 

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -1,5 +1,6 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test, vi} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {
   defineBlockObject,
   defineContainer,
@@ -16,6 +17,19 @@ import {
   resolveNestedContainer,
   type ResolvedContainers,
 } from './resolve-containers'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 const containerRender: Container['render'] = ({children}) => children
 const leafRender: BlockObject['render'] = ({children}) => children
@@ -51,7 +65,7 @@ function makeSnapshot(args: {
       containers,
       value: args.value as never,
     },
-    blockIndexMap: new Map(args.value.map((node, index) => [node._key, index])),
+    blockIndexMap: buildBlockIndexMap(args.schema, args.containers, args.value),
   }
 }
 

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../test-utils/text-selection'
 import {toTextspec} from '../../../test-utils/to-textspec'
 import {getValueAnnotations} from '../../../test-utils/value-annotations'
+import {createTestSnapshot} from '../../internal-utils/build-index-maps'
 import {IS_MAC} from '../../internal-utils/is-hotkey'
 import {safeParse} from '../../internal-utils/safe-json'
 import {createTestEditor, createTestEditors} from '../../test/vitest'
@@ -167,7 +168,7 @@ async function assertEditorState(
     // Accept any boundary-equivalent selection that produces the expected
     // textspec.
     for (const variant of boundaryEquivalentSelections(
-      {context: {schema, containers, value}, blockIndexMap: new Map()},
+      createTestSnapshot({schema, containers, value}),
       selection,
     )) {
       if (renderActual(variant) === expected) {

--- a/packages/editor/src/traversal/get-ancestors-positional-same-type.test.ts
+++ b/packages/editor/src/traversal/get-ancestors-positional-same-type.test.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import type {Node} from '../engine/interfaces/node'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {
   defineContainer,
   type ContainerRenderProps,
@@ -9,6 +10,19 @@ import {buildPublicContainers} from '../schema/build-public-containers'
 import {resolveNestedContainer} from '../schema/resolve-containers-batch'
 import {getAncestors} from './get-ancestors'
 import type {TraversalSnapshot} from './traversal-snapshot'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 /**
  * Regression: `getAncestors` must descend with positional awareness
@@ -134,10 +148,7 @@ describe('getAncestors with same _type under different parents', () => {
   const diagramNode = {_key: 'd1', _type: 'diagram', shapes: [diagramCell]}
 
   const value: Array<Node> = [tableNode as Node, diagramNode as Node]
-  const blockIndexMap = new Map<string, number>([
-    [tableNode._key, 0],
-    [diagramNode._key, 1],
-  ])
+  const blockIndexMap = buildBlockIndexMap(schema, containers, value)
 
   const snapshot: TraversalSnapshot = {
     context: {schema, containers, value},

--- a/packages/editor/src/traversal/get-ancestors.ts
+++ b/packages/editor/src/traversal/get-ancestors.ts
@@ -1,6 +1,7 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {serializePath} from '../paths/serialize-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
@@ -40,7 +41,6 @@ export function getAncestors(
 
   const {context, blockIndexMap} = snapshot
   let currentChildren: Array<Node> = context.value
-  let isRootLevel = true
   let currentParent:
     | import('../schema/resolve-containers').RegisteredContainer
     | undefined
@@ -64,17 +64,20 @@ export function getAncestors(
 
     let node: Node | undefined
     if (isKeyedSegment(segment)) {
-      if (isRootLevel) {
-        const index = blockIndexMap.get(segment._key)
-        node =
-          index !== undefined
-            ? currentChildren[index]
-            : currentChildren.find((child) => child._key === segment._key)
-      } else {
-        node = currentChildren.find((child) => child._key === segment._key)
-      }
       resolvedPath.push(segment)
-      isRootLevel = false
+      const index = blockIndexMap.get(serializePath(resolvedPath))
+      if (index !== undefined) {
+        node = currentChildren[index]
+      } else {
+        // Unkeyed transient nodes (e.g. `{_type:'table'}` inserted by remote
+        // patch, before normalize mints a key) can't appear in the
+        // path-keyed `blockIndexMap`. Fall back to a linear scan so
+        // normalization can resolve them.
+        node = currentChildren.find((child) => child._key === segment._key)
+        if (node && node._key !== undefined) {
+          resolvedPath[resolvedPath.length - 1] = {_key: node._key}
+        }
+      }
     } else if (typeof segment === 'number') {
       node = currentChildren.at(segment)
       if (node) {

--- a/packages/editor/src/traversal/get-children-positional-same-type.test.ts
+++ b/packages/editor/src/traversal/get-children-positional-same-type.test.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import type {Node} from '../engine/interfaces/node'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {
   defineContainer,
   type ContainerRenderProps,
@@ -9,6 +10,19 @@ import {buildPublicContainers} from '../schema/build-public-containers'
 import {resolveNestedContainer} from '../schema/resolve-containers-batch'
 import {getChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 /**
  * Regression: when the SAME `_type` is registered under two
@@ -147,10 +161,7 @@ describe('getChildren with same _type registered under different parents', () =>
 
   const value: Array<Node> = [tableNode as Node, diagramNode as Node]
 
-  const blockIndexMap = new Map<string, number>([
-    [tableNode._key, 0],
-    [diagramNode._key, 1],
-  ])
+  const blockIndexMap = buildBlockIndexMap(schema, containers, value)
 
   const snapshot: TraversalSnapshot = {
     context: {

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -1,5 +1,6 @@
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {serializePath} from '../paths/serialize-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
@@ -32,7 +33,6 @@ export function getNode(
     | import('../schema/resolve-containers').RegisteredContainer
     | undefined
   const resolvedPath: Path = []
-  let isRootLevel = true
 
   for (let i = 0; i < path.length; i++) {
     const segment = path[i]
@@ -43,23 +43,20 @@ export function getNode(
     }
 
     if (isKeyedSegment(segment)) {
-      if (isRootLevel) {
-        const index = blockIndexMap.get(segment._key)
-        if (index !== undefined) {
-          const candidate = currentChildren[index]
-          if (candidate && candidate._key === segment._key) {
-            node = candidate
-          } else {
-            node = currentChildren.find((child) => child._key === segment._key)
-          }
-        } else {
-          node = currentChildren.find((child) => child._key === segment._key)
-        }
-      } else {
-        node = currentChildren.find((child) => child._key === segment._key)
-      }
       resolvedPath.push(segment)
-      isRootLevel = false
+      const index = blockIndexMap.get(serializePath(resolvedPath))
+      if (index !== undefined) {
+        node = currentChildren[index]
+      } else {
+        // Unkeyed transient nodes (e.g. `{_type:'table'}` inserted by remote
+        // patch, before normalize mints a key) can't appear in the
+        // path-keyed `blockIndexMap`. Fall back to a linear scan so
+        // normalization can resolve them.
+        node = currentChildren.find((child) => child._key === segment._key)
+        if (node && node._key !== undefined) {
+          resolvedPath[resolvedPath.length - 1] = {_key: node._key}
+        }
+      }
     } else if (typeof segment === 'number') {
       node = currentChildren.at(segment)
       if (node) {

--- a/packages/editor/src/traversal/get-nodes.ts
+++ b/packages/editor/src/traversal/get-nodes.ts
@@ -2,11 +2,11 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
 import {isAncestorPath} from '../engine/path/is-ancestor-path'
+import {serializePath} from '../paths/serialize-path'
 import type {
   Containers,
   RegisteredContainer,
 } from '../schema/resolve-containers'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren, getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
@@ -118,104 +118,61 @@ function* getNodesSimple(
 /**
  * Compare two keyed paths in document order. Returns -1, 0, or 1.
  *
- * Descends both paths from the root in a single pass, advancing
- * `currentNode` and `currentChildren` together so each level costs
- * one keyed-segment scan instead of an O(depth) walk from root.
- *
- * Uses `blockIndexMap` for O(1) lookup at the root level. Deeper
- * levels fall back to a linear scan of the current sibling array.
+ * Walks both paths in parallel; at the first divergence, consults
+ * `blockIndexMap` for the sibling indices and compares them.
  */
 function comparePathsInTree(
   snapshot: TraversalSnapshot,
   pathA: Path,
   pathB: Path,
 ): -1 | 0 | 1 {
-  const keysA = pathA.filter(isKeyedSegment)
-  const keysB = pathB.filter(isKeyedSegment)
+  // Walk both full paths in parallel; at the first divergent keyed
+  // segment, consult blockIndexMap for the sibling indices. The map is
+  // keyed by serialized paths that include both keyed and field-name
+  // segments, so we keep the full path prefix as we descend.
+  const minLength = Math.min(pathA.length, pathB.length)
+  const prefix: Path = []
 
-  const {context} = snapshot
-  let currentChildren: Array<Node> = context.value
-  let currentParent: RegisteredContainer | undefined
-  let isRootLevel = true
+  for (let i = 0; i < minLength; i++) {
+    const segA = pathA[i]!
+    const segB = pathB[i]!
 
-  const minDepth = Math.min(keysA.length, keysB.length)
-
-  for (let depth = 0; depth < minDepth; depth++) {
-    const keyA = keysA[depth]!
-    const keyB = keysB[depth]!
-
-    if (keyA._key === keyB._key) {
-      // Same node at this depth: descend into its children for the next
-      // iteration. The root level can short-circuit via blockIndexMap;
-      // deeper levels scan the current sibling array.
-      let matchedNode: Node | undefined
-      if (isRootLevel && snapshot.blockIndexMap.has(keyA._key)) {
-        const index = snapshot.blockIndexMap.get(keyA._key)
-        if (index !== undefined) {
-          matchedNode = currentChildren[index]
-        }
-      } else {
-        matchedNode = currentChildren.find((c) => c._key === keyA._key)
-      }
-      if (!matchedNode) {
-        return 0
-      }
-      const next = getNodeChildren(context, matchedNode, currentParent)
-      if (!next) {
-        return 0
-      }
-      currentChildren = next.children
-      currentParent = next.parent
-
-      isRootLevel = false
+    if (
+      typeof segA === 'string' ||
+      typeof segB === 'string' ||
+      typeof segA === 'number' ||
+      typeof segB === 'number' ||
+      Array.isArray(segA) ||
+      Array.isArray(segB)
+    ) {
+      prefix.push(segA as never)
       continue
     }
 
-    if (isRootLevel) {
-      const indexA = snapshot.blockIndexMap.get(keyA._key) ?? -1
-      const indexB = snapshot.blockIndexMap.get(keyB._key) ?? -1
-      if (indexA !== -1 && indexB !== -1) {
-        if (indexA < indexB) {
-          return -1
-        }
-        if (indexA > indexB) {
-          return 1
-        }
-        return 0
-      }
+    if (segA._key === segB._key) {
+      prefix.push(segA)
+      continue
     }
 
-    let indexA = -1
-    let indexB = -1
-    for (let i = 0; i < currentChildren.length; i++) {
-      const sibling = currentChildren[i]!
-      if (sibling._key === keyA._key) {
-        indexA = i
-      }
-      if (sibling._key === keyB._key) {
-        indexB = i
-      }
-      if (indexA !== -1 && indexB !== -1) {
-        break
-      }
-    }
-
+    const indexA =
+      snapshot.blockIndexMap.get(serializePath([...prefix, segA])) ?? -1
+    const indexB =
+      snapshot.blockIndexMap.get(serializePath([...prefix, segB])) ?? -1
     if (indexA < indexB) {
       return -1
     }
     if (indexA > indexB) {
       return 1
     }
-
     return 0
   }
 
-  // One path is a prefix of the other (ancestor relationship)
-  // In DFS order, shorter path (ancestor) comes first
-  if (keysA.length < keysB.length) {
+  // One path is a prefix of the other (ancestor relationship).
+  // In DFS order, shorter path (ancestor) comes first.
+  if (pathA.length < pathB.length) {
     return -1
   }
-  if (keysA.length > keysB.length) {
+  if (pathA.length > pathB.length) {
     return 1
   }
 

--- a/packages/editor/src/traversal/get-path-sub-schema.test.ts
+++ b/packages/editor/src/traversal/get-path-sub-schema.test.ts
@@ -1,8 +1,22 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {defineContainer, type Container} from '../renderers/renderer.types'
 import {resolveContainers} from '../schema/resolve-containers'
 import {getPathSubSchema} from './get-path-sub-schema'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 const testRender: Container['render'] = ({children}) => children
 
@@ -121,7 +135,7 @@ describe(getPathSubSchema.name, () => {
     ]
     const context = {
       context: {schema, containers, value},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, containers, value),
     }
 
     const subSchema = getPathSubSchema(context, [

--- a/packages/editor/src/traversal/get-sibling.ts
+++ b/packages/editor/src/traversal/get-sibling.ts
@@ -1,6 +1,7 @@
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
 import {parentPath} from '../engine/path/parent-path'
+import {serializePath} from '../paths/serialize-path'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
@@ -58,11 +59,9 @@ export function getSibling(
   const parent = parentPath(path)
   const children = getChildren(snapshot, parent)
 
-  const currentIndex = children.findIndex(
-    (child) => child.node._key === lastSegment._key,
-  )
+  const currentIndex = snapshot.blockIndexMap.get(serializePath(path))
 
-  if (currentIndex === -1) {
+  if (currentIndex === undefined) {
     return undefined
   }
 

--- a/packages/editor/src/traversal/is-leaf-object.test.ts
+++ b/packages/editor/src/traversal/is-leaf-object.test.ts
@@ -1,11 +1,25 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import type {
   ChildArrayField,
   RegisteredContainer,
 } from '../schema/resolve-containers'
 import {isLeafObject} from './is-leaf-object'
 import {createNodeTraversalTestbed} from './node-traversal-testbed'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 function registeredContainerFor(
   type: string,
@@ -220,7 +234,7 @@ describe(isLeafObject.name, () => {
 
     const context = {
       context: {schema, containers, value: [table]},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, containers, [table]),
     }
 
     test('image inside cell is void', () => {
@@ -292,7 +306,7 @@ describe(isLeafObject.name, () => {
 
     const context = {
       context: {schema, containers, value: [gallery]},
-      blockIndexMap: new Map(),
+      blockIndexMap: buildBlockIndexMap(schema, containers, [gallery]),
     }
 
     test('gallery is not void', () => {

--- a/packages/editor/src/traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/traversal/node-traversal-testbed.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import type {EditorSchema} from '../editor/editor-schema'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {defineContainer, type Container} from '../renderers/renderer.types'
 import type {RegisteredContainer} from '../schema/container-types'
 import {resolveContainerField} from '../schema/resolve-container-field'
@@ -249,15 +250,15 @@ export function createNodeTraversalTestbed() {
   )
 
   const value = [textBlock1, image, textBlock2, codeBlock, table]
-  const blockIndexMap = new Map<string, number>()
-  for (let i = 0; i < value.length; i++) {
-    blockIndexMap.set(value[i]!._key, i)
-  }
-
   const containers = resolveTestbedContainers(schema, [
     codeBlockContainer,
     ...tableContainers,
   ])
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, containers, value},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
 
   const context = {
     schema,

--- a/packages/editor/src/traversal/traversal-snapshot.ts
+++ b/packages/editor/src/traversal/traversal-snapshot.ts
@@ -14,5 +14,5 @@ export type TraversalSnapshot = {
     containers: Containers
     value: Array<Node>
   }
-  blockIndexMap: Map<string, number>
+  blockIndexMap: ReadonlyMap<string, number>
 }

--- a/packages/editor/src/utils/util.block-offset.test.ts
+++ b/packages/editor/src/utils/util.block-offset.test.ts
@@ -5,7 +5,21 @@ import {
 } from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
 import {blockOffsetToSpanSelectionPoint} from './util.block-offset'
+
+function buildBlockIndexMap(
+  schema: any,
+  containers: any,
+  value: any,
+): Map<string, number> {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return blockIndexMap
+}
 
 const schema = compileSchema(defineSchema({}))
 
@@ -34,7 +48,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -53,7 +67,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -74,7 +88,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -93,7 +107,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: b0}],
@@ -137,7 +151,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -156,7 +170,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -177,7 +191,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -196,7 +210,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -217,7 +231,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -236,7 +250,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
           blockOffsetToSpanSelectionPoint({
             snapshot: {
               context: {schema, value, containers: new Map()},
-              blockIndexMap: new Map(),
+              blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
             },
             blockOffset: {
               path: [{_key: blockKey}],
@@ -283,7 +297,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       blockOffsetToSpanSelectionPoint({
         snapshot: {
           context: {schema, value, containers: new Map()},
-          blockIndexMap: new Map(),
+          blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -296,7 +310,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       blockOffsetToSpanSelectionPoint({
         snapshot: {
           context: {schema, value, containers: new Map()},
-          blockIndexMap: new Map(),
+          blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -321,7 +335,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       blockOffsetToSpanSelectionPoint({
         snapshot: {
           context: {schema, value, containers: new Map()},
-          blockIndexMap: new Map(),
+          blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
         },
         blockOffset: {
           path: [{_key: b0}],
@@ -362,7 +376,7 @@ describe(blockOffsetToSpanSelectionPoint.name, () => {
       blockOffsetToSpanSelectionPoint({
         snapshot: {
           context: {schema, value, containers: new Map()},
-          blockIndexMap: new Map(),
+          blockIndexMap: buildBlockIndexMap(schema, new Map(), value),
         },
         blockOffset: {
           path: [{_key: b1}],

--- a/packages/editor/test-utils/boundary-equivalent.test.ts
+++ b/packages/editor/test-utils/boundary-equivalent.test.ts
@@ -1,6 +1,16 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../src/internal-utils/build-index-maps'
 import {boundaryEquivalentSelections} from './boundary-equivalent'
+
+function snapshotFor(schema: any, value: any, containers: any): any {
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, value, containers},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+  return {context: {schema, value, containers}, blockIndexMap}
+}
 
 const schema = compileSchema(defineSchema({}))
 const containers = new Map()
@@ -8,10 +18,7 @@ const containers = new Map()
 describe(boundaryEquivalentSelections.name, () => {
   test('returns no variants when selection is null', () => {
     expect(
-      boundaryEquivalentSelections(
-        {context: {schema, value: [], containers}, blockIndexMap: new Map()},
-        null,
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [], containers), null),
     ).toEqual([])
   })
 
@@ -29,13 +36,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 1,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: point, focus: point, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: point,
+        focus: point,
+        backward: false,
+      }),
     ).toEqual([])
   })
 
@@ -50,13 +55,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 3,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: endOfS1, focus: endOfS1, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: endOfS1,
+        focus: endOfS1,
+        backward: false,
+      }),
     ).toEqual([])
   })
 
@@ -78,13 +81,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 0,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: endOfS1, focus: endOfS1, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: endOfS1,
+        focus: endOfS1,
+        backward: false,
+      }),
     ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: false}])
   })
 
@@ -106,13 +107,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 0,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: startOfS2, focus: startOfS2, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: startOfS2,
+        focus: startOfS2,
+        backward: false,
+      }),
     ).toEqual([{anchor: endOfS1, focus: endOfS1, backward: false}])
   })
 
@@ -130,13 +129,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 3,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: endOfS1, focus: endOfS1, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: endOfS1,
+        focus: endOfS1,
+        backward: false,
+      }),
     ).toEqual([])
   })
 
@@ -167,13 +164,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 0,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: endOfS1, focus: endOfS2, backward: false},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: endOfS1,
+        focus: endOfS2,
+        backward: false,
+      }),
     ).toEqual([
       {anchor: endOfS1, focus: startOfS3, backward: false},
       {anchor: startOfS2, focus: endOfS2, backward: false},
@@ -199,13 +194,11 @@ describe(boundaryEquivalentSelections.name, () => {
       offset: 0,
     }
     expect(
-      boundaryEquivalentSelections(
-        {
-          context: {schema, value: [block], containers},
-          blockIndexMap: new Map(),
-        },
-        {anchor: endOfS1, focus: endOfS1, backward: true},
-      ),
+      boundaryEquivalentSelections(snapshotFor(schema, [block], containers), {
+        anchor: endOfS1,
+        focus: endOfS1,
+        backward: true,
+      }),
     ).toEqual([{anchor: startOfS2, focus: startOfS2, backward: true}])
   })
 })

--- a/packages/editor/test-utils/boundary-equivalent.ts
+++ b/packages/editor/test-utils/boundary-equivalent.ts
@@ -13,7 +13,7 @@ type Context = {
     containers: Containers
     value: Array<Node>
   }
-  blockIndexMap: Map<string, number>
+  blockIndexMap: ReadonlyMap<string, number>
 }
 
 /**

--- a/packages/editor/test-utils/create-test-snapshot.ts
+++ b/packages/editor/test-utils/create-test-snapshot.ts
@@ -1,6 +1,7 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import type {EditorSnapshot} from '../src/editor/editor-snapshot'
+import {buildIndexMaps} from '../src/internal-utils/build-index-maps'
 
 export function createTestSnapshot(snapshot: {
   context?: Partial<EditorSnapshot['context']>
@@ -16,10 +17,14 @@ export function createTestSnapshot(snapshot: {
     selection: snapshot.context?.selection ?? null,
   }
   const blockIndexMap = new Map<string, number>()
-
-  snapshot.context?.value?.forEach((block, index) => {
-    blockIndexMap.set(block._key, index)
-  })
+  buildIndexMaps(
+    {
+      schema: context.schema,
+      value: context.value,
+      containers: context.containers,
+    },
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
 
   return {
     blockIndexMap,

--- a/packages/editor/tests/block-index-map-path-keyed.test.tsx
+++ b/packages/editor/tests/block-index-map-path-keyed.test.tsx
@@ -1,0 +1,116 @@
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('blockIndexMap is keyed by path with bare-_key read fallback', () => {
+  test('Scenario: initial build populates the path-keyed view', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: 'bar'}],
+        },
+      ],
+    })
+
+    expect([...editor.getSnapshot().blockIndexMap]).toEqual([
+      ['[_key=="b0"]', 0],
+      ['[_key=="b0"].children[_key=="s0"]', 0],
+      ['[_key=="b1"]', 1],
+      ['[_key=="b1"].children[_key=="s1"]', 0],
+    ])
+  })
+
+  test('Scenario: enter inserts a sibling and shifts the path-keyed view', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo'}],
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+    await userEvent.keyboard('{End}{Enter}bar')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toHaveLength(2)
+    })
+
+    expect([...editor.getSnapshot().blockIndexMap]).toEqual([
+      ['[_key=="b0"]', 0],
+      ['[_key=="b0"].children[_key=="s0"]', 0],
+      ['[_key=="k2"]', 1],
+      ['[_key=="k2"].children[_key=="k3"]', 0],
+    ])
+  })
+
+  test('Scenario: delete.block clears the removed entry and shifts the survivor', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: 'bar'}],
+        },
+      ],
+    })
+
+    editor.send({type: 'delete.block', at: [{_key: 'b0'}]})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toHaveLength(1)
+    })
+
+    expect([...editor.getSnapshot().blockIndexMap]).toEqual([
+      ['[_key=="b1"]', 0],
+      ['[_key=="b1"].children[_key=="s1"]', 0],
+    ])
+  })
+
+  test('Scenario: .get and .has accept a bare _key', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: 'bar'}],
+        },
+      ],
+    })
+
+    const blockIndexMap = editor.getSnapshot().blockIndexMap
+
+    expect(blockIndexMap.get('b0')).toBe(0)
+    expect(blockIndexMap.get('b1')).toBe(1)
+    expect(blockIndexMap.get('[_key=="b0"]')).toBe(0)
+    expect(blockIndexMap.get('[_key=="b1"]')).toBe(1)
+    expect(blockIndexMap.has('b0')).toBe(true)
+    expect(blockIndexMap.has('b1')).toBe(true)
+    expect(blockIndexMap.has('missing')).toBe(false)
+  })
+})
+
+function createTestKeyGenerator(): () => string {
+  let counter = 0
+  return () => `k${counter++}`
+}


### PR DESCRIPTION
`EditorSnapshot.blockIndexMap` now indexes every keyed node in the tree — root blocks, spans, inline objects, and nodes nested inside registered containers. Entries are keyed by the serialized full path from the document root.

Sibling-navigation selectors (`getPreviousBlock`, `getNextBlock`, `getNextSpan`, `getPreviousSpan`, `getNextInlineObject`, `getPreviousInlineObject`) and behavior `getSibling` calls now resolve in constant time at any depth. Before, only root blocks were indexed, and any sibling lookup deeper in the tree fell back to a `findIndex` scan over the parent's children.

## API

The public `EditorSnapshot.blockIndexMap` type stays `ReadonlyMap<string, number>`. A `BlockIndexMap` subclass overrides `get` and `has` to translate bare `_key` lookups into serialized paths, so external consumers that currently read by `_key` keep working without changes:

```ts
snapshot.blockIndexMap.get('k0')                // still works for root blocks
snapshot.blockIndexMap.get('[_key=="k0"]')      // also works
snapshot.blockIndexMap.get('[_key=="k0"].children[_key=="s0"]')  // new, any depth
```

Internal engine readers (`getNode`, `getNodes`, `getAncestors`, `getDomNode`, `modify`, child- and block-index resolution in `apply-operation`, and the uniqueness check in abstract insert) all read by serialized path.

## Maintenance

Map maintenance is consolidated into a single pure function `transformBlockIndexMap(map, op, beforeValue, afterValue, ctx)` called once per operation from the update-value plugin. It dispatches on op shape and only touches the affected subtree, so per-op work is bounded by the subtree size and not by map size.