### PR TITLE
refactor: drop blockIndexMap fixture-tolerance guards

### DIFF
--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -578,7 +578,7 @@ function resolveChildIndex(
   key: string,
   blockIndexMap: Map<string, number> | undefined,
 ): number {
-  if (blockIndexMap && blockIndexMap.size === children.length) {
+  if (blockIndexMap) {
     const index = blockIndexMap.get(key)
     if (index !== undefined) {
       const candidate = children[index]

--- a/packages/editor/src/engine/editor/unhang-range.test.ts
+++ b/packages/editor/src/engine/editor/unhang-range.test.ts
@@ -1,6 +1,8 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
+import type {PortableTextBlock} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
+import {createTestSnapshot} from '../../internal-utils/build-index-maps'
 import {defineContainer} from '../../renderers/renderer.types'
 import {resolveContainers} from '../../schema/resolve-containers'
 import type {Node} from '../interfaces/node'
@@ -17,14 +19,7 @@ function buildContext(...value: Array<Node>) {
       blockObjects: [{name: 'image'}],
     }),
   )
-  const blockIndexMap = new Map<string, number>()
-  value.forEach((node, index) => {
-    blockIndexMap.set((node as {_key: string})._key, index)
-  })
-  return {
-    context: {schema, containers: new Map(), value},
-    blockIndexMap,
-  }
+  return createTestSnapshot({schema, value: value as Array<PortableTextBlock>})
 }
 
 const keyGenerator = createTestKeyGenerator()
@@ -347,14 +342,11 @@ function buildContainerContext(...value: Array<Node>) {
       arrayField: 'lines',
     }),
   ])
-  const blockIndexMap = new Map<string, number>()
-  value.forEach((node, index) => {
-    blockIndexMap.set((node as {_key: string})._key, index)
+  return createTestSnapshot({
+    schema,
+    containers,
+    value: value as Array<PortableTextBlock>,
   })
-  return {
-    context: {schema, containers, value},
-    blockIndexMap,
-  }
 }
 
 describe(`${unhangRange.name} (container-aware)`, () => {

--- a/packages/editor/src/engine/utils/modify.ts
+++ b/packages/editor/src/engine/utils/modify.ts
@@ -183,10 +183,7 @@ export const modifyDescendant = <N extends Node>(
     rootIndex = rootNumericIndex
   } else if (keyedSegments.length > 0) {
     const rootKey = keyedSegments[0]!._key
-    if (
-      editor.blockIndexMap.size === editor.snapshot.context.value.length &&
-      editor.blockIndexMap.has(rootKey)
-    ) {
+    if (editor.blockIndexMap.has(rootKey)) {
       rootIndex = editor.blockIndexMap.get(rootKey)!
     } else {
       rootIndex = findIndexByKey(editor.snapshot.context.value, rootKey)

--- a/packages/editor/src/internal-utils/apply-selection.test.ts
+++ b/packages/editor/src/internal-utils/apply-selection.test.ts
@@ -3,6 +3,7 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {createNodeTraversalTestbed} from '../traversal/node-traversal-testbed'
 import {resolveSelection} from './apply-selection'
+import {createTestSnapshot} from './build-index-maps'
 
 describe(resolveSelection.name, () => {
   const schema = compileSchema(
@@ -20,35 +21,32 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockKey,
-                _type: 'block',
-                children: [
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: 'foo',
-                  },
-                  {
-                    _key: keyGenerator(),
-                    _type: 'stock-ticker',
-                  },
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: 'bar',
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: 'foo',
+                },
+                {
+                  _key: keyGenerator(),
+                  _type: 'stock-ticker',
+                },
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: 'bar',
+                },
+              ],
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -76,35 +74,32 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockKey,
-                _type: 'block',
-                children: [
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: "'",
-                  },
-                  {
-                    _key: keyGenerator(),
-                    _type: 'stock-ticker',
-                  },
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: "foo'",
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: "'",
+                },
+                {
+                  _key: keyGenerator(),
+                  _type: 'stock-ticker',
+                },
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: "foo'",
+                },
+              ],
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -130,19 +125,16 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockObjectKey,
-                _type: 'image',
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockObjectKey,
+              _type: 'image',
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -170,26 +162,23 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockKey,
-                _type: 'block',
-                children: [
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: 'foobar',
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: 'foobar',
+                },
+              ],
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -216,26 +205,23 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockKey,
-                _type: 'block',
-                children: [
-                  {
-                    _key: spanKey,
-                    _type: 'span',
-                    text: 'foo',
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {
+                  _key: spanKey,
+                  _type: 'span',
+                  text: 'foo',
+                },
+              ],
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -262,32 +248,29 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema,
-            containers: new Map(),
-            value: [
-              {
-                _key: blockKey,
-                _type: 'block',
-                children: [
-                  {_key: keyGenerator(), _type: 'span', text: 'foo'},
-                  {
-                    _key: inlineObjectKey,
-                    _type: 'stock-ticker',
-                    symbol: 'AAPL',
-                  },
-                  {
-                    _key: keyGenerator(),
-                    _type: 'span',
-                    text: 'bar',
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema,
+          containers: new Map(),
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {_key: keyGenerator(), _type: 'span', text: 'foo'},
+                {
+                  _key: inlineObjectKey,
+                  _type: 'stock-ticker',
+                  symbol: 'AAPL',
+                },
+                {
+                  _key: keyGenerator(),
+                  _type: 'span',
+                  text: 'bar',
+                },
+              ],
+            },
+          ],
+        }),
       },
       {
         anchor: {
@@ -313,14 +296,11 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema: context.schema,
-            containers: context.containers,
-            value: context.value,
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema: context.schema,
+          containers: context.containers,
+          value: context.value,
+        }),
       },
       {
         anchor: {
@@ -364,14 +344,11 @@ describe(resolveSelection.name, () => {
 
     const range = resolveSelection(
       {
-        snapshot: {
-          context: {
-            schema: context.schema,
-            containers: context.containers,
-            value: context.value,
-          },
-          blockIndexMap: new Map(),
-        } as any,
+        snapshot: createTestSnapshot({
+          schema: context.schema,
+          containers: context.containers,
+          value: context.value,
+        }),
       },
       {
         anchor: {

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -1,4 +1,5 @@
-import type {EditorContext} from '../editor/editor-snapshot'
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorContext, EditorSnapshot} from '../editor/editor-snapshot'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
 import {serializePath} from '../paths/serialize-path'
 
@@ -128,5 +129,35 @@ export function buildIndexMaps(
       listItem: block.listItem,
       level: block.level,
     }
+  }
+}
+
+// Build a complete `EditorSnapshot` for tests. Populates
+// `blockIndexMap` and `listIndexMap` via `buildIndexMaps` so consumers
+// can assume the invariant that production maintains.
+export function createTestSnapshot(input: {
+  value: Array<PortableTextBlock>
+  schema: EditorContext['schema']
+  containers?: EditorContext['containers']
+  selection?: EditorContext['selection']
+}): EditorSnapshot {
+  const blockIndexMap = new Map<string, number>()
+  const listIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema: input.schema, value: input.value},
+    {blockIndexMap, listIndexMap},
+  )
+  return {
+    context: {
+      containers: input.containers ?? new Map(),
+      converters: [],
+      keyGenerator: () => '',
+      readOnly: false,
+      schema: input.schema,
+      selection: input.selection ?? null,
+      value: input.value,
+    },
+    blockIndexMap,
+    decoratorState: {},
   }
 }

--- a/packages/editor/src/internal-utils/get-unwrap-target.test.ts
+++ b/packages/editor/src/internal-utils/get-unwrap-target.test.ts
@@ -2,6 +2,7 @@ import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
 import {defineContainer, type Container} from '../renderers/renderer.types'
 import {resolveContainers} from '../schema/resolve-containers'
+import {createTestSnapshot} from './build-index-maps'
 import {getUnwrapTarget} from './get-unwrap-target'
 
 const testRender: Container['render'] = ({children}) => children
@@ -53,34 +54,31 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'cell',
-                _key: 'c0',
-                content: [
-                  {
-                    _type: 'callout',
-                    _key: 'co0',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'cb0',
-                        children: [
-                          {_type: 'span', _key: 'cs0', text: '', marks: []},
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block']),
       ),
@@ -166,51 +164,48 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'table',
-                _key: 't0',
-                rows: [
-                  {
-                    _type: 'row',
-                    _key: 'r0',
-                    cells: [
-                      {
-                        _type: 'cell',
-                        _key: 'c0',
-                        content: [
-                          {
-                            _type: 'callout',
-                            _key: 'co0',
-                            content: [
-                              {
-                                _type: 'block',
-                                _key: 'cb0',
-                                children: [
-                                  {
-                                    _type: 'span',
-                                    _key: 'cs0',
-                                    text: '',
-                                    marks: [],
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'table',
+              _key: 't0',
+              rows: [
+                {
+                  _type: 'row',
+                  _key: 'r0',
+                  cells: [
+                    {
+                      _type: 'cell',
+                      _key: 'c0',
+                      content: [
+                        {
+                          _type: 'callout',
+                          _key: 'co0',
+                          content: [
+                            {
+                              _type: 'block',
+                              _key: 'cb0',
+                              children: [
+                                {
+                                  _type: 'span',
+                                  _key: 'cs0',
+                                  text: '',
+                                  marks: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [
           {_key: 't0'},
           'rows',
@@ -287,64 +282,61 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'row',
-                _key: 'r0',
-                cells: [
-                  {
-                    _type: 'cell',
-                    _key: 'c0',
-                    content: [
-                      {
-                        _type: 'callout',
-                        _key: 'co0',
-                        content: [
-                          {
-                            _type: 'block',
-                            _key: 'cb0',
-                            children: [
-                              {_type: 'span', _key: 'cs0', text: '', marks: []},
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    _type: 'cell',
-                    _key: 'c1',
-                    content: [
-                      {
-                        _type: 'callout',
-                        _key: 'co1',
-                        content: [
-                          {
-                            _type: 'block',
-                            _key: 'cb1',
-                            children: [
-                              {
-                                _type: 'span',
-                                _key: 'cs1',
-                                text: 'bar',
-                                marks: [],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co1',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb1',
+                          children: [
+                            {
+                              _type: 'span',
+                              _key: 'cs1',
+                              text: 'bar',
+                              marks: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'r0'}, 'cells', {_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block']),
       ),
@@ -373,28 +365,23 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'callout',
-                _key: 'co0',
-                content: [
-                  {
-                    _type: 'block',
-                    _key: 'cb0',
-                    children: [
-                      {_type: 'span', _key: 'cs0', text: '', marks: []},
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'callout',
+              _key: 'co0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'co0'}],
         new Set(['block']),
       ),
@@ -449,35 +436,32 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'cell',
-                _key: 'c0',
-                content: [
-                  {
-                    _type: 'callout',
-                    _key: 'co0',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'cb0',
-                        children: [
-                          {_type: 'span', _key: 'cs0', text: '', marks: []},
-                        ],
-                      },
-                      {_type: 'image', _key: 'im0'},
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
       ),
@@ -530,35 +514,32 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'cell',
-                _key: 'c0',
-                content: [
-                  {
-                    _type: 'callout',
-                    _key: 'co0',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'cb0',
-                        children: [
-                          {_type: 'span', _key: 'cs0', text: '', marks: []},
-                        ],
-                      },
-                      {_type: 'image', _key: 'im0'},
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
       ),
@@ -610,35 +591,32 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'cell',
-                _key: 'c0',
-                content: [
-                  {
-                    _type: 'callout',
-                    _key: 'co0',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'cb0',
-                        children: [
-                          {_type: 'span', _key: 'cs0', text: '', marks: []},
-                        ],
-                      },
-                      {_type: 'image', _key: 'im0'},
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'callout',
+                  _key: 'co0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'cb0',
+                      children: [
+                        {_type: 'span', _key: 'cs0', text: '', marks: []},
+                      ],
+                    },
+                    {_type: 'image', _key: 'im0'},
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'c0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
       ),
@@ -690,47 +668,44 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'row',
-                _key: 'r0',
-                cells: [
-                  {
-                    _type: 'cell',
-                    _key: 'c0',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'b0',
-                        children: [
-                          {_type: 'span', _key: 's0', text: '', marks: []},
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    _type: 'cell',
-                    _key: 'c1',
-                    content: [
-                      {
-                        _type: 'block',
-                        _key: 'b1',
-                        children: [
-                          {_type: 'span', _key: 's1', text: 'bar', marks: []},
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c0',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b0',
+                      children: [
+                        {_type: 'span', _key: 's0', text: '', marks: []},
+                      ],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      children: [
+                        {_type: 'span', _key: 's1', text: 'bar', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'r0'}, 'cells', {_key: 'c0'}],
         new Set(['block']),
       ),
@@ -802,41 +777,38 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'cell',
-                _key: 'c0',
-                content: [
-                  {
-                    _type: 'section',
-                    _key: 'se0',
-                    content: [
-                      {
-                        _type: 'callout',
-                        _key: 'co0',
-                        content: [
-                          {
-                            _type: 'block',
-                            _key: 'cb0',
-                            children: [
-                              {_type: 'span', _key: 'cs0', text: '', marks: []},
-                            ],
-                          },
-                          {_type: 'image', _key: 'im0'},
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              content: [
+                {
+                  _type: 'section',
+                  _key: 'se0',
+                  content: [
+                    {
+                      _type: 'callout',
+                      _key: 'co0',
+                      content: [
+                        {
+                          _type: 'block',
+                          _key: 'cb0',
+                          children: [
+                            {_type: 'span', _key: 'cs0', text: '', marks: []},
+                          ],
+                        },
+                        {_type: 'image', _key: 'im0'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
         [{_key: 'c0'}, 'content', {_key: 'se0'}, 'content', {_key: 'co0'}],
         new Set(['block', 'image']),
       ),
@@ -871,29 +843,24 @@ describe(getUnwrapTarget.name, () => {
 
     expect(
       getUnwrapTarget(
-        {
-          context: {
-            schema,
-            containers,
-            value: [
-              {
-                _type: 'callout',
-                _key: 'co0',
-                content: [
-                  {
-                    _type: 'block',
-                    _key: 'cb0',
-                    children: [
-                      {_type: 'span', _key: 'cs0', text: '', marks: []},
-                    ],
-                  },
-                  {_type: 'image', _key: 'im0'},
-                ],
-              },
-            ],
-          },
-          blockIndexMap: new Map(),
-        },
+        createTestSnapshot({
+          schema,
+          containers,
+          value: [
+            {
+              _type: 'callout',
+              _key: 'co0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cs0', text: '', marks: []}],
+                },
+                {_type: 'image', _key: 'im0'},
+              ],
+            },
+          ],
+        }),
         [{_key: 'co0'}],
         new Set(['block', 'image']),
       ),

--- a/packages/editor/src/traversal/get-ancestors.ts
+++ b/packages/editor/src/traversal/get-ancestors.ts
@@ -64,13 +64,7 @@ export function getAncestors(
 
     let node: Node | undefined
     if (isKeyedSegment(segment)) {
-      // Production snapshots maintain `blockIndexMap` in lockstep with
-      // `context.value` so this fast path always fires. Some test
-      // fixtures still pass empty or stale maps, which is the debt this
-      // size check is working around - see /specs/snapshot-invariants.md.
-      // When the fixtures are aligned, drop the guard and use the map
-      // directly.
-      if (isRootLevel && blockIndexMap.size === currentChildren.length) {
+      if (isRootLevel) {
         const index = blockIndexMap.get(segment._key)
         node =
           index !== undefined

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -43,7 +43,7 @@ export function getNode(
     }
 
     if (isKeyedSegment(segment)) {
-      if (isRootLevel && blockIndexMap.size === currentChildren.length) {
+      if (isRootLevel) {
         const index = blockIndexMap.get(segment._key)
         if (index !== undefined) {
           const candidate = currentChildren[index]


### PR DESCRIPTION
Production snapshots maintain `blockIndexMap` in lockstep with `context.value` so the size-equality guards in `get-ancestors`, `get-node`, `modify` and `apply-operation`'s `resolveChildIndex` never fired in production. They existed solely to tolerate test fixtures that hand-built a partial `EditorSnapshot` and passed `blockIndexMap: new Map()` with an `as any` cast.

Add `createTestSnapshot` alongside `buildIndexMaps`. The helper builds a complete `EditorSnapshot` for tests, populating both index maps from the value. Migrate the 12 fixture sites across `apply-selection.test`, `get-unwrap-target.test` and `unhang-range.test` to call it.

With the fixtures aligned, the guards become noise and the slow-path `children.find(...)` fallback becomes dead code in production. Drop the size guards. The candidate-key check in `get-node` / `resolveChildIndex` stays as defence against transient inconsistency, and the `findIndexByKey` fallback in `modify` stays in case the map genuinely doesn't know the key (numeric-only paths, etc).

Net behavior unchanged. Hot paths now hit the map directly without the size accounting.

The followup PR for path-keyed `blockIndexMap` dual-write builds on top of this — once the guards are gone, the dual-write doesn't need to introduce divisor-style accounting (`map.size / 2 === children.length`) to keep them alive.