### PR TITLE
feat: emit behavior events from `editor.on`

### DIFF
--- a/.changeset/editor-on-behavior-event.md
+++ b/.changeset/editor-on-behavior-event.md
@@ -1,0 +1,20 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: emit behavior events from `editor.on`
+
+Behavior events flowing through the chain are now emitted on `editor.on`. Subscribe to a single event type by name:
+
+```ts
+editor.on('drag.dragover', (event) => {
+  console.log('drag.dragover at', event.position)
+})
+editor.on('insert.text', (event) => {
+  console.log('insert.text:', event.text)
+})
+```
+
+`editor.on('*', listener)` and `EventListenerPlugin` see behavior events alongside the existing emitted events.
+
+The tap fires once per behavior event, before the behavior chain runs. Observers see user intent regardless of whether a high-priority handler decides to swallow it.

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -14,7 +14,11 @@ import {createEditorDom} from './editor-dom'
 import type {EditorActor} from './editor-machine'
 import {editorMachine, rerouteExternalBehaviorEvent} from './editor-machine'
 import {mutationMachine, type MutationActor} from './mutation-machine'
-import {relayMachine, type RelayActor} from './relay-machine'
+import {
+  relayMachine,
+  type EditorEmittedEvent,
+  type RelayActor,
+} from './relay-machine'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export function createInternalEditor(config: EditorConfig): {
@@ -126,6 +130,11 @@ export function createInternalEditor(config: EditorConfig): {
           case 'value changed':
             listener(event)
             break
+          default:
+            // Behavior events (`insert`, `insert.text`, `drag.dragover`,
+            // `serialize`, etc.) are forwarded through the relay so consumers
+            // can subscribe by name: `editor.on('insert.text', listener)`.
+            listener(event)
         }
       })
 
@@ -279,6 +288,15 @@ function createActors(config: {
         case 'internal.patch':
           mutationActor.send({...event, type: 'patch'})
           break
+        case 'patches':
+          // PatchesEvent is an editor-machine internal event; not a behavior
+          // event and not forwarded to the relay.
+          break
+        default:
+          // Behavior events are emitted from the editor machine's
+          // `handle behavior event` action before the chain runs. Forward to
+          // the relay so `editor.on(behaviorEventType, ...)` fires.
+          config.relayActor.send(event as EditorEmittedEvent)
       }
     })
 

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -398,47 +398,51 @@ export const editorMachine = setup({
         )
       }
     },
-    'handle behavior event': ({context, event, self}) => {
-      assertEvent(event, ['behavior event'])
+    'handle behavior event': enqueueActions(
+      ({context, event, self, enqueue}) => {
+        assertEvent(event, ['behavior event'])
 
-      try {
-        const behaviors = [...context.behaviors.values()].map(
-          (config) => config.behavior,
-        )
+        enqueue.emit(event.behaviorEvent)
 
-        performEvent({
-          mode: 'send',
-          behaviors,
-          remainingEventBehaviors: behaviors,
-          event: event.behaviorEvent,
-          editor: event.editor,
-          converters: event.editor.snapshot.context.converters,
-          keyGenerator: event.editor.snapshot.context.keyGenerator,
-          schema: event.editor.snapshot.context.schema,
-          readOnly: event.editor.snapshot.context.readOnly,
-          nativeEvent: event.nativeEvent,
-          sendBack: (eventSentBack) => {
-            if (eventSentBack.type === 'set drag ghost') {
-              self.send(eventSentBack)
-              return
-            }
+        try {
+          const behaviors = [...context.behaviors.values()].map(
+            (config) => config.behavior,
+          )
 
-            self.send(
-              rerouteExternalBehaviorEvent({
-                event: eventSentBack,
-                editorEngine: event.editor,
-              }),
-            )
-          },
-        })
-      } catch (error) {
-        console.error(
-          new Error(
-            `Raising "${event.behaviorEvent.type}" failed due to: ${error instanceof Error ? error.message : error}`,
-          ),
-        )
-      }
-    },
+          performEvent({
+            mode: 'send',
+            behaviors,
+            remainingEventBehaviors: behaviors,
+            event: event.behaviorEvent,
+            editor: event.editor,
+            converters: event.editor.snapshot.context.converters,
+            keyGenerator: event.editor.snapshot.context.keyGenerator,
+            schema: event.editor.snapshot.context.schema,
+            readOnly: event.editor.snapshot.context.readOnly,
+            nativeEvent: event.nativeEvent,
+            sendBack: (eventSentBack) => {
+              if (eventSentBack.type === 'set drag ghost') {
+                self.send(eventSentBack)
+                return
+              }
+
+              self.send(
+                rerouteExternalBehaviorEvent({
+                  event: eventSentBack,
+                  editorEngine: event.editor,
+                }),
+              )
+            },
+          })
+        } catch (error) {
+          console.error(
+            new Error(
+              `Raising "${event.behaviorEvent.type}" failed due to: ${error instanceof Error ? error.message : error}`,
+            ),
+          )
+        }
+      },
+    ),
     'sort behaviors': assign({
       behaviors: ({context}) =>
         !context.behaviorsSorted

--- a/packages/editor/src/editor/relay-machine.ts
+++ b/packages/editor/src/editor/relay-machine.ts
@@ -2,12 +2,14 @@ import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {FocusEvent} from 'react'
 import {assign, emit, setup, type ActorRefFrom} from 'xstate'
+import type {BehaviorEvent} from '../behaviors/behavior.types.event'
 import type {EditorSelection, InvalidValueResolution} from '../types/editor'
 
 /**
  * @public
  */
 export type EditorEmittedEvent =
+  | BehaviorEvent
   | {
       type: 'blurred'
       event: FocusEvent<HTMLDivElement, Element>
@@ -64,7 +66,7 @@ type ErrorEvent = {
   data: unknown
 }
 
-type InternalEditorEmittedEvent = EditorEmittedEvent | UnsetEvent
+type InternalEditorEmittedEvent = EditorEmittedEvent
 
 /**
  * @public
@@ -78,14 +80,6 @@ export type MutationEvent = {
 export type PatchEvent = {
   type: 'patch'
   patch: Patch
-}
-
-type UnsetEvent = {
-  /**
-   * @deprecated Use `'patch'` events instead
-   */
-  type: 'unset'
-  previousValue: Array<PortableTextBlock>
 }
 
 export type RelayActor = ActorRefFrom<typeof relayMachine>

--- a/packages/editor/src/engine-plugins/engine-plugin.patches.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.patches.ts
@@ -33,7 +33,6 @@ interface Options {
 
 export function createPatchesPlugin({
   editorActor,
-  relayActor,
   subscriptions,
 }: Options): (editor: PortableTextEditorEngine) => PortableTextEditorEngine {
   // The previous editor value are needed to figure out the _key of deleted nodes
@@ -175,10 +174,6 @@ export function createPatchesPlugin({
         ['set', 'unset', 'remove_text'].includes(operation.type)
       ) {
         patches = [...patches, unset([])]
-        relayActor.send({
-          type: 'unset',
-          previousValue,
-        })
       }
 
       // Prepend patches with setIfMissing if going from empty editor to something involving a patch.

--- a/packages/editor/tests/editor-on-behavior-event.test.tsx
+++ b/packages/editor/tests/editor-on-behavior-event.test.tsx
@@ -1,0 +1,161 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {EventListenerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('editor.on behavior event', () => {
+  test('editor.on fires per behavior event by name', async () => {
+    const onInsertText = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'k0',
+        children: [{_type: 'span', _key: 'k1', text: 'hi', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+    })
+
+    const subscription = editor.on('insert.text', onInsertText)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        backward: false,
+      },
+    })
+
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(onInsertText).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onInsertText).toHaveBeenCalledWith({
+      type: 'insert.text',
+      text: '!',
+    })
+
+    subscription.unsubscribe()
+  })
+
+  test('editor.on fires before the behavior chain consumes the event', async () => {
+    const observed: Array<string> = []
+    const keyGenerator = createTestKeyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'hi', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.on('insert.text', (event) => {
+      observed.push(`tap:${event.text}`)
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        backward: false,
+      },
+    })
+
+    editor.send({type: 'insert.text', text: '?'})
+
+    await vi.waitFor(() => {
+      expect(observed).toContain('tap:?')
+    })
+  })
+
+  test('editor.on(*) sees behavior events alongside relay events', async () => {
+    const events: Array<string> = []
+    const keyGenerator = createTestKeyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'hi', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            events.push(event.type)
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 2},
+        backward: false,
+      },
+    })
+
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(events).toContain('insert.text')
+    })
+  })
+
+  test('editor.on fires for top-level behavior events that have no dot', async () => {
+    const onSelect = vi.fn()
+    const keyGenerator = createTestKeyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'hi', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.on('select', onSelect)
+
+    const at = {
+      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 1},
+      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 1},
+      backward: false,
+    }
+
+    editor.send({type: 'select', at})
+
+    await vi.waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onSelect).toHaveBeenCalledWith({type: 'select', at})
+  })
+})


### PR DESCRIPTION
Today `editor.on` exposes a fixed set of events (`patch`, `mutation`, `selection`, plus lifecycle). The behavior events that flow through the chain — `insert.text`, `drag.dragover`, `serialize`, `select`, etc. — have no public subscription surface. A plugin author who wants to derive state from "the user is dragging over this position" can't do it cleanly: either they reach into engine internals, or they request a new `RenderProps` field.

This PR widens `EditorEmittedEvent` to include `BehaviorEvent`. Behavior events are emitted from the editor machine and forwarded through the relay, so consumers subscribe by name:

```ts
editor.on('drag.dragover', (event) => {
  // event.position, event.dragOrigin
})

editor.on('insert.text', (event) => {
  // event.text
})

editor.on('*', (event) => {
  // sees behavior events alongside the existing emitted events
})
```

`editor.on(type, listener)` is typed-narrowed via xstate's existing channel overload, so call sites get the right event shape without `event.type === '...'` guards. `EventListenerPlugin` sees behavior events too.

## Pre- vs post-handler tap

The tap fires once per behavior event, **before the behavior chain runs**. Observers see user intent regardless of whether a high-priority handler decides to swallow the event.

Post-handler would miss intercepted events, which is the wrong default for plugin authors building providers. Example: a `dropPosition` provider needs to track the latest `drag.dragover` even when `behavior.core.dnd` ends up swallowing the dragover to set its own internal state — the provider's view of "where the user is dragging" shouldn't depend on which handler wins.

A consequence of this placement: `raise(event)` calls inside an action body do *not* re-enter the `handle behavior event` action, so they're invisible to `editor.on`. Only externally-dispatched and `sendBack`-routed behavior events reach subscribers. That preserves the "observe intent" semantic (subscribers see the events users sent, not decomposition machinery).

## Removed: deprecated `'unset'` emitted event

The deprecated `'unset'` emitted event collided with the `BehaviorEvent` variant of the same name and is removed. It was `@deprecated` in favor of `'patch'`. No consumers in this repo's downstream apps (`sanity-io/sanity`, `sanity-io/canvas`) subscribe to it.

## Downstream impact

**Studio (`sanity-io/sanity`)**: Three `EventListenerPlugin` consumers — `PortableTextInput`, `StringInputPortableText`, `CommentInput`. All use exhaustive `switch (event.type)` with empty `default:`, so unknown event types are silently ignored. No runtime break and no TS break (the widened union still type-checks against an empty default). A real consequence worth flagging: these handlers now fire on every `insert.text` keystroke and `drag.dragover` mousemove, each hitting the switch and falling through to `default`. Sub-millisecond per event but a real hot-path cost on the most-used PT input. Worth measuring post-merge if anything feels sluggish.

**Canvas (`sanity-io/canvas`)**: Five `editor.on` subscriptions — all subscribe by specific type (`'selection'`, `'blurred'`, `'value changed'`). Unaffected. No exposure to the `'unset'` deprecation removal.

## Open questions

- The operation channel: `editor.on('patch', …)` carries Sanity patches. A `editor.on('operation', …)` channel carrying engine operations (`insert_node`, `unset`, `set`, etc.) would let plugins derive state like `listIndexMap` and `blockIndexMap` outside the engine without re-deriving from `value`. Follow-up.
- Naming: `drag.dragover` mirrors the DOM event name verbatim. Verbose but explicit. Worth a sanity check before locking the @public surface.

Spec: `/specs/shared-state-primitive.md` v5.