### PR TITLE
refactor: rename engine operation types to dot notation

### DIFF
--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -246,9 +246,9 @@ export const PortableTextEditable = forwardRef<
           )
         }
         editorEngine.select(resolvedSelection)
-        // Output selection here in those cases where the editor selection was the same, and there are no set_selection operations made.
-        // The selection is usually automatically emitted by the withPortableTextSelections plugin whenever there is a set_selection operation applied.
-        if (!editorEngine.operations.some((o) => o.type === 'set_selection')) {
+        // Output selection here in those cases where the editor selection was the same, and there are no set.selection operations made.
+        // The selection is usually automatically emitted by the withPortableTextSelections plugin whenever there is a set.selection operation applied.
+        if (!editorEngine.operations.some((o) => o.type === 'set.selection')) {
           editorActor.send({
             type: 'update selection',
             selection: resolvedSelection,

--- a/packages/editor/src/editor/mutation-batcher.ts
+++ b/packages/editor/src/editor/mutation-batcher.ts
@@ -126,7 +126,7 @@ export function createMutationBatcher({
   }
 
   function handleOperation(operationType: string) {
-    if (operationType === 'insert_text' || operationType === 'remove_text') {
+    if (operationType === 'insert.text' || operationType === 'remove.text') {
       isTyping = true
 
       if (typeDebounce !== undefined) {

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -31,7 +31,7 @@ const engineOperationCallback: CallbackLogicFunction<
   return subscribeToOperations(
     input.editorEngine,
     (event) => {
-      if (event.operation.type !== 'set_selection') {
+      if (event.operation.type !== 'set.selection') {
         // `transform range decorations` reads the editor snapshot
         // synchronously and needs the pre-apply tree (removed nodes must
         // still be present to resolve document order) — hence the

--- a/packages/editor/src/editor/subscriber.history.ts
+++ b/packages/editor/src/editor/subscriber.history.ts
@@ -96,7 +96,7 @@ export function subscribeHistory({
         operation.type === 'unset' ||
         operation.type === 'insert') &&
         !operation.inverse) ||
-      ((operation.type === 'insert_text' || operation.type === 'remove_text') &&
+      ((operation.type === 'insert.text' || operation.type === 'remove.text') &&
         operation.text.length === 0)
 
     if (isNoOp) {
@@ -104,7 +104,7 @@ export function subscribeHistory({
       return
     }
 
-    if (operation.type !== 'set_selection') {
+    if (operation.type !== 'set.selection') {
       // Clear the redo steps if any actual changes are made
       if (editor.history.redos.length > 0) {
         editor.history.redos = []

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -55,19 +55,19 @@ export function subscribePatchGeneration({
     if (
       editorWasEmpty &&
       !editorIsEmpty &&
-      operation.type !== 'set_selection'
+      operation.type !== 'set.selection'
     ) {
       patches.push(insert(previousValue, 'before', [0]))
     }
 
     switch (operation.type) {
-      case 'insert_text':
+      case 'insert.text':
         patches = [
           ...patches,
           ...textPatch(editor.snapshot, operation, previousValue),
         ]
         break
-      case 'remove_text':
+      case 'remove.text':
         patches = [
           ...patches,
           ...textPatch(editor.snapshot, operation, previousValue),
@@ -90,7 +90,7 @@ export function subscribePatchGeneration({
     if (
       !editorWasEmpty &&
       editorIsEmpty &&
-      ['set', 'unset', 'remove_text'].includes(operation.type)
+      ['set', 'unset', 'remove.text'].includes(operation.type)
     ) {
       patches = [...patches, unset([])]
     }

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -34,11 +34,11 @@ export function subscribeUpdateValue(
   const unsubscribeIndexMaps = subscribeToOperations(editor, (event) => {
     const operation = event.operation
 
-    if (operation.type === 'set_selection') {
+    if (operation.type === 'set.selection') {
       return
     }
 
-    if (operation.type === 'insert_text' || operation.type === 'remove_text') {
+    if (operation.type === 'insert.text' || operation.type === 'remove.text') {
       // Inserting and removing text has no effect on index maps so there is
       // no need to rebuild those.
       return

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -1066,7 +1066,7 @@ function updateBlock({
               }
 
               editorEngine.apply({
-                type: 'insert_text',
+                type: 'insert.text',
                 path,
                 offset: 0,
                 text: currentBlockChild.text,

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -42,7 +42,7 @@ export function createUndoSteps({
   }
 
   if (
-    op.type === 'set_selection' &&
+    op.type === 'set.selection' &&
     currentUndoStepId === undefined &&
     previousUndoStepId !== undefined
   ) {
@@ -51,7 +51,7 @@ export function createUndoSteps({
   }
 
   if (
-    op.type === 'set_selection' &&
+    op.type === 'set.selection' &&
     currentUndoStepId !== undefined &&
     previousUndoStepId !== undefined &&
     previousUndoStepId !== currentUndoStepId
@@ -62,7 +62,7 @@ export function createUndoSteps({
 
   // Handle case when both IDs are undefined
   if (currentUndoStepId === undefined && previousUndoStepId === undefined) {
-    if (op.type === 'set_selection') {
+    if (op.type === 'set.selection') {
       return mergeIntoLastStep(steps, lastStep, op)
     }
 
@@ -70,8 +70,8 @@ export function createUndoSteps({
 
     if (
       lastOp &&
-      op.type === 'insert_text' &&
-      lastOp.type === 'insert_text' &&
+      op.type === 'insert.text' &&
+      lastOp.type === 'insert.text' &&
       op.offset === lastOp.offset + lastOp.text.length &&
       pathEquals(op.path, lastOp.path) &&
       op.text !== ' '
@@ -81,8 +81,8 @@ export function createUndoSteps({
 
     if (
       lastOp &&
-      op.type === 'remove_text' &&
-      lastOp.type === 'remove_text' &&
+      op.type === 'remove.text' &&
+      lastOp.type === 'remove.text' &&
       op.offset + op.text.length === lastOp.offset &&
       pathEquals(op.path, lastOp.path)
     ) {
@@ -103,8 +103,8 @@ export function createUndoSteps({
 
     if (
       lastOp &&
-      op.type === 'insert_text' &&
-      lastOp.type === 'insert_text' &&
+      op.type === 'insert.text' &&
+      lastOp.type === 'insert.text' &&
       op.offset === lastOp.offset + lastOp.text.length &&
       pathEquals(op.path, lastOp.path) &&
       op.text !== ' '
@@ -114,8 +114,8 @@ export function createUndoSteps({
 
     if (
       lastOp &&
-      op.type === 'remove_text' &&
-      lastOp.type === 'remove_text' &&
+      op.type === 'remove.text' &&
+      lastOp.type === 'remove.text' &&
       op.offset + op.text.length === lastOp.offset &&
       pathEquals(op.path, lastOp.path)
     ) {
@@ -130,8 +130,8 @@ export function createUndoSteps({
 
     if (
       lastOp &&
-      op.type === 'insert_text' &&
-      lastOp.type === 'insert_text' &&
+      op.type === 'insert.text' &&
+      lastOp.type === 'insert.text' &&
       op.offset === lastOp.offset + lastOp.text.length &&
       pathEquals(op.path, lastOp.path) &&
       op.text !== ' '
@@ -153,7 +153,7 @@ function createNewStep(
       ? [op]
       : [
           {
-            type: 'set_selection' as const,
+            type: 'set.selection' as const,
             properties: {...selectionBeforeApply},
             newProperties: {...selectionBeforeApply},
           },

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -115,7 +115,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       break
     }
 
-    case 'insert_text': {
+    case 'insert.text': {
       const {path, offset, text} = op
       if (text.length === 0) {
         break
@@ -135,7 +135,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       break
     }
 
-    case 'remove_text': {
+    case 'remove.text': {
       const {path, offset, text} = op
       if (text.length === 0) {
         break
@@ -481,7 +481,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       break
     }
 
-    case 'set_selection': {
+    case 'set.selection': {
       const {newProperties} = op
 
       if (newProperties == null) {
@@ -492,7 +492,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       if (editor.snapshot.context.selection == null) {
         if (!isRange(newProperties)) {
           throw new Error(
-            `Cannot apply an incomplete "set_selection" operation properties ${safeStringify(
+            `Cannot apply an incomplete "set.selection" operation properties ${safeStringify(
               newProperties,
             )} when there is no current selection.`,
           )
@@ -546,7 +546,7 @@ export function applyOperation(editor: Editor, op: Operation): void {
       // move the point. If neither endpoint moved, the selection is identity-
       // stable and we leave `editor.snapshot.context.selection` alone. This lets internal sync
       // paths (e.g. remote patches arriving via `update value`) run set/unset/
-      // insert_text operations without forcing downstream consumers to re-derive
+      // insert.text operations without forcing downstream consumers to re-derive
       // selection-keyed state for no semantic reason.
       editor.snapshot.context.selection = {
         anchor,

--- a/packages/editor/src/engine/core/apply.ts
+++ b/packages/editor/src/engine/core/apply.ts
@@ -51,7 +51,7 @@ export const apply: WithEditorFirstArg<Editor['apply']> = (editor, op) => {
   })
 
   // Clear any formats applied to the cursor if the selection changes.
-  if (op.type === 'set_selection') {
+  if (op.type === 'set.selection') {
     if (
       op.properties &&
       op.newProperties &&

--- a/packages/editor/src/engine/core/deselect.ts
+++ b/packages/editor/src/engine/core/deselect.ts
@@ -5,7 +5,7 @@ export function deselect(editor: Editor): void {
 
   if (selection) {
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: selection,
       newProperties: null,
     })

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -58,7 +58,7 @@ function getSpanText(value: Array<PortableTextBlock>): string {
 }
 
 const insertTextOperation: Operation = {
-  type: 'insert_text',
+  type: 'insert.text',
   path: [{_key: 'b1'}, 'children', {_key: 's1'}],
   offset: 3,
   text: 'bar',
@@ -174,7 +174,7 @@ describe('operation channel', () => {
     }
 
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: null,
       newProperties: range,
     })
@@ -189,7 +189,7 @@ describe('operation channel', () => {
   test('operations replace the value instead of mutating it, keeping `beforeValue` intact', () => {
     const operationCases: Array<{name: string; operation: Operation}> = [
       {
-        name: 'insert_text on a span',
+        name: 'insert.text on a span',
         operation: insertTextOperation,
       },
       {
@@ -341,8 +341,8 @@ describe('operation channel', () => {
     // operation’s.
     expect(eventLog).toEqual([
       'before:set:local',
-      'before:insert_text:normalization',
-      'after:insert_text:normalization',
+      'before:insert.text:normalization',
+      'after:insert.text:normalization',
       'after:set:local',
     ])
   })

--- a/packages/editor/src/engine/core/select.ts
+++ b/packages/editor/src/engine/core/select.ts
@@ -22,7 +22,7 @@ export function select(editor: Editor, target: Location): void {
   }
 
   editor.apply({
-    type: 'set_selection',
+    type: 'set.selection',
     properties: selection,
     newProperties: target,
   })

--- a/packages/editor/src/engine/core/set-selection.ts
+++ b/packages/editor/src/engine/core/set-selection.ts
@@ -30,7 +30,7 @@ export function setSelection(editor: Editor, props: Partial<Range>): void {
 
   if (Object.keys(oldProps).length > 0) {
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: oldProps,
       newProperties: newProps,
     })

--- a/packages/editor/src/engine/dom/plugin/with-dom.ts
+++ b/packages/editor/src/engine/dom/plugin/with-dom.ts
@@ -65,7 +65,7 @@ export const withDOM = <T extends Editor>(editor: T): T & DOMEditor => {
         e.pendingAction = at ? {...pendingAction, at} : null
       }
 
-      if (operation.type === 'set_selection') {
+      if (operation.type === 'set.selection') {
         // Selection was manually set, don't restore the user selection after the change.
         e.userSelection?.unref()
         e.userSelection = null
@@ -81,9 +81,9 @@ export const withDOM = <T extends Editor>(editor: T): T & DOMEditor => {
     switch (event.operation.type) {
       case 'insert':
       case 'unset':
-      case 'insert_text':
-      case 'remove_text':
-      case 'set_selection': {
+      case 'insert.text':
+      case 'remove.text':
+      case 'set.selection': {
         // FIXME: Rename to something like IS_DOM_EDITOR_DESYNCED
         // to better reflect reality, see #5792
         e.isNodeMapDirty = true

--- a/packages/editor/src/engine/dom/utils/diff-text.ts
+++ b/packages/editor/src/engine/dom/utils/diff-text.ts
@@ -314,7 +314,7 @@ export function transformTextDiff(
   const {path, diff, id} = textDiff
 
   switch (op.type) {
-    case 'insert_text': {
+    case 'insert.text': {
       if (!pathEquals(op.path, path) || op.offset >= diff.end) {
         return textDiff
       }
@@ -341,7 +341,7 @@ export function transformTextDiff(
         path,
       }
     }
-    case 'remove_text': {
+    case 'remove.text': {
       if (!pathEquals(op.path, path) || op.offset >= diff.end) {
         return textDiff
       }

--- a/packages/editor/src/engine/interfaces/operation.ts
+++ b/packages/editor/src/engine/interfaces/operation.ts
@@ -11,14 +11,14 @@ export type InsertOperation = {
 }
 
 export type InsertTextOperation = {
-  type: 'insert_text'
+  type: 'insert.text'
   path: Path
   offset: number
   text: string
 }
 
 export type RemoveTextOperation = {
-  type: 'remove_text'
+  type: 'remove.text'
   path: Path
   offset: number
   text: string
@@ -80,17 +80,17 @@ type UnsetOperation = {
 
 type SetSelectionOperation =
   | {
-      type: 'set_selection'
+      type: 'set.selection'
       properties: null
       newProperties: Range
     }
   | {
-      type: 'set_selection'
+      type: 'set.selection'
       properties: Partial<Range>
       newProperties: Partial<Range>
     }
   | {
-      type: 'set_selection'
+      type: 'set.selection'
       properties: Range
       newProperties: null
     }

--- a/packages/editor/src/engine/operation/inverse-operation.test.ts
+++ b/packages/editor/src/engine/operation/inverse-operation.test.ts
@@ -55,30 +55,30 @@ describe(inverseOperation.name, () => {
     })
   })
 
-  test('insert_text -> remove_text', () => {
+  test('insert.text -> remove.text', () => {
     const op: Operation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
       text: 'abc',
     }
     expect(inverseOperation(op)).toEqual({
-      type: 'remove_text',
+      type: 'remove.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
       text: 'abc',
     })
   })
 
-  test('remove_text -> insert_text', () => {
+  test('remove.text -> insert.text', () => {
     const op: Operation = {
-      type: 'remove_text',
+      type: 'remove.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
       text: 'ab',
     }
     expect(inverseOperation(op)).toEqual({
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
       text: 'ab',

--- a/packages/editor/src/engine/operation/inverse-operation.ts
+++ b/packages/editor/src/engine/operation/inverse-operation.ts
@@ -15,12 +15,12 @@ export function inverseOperation(op: Operation): Operation {
       }
     }
 
-    case 'insert_text': {
-      return {...op, type: 'remove_text'}
+    case 'insert.text': {
+      return {...op, type: 'remove.text'}
     }
 
-    case 'remove_text': {
-      return {...op, type: 'insert_text'}
+    case 'remove.text': {
+      return {...op, type: 'insert.text'}
     }
 
     case 'set': {
@@ -71,7 +71,7 @@ export function inverseOperation(op: Operation): Operation {
       }
     }
 
-    case 'set_selection': {
+    case 'set.selection': {
       const {properties, newProperties} = op
 
       if (properties == null) {

--- a/packages/editor/src/engine/point/transform-point.test.ts
+++ b/packages/editor/src/engine/point/transform-point.test.ts
@@ -5,7 +5,7 @@ import {transformPoint} from './transform-point'
 describe(transformPoint.name, () => {
   test('null point returns null', () => {
     const op: Operation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 0,
       text: 'hello',
@@ -13,13 +13,13 @@ describe(transformPoint.name, () => {
     expect(transformPoint(null, op)).toEqual(null)
   })
 
-  test('insert_text adjusts offset forward', () => {
+  test('insert.text adjusts offset forward', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
     const op: Operation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
       text: 'abc',
@@ -30,13 +30,13 @@ describe(transformPoint.name, () => {
     })
   })
 
-  test('insert_text before offset is no-op', () => {
+  test('insert.text before offset is no-op', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
     }
     const op: Operation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
       text: 'abc',
@@ -47,13 +47,13 @@ describe(transformPoint.name, () => {
     })
   })
 
-  test('insert_text different path is no-op', () => {
+  test('insert.text different path is no-op', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
     const op: Operation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's2'}],
       offset: 0,
       text: 'abc',
@@ -64,13 +64,13 @@ describe(transformPoint.name, () => {
     })
   })
 
-  test('remove_text adjusts offset backward', () => {
+  test('remove.text adjusts offset backward', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
     const op: Operation = {
-      type: 'remove_text',
+      type: 'remove.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
       text: 'ab',
@@ -137,13 +137,13 @@ describe(transformPoint.name, () => {
     })
   })
 
-  test('set_selection is no-op', () => {
+  test('set.selection is no-op', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
     const op: Operation = {
-      type: 'set_selection',
+      type: 'set.selection',
       properties: null,
       newProperties: {
         anchor: {path: [], offset: 0},

--- a/packages/editor/src/engine/point/transform-point.ts
+++ b/packages/editor/src/engine/point/transform-point.ts
@@ -14,10 +14,10 @@ import {pathEquals} from '../path/path-equals'
  * - insert: no-op (new node has its own key, doesn't shift siblings)
  * - unset (node removal): invalidates if the point is at or inside the removed node
  * - unset (property removal): collapses offset when `text` is unset from a span
- * - insert_text: adjusts offset if in the same span
- * - remove_text: adjusts offset if in the same span
+ * - insert.text: adjusts offset if in the same span
+ * - remove.text: adjusts offset if in the same span
  * - set: updates keyed segments when `_key` changes, clamps offset when `text` changes
- * - set_selection: no-op
+ * - set.selection: no-op
  */
 export function transformPoint(
   point: Point | null,
@@ -31,7 +31,7 @@ export function transformPoint(
   const {affinity = 'forward'} = options
 
   switch (op.type) {
-    case 'insert_text': {
+    case 'insert.text': {
       if (
         pathEquals(op.path, point.path) &&
         (op.offset < point.offset ||
@@ -43,7 +43,7 @@ export function transformPoint(
       return point
     }
 
-    case 'remove_text': {
+    case 'remove.text': {
       if (pathEquals(op.path, point.path) && op.offset <= point.offset) {
         return {
           path: point.path,
@@ -129,7 +129,7 @@ export function transformPoint(
       return point
     }
 
-    // set_selection: no transform needed
+    // set.selection: no transform needed
     default:
       return point
   }

--- a/packages/editor/src/engine/range/transform-range.test.ts
+++ b/packages/editor/src/engine/range/transform-range.test.ts
@@ -19,7 +19,7 @@ describe(transformRange.name, () => {
       transformRange(
         null,
         {
-          type: 'insert_text',
+          type: 'insert.text',
           path: [{_key: 'b1'}, 'children', {_key: 's1'}],
           offset: 0,
           text: 'x',
@@ -35,7 +35,7 @@ describe(transformRange.name, () => {
       focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
     }
     const op: InsertTextOperation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 0,
       text: 'foo',
@@ -52,7 +52,7 @@ describe(transformRange.name, () => {
       focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
     }
     const op: InsertTextOperation = {
-      type: 'insert_text',
+      type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 'other'}],
       offset: 0,
       text: 'foo',

--- a/packages/editor/src/internal-utils/apply-merge-node.ts
+++ b/packages/editor/src/internal-utils/apply-merge-node.ts
@@ -14,7 +14,7 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
 /**
  * Merge a node at the given path into its previous sibling using only
- * patch-compliant operations (insert_text/insert + unset).
+ * patch-compliant operations (insert.text/insert + unset).
  *
  * Because the decomposed operations would produce different ref-transform
  * semantics than a single merge, we pre-transform all active refs with
@@ -196,7 +196,7 @@ export function applyMergeNode(
         // Merge text: insert the text into the previous sibling at the position
         if (node.text.length > 0) {
           editor.apply({
-            type: 'insert_text',
+            type: 'insert.text',
             path: prevPath,
             offset: position,
             text: node.text,

--- a/packages/editor/src/internal-utils/apply-selection.ts
+++ b/packages/editor/src/internal-utils/apply-selection.ts
@@ -188,14 +188,14 @@ export function applySelect(
 
     if (Object.keys(oldProps).length > 0) {
       editor.apply({
-        type: 'set_selection',
+        type: 'set.selection',
         properties: oldProps,
         newProperties: newProps,
       })
     }
   } else {
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: null,
       newProperties: range,
     })
@@ -210,7 +210,7 @@ export function applyDeselect(editor: PortableTextEditorEngine): void {
 
   if (selection) {
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: selection,
       newProperties: null,
     })

--- a/packages/editor/src/internal-utils/apply-split-node.ts
+++ b/packages/editor/src/internal-utils/apply-split-node.ts
@@ -13,7 +13,7 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
 /**
  * Split a node at the given path and position using only patch-compliant
- * operations (remove_text/unset + insert).
+ * operations (remove.text/unset + insert).
  *
  * Because the decomposed operations would produce different ref-transform
  * semantics than a single split, we pre-transform all active refs with
@@ -151,7 +151,7 @@ export function applySplitNode(
         const afterText = node.text.slice(position)
         const newNode = {...properties, _key: newKey, text: afterText} as Node
         editor.apply({
-          type: 'remove_text',
+          type: 'remove.text',
           path,
           offset: position,
           text: afterText,

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -93,7 +93,7 @@ function diffMatchPatch(
   for (const [op, text] of diff) {
     if (op === DIFF_INSERT) {
       editor.apply({
-        type: 'insert_text',
+        type: 'insert.text',
         path: spanEntry.path,
         offset,
         text,
@@ -101,7 +101,7 @@ function diffMatchPatch(
       offset += text.length
     } else if (op === DIFF_DELETE) {
       editor.apply({
-        type: 'remove_text',
+        type: 'remove.text',
         path: spanEntry.path,
         offset,
         text,

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -114,7 +114,7 @@ export function applyDelete(
     const reinsert = removedText.slice(0, removedText.length - 1)
     if (editor.snapshot.context.selection) {
       const {path, offset} = editor.snapshot.context.selection.anchor
-      editor.apply({type: 'insert_text', path, offset, text: reinsert})
+      editor.apply({type: 'insert.text', path, offset, text: reinsert})
     }
   }
 }
@@ -460,7 +460,7 @@ function removeTextRange(
   if (text.length === 0) {
     return null
   }
-  editor.apply({type: 'remove_text', path, offset: startOffset, text})
+  editor.apply({type: 'remove.text', path, offset: startOffset, text})
   return capture ? text : null
 }
 
@@ -476,7 +476,7 @@ function removeTextFromOffset(
     return null
   }
   const text = span.node.text.slice(offset)
-  editor.apply({type: 'remove_text', path, offset, text})
+  editor.apply({type: 'remove.text', path, offset, text})
   return capture ? text : null
 }
 
@@ -494,7 +494,7 @@ function removeTextUpToOffset(
     return
   }
   editor.apply({
-    type: 'remove_text',
+    type: 'remove.text',
     path,
     offset: 0,
     text: span.node.text.slice(0, offset),

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -215,7 +215,7 @@ describe('operationToPatches', () => {
       textPatch(
         editor.snapshot,
         {
-          type: 'insert_text',
+          type: 'insert.text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
           text: '1',
           offset: 0,
@@ -271,7 +271,7 @@ describe('operationToPatches', () => {
           blockIndexMap: new Map(),
         },
         {
-          type: 'insert_text',
+          type: 'insert.text',
           path: [{_key: 'img1'}, 'children', {_key: 'void-child'}],
           text: 'foo',
           offset: 0,
@@ -288,7 +288,7 @@ describe('operationToPatches', () => {
       textPatch(
         editor.snapshot,
         {
-          type: 'remove_text',
+          type: 'remove.text',
           path: [{_key: '1f2e64b47787'}, 'children', {_key: 'fd9b4a4e6c0b'}],
           text: '1',
           offset: 1,

--- a/packages/editor/src/internal-utils/transform-operation.test.ts
+++ b/packages/editor/src/internal-utils/transform-operation.test.ts
@@ -10,7 +10,7 @@ const testSchema = compileSchema(defineSchema({}))
 /**
  * Minimal editor mock. transformOperation only reads editor.snapshot.context.value,
  * editor.snapshot.context.schema, editor.containers (for block resolution), and
- * editor.snapshot.context.selection (for set_selection target resolution).
+ * editor.snapshot.context.selection (for set.selection target resolution).
  */
 function createMockEditor(
   children: Array<{_key: string; _type: string; [key: string]: unknown}>,
@@ -43,7 +43,7 @@ describe('transformOperation', () => {
       }
 
       const insertTextOperation: Operation = {
-        type: 'insert_text',
+        type: 'insert.text',
         path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
         offset: 0,
         text: 'hello',
@@ -57,7 +57,7 @@ describe('transformOperation', () => {
 
       expect(result).toEqual([
         {
-          type: 'insert_text',
+          type: 'insert.text',
           path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
           offset: 0,
           text: 'hello',
@@ -76,7 +76,7 @@ describe('transformOperation', () => {
       }
 
       const insertTextOperation: Operation = {
-        type: 'insert_text',
+        type: 'insert.text',
         path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
         offset: 0,
         text: 'hello',
@@ -96,7 +96,7 @@ describe('transformOperation', () => {
       }
 
       const insertTextOperation: Operation = {
-        type: 'insert_text',
+        type: 'insert.text',
         path: [{_key: 'block2'}, 'children', {_key: 'span2'}],
         offset: 0,
         text: 'world',
@@ -106,7 +106,7 @@ describe('transformOperation', () => {
 
       expect(result).toEqual([
         {
-          type: 'insert_text',
+          type: 'insert.text',
           path: [{_key: 'block2'}, 'children', {_key: 'span2'}],
           offset: 0,
           text: 'world',
@@ -114,7 +114,7 @@ describe('transformOperation', () => {
       ])
     })
 
-    test('preserves set_selection operation (no path property)', () => {
+    test('preserves set.selection operation (no path property)', () => {
       const editor = createMockEditor([{_key: 'block2', _type: 'block'}])
 
       const unsetPatch: Patch = {
@@ -123,7 +123,7 @@ describe('transformOperation', () => {
       }
 
       const setSelectionOperation: Operation = {
-        type: 'set_selection',
+        type: 'set.selection',
         properties: {
           anchor: {
             path: [{_key: 'block2'}, 'children', {_key: 'span2'}],
@@ -154,7 +154,7 @@ describe('transformOperation', () => {
 
       expect(result).toEqual([
         {
-          type: 'set_selection',
+          type: 'set.selection',
           properties: {
             anchor: {
               path: [{_key: 'block2'}, 'children', {_key: 'span2'}],

--- a/packages/editor/src/internal-utils/transform-operation.ts
+++ b/packages/editor/src/internal-utils/transform-operation.ts
@@ -97,13 +97,13 @@ export function transformOperation(
         }
       })
       // Adjust accordingly if someone inserted text in the same node before us
-      if (transformedOperation.type === 'insert_text') {
+      if (transformedOperation.type === 'insert.text') {
         if (changedOffset < transformedOperation.offset) {
           transformedOperation.offset += adjustOffsetBy
         }
       }
       // Adjust accordingly if someone removed text in the same node before us
-      if (transformedOperation.type === 'remove_text') {
+      if (transformedOperation.type === 'remove.text') {
         if (
           changedOffset <=
           transformedOperation.offset - transformedOperation.text.length
@@ -111,8 +111,8 @@ export function transformOperation(
           transformedOperation.offset += adjustOffsetBy
         }
       }
-      // Adjust set_selection operation's points to new offset
-      if (transformedOperation.type === 'set_selection') {
+      // Adjust set.selection operation's points to new offset
+      if (transformedOperation.type === 'set.selection') {
         const currentFocus = transformedOperation.properties?.focus
           ? {...transformedOperation.properties.focus}
           : undefined
@@ -157,7 +157,7 @@ function findOperationTargetBlock(
   editor: PortableTextEditorEngine,
   operation: Operation,
 ): Node | undefined {
-  if (operation.type === 'set_selection' && editor.snapshot.context.selection) {
+  if (operation.type === 'set.selection' && editor.snapshot.context.selection) {
     const block = getEnclosingBlock(
       snapshot,
       editor.snapshot.context.selection.focus.path,

--- a/packages/editor/src/internal-utils/unwrap-container.ts
+++ b/packages/editor/src/internal-utils/unwrap-container.ts
@@ -66,7 +66,7 @@ export function unwrapContainer(
     const anchor = transformPoint(previousSelection.anchor, innerPrefix)
     const focus = transformPoint(previousSelection.focus, innerPrefix)
     editor.apply({
-      type: 'set_selection',
+      type: 'set.selection',
       properties: editor.snapshot.context.selection,
       newProperties: {anchor, focus},
     })

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -40,14 +40,14 @@ export const childSetOperationImplementation: OperationImplementation<
     if (typeof text === 'string') {
       if (child.text !== text) {
         operation.editor.apply({
-          type: 'remove_text',
+          type: 'remove.text',
           path: textPath,
           offset: 0,
           text: child.text,
         })
 
         operation.editor.apply({
-          type: 'insert_text',
+          type: 'insert.text',
           path: textPath,
           offset: 0,
           text,

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -536,7 +536,7 @@ function applyPostInsertSelection(
 
     if (editor.snapshot.context.selection) {
       editor.apply({
-        type: 'set_selection',
+        type: 'set.selection',
         properties: editor.snapshot.context.selection,
         newProperties: null,
       })
@@ -796,7 +796,7 @@ function adjustFragmentKeys(args: {
 
 /**
  * Insert a text block's children at a point within another text block.
- * Prepending a single span at offset 0 uses insert_text so React's DOM
+ * Prepending a single span at offset 0 uses insert.text so React's DOM
  * selection stays valid through deferred normalization.
  */
 function insertFragmentChildren(
@@ -829,7 +829,7 @@ function insertFragmentChildren(
     ) {
       if (firstChild.text.length > 0) {
         editor.apply({
-          type: 'insert_text',
+          type: 'insert.text',
           path: at.path,
           offset: 0,
           text: firstChild.text,

--- a/packages/editor/src/operations/operation.insert.text.ts
+++ b/packages/editor/src/operations/operation.insert.text.ts
@@ -19,7 +19,7 @@ export const insertTextOperationImplementation: OperationImplementation<
     }
 
     operation.editor.apply({
-      type: 'insert_text',
+      type: 'insert.text',
       path: operation.at,
       offset: operation.offset,
       text: operation.text,
@@ -69,7 +69,7 @@ export const insertTextOperationImplementation: OperationImplementation<
 
   if (operation.text.length > 0) {
     editor.apply({
-      type: 'insert_text',
+      type: 'insert.text',
       path,
       offset,
       text: operation.text,

--- a/packages/editor/src/operations/operation.remove.text.ts
+++ b/packages/editor/src/operations/operation.remove.text.ts
@@ -4,7 +4,7 @@ export const removeTextOperationImplementation: OperationImplementation<
   'remove.text'
 > = ({operation}) => {
   operation.editor.apply({
-    type: 'remove_text',
+    type: 'remove.text',
     path: operation.at,
     offset: operation.offset,
     text: operation.text,

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -78,8 +78,8 @@ const tableContainers: Containers = resolveContainers(schema, [
 ])
 
 describe(getDirtyPaths.name, () => {
-  describe('insert_text / remove_text', () => {
-    test('insert_text returns path levels of the operation path', () => {
+  describe('insert.text / remove.text', () => {
+    test('insert.text returns path levels of the operation path', () => {
       expect(
         getDirtyPaths(
           {
@@ -88,7 +88,7 @@ describe(getDirtyPaths.name, () => {
             value: [],
           },
           {
-            type: 'insert_text',
+            type: 'insert.text',
             path: [{_key: 'b1'}, 'children', {_key: 's1'}],
             offset: 0,
             text: 'hello',
@@ -97,7 +97,7 @@ describe(getDirtyPaths.name, () => {
       ).toEqual([[], [{_key: 'b1'}], [{_key: 'b1'}, 'children', {_key: 's1'}]])
     })
 
-    test('remove_text returns path levels of the operation path', () => {
+    test('remove.text returns path levels of the operation path', () => {
       expect(
         getDirtyPaths(
           {
@@ -106,7 +106,7 @@ describe(getDirtyPaths.name, () => {
             value: [],
           },
           {
-            type: 'remove_text',
+            type: 'remove.text',
             path: [{_key: 'b1'}, 'children', {_key: 's1'}],
             offset: 0,
             text: 'hello',
@@ -115,7 +115,7 @@ describe(getDirtyPaths.name, () => {
       ).toEqual([[], [{_key: 'b1'}], [{_key: 'b1'}, 'children', {_key: 's1'}]])
     })
 
-    test('insert_text inside callout text block returns path levels at each node boundary', () => {
+    test('insert.text inside callout text block returns path levels at each node boundary', () => {
       expect(
         getDirtyPaths(
           {
@@ -124,7 +124,7 @@ describe(getDirtyPaths.name, () => {
             value: [],
           },
           {
-            type: 'insert_text',
+            type: 'insert.text',
             path: [
               {_key: 'c1'},
               'content',
@@ -144,7 +144,7 @@ describe(getDirtyPaths.name, () => {
       ])
     })
 
-    test('remove_text inside callout text block returns path levels at each node boundary', () => {
+    test('remove.text inside callout text block returns path levels at each node boundary', () => {
       expect(
         getDirtyPaths(
           {
@@ -153,7 +153,7 @@ describe(getDirtyPaths.name, () => {
             value: [],
           },
           {
-            type: 'remove_text',
+            type: 'remove.text',
             path: [
               {_key: 'c1'},
               'content',

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -89,8 +89,8 @@ export function getDirtyPaths(
   op: Operation,
 ): Array<Path> {
   switch (op.type) {
-    case 'insert_text':
-    case 'remove_text': {
+    case 'insert.text':
+    case 'remove.text': {
       return pathLevels(op.path)
     }
 

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -743,7 +743,7 @@ describe('event.history.undo', () => {
     })
 
     // Second undo reverts the forwarded 'i' and the first raise ('!' after 'h')
-    // These merge because the raise's insert_text is adjacent to the forward's
+    // These merge because the raise's insert.text is adjacent to the forward's
     editor.send({type: 'history.undo'})
 
     await vi.waitFor(() => {

--- a/packages/editor/tests/no-op-history-skip.test.tsx
+++ b/packages/editor/tests/no-op-history-skip.test.tsx
@@ -40,7 +40,7 @@ describe('no-op operations are not recorded to history', () => {
     })
   })
 
-  test('Scenario: insert_text with empty text does not pollute history', async () => {
+  test('Scenario: insert.text with empty text does not pollute history', async () => {
     const engineRef = React.createRef<PortableTextEditorEngine>()
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
@@ -70,7 +70,7 @@ describe('no-op operations are not recorded to history', () => {
     })
   })
 
-  test('Scenario: remove_text with empty text does not pollute history', async () => {
+  test('Scenario: remove.text with empty text does not pollute history', async () => {
     const engineRef = React.createRef<PortableTextEditorEngine>()
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),


### PR DESCRIPTION
Precedes #2772, which makes the operation type names public via `editor.on('operation', ...)` — renaming after that ships would be a breaking change; right now it's a zero-cost internal rename.

`insert_text` → `insert.text`, `remove_text` → `remove.text`, `set_selection` → `set.selection` (`insert`/`set`/`unset` unchanged), aligning the operation vocabulary with the behavior-event naming convention — a behavior event like `insert.text` now produces an operation of the same name.

No compatibility surface: operations are never serialized (patches use their own type vocabulary; undo history is in-memory) and no other package references these literals. Mechanical rename of 118 occurrences across 38 files, with the few non-type-checked spots (the raw string array in patch generation, comments) verified by hand.

Verified: types, lint, 768 unit tests, full chromium suite (1630), mutation/undo-redo suites on all three browsers.