### PR TITLE
refactor: split `set` and `unset` operations by what they target

### DIFF
--- a/.changeset/public-operation-channel.md
+++ b/.changeset/public-operation-channel.md
@@ -4,7 +4,7 @@
 
 feat: subscribe to low-level editor operations via `editor.on('operation', ...)`
 
-Every change to the editor — local edits, remote patches, value sync, normalization, undo/redo — is expressed as a sequence of six low-level operations (`insert`, `insert.text`, `remove.text`, `set`, `unset`, `set.selection`). A new `@beta` event exposes that stream so derived state can be maintained incrementally in userland:
+Every change to the editor — local edits, remote patches, value sync, normalization, undo/redo — is expressed as a sequence of low-level operations. A new `@beta` event exposes that stream so derived state can be maintained incrementally in userland:
 
 ```ts
 editor.on('operation', (event) => {
@@ -14,4 +14,6 @@ editor.on('operation', (event) => {
 })
 ```
 
-Operation events deliver synchronously after each operation applies, and — unlike `patch`/`mutation` events — are not held back while the editor is pristine or setting up, so value-sync and normalization operations are observable too. The new `EditorOperation` type is exported, and `EditorEmittedEvent` gains the `{type: 'operation'}` member (exhaustive switches over `event.type` gain a case). Throwing listeners no longer prevent delivery to other listeners of the same event; errors are reported via `console.error`.
+The `EditorOperation` type is exported and `EditorEmittedEvent` gains the `{type: 'operation'}` member (exhaustive switches over `event.type` gain a case). The union is split by what each operation acts on — `insert.node`, `insert.text`, `set.value`, `set.node`, `set.property`, `set.selection`, `unset.value`, `unset.node`, `unset.property`, `remove.text` — so consumers don't have to inspect path shape to know what changed. `set.property` and `unset.property` lift the property name out into its own field.
+
+Operation events deliver synchronously after each operation applies, and — unlike `patch`/`mutation` events — are not held back while the editor is pristine or setting up, so value-sync and normalization operations are observable too. Throwing listeners no longer prevent delivery to other listeners of the same event; errors are reported via `console.error`.

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -1,15 +1,20 @@
-import {compileSchema} from '@portabletext/schema'
+import {compileSchema, type PortableTextBlock} from '@portabletext/schema'
 import {createActor} from 'xstate'
 import {coreConverters} from '../converters/converters.core'
 import type {Editor, EditorConfig} from '../editor'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import type {Operation as EngineOperation} from '../engine/interfaces/operation'
+import type {Path} from '../engine/interfaces/path'
 import {debug} from '../internal-utils/debug'
 import {corePriority} from '../priority/priority.core'
 import {createEditorPriority} from '../priority/priority.types'
 import type {EditableAPI} from '../types/editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
-import type {EditorOperation} from '../types/operation'
+import type {
+  EditorInsertNodeOperation,
+  EditorOperation,
+  EditorSetNodeOperation,
+} from '../types/operation'
 import {defaultKeyGenerator} from '../utils/key-generator'
 import {createEditableAPI} from './create-editable-api'
 import {createEditorEngine} from './create-editor-engine'
@@ -273,14 +278,77 @@ function createActors(config: {
 }
 
 function toPublicOperation(operation: EngineOperation): EditorOperation {
-  if ('inverse' in operation && operation.inverse !== undefined) {
-    // The engine's undo bookkeeping is not part of the public operation
-    // shape, and the type alone doesn't hide it from consumers that log
-    // or spread the object. Only local `insert`/`set`/`unset` operations
-    // carry an inverse, so typing and selection operations pass through
-    // without allocating.
-    const {inverse: _inverse, ...publicOperation} = operation
-    return publicOperation
+  // The engine's `set`/`unset` ops are path-polymorphic — the public union
+  // splits them into property/node/value variants based on the path-shape
+  // discriminator. The engine's `insert` op is `insert.node` publicly so
+  // it pairs with `insert.text` under the same family. The `inverse`
+  // bookkeeping is engine-internal and not part of the public shape.
+  switch (operation.type) {
+    case 'insert':
+      return {
+        type: 'insert.node',
+        path: operation.path,
+        node: operation.node as EditorInsertNodeOperation['node'],
+        position: operation.position,
+      }
+    case 'insert.text':
+      return {
+        type: 'insert.text',
+        path: operation.path,
+        offset: operation.offset,
+        text: operation.text,
+      }
+    case 'remove.text':
+      return {
+        type: 'remove.text',
+        path: operation.path,
+        offset: operation.offset,
+        text: operation.text,
+      }
+    case 'set.selection':
+      return operation as EditorOperation
+    case 'set':
+      return toPublicSetOperation(operation.path, operation.value)
+    case 'unset':
+      return toPublicUnsetOperation(operation.path)
   }
-  return operation
+}
+
+function toPublicSetOperation(path: Path, value: unknown): EditorOperation {
+  if (path.length === 0) {
+    return {type: 'set.value', value: value as Array<PortableTextBlock>}
+  }
+  const lastSegment = path.at(-1)
+  if (typeof lastSegment === 'string') {
+    // Property write: path ends in a property name. Lift the property name
+    // out of the path so consumers don't have to slice it back off.
+    return {
+      type: 'set.property',
+      path: path.slice(0, -1),
+      propertyName: lastSegment,
+      value,
+    }
+  }
+  // Full node replace: path ends in a keyed or numeric segment pointing at
+  // the node, `value` is the new node.
+  return {
+    type: 'set.node',
+    path,
+    node: value as EditorSetNodeOperation['node'],
+  }
+}
+
+function toPublicUnsetOperation(path: Path): EditorOperation {
+  if (path.length === 0) {
+    return {type: 'unset.value'}
+  }
+  const lastSegment = path.at(-1)
+  if (typeof lastSegment === 'string') {
+    return {
+      type: 'unset.property',
+      path: path.slice(0, -1),
+      propertyName: lastSegment,
+    }
+  }
+  return {type: 'unset.node', path}
 }

--- a/packages/editor/src/types/operation.ts
+++ b/packages/editor/src/types/operation.ts
@@ -1,4 +1,5 @@
 import type {
+  PortableTextBlock,
   PortableTextObject,
   PortableTextSpan,
   PortableTextTextBlock,
@@ -9,65 +10,94 @@ import type {Path} from './paths'
 /**
  * A low-level operation applied by the editor engine. Every change to the
  * editor — local edits, remote patches, value sync, normalization fixes,
- * undo/redo — is expressed as a sequence of these six operations.
+ * undo/redo — is expressed as a sequence of these operations.
  *
  * Subscribe via `editor.on('operation', ...)`.
+ *
+ * Operation types are dot-grouped by verb (`insert.*`, `set.*`, `unset.*`,
+ * `remove.*`), with the suffix naming what the operation acts on. Where the
+ * engine's internal `set`/`unset` ops branch on the shape of `path`, the
+ * public type carries the discriminator in the type tag.
  *
  * @beta
  */
 export type EditorOperation =
-  | {
-      /**
-       * Insert a node before or after the sibling at `path`.
-       */
-      type: 'insert'
-      path: Path
-      node: PortableTextTextBlock | PortableTextObject | PortableTextSpan
-      position: 'before' | 'after'
-    }
-  | {
-      /**
-       * Insert `text` into the span at `path`, at `offset`.
-       */
-      type: 'insert.text'
-      path: Path
-      offset: number
-      text: string
-    }
-  | {
-      /**
-       * Remove `text` from the span at `path`, starting at `offset`.
-       */
-      type: 'remove.text'
-      path: Path
-      offset: number
-      text: string
-    }
-  | {
-      /**
-       * Set a property on a node. The path is `[...nodePath, propertyName]`.
-       */
-      type: 'set'
-      path: Path
-      value: unknown
-    }
-  | {
-      /**
-       * Remove a property from a node, or remove a node from its parent.
-       *
-       * Property removal: path is `[...nodePath, propertyName]` (last segment
-       * is a string). Node removal: the last segment is a keyed segment
-       * pointing at the node to remove.
-       */
-      type: 'unset'
-      path: Path
-    }
+  | EditorInsertNodeOperation
+  | EditorInsertTextOperation
+  | EditorSetValueOperation
+  | EditorSetNodeOperation
+  | EditorSetPropertyOperation
   | EditorSetSelectionOperation
+  | EditorUnsetValueOperation
+  | EditorUnsetNodeOperation
+  | EditorUnsetPropertyOperation
+  | EditorRemoveTextOperation
+
+/**
+ * Insert `node` as a sibling of the node at `path`. `position` selects which
+ * side the new node lands on.
+ *
+ * @beta
+ */
+export type EditorInsertNodeOperation = {
+  type: 'insert.node'
+  path: Path
+  node: PortableTextTextBlock | PortableTextObject | PortableTextSpan
+  position: 'before' | 'after'
+}
+
+/**
+ * Insert `text` into the span at `path`, at `offset`.
+ *
+ * @beta
+ */
+export type EditorInsertTextOperation = {
+  type: 'insert.text'
+  path: Path
+  offset: number
+  text: string
+}
+
+/**
+ * Replace the editor's entire value. Emitted when a root-level `set` patch
+ * is applied — typically from `editor.send({type: 'update value', ...})` or
+ * a remote patch overwriting the document.
+ *
+ * @beta
+ */
+export type EditorSetValueOperation = {
+  type: 'set.value'
+  value: Array<PortableTextBlock>
+}
+
+/**
+ * Replace the node at `path` with `node`.
+ *
+ * @beta
+ */
+export type EditorSetNodeOperation = {
+  type: 'set.node'
+  path: Path
+  node: PortableTextTextBlock | PortableTextObject | PortableTextSpan
+}
+
+/**
+ * Set the property `propertyName` on the node at `path` to `value`. `path`
+ * points to the node, not the property — the property name is its own field.
+ *
+ * @beta
+ */
+export type EditorSetPropertyOperation = {
+  type: 'set.property'
+  path: Path
+  propertyName: string
+  value: unknown
+}
 
 /**
  * @beta
  */
-type EditorSetSelectionOperation =
+export type EditorSetSelectionOperation =
   | {
       type: 'set.selection'
       properties: null
@@ -83,6 +113,50 @@ type EditorSetSelectionOperation =
       properties: EditorOperationRange
       newProperties: null
     }
+
+/**
+ * Clear the editor's entire value. Emitted when a root-level `unset` patch
+ * is applied.
+ *
+ * @beta
+ */
+export type EditorUnsetValueOperation = {
+  type: 'unset.value'
+}
+
+/**
+ * Remove the node at `path` from its parent.
+ *
+ * @beta
+ */
+export type EditorUnsetNodeOperation = {
+  type: 'unset.node'
+  path: Path
+}
+
+/**
+ * Remove the property `propertyName` from the node at `path`. `path` points
+ * to the node, not the property.
+ *
+ * @beta
+ */
+export type EditorUnsetPropertyOperation = {
+  type: 'unset.property'
+  path: Path
+  propertyName: string
+}
+
+/**
+ * Remove `text` from the span at `path`, starting at `offset`.
+ *
+ * @beta
+ */
+export type EditorRemoveTextOperation = {
+  type: 'remove.text'
+  path: Path
+  offset: number
+  text: string
+}
 
 /**
  * @beta

--- a/packages/editor/tests/event.operation.test.tsx
+++ b/packages/editor/tests/event.operation.test.tsx
@@ -53,7 +53,7 @@ describe('event.operation', () => {
 
     await vi.waitFor(() => {
       expect(
-        operations.filter((operation) => operation.type === 'insert'),
+        operations.filter((operation) => operation.type === 'insert.node'),
       ).not.toHaveLength(0)
     })
 
@@ -62,6 +62,191 @@ describe('event.operation', () => {
     expect(
       operations.filter((operation) => 'inverse' in operation),
     ).toHaveLength(0)
+  })
+
+  test('Scenario: `set` operations split by what they target', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [createBlock('b1', 'one')],
+    })
+    const operations: Array<EditorOperation> = []
+
+    editor.on('operation', (event) => {
+      operations.push(event.operation)
+    })
+
+    // Property write — remote `set` patch with a property-terminated path.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: 'b1'}, 'style'],
+          value: 'h1',
+          origin: 'remote',
+        },
+      ],
+      snapshot: [{...createBlock('b1', 'one'), style: 'h1'}],
+    })
+
+    // Value replace — remote `set` patch with a root path.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [],
+          value: [
+            {
+              _type: 'block',
+              _key: 'c1',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {_type: 'span', _key: 'c1-span', text: 'replaced', marks: []},
+              ],
+            },
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [createBlock('c1', 'replaced')],
+    })
+
+    // Full node replace — remote `set` patch with a keyed-terminated path.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: 'c1'}],
+          value: {
+            _type: 'block',
+            _key: 'c1',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {
+                _type: 'span',
+                _key: 'c1-span',
+                text: 'fully-replaced',
+                marks: [],
+              },
+            ],
+          },
+          origin: 'remote',
+        },
+      ],
+      snapshot: [createBlock('c1', 'fully-replaced')],
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        operations.find((operation) => operation.type === 'set.property'),
+      ).toEqual({
+        type: 'set.property',
+        path: [{_key: 'b1'}],
+        propertyName: 'style',
+        value: 'h1',
+      })
+      expect(
+        operations.find((operation) => operation.type === 'set.value'),
+      ).toEqual({
+        type: 'set.value',
+        value: [
+          {
+            _type: 'block',
+            _key: 'c1',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {_type: 'span', _key: 'c1-span', text: 'replaced', marks: []},
+            ],
+          },
+        ],
+      })
+      expect(
+        operations.find((operation) => operation.type === 'set.node'),
+      ).toEqual({
+        type: 'set.node',
+        path: [{_key: 'c1'}],
+        node: {
+          _type: 'block',
+          _key: 'c1',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: 'c1-span',
+              text: 'fully-replaced',
+              marks: [],
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  test('Scenario: `unset` operations split by what they target', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [createBlock('b1', 'one'), createBlock('b2', 'two')],
+    })
+    const operations: Array<EditorOperation> = []
+
+    editor.on('operation', (event) => {
+      operations.push(event.operation)
+    })
+
+    // Node removal: local delete of a block.
+    editor.send({
+      type: 'delete.block',
+      at: [{_key: 'b2'}],
+    })
+
+    // Property removal — remote `unset` patch with property-terminated path.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          path: [{_key: 'b1'}, 'style'],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [{...createBlock('b1', 'one'), style: undefined}],
+    })
+
+    // Value clear — remote `unset` patch with a root path.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          path: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        operations.find((operation) => operation.type === 'unset.node'),
+      ).toEqual({
+        type: 'unset.node',
+        path: [{_key: 'b2'}],
+      })
+      expect(
+        operations.find((operation) => operation.type === 'unset.property'),
+      ).toEqual({
+        type: 'unset.property',
+        path: [{_key: 'b1'}],
+        propertyName: 'style',
+      })
+      expect(
+        operations.find((operation) => operation.type === 'unset.value'),
+      ).toEqual({type: 'unset.value'})
+    })
   })
 
   test('Scenario: Maintaining a block index map in userland', async () => {


### PR DESCRIPTION
Stacked on #2772. The public `EditorOperation` union currently exposes the engine's `set`, `unset`, and `insert` ops as one tag per verb. `set` and `unset` are path-polymorphic — the engine inspects the path-terminus to know whether it's writing/removing a property, a node, or the root — and `insert` reads as the node-level peer of `insert.text`. Consumers have to recompute that discrimination from path shape.

## What

Split each at the public type union, naming what the operation acts on:

| before | after |
|---|---|
| `insert` | `insert.node` |
| `set` | `set.value` / `set.node` / `set.property` |
| `unset` | `unset.value` / `unset.node` / `unset.property` |

Every member of `EditorOperation['type']` now describes its target. The verb-grouped families (`insert.*`, `set.*`, `unset.*`, `remove.*`) have real members:

- `insert.*` — `insert.node`, `insert.text`
- `set.*` — `set.value`, `set.node`, `set.property`, `set.selection`
- `unset.*` — `unset.value`, `unset.node`, `unset.property`
- `remove.*` — `remove.text`

`set.property` and `unset.property` lift the property name out of the path into their own `propertyName` field, so consumers don't slice the path back off — the path points at the node, the `propertyName` says which property was touched. `set.value` carries the new root value directly. `unset.value` is a tag-only variant.

## Where the discrimination lives

`toPublicOperation` in `create-editor.ts` is the channel boundary that runs the discrimination once. The engine's internal `apply-operation.ts` vocabulary is unchanged; consumers see a precise union, the engine keeps the path-shape-handling code in one place.

## Tests

`event.operation.test.tsx` adds scenarios for each new variant via the flow that emits it:

- `set.property` / `set.value` / `set.node` — remote `set` patches at every path shape
- `unset.node` — local `delete.block`
- `unset.property` / `unset.value` — remote `unset` patches at property/root paths

The existing `Scenario: Maintaining a block index map in userland` switch already filters non-selection ops; no consumer-side change required.
