### PR TITLE
fix: isolate throwing listeners in relay delivery

### DIFF
--- a/.changeset/relay-listener-error-isolation.md
+++ b/.changeset/relay-listener-error-isolation.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: a throwing `editor.on` listener no longer affects other listeners
+
+When a listener registered via `editor.on(...)` threw, it prevented the remaining listeners from receiving that event and propagated the error into the editor flow that emitted it — a throwing `patch` listener, for example, could interrupt the mutation batcher mid-flush. Listener errors are now contained per listener and reported via `console.error`; delivery to the other listeners continues, and the emitting flow is unaffected.

--- a/packages/editor/src/editor/relay.test.ts
+++ b/packages/editor/src/editor/relay.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 import type {EditorSelection} from '../types/editor'
 import {createRelay} from './relay'
 
@@ -119,6 +119,30 @@ describe('relay', () => {
     relay.stop()
     relay.send({type: 'ready'})
     expect(deliveries).toEqual(['ready'])
+  })
+
+  test('a throwing listener does not prevent delivery to remaining listeners', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const relay = createRelay()
+    relay.start()
+    const deliveries: Array<string> = []
+
+    relay.on('ready', () => {
+      throw new Error('listener bug')
+    })
+    relay.on('ready', () => {
+      deliveries.push('second')
+    })
+    relay.on('*', () => {
+      deliveries.push('star')
+    })
+
+    relay.send({type: 'ready'})
+    relay.send({type: 'ready'})
+
+    expect(deliveries).toEqual(['second', 'star', 'second', 'star'])
+    expect(consoleError).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
   })
 
   test('unsubscribing during dispatch does not skip other listeners', () => {

--- a/packages/editor/src/editor/relay.ts
+++ b/packages/editor/src/editor/relay.ts
@@ -92,6 +92,8 @@ type RelayListener = (event: EditorEmittedEvent) => void
  *   events sent after `stop()` are dropped.
  * - Consecutive `selection` events carrying the same selection reference are
  *   deduplicated, unless the previous event was `focused`.
+ * - A throwing listener does not prevent delivery to the remaining
+ *   listeners; the error is reported via `console.error`.
  */
 export type Relay = {
   send: (event: EditorEmittedEvent) => void
@@ -123,15 +125,29 @@ export function createRelay(): Relay {
     const typeListeners = listeners.get(event.type)
     if (typeListeners) {
       for (let index = 0; index < typeListeners.length; index++) {
-        typeListeners[index]?.(event)
+        callListener(typeListeners[index], event)
       }
     }
 
     const everyEventListeners = listeners.get('*')
     if (everyEventListeners) {
       for (let index = 0; index < everyEventListeners.length; index++) {
-        everyEventListeners[index]?.(event)
+        callListener(everyEventListeners[index], event)
       }
+    }
+  }
+
+  function callListener(
+    listener: RelayListener | undefined,
+    event: EditorEmittedEvent,
+  ) {
+    try {
+      listener?.(event)
+    } catch (error) {
+      // One consumer's throwing listener must not starve other listeners of
+      // the event, nor break the editor flow that emitted it — patch events,
+      // for example, are sent synchronously from the mutation batcher.
+      console.error(error)
     }
   }
 
@@ -178,8 +194,9 @@ export function createRelay(): Relay {
         }
       }
     } finally {
-      // A throwing listener must not leave the relay stuck mid-dispatch.
-      // Drop everything up to and including the throwing event and let the
+      // Listener errors are contained in `callListener`, so this only
+      // triggers on unexpected dispatch failures — recover rather than
+      // staying stuck mid-dispatch: drop the processed events and let the
       // error propagate; later sends keep working.
       mailbox.splice(0, index)
       dispatching = false


### PR DESCRIPTION
Extracted from #2772 because it changes behavior for all existing `editor.on` events, not just the new one — it deserves its own changelog entry and shouldn't disappear if the feature PR is ever reverted.

Previously, a throwing listener (a) prevented the remaining listeners from receiving that event, and (b) propagated the error into the editor flow that emitted it — a throwing `patch` listener could interrupt the mutation batcher mid-flush. Errors are now contained per listener and reported via `console.error`; delivery continues and the emitting flow is unaffected. Pinned with a relay unit test (throwing listener → remaining type-specific and `'*'` listeners still receive the event, on this and subsequent sends).

#2772 stacks on this — its synchronous in-apply delivery of `operation` events is what makes the isolation load-bearing.