### PR TITLE
refactor: rename the engine operation type to `EngineOperation`

### DIFF
--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -9,7 +9,7 @@ import {
 } from 'xstate'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import type {Node, NodeEntry} from '../engine/interfaces/node'
-import type {Operation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Range} from '../engine/interfaces/range'
 import {isCollapsedRange} from '../engine/range/is-collapsed-range'
 import {rangeIntersection} from '../engine/range/range-intersection'
@@ -25,7 +25,7 @@ import type {EditorSchema} from './editor-schema'
 
 const engineOperationCallback: CallbackLogicFunction<
   AnyEventObject,
-  {type: 'engine operation'; operation: Operation},
+  {type: 'engine operation'; operation: EngineOperation},
   {editorEngine: PortableTextEditorEngine}
 > = ({input, sendBack}) => {
   return subscribeToOperations(
@@ -72,7 +72,7 @@ export const rangeDecorationsMachine = setup({
         }
       | {
           type: 'engine operation'
-          operation: Operation
+          operation: EngineOperation
         }
       | {
           type: 'update read only'

--- a/packages/editor/src/editor/undo-step.ts
+++ b/packages/editor/src/editor/undo-step.ts
@@ -1,9 +1,9 @@
-import type {Operation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Range} from '../engine/interfaces/range'
 import {pathEquals} from '../engine/path/path-equals'
 
 type UndoStep = {
-  operations: Array<Operation>
+  operations: Array<EngineOperation>
   timestamp: Date
 }
 
@@ -17,7 +17,7 @@ export function createUndoSteps({
   selectionBeforeApply,
 }: {
   steps: Array<UndoStep>
-  op: Operation
+  op: EngineOperation
   currentUndoStepId: string | undefined
   previousUndoStepId: string | undefined
   /** Snapshots of pre-apply editor state — volatile during apply. */
@@ -145,7 +145,7 @@ export function createUndoSteps({
 
 function createNewStep(
   steps: Array<UndoStep>,
-  op: Operation,
+  op: EngineOperation,
   selectionBeforeApply: Range | null,
 ): Array<UndoStep> {
   const operations =
@@ -171,7 +171,7 @@ function createNewStep(
 function mergeIntoLastStep(
   steps: Array<UndoStep>,
   lastStep: UndoStep,
-  op: Operation,
+  op: EngineOperation,
 ): Array<UndoStep> {
   lastStep.operations.push(op)
 

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -13,7 +13,7 @@ import type {EditorSelection} from '../../types/editor'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import type {Editor} from '../interfaces/editor'
 import type {Node, NodeEntry} from '../interfaces/node'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Path} from '../interfaces/path'
 import type {Range} from '../interfaces/range'
 import {commonPath} from '../path/common-path'
@@ -33,7 +33,7 @@ import {
   removeChildren,
 } from '../utils/modify'
 
-export function applyOperation(editor: Editor, op: Operation): void {
+export function applyOperation(editor: Editor, op: EngineOperation): void {
   let transformSelection = false
 
   switch (op.type) {

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -8,7 +8,7 @@ import {
 import {describe, expect, test} from 'vitest'
 import {createEditor} from '../create-editor'
 import type {Editor} from '../interfaces/editor'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import {subscribeToOperations, type OperationEvent} from './operation-channel'
 
 const schema = compileSchema(defineSchema({}))
@@ -57,7 +57,7 @@ function getSpanText(value: Array<PortableTextBlock>): string {
   return span.text
 }
 
-const insertTextOperation: Operation = {
+const insertTextOperation: EngineOperation = {
   type: 'insert.text',
   path: [{_key: 'b1'}, 'children', {_key: 's1'}],
   offset: 3,
@@ -187,7 +187,7 @@ describe('operation channel', () => {
   })
 
   test('operations replace the value instead of mutating it, keeping `beforeValue` intact', () => {
-    const operationCases: Array<{name: string; operation: Operation}> = [
+    const operationCases: Array<{name: string; operation: EngineOperation}> = [
       {
         name: 'insert.text on a span',
         operation: insertTextOperation,

--- a/packages/editor/src/engine/core/operation-channel.ts
+++ b/packages/editor/src/engine/core/operation-channel.ts
@@ -1,10 +1,10 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelection} from '../../types/editor'
 import type {Editor} from '../interfaces/editor'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 
 /**
- * The operation channel is the single place to observe every `Operation` the
+ * The operation channel is the single place to observe every `EngineOperation` the
  * engine applies.
  *
  * Guarantees:
@@ -31,7 +31,7 @@ export type OperationEvent = {
    * populated and inserted nodes may be re-keyed — so `after` listeners
    * observe the final operation.
    */
-  operation: Operation
+  operation: EngineOperation
   /**
    * `editor.snapshot.context.value` captured at apply entry. Operations
    * replace the value array instead of mutating it, so this reference keeps
@@ -103,7 +103,7 @@ export function subscribeToOperations(
  */
 export function createOperationEvent(
   editor: Editor,
-  operation: Operation,
+  operation: EngineOperation,
 ): OperationEvent {
   const isNormalizingNode = Boolean(editor.isNormalizingNode)
   const isProcessingRemoteChanges = Boolean(editor.isProcessingRemoteChanges)

--- a/packages/editor/src/engine/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/engine/dom/plugin/dom-editor.ts
@@ -8,7 +8,7 @@ import {isLeafObject} from '../../../traversal/is-leaf-object'
 import {path as editorPath} from '../../editor/path'
 import {start as editorStart} from '../../editor/start'
 import type {BaseEditor, Editor} from '../../interfaces/editor'
-import type {Operation} from '../../interfaces/operation'
+import type {EngineOperation} from '../../interfaces/operation'
 import type {Point} from '../../interfaces/point'
 import type {Range} from '../../interfaces/range'
 import type {RangeRef} from '../../interfaces/range-ref'
@@ -62,7 +62,7 @@ export interface DOMEditor extends BaseEditor {
   focused: boolean
   composing: boolean
   userSelection: RangeRef | null
-  onContextChange: ((options?: {operation?: Operation}) => void) | null
+  onContextChange: ((options?: {operation?: EngineOperation}) => void) | null
   scheduleFlush: (() => void) | null
   pendingDiffs: TextDiff[]
   pendingAction: Action | null

--- a/packages/editor/src/engine/dom/utils/diff-text.ts
+++ b/packages/editor/src/engine/dom/utils/diff-text.ts
@@ -6,7 +6,7 @@ import {getSpan} from '../../../traversal/get-span'
 import {hasNode} from '../../../traversal/has-node'
 import {after} from '../../editor/after'
 import type {Editor} from '../../interfaces/editor'
-import type {Operation} from '../../interfaces/operation'
+import type {EngineOperation} from '../../interfaces/operation'
 import type {Path} from '../../interfaces/path'
 import type {Point} from '../../interfaces/point'
 import type {Range} from '../../interfaces/range'
@@ -239,7 +239,7 @@ export function normalizeRange(editor: Editor, range: Range): Range | null {
 export function transformPendingPoint(
   editor: Editor,
   point: Point,
-  op: Operation,
+  op: EngineOperation,
 ): Point | null {
   const pendingDiffs = editor.pendingDiffs
   const textDiff = pendingDiffs?.find(({path}) => pathEquals(path, point.path))
@@ -288,7 +288,7 @@ export function transformPendingPoint(
 export function transformPendingRange(
   editor: Editor,
   range: Range,
-  op: Operation,
+  op: EngineOperation,
 ): Range | null {
   const anchor = transformPendingPoint(editor, range.anchor, op)
   if (!anchor) {
@@ -309,7 +309,7 @@ export function transformPendingRange(
 
 export function transformTextDiff(
   textDiff: TextDiff,
-  op: Operation,
+  op: EngineOperation,
 ): TextDiff | null {
   const {path, diff, id} = textDiff
 

--- a/packages/editor/src/engine/editor/normalize.ts
+++ b/packages/editor/src/engine/editor/normalize.ts
@@ -4,14 +4,14 @@ import {getNode} from '../../traversal/get-node'
 import {getNodes} from '../../traversal/get-nodes'
 import {hasNode} from '../../traversal/has-node'
 import type {Editor} from '../interfaces/editor'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Path} from '../interfaces/path'
 import {isNormalizing} from './is-normalizing'
 import {withoutNormalizing} from './without-normalizing'
 
 export function normalize(
   editor: Editor,
-  options: {force?: boolean; operation?: Operation} = {},
+  options: {force?: boolean; operation?: EngineOperation} = {},
 ): void {
   const {force = false, operation} = options
   const getDirtyPaths = (editor: Editor) => {

--- a/packages/editor/src/engine/interfaces/editor.ts
+++ b/packages/editor/src/engine/interfaces/editor.ts
@@ -3,7 +3,7 @@ import type {OperationListener} from '../core/operation-channel'
 import type {DOMEditor} from '../dom/plugin/dom-editor'
 import type {Location} from './location'
 import type {Node} from './node'
-import type {Operation} from './operation'
+import type {EngineOperation} from './operation'
 import type {Path} from './path'
 import type {PathRef} from './path-ref'
 import type {PointRef} from './point-ref'
@@ -17,7 +17,7 @@ import type {RangeRef} from './range-ref'
 export interface BaseEditor {
   // Core state.
 
-  operations: Operation[]
+  operations: EngineOperation[]
   operationListeners: {
     before: Array<OperationListener>
     after: Array<OperationListener>
@@ -32,14 +32,14 @@ export interface BaseEditor {
 
   // Overrideable core methods.
 
-  apply: (operation: Operation) => void
+  apply: (operation: EngineOperation) => void
   normalizeNode: (
     entry: [Editor | Node, Path],
     options?: {
-      operation?: Operation
+      operation?: EngineOperation
     },
   ) => void
-  onChange: (options?: {operation?: Operation}) => void
+  onChange: (options?: {operation?: EngineOperation}) => void
   shouldNormalize: ({
     iteration,
     dirtyPaths,
@@ -48,7 +48,7 @@ export interface BaseEditor {
     iteration: number
     initialDirtyPathsLength: number
     dirtyPaths: Path[]
-    operation?: Operation
+    operation?: EngineOperation
   }) => boolean
 
   // Overrideable commands.

--- a/packages/editor/src/engine/interfaces/operation.ts
+++ b/packages/editor/src/engine/interfaces/operation.ts
@@ -95,7 +95,7 @@ type SetSelectionOperation =
       newProperties: null
     }
 
-export type Operation =
+export type EngineOperation =
   | InsertOperation
   | SetOperation
   | UnsetOperation

--- a/packages/editor/src/engine/interfaces/path-ref.ts
+++ b/packages/editor/src/engine/interfaces/path-ref.ts
@@ -1,5 +1,5 @@
 import {transformPath} from '../path/transform-path'
-import type {Operation} from './operation'
+import type {EngineOperation} from './operation'
 import type {Path} from './path'
 
 /**
@@ -15,12 +15,12 @@ export interface PathRef {
 }
 
 interface PathRefInterface {
-  transform: (ref: PathRef, op: Operation) => void
+  transform: (ref: PathRef, op: EngineOperation) => void
 }
 
 // eslint-disable-next-line no-redeclare
 export const PathRef: PathRefInterface = {
-  transform(ref: PathRef, op: Operation): void {
+  transform(ref: PathRef, op: EngineOperation): void {
     const {current} = ref
 
     if (current == null) {

--- a/packages/editor/src/engine/interfaces/point-ref.ts
+++ b/packages/editor/src/engine/interfaces/point-ref.ts
@@ -1,6 +1,6 @@
 import {transformPoint} from '../point/transform-point'
 import type {TextDirection} from '../types/types'
-import type {Operation} from './operation'
+import type {EngineOperation} from './operation'
 import type {Point} from './point'
 
 /**
@@ -16,12 +16,12 @@ export interface PointRef {
 }
 
 interface PointRefInterface {
-  transform: (ref: PointRef, op: Operation) => void
+  transform: (ref: PointRef, op: EngineOperation) => void
 }
 
 // eslint-disable-next-line no-redeclare
 export const PointRef: PointRefInterface = {
-  transform(ref: PointRef, op: Operation): void {
+  transform(ref: PointRef, op: EngineOperation): void {
     const {current, affinity} = ref
 
     if (current == null) {

--- a/packages/editor/src/engine/operation/inverse-operation.test.ts
+++ b/packages/editor/src/engine/operation/inverse-operation.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import {inverseOperation} from './inverse-operation'
 
 describe(inverseOperation.name, () => {
   test('insert -> unset', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       node: {_key: 's2', _type: 'span', text: ''},
@@ -18,7 +18,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('unset (node removal) -> insert', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}, 'children', {_key: 's2'}],
       inverse: {
@@ -37,7 +37,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('unset (node removal) first child -> insert before', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       inverse: {
@@ -56,7 +56,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('insert.text -> remove.text', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
@@ -71,7 +71,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('remove.text -> insert.text', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'remove.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
@@ -86,7 +86,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('set with existing property inverts to set with old value', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'set',
       path: [{_key: 'b1'}, 'style'],
       value: 'h1',
@@ -101,7 +101,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('set with new property inverts to unset', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'set',
       path: [{_key: 'b1'}, 'listItem'],
       value: 'bullet',
@@ -119,7 +119,7 @@ describe(inverseOperation.name, () => {
   })
 
   test('unset (property removal) inverts to set with old value', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}, 'listItem'],
       inverse: {

--- a/packages/editor/src/engine/operation/inverse-operation.ts
+++ b/packages/editor/src/engine/operation/inverse-operation.ts
@@ -1,7 +1,7 @@
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Range} from '../interfaces/range'
 
-export function inverseOperation(op: Operation): Operation {
+export function inverseOperation(op: EngineOperation): EngineOperation {
   switch (op.type) {
     case 'insert': {
       if (!op.inverse) {

--- a/packages/editor/src/engine/path/transform-path.ts
+++ b/packages/editor/src/engine/path/transform-path.ts
@@ -1,6 +1,6 @@
 import {pathContains} from '../../traversal/path-contains'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Path} from '../interfaces/path'
 
 /**
@@ -11,7 +11,7 @@ import type {Path} from '../interfaces/path'
  */
 export function transformPath(
   path: Path | null,
-  operation: Operation,
+  operation: EngineOperation,
 ): Path | null {
   if (!path) {
     return null

--- a/packages/editor/src/engine/point/transform-point.test.ts
+++ b/packages/editor/src/engine/point/transform-point.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, test} from 'vitest'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import {transformPoint} from './transform-point'
 
 describe(transformPoint.name, () => {
   test('null point returns null', () => {
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 0,
@@ -18,7 +18,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
@@ -35,7 +35,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
@@ -52,7 +52,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert.text',
       path: [{_key: 'b1'}, 'children', {_key: 's2'}],
       offset: 0,
@@ -69,7 +69,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 5,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'remove.text',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 2,
@@ -86,7 +86,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
     }
@@ -98,7 +98,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}],
     }
@@ -110,7 +110,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b2'}],
     }
@@ -125,7 +125,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'insert',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       node: {_key: 's2', _type: 'span', text: ''},
@@ -142,7 +142,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'set.selection',
       properties: null,
       newProperties: {
@@ -161,7 +161,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'set',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}, '_key'],
       value: 's2',
@@ -182,7 +182,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 3,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'set',
       path: [{_key: 'b1'}, 'style'],
       value: 'h1',
@@ -203,7 +203,7 @@ describe(transformPoint.name, () => {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],
       offset: 4,
     }
-    const op: Operation = {
+    const op: EngineOperation = {
       type: 'unset',
       path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
       inverse: {

--- a/packages/editor/src/engine/point/transform-point.ts
+++ b/packages/editor/src/engine/point/transform-point.ts
@@ -1,6 +1,6 @@
 import {pathContains} from '../../traversal/path-contains'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Path} from '../interfaces/path'
 import type {Point, PointTransformOptions} from '../interfaces/point'
 import {pathEquals} from '../path/path-equals'
@@ -21,7 +21,7 @@ import {pathEquals} from '../path/path-equals'
  */
 export function transformPoint(
   point: Point | null,
-  op: Operation,
+  op: EngineOperation,
   options: PointTransformOptions = {},
 ): Point | null {
   if (point === null) {

--- a/packages/editor/src/engine/range-ref/transform-range-ref.ts
+++ b/packages/editor/src/engine/range-ref/transform-range-ref.ts
@@ -1,11 +1,11 @@
 import type {Node} from '../interfaces/node'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {RangeRef} from '../interfaces/range-ref'
 import {transformRange} from '../range/transform-range'
 
 export function transformRangeRef(
   ref: RangeRef,
-  op: Operation,
+  op: EngineOperation,
   root: {value: Array<Node>},
 ): void {
   const {current, affinity} = ref

--- a/packages/editor/src/engine/range/transform-range.ts
+++ b/packages/editor/src/engine/range/transform-range.ts
@@ -1,5 +1,5 @@
 import type {Node} from '../interfaces/node'
-import type {Operation} from '../interfaces/operation'
+import type {EngineOperation} from '../interfaces/operation'
 import type {Range, RangeTransformOptions} from '../interfaces/range'
 import {transformPoint} from '../point/transform-point'
 import {resolveRangeAffinities} from './resolve-range-affinities'
@@ -11,7 +11,7 @@ import {resolveRangeAffinities} from './resolve-range-affinities'
  */
 export function transformRange(
   range: Range | null,
-  op: Operation,
+  op: EngineOperation,
   root: {value: Array<Node>},
   options: RangeTransformOptions = {},
 ): Range | null {

--- a/packages/editor/src/internal-utils/transform-operation.test.ts
+++ b/packages/editor/src/internal-utils/transform-operation.test.ts
@@ -1,7 +1,7 @@
 import type {Patch} from '@portabletext/patches'
 import {compileSchema, defineSchema} from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
-import type {Operation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {transformOperation} from './transform-operation'
 
@@ -42,7 +42,7 @@ describe('transformOperation', () => {
         position: 'after',
       }
 
-      const insertTextOperation: Operation = {
+      const insertTextOperation: EngineOperation = {
         type: 'insert.text',
         path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
         offset: 0,
@@ -75,7 +75,7 @@ describe('transformOperation', () => {
         path: [{_key: 'block1'}],
       }
 
-      const insertTextOperation: Operation = {
+      const insertTextOperation: EngineOperation = {
         type: 'insert.text',
         path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
         offset: 0,
@@ -95,7 +95,7 @@ describe('transformOperation', () => {
         path: [{_key: 'block1'}],
       }
 
-      const insertTextOperation: Operation = {
+      const insertTextOperation: EngineOperation = {
         type: 'insert.text',
         path: [{_key: 'block2'}, 'children', {_key: 'span2'}],
         offset: 0,
@@ -122,7 +122,7 @@ describe('transformOperation', () => {
         path: [{_key: 'block1'}],
       }
 
-      const setSelectionOperation: Operation = {
+      const setSelectionOperation: EngineOperation = {
         type: 'set.selection',
         properties: {
           anchor: {

--- a/packages/editor/src/internal-utils/transform-operation.ts
+++ b/packages/editor/src/internal-utils/transform-operation.ts
@@ -6,7 +6,7 @@ import {
   parsePatch,
 } from '@sanity/diff-match-patch'
 import type {Node} from '../engine/interfaces/node'
-import type {Operation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import {getEnclosingBlock} from '../traversal/get-enclosing-block'
 import {pathContains} from '../traversal/path-contains'
 import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
@@ -24,8 +24,8 @@ import {debug} from './debug'
 export function transformOperation(
   editor: PortableTextEditorEngine,
   patch: Patch,
-  operation: Operation,
-): Operation[] {
+  operation: EngineOperation,
+): EngineOperation[] {
   const snapshot: TraversalSnapshot = editor.snapshot
   const transformedOperation = {...operation}
 
@@ -155,7 +155,7 @@ export function transformOperation(
 function findOperationTargetBlock(
   snapshot: TraversalSnapshot,
   editor: PortableTextEditorEngine,
-  operation: Operation,
+  operation: EngineOperation,
 ): Node | undefined {
   if (operation.type === 'set.selection' && editor.snapshot.context.selection) {
     const block = getEnclosingBlock(

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -1,7 +1,7 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
-import type {Operation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Path} from '../engine/interfaces/path'
 import {parentPath} from '../engine/path/parent-path'
 import {pathLevels} from '../engine/path/path-levels'
@@ -86,7 +86,7 @@ export function getDirtyPaths(
     containers: Containers
     value: Array<Node>
   },
-  op: Operation,
+  op: EngineOperation,
 ): Array<Path> {
   switch (op.type) {
     case 'insert.text':

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -3,7 +3,7 @@ import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
 import type {DOMEditor} from '../engine/dom/plugin/dom-editor'
-import type {Operation as EngineOperation} from '../engine/interfaces/operation'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {
   BlockObjectConfig,
   InlineObjectConfig,


### PR DESCRIPTION
The engine's operation union is named `Operation`, and the codebase has been quietly routing around that name for a while: `types/editor-engine.ts` imports it as `Operation as EngineOperation`, and the upcoming public `Operation` type emitted via `editor.on('operation', ...)` has to do the same aliasing dance to keep the two apart. When a name needs an alias at every border crossing, the type is named wrong at the source.

This renames the union to `EngineOperation` in `engine/interfaces/operation.ts` and updates all importers to use the name directly, dropping the alias in `types/editor-engine.ts`. The member types (`InsertOperation`, `InsertTextOperation`, and friends) keep their names since they don't collide with anything, and the behavior-level `Operation` in `operations/operation.types.ts` is untouched.
