### PR TITLE
feat: add `@portabletext/plugin-list-index`

### DIFF
--- a/packages/plugin-list-index/README.md
+++ b/packages/plugin-list-index/README.md
@@ -1,0 +1,34 @@
+# `@portabletext/plugin-list-index`
+
+A helper plugin for calculating list indices for flat blocks based on `listItem` and `level`.
+
+Portable Text has no nested list structure: a list is a run of flat sibling blocks carrying `listItem` and `level` properties. That makes the 1-based position of an item within its list a _derived_ value: same-type items count up across consecutive blocks on the same level, deeper levels restart at 1, and non-list blocks break the sequence. This plugin derives it for you and keeps it correct as the value changes.
+
+```tsx
+import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'
+
+function MyEditor() {
+  return (
+    <EditorProvider initialConfig={...}>
+      <ListIndexProvider>
+        <PortableTextEditable />
+      </ListIndexProvider>
+    </EditorProvider>
+  )
+}
+```
+
+Typical use: custom text-block renders (`defineTextBlock`) that need to render numbered list markers, since the engine's default list-item wrapping (and the index it computes) does not apply to custom renders. Call `useListIndex` from a component the render returns, not inline in the `render` callback (it is a hook):
+
+```tsx
+function TextBlock(props: TextBlockRenderProps) {
+  const listIndex = useListIndex(props.path)
+  return <div {...props.attributes}>{props.children}</div>
+}
+
+defineTextBlock({type: '*', render: (props) => <TextBlock {...props} />})
+```
+
+The index map is rebuilt at most once per editor operation, regardless of how many components read it, and only for operations that can affect list indices: text insertions/removals and operations nested deeper than the root are skipped. Reads via `useListIndex` re-render only when the index at their own path changes.
+
+Because the plugin observes every change source (local edits, remote patches, value sync, normalization), indices are correct on first render and stay correct when collaborators change the document.

--- a/packages/plugin-list-index/eslint.config.js
+++ b/packages/plugin-list-index/eslint.config.js
@@ -1,0 +1,19 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import {globalIgnores} from 'eslint/config'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config([
+  globalIgnores(['dist', '*.test.tsx']),
+  reactHooks.configs.flat.recommended,
+  {
+    files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {'react-hooks/exhaustive-deps': 'error'},
+  },
+])

--- a/packages/plugin-list-index/package.config.ts
+++ b/packages/plugin-list-index/package.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  babel: {reactCompiler: true},
+  reactCompilerOptions: {target: '19'},
+})

--- a/packages/plugin-list-index/package.json
+++ b/packages/plugin-list-index/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@portabletext/plugin-list-index",
+  "version": "1.0.0",
+  "description": "A helper plugin for calculating list indices for flat blocks based on listItem and level",
+  "keywords": [
+    "portabletext",
+    "plugin",
+    "list-index",
+    "lists"
+  ],
+  "homepage": "https://portabletext.org",
+  "bugs": {
+    "url": "https://github.com/portabletext/editor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/portabletext/editor.git",
+    "directory": "packages/plugin-list-index"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg-utils build --strict --check --clean",
+    "check:lint": "biome lint .",
+    "check:react-compiler": "eslint .",
+    "check:types": "tsc",
+    "check:types:watch": "tsc --watch",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "pkg-utils watch",
+    "lint:fix": "biome lint --write .",
+    "prepublishOnly": "turbo run build",
+    "test:browser": "vitest --run --project browser",
+    "test:browser:chromium": "vitest --run --project \"browser (chromium)\"",
+    "test:unit": "vitest --run --project unit",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "@portabletext/schema": "workspace:^",
+    "@portabletext/test": "workspace:^",
+    "@sanity/tsconfig": "^2.1.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/browser": "^4.1.8",
+    "@vitest/browser-playwright": "^4.1.8",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0",
+    "vitest": "^4.1.8",
+    "vitest-browser-react": "^2.2.0"
+  },
+  "peerDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "react": "^19.2"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/plugin-list-index/src/build-list-index-map.test.ts
+++ b/packages/plugin-list-index/src/build-list-index-map.test.ts
@@ -1,0 +1,396 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import {buildListIndexMap} from './build-list-index-map'
+
+/**
+ * These scenarios mirror the engine's `build-index-maps.test.ts`
+ * (`listIndexMap` assertions). `buildListIndexMap` is a duplicate of the
+ * engine's internal computation, and this suite is the drift alarm: if the
+ * engine's list semantics change, update both implementations and both
+ * suites together.
+ */
+
+function blockObject(_key: string, name: string) {
+  return {
+    _key,
+    _type: name,
+  }
+}
+
+let keyCounter = 0
+
+function textBlock(
+  _key: string,
+  {
+    listItem,
+    level,
+  }: {
+    listItem?: 'bullet' | 'number'
+    level?: number
+  },
+): PortableTextBlock {
+  return {
+    _key,
+    _type: 'block',
+    children: [
+      {
+        _key: `span-${keyCounter++}`,
+        _type: 'span',
+        text: `${listItem}-${level}`,
+      },
+    ],
+    style: 'normal',
+    level,
+    listItem,
+  }
+}
+
+const schema = compileSchema(
+  defineSchema({
+    blockObjects: [{name: 'image'}],
+  }),
+)
+
+describe(buildListIndexMap.name, () => {
+  test('empty', () => {
+    expect(buildListIndexMap({schema, value: []})).toEqual(new Map())
+  })
+
+  /**
+   * #
+   */
+  test('single list item', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [textBlock('k0', {listItem: 'number', level: 1})],
+      }),
+    ).toEqual(new Map([['[_key=="k0"]', 1]]))
+  })
+
+  /**
+   *   #
+   */
+  test('single indented list item', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [textBlock('k0', {listItem: 'number', level: 2})],
+      }),
+    ).toEqual(new Map([['[_key=="k0"]', 1]]))
+  })
+
+  /**
+   * #
+   * #
+   *
+   * #
+   * #
+   */
+  test('two lists broken up by a paragraph', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 1}),
+          textBlock('k2', {}),
+          textBlock('k3', {listItem: 'number', level: 1}),
+          textBlock('k4', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   * #
+   * {image}
+   * #
+   * #
+   */
+  test('two lists broken up by an image', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 1}),
+          blockObject('k2', 'image'),
+          textBlock('k3', {listItem: 'number', level: 1}),
+          textBlock('k4', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   * -
+   * #
+   */
+  test('numbered lists broken up by a bulleted list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'bullet', level: 1}),
+          textBlock('k2', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   *   -
+   * #
+   */
+  test('numbered list broken up by an indented bulleted list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'bullet', level: 2}),
+          textBlock('k2', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   * #
+   * -
+   *   -
+   * #
+   */
+  test('numbered list broken up by a nested bulleted list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 1}),
+          textBlock('k2', {listItem: 'bullet', level: 1}),
+          textBlock('k3', {listItem: 'bullet', level: 2}),
+          textBlock('k4', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 1],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   * #
+   *   -
+   * -
+   *   -
+   * #
+   */
+  test('numbered list broken up by an inverse-indented bulleted list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 1}),
+          textBlock('k2', {listItem: 'bullet', level: 2}),
+          textBlock('k3', {listItem: 'bullet', level: 1}),
+          textBlock('k4', {listItem: 'bullet', level: 2}),
+          textBlock('k5', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 2],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 1],
+        ['[_key=="k5"]', 1],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   *   #
+   *   #
+   * #
+   */
+  test('simple indented list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 2}),
+          textBlock('k2', {listItem: 'number', level: 2}),
+          textBlock('k3', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
+        ['[_key=="k3"]', 2],
+      ]),
+    )
+  })
+
+  /**
+   *   #
+   * #
+   *   #
+   */
+  test('reverse indented list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 2}),
+          textBlock('k1', {listItem: 'number', level: 1}),
+          textBlock('k2', {listItem: 'number', level: 2}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
+      ]),
+    )
+  })
+
+  /**
+   * #
+   *     #
+   *   #
+   *     #
+   * #
+   *     #
+   *       #
+   *     #
+   * #
+   */
+  test('complex list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 3}),
+          textBlock('k2', {listItem: 'number', level: 2}),
+          textBlock('k3', {listItem: 'number', level: 3}),
+          textBlock('k4', {listItem: 'number', level: 1}),
+          textBlock('k5', {listItem: 'number', level: 3}),
+          textBlock('k6', {listItem: 'number', level: 4}),
+          textBlock('k7', {listItem: 'number', level: 3}),
+          textBlock('k8', {listItem: 'number', level: 1}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k3"]', 1],
+        ['[_key=="k4"]', 2],
+        ['[_key=="k5"]', 1],
+        ['[_key=="k6"]', 1],
+        ['[_key=="k7"]', 2],
+        ['[_key=="k8"]', 3],
+      ]),
+    )
+  })
+
+  /**
+   * -
+   *   #
+   *   #
+   */
+  test('bulleted list with indented numbered list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'bullet', level: 1}),
+          textBlock('k1', {listItem: 'number', level: 2}),
+          textBlock('k2', {listItem: 'number', level: 2}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k2"]', 2],
+      ]),
+    )
+  })
+
+  /**
+   *   #
+   * -
+   *   #
+   */
+  test('indented numbered list broken up by outdented bulleted list', () => {
+    expect(
+      buildListIndexMap({
+        schema,
+        value: [
+          textBlock('k0', {listItem: 'number', level: 2}),
+          textBlock('k1', {listItem: 'bullet', level: 1}),
+          textBlock('k3', {listItem: 'number', level: 2}),
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['[_key=="k0"]', 1],
+        ['[_key=="k1"]', 1],
+        ['[_key=="k3"]', 1],
+      ]),
+    )
+  })
+})

--- a/packages/plugin-list-index/src/build-list-index-map.ts
+++ b/packages/plugin-list-index/src/build-list-index-map.ts
@@ -1,0 +1,152 @@
+import type {EditorContext, Path} from '@portabletext/editor'
+import {isKeyedSegment, isTextBlock} from '@portabletext/editor/utils'
+
+/**
+ * Serialize a keyed path to a string using Sanity's bracket notation,
+ * e.g. `[{_key: 'k0'}]` becomes `[_key=="k0"]`.
+ *
+ * Duplicated from the editor's internal `serializePath` rather than
+ * imported: exporting it from core would add permanent public API for what
+ * is an implementation detail of this plugin.
+ */
+export function serializePath(path: Path): string {
+  return path.reduce<string>((result, segment, index) => {
+    if (isKeyedSegment(segment)) {
+      return `${result}[_key=="${segment._key}"]`
+    }
+
+    const separator = index === 0 ? '' : '.'
+    return `${result}${separator}${segment}`
+  }, '')
+}
+
+/**
+ * Compute the list index for every list item block in the value.
+ *
+ * Returns a fresh `Map` keyed by serialized block path with the 1-based
+ * index of the block within its list, honoring list type and indentation
+ * level: same-type items count up across consecutive blocks on the same
+ * level, deeper levels restart at 1, and non-list blocks break the
+ * sequence.
+ *
+ * Duplicated from the editor's internal `buildIndexMaps` (the part that
+ * fills `listIndexMap`) rather than imported, for the same reason as
+ * `serializePath` above. Keep the list semantics in sync with
+ * `packages/editor/src/internal-utils/build-index-maps.ts`.
+ */
+export function buildListIndexMap(
+  context: Pick<EditorContext, 'schema' | 'value'>,
+): Map<string, number> {
+  const listIndexMap = new Map<string, number>()
+
+  // Maps for each list type, keeping track of the current list count for
+  // each level.
+  const levelIndexMaps = new Map<string, Map<number, number>>()
+
+  let previousListItem:
+    | {
+        listItem: string
+        level: number
+      }
+    | undefined
+
+  for (const block of context.value) {
+    if (block === undefined) {
+      continue
+    }
+
+    // Clear the state if we encounter a non-text block. Unlike the engine's
+    // internal check, `isTextBlock` also requires `children`, which holds
+    // for the post-apply snapshot values this plugin reads.
+    if (!isTextBlock(context, block)) {
+      levelIndexMaps.clear()
+      previousListItem = undefined
+
+      continue
+    }
+
+    // Clear the state if we encounter a non-list text block
+    if (block.listItem === undefined || block.level === undefined) {
+      levelIndexMaps.clear()
+      previousListItem = undefined
+
+      continue
+    }
+
+    // If we encounter a new list item, we set the initial index to 1 for the
+    // list type on that level.
+    if (!previousListItem) {
+      const listIndex = 1
+      const levelIndexMap =
+        levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+      levelIndexMap.set(block.level, listIndex)
+      levelIndexMaps.set(block.listItem, levelIndexMap)
+
+      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
+
+      previousListItem = {
+        listItem: block.listItem,
+        level: block.level,
+      }
+
+      continue
+    }
+
+    // If the previous list item is of the same type but on a lower level, we
+    // need to reset the level index map for that type.
+    if (
+      previousListItem.listItem === block.listItem &&
+      previousListItem.level < block.level
+    ) {
+      const listIndex = 1
+      const levelIndexMap =
+        levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+      levelIndexMap.set(block.level, listIndex)
+      levelIndexMaps.set(block.listItem, levelIndexMap)
+
+      listIndexMap.set(serializePath([{_key: block._key}]), listIndex)
+
+      previousListItem = {
+        listItem: block.listItem,
+        level: block.level,
+      }
+
+      continue
+    }
+
+    // Reset other list types at current level and deeper
+    levelIndexMaps.forEach((levelIndexMap, listItem) => {
+      if (listItem === block.listItem) {
+        return
+      }
+
+      // Reset all levels that are >= current level
+      const levelsToDelete: number[] = []
+
+      levelIndexMap.forEach((_, level) => {
+        if (block.level !== undefined && level >= block.level) {
+          levelsToDelete.push(level)
+        }
+      })
+
+      levelsToDelete.forEach((level) => {
+        levelIndexMap.delete(level)
+      })
+    })
+
+    const levelIndexMap =
+      levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
+    const levelCounter = levelIndexMap.get(block.level) ?? 0
+    levelIndexMap.set(block.level, levelCounter + 1)
+    levelIndexMaps.set(block.listItem, levelIndexMap)
+
+    listIndexMap.set(serializePath([{_key: block._key}]), levelCounter + 1)
+
+    previousListItem = {
+      listItem: block.listItem,
+      level: block.level,
+    }
+  }
+
+  return listIndexMap
+}

--- a/packages/plugin-list-index/src/data-list-index.test.tsx
+++ b/packages/plugin-list-index/src/data-list-index.test.tsx
@@ -1,0 +1,138 @@
+import type {Editor, TextBlockRenderProps} from '@portabletext/editor'
+import {
+  defineTextBlock,
+  EditorProvider,
+  PortableTextEditable,
+} from '@portabletext/editor'
+import {EditorRefPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {createRef} from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {ListIndexProvider, useListIndex} from './plugin.list-index'
+
+/**
+ * Pins the consumer story end-to-end: a `defineTextBlock` render in the new
+ * pipeline uses `useListIndex` to reproduce the `data-list-index` attribute
+ * the engine's default text-block render emits in the legacy pipeline. This
+ * is the exact shape Studio's catch-all text-block render uses.
+ */
+describe('data-list-index in the new render pipeline', () => {
+  test('Scenario: A registered text-block render reproduces `data-list-index`', async () => {
+    const editor = await renderEditorWithListIndexRender([
+      paragraph('b0'),
+      numberListItem('b1'),
+      numberListItem('b2'),
+    ])
+
+    await expectListIndices({b0: null, b1: '1', b2: '2'})
+
+    editor.send({
+      type: 'update value',
+      value: [
+        paragraph('b0'),
+        numberListItem('b3'),
+        numberListItem('b1'),
+        numberListItem('b2'),
+      ],
+    })
+
+    await expectListIndices({b0: null, b3: '1', b1: '2', b2: '3'})
+  })
+})
+
+function TextBlockWithListIndex(props: TextBlockRenderProps) {
+  // The registered render returns this component rather than calling hooks
+  // directly: the engine invokes `render` as a plain function, so hooks
+  // belong in a component the render returns.
+  const listIndex = useListIndex(props.path)
+
+  return (
+    <div
+      {...props.attributes}
+      data-testid={`text-block-${props.node._key}`}
+      {...(listIndex === undefined ? {} : {'data-list-index': listIndex})}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+const textBlockNodes = [
+  defineTextBlock({
+    type: '*',
+    render: (props) => <TextBlockWithListIndex {...props} />,
+  }),
+]
+
+/**
+ * Hand-rolled render instead of `createTestEditor`: the harness mounts
+ * `children` as siblings after `PortableTextEditable`, but this test needs
+ * `ListIndexProvider` to wrap the editable so the registered render's
+ * component can read the context.
+ */
+async function renderEditorWithListIndexRender(
+  initialValue: Array<PortableTextBlock>,
+): Promise<Editor> {
+  const editorRef = createRef<Editor>()
+
+  await render(
+    <EditorProvider
+      initialConfig={{
+        schemaDefinition: defineSchema({
+          lists: [{name: 'bullet'}, {name: 'number'}],
+        }),
+        initialValue,
+        keyGenerator: createTestKeyGenerator(),
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <NodePlugin nodes={textBlockNodes} />
+      <ListIndexProvider>
+        <PortableTextEditable />
+      </ListIndexProvider>
+    </EditorProvider>,
+  )
+
+  await vi.waitFor(() => {
+    expect(editorRef.current).not.toBeNull()
+  })
+
+  return editorRef.current as Editor
+}
+
+async function expectListIndices(
+  expected: Record<string, string | null>,
+): Promise<void> {
+  await vi.waitFor(() => {
+    for (const [blockKey, listIndex] of Object.entries(expected)) {
+      const textBlock = document.querySelector(
+        `[data-testid="text-block-${blockKey}"]`,
+      )
+      expect(textBlock, `text block ${blockKey}`).not.toBeNull()
+      expect(
+        textBlock?.getAttribute('data-list-index'),
+        `data-list-index of ${blockKey}`,
+      ).toBe(listIndex)
+    }
+  })
+}
+
+function paragraph(key: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    children: [{_type: 'span', _key: `${key}-span`, text: key, marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+}
+
+function numberListItem(key: string): PortableTextBlock {
+  return {
+    ...paragraph(key),
+    listItem: 'number',
+    level: 1,
+  }
+}

--- a/packages/plugin-list-index/src/index.ts
+++ b/packages/plugin-list-index/src/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin.list-index'

--- a/packages/plugin-list-index/src/plugin.list-index.test.tsx
+++ b/packages/plugin-list-index/src/plugin.list-index.test.tsx
@@ -1,0 +1,153 @@
+import type {Path} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {describe, expect, test, vi} from 'vitest'
+import {page} from 'vitest/browser'
+import {ListIndexProvider, useListIndex} from './plugin.list-index'
+
+const schemaDefinition = defineSchema({
+  lists: [{name: 'bullet'}, {name: 'number'}],
+})
+
+function numberBlock(key: string, text: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    children: [{_type: 'span', _key: `${key}-span`, text, marks: []}],
+    markDefs: [],
+    style: 'normal',
+    listItem: 'number',
+    level: 1,
+  }
+}
+
+function paragraphBlock(key: string, text: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    children: [{_type: 'span', _key: `${key}-span`, text, marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+}
+
+function ListIndexProbe(props: {
+  blockKey: string
+  onRender: (blockKey: string) => void
+}) {
+  const path: Path = [{_key: props.blockKey}]
+  const listIndex = useListIndex(path)
+  props.onRender(props.blockKey)
+  return (
+    <div data-testid={`probe-${props.blockKey}`}>
+      {listIndex === undefined ? 'none' : listIndex}
+    </div>
+  )
+}
+
+function probes(
+  probeKeys: Array<string>,
+  onRender: (blockKey: string) => void,
+) {
+  return (
+    <ListIndexProvider>
+      {probeKeys.map((blockKey) => (
+        <ListIndexProbe
+          key={blockKey}
+          blockKey={blockKey}
+          onRender={onRender}
+        />
+      ))}
+    </ListIndexProvider>
+  )
+}
+
+describe('ListIndexProvider', () => {
+  test('Scenario: Indices are correct on first render', async () => {
+    await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        paragraphBlock('b0', 'intro'),
+        numberBlock('b1', 'one'),
+        numberBlock('b2', 'two'),
+      ],
+      children: probes(['b0', 'b1', 'b2'], () => {}),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b0').element().textContent).toBe('none')
+      expect(page.getByTestId('probe-b1').element().textContent).toBe('1')
+      expect(page.getByTestId('probe-b2').element().textContent).toBe('2')
+    })
+  })
+
+  test('Scenario: A structural change shifts indices, and only changed paths re-render', async () => {
+    const renders: Array<string> = []
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        paragraphBlock('b0', 'intro'),
+        numberBlock('b1', 'one'),
+        numberBlock('b2', 'two'),
+      ],
+      children: probes(['b0', 'b1', 'b2'], (blockKey) =>
+        renders.push(blockKey),
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b2').element().textContent).toBe('2')
+    })
+    renders.length = 0
+
+    editor.send({
+      type: 'update value',
+      value: [
+        paragraphBlock('b0', 'intro'),
+        numberBlock('b3', 'zero'),
+        numberBlock('b1', 'one'),
+        numberBlock('b2', 'two'),
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b1').element().textContent).toBe('2')
+      expect(page.getByTestId('probe-b2').element().textContent).toBe('3')
+    })
+
+    // The paragraph's index is `undefined` before and after, so its bucket
+    // is never notified.
+    expect(renders).not.toContain('b0')
+
+    // Rebuilds coalesce per microtask, so the bulk update re-renders each
+    // changed probe once, not once per operation in the transaction.
+    expect(renders.filter((blockKey) => blockKey === 'b1')).toHaveLength(1)
+    expect(renders.filter((blockKey) => blockKey === 'b2')).toHaveLength(1)
+  })
+
+  test('Scenario: Typing inside a list item does not move indices', async () => {
+    const renders: Array<string> = []
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [numberBlock('b1', 'one'), numberBlock('b2', 'two')],
+      children: probes(['b1', 'b2'], (blockKey) => renders.push(blockKey)),
+    })
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('probe-b2').element().textContent).toBe('2')
+    })
+    renders.length = 0
+
+    editor.send({type: 'focus'})
+    editor.send({type: 'insert.text', text: ' more'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(JSON.stringify(snapshot.context.value)).toContain(' more')
+    })
+
+    expect(page.getByTestId('probe-b1').element().textContent).toBe('1')
+    expect(page.getByTestId('probe-b2').element().textContent).toBe('2')
+    expect(renders).toEqual([])
+  })
+})

--- a/packages/plugin-list-index/src/plugin.list-index.tsx
+++ b/packages/plugin-list-index/src/plugin.list-index.tsx
@@ -1,0 +1,194 @@
+import {useEditor, type Editor, type Path} from '@portabletext/editor'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react'
+import {buildListIndexMap, serializePath} from './build-list-index-map'
+
+/**
+ * One store per editor: a single `operation` subscription maintains the
+ * list index map, and per-path subscriber buckets make notification
+ * O(changed paths) rather than O(subscribers).
+ */
+type ListIndexStore = {
+  get: (serializedPath: string) => number | undefined
+  subscribeKey: (serializedPath: string, callback: () => void) => () => void
+  /**
+   * Starts the `operation` subscription. Returns the unsubscribe.
+   */
+  subscribe: () => () => void
+}
+
+function createListIndexStore(editor: Editor): ListIndexStore {
+  let listIndexMap = buildListIndexMap(editor.getSnapshot().context)
+  const subscribers = new Map<string, Set<() => void>>()
+  let rebuildScheduled = false
+  let subscribed = false
+
+  function scheduleRebuild() {
+    if (rebuildScheduled) {
+      return
+    }
+
+    rebuildScheduled = true
+
+    // Coalesce per microtask: bulk transactions (value sync, multi-block
+    // inserts) deliver one operation per affected block, and rebuilding per
+    // operation would be O(blocks^2). The map has only React consumers and
+    // they read post-commit, so deferring to the end of the JS turn is
+    // safe; the microtask drains before React's commit.
+    queueMicrotask(() => {
+      rebuildScheduled = false
+
+      if (subscribed) {
+        rebuild()
+      }
+    })
+  }
+
+  function rebuild() {
+    const previousListIndexMap = listIndexMap
+
+    // Swap before notifying: `useSyncExternalStore` re-reads the snapshot
+    // synchronously on notification and skips the re-render when it reads
+    // an unchanged (stale) value.
+    listIndexMap = buildListIndexMap(editor.getSnapshot().context)
+
+    for (const [serializedPath, callbacks] of subscribers) {
+      if (
+        previousListIndexMap.get(serializedPath) !==
+        listIndexMap.get(serializedPath)
+      ) {
+        for (const callback of callbacks) {
+          callback()
+        }
+      }
+    }
+  }
+
+  return {
+    get: (serializedPath) => listIndexMap.get(serializedPath),
+    subscribeKey: (serializedPath, callback) => {
+      let bucket = subscribers.get(serializedPath)
+
+      if (bucket === undefined) {
+        bucket = new Set()
+        subscribers.set(serializedPath, bucket)
+      }
+
+      bucket.add(callback)
+
+      return () => {
+        bucket.delete(callback)
+
+        if (bucket.size === 0) {
+          subscribers.delete(serializedPath)
+        }
+      }
+    },
+    subscribe: () => {
+      subscribed = true
+
+      // Operations applied between store creation (render) and subscription
+      // (effect) are not observed, so reconcile once up front.
+      rebuild()
+
+      const subscription = editor.on('operation', (event) => {
+        if (
+          event.operation.type === 'insert.text' ||
+          event.operation.type === 'remove.text'
+        ) {
+          // Inserting and removing text has no effect on list indices so
+          // there is no need to rebuild those.
+          return
+        }
+
+        if (event.operation.path.length > 2) {
+          // Operations deep inside blocks only modify nested structure and
+          // cannot affect root-level list indices.
+          return
+        }
+
+        scheduleRebuild()
+      })
+
+      return () => {
+        subscribed = false
+        subscription.unsubscribe()
+      }
+    },
+  }
+}
+
+const ListIndexContext = createContext<ListIndexStore | undefined>(undefined)
+
+/**
+ * Maintains a list index map for the editor and serves it through context.
+ * Mount inside `EditorProvider`, wrapping whatever reads the indices:
+ *
+ * ```tsx
+ * <EditorProvider initialConfig={...}>
+ *   <ListIndexProvider>
+ *     <PortableTextEditable />
+ *   </ListIndexProvider>
+ * </EditorProvider>
+ * ```
+ *
+ * The map is rebuilt at most once per editor operation, regardless of how
+ * many components read it, and only for operations that can affect list
+ * indices. Reads via {@link useListIndex} only re-render when the index at
+ * their own path changes.
+ *
+ * @beta
+ */
+export function ListIndexProvider(props: {children?: ReactNode}) {
+  const editor = useEditor()
+  const store = useMemo(() => createListIndexStore(editor), [editor])
+
+  useEffect(() => {
+    return store.subscribe()
+  }, [store])
+
+  return (
+    <ListIndexContext.Provider value={store}>
+      {props.children}
+    </ListIndexContext.Provider>
+  )
+}
+
+/**
+ * Read the 1-based list index of the block at `path`, or `undefined` when
+ * the block is not a list item. Re-renders only when the index at this
+ * path changes.
+ *
+ * `path` is the keyed block path render callbacks receive, e.g.
+ * `[{_key: 'b0'}]`.
+ *
+ * @beta
+ */
+export function useListIndex(path: Path): number | undefined {
+  const store = useContext(ListIndexContext)
+
+  if (store === undefined) {
+    throw new Error('useListIndex must be used below a <ListIndexProvider>')
+  }
+
+  // Callers typically pass a fresh `path` array every render, so the
+  // serialized string, not the array, is what keeps `subscribe` stable
+  // below. Memoizing on the array would never hit.
+  const serializedPath = serializePath(path)
+
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribeKey(serializedPath, callback),
+    [store, serializedPath],
+  )
+
+  const getSnapshot = () => store.get(serializedPath)
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}

--- a/packages/plugin-list-index/tsconfig.dist.json
+++ b/packages/plugin-list-index/tsconfig.dist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-list-index/tsconfig.json
+++ b/packages/plugin-list-index/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["**/*.ts", "**/*.tsx", "src/index.ts"],
+  "exclude": ["dist", "./node_modules"]
+}

--- a/packages/plugin-list-index/tsconfig.settings.json
+++ b/packages/plugin-list-index/tsconfig.settings.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false
+  }
+}

--- a/packages/plugin-list-index/vitest.config.ts
+++ b/packages/plugin-list-index/vitest.config.ts
@@ -1,0 +1,48 @@
+import react from '@vitejs/plugin-react'
+import {playwright} from '@vitest/browser-playwright'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        plugins: [
+          react({
+            babel: {
+              plugins: [['babel-plugin-react-compiler', {target: '19'}]],
+            },
+          }),
+        ],
+        test: {
+          name: 'browser',
+          include: ['src/**/*.test.tsx'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [
+              {
+                browser: 'chromium',
+              },
+              {
+                browser: 'firefox',
+              },
+              {
+                browser: 'webkit',
+              },
+            ],
+            screenshotFailures: false,
+          },
+        },
+      },
+      {
+        plugins: [],
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+    ],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -831,6 +831,63 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/plugin-list-index:
+    devDependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../editor
+      '@portabletext/schema':
+        specifier: workspace:^
+        version: link:../schema
+      '@portabletext/test':
+        specifier: workspace:^
+        version: link:../test
+      '@sanity/tsconfig':
+        specifier: ^2.1.0
+        version: 2.1.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser':
+        specifier: ^4.1.8
+        version: 4.1.8(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest-browser-react:
+        specifier: ^2.2.0
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.8)
+
   packages/plugin-markdown-shortcuts:
     dependencies:
       '@portabletext/plugin-character-pair-decorator':
@@ -5348,9 +5405,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
   '@types/event-source-polyfill@1.0.5':
     resolution: {integrity: sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==}
 
@@ -7170,6 +7224,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.3.2:
+    resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
+    engines: {node: 20 || >=22}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -9193,8 +9251,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9298,7 +9356,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.3.6
+      lru-cache: 11.3.2
 
   '@asamuzakjp/dom-selector@6.7.5':
     dependencies:
@@ -9737,7 +9795,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -9814,7 +9872,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.0
+      semver: 7.7.3
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -9823,7 +9881,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.0
+      semver: 7.7.3
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -9889,7 +9947,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.0
+      semver: 7.7.3
 
   '@changesets/get-github-info@0.7.0':
     dependencies:
@@ -10755,7 +10813,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
@@ -12645,7 +12703,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.53.3)':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -12653,7 +12711,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -12661,7 +12719,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.3)':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -13654,11 +13712,9 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
-
-  '@types/estree@1.0.9': {}
 
   '@types/event-source-polyfill@1.0.5': {}
 
@@ -13838,8 +13894,8 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.48.0
       debug: 4.4.3
       minimatch: 9.0.5
-      semver: 7.8.0
-      tinyglobby: 0.2.16
+      semver: 7.7.3
+      tinyglobby: 0.2.15
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14038,7 +14094,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.0.18(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
-      ws: 8.20.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14056,7 +14112,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@types/node@20.19.25)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.2(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
-      ws: 8.20.1
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14073,7 +14129,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@types/node@20.19.25)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
-      ws: 8.20.1
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14091,7 +14147,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
-      ws: 8.20.1
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14320,7 +14376,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.2
       pathe: 2.0.3
 
   ast-types@0.16.1:
@@ -14990,7 +15046,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -15038,7 +15094,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -15051,7 +15107,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -15069,7 +15125,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -15266,7 +15322,7 @@ snapshots:
       get-it: 8.7.0(debug@4.4.3)
       registry-auth-token: 5.1.0
       registry-url: 5.1.0
-      semver: 7.8.0
+      semver: 7.7.3
     transitivePeerDependencies:
       - debug
 
@@ -15484,7 +15540,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -15519,7 +15575,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -15713,7 +15769,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   is-retry-allowed@2.2.0: {}
 
@@ -15740,10 +15796,10 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.0
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15830,7 +15886,7 @@ snapshots:
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       pretty-format: 30.3.0
-      semver: 7.8.0
+      semver: 7.7.3
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
@@ -16066,6 +16122,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.3.2: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@11.3.6: {}
@@ -16100,7 +16158,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.7.3
 
   makeerror@1.0.12:
     dependencies:
@@ -16420,7 +16478,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -16431,7 +16489,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -16448,7 +16506,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -16484,7 +16542,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -16548,7 +16606,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -16904,7 +16962,7 @@ snapshots:
 
   path-scurry@2.0.1:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.3.2
       minipass: 7.1.2
 
   path-type@4.0.0: {}
@@ -17245,7 +17303,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -17260,14 +17318,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -17325,7 +17383,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -17465,7 +17523,7 @@ snapshots:
   rolldown-plugin-dts@0.18.1(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.52)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 2.8.0
@@ -17482,7 +17540,7 @@ snapshots:
   rolldown-plugin-dts@0.18.3(oxc-resolver@11.19.1)(rolldown@1.0.0-beta.54)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       ast-kit: 2.2.0
       birpc: 3.0.0
@@ -17841,9 +17899,9 @@ snapshots:
       detect-newline: 4.0.1
       git-hooks-list: 4.1.1
       is-plain-obj: 4.1.0
-      semver: 7.8.0
+      semver: 7.7.3
       sort-object-keys: 2.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 
@@ -18619,7 +18677,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  ws@8.20.1: {}
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
When a consumer takes over text-block rendering through the `defineX` pipeline, the engine no longer applies its default list-item wrapping, and with it goes the list index the old pipeline computed for free. Studio hits this directly in its render pipeline adoption (sanity-io/sanity#12963): its `ListItem` chrome needs the index and has nowhere to get it. The same applies to anyone rendering ordered lists through custom renders.

We deliberately do not put `listIndex` on `TextBlockRenderProps`. Render props are the least removable surface in the API: every Studio consumer who customizes a render callback types against them, so removal means a coordinated major across the lib and the app plus the long tail of every studio that destructured the prop. A plugin is opt-in and independently versioned; if it turns out wrong, it deprecates on its own cadence and core never moves. It is also the first real consumer of the operation channel (#2772), which this branch stacks on.

```tsx
import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'

<EditorProvider initialConfig={...}>
  <ListIndexProvider>
    <PortableTextEditable />
  </ListIndexProvider>
</EditorProvider>

// in any render callback or component below the provider
const listIndex = useListIndex(props.path) // 1-based, or undefined for non-list blocks
```

## Design notes

The list-index computation and path serialization are duplicated from the editor's internals (`buildIndexMaps`, `serializePath`) rather than exported from core. An export is permanent public API surface for what is an implementation detail of this plugin; a duplicate inside a plugin we own can be changed or deleted freely. The copies are built on public primitives only (`isTextBlock`, `isKeyedSegment`) and carry keep-in-sync pointers to their sources. One semantic note: the duplicate uses the public `isTextBlock`, which also requires `children`, where the engine's internal check is `_type`-only to handle pre-normalization states; the plugin only reads post-apply snapshot values, where `children` is guaranteed.

The cost model is the design driver: a 1000-block document must not compute indices 1000 times per operation, so the index map lives in one store per editor, shared through context. A single `editor.on('operation')` subscription skips operations that cannot affect indices (`insert.text`, `remove.text`, and operations nested deeper than the root level, mirroring the heuristics the engine's own `subscriber.update-value` proved out) and otherwise schedules a rebuild. Rebuilds coalesce per microtask: bulk transactions (value sync of a large document, multi-block inserts) deliver one operation per affected block, and rebuilding per operation would be O(blocks^2), the same failure mode the selection-state provider hit and fixed in #2679. Unlike the engine's own `listIndexMap`, which engine code reads mid-apply and must stay synchronously fresh, this map has only React consumers reading post-commit, so deferring to the end of the JS turn is safe; the microtask drains before React's commit. A test pins that a bulk update re-renders each changed consumer once, not once per operation. The context carries the stable store handle, never the map, so the provider never re-renders its subtree.

Reads go through `useSyncExternalStore` with key-bucketed subscriptions: subscribers are stored per serialized path, and the store diffs the old map against the new during rebuild, notifying only paths whose index changed. Notification is O(changed paths) instead of O(subscribers): inserting a block above a 100-item list in a 1000-block document is one rebuild and 100 re-renders. One ordering subtlety is load-bearing and commented in the code: the store must swap the map before notifying, because `useSyncExternalStore` re-reads the snapshot synchronously on notification and skips the re-render when it reads an unchanged value. The first version of this code notified first and every test failed with stale reads.

Because the operation stream is ungated, the store sees value sync and normalization, so indices are correct on first render rather than after the first local edit, and they stay correct under remote changes. The store also rebuilds once when its subscription starts, covering operations applied between store creation (render) and subscription (effect).

The hook is path-based (`useListIndex(props.path)`), matching the engine map's serialized-path keying and staying container-ready. `blockIndex` does not ride along; the same traversal could produce it, but no consumer has asked. Hand-rolled store rather than a store library: the repo precedent is `selection-state-context.tsx`, and a derived map has no states or transitions to justify more machinery.

Browser tests (chromium, firefox, webkit) pin four contracts: indices correct on first render from the initial value, a structural change shifts indices while paths whose index is unchanged are never notified, typing inside a list item triggers no notification at all, and the consumer story end to end: a `defineTextBlock({type: '*'})` render in the new pipeline reproduces the engine's `data-list-index` attribute via `useListIndex`. That last test also pins the hook-usage shape: the engine invokes registered renders as plain functions, so the render returns a component and the hook lives there, the same shape Studio's catch-all uses.
