### PR TITLE
feat: add `@portabletext/plugin-dnd`

### DIFF
--- a/packages/plugin-dnd/README.md
+++ b/packages/plugin-dnd/README.md
@@ -1,0 +1,59 @@
+# `@portabletext/plugin-dnd`
+
+A helper plugin for tracking the drop position during drag and drop.
+
+When a consumer takes over block rendering through the `defineX` pipeline, the engine renders no drop-indicator chrome: where a dragged block would land is deliberately left to the consumer, since drop indication is pointer-driven UI, not document structure. This plugin tracks the position for you, derived from the editor's public `drag.*` behavior events.
+
+```tsx
+import {DndProvider, useDropPosition} from '@portabletext/plugin-dnd'
+
+function MyEditor() {
+  return (
+    <EditorProvider initialConfig={...}>
+      <DndProvider>
+        <PortableTextEditable />
+      </DndProvider>
+    </EditorProvider>
+  )
+}
+
+function MyTextBlock(props: TextBlockRenderProps) {
+  // `'start' | 'end'` while a block drag hovers this block, `undefined`
+  // otherwise.
+  const dropPosition = useDropPosition(props.path)
+  return (
+    <div {...props.attributes} style={{position: 'relative'}}>
+      {props.children}
+      {dropPosition ? <DropIndicator edge={dropPosition} /> : null}
+    </div>
+  )
+}
+
+// A line across the top of the block for 'start', the bottom for 'end'.
+// `position: absolute` keeps it out of flow so it doesn't shift the text.
+function DropIndicator({edge}: {edge: 'start' | 'end'}) {
+  return (
+    <div
+      contentEditable={false}
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: edge === 'start' ? 0 : 'auto',
+        bottom: edge === 'end' ? 0 : 'auto',
+        borderTop: '1px solid currentColor',
+      }}
+    />
+  )
+}
+```
+
+Call `useDropPosition` from a component the render returns, not inline in the `render` callback (it is a hook):
+
+```tsx
+defineTextBlock({type: '*', render: (props) => <MyTextBlock {...props} />})
+```
+
+The position only appears for block drags (dragging an entire block or a multi-block selection), never for text drags, and never over the dragged blocks themselves. The plugin observes the drag events and forwards them untouched, so the editor's own drag handling is unaffected.
+
+`dragover` fires at mousemove frequency, so granularity matters: reads via `useDropPosition` re-render only when the position at their own path changes. Moving the drag from one block to another re-renders exactly two blocks, the one losing the indicator and the one gaining it.

--- a/packages/plugin-dnd/eslint.config.js
+++ b/packages/plugin-dnd/eslint.config.js
@@ -1,0 +1,19 @@
+import reactHooks from 'eslint-plugin-react-hooks'
+import {globalIgnores} from 'eslint/config'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config([
+  globalIgnores(['dist', '*.test.tsx']),
+  reactHooks.configs.flat.recommended,
+  {
+    files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {'react-hooks/exhaustive-deps': 'error'},
+  },
+])

--- a/packages/plugin-dnd/package.config.ts
+++ b/packages/plugin-dnd/package.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  babel: {reactCompiler: true},
+  reactCompilerOptions: {target: '19'},
+})

--- a/packages/plugin-dnd/package.json
+++ b/packages/plugin-dnd/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@portabletext/plugin-dnd",
+  "version": "1.0.0",
+  "description": "A helper plugin for tracking the drop position during drag and drop",
+  "keywords": [
+    "portabletext",
+    "plugin",
+    "dnd",
+    "drag-and-drop",
+    "drop-indicator"
+  ],
+  "homepage": "https://portabletext.org",
+  "bugs": {
+    "url": "https://github.com/portabletext/editor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/portabletext/editor.git",
+    "directory": "packages/plugin-dnd"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkg-utils build --strict --check --clean",
+    "check:lint": "biome lint .",
+    "check:react-compiler": "eslint .",
+    "check:types": "tsc",
+    "check:types:watch": "tsc --watch",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "pkg-utils watch",
+    "lint:fix": "biome lint --write .",
+    "prepublishOnly": "turbo run build",
+    "test:browser": "vitest --run --project browser",
+    "test:browser:chromium": "vitest --run --project \"browser (chromium)\"",
+    "test:unit": "vitest --run --project unit",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "@portabletext/schema": "workspace:^",
+    "@portabletext/test": "workspace:^",
+    "@sanity/tsconfig": "^2.1.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/browser": "^4.1.8",
+    "@vitest/browser-playwright": "^4.1.8",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "react": "^19.2.5",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.48.0",
+    "vitest": "^4.1.8"
+  },
+  "peerDependencies": {
+    "@portabletext/editor": "workspace:^",
+    "react": "^19.2"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/plugin-dnd/src/drag-selection.test.ts
+++ b/packages/plugin-dnd/src/drag-selection.test.ts
@@ -1,0 +1,609 @@
+import type {EditorSelection, EditorSnapshot} from '@portabletext/editor'
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {getDragSelection} from './drag-selection'
+
+/**
+ * Mirrors the engine's `drag-selection.test.ts`. `getDragSelection` is a
+ * duplicate of the engine's internal selector, and this suite is the drift
+ * alarm: if the engine's drag-selection semantics change, update both
+ * implementations and both suites together.
+ */
+
+function createTestSnapshot(snapshot: {
+  context?: Partial<EditorSnapshot['context']>
+}): EditorSnapshot {
+  const context = {
+    containers: snapshot.context?.containers ?? new Map(),
+    converters: snapshot.context?.converters ?? [],
+    schema: snapshot.context?.schema ?? compileSchema(defineSchema({})),
+    keyGenerator: snapshot.context?.keyGenerator ?? createTestKeyGenerator(),
+    readOnly: snapshot.context?.readOnly ?? false,
+    value: snapshot.context?.value ?? [],
+    selection: snapshot.context?.selection ?? null,
+  }
+  const blockIndexMap = new Map<string, number>()
+
+  snapshot.context?.value?.forEach((block, index) => {
+    blockIndexMap.set(block._key, index)
+  })
+
+  return {
+    blockIndexMap,
+    context,
+    decoratorState: {},
+  }
+}
+
+describe(getDragSelection.name, () => {
+  const keyGenerator = createTestKeyGenerator()
+  const foo = {
+    _key: keyGenerator(),
+    _type: 'block',
+    children: [
+      {
+        _key: keyGenerator(),
+        _type: 'span',
+        text: 'foo',
+      },
+      {
+        _key: keyGenerator(),
+        _type: 'stock-ticker',
+      },
+      {
+        _key: keyGenerator(),
+        _type: 'span',
+        text: 'bar',
+      },
+    ],
+  }
+  const fooPath = [{_key: foo._key}, 'children', {_key: foo.children[0]!._key}]
+  const stockTickerPath = [
+    {_key: foo._key},
+    'children',
+    {_key: foo.children[1]!._key},
+  ]
+  const barPath = [{_key: foo._key}, 'children', {_key: foo.children[2]!._key}]
+  const baz = {
+    _key: keyGenerator(),
+    _type: 'block',
+    children: [
+      {
+        _key: keyGenerator(),
+        _type: 'span',
+        text: 'baz',
+      },
+    ],
+  }
+  const bazPath = [{_key: baz._key}, 'children', {_key: baz.children[0]!._key}]
+  const image = {
+    _key: keyGenerator(),
+    _type: 'image',
+  }
+  const imagePath = [{_key: image._key}]
+
+  function snapshot(selection: EditorSelection) {
+    return createTestSnapshot({
+      context: {
+        keyGenerator,
+        schema: compileSchema(defineSchema({blockObjects: [{name: 'image'}]})),
+        selection,
+        value: [foo, baz, image],
+      },
+    })
+  }
+
+  test('dragging one text block', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot(null),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: barPath,
+        offset: 3,
+      },
+    })
+  })
+
+  test('dragging one text block with an existing selection', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 3,
+          },
+        }),
+      }),
+    )
+  })
+
+  test('dragging one text block with a selection elsewhere', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: imagePath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: barPath,
+        offset: 3,
+      },
+    })
+  })
+
+  test('dragging one block object with a selection elsewhere', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: imagePath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: imagePath,
+        offset: 0,
+      },
+      focus: {
+        path: imagePath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging one block object with an expanded selection elsewhere', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: imagePath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 1,
+          },
+          focus: {
+            path: fooPath,
+            offset: 2,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: imagePath,
+        offset: 0,
+      },
+      focus: {
+        path: imagePath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging a text block with an expanded selected', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: imagePath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging two text blocks with the top drag handle', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 1,
+          },
+          focus: {
+            path: bazPath,
+            offset: 3,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: bazPath,
+        offset: 3,
+      },
+    })
+  })
+
+  test('dragging two text blocks with the bottom drag handle', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: bazPath,
+            offset: 0,
+          },
+          focus: {
+            path: bazPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 1,
+          },
+          focus: {
+            path: bazPath,
+            offset: 3,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: bazPath,
+        offset: 3,
+      },
+    })
+  })
+
+  test('dragging a block object with an expanded selected', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: imagePath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: imagePath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: imagePath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging inline object', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot(null),
+      }),
+    ).toEqual({
+      anchor: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+      focus: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging inline object already selected', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+      focus: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging inline object with selection elsewhere', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+      focus: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging inline object with expanded selection elsewhere', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 3,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+      focus: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging inline object in an expanded selection', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: fooPath,
+            offset: 2,
+          },
+          focus: {
+            path: bazPath,
+            offset: 2,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+      focus: {
+        path: stockTickerPath,
+        offset: 0,
+      },
+    })
+  })
+
+  test('dragging text block with inline object selected', () => {
+    expect(
+      getDragSelection({
+        eventSelection: {
+          anchor: {
+            path: fooPath,
+            offset: 0,
+          },
+          focus: {
+            path: fooPath,
+            offset: 0,
+          },
+        },
+        snapshot: snapshot({
+          anchor: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+          focus: {
+            path: stockTickerPath,
+            offset: 0,
+          },
+        }),
+      }),
+    ).toEqual({
+      anchor: {
+        path: fooPath,
+        offset: 0,
+      },
+      focus: {
+        path: barPath,
+        offset: 3,
+      },
+    })
+  })
+})

--- a/packages/plugin-dnd/src/drag-selection.ts
+++ b/packages/plugin-dnd/src/drag-selection.ts
@@ -1,0 +1,124 @@
+import type {EditorSelection, EditorSnapshot} from '@portabletext/editor'
+import {
+  getFocusInlineObject,
+  getFocusSpan,
+  getFocusTextBlock,
+  getFragment,
+  getSelectionEndBlock,
+  getSelectionStartBlock,
+  isOverlappingSelection,
+  isSelectionCollapsed,
+  isSelectionExpanded,
+} from '@portabletext/editor/selectors'
+import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
+
+/**
+ * Given the current editor `snapshot` and an `eventSelection` representing
+ * where the drag event originates from, calculate the selection in the
+ * editor that should be dragged.
+ *
+ * Duplicated from the editor's internal `getDragSelection` rather than
+ * imported: exporting it from core would add permanent public API for what
+ * is an implementation detail of this plugin. Built on public selectors
+ * only. Keep in sync with
+ * `packages/editor/src/selectors/drag-selection.ts`.
+ */
+export function getDragSelection({
+  eventSelection,
+  snapshot,
+}: {
+  eventSelection: NonNullable<EditorSelection>
+  snapshot: EditorSnapshot
+}): NonNullable<EditorSelection> {
+  let dragSelection = eventSelection
+
+  const draggedInlineObject = getFocusInlineObject({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: eventSelection,
+    },
+  })
+
+  if (draggedInlineObject) {
+    return dragSelection
+  }
+
+  const draggingCollapsedSelection = isSelectionCollapsed({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: eventSelection,
+    },
+  })
+  const draggedTextBlock = getFocusTextBlock({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: eventSelection,
+    },
+  })
+  const draggedSpan = getFocusSpan({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: eventSelection,
+    },
+  })
+
+  if (draggingCollapsedSelection && draggedTextBlock && draggedSpan) {
+    // Looks like we are dragging an empty span
+    // Let's drag the entire block instead
+    dragSelection = {
+      anchor: getBlockStartPoint({
+        context: snapshot.context,
+        block: draggedTextBlock,
+      }),
+      focus: getBlockEndPoint({
+        context: snapshot.context,
+        block: draggedTextBlock,
+      }),
+    }
+  }
+
+  const selectedBlocks = getFragment(snapshot)
+
+  if (
+    snapshot.context.selection &&
+    isSelectionExpanded(snapshot) &&
+    selectedBlocks.length > 1
+  ) {
+    const selectionStartBlock = getSelectionStartBlock(snapshot)
+    const selectionEndBlock = getSelectionEndBlock(snapshot)
+
+    if (!selectionStartBlock || !selectionEndBlock) {
+      return dragSelection
+    }
+
+    const selectionStartPoint = getBlockStartPoint({
+      context: snapshot.context,
+      block: selectionStartBlock,
+    })
+    const selectionEndPoint = getBlockEndPoint({
+      context: snapshot.context,
+      block: selectionEndBlock,
+    })
+
+    const eventSelectionInsideBlocks = isOverlappingSelection(eventSelection)({
+      ...snapshot,
+      context: {
+        ...snapshot.context,
+        selection: {anchor: selectionStartPoint, focus: selectionEndPoint},
+      },
+    })
+
+    if (eventSelectionInsideBlocks) {
+      dragSelection = {
+        anchor: selectionStartPoint,
+        focus: selectionEndPoint,
+      }
+    }
+  }
+
+  return dragSelection
+}

--- a/packages/plugin-dnd/src/index.ts
+++ b/packages/plugin-dnd/src/index.ts
@@ -1,0 +1,1 @@
+export {DndProvider, useDropPosition, type DropPosition} from './plugin.dnd'

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -1,0 +1,211 @@
+import type {EditorSelection, Path} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {describe, expect, test, vi} from 'vitest'
+import {page} from 'vitest/browser'
+import {DndProvider, useDropPosition} from './plugin.dnd'
+
+const schemaDefinition = defineSchema({})
+
+describe('DndProvider', () => {
+  test('Scenario: Dragging an entire block over another block shows the drop position', async () => {
+    const {editor, renders} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'end'})
+    expect(renders.filter((blockKey) => blockKey === 'b2')).toHaveLength(1)
+    expect(renders).not.toContain('b0')
+    expect(renders).not.toContain('b1')
+  })
+
+  test('Scenario: Dragging over the dragged block itself shows nothing', async () => {
+    const {editor} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b0'),
+        block: 'start',
+      }),
+    )
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+  })
+
+  test('Scenario: Dragging a text selection shows nothing', async () => {
+    const {editor} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        // Only part of `b0`'s text, so this is a text drag, not a block drag
+        dragOrigin: {
+          anchor: {path: spanPath('b0'), offset: 0},
+          focus: {path: spanPath('b0'), offset: 2},
+        },
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+  })
+
+  test('Scenario: Moving the drag notifies only the blocks losing and gaining the indicator', async () => {
+    const {editor, renders} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b1'),
+        block: 'start',
+      }),
+    )
+    await expectDropPositions({b1: 'start', b2: 'none'})
+    renders.length = 0
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'start',
+      }),
+    )
+    await expectDropPositions({b1: 'none', b2: 'start'})
+
+    expect(renders.filter((blockKey) => blockKey === 'b1')).toHaveLength(1)
+    expect(renders.filter((blockKey) => blockKey === 'b2')).toHaveLength(1)
+    expect(renders).not.toContain('b0')
+  })
+
+  test('Scenario: Ending the drag clears the drop position', async () => {
+    const {editor} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'end'})
+
+    editor.send({
+      type: 'drag.dragend',
+      originEvent: {dataTransfer: new DataTransfer()},
+    })
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+  })
+})
+
+function DropPositionProbe(props: {
+  blockKey: string
+  onRender: (blockKey: string) => void
+}) {
+  const path: Path = [{_key: props.blockKey}]
+  const dropPosition = useDropPosition(path)
+  props.onRender(props.blockKey)
+  return (
+    <div data-testid={`probe-${props.blockKey}`}>{dropPosition ?? 'none'}</div>
+  )
+}
+
+async function renderEditorWithProbes() {
+  const renders: Array<string> = []
+
+  const {editor} = await createTestEditor({
+    schemaDefinition,
+    initialValue: [
+      block('b0', 'first'),
+      block('b1', 'second'),
+      block('b2', 'third'),
+    ],
+    children: (
+      <DndProvider>
+        {['b0', 'b1', 'b2'].map((blockKey) => (
+          <DropPositionProbe
+            key={blockKey}
+            blockKey={blockKey}
+            onRender={(renderedKey) => renders.push(renderedKey)}
+          />
+        ))}
+      </DndProvider>
+    ),
+  })
+
+  // Settle the initial probe renders before tests start counting
+  await vi.waitFor(() => {
+    expect(page.getByTestId('probe-b2').element().textContent).toBe('none')
+  })
+  renders.length = 0
+
+  return {editor, renders}
+}
+
+async function expectDropPositions(
+  expected: Record<string, string>,
+): Promise<void> {
+  await vi.waitFor(() => {
+    for (const [blockKey, dropPosition] of Object.entries(expected)) {
+      expect(
+        page.getByTestId(`probe-${blockKey}`).element().textContent,
+        `drop position of ${blockKey}`,
+      ).toBe(dropPosition)
+    }
+  })
+}
+
+function dragover(options: {
+  dragOrigin: NonNullable<EditorSelection>
+  over: NonNullable<EditorSelection>
+  block: 'start' | 'end'
+}) {
+  return {
+    type: 'drag.dragover' as const,
+    originEvent: {dataTransfer: new DataTransfer()},
+    dragOrigin: {selection: options.dragOrigin},
+    position: {
+      block: options.block,
+      isEditor: false,
+      isContainer: false,
+      selection: options.over,
+    },
+  }
+}
+
+function block(key: string, text: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    children: [{_type: 'span', _key: `${key}-span`, text, marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+}
+
+function spanPath(blockKey: string): Path {
+  return [{_key: blockKey}, 'children', {_key: `${blockKey}-span`}]
+}
+
+function blockSelection(blockKey: string): NonNullable<EditorSelection> {
+  const textLength = blockKey === 'b0' ? 5 : blockKey === 'b1' ? 6 : 5
+
+  return {
+    anchor: {path: spanPath(blockKey), offset: 0},
+    focus: {path: spanPath(blockKey), offset: textLength},
+  }
+}
+
+function caretIn(blockKey: string): NonNullable<EditorSelection> {
+  return {
+    anchor: {path: spanPath(blockKey), offset: 0},
+    focus: {path: spanPath(blockKey), offset: 0},
+  }
+}

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -1,0 +1,304 @@
+import type {Path} from '@portabletext/editor'
+import {
+  defineBehavior,
+  effect,
+  forward,
+  type Behavior,
+} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin} from '@portabletext/editor/plugins'
+import {
+  getFocusBlock,
+  getSelectedBlocks,
+  isSelectingEntireBlocks,
+} from '@portabletext/editor/selectors'
+import {isKeyedSegment} from '@portabletext/editor/utils'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react'
+import {getDragSelection} from './drag-selection'
+
+/**
+ * The block-relative position a drop would land at.
+ *
+ * @beta
+ */
+export type DropPosition = {
+  path: Path
+  position: 'start' | 'end'
+}
+
+/**
+ * One store per editor: the drag behaviors below maintain the current drop
+ * position, and per-path subscriber buckets make notification O(changed
+ * paths) rather than O(subscribers). `dragover` fires at mousemove
+ * frequency, so only the block losing and the block gaining the indicator
+ * re-render.
+ */
+type DropPositionStore = {
+  get: (serializedPath: string) => DropPosition['position'] | undefined
+  subscribeKey: (serializedPath: string, callback: () => void) => () => void
+  set: (next: DropPosition | undefined) => void
+}
+
+function createDropPositionStore(): DropPositionStore {
+  let current:
+    | {serializedPath: string; position: DropPosition['position']}
+    | undefined
+  const subscribers = new Map<string, Set<() => void>>()
+
+  function notify(serializedPath: string | undefined) {
+    if (serializedPath === undefined) {
+      return
+    }
+
+    const bucket = subscribers.get(serializedPath)
+
+    if (bucket === undefined) {
+      return
+    }
+
+    for (const callback of bucket) {
+      callback()
+    }
+  }
+
+  return {
+    get: (serializedPath) =>
+      current?.serializedPath === serializedPath ? current.position : undefined,
+    subscribeKey: (serializedPath, callback) => {
+      let bucket = subscribers.get(serializedPath)
+
+      if (bucket === undefined) {
+        bucket = new Set()
+        subscribers.set(serializedPath, bucket)
+      }
+
+      bucket.add(callback)
+
+      return () => {
+        bucket.delete(callback)
+
+        if (bucket.size === 0) {
+          subscribers.delete(serializedPath)
+        }
+      }
+    },
+    set: (next) => {
+      const previous = current
+
+      // Swap before notifying: `useSyncExternalStore` re-reads the snapshot
+      // synchronously on notification and skips the re-render when it reads
+      // an unchanged (stale) value.
+      current = next
+        ? {serializedPath: serializePath(next.path), position: next.position}
+        : undefined
+
+      if (
+        previous?.serializedPath === current?.serializedPath &&
+        previous?.position === current?.position
+      ) {
+        return
+      }
+
+      if (previous?.serializedPath !== current?.serializedPath) {
+        notify(previous?.serializedPath)
+      }
+
+      notify(current?.serializedPath)
+    },
+  }
+}
+
+/**
+ * The behaviors observe the public `drag.*` events and `forward` every
+ * event they handle: consumer behaviors run before the editor's own drag
+ * handling, so omitting the forward would swallow the event and break the
+ * drag itself. (The editor's internal drop-position tracking gets away
+ * without forwarding because it registers below core priority.)
+ */
+function createDropPositionBehaviors(
+  setDropPosition: (next: DropPosition | undefined) => void,
+): Array<Behavior> {
+  return [
+    defineBehavior({
+      on: 'drag.dragover',
+      guard: ({snapshot, event}) => {
+        const dropFocusBlock = getFocusBlock({
+          ...snapshot,
+          context: {
+            ...snapshot.context,
+            selection: event.position.selection,
+          },
+        })
+
+        if (!dropFocusBlock) {
+          return false
+        }
+
+        const dragOrigin = event.dragOrigin
+
+        if (!dragOrigin) {
+          return false
+        }
+
+        const dragSelection = getDragSelection({
+          eventSelection: dragOrigin.selection,
+          snapshot,
+        })
+
+        const draggedBlocks = getSelectedBlocks({
+          ...snapshot,
+          context: {
+            ...snapshot.context,
+            selection: dragSelection,
+          },
+        })
+
+        if (
+          draggedBlocks.some(
+            (draggedBlock) =>
+              draggedBlock.node._key === dropFocusBlock.node._key,
+          )
+        ) {
+          return false
+        }
+
+        const draggingEntireBlocks = isSelectingEntireBlocks({
+          ...snapshot,
+          context: {
+            ...snapshot.context,
+            selection: dragSelection,
+          },
+        })
+
+        if (!draggingEntireBlocks) {
+          return false
+        }
+
+        return {dropFocusBlock}
+      },
+      actions: [
+        ({event}, {dropFocusBlock}) => [
+          effect(() => {
+            setDropPosition({
+              path: dropFocusBlock.path,
+              position: event.position.block,
+            })
+          }),
+          forward(event),
+        ],
+      ],
+    }),
+    defineBehavior({
+      on: 'drag.*',
+      guard: ({event}) => event.type !== 'drag.dragover',
+      actions: [
+        ({event}) => [
+          effect(() => {
+            setDropPosition(undefined)
+          }),
+          forward(event),
+        ],
+      ],
+    }),
+  ]
+}
+
+const DndContext = createContext<DropPositionStore | undefined>(undefined)
+
+/**
+ * Tracks the drop position during drag and drop and serves it through
+ * context. Mount inside `EditorProvider`, wrapping whatever reads the
+ * position:
+ *
+ * ```tsx
+ * <EditorProvider initialConfig={...}>
+ *   <DndProvider>
+ *     <PortableTextEditable />
+ *   </DndProvider>
+ * </EditorProvider>
+ * ```
+ *
+ * Reads via {@link useDropPosition} only re-render when the drop position
+ * at their own path changes.
+ *
+ * @beta
+ */
+export function DndProvider(props: {children?: ReactNode}) {
+  const store = useMemo(() => createDropPositionStore(), [])
+  const behaviors = useMemo(
+    () => createDropPositionBehaviors(store.set),
+    [store],
+  )
+
+  useEffect(() => {
+    return () => {
+      // A drag in progress when the provider unmounts never delivers its
+      // clearing event.
+      store.set(undefined)
+    }
+  }, [store])
+
+  return (
+    <DndContext.Provider value={store}>
+      <BehaviorPlugin behaviors={behaviors} />
+      {props.children}
+    </DndContext.Provider>
+  )
+}
+
+/**
+ * Read where a drop would land relative to the block at `path`: `'start'`,
+ * `'end'`, or `undefined` when no drag is hovering this block. Re-renders
+ * only when the position at this path changes.
+ *
+ * `path` is the keyed block path render callbacks receive, e.g.
+ * `[{_key: 'b0'}]`.
+ *
+ * @beta
+ */
+export function useDropPosition(
+  path: Path,
+): DropPosition['position'] | undefined {
+  const store = useContext(DndContext)
+
+  if (store === undefined) {
+    throw new Error('useDropPosition must be used below a <DndProvider>')
+  }
+
+  // Callers typically pass a fresh `path` array every render, so the
+  // serialized string, not the array, is what keeps `subscribe` stable
+  // below.
+  const serializedPath = serializePath(path)
+
+  const subscribe = useCallback(
+    (callback: () => void) => store.subscribeKey(serializedPath, callback),
+    [store, serializedPath],
+  )
+
+  const getSnapshot = () => store.get(serializedPath)
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/**
+ * Serialize a keyed path to a string using Sanity's bracket notation.
+ * Duplicated from the editor's internal `serializePath`; see
+ * `drag-selection.ts` for the duplication rationale.
+ */
+function serializePath(path: Path): string {
+  return path.reduce<string>((result, segment, index) => {
+    if (isKeyedSegment(segment)) {
+      return `${result}[_key=="${segment._key}"]`
+    }
+
+    const separator = index === 0 ? '' : '.'
+    return `${result}${separator}${segment}`
+  }, '')
+}

--- a/packages/plugin-dnd/tsconfig.dist.json
+++ b/packages/plugin-dnd/tsconfig.dist.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-dnd/tsconfig.json
+++ b/packages/plugin-dnd/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["**/*.ts", "**/*.tsx", "src/index.ts"],
+  "exclude": ["dist", "./node_modules"]
+}

--- a/packages/plugin-dnd/tsconfig.settings.json
+++ b/packages/plugin-dnd/tsconfig.settings.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": false
+  }
+}

--- a/packages/plugin-dnd/vitest.config.ts
+++ b/packages/plugin-dnd/vitest.config.ts
@@ -1,0 +1,48 @@
+import react from '@vitejs/plugin-react'
+import {playwright} from '@vitest/browser-playwright'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        plugins: [
+          react({
+            babel: {
+              plugins: [['babel-plugin-react-compiler', {target: '19'}]],
+            },
+          }),
+        ],
+        test: {
+          name: 'browser',
+          include: ['src/**/*.test.tsx'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [
+              {
+                browser: 'chromium',
+              },
+              {
+                browser: 'firefox',
+              },
+              {
+                browser: 'webkit',
+              },
+            ],
+            screenshotFailures: false,
+          },
+        },
+      },
+      {
+        plugins: [],
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+    ],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,57 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/plugin-dnd:
+    devDependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../editor
+      '@portabletext/schema':
+        specifier: workspace:^
+        version: link:../schema
+      '@portabletext/test':
+        specifier: workspace:^
+        version: link:../test
+      '@sanity/tsconfig':
+        specifier: ^2.1.0
+        version: 2.1.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser':
+        specifier: ^4.1.8
+        version: 4.1.8(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.1(jiti@2.6.1))
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.48.0
+        version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/plugin-emoji-picker:
     dependencies:
       '@portabletext/keyboard-shortcuts':
@@ -13788,6 +13839,10 @@ snapshots:
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
 
   '@types/react-is@19.2.0':
     dependencies:


### PR DESCRIPTION
Consumers who take over block rendering through the `defineX` pipeline see no indicator while dragging a block: the engine threads `dropPosition` only into the legacy render branch. That is deliberate. Drop indication is pointer-driven UI chrome, not document structure, and core should not be opinionated about it: some consumers want a line, some a gap animation, some nothing. Studio hits this directly in its render pipeline adoption, where its catch-all renders need to draw Studio's own indicator. The plugin owns the opinion instead.

```tsx
import {DndProvider, useDropPosition} from '@portabletext/plugin-dnd'

<EditorProvider initialConfig={...}>
  <DndProvider>
    <PortableTextEditable />
  </DndProvider>
</EditorProvider>

// in any render callback or component below the provider
const dropPosition = useDropPosition(props.path) // 'start' | 'end' | undefined
```

## Design notes

The position is derived entirely from the public `drag.*` behavior events. Two observe-and-forward behaviors mirror the engine's internal `behavior.core.drop-position.ts`: `drag.dragover` resolves a `DropPosition {path, position}` through the same guard chain (focus block at the event position, drag origin present, entire-blocks drag, never over the dragged blocks), and every other drag event clears it. One asymmetry against the internal implementation is load-bearing: the internal registration sits below core priority and can omit forwarding, but consumer behaviors run before the editor's own drag handling, so both behaviors here `forward` every event they touch or they would swallow the drag. Browser tests pin the guard contracts: block drags show the position, text drags show nothing, dragging over the dragged block itself shows nothing, and ending the drag clears.

The store follows the architecture established by `plugin-list-index`: one store per editor, stable handle through context, per-path subscriber buckets read via `useSyncExternalStore`, swap-before-notify. Granularity matters doubly here since `dragover` fires at mousemove frequency: moving a drag from one block to another notifies exactly the two affected buckets, the block losing the indicator and the block gaining it, pinned by a render-count test. The provider also clears the position on unmount, since a drag in progress never delivers its clearing event to a dead subscription.

`getDragSelection` (the entire-blocks expansion of the drag origin) and `serializePath` are duplicated from editor internals rather than exported: an export is permanent public API surface for what is an implementation detail of this plugin. Both duplicates are built on public primitives only and carry keep-in-sync pointers; the engine's 15-scenario `drag-selection` suite is ported wholesale as the drift alarm, with a local `createTestSnapshot` built on public types.
