### PR TITLE
docs: improve plugin-list-index README example and list it in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For documentation and guides, visit [portabletext.org](https://www.portabletext.
 | [`@portabletext/plugin-character-pair-decorator`](./packages/plugin-character-pair-decorator/) | Automatically match a pair of characters and decorate the text in between |
 | [`@portabletext/plugin-emoji-picker`](./packages/plugin-emoji-picker/)                         | Easily configure an Emoji Picker for the Portable Text Editor             |
 | [`@portabletext/plugin-input-rule`](./packages/plugin-input-rule/)                             | Easily configure Input Rules in the Portable Text Editor                  |
+| [`@portabletext/plugin-list-index`](./packages/plugin-list-index/)                             | Computes the list index of each list item for custom list rendering       |
 | [`@portabletext/plugin-markdown-shortcuts`](./packages/plugin-markdown-shortcuts/)             | Adds helpful Markdown shortcuts to the editor                             |
 | [`@portabletext/plugin-one-line`](./packages/plugin-one-line/)                                 | Restricts the Portable Text Editor to a single line                       |
 | [`@portabletext/plugin-paste-link`](./packages/plugin-paste-link/)                             | Allows pasting links in the Portable Text Editor                          |

--- a/packages/plugin-list-index/README.md
+++ b/packages/plugin-list-index/README.md
@@ -22,8 +22,17 @@ Typical use: custom text-block renders (`defineTextBlock`) that need to render n
 
 ```tsx
 function TextBlock(props: TextBlockRenderProps) {
+  // The 1-based position within the list, or `undefined` for a block that
+  // is not a list item. Render it as the marker for ordered lists.
   const listIndex = useListIndex(props.path)
-  return <div {...props.attributes}>{props.children}</div>
+  return (
+    <div {...props.attributes}>
+      {listIndex !== undefined ? (
+        <span contentEditable={false}>{listIndex}. </span>
+      ) : null}
+      {props.children}
+    </div>
+  )
 }
 
 defineTextBlock({type: '*', render: (props) => <TextBlock {...props} />})


### PR DESCRIPTION
Two small docs improvements now that `@portabletext/plugin-list-index` is published.

The package README's render example read `useListIndex(props.path)` but never used the value, leaving the one thing a consumer wants (rendering the marker) as a hand-wave. It now renders the 1-based index as an ordered-list marker, the actual use case.

The main README's plugins table didn't list `plugin-list-index`. Added, alphabetically.
