### PR TITLE
fix: select the inline object on dragstart instead of its text block

### DIFF
--- a/.changeset/dnd-inline-object-drag-selection.md
+++ b/.changeset/dnd-inline-object-drag-selection.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: select the inline object on dragstart instead of its text block
+
+Starting a drag on an inline object now drags only that inline object. Previously the entire enclosing text block was picked up and dragged instead.

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -10,6 +10,7 @@ import {isAncestorPath} from '../engine/path/is-ancestor-path'
 import {isEditableContainer} from '../schema/is-editable-container'
 import {getEnclosingBlock} from '../traversal/get-enclosing-block'
 import {getNode} from '../traversal/get-node'
+import {isLeafObject} from '../traversal/is-leaf-object'
 import type {EditorSelection} from '../types/editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
@@ -63,6 +64,27 @@ export function getEventPosition({
     event,
   })
   const eventSelection = getSelectionFromEvent(editorEngine, event) ?? null
+
+  if (
+    eventBlockPath &&
+    eventPositionBlock &&
+    !eventSelection &&
+    isLeafObject(editorEngine.snapshot, eventNode, eventPath) &&
+    eventPath.length > eventBlockPath.length
+  ) {
+    // An inline object produces no DOM caret selection on `dragstart`, so the
+    // whole-block fallback below would widen to the enclosing text block.
+    // Select the inline object itself instead.
+    return {
+      block: eventPositionBlock,
+      isEditor: false,
+      isContainer: false,
+      selection: {
+        anchor: {path: eventPath, offset: 0},
+        focus: {path: eventPath, offset: 0},
+      },
+    }
+  }
 
   if (
     eventBlock &&

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -8,6 +8,77 @@ import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('event.drag.drop', () => {
+  test('Scenario: dragstart on an inline object drags only the inline object', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const barKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo', marks: []},
+            {_type: 'stock-ticker', _key: stockTickerKey, symbol: 'AAPL'},
+            {_key: barKey, _type: 'span', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await userEvent.click(locator)
+
+    const stockTickerPath = [
+      {_key: blockKey},
+      'children',
+      {_key: stockTickerKey},
+    ]
+
+    // Unlike the other drag scenarios in this file, this one dispatches a real
+    // DOM `dragstart` instead of sending a hand-built `position`. The
+    // regression lives in `getEventPosition`, the DOM-event -> `position`
+    // translation that every payload-style drag test skips: a `dragstart` on
+    // an inline object produces no DOM caret selection, and the null-selection
+    // fallback used to widen to the whole enclosing text block. Dispatching the
+    // native event is the only seam that exercises that translation, and the
+    // resulting drag selection (which `drag.dragstart` writes back via
+    // `select`) is the observable proof of what was dragged.
+    const draggableElement = locator
+      .element()
+      .querySelector('[data-pt-inline="object"] [draggable="true"]')
+    assert(draggableElement, 'Expected the inline object to have a drag source')
+
+    const rect = draggableElement.getBoundingClientRect()
+    draggableElement.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: stockTickerPath, offset: 0},
+        focus: {path: stockTickerPath, offset: 0},
+        backward: false,
+      })
+    })
+  })
+
   test('Scenario: Dragging inline object', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()


### PR DESCRIPTION
Dragging an inline object (a `stock-ticker`, a mention chip, anything that renders inline) drags the entire enclosing text block instead of just the object. You grab the chip and the whole paragraph lifts with it.

`getEventPosition` is the function that turns a raw DOM drag/click event into an editor `position`, reading the DOM caret under the pointer via `getSelectionFromEvent`. An inline object is a void leaf with no editable text, so a `dragstart` fired on it yields no caret and `getSelectionFromEvent` returns `null`. When that happens `getEventPosition` falls back to "select whatever block the event came from", and resolves the event's *enclosing* block, which for an inline object is the text block that contains it. `getDragSelection` then faithfully drags that whole-block selection.

This is absent in v6 and present on v7; the exact commit that introduced it sits somewhere in the v7-line event-position rework (the Slate removal and the surrounding `getEventPosition` changes) and is not bisected here. It stayed silent regardless of origin because every drag test injects `position` directly via `editor.send` and never exercises `getEventPosition`, the seam the bug lives in.

The inline-object case is already handled correctly one layer down: `getDragSelection` has a branch (and unit coverage) that keeps a collapsed selection on the inline object. It just never gets to run, because the selection it receives from `getEventPosition` already points at the whole block. So the fix sits at the source. Before widening to the enclosing block, the missing-selection fallback now checks whether the event landed on an inline object: an `isLeafObject` node at a path deeper than its enclosing block. If so it returns a collapsed selection on the object itself.

```ts
if (
  eventBlockPath &&
  eventPositionBlock &&
  !eventSelection &&
  isLeafObject(snapshot, eventNode, eventPath) &&
  eventPath.length > eventBlockPath.length
) {
  return {/* ...collapsed selection on eventPath */}
}
```

The branch must precede the existing block fallback, otherwise the block fallback claims the event first. Net behavior is unchanged for every other drag source: a block object fails the depth check (its path *is* its enclosing block) and keeps the block-level path, a text span fails the leaf-object check and keeps the caret path. The emitted `position` only changes in the narrow case of a selection-less event landing on an inline object.

Because `getEventPosition` is the untested seam, the regression test has to drive it for real. The new scenario in `event.drag.drop.test.tsx` is the only drag test that dispatches a native DOM `dragstart` on the inline object's drag source and asserts the resulting drag selection collapses on the object; it fails on `main` (selection spans the whole block) and passes here. Existing drag browser tests and the 15-scenario `getDragSelection` unit suite stay green.
