### PR TITLE
fix(perf): stop per-operation O(n) rescans during bulk structural edits

### DIFF
--- a/.changeset/lazy-list-index-map.md
+++ b/.changeset/lazy-list-index-map.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): rebuild the list-index map lazily on read instead of per operation
+
+The map behind `data-list-index` on list items is now rebuilt once when the
+renderer reads it, rather than recomputed after every structural operation.
+Inserting or moving many blocks in one go no longer does per-block work that
+grows with document size, and the rendered index values are unchanged.

--- a/.changeset/verified-unique-key-scan.md
+++ b/.changeset/verified-unique-key-scan.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): scan each sibling group for duplicate keys once instead of per node
+
+Duplicate-`_key` normalization no longer slows down quadratically on large
+sibling groups: a group's keys are checked once and the verdict reused until
+the group changes, so bulk-inserting blocks or editing inside big documents
+is faster. Duplicate keys are still detected and fixed the same way.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -69,6 +69,7 @@ export function createEditorEngine(
   editor.history = {undos: [], redos: []}
 
   editor.listIndexMap = new Map<string, number>()
+  editor.listIndexMapDirty = false
   editor.remotePatches = []
   editor.undoStepId = undefined
 

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -70,6 +70,7 @@ export function createEditorEngine(
 
   editor.listIndexMap = new Map<string, number>()
   editor.listIndexMapDirty = false
+  editor.rootKeysVerifiedUnique = false
   editor.remotePatches = []
   editor.undoStepId = undefined
 

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -6,6 +6,7 @@ import {useRef, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
 import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
+import {getListIndexMap} from '../internal-utils/build-index-maps'
 import {serializePath} from '../paths/serialize-path'
 import type {
   BlockListItemRenderProps,
@@ -45,7 +46,7 @@ export function RenderTextBlock(props: {
   const focused = useIsFocusedContainer(serializedPath)
   const dropPosition = useElementDropPosition(props.path)
   const listIndex = useEngineSelector((editor) =>
-    editor.listIndexMap.get(serializedPath),
+    getListIndexMap(editor).get(serializedPath),
   )
   const subSchema = useBlockSubSchema(props.path)
 

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -1,5 +1,4 @@
 import {subscribeToOperations} from '../engine/core/operation-channel'
-import {buildListIndexMap} from '../internal-utils/build-index-maps'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
 import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
@@ -7,12 +6,15 @@ import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorContext} from './editor-snapshot'
 
 /**
- * Keeps `blockIndexMap` and `listIndexMap` in sync with the value.
- * `blockIndexMap` is transformed incrementally per operation;
- * `listIndexMap` is rebuilt because list-item numbering depends on
- * root-block adjacency, which any shallow op can disturb non-locally.
- * Both update synchronously within the apply that changed the value, so
- * subsequent operations and readers never observe stale maps.
+ * Keeps `blockIndexMap` in sync with the value, transforming it
+ * incrementally per operation so the operation pipeline (which resolves
+ * keyed paths through it) never observes a stale map.
+ *
+ * `listIndexMap` is only consumed by the text-block renderer, never by
+ * operations or selectors, so it is invalidated here and rebuilt lazily
+ * on read (`getListIndexMap`) instead of per operation. List-item
+ * numbering depends on block adjacency that any structural op can disturb
+ * non-locally, so any structural op marks it dirty.
  */
 export function subscribeUpdateValue(
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>,
@@ -59,19 +61,11 @@ export function subscribeUpdateValue(
       },
     )
 
-    // List index can only change as a result of root-level insert/remove or
-    // a property change on a root block. Deeper ops cannot shift list
-    // indexes.
-    if (operation.path.length <= 2) {
-      buildListIndexMap(
-        {
-          schema: context.schema,
-          value: editor.snapshot.context.value,
-          containers: editor.snapshot.context.containers,
-        },
-        editor.listIndexMap,
-      )
-    }
+    // List-item numbering depends on block adjacency that a structural op
+    // anywhere in the tree can disturb non-locally, so invalidate rather
+    // than reason about which paths matter. The map is rebuilt lazily the
+    // next time the renderer reads it.
+    editor.listIndexMapDirty = true
   })
 
   return () => {

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -1,9 +1,56 @@
 import {subscribeToOperations} from '../engine/core/operation-channel'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
 import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {EditorContext} from './editor-snapshot'
+
+/**
+ * Whether an operation can add, remove, or re-key a *direct* child of the
+ * root value array, the only kind of change that can introduce a duplicate
+ * key among root blocks. Deep operations (two or more node segments) edit
+ * inside a block and never touch root membership. Used to invalidate
+ * `editor.rootKeysVerifiedUnique`; over-reporting only costs an extra root
+ * scan, under-reporting would miss a duplicate, so the `set` case is the
+ * only one narrowed (a plain property write can't collide a key).
+ */
+function affectsRootMembership(operation: EngineOperation): boolean {
+  if (operation.type === 'set.selection') {
+    return false
+  }
+
+  if (operation.type === 'set' && operation.path.length === 0) {
+    return true
+  }
+
+  let nodeSegments = 0
+  for (const segment of operation.path) {
+    if (typeof segment === 'number' || isKeyedSegment(segment)) {
+      nodeSegments++
+    }
+  }
+
+  if (nodeSegments > 1) {
+    return false
+  }
+
+  if (operation.type === 'insert' || operation.type === 'unset') {
+    return true
+  }
+
+  if (operation.type === 'set') {
+    const lastSegment = operation.path[operation.path.length - 1]
+    return (
+      typeof lastSegment === 'number' ||
+      isKeyedSegment(lastSegment) ||
+      lastSegment === '_key'
+    )
+  }
+
+  return false
+}
 
 /**
  * Keeps `blockIndexMap` in sync with the value, transforming it
@@ -66,6 +113,10 @@ export function subscribeUpdateValue(
     // than reason about which paths matter. The map is rebuilt lazily the
     // next time the renderer reads it.
     editor.listIndexMapDirty = true
+
+    if (affectsRootMembership(operation)) {
+      editor.rootKeysVerifiedUnique = false
+    }
   })
 
   return () => {

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -30,6 +30,41 @@ import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
 
+/**
+ * Parent nodes whose direct children have been verified to carry no
+ * duplicate `_key`s. A node is an immutable reference: any structural
+ * change to its children mints a fresh parent reference, which is simply
+ * absent from the map, so the verdict can never go stale. A `WeakMap`
+ * lets collected nodes drop their entries.
+ *
+ * The root sibling group has no parent node (its container is the editor,
+ * whose reference never changes), so its verdict can't be tracked by
+ * reference. It lives in `editor.rootKeysVerifiedUnique` and is
+ * invalidated explicitly by the op stream whenever a root-level
+ * membership change occurs (see `subscribeUpdateValue`).
+ */
+const verifiedUniqueSiblingGroups = new WeakMap<object, true>()
+
+function siblingGroupIsVerifiedUnique(
+  editor: Editor,
+  parent: {node: Node} | undefined,
+): boolean {
+  return parent
+    ? verifiedUniqueSiblingGroups.has(parent.node)
+    : editor.rootKeysVerifiedUnique
+}
+
+function markSiblingGroupVerified(
+  editor: Editor,
+  parent: {node: Node} | undefined,
+): void {
+  if (parent) {
+    verifiedUniqueSiblingGroups.set(parent.node, true)
+  } else {
+    editor.rootKeysVerifiedUnique = true
+  }
+}
+
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
   entry,
@@ -169,49 +204,81 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Fix duplicate _key among siblings
   if (path.length > 0 && nodeRecord['_key'] !== undefined) {
     const parent = getParent(editor.snapshot, path)
-    const siblings = parent
-      ? getChildren(editor.snapshot, parent.path)
-      : editor.snapshot.context.value.map((child, index) => ({
-          node: child,
-          path: [{_key: child._key}],
-          index,
-        }))
+    // Verifying a sibling group has no duplicate keys is O(siblings); doing
+    // it per node is O(siblings^2) across the group. Skip the scan when the
+    // group was already verified unique (and not invalidated since). Without
+    // this, a bulk insert of n pre-keyed root blocks rescans the whole root
+    // group n times.
+    if (!siblingGroupIsVerifiedUnique(editor, parent)) {
+      const key = nodeRecord['_key'] as string
+      // The child array holding this node is the field segment right after
+      // the parent's path, so read it straight off the parent node instead
+      // of re-resolving children from the root through the schema. Fall
+      // back to `getChildren` only if that field isn't a plain array.
+      const childFieldName = parent ? path[parent.path.length] : undefined
+      const rawSiblings =
+        parent && typeof childFieldName === 'string'
+          ? (parent.node as Record<string, unknown>)[childFieldName]
+          : undefined
+      const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
+        ? editor.snapshot.context.value
+        : Array.isArray(rawSiblings)
+          ? (rawSiblings as ReadonlyArray<{_key?: string}>)
+          : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
 
-    const siblingList = [...siblings]
-    const key = nodeRecord['_key'] as string
+      let groupIsUnique = true
+      let duplicateIndexOfKey = -1
 
-    // Find all siblings with this key
-    let firstIndex = -1
-    for (let i = 0; i < siblingList.length; i++) {
-      if (siblingList[i]!.node._key === key) {
-        if (firstIndex === -1) {
-          firstIndex = i
-        } else {
-          // Found a duplicate: rename the later occurrence
-          const newKey = editor.snapshot.context.keyGenerator()
-          debug.normalization('Fixing duplicate key on node')
-          const dupParentPath = parent ? parent.path : []
-          const numericPath: Path =
-            dupParentPath.length === 0
-              ? [i]
-              : [
-                  ...dupParentPath,
-                  getChildFieldName(editor.snapshot.context, parent!.path) ??
-                    'children',
-                  i,
-                ]
-          editor.apply({
+      // A group of zero or one child can't hold a duplicate key, so skip
+      // the set-building scan. This is the common shape for container
+      // fields (a row's single cell, a cell's single content block).
+      if (siblingNodes.length > 1) {
+        const seenKeys = new Set<string>()
+        for (let index = 0; index < siblingNodes.length; index++) {
+          const siblingKey = siblingNodes[index]?._key
+          if (siblingKey === undefined) {
+            continue
+          }
+          if (seenKeys.has(siblingKey)) {
+            groupIsUnique = false
+            // The second occurrence of this node's own key is the one the
+            // previous per-node implementation renamed; preserve that so
+            // generated keys land on the same node.
+            if (siblingKey === key && duplicateIndexOfKey === -1) {
+              duplicateIndexOfKey = index
+            }
+          } else {
+            seenKeys.add(siblingKey)
+          }
+        }
+      }
+
+      if (duplicateIndexOfKey !== -1) {
+        const newKey = editor.snapshot.context.keyGenerator()
+        debug.normalization('Fixing duplicate key on node')
+        const numericPath: Path = parent
+          ? [
+              ...parent.path,
+              getChildFieldName(editor.snapshot.context, parent.path) ??
+                'children',
+              duplicateIndexOfKey,
+            ]
+          : [duplicateIndexOfKey]
+        editor.apply({
+          type: 'set',
+          path: [...numericPath, '_key'],
+          value: newKey,
+          inverse: {
             type: 'set',
             path: [...numericPath, '_key'],
-            value: newKey,
-            inverse: {
-              type: 'set',
-              path: [...numericPath, '_key'],
-              value: key,
-            },
-          })
-          return
-        }
+            value: key,
+          },
+        })
+        return
+      }
+
+      if (groupIsUnique) {
+        markSiblingGroupVerified(editor, parent)
       }
     }
   }

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -57,11 +57,10 @@ export function buildIndexMaps(
 
 /**
  * Mutates `listIndexMap` in place. Recomputes list-item indices for every
- * root block. Called per op by `updateValuePlugin` because list-item
- * numbering depends on root-block adjacency, which any structural op can
- * disturb non-locally.
+ * root block. Called lazily by `getListIndexMap` when the map is read after
+ * a structural change, and once at startup by `buildIndexMaps`.
  */
-export function buildListIndexMap(
+function buildListIndexMap(
   context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   listIndexMap: Map<string, number>,
 ): void {
@@ -175,6 +174,26 @@ export function buildListIndexMap(
       level: block.level,
     }
   }
+}
+
+/**
+ * Return `listIndexMap`, rebuilding it first if a structural operation has
+ * marked it dirty since the last read. The renderer is the only reader, so
+ * deferring the rebuild to read time turns a per-operation O(value) walk
+ * into at most one rebuild per render.
+ */
+export function getListIndexMap(editor: {
+  listIndexMap: Map<string, number>
+  listIndexMapDirty: boolean
+  snapshot: {
+    context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  }
+}): Map<string, number> {
+  if (editor.listIndexMapDirty) {
+    buildListIndexMap(editor.snapshot.context, editor.listIndexMap)
+    editor.listIndexMapDirty = false
+  }
+  return editor.listIndexMap
 }
 
 export function collectDescendantIndexes(

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -52,6 +52,16 @@ export interface PortableTextEditorEngine extends DOMEditor {
    * per render, regardless of how many operations a batch applied.
    */
   listIndexMapDirty: boolean
+  /**
+   * Whether the root sibling group (the editor's direct children) is known
+   * to carry no duplicate `_key`s. Normalization sets it after a clean scan
+   * and the op stream clears it whenever a root-level membership change
+   * could introduce a collision, letting per-node duplicate-key
+   * normalization skip re-scanning an unchanged root group. Nested groups
+   * track the same verdict by parent-node reference inside `normalizeNode`;
+   * the root has no stable parent node, so it needs an explicit flag.
+   */
+  rootKeysVerifiedUnique: boolean
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
 

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -43,6 +43,15 @@ export interface PortableTextEditorEngine extends DOMEditor {
   blockIndexMap: Map<string, number>
   history: History
   listIndexMap: Map<string, number>
+  /**
+   * `listIndexMap` is derived from the whole value (list-item numbering
+   * depends on block adjacency), so structural operations invalidate it
+   * rather than rebuild it. The only reader is the text-block renderer,
+   * which rebuilds on demand via `getListIndexMap`. Deferring the rebuild
+   * to read time collapses a per-operation O(value) walk into one rebuild
+   * per render, regardless of how many operations a batch applied.
+   */
+  listIndexMapDirty: boolean
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
 


### PR DESCRIPTION
Inserting many blocks at once, or editing inside a large document, did work whose cost grew with the size of the whole document on every operation, so a bulk insert of N blocks spent O(N^2) in the engine before React ever rendered. Two independent per-operation rescans were responsible; this removes both. Each is its own commit.

## `listIndexMap` rebuilt on every operation

`listIndexMap` (the source of `data-list-index` on rendered list items) is derived from the whole value, because list-item numbering depends on block adjacency. The update-value subscriber rebuilt it from scratch after every operation whose path was at most two segments deep, walking all root blocks each time. A batch of N root operations therefore did N full walks, O(N^2), even though nothing reads the map until the next render, and the `path.length <= 2` gate silently assumed list numbering can only live at the document root.

The only reader is the text-block renderer. Structural operations now just mark the map dirty (on any path, dropping the depth assumption) and `getListIndexMap` rebuilds it on the next read, so a batch collapses to a single rebuild per render and the map stays correct for structural changes at any depth.

## Duplicate-`_key` normalization scanned siblings per node

`normalizeNode`'s duplicate-key fix resolved one node at a time: for each dirty node it fetched the node's siblings and scanned them for a collision, and at the root it rebuilt a wrapper array (`value.map(...)` plus a spread) per node. Normalizing a sibling group of n nodes was O(n^2) and, at the root, allocated O(n) throwaway arrays per node, so a bulk insert of pre-keyed blocks spent O(n^2) here finding nothing, because the keys were already unique.

A sibling group's key-uniqueness only changes when its membership changes, which mints a fresh parent reference. Nested groups now cache the verified-unique verdict in a `WeakMap` keyed by parent node and re-scan only when that reference changes. The root group has no parent node (its container is the editor, whose reference never changes), so its verdict lives in `editor.rootKeysVerifiedUnique`, set after a clean scan and cleared by the op stream only when an operation can add, remove, or re-key a direct root child (`affectsRootMembership`). The scan itself reads the raw child array straight off the parent node (the field segment is already in the node's path) instead of re-resolving children through the schema, and short-circuits groups of one child, which can never collide. The membership condition is exact, not a depth heuristic, and over-reports rather than under-reports, so a missed duplicate is impossible.

## Blast radius

Net behavior is unchanged: rendered `data-list-index` values are identical, and duplicate keys are still detected and the same later occurrence re-keyed in the same order. Only when the work happens changed (per-operation to per-read for the list map; once-per-group instead of once-per-node for the key scan). The full unit suite (801) and the chromium (1645) and webkit (1624) browser suites pass; `tests/focus.test.tsx` fails only in firefox and fails identically on `main` (it passes in isolation; a pre-existing focus-stealing flake), so it is untouched by this change.

Chromium, headless, medians of 3 runs, `tests/performance.test.tsx`:

| scenario | before | after |
|---|---|---|
| insert 1000 blocks (empty editor) | 244ms | 210ms |
| insert 1000 blocks before a block | 182ms | 149ms |
| insert 1000 blocks after a block | 159ms | 130ms |
| insert 1000 tables (empty editor) | 723ms | 624ms |
| insert 1000 tables before a block | 739ms | 635ms |
| insert 1000 tables after a block | 767ms | 591ms |

The remaining time is dominated by React mounting the 1000 components, which is inherent and untouched.
