### PR TITLE
fix(perf): rebuild the list-index map lazily on read instead of per operation

### DIFF
--- a/.changeset/lazy-list-index-map.md
+++ b/.changeset/lazy-list-index-map.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): rebuild the list-index map lazily on read instead of per operation
+
+The map behind `data-list-index` on list items is now rebuilt once when the
+renderer reads it, rather than recomputed after every structural operation.
+Inserting or moving many blocks in one go no longer does per-block work that
+grows with document size, and the rendered index values are unchanged.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -69,6 +69,7 @@ export function createEditorEngine(
   editor.history = {undos: [], redos: []}
 
   editor.listIndexMap = new Map<string, number>()
+  editor.listIndexMapDirty = false
   editor.remotePatches = []
   editor.undoStepId = undefined
 

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -6,6 +6,7 @@ import {useRef, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
 import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
+import {getListIndexMap} from '../internal-utils/build-index-maps'
 import {serializePath} from '../paths/serialize-path'
 import type {
   BlockListItemRenderProps,
@@ -45,7 +46,7 @@ export function RenderTextBlock(props: {
   const focused = useIsFocusedContainer(serializedPath)
   const dropPosition = useElementDropPosition(props.path)
   const listIndex = useEngineSelector((editor) =>
-    editor.listIndexMap.get(serializedPath),
+    getListIndexMap(editor).get(serializedPath),
   )
   const subSchema = useBlockSubSchema(props.path)
 

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -1,5 +1,4 @@
 import {subscribeToOperations} from '../engine/core/operation-channel'
-import {buildListIndexMap} from '../internal-utils/build-index-maps'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
 import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
@@ -7,12 +6,15 @@ import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorContext} from './editor-snapshot'
 
 /**
- * Keeps `blockIndexMap` and `listIndexMap` in sync with the value.
- * `blockIndexMap` is transformed incrementally per operation;
- * `listIndexMap` is rebuilt because list-item numbering depends on
- * root-block adjacency, which any shallow op can disturb non-locally.
- * Both update synchronously within the apply that changed the value, so
- * subsequent operations and readers never observe stale maps.
+ * Keeps `blockIndexMap` in sync with the value, transforming it
+ * incrementally per operation so the operation pipeline (which resolves
+ * keyed paths through it) never observes a stale map.
+ *
+ * `listIndexMap` is only consumed by the text-block renderer, never by
+ * operations or selectors, so it is invalidated here and rebuilt lazily
+ * on read (`getListIndexMap`) instead of per operation. List-item
+ * numbering depends on block adjacency that any structural op can disturb
+ * non-locally, so any structural op marks it dirty.
  */
 export function subscribeUpdateValue(
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>,
@@ -59,19 +61,11 @@ export function subscribeUpdateValue(
       },
     )
 
-    // List index can only change as a result of root-level insert/remove or
-    // a property change on a root block. Deeper ops cannot shift list
-    // indexes.
-    if (operation.path.length <= 2) {
-      buildListIndexMap(
-        {
-          schema: context.schema,
-          value: editor.snapshot.context.value,
-          containers: editor.snapshot.context.containers,
-        },
-        editor.listIndexMap,
-      )
-    }
+    // List-item numbering depends on block adjacency that a structural op
+    // anywhere in the tree can disturb non-locally, so invalidate rather
+    // than reason about which paths matter. The map is rebuilt lazily the
+    // next time the renderer reads it.
+    editor.listIndexMapDirty = true
   })
 
   return () => {

--- a/packages/editor/src/internal-utils/build-index-maps.ts
+++ b/packages/editor/src/internal-utils/build-index-maps.ts
@@ -57,11 +57,10 @@ export function buildIndexMaps(
 
 /**
  * Mutates `listIndexMap` in place. Recomputes list-item indices for every
- * root block. Called per op by `updateValuePlugin` because list-item
- * numbering depends on root-block adjacency, which any structural op can
- * disturb non-locally.
+ * root block. Called lazily by `getListIndexMap` when the map is read after
+ * a structural change, and once at startup by `buildIndexMaps`.
  */
-export function buildListIndexMap(
+function buildListIndexMap(
   context: Pick<EditorContext, 'schema' | 'value' | 'containers'>,
   listIndexMap: Map<string, number>,
 ): void {
@@ -175,6 +174,26 @@ export function buildListIndexMap(
       level: block.level,
     }
   }
+}
+
+/**
+ * Return `listIndexMap`, rebuilding it first if a structural operation has
+ * marked it dirty since the last read. The renderer is the only reader, so
+ * deferring the rebuild to read time turns a per-operation O(value) walk
+ * into at most one rebuild per render.
+ */
+export function getListIndexMap(editor: {
+  listIndexMap: Map<string, number>
+  listIndexMapDirty: boolean
+  snapshot: {
+    context: Pick<EditorContext, 'schema' | 'value' | 'containers'>
+  }
+}): Map<string, number> {
+  if (editor.listIndexMapDirty) {
+    buildListIndexMap(editor.snapshot.context, editor.listIndexMap)
+    editor.listIndexMapDirty = false
+  }
+  return editor.listIndexMap
 }
 
 export function collectDescendantIndexes(

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -43,6 +43,15 @@ export interface PortableTextEditorEngine extends DOMEditor {
   blockIndexMap: Map<string, number>
   history: History
   listIndexMap: Map<string, number>
+  /**
+   * `listIndexMap` is derived from the whole value (list-item numbering
+   * depends on block adjacency), so structural operations invalidate it
+   * rather than rebuild it. The only reader is the text-block renderer,
+   * which rebuilds on demand via `getListIndexMap`. Deferring the rebuild
+   * to read time collapses a per-operation O(value) walk into one rebuild
+   * per render, regardless of how many operations a batch applied.
+   */
+  listIndexMapDirty: boolean
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
 


### PR DESCRIPTION
Editing a document rebuilt `listIndexMap` from scratch on every structural operation, walking the entire value each time, so a batch of N operations did N full O(value) walks before React ever rendered. Nothing reads the map until render, and the rebuild was gated on `operation.path.length <= 2`, silently assuming list-item numbering can only live at the document root.

`listIndexMap` (the source of `data-list-index` on rendered list items) is consumed only by the text-block renderer, never by operations or selectors. Structural operations now just mark it dirty (on any path, dropping the depth assumption) and `getListIndexMap` rebuilds it the next time the renderer reads it. A batch of operations collapses to one rebuild per render regardless of size, and the map stays correct for structural changes at any depth, not just the root.

Net behavior is unchanged: the rendered `data-list-index` values are identical; only when the rebuild happens moved from per-operation to per-read.

This is one of two extracted performance PRs. The other (`editor-perf-dedupe-key-scan`) removes a separate per-operation O(n) rescan from duplicate-key normalization; the two target different costs and are additive. They touch the same engine fields (`subscribeUpdateValue`, the engine type, engine setup), so whichever merges second needs a trivial rebase.

Chromium, headless, medians of 3 runs, `tests/performance.test.tsx`, this change alone vs `main`:

| scenario | before | after |
|---|---|---|
| insert 1000 blocks (empty editor) | 244ms | 237ms |
| insert 1000 tables (empty editor) | 723ms | 681ms |

The larger win shows on list-heavy or large documents, where the per-operation full walk dominated; the generic insert benchmark only lightly exercises it.
