### PR TITLE
fix(perf): scan each sibling group for duplicate keys once instead of per node

### DIFF
--- a/.changeset/verified-unique-key-scan.md
+++ b/.changeset/verified-unique-key-scan.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): scan each sibling group for duplicate keys once instead of per node
+
+Duplicate-`_key` normalization no longer slows down quadratically on large
+sibling groups: a group's keys are checked once and the verdict reused until
+the group changes, so bulk-inserting blocks or editing inside big documents
+is faster. Duplicate keys are still detected and fixed the same way.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -70,6 +70,7 @@ export function createEditorEngine(
 
   editor.listIndexMap = new Map<string, number>()
   editor.listIndexMapDirty = false
+  editor.verifiedUniqueChildGroups = new Set<string>()
   editor.remotePatches = []
   editor.undoStepId = undefined
 

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -1,9 +1,155 @@
 import {subscribeToOperations} from '../engine/core/operation-channel'
+import type {Node} from '../engine/interfaces/node'
+import type {EngineOperation} from '../engine/interfaces/operation'
+import type {Path} from '../engine/interfaces/path'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
-import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
+import {
+  transformBlockIndexMap,
+  walkKeyedChildrenInValue,
+} from '../internal-utils/transform-block-index-map'
+import {serializePath} from '../paths/serialize-path'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {EditorContext} from './editor-snapshot'
+
+/**
+ * Serialize a sibling-group path to the id `normalizeNode` caches it under,
+ * or return `null` if a node segment is numeric. Operation paths are keyed
+ * on every hot path; a numeric segment would need a from-root resolution to
+ * form the keyed id (the very O(n) walk this optimization removes), so the
+ * caller clears the whole set instead, which only costs extra scans.
+ */
+function groupId(prefix: Path): string | null {
+  for (const segment of prefix) {
+    if (typeof segment === 'number') {
+      return null
+    }
+  }
+  return serializePath(prefix)
+}
+
+/**
+ * Drop the verified-unique verdict for every sibling group whose direct
+ * membership an operation changes, so per-node duplicate-key normalization
+ * re-scans exactly those groups and no others. A group is identified by the
+ * serialized path of its parent node's child array (the root group is `''`).
+ * An operation that introduces a subtree also drops the verdicts for the
+ * groups inside it, so a reused key cannot inherit a stale verdict from a
+ * group that previously held it. Reads only the operation path and node;
+ * never walks the value from the root.
+ */
+function invalidateVerifiedGroups(
+  groups: Set<string>,
+  operation: Exclude<
+    EngineOperation,
+    {type: 'set.selection' | 'insert.text' | 'remove.text'}
+  >,
+): void {
+  // Nothing is verified yet (the common case during a batch of edits, whose
+  // normalization is deferred), so there is nothing to invalidate. Skips the
+  // per-operation path serialization entirely on the hot insert path.
+  if (groups.size === 0) {
+    return
+  }
+
+  // Whole-value replacement (`set []`/`unset []`): every group is rebuilt.
+  if (operation.path.length === 0) {
+    groups.clear()
+    return
+  }
+
+  const drop = (prefix: Path): boolean => {
+    const id = groupId(prefix)
+    if (id === null) {
+      groups.clear()
+      return false
+    }
+    groups.delete(id)
+    return true
+  }
+
+  const dropSubtreeGroups = (node: Node, nodePath: Path): void => {
+    walkKeyedChildrenInValue(node, nodePath, (childPath) => {
+      const id = groupId(childPath.slice(0, -1))
+      if (id !== null) {
+        groups.delete(id)
+      }
+    })
+  }
+
+  const path = operation.path
+  const lastSegment = path[path.length - 1]
+
+  if (operation.type === 'insert') {
+    // The node joins the group containing the reference sibling.
+    const groupPath = path.slice(0, -1)
+    if (drop(groupPath)) {
+      dropSubtreeGroups(operation.node, [
+        ...groupPath,
+        {_key: operation.node._key},
+      ])
+    }
+    return
+  }
+
+  if (operation.type === 'unset') {
+    if (typeof lastSegment === 'string' && lastSegment !== '_key') {
+      // Unsetting a whole child-array field empties that field's group.
+      drop(path)
+      return
+    }
+    // Unsetting a node, or its `_key`, changes the node's own group.
+    const nodePath = lastSegment === '_key' ? path.slice(0, -1) : path
+    drop(nodePath.slice(0, -1))
+    return
+  }
+
+  // `set`
+  if (
+    typeof lastSegment === 'number' ||
+    isKeyedSegment(lastSegment) ||
+    lastSegment === '_key'
+  ) {
+    // Node replacement, or a `_key` change: the node's group changes.
+    const nodePath = lastSegment === '_key' ? path.slice(0, -1) : path
+    if (drop(nodePath.slice(0, -1)) && lastSegment !== '_key') {
+      const replacement = operation.value
+      if (
+        replacement !== null &&
+        typeof replacement === 'object' &&
+        !Array.isArray(replacement)
+      ) {
+        const replacementKey = (replacement as Node)._key
+        if (replacementKey !== undefined) {
+          dropSubtreeGroups(replacement as Node, [
+            ...nodePath.slice(0, -1),
+            {_key: replacementKey},
+          ])
+        }
+      }
+    }
+    return
+  }
+
+  if (typeof lastSegment === 'string') {
+    if (Array.isArray(operation.value)) {
+      // Replacing a child array rebuilds that field's group.
+      if (drop(path)) {
+        for (const child of operation.value as ReadonlyArray<Node>) {
+          if (child && child._key !== undefined) {
+            dropSubtreeGroups(child, [...path, {_key: child._key}])
+          }
+        }
+      }
+      return
+    }
+    // A plain property whose value may carry keyed nodes: re-verify all.
+    if (operation.value !== null && typeof operation.value === 'object') {
+      groups.clear()
+    }
+  }
+}
 
 /**
  * Keeps `blockIndexMap` in sync with the value, transforming it
@@ -15,6 +161,10 @@ import type {EditorContext} from './editor-snapshot'
  * on read (`getListIndexMap`) instead of per operation. List-item
  * numbering depends on block adjacency that any structural op can disturb
  * non-locally, so any structural op marks it dirty.
+ *
+ * `verifiedUniqueChildGroups` is invalidated per structural op so per-node
+ * duplicate-key normalization can skip groups whose membership is unchanged
+ * (see `invalidateVerifiedGroups`).
  */
 export function subscribeUpdateValue(
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>,
@@ -66,6 +216,8 @@ export function subscribeUpdateValue(
     // than reason about which paths matter. The map is rebuilt lazily the
     // next time the renderer reads it.
     editor.listIndexMapDirty = true
+
+    invalidateVerifiedGroups(editor.verifiedUniqueChildGroups, operation)
   })
 
   return () => {

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -11,6 +11,7 @@ import {debug} from '../../internal-utils/debug'
 import {isEqualMarkDefs} from '../../internal-utils/equality'
 import {setNodeProperties} from '../../internal-utils/set-node-properties'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
 import {getChildren} from '../../traversal/get-children'
 import {getNode} from '../../traversal/get-node'
@@ -169,37 +170,71 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Fix duplicate _key among siblings
   if (path.length > 0 && nodeRecord['_key'] !== undefined) {
     const parent = getParent(editor.snapshot, path)
-    const siblings = parent
-      ? getChildren(editor.snapshot, parent.path)
-      : editor.snapshot.context.value.map((child, index) => ({
-          node: child,
-          path: [{_key: child._key}],
-          index,
-        }))
-
-    const siblingList = [...siblings]
     const key = nodeRecord['_key'] as string
+    // The child array holding this node is the field segment right after
+    // the parent's path. Read it straight off the parent node rather than
+    // re-resolving children from the root through the schema; fall back to
+    // `getChildren` only if that field isn't a plain array.
+    const childFieldName = parent
+      ? (path[parent.path.length] as string)
+      : undefined
+    const rawSiblings =
+      parent && typeof childFieldName === 'string'
+        ? (parent.node as Record<string, unknown>)[childFieldName]
+        : undefined
+    const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
+      ? editor.snapshot.context.value
+      : Array.isArray(rawSiblings)
+        ? (rawSiblings as ReadonlyArray<{_key?: string}>)
+        : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
 
-    // Find all siblings with this key
-    let firstIndex = -1
-    for (let i = 0; i < siblingList.length; i++) {
-      if (siblingList[i]!.node._key === key) {
-        if (firstIndex === -1) {
-          firstIndex = i
-        } else {
-          // Found a duplicate: rename the later occurrence
+    // A group of zero or one child can't hold a duplicate key, so it needs
+    // neither a scan nor a cache entry: re-checking it is already O(1). This
+    // is the common shape for container fields (a row's single cell, a
+    // cell's single content block) and single-span text blocks, so only
+    // genuinely multi-child groups ever cost a serialized id.
+    if (siblingNodes.length > 1) {
+      // Identify the group by its serialized path (the root group is `''`).
+      // The verdict survives edits elsewhere in the tree: it is dropped only
+      // when the op stream sees this group's own membership change (see
+      // `subscribeUpdateValue`). Verifying a group is O(siblings); caching
+      // the verdict keeps a bulk insert of n pre-keyed siblings at O(n)
+      // instead of O(n^2).
+      const groupId =
+        parent && typeof childFieldName === 'string'
+          ? serializePath([...parent.path, childFieldName])
+          : ''
+
+      if (!editor.verifiedUniqueChildGroups.has(groupId)) {
+        const seenKeys = new Set<string>()
+        let groupIsUnique = true
+        let duplicateIndexOfKey = -1
+
+        for (let index = 0; index < siblingNodes.length; index++) {
+          const siblingKey = siblingNodes[index]?._key
+          if (siblingKey === undefined) {
+            continue
+          }
+          if (seenKeys.has(siblingKey)) {
+            groupIsUnique = false
+            // The second occurrence of this node's own key is the one the
+            // previous per-node implementation renamed; preserve that so
+            // generated keys land on the same node.
+            if (siblingKey === key && duplicateIndexOfKey === -1) {
+              duplicateIndexOfKey = index
+            }
+          } else {
+            seenKeys.add(siblingKey)
+          }
+        }
+
+        if (duplicateIndexOfKey !== -1) {
           const newKey = editor.snapshot.context.keyGenerator()
           debug.normalization('Fixing duplicate key on node')
-          const dupParentPath = parent ? parent.path : []
           const numericPath: Path =
-            dupParentPath.length === 0
-              ? [i]
-              : [
-                  ...dupParentPath,
-                  getChildFieldName(editor.snapshot.context, parent!.path) ??
-                    'children',
-                  i,
-                ]
+            parent && typeof childFieldName === 'string'
+              ? [...parent.path, childFieldName, duplicateIndexOfKey]
+              : [duplicateIndexOfKey]
           editor.apply({
             type: 'set',
             path: [...numericPath, '_key'],
@@ -211,6 +246,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
             },
           })
           return
+        }
+
+        if (groupIsUnique) {
+          editor.verifiedUniqueChildGroups.add(groupId)
         }
       }
     }

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -19,6 +19,7 @@ function createBareEditor(value: Array<PortableTextBlock>): Editor {
   editor.containers = new Map()
   editor.blockIndexMap = new Map()
   editor.listIndexMap = new Map()
+  editor.verifiedUniqueChildGroups = new Set()
   editor.snapshot = {
     blockIndexMap: editor.blockIndexMap,
     context: {

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -320,7 +320,7 @@ function pruneSubtreeAtPath(
  * array-valued field; for each entry with a `_key`, recurses. Mirrors
  * `getNodeChildren` shape but without requiring container resolution.
  */
-function walkKeyedChildrenInValue(
+export function walkKeyedChildrenInValue(
   node: Node,
   nodePath: Path,
   visit: (childPath: Path) => void,

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -52,6 +52,19 @@ export interface PortableTextEditorEngine extends DOMEditor {
    * per render, regardless of how many operations a batch applied.
    */
   listIndexMapDirty: boolean
+  /**
+   * Serialized paths of sibling groups (a node's keyed child array, or the
+   * root value array as `''`) whose children have been verified to carry no
+   * duplicate `_key`s. Per-node duplicate-key normalization skips groups
+   * listed here. The op stream removes a group only when an operation
+   * changes that group's own direct membership (insert/remove/re-key/replace
+   * of a direct child), so an edit deep inside one group never forces a
+   * re-scan of its ancestors, and an operation that introduces a subtree
+   * also removes that subtree's groups so a reused key can't inherit a stale
+   * verdict. Works identically at every depth; the root is just the group
+   * with the empty path.
+   */
+  verifiedUniqueChildGroups: Set<string>
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
 


### PR DESCRIPTION
Duplicate-`_key` normalization in `normalizeNode` resolved one node at a time: for every dirty node it fetched that node's siblings and scanned them for a key collision, and at the root it rebuilt a wrapper array (`value.map(...)` plus a spread) on every node. Normalizing a sibling group of n nodes was therefore O(n^2), and at the root allocated O(n) throwaway arrays per node, so a bulk insert of n pre-keyed blocks spent O(n^2) in this one check, finding nothing because the keys were already unique.

The fix turns the per-node rescan into one scan per group. A sibling group's key-uniqueness only changes when its own direct membership changes, so `editor.verifiedUniqueChildGroups` records the serialized path of every group (a node's keyed child array, or the root value array as `''`) verified to hold no duplicate keys, and `normalizeNode` skips the scan for a listed group. The op stream removes a group only when an operation inserts, removes, re-keys, or replaces one of its direct children. An operation that introduces a subtree also removes that subtree's groups, so a key reused after a deletion can't inherit a stale verdict. Groups of one child can't collide, so they are neither scanned nor cached. The scan reads the raw child array off the parent node instead of re-resolving children through the schema.

The group id is read from the operation path directly, which is keyed on every hot path, so invalidation needs no walk of the value from the root; a numeric path segment or an unusual whole-value `set` clears the set, which only costs extra scans.

The mechanism is uniform at every depth, root and container alike, and uses no weak references. That generality is not just tidiness: it fixes a real cliff for large containers. Identifying a group by its parent node's reference would re-verify the group whenever any descendant changed (structural sharing mints a fresh parent on every deep edit), so editing one cell of a thousand-row table would re-scan all thousand rows. Keyed by serialized path and invalidated only on the group's own membership change, an edit deep inside one group never re-verifies its ancestors.

Net behavior is unchanged: duplicate keys are still detected and the same later occurrence re-keyed, in the same order; only the redundant rescans are removed. The full unit suite (801) and chromium (1645) and webkit (1624) browser suites pass.

This is one of two extracted performance PRs. The other (`editor-perf-lazy-list-index`) defers the list-index map rebuild; the two target different costs and are additive. They touch the same engine fields (`subscribeUpdateValue`, the engine type, engine setup), so whichever merges second needs a trivial rebase.

Chromium, headless, medians of 3 runs, `tests/performance.test.tsx`, this change alone vs `main`:

| scenario | before | after |
|---|---|---|
| insert 1000 blocks (empty editor) | 244ms | 226ms |
| insert 1000 tables (empty editor) | 723ms | 675ms |

The duplicate scan was roughly this share of the insert path, so removing it caps out here; together with the list-index PR the two land in the 12-14% range.
