### PR TITLE
docs: generate `llms.txt` and serve `robots.txt`

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight'
 import tailwindcss from '@tailwindcss/vite'
 import {defineConfig} from 'astro/config'
 import starlightLinksValidator from 'starlight-links-validator'
+import starlightLlmsTxt from 'starlight-llms-txt'
 import {createStarlightTypeDocPlugin} from 'starlight-typedoc'
 
 const [editorTypeDoc, editorTypeDocSidebar] = createStarlightTypeDocPlugin()
@@ -194,6 +195,14 @@ export default defineConfig({
         },
       ],
       plugins: [
+        starlightLlmsTxt({
+          description:
+            'Portable Text is a JSON-based specification for structured block content, with an official headless React editor and serializers for React, HTML, Markdown, Vue, and Svelte.',
+          // The splash page mounts a live <PortableTextEditor> React island, and
+          // the plugin's container has no React renderer, so it serves the raw
+          // MDX body instead of trying to render framework components to text.
+          rawContent: true,
+        }),
         editorTypeDoc({
           entryPoints: ['../../packages/editor/src/index.ts'],
           output: 'api/editor',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,5 +46,8 @@
     "ts-morph": "^27.0.2",
     "typedoc": "^0.28.15",
     "typedoc-plugin-markdown": "^4.8.0"
+  },
+  "devDependencies": {
+    "starlight-llms-txt": "^0.10.0"
   }
 }

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.portabletext.org/sitemap-index.xml

--- a/apps/docs/src/content/docs/editor/concepts/behavior.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/behavior.mdx
@@ -1,6 +1,6 @@
 ---
 title: Behaviors
-description: Description of behaviors
+description: How behaviors intercept and transform editor events to customize the Portable Text Editor's editing logic.
 ---
 
 import {CardGrid, LinkCard} from '@astrojs/starlight/components'

--- a/apps/docs/src/content/docs/editor/reference/editor.mdx
+++ b/apps/docs/src/content/docs/editor/reference/editor.mdx
@@ -1,6 +1,6 @@
 ---
 title: Editor API overview
-description: Editor API reference overview
+description: Hooks for accessing the Portable Text Editor instance and deriving state with selectors.
 ---
 
 The editor API provides access to the editor instance and selectors for deriving state.

--- a/apps/docs/src/content/docs/editor/reference/keyboard-shortcuts.mdx
+++ b/apps/docs/src/content/docs/editor/reference/keyboard-shortcuts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Keyboard shortcuts API overview
-description: Keyboard Shortcuts reference
+description: Drop-in and custom keyboard shortcuts for the Portable Text Editor via @portabletext/keyboard-shortcuts.
 prev: false
 next: false
 ---

--- a/apps/docs/src/content/docs/editor/reference/plugins.mdx
+++ b/apps/docs/src/content/docs/editor/reference/plugins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-description: Plugins reference
+description: React components placed inside the EditorProvider to register behaviors and extend the Portable Text Editor.
 prev: false
 next: false
 ---

--- a/apps/docs/src/content/docs/editor/reference/selectors.mdx
+++ b/apps/docs/src/content/docs/editor/reference/selectors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Selectors API overview
-description: Selectors reference
+description: Pure functions that derive state from the editor snapshot, used to build behaviors and toolbar components.
 prev: false
 next: false
 ---

--- a/apps/docs/src/content/docs/editor/reference/toolbar.mdx
+++ b/apps/docs/src/content/docs/editor/reference/toolbar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toolbar API overview
-description: Toolbar reference
+description: Hooks and types from @portabletext/toolbar for building custom toolbars for the Portable Text Editor.
 prev: false
 next: false
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,10 @@ importers:
       typedoc-plugin-markdown:
         specifier: ^4.8.0
         version: 4.9.0(typedoc@0.28.15(typescript@5.9.3))
+    devDependencies:
+      starlight-llms-txt:
+        specifier: ^0.10.0
+        version: 0.10.0(@astrojs/starlight@0.38.2(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/playground:
     dependencies:
@@ -5324,6 +5328,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -5386,6 +5393,9 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/micromatch@4.0.10':
+    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -6675,6 +6685,9 @@ packages:
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-mdast@10.1.2:
+    resolution: {integrity: sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==}
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
@@ -8035,6 +8048,9 @@ packages:
   rehype-format@5.0.1:
     resolution: {integrity: sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==}
 
+  rehype-minify-whitespace@6.0.2:
+    resolution: {integrity: sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -8043,6 +8059,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-remark@10.0.1:
+    resolution: {integrity: sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -8375,6 +8394,12 @@ packages:
       '@astrojs/starlight': '>=0.38.0'
       astro: '>=6.0.0'
 
+  starlight-llms-txt@0.10.0:
+    resolution: {integrity: sha512-LgkSjkvdACsGHkFq1ES00F0BU4lRepjJoaUmOgxBxNWx4txwpySVPtntKdAvDvlhinyN0ZBRpnAsN/sVQ1UEfA==}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.38.0'
+      astro: ^6.0.0
+
   starlight-package-managers@0.12.0:
     resolution: {integrity: sha512-hAIVzOT0/Git+T2Uwckh2rs51fYiDM6/X+Z2f3LtKMSwOwm+nSUAX2Ilp7k+07LDtxYjmvfTCxhfIBt0PgOF5g==}
     engines: {node: '>=18.17.1'}
@@ -8621,6 +8646,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trim-trailing-lines@2.1.0:
+    resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -8749,6 +8777,9 @@ packages:
 
   unist-util-remove-position@5.0.0:
     resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
+
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -13570,6 +13601,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/braces@3.0.5': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -13635,6 +13668,10 @@ snapshots:
   '@types/mdurl@2.0.0': {}
 
   '@types/mdx@2.0.13': {}
+
+  '@types/micromatch@4.0.10':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@2.1.0': {}
 
@@ -15417,6 +15454,23 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-mdast@10.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      hast-util-phrasing: 3.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-text: 4.0.2
+      hast-util-whitespace: 3.0.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-hast: 13.2.1
+      mdast-util-to-string: 4.0.0
+      rehype-minify-whitespace: 6.0.2
+      trim-trailing-lines: 2.1.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
 
   hast-util-to-parse5@8.0.1:
     dependencies:
@@ -17206,6 +17260,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-format: 1.1.0
 
+  rehype-minify-whitespace@6.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-minify-whitespace: 1.0.1
+
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -17225,6 +17284,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-remark@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      hast-util-to-mdast: 10.1.2
+      unified: 11.0.5
+      vfile: 6.0.3
 
   rehype-stringify@10.0.1:
     dependencies:
@@ -17783,6 +17850,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  starlight-llms-txt@0.10.0(@astrojs/starlight@0.38.2(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@astrojs/mdx': 5.0.3(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.2(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/hast': 3.0.4
+      '@types/micromatch': 4.0.10
+      astro: 6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      github-slugger: 2.0.0
+      hast-util-select: 6.0.4
+      micromatch: 4.0.8
+      rehype-parse: 9.0.1
+      rehype-remark: 10.0.1
+      remark-gfm: 4.0.1
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-remove: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   starlight-package-managers@0.12.0(@astrojs/starlight@0.38.2(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@astrojs/starlight': 0.38.2(astro@6.4.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.62.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -17994,6 +18080,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trim-trailing-lines@2.1.0: {}
+
   trough@2.2.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
@@ -18129,6 +18217,12 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
+
+  unist-util-remove@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@4.0.0:
     dependencies:


### PR DESCRIPTION
The docs site scores poorly on AI and crawler discovery because the machine-readable entry points don't exist: `https://www.portabletext.org/llms.txt`, `/llms-full.txt`, and `/robots.txt` all return 404, while the sitemap is fine. AI crawlers have nothing to read, and search crawlers have no `robots.txt` pointing them at the sitemap.

This wires up the `starlight-llms-txt` plugin, which generates an `llms.txt` index plus `llms-full.txt`/`llms-small.txt` from the same content collection Starlight already renders, and adds a static `public/robots.txt` that allows all user agents and points at the existing `sitemap-index.xml`.

The one wrinkle is the splash page (`src/content/docs/index.mdx`), which mounts a live `<PortableTextEditor>` React island. The plugin renders each page through an `experimental_AstroContainer` that registers only the `astro:jsx` renderer, so rendering that page throws `NoMatchingRenderer: Unable to render PortableTextEditor`. The plugin's `exclude` option only filters `llms-small.txt`, not `llms-full.txt` (see [starlight-llms-txt#26fa616](https://github.com/delucis/starlight-llms-txt/commit/26fa616793798bda41911bfe7dc229475f89db26)), so it can't drop the offending page from the full build. `rawContent: true` is the plugin's documented path for sites with framework components: it serves each page's raw MDX body instead of rendering it, which sidesteps the missing renderer entirely.

```js
starlightLlmsTxt({
  description: '...',
  rawContent: true,
}),
```

A separate commit replaces six pages' placeholder `description` frontmatter (`Description of behaviors`, `Plugins reference`, `Toolbar reference`, and the like) with one-line summaries of what each page covers. That frontmatter feeds each page's `<meta name="description">` and the in-site search snippets, so the placeholders gave crawlers and search nothing useful to index.

Blast radius is the docs site only, no published package, no changeset. Three new generated routes (`/llms.txt`, `/llms-full.txt`, `/llms-small.txt`) plus `/robots.txt`. One semantic note worth flagging: under `rawContent`, `llms-small.txt` is byte-identical to `llms-full.txt` (the minification pass is skipped) and both carry raw MDX (import lines, JSX tags) rather than rendered Markdown. That's the accepted trade for crash-free generation on a site with React islands; cleaning it up would mean patching the plugin's container to register the React renderer, which isn't worth it for the score.

The score is computed from the live site, so these only register once `www.portabletext.org` redeploys.