### PR TITLE
fix(perf): resolve `getChildren` segments via `blockIndexMap`

### DIFF
--- a/.changeset/get-children-block-index-map.md
+++ b/.changeset/get-children-block-index-map.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): resolve `getChildren` segments via `blockIndexMap`
+
+`getChildren` now resolves keyed path segments through the editor's
+`blockIndexMap` (O(1)) with a linear-scan fallback, matching `getNode`,
+`getAncestors`, and `getSibling`. Behavior is unchanged; resolution is faster
+on wide sibling arrays and on repeated descents into the same subtree.

--- a/packages/editor/src/traversal/get-children.test.ts
+++ b/packages/editor/src/traversal/get-children.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from 'vitest'
+import {serializePath} from '../paths/serialize-path'
 import {getChildren} from './get-children'
 import {
   codeBlockContainer,
@@ -194,5 +195,30 @@ describe(getChildren.name, () => {
         [{_key: 'k26'}],
       ),
     ).toEqual([])
+  })
+
+  // The existing cases above run with a populated `blockIndexMap`, so they
+  // exercise the O(1) fast path. These pin the linear-scan fallback.
+  test('resolves correctly when blockIndexMap is empty (fallback)', () => {
+    const snapshot = {
+      ...testbed.snapshot,
+      blockIndexMap: new Map<string, number>(),
+    }
+    expect(getChildren(snapshot, [{_key: 'k11'}])).toEqual([
+      {node: testbed.codeLine1, path: [{_key: 'k11'}, 'code', {_key: 'k8'}]},
+      {node: testbed.codeLine2, path: [{_key: 'k11'}, 'code', {_key: 'k10'}]},
+    ])
+  })
+
+  test('resolves correctly when blockIndexMap disagrees with the value (fallback)', () => {
+    // Point the `k11` lookup at the wrong sibling; the `_key` check rejects it
+    // and rescans, so the result is unchanged.
+    const staleMap = new Map(testbed.snapshot.blockIndexMap)
+    staleMap.set(serializePath([{_key: 'k11'}]), 0)
+    const snapshot = {...testbed.snapshot, blockIndexMap: staleMap}
+    expect(getChildren(snapshot, [{_key: 'k11'}])).toEqual([
+      {node: testbed.codeLine1, path: [{_key: 'k11'}, 'code', {_key: 'k8'}]},
+      {node: testbed.codeLine2, path: [{_key: 'k11'}, 'code', {_key: 'k10'}]},
+    ])
   })
 })

--- a/packages/editor/src/traversal/get-children.ts
+++ b/packages/editor/src/traversal/get-children.ts
@@ -2,6 +2,7 @@ import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {serializePath} from '../paths/serialize-path'
 import type {
   Containers,
   RegisteredContainer,
@@ -32,7 +33,17 @@ export function getChildren(
 
     let node: Node | undefined
     if (isKeyedSegment(segment)) {
-      node = currentChildren.find((child) => child._key === segment._key)
+      // Resolve via `blockIndexMap` (O(1)) and fall back to a linear scan on a
+      // miss or when the snapshot's map disagrees with the value, mirroring
+      // `getNode`. The candidate path is this segment's full keyed path.
+      const candidatePath: Path = isRoot
+        ? [{_key: segment._key}]
+        : [...currentPath, currentFieldName, {_key: segment._key}]
+      const index = snapshot.blockIndexMap.get(serializePath(candidatePath))
+      node =
+        index !== undefined && currentChildren[index]?._key === segment._key
+          ? currentChildren[index]
+          : currentChildren.find((child) => child._key === segment._key)
     } else if (typeof segment === 'number') {
       node = currentChildren.at(segment)
     }


### PR DESCRIPTION
`getChildren` walks a path resolving each keyed segment with a linear `children.find(c => c._key === segment._key)`. Its siblings `getNode`, `getAncestors`, and `getSibling` were migrated to resolve keyed segments through the editor's path-keyed `blockIndexMap` (O(1)) with a linear-scan fallback; `getChildren` was left behind, even though it already receives `blockIndexMap` in its snapshot and ignores it.

This adopts the same pattern: look up `blockIndexMap.get(serializePath(prefix))`, verify the candidate's `_key`, and fall back to a scan on a miss or when the snapshot's map disagrees with the value. Per-segment resolution drops from O(siblings) to O(1), which matters on wide sibling arrays and on repeated descents into the same subtree (e.g. numbering lists across many container cells).

Behavior is identical. The existing `get-children` cases already run with a populated `blockIndexMap`, so they exercise the new fast path unchanged; two added tests pin the fallback (empty map, and a stale map that points at the wrong sibling) returning the same result.
