### PR TITLE
docs: clarify selector and container render contracts

### DIFF
--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -34,6 +34,21 @@ export type EditorSelector<TSelected> = (snapshot: EditorSnapshot) => TSelected
  *  const schema = useEditorSelector(editor, (snapshot) => snapshot.context.schema)
  * }
  * ```
+ * @example
+ * Pass a `compare` function as the third argument for selectors that
+ * return a fresh array or object on every call. Selectors like
+ * {@link getSelectedValue}, {@link getFocusBlock}, and
+ * {@link getApplicableSchema} allocate new aggregates per read. The
+ * default `===` comparator will treat each as a change and trigger a
+ * re-render even when the underlying state is identical.
+ * ```tsx
+ * import { useEditorSelector, getSelectedValue } from '@portabletext/editor'
+ * import { isEqual } from 'lodash'
+ *
+ * function MyComponent(editor) {
+ *  const selected = useEditorSelector(editor, getSelectedValue, isEqual)
+ * }
+ * ```
  * @group Hooks
  */
 export function useEditorSelector<TSelected>(

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -30,6 +30,13 @@ export type ContainerNodeForType<TType extends string> = TType extends
  * `node` is `PortableTextObject` because containers cannot register the
  * built-in `'span'` or `'block'` types (those are leaves and text blocks
  * respectively).
+ *
+ * `focused` and `selected` are not equivalent. `focused` is true only for
+ * the nearest container ancestor of a collapsed selection focus. For a
+ * caret inside a container's editable children, the inner text block
+ * resolves as the focus block, so the outer container reports
+ * `focused: false`, `selected: true`. Gate caret-inside-container UI on
+ * `selected`, not `focused`.
  */
 export type ContainerRenderProps = {
   attributes: Record<string, unknown>

--- a/packages/editor/src/selectors/selector.get-focus-block.ts
+++ b/packages/editor/src/selectors/selector.get-focus-block.ts
@@ -10,6 +10,12 @@ import type {BlockPath} from '../types/paths'
  * this returns the innermost block ancestor (the line), not the outer
  * container. When the focus is at root, behavior is unchanged.
  *
+ * To gate UI on "is the focus inside a container of type X?", do not compare
+ * `getFocusBlock(snapshot)?.node._type` against the container's `_type`. It
+ * will never match because this selector resolves past the container to the
+ * inner block. Walk the ancestor chain instead with
+ * {@link getAncestors} from `@portabletext/editor/traversal`.
+ *
  * @public
  */
 export const getFocusBlock: EditorSelector<


### PR DESCRIPTION
Three JSDoc tightenings prompted by a v7 consumer migration where the documented API was correct but a docstring on a sibling selector left enough room to wire UI to the wrong field.

### `getFocusBlock`

A consumer wired "is the caret inside a container of type X?" to `getFocusBlock(snapshot)?.node._type === containerType`. That expression is always false when the caret is inside the container, because `getFocusBlock` resolves past the container to the innermost block ancestor (the container's inner text block, the "line"). The existing JSDoc described this behavior accurately but did not point at the corrective pattern. The new paragraph names the anti-pattern and points consumers at `getAncestors` from `@portabletext/editor/traversal`.

### `ContainerRenderProps`

The same consumer also wired container UI on `focused`, expecting it to track the caret. `focused` only resolves to the nearest container ancestor of the collapsed selection focus, so for a caret inside a container's editable children the inner text block wins the race and the outer container reports `focused: false`, `selected: true`. The new paragraph spells out the contract and tells consumers to gate caret-inside-container UI on `selected`.

### `useEditorSelector`

The hook accepts a `compare` function as its third argument, but the JSDoc only showed the two-argument form. Selectors that allocate fresh aggregates per call (`getSelectedValue`, `getFocusBlock`, `getApplicableSchema`) trigger spurious re-renders under the default `===` comparator. The new example shows how to opt into a deep-equal comparator for those selectors.

No behavior change. Pure JSDoc.