### PR TITLE
docs: serve per-page Markdown and agent directives for portabletext.org

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig({
       title: 'Portable Text',
       components: {
         PageTitle: './src/components/overrides/page-title.astro',
+        Banner: './src/components/overrides/banner.astro',
       },
       customCss: ['./src/styles/globals.css'],
       editLink: {

--- a/apps/docs/public/skill.md
+++ b/apps/docs/public/skill.md
@@ -1,0 +1,57 @@
+---
+name: portable-text
+description: Work with Portable Text, a JSON-based specification for structured block content. Use this skill to render Portable Text in React, HTML, Vue, Svelte, or Markdown, to build a block content editor with @portabletext/editor, or to convert HTML and Markdown into Portable Text.
+---
+
+# Portable Text
+
+Portable Text is an open, JSON-based specification for structured block content.
+Content is stored as an array of typed blocks: each block has a `_type` and
+carries its own data. The same content renders to React, HTML, Markdown, or any
+other target through a serializer.
+
+Full documentation index: https://www.portabletext.org/llms.txt
+Complete corpus: https://www.portabletext.org/llms-full.txt
+Every page is available as Markdown by appending `.md` (e.g. `/rendering/react.md`).
+
+## Rendering existing Portable Text
+
+Pick the serializer for the target. Pass the Portable Text value to it.
+
+- React: `@portabletext/react` exposes `<PortableText value={value} />`. Override
+  defaults with the `components` prop (`marks`, `types`, `block`, `list`).
+  See `/rendering/react.md`.
+- HTML string: `@portabletext/to-html` (`toHTML`). Works in Node, Deno, edge, and
+  browsers. See `/rendering/html.md`.
+- Vue: `@portabletext/vue`. See `/rendering/vue.md`.
+- Svelte: `@portabletext/svelte`. See `/rendering/svelte.md`.
+- Markdown: `@portabletext/markdown`. See `/rendering/markdown.md`.
+
+Unknown block types are skipped unless you provide a component for them, so
+custom types never crash a render.
+
+## Building an editor
+
+`@portabletext/editor` is a headless, schema-driven React editor.
+
+1. Define a schema with `defineSchema({decorators, styles, lists, ...})`.
+2. Wrap the editor in `EditorProvider` to supply the schema and initial value.
+3. Render `PortableTextEditable` for the editable surface.
+4. Listen for changes with `EventListenerPlugin` from `@portabletext/editor/plugins`.
+
+Toolbars come from `@portabletext/toolbar` and keyboard shortcuts from
+`@portabletext/keyboard-shortcuts`. Editor behavior is customized through the
+Behavior API (`defineBehavior`). Start at `/editor/getting-started.md`.
+
+## Converting into Portable Text
+
+- HTML to Portable Text: `@portabletext/block-tools` (`htmlToBlocks`).
+  See `/conversion/html-to-portable-text.md`.
+- Markdown to Portable Text: `@portabletext/markdown`.
+  See `/conversion/markdown-to-portable-text.md`.
+
+## When unsure
+
+Read `/llms-full.txt` for the full documentation, or fetch the `.md` variant of
+the relevant page. Do not invent block types or component APIs; the schema and
+the serializer `components` map define what exists.

--- a/apps/docs/src/components/overrides/banner.astro
+++ b/apps/docs/src/components/overrides/banner.astro
@@ -1,0 +1,25 @@
+---
+import Default from '@astrojs/starlight/components/Banner.astro'
+
+// Agent-facing directive: a visually hidden pointer to the Markdown variants and
+// the llms.txt index, rendered at the top of <main> on every page. This is what
+// the "llms.txt directive in HTML" check scans for. Splash pages have no `id`
+// and no Markdown variant, so they only advertise the index.
+const id = Astro.locals.starlightRoute.entry.id
+const markdownHref = id ? `/${id}.md` : undefined
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<div class="sr-only" data-llms-txt>
+  {
+    markdownHref ? (
+      <span>
+        This page is available as Markdown at{' '}
+        <a href={markdownHref}>{markdownHref}</a>.{' '}
+      </span>
+    ) : null
+  }
+  For the full documentation index, see <a href="/llms.txt">/llms.txt</a>, or
+  the complete corpus at <a href="/llms-full.txt">/llms-full.txt</a>.
+</div>

--- a/apps/docs/src/pages/[...slug].md.ts
+++ b/apps/docs/src/pages/[...slug].md.ts
@@ -1,0 +1,27 @@
+import type {APIRoute, GetStaticPaths} from 'astro'
+import {getCollection} from 'astro:content'
+
+// Serve a raw-Markdown variant of every docs page at `/<slug>.md` so agents can
+// fetch content without stripping the Starlight HTML shell. The leading
+// blockquote is the llms.txt directive the Markdown checks look for.
+export const getStaticPaths: GetStaticPaths = async () => {
+  const docs = await getCollection('docs')
+  return docs
+    .filter((entry) => entry.id && entry.data.template !== 'splash')
+    .map((entry) => ({params: {slug: entry.id}, props: {entry}}))
+}
+
+export const GET: APIRoute = ({props}) => {
+  const {entry} = props
+  const directive =
+    '> For the complete documentation index, see [llms.txt](/llms.txt).\n' +
+    '> The full corpus is at [llms-full.txt](/llms-full.txt).'
+  const description = entry.data.description
+    ? `> ${entry.data.description}\n\n`
+    : ''
+  const body = `${directive}\n\n# ${entry.data.title}\n\n${description}${entry.body ?? ''}`
+
+  return new Response(body, {
+    headers: {'Content-Type': 'text/markdown; charset=utf-8'},
+  })
+}


### PR DESCRIPTION
Follow-up to #2805. That PR added `llms.txt`/`llms-full.txt` and `robots.txt`; the agent-readiness audit (afdocs.dev, via mintlify.com/score) still flagged the docs site because agents could not reach the content as Markdown, had no in-page pointer to the index, and had no product-specific operating guide. This PR closes those gaps.

Every page previously returned only the Starlight HTML shell, with the header and the (large, generated) API sidebar serialized ahead of the content, so a crawler converting a page to Markdown saw the real content start past 50% of the output. A new `src/pages/[...slug].md.ts` route emits a raw-Markdown variant of every non-splash docs page at `/<slug>.md`, built straight from the content collection (`entry.body`). Each `.md` file opens with a blockquote directive pointing at `/llms.txt` and `/llms-full.txt`, which is the form the Markdown-directive check looks for. Agents that discover these get clean content with no shell to strip.

To advertise those variants in the HTML, this overrides Starlight's `Banner` component. `Banner` renders at the top of `<main>` on every page (splash included), so a visually hidden (`sr-only`) block there links to the page's `.md` variant, `/llms.txt`, and `/llms-full.txt` without touching the visible layout. Splash pages have no collection `id`, so they advertise only the index.

A separate commit adds an Anthropic-style agent skill at `public/skill.md` (served at `/skill.md`) with `name`/`description` frontmatter and instructions grounded in the existing docs: which serializer renders each target (`@portabletext/react`, `@portabletext/to-html`, vue, svelte, markdown), how to stand up the editor with `defineSchema`/`EditorProvider`/`PortableTextEditable`, and which packages convert HTML and Markdown into Portable Text. It points at the index and `.md` variants rather than restating page content.

Blast radius is the docs site only, no published package, no changeset. 301 new `/<slug>.md` routes, one `/skill.md`, and a hidden directive in the body of every page; the visible, rendered documentation is byte-for-byte unchanged.

## Checks this does not address

Three audit checks need infrastructure or a decision beyond docs content, so they are deliberately out of scope here:

- **Content negotiation (`Accept: text/markdown`)**: the site is a static Astro build with no server adapter, so honoring the header needs a hosting-level rewrite/middleware (Vercel/Netlify edge). The `.md` URLs already cover the agents that probe for them (Mintlify/Cursor style).
- **MCP server discoverable**: there is no MCP server; standing one up is its own effort, not a docs edit.
- **Content start position**: fully fixing the HTML variant means removing the generated API tree from the rendered sidebar DOM, which is a Starlight structural change. The `.md` variants are the practical remedy for agents (content starts at offset 0).

One trailing-slash caveat worth flagging: pages resolve canonically at `/<slug>/`, and the `.md` route serves `/<slug>.md` (the Mintlify/Fern convention). If the audit appends `.md` to the trailing-slash URL (`/<slug>/.md`) rather than the bare slug, we will need to also emit `/<slug>/index.md`; easy to add once we see how it probes.