### PR TITLE
fix: skip native character insertion while a decorator toggle is pending

### DIFF
--- a/.changeset/native-insert-decorator-ghost.md
+++ b/.changeset/native-insert-decorator-ghost.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: skip native character insertion while a decorator toggle is pending
+
+Toggling a decorator on a collapsed cursor (e.g. Cmd/Ctrl+B) and then typing
+no longer renders a duplicate, undecorated copy of the typed character before
+the decorated one. The model was always correct; only the rendered DOM showed
+the ghost, which cleared on the next re-render.

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -629,7 +629,15 @@ export const Editable = forwardRef(
             // Chrome has issues correctly editing the start of nodes: https://bugs.chromium.org/p/chromium/issues/detail?id=1249405
             // When there is an inline element, e.g. a link, and you select
             // right after it (the start of the next node).
-            selection.anchor.offset !== 0
+            selection.anchor.offset !== 0 &&
+            // A pending decorator toggle (e.g. Cmd+B on a collapsed cursor)
+            // makes the next `insert.text` create a NEW span carrying the
+            // toggled marks instead of extending the focus span. Native
+            // character insertion mutates the focus span's text node in place,
+            // so that mutation would land in the wrong (old) span and never be
+            // reconciled away, leaving a ghost character in the DOM. Defer to
+            // the model insert here so React renders the new span cleanly.
+            Object.keys(editor.snapshot.decoratorState).length === 0
           ) {
             native = true
 

--- a/packages/editor/tests/native-insert-decorator-ghost.test.tsx
+++ b/packages/editor/tests/native-insert-decorator-ghost.test.tsx
@@ -1,0 +1,32 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {IS_MAC} from '../src/internal-utils/is-hotkey'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+describe('native insertion with an active decorator', () => {
+  test('Scenario: the rendered DOM matches the model (no ghost character)', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await userEvent.keyboard(
+      IS_MAC ? '{Meta>}b{/Meta}' : '{Control>}b{/Control}',
+    )
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo[strong:bar|]',
+      )
+    })
+
+    expect(locator.element().textContent).toEqual('foobar')
+  })
+})


### PR DESCRIPTION
## The bug

It takes a specific but real sequence: a collapsed cursor **after existing text in a span** (a non-zero offset), a **pending decorator toggle** (Cmd/Ctrl+B), then a keystroke. The first character typed after the toggle is rendered twice, an undecorated copy in the original span plus the decorated one. Type `foo`, ⌘B, `bar` and the DOM shows `foobbar`.

```
type:   foo   then ⌘B (toggle bold)   then bar
model:  span "foo"          span "bar" {strong}     →  "foobar"   correct
DOM:    span "foob"         span "bar" {strong}     →  "foobbar"  ghost
              ^ the browser wrote this "b"; the model never did
```

It is conditional, not constant, which is why it is easy to miss by hand. Verified against the un-fixed editor: toggling and typing in an empty block (offset 0) does **not** ghost, and typing with no pending toggle does **not** ghost; only the non-zero-offset + pending-toggle combination does. The model is always correct (`foo` + `bar` with `strong`); only the contentEditable shows the ghost, and it clears on the next re-render (blur/refocus). It reproduces in both Studio render pipelines and all three browsers with no container, which localizes it to the editor's native-insertion reconciliation.

## Why it happens

`Editable`'s `onDOMBeforeInput` has a native fast-path for a single-character `insertText` on a collapsed selection **at a non-zero offset**: instead of `preventDefault()`-ing and driving the model, it lets the browser mutate the focus span's text node in place and defers the model `insert.text` to the `input` event. (That offset guard is why typing at the start of an empty block never takes this path and never ghosts.) On non-Android, `RestoreDOM` is a pass-through, so the only thing that re-syncs the DOM to the model afterward is the per-render layout effect in `TextString`, which resets a span's `textContent` only when that span's component re-renders.

A decorator toggle on a collapsed cursor sets `editor.snapshot.decoratorState`, which makes the next `insert.text` route through the core insert behavior's `insert.child` branch: it creates a **new** span with the toggled marks instead of extending the focus span. (With no pending toggle the insert extends the focus span, which is why "no toggle" never ghosts.) Now the two layers disagree:

- the browser already wrote the character into the **focus** span (`foo` -> `foob`), but
- the model put the character in a **new** span and left the focus span untouched.

Because the focus span's model node is unchanged, its memoized component never re-renders, so the `TextString` layout effect never runs and never reverts the stray character. React mounts the new decorated span beside it, and the DOM keeps both.

So the corruption is a native contentEditable edit, and the reason it *persists* is React memoization: the self-healing reset is gated on a re-render that never happens for the span the browser touched.

## The fix

Gate the native fast-path on an empty `decoratorState`:

```ts
// ...existing fast-path conditions...
selection.anchor.offset !== 0 &&
// A pending decorator toggle makes the next insert create a NEW span, so the
// browser's in-place edit would land in the old span and never reconcile.
// Defer to the model insert here so React renders the new span cleanly.
Object.keys(editor.snapshot.decoratorState).length === 0
```

The correctness argument is the contrapositive, not a prediction: **when `decoratorState` is empty the insert keeps the focus span's marks and therefore extends that span** — exactly the case where the browser's in-place edit matches what the model becomes. So the fast-path is only ever *enabled* when it is provably safe. When a toggle is pending we fall through to `preventDefault()` + model `insert.text`; the browser never touches the DOM and React renders the new span from the model.

Net behavior is unchanged for ordinary typing. The first character materializes the toggle and clears `decoratorState` (any op other than an inter-span selection move resets it in `apply`), so every subsequent keystroke extends the now-decorated span through the native path as before. The only delta is the single keystroke immediately after a toggle, which now goes through the model insert. The symmetric case (toggling a decorator *off* inside a decorated span, which likewise yields a differently-marked span) is covered by the same gate.

Pinned by `native-insert-decorator-ghost.test.tsx` (browser), committed as a separate `test:` so the red state is in history: type `foo`, toggle bold, type `bar`, and assert the rendered `textContent` equals the model text. It reads `foobbar` before the gate and `foobar` after, in chromium/firefox/webkit. Full editor browser and unit suites stay green.

## What this does not fix

This is the instance fix, and it leans on the stock insert behavior, where empty `decoratorState` reliably means "extend the focus span." A custom `insert.text`/`insert.child` behavior that decoupled the two, creating a new span with no pending toggle, could reintroduce the same ghost, because the underlying fragility is still there: the DOM reset is gated on a re-render. The class-level fix would be to reconcile the focus span's text node regardless of whether it re-rendered (or to choose native-vs-model from the actual resulting model change rather than predicting it from `decoratorState`). That is larger and riskier, so it is out of scope here and left to a follow-up.
