### PR TITLE
feat: every container around the selection is focused

### DIFF
--- a/.changeset/focused-ancestors-rule.md
+++ b/.changeset/focused-ancestors-rule.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: every container around the selection is focused
+
+A container's `focused` prop in a `defineContainer` render callback is now `true` for every container ancestor that fully contains the current selection, matching the symmetry that `selected` already had. Previously only the innermost container reported `focused: true`, so an outer container chrome (table around a focused cell, code block around a focused line) had no way to react to the caret being inside it.
+
+For a collapsed caret, every container ancestor reports focused. For an expanded selection, only containers whose subtree contains both endpoints report focused: a selection across two cells reports the row and table focused but not the cells.

--- a/packages/editor/src/editor/get-selection-state.test.ts
+++ b/packages/editor/src/editor/get-selection-state.test.ts
@@ -10,7 +10,7 @@ describe(getSelectionState.name, () => {
     expect(getSelectionState(testbed.snapshot, null)).toEqual({
       focusedLeafPath: undefined,
       selectedLeafPaths: new Set(),
-      focusedContainerPath: undefined,
+      focusedContainerPaths: new Set(),
       selectedContainerPaths: new Set(),
     })
   })
@@ -34,9 +34,9 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
     })
 
-    test('focused container is the text block', () => {
-      expect(result.focusedContainerPath).toEqual(
-        serializePath([{_key: testbed.textBlock1._key}]),
+    test('focused containers contain the text block', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
       )
     })
 
@@ -68,8 +68,8 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
     })
 
-    test('no focused container (image is root-level leaf)', () => {
-      expect(result.focusedContainerPath).toBeUndefined()
+    test('no focused containers (image is root-level leaf)', () => {
+      expect(result.focusedContainerPaths).toEqual(new Set())
     })
 
     test('selected leaves contain the image', () => {
@@ -102,9 +102,9 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
     })
 
-    test('focused container is the text block', () => {
-      expect(result.focusedContainerPath).toEqual(
-        serializePath([{_key: testbed.textBlock1._key}]),
+    test('focused containers contain the text block', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
       )
     })
   })
@@ -134,16 +134,31 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
     })
 
-    test('focused container is the nearest ancestor (text block)', () => {
-      expect(result.focusedContainerPath).toEqual(
-        serializePath([
-          {_key: testbed.table._key},
-          'rows',
-          {_key: testbed.row1._key},
-          'cells',
-          {_key: testbed.cell1._key},
-          'content',
-          {_key: testbed.cellBlock1._key},
+    test('every container ancestor is focused', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.table._key}]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock1._key},
+          ]),
         ]),
       )
     })
@@ -209,16 +224,31 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toEqual(serializePath(focusPath))
     })
 
-    test('focused container is the nearest text block', () => {
-      expect(result.focusedContainerPath).toEqual(
-        serializePath([
-          {_key: testbed.table._key},
-          'rows',
-          {_key: testbed.row1._key},
-          'cells',
-          {_key: testbed.cell1._key},
-          'content',
-          {_key: testbed.cellBlock1._key},
+    test('every container ancestor is focused', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.table._key}]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+          ]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+            'cells',
+            {_key: testbed.cell1._key},
+            'content',
+            {_key: testbed.cellBlock1._key},
+          ]),
         ]),
       )
     })
@@ -248,8 +278,10 @@ describe(getSelectionState.name, () => {
       expect(result.focusedLeafPath).toBeUndefined()
     })
 
-    test('no focused container (selection is expanded)', () => {
-      expect(result.focusedContainerPath).toBeUndefined()
+    test('the text block fully contains the selection and is focused', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
+      )
     })
 
     test('selected leaves include all three children of the text block', () => {
@@ -291,6 +323,10 @@ describe(getSelectionState.name, () => {
       focusPath,
       backward: false,
       isCollapsed: false,
+    })
+
+    test('no container fully contains the selection', () => {
+      expect(result.focusedContainerPaths).toEqual(new Set())
     })
 
     test('selected containers include both text blocks', () => {
@@ -353,6 +389,19 @@ describe(getSelectionState.name, () => {
       focusPath,
       backward: false,
       isCollapsed: false,
+    })
+
+    test('table and row are focused but neither cell is', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([
+          serializePath([{_key: testbed.table._key}]),
+          serializePath([
+            {_key: testbed.table._key},
+            'rows',
+            {_key: testbed.row1._key},
+          ]),
+        ]),
+      )
     })
 
     test('selected containers include the table, row, both cells, and text blocks in range', () => {
@@ -445,7 +494,7 @@ describe(getSelectionState.name, () => {
     const testbed = createNodeTraversalTestbed()
     // Caret sits at offset 0 of span2 (the span after the inline object).
     // Shift+Left extends the focus backwards to the end of span1,
-    // so anchor=span2 and focus=span1 — i.e. anchor is LATER than focus
+    // so anchor=span2 and focus=span1 - i.e. anchor is LATER than focus
     // in document order.
     const anchorPath = [
       {_key: testbed.textBlock1._key},
@@ -463,6 +512,12 @@ describe(getSelectionState.name, () => {
       focusPath,
       backward: true,
       isCollapsed: false,
+    })
+
+    test('the text block fully contains the selection and is focused', () => {
+      expect(result.focusedContainerPaths).toEqual(
+        new Set([serializePath([{_key: testbed.textBlock1._key}])]),
+      )
     })
 
     test('inline object between anchor and focus is in selectedLeafPaths', () => {

--- a/packages/editor/src/editor/get-selection-state.ts
+++ b/packages/editor/src/editor/get-selection-state.ts
@@ -17,11 +17,19 @@ export type SelectionState = {
    */
   selectedLeafPaths: Set<string>
   /**
-   * Serialized path of the focused container (text block or editable
-   * container). Set when the selection is collapsed and has a container
-   * ancestor.
+   * Set of serialized paths of containers that fully contain the
+   * current selection.
+   *
+   * For a collapsed caret, every container ancestor satisfies this:
+   * the caret is a point, and every ancestor contains that point. So
+   * every ancestor is in the set.
+   *
+   * For an expanded selection, only containers whose subtree contains
+   * both endpoints satisfy this. Computed as the intersection of the
+   * anchor's container ancestors and the focus's container ancestors -
+   * a container holds both endpoints iff it is an ancestor of both.
    */
-  focusedContainerPath: string | undefined
+  focusedContainerPaths: Set<string>
   /**
    * Set of serialized paths of containers within the current selection.
    */
@@ -33,7 +41,7 @@ const emptySet = new Set<string>()
 const emptyState: SelectionState = {
   focusedLeafPath: undefined,
   selectedLeafPaths: emptySet,
-  focusedContainerPath: undefined,
+  focusedContainerPaths: emptySet,
   selectedContainerPaths: emptySet,
 }
 
@@ -44,9 +52,12 @@ const emptyState: SelectionState = {
  * container. All other nodes (spans, inline objects, block objects) are
  * leaves.
  *
- * For a collapsed selection:
- * - `focusedLeafPath` is the focus path when it resolves to a leaf.
- * - `focusedContainerPath` is the nearest ancestor container of the focus.
+ * - `focusedLeafPath` is the focus path when collapsed and it resolves
+ *   to a leaf.
+ * - `focusedContainerPaths` is the set of containers that fully
+ *   contain the current selection (every ancestor for a collapsed
+ *   caret; the intersection of anchor and focus ancestors for an
+ *   expanded selection).
  */
 export function getSelectionState(
   snapshot: TraversalSnapshot,
@@ -86,7 +97,7 @@ export function getSelectionState(
   }
 
   let focusedLeafPath: string | undefined
-  let focusedContainerPath: string | undefined
+  const focusedContainerPaths = new Set<string>()
 
   if (selection.isCollapsed) {
     const serializedFocusPath = serializePath(selection.focusPath)
@@ -95,15 +106,44 @@ export function getSelectionState(
       focusedLeafPath = serializedFocusPath
     }
 
-    for (const {path: ancestorPath} of getAncestors(
+    for (const {node, path: ancestorPath} of getAncestors(
       snapshot,
       selection.focusPath,
     )) {
-      const serializedAncestorPath = serializePath(ancestorPath)
-
-      if (selectedContainerPaths.has(serializedAncestorPath)) {
-        focusedContainerPath = serializedAncestorPath
-        break
+      if (
+        isTextBlock({schema: snapshot.context.schema}, node) ||
+        isEditableContainer(snapshot, node, ancestorPath)
+      ) {
+        focusedContainerPaths.add(serializePath(ancestorPath))
+      }
+    }
+  } else {
+    // A container fully contains an expanded selection iff it is an
+    // ancestor of BOTH endpoints. Intersect anchor-side and focus-side
+    // container ancestors.
+    const anchorContainerAncestors = new Set<string>()
+    for (const {node, path: ancestorPath} of getAncestors(
+      snapshot,
+      selection.anchorPath,
+    )) {
+      if (
+        isTextBlock({schema: snapshot.context.schema}, node) ||
+        isEditableContainer(snapshot, node, ancestorPath)
+      ) {
+        anchorContainerAncestors.add(serializePath(ancestorPath))
+      }
+    }
+    for (const {node, path: ancestorPath} of getAncestors(
+      snapshot,
+      selection.focusPath,
+    )) {
+      const serialized = serializePath(ancestorPath)
+      if (
+        anchorContainerAncestors.has(serialized) &&
+        (isTextBlock({schema: snapshot.context.schema}, node) ||
+          isEditableContainer(snapshot, node, ancestorPath))
+      ) {
+        focusedContainerPaths.add(serialized)
       }
     }
   }
@@ -112,7 +152,8 @@ export function getSelectionState(
     focusedLeafPath,
     selectedLeafPaths:
       selectedLeafPaths.size > 0 ? selectedLeafPaths : emptySet,
-    focusedContainerPath,
+    focusedContainerPaths:
+      focusedContainerPaths.size > 0 ? focusedContainerPaths : emptySet,
     selectedContainerPaths:
       selectedContainerPaths.size > 0 ? selectedContainerPaths : emptySet,
   }

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -17,7 +17,7 @@ const emptySet = new Set<string>()
 const defaultSelectionState: SelectionState = {
   focusedLeafPath: undefined,
   selectedLeafPaths: emptySet,
-  focusedContainerPath: undefined,
+  focusedContainerPaths: emptySet,
   selectedContainerPaths: emptySet,
 }
 
@@ -38,8 +38,15 @@ function selectionStatesEqual(
   if (prev.focusedLeafPath !== next.focusedLeafPath) {
     return false
   }
-  if (prev.focusedContainerPath !== next.focusedContainerPath) {
-    return false
+  if (prev.focusedContainerPaths !== next.focusedContainerPaths) {
+    if (prev.focusedContainerPaths.size !== next.focusedContainerPaths.size) {
+      return false
+    }
+    for (const path of prev.focusedContainerPaths) {
+      if (!next.focusedContainerPaths.has(path)) {
+        return false
+      }
+    }
   }
   if (prev.selectedLeafPaths !== next.selectedLeafPaths) {
     if (prev.selectedLeafPaths.size !== next.selectedLeafPaths.size) {
@@ -214,9 +221,8 @@ export function SelectionStateProvider({
  */
 export function useIsFocusedContainer(serializedPath: string): boolean {
   const store = useContext(SelectionStateStoreContext)
-  return useSyncExternalStore(
-    store.subscribe,
-    () => store.getSnapshot().focusedContainerPath === serializedPath,
+  return useSyncExternalStore(store.subscribe, () =>
+    store.getSnapshot().focusedContainerPaths.has(serializedPath),
   )
 }
 

--- a/packages/editor/tests/container-render-focused-selected.test.tsx
+++ b/packages/editor/tests/container-render-focused-selected.test.tsx
@@ -55,7 +55,7 @@ const tableSchema = defineSchema({
 })
 
 describe('container render focused, selected, and path', () => {
-  test('Only the innermost container is focused; ancestors are selected', async () => {
+  test('Every container ancestor reports focused; ancestors are selected', async () => {
     const calloutValues: Array<{
       focused: boolean
       selected: boolean
@@ -131,7 +131,7 @@ describe('container render focused, selected, and path', () => {
         path: [{_key: 'callout'}, 'content', {_key: 'inner'}],
       })
       expect(calloutValues.at(-1)).toEqual({
-        focused: false,
+        focused: true,
         selected: true,
         path: [{_key: 'callout'}],
       })
@@ -197,7 +197,7 @@ describe('container render focused, selected, and path', () => {
     })
   })
 
-  test('selected cascades up nested containers; focused stays on the innermost', async () => {
+  test('selected and focused both cascade up nested containers', async () => {
     const tableValues: Array<{focused: boolean; selected: boolean}> = []
     const rowValues: Array<{focused: boolean; selected: boolean}> = []
     const cellValues: Array<{focused: boolean; selected: boolean}> = []
@@ -298,9 +298,9 @@ describe('container render focused, selected, and path', () => {
     editor.send({type: 'select', at: {anchor: caret, focus: caret}})
 
     await vi.waitFor(() => {
-      expect(tableValues.at(-1)).toEqual({focused: false, selected: true})
-      expect(rowValues.at(-1)).toEqual({focused: false, selected: true})
-      expect(cellValues.at(-1)).toEqual({focused: false, selected: true})
+      expect(tableValues.at(-1)).toEqual({focused: true, selected: true})
+      expect(rowValues.at(-1)).toEqual({focused: true, selected: true})
+      expect(cellValues.at(-1)).toEqual({focused: true, selected: true})
       expect(cellBlockValues.at(-1)).toEqual({focused: true, selected: true})
     })
   })


### PR DESCRIPTION
A container's `focused` prop in a `defineContainer` render callback now reports `true` for every container ancestor that fully contains the current selection, matching the symmetry `selected` has had since v7.

Previously the focused-container loop in `get-selection-state` stopped at the first hit — only the innermost container reported `focused: true`. An outer container chrome (the table around a focused cell, the code block around a focused line) was silently saying it wasn't focused even though the caret was inside it. Consumers wiring container chrome to focused state either accepted the lie or rebuilt the ancestor walk themselves.

### The rule

A container reports `focused: true` when the **entire current selection is contained within it**.

For a collapsed caret, every container ancestor satisfies this — the caret is a point, every ancestor contains that point, every ancestor reports focused.

For an expanded selection, only containers whose subtree contains both endpoints satisfy this. Computed as the intersection of the anchor's and focus's container ancestors — a container holds both endpoints iff it is an ancestor of both.

### Behaviour delta

| Scenario | Before | After |
| --- | --- | --- |
| Caret in a code-block line | code block: `false`, line: `true` | code block: `true`, line: `true` |
| Caret in a table cell paragraph | table/row/cell: `false`, paragraph: `true` | all four: `true` |
| Selection across two cells in one row | nothing focused | row + table focused; cells not |
| Selection across two rows | nothing focused | table focused; rows + cells not |
| Selection across two top-level paragraphs | nothing focused | unchanged — no common container |

No existing `true` becomes `false`. All deltas are `false → true` for legitimate "the user is editing inside me" cases.

### Implementation

`SelectionState.focusedContainerPath: string | undefined` becomes `focusedContainerPaths: Set<string>`, mirroring `selectedContainerPaths`. `useIsFocusedContainer` keeps its signature and contract (subscribe to "is this container holding the focus"); the implementation swaps the scalar equality check for `.has(serializedPath)`. The store-and-subscribe shape in `selection-state-context.tsx` is unchanged — same per-slice `useSyncExternalStore` mechanism, same re-render surface.

The collapsed branch walks ancestors once. The expanded branch walks anchor ancestors and focus ancestors and intersects — no new traversal util needed.

### Tests

- `src/editor/get-selection-state.test.ts` — covers every case in the matrix above plus backward selection. Each test asserts the FULL `focusedContainerPaths` set via `toEqual(new Set([...]))`, not spot checks.
- `tests/container-render-focused-selected.test.tsx` — updates the existing browser tests where they encoded the innermost-only rule. The expanded-across-cells test keeps its expectations: cells still report `focused: false` because neither cell contains both endpoints.

Targeted browser sweep: all container suites green (64/64).
