### PR TITLE
fix: keep `EngineString`/`TextString` uncompiled so the DOM-reconcile effect runs every render

### DIFF
--- a/.changeset/string-reconcile-react-compiler.md
+++ b/.changeset/string-reconcile-react-compiler.md
@@ -1,0 +1,11 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: keep `EngineString`/`TextString` uncompiled so the DOM-reconcile effect runs every render
+
+In builds that compile the editor with React Compiler, a browser edit that
+diverged from the model could leave a stray character in the rendered text
+while the document itself stayed correct (for example, typing immediately
+after toggling a decorator at a collapsed cursor). The rendered text now
+always matches the document again.

--- a/packages/editor/src/engine/react/components/string.tsx
+++ b/packages/editor/src/engine/react/components/string.tsx
@@ -55,6 +55,15 @@ const EngineString = (props: {
   path: Path
   text: PortableTextSpan
 }) => {
+  // `EngineString` returns a `<TextString>` element whose only prop is the
+  // leaf's text. React Compiler memoizes that element on `text`, so when the
+  // text is unchanged it reuses the previous element and React bails on
+  // re-rendering `TextString`. That defeats `TextString`'s reconcile-on-render
+  // layout effect (see below), which is the only thing that resets a text node
+  // the browser mutated out from under the model (native insertion). Opt this
+  // component out of the compiler so the element is recreated every render and
+  // `TextString` always gets a chance to reconcile.
+  'use no memo'
   const {isLast, leaf, parent, path, text} = props
   const editor = useEngineStatic()
   const parentPath = getParentPath(path)
@@ -92,6 +101,12 @@ const EngineString = (props: {
  * Leaf strings with text in them.
  */
 const TextString = (props: {text: string; isTrailing?: boolean}) => {
+  // This component reconciles the DOM text node against the model on every
+  // render (the dependency-less layout effect below). React Compiler must not
+  // memoize it: a skipped render is a skipped reconcile, which strands any
+  // text the browser wrote ahead of the model. Keep it uncompiled regardless
+  // of which build (lib, tests, playground) sets the react-compiler boundary.
+  'use no memo'
   const {text, isTrailing = false} = props
   const isInNewPipeline = useContext(NewPipelineContext)
   const ref = useRef<HTMLSpanElement>(null)

--- a/packages/editor/tests/string-reconcile-under-react-compiler.test.tsx
+++ b/packages/editor/tests/string-reconcile-under-react-compiler.test.tsx
@@ -1,0 +1,41 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {IS_MAC} from '../src/internal-utils/is-hotkey'
+import {createTestEditor} from '../src/test/vitest'
+import {toTextspec} from '../test-utils/to-textspec'
+
+// `TextString` reconciles the DOM text node against the model on every render
+// via a dependency-less layout effect. React Compiler compiles `string.tsx`
+// in this build, and would otherwise memoize `EngineString`'s `<TextString>`
+// element on the unchanged leaf text, skip the re-render, and skip the
+// reconcile. `EngineString`/`TextString` carry a `"use no memo"` directive so
+// that cannot happen. This test exercises the path that exposed it: a native
+// single-character insertion lands in the focus span while a pending decorator
+// toggle routes the model insert into a new span, so the focus span's DOM text
+// diverges from its model text and only the reconcile effect can fix it.
+describe('string reconcile under react compiler', () => {
+  test('Scenario: a native edit that diverges from the model is reconciled away', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await userEvent.keyboard(
+      IS_MAC ? '{Meta>}b{/Meta}' : '{Control>}b{/Control}',
+    )
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        'B: foo[strong:bar|]',
+      )
+    })
+
+    expect(locator.element().textContent).toEqual('foobar')
+  })
+})


### PR DESCRIPTION
In any build that compiles the editor with React Compiler (the published
`lib`, and therefore Studio), a browser edit that diverged from the model could
leave a stray character in the rendered text while the document itself stayed
correct. The clearest repro is typing a single character immediately after
toggling a decorator at a collapsed cursor: `foo`, ⌘B, `bar` rendered
`foobbar` while the model held the correct `foo` + bold `bar`. It cleared on
the next unrelated re-render, so it read as a flaky ghost.

The reconcile that should have prevented it lives in `TextString`. It keeps
the DOM text node in sync with the model through a dependency-less layout
effect that runs on every render and rewrites the node whenever it has drifted
from the model. That effect is the only thing that resets a character the
browser wrote directly into a text node (native contenteditable insertion)
when the model edit lands somewhere else. With a pending decorator toggle the
model insert creates a new span, so the browser's in-place edit stays in the
focus span while the model grows a new one, and the focus span's DOM text and
model text diverge until the effect runs.

`string.tsx` is in the Tier-3 react-compiler un-exclusion set, so `lib` and the
vitest suite compile it. The compiler memoizes the `<TextString text={leafText}>`
element that `EngineString` returns, keyed on `leafText`; when the text is
unchanged it reuses the element, React bails on re-rendering `TextString`, and
the reconcile effect never runs, so the stray character is stranded. The hosted
playground never showed this because its build carves the whole engine out of
react-compiler, so its `EngineString` produces a fresh element every render and
the effect always fires. Same source, three different compiler boundaries, and
the one that ships is the one that breaks.

The fix marks `EngineString` and `TextString` with `"use no memo"`. The
directive lives in the source rather than in a build config, so every build
(lib, tests, playground) honors it uniformly without depending on three
separate compiler-boundary configs agreeing with each other. The element is
recreated each render, `TextString` re-renders, and the reconcile effect runs
as designed.

The behavior change is confined to compiled builds, where a native edit that
diverged from the model is now reconciled away instead of ghosting; uncompiled
builds already behaved this way. `tests/string-reconcile-under-react-compiler.test.tsx`
pins it and is red before this change and green after, in the compiled browser
build. `string.tsx` stays in the Tier-3 set (its other contents remain
compiled); only the two render-driven-reconciliation components opt out.

This targets the general hazard of React Compiler silently skipping a
render-driven reconcile, so it also closes the decorator-ghost symptom on its
own, independently of the narrower `decoratorState` fast-path guard (#2812) and
of removing the native fast-path entirely (#2814). The broader question of
making the three compiler boundaries one intentional thing (and the stale
`/src/slate*` globs in the vitest config that compile the engine by accident)
is tracked separately and not addressed here.
