### PR TITLE
fix: preserve container block-member schema restrictions in `sanitySchemaToPortableTextSchema`

### DIFF
--- a/.changeset/container-block-member-subschema.md
+++ b/.changeset/container-block-member-subschema.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/sanity-bridge': patch
+---
+
+fix: preserve container block-member schema restrictions in `sanitySchemaToPortableTextSchema`
+
+Converting a Sanity schema with a container (e.g. a code block) whose block member restricts decorators, annotations, styles, or lists now carries those restrictions into the resulting sub-schema. Previously every restricted list fell back to the root schema, so schema-driven plugins like `@portabletext/plugin-markdown-shortcuts` and `@portabletext/plugin-character-pair-decorator` would fire inside the container (turning `# ` into a heading, `**bold**` into bold) and produce schema-invalid content.

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
@@ -1,4 +1,9 @@
-import type {Schema} from '@portabletext/schema'
+import {
+  getSubSchema,
+  type FieldDefinition,
+  type OfDefinition,
+  type Schema,
+} from '@portabletext/schema'
 import {Schema as SanitySchema} from '@sanity/schema'
 import {builtinTypes} from '@sanity/schema/_internal'
 import {
@@ -821,5 +826,269 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         of: [{type: 'block'}, cInline],
       },
     ])
+  })
+
+  test('a container whose block member restricts marks/styles/lists produces a sub-schema that does not leak the root schema', () => {
+    // A code-block container: `lines` is an array of a block that strips
+    // every mark, every style except `code`, and every list. This is the
+    // Sanity shape Canvas uses (decorators/annotations under `marks`,
+    // `styles`/`lists` top-level). The resolved sub-schema for the lines
+    // must reflect those restrictions, otherwise markdown-shortcuts and
+    // character-pair-decorator (which gate on the sub-schema) fire inside
+    // the container and corrupt content.
+    const codeBlockType = defineType({
+      type: 'object',
+      name: 'code-block',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'lines',
+          of: [
+            defineArrayMember({
+              type: 'block',
+              name: 'block',
+              styles: [{title: 'Code', value: 'code'}],
+              lists: [],
+              marks: {decorators: [], annotations: []},
+              of: [],
+            }),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'code-block'}),
+      ],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(
+      SanitySchema.compile({types: [portableTextType, codeBlockType]}).get(
+        'body',
+      ),
+    )
+
+    const codeBlock = schema.blockObjects?.find(
+      (bo) => bo.name === 'code-block',
+    )
+    const linesField = codeBlock?.fields?.find(
+      (field) => field.name === 'lines',
+    ) as {of: ReadonlyArray<OfDefinition>} | undefined
+    const subSchema = getSubSchema(schema, linesField?.of ?? [])
+
+    expect({
+      styles: subSchema.styles.map((style) => style.name),
+      decorators: subSchema.decorators.map((decorator) => decorator.name),
+      annotations: subSchema.annotations.map((annotation) => annotation.name),
+      lists: subSchema.lists.map((list) => list.name),
+    }).toEqual({
+      // Sanity always injects the `normal` style; the restriction strips
+      // everything else (no headings), all decorators, all annotations,
+      // and all lists.
+      styles: ['normal', 'code'],
+      decorators: [],
+      annotations: [],
+      lists: [],
+    })
+  })
+
+  test('the restriction is honored at arbitrary nesting depth', () => {
+    // table → row → cell → content[block]. The deepest block-member
+    // strips every mark and every style except `normal`. The PR's
+    // resolveBlockOfMember compares against the root block's enabled
+    // names; the intermediate containers must not shadow that
+    // comparison, so the restriction must survive at depth.
+    const tableType = defineType({
+      type: 'object',
+      name: 'table',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'rows',
+          of: [
+            defineArrayMember({
+              type: 'object',
+              name: 'row',
+              fields: [
+                defineField({
+                  type: 'array',
+                  name: 'cells',
+                  of: [
+                    defineArrayMember({
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        defineField({
+                          type: 'array',
+                          name: 'content',
+                          of: [
+                            defineArrayMember({
+                              type: 'block',
+                              name: 'block',
+                              styles: [{title: 'Normal', value: 'normal'}],
+                              lists: [],
+                              marks: {decorators: [], annotations: []},
+                              of: [],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'table'}),
+      ],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(
+      SanitySchema.compile({types: [portableTextType, tableType]}).get('body'),
+    )
+
+    // Walk down to the deepest `of` array.
+    const table = schema.blockObjects?.find((bo) => bo.name === 'table')
+    const rowsField = table?.fields?.find((f) => f.name === 'rows') as
+      | {of: ReadonlyArray<OfDefinition>}
+      | undefined
+    const row = rowsField?.of?.find(
+      (
+        member,
+      ): member is OfDefinition & {
+        name: string
+        fields: ReadonlyArray<FieldDefinition>
+      } => (member as {name?: string}).name === 'row',
+    )
+    const cellsField = row?.fields?.find((f) => f.name === 'cells') as
+      | {of: ReadonlyArray<OfDefinition>}
+      | undefined
+    const cell = cellsField?.of?.find(
+      (
+        member,
+      ): member is OfDefinition & {
+        name: string
+        fields: ReadonlyArray<FieldDefinition>
+      } => (member as {name?: string}).name === 'cell',
+    )
+    const contentField = cell?.fields?.find((f) => f.name === 'content') as
+      | {of: ReadonlyArray<OfDefinition>}
+      | undefined
+    const subSchema = getSubSchema(schema, contentField?.of ?? [])
+
+    expect({
+      styles: subSchema.styles.map((style) => style.name),
+      decorators: subSchema.decorators.map((decorator) => decorator.name),
+      annotations: subSchema.annotations.map((annotation) => annotation.name),
+      lists: subSchema.lists.map((list) => list.name),
+    }).toEqual({
+      styles: ['normal'],
+      decorators: [],
+      annotations: [],
+      lists: [],
+    })
+  })
+
+  test('two restricted block members in the same container resolve independently', () => {
+    // A container whose `lines` declares two block types with different
+    // restrictions: `code-line` strips everything; `quote-line` allows the
+    // `em` decorator and the `blockquote` style. Each member's resolved
+    // shape must reflect its OWN restrictions, not be cross-contaminated
+    // by the sibling member's resolution.
+    const codeBlockType = defineType({
+      type: 'object',
+      name: 'code-block',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'lines',
+          of: [
+            defineArrayMember({
+              type: 'block',
+              name: 'code-line',
+              styles: [{title: 'Code', value: 'code'}],
+              lists: [],
+              marks: {decorators: [], annotations: []},
+              of: [],
+            }),
+            defineArrayMember({
+              type: 'block',
+              name: 'quote-line',
+              styles: [{title: 'Quote', value: 'blockquote'}],
+              lists: [],
+              marks: {
+                decorators: [{title: 'Emphasis', value: 'em'}],
+                annotations: [],
+              },
+              of: [],
+            }),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'code-block'}),
+      ],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(
+      SanitySchema.compile({types: [portableTextType, codeBlockType]}).get(
+        'body',
+      ),
+    )
+
+    const codeBlock = schema.blockObjects?.find(
+      (bo) => bo.name === 'code-block',
+    )
+    const linesField = codeBlock?.fields?.find(
+      (field) => field.name === 'lines',
+    ) as {of: ReadonlyArray<OfDefinition>} | undefined
+    const of = linesField?.of ?? []
+
+    // Each member's resolved shape, asserted independently.
+    // Sanity drops the `name` field on bridge output, so members are
+    // identified by their position in the `of` array.
+    const codeLine = of[0]
+    const quoteLine = of[1]
+
+    expect({
+      codeLine: {
+        styles: (
+          codeLine as {styles?: ReadonlyArray<{value: string}>}
+        )?.styles?.map((s) => s.value),
+        decorators: (
+          codeLine as {decorators?: ReadonlyArray<{value: string}>}
+        )?.decorators?.map((d) => d.value),
+      },
+      quoteLine: {
+        styles: (
+          quoteLine as {styles?: ReadonlyArray<{value: string}>}
+        )?.styles?.map((s) => s.value),
+        decorators: (
+          quoteLine as {decorators?: ReadonlyArray<{value: string}>}
+        )?.decorators?.map((d) => d.value),
+      },
+    }).toEqual({
+      // Sanity always injects the `normal` style on every block, so the
+      // restricted set is `['normal', <restriction>]` not just the
+      // restriction value.
+      codeLine: {styles: ['normal', 'code'], decorators: []},
+      quoteLine: {styles: ['normal', 'blockquote'], decorators: ['em']},
+    })
   })
 })

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
@@ -1,4 +1,9 @@
-import type {FieldDefinition, OfDefinition, Schema} from '@portabletext/schema'
+import type {
+  BlockOfDefinition,
+  FieldDefinition,
+  OfDefinition,
+  Schema,
+} from '@portabletext/schema'
 import {Schema as SanitySchema} from '@sanity/schema'
 import {builtinTypes} from '@sanity/schema/_internal'
 import type {
@@ -101,7 +106,23 @@ function sanitySchemaTypeToSchema(
   // the walk linear in the size of the compiled schema. Without it, the
   // per-branch ancestor sets below enumerate every simple path through
   // mutually-embedding types, which grows combinatorially.
-  const memo = new Map<SchemaType, OfDefinition>()
+  //
+  // The root block's enabled names ride along so a nested `{type: 'block'}`
+  // member can be compared against them: a member that enables the same
+  // marks/styles/lists as the root inherits the root sub-schema (emitted as
+  // a bare `{type: 'block'}`), while a member that restricts any of them is
+  // resolved so the restriction survives in `getSubSchema`.
+  const context: ConversionContext = {
+    memo: new Map<SchemaType, OfDefinition>(),
+    rootBlockNames: {
+      styles: styles.map((style: BlockStyleDefinition) => style.value),
+      decorators: decorators.map(
+        (decorator: BlockDecoratorDefinition) => decorator.value,
+      ),
+      lists: lists.map((list: BlockListDefinition) => list.value),
+      annotations: annotations.map((annotation) => annotation.name),
+    },
+  }
 
   return {
     block: {
@@ -129,24 +150,141 @@ function sanitySchemaTypeToSchema(
       name: annotation.name,
       title: annotation.title,
       fields: annotation.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set(), memo),
+        sanityFieldToSchemaField(field, new Set(), context),
       ),
     })),
     blockObjects: blockObjectTypes.map((blockObject) => ({
       name: blockObject.name,
       title: blockObject.title,
       fields: blockObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([blockObject.name]), memo),
+        sanityFieldToSchemaField(field, new Set([blockObject.name]), context),
       ),
     })),
     inlineObjects: inlineObjectTypes.map((inlineObject) => ({
       name: inlineObject.name,
       title: inlineObject.title,
       fields: inlineObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([inlineObject.name]), memo),
+        sanityFieldToSchemaField(field, new Set([inlineObject.name]), context),
       ),
     })),
   }
+}
+
+type ConversionContext = {
+  memo: Map<SchemaType, OfDefinition>
+  rootBlockNames: {
+    styles: ReadonlyArray<string>
+    decorators: ReadonlyArray<string>
+    lists: ReadonlyArray<string>
+    annotations: ReadonlyArray<string>
+  }
+}
+
+/**
+ * Resolve a container's `{type: 'block'}` `of` member.
+ *
+ * A nested block declares its sub-schema the same way the root block does:
+ * `styles`/`lists` as field options, `decorators`/`annotations` on the
+ * span. Each list is emitted only when the member restricts it relative to
+ * the root block (the enabled names differ); when the member enables the
+ * same set as the root, the list is omitted so `getSubSchema` inherits the
+ * root schema (the documented `BlockOfDefinition` contract). Without this, a
+ * restricted nested block (e.g. a code-block line that strips marks and
+ * styles) would fall back to the root schema and let markdown-shortcuts and
+ * character-pair-decorator fire inside the container.
+ *
+ * `inlineObjects` is intentionally left to inherit the root: the compiled
+ * span shape can't distinguish "no inline objects declared" from "inline
+ * objects restricted to none", and no current consumer gates on it.
+ */
+function resolveBlockOfMember(
+  blockType: BlockSchemaType,
+  ancestorNames: ReadonlySet<string>,
+  context: ConversionContext,
+): BlockOfDefinition {
+  const root = context.rootBlockNames
+
+  const styleList = blockType.fields?.find((field) => field.name === 'style')
+    ?.type.options?.list
+  const styles = (Array.isArray(styleList) ? styleList : [])
+    .filter((style: BlockStyleDefinition) => style.value)
+    .map((style: BlockStyleDefinition) => ({
+      name: style.value,
+      title: style.title,
+      value: style.value,
+    }))
+
+  const listItemList = blockType.fields?.find(
+    (field) => field.name === 'listItem',
+  )?.type.options?.list
+  const lists = (Array.isArray(listItemList) ? listItemList : [])
+    .filter((list: BlockListDefinition) => list.value)
+    .map((list: BlockListDefinition) => ({
+      name: list.value,
+      title: list.title,
+      value: list.value,
+    }))
+
+  const spanType = (
+    blockType.fields?.find((field) => field.name === 'children') as
+      | {type: ArraySchemaType}
+      | undefined
+  )?.type.of?.find((memberType) => memberType.name === 'span') as
+    | ObjectSchemaType
+    | undefined
+  const spanDecorators = (
+    spanType as unknown as {
+      decorators?: ReadonlyArray<BlockDecoratorDefinition>
+    }
+  )?.decorators
+  const decorators = (Array.isArray(spanDecorators) ? spanDecorators : []).map(
+    (decorator: BlockDecoratorDefinition) => ({
+      name: decorator.value,
+      title: decorator.title,
+      value: decorator.value,
+    }),
+  )
+  const spanAnnotations = (spanType as SpanSchemaType | undefined)?.annotations
+  const annotations = (
+    Array.isArray(spanAnnotations) ? spanAnnotations : []
+  ).map((annotation) => ({
+    name: annotation.name,
+    title: annotation.title,
+    fields: annotation.fields.map((field) =>
+      sanityFieldToSchemaField(field, ancestorNames, context),
+    ),
+  }))
+
+  return {
+    type: 'block',
+    ...(Array.isArray(styleList) && !sameNames(styles, root.styles)
+      ? {styles}
+      : {}),
+    ...(Array.isArray(listItemList) && !sameNames(lists, root.lists)
+      ? {lists}
+      : {}),
+    ...(Array.isArray(spanDecorators) && !sameNames(decorators, root.decorators)
+      ? {decorators}
+      : {}),
+    ...(Array.isArray(spanAnnotations) &&
+    !sameNames(annotations, root.annotations)
+      ? {annotations}
+      : {}),
+  }
+}
+
+/**
+ * `true` when the resolved members enable exactly the root block's names in
+ * the same order, i.e. the nested block does not restrict this list.
+ */
+function sameNames(
+  members: ReadonlyArray<{name: string}>,
+  rootNames: ReadonlyArray<string>,
+): boolean {
+  return (
+    members.length === rootNames.length &&
+    members.every((member, index) => member.name === rootNames[index])
+  )
 }
 
 function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
@@ -167,7 +305,7 @@ function sanityFieldToSchemaField(
     type: SchemaType
   },
   ancestorNames: ReadonlySet<string>,
-  memo: Map<SchemaType, OfDefinition>,
+  context: ConversionContext,
 ): FieldDefinition {
   if (field.type.jsonType === 'array') {
     const ofMembers = safeGetOf(field.type)
@@ -177,7 +315,7 @@ function sanityFieldToSchemaField(
       ...(field.type.title ? {title: field.type.title} : {}),
       of: ofMembers
         ? ofMembers.map((member) =>
-            sanityOfMemberToOfDefinition(member, ancestorNames, memo),
+            sanityOfMemberToOfDefinition(member, ancestorNames, context),
           )
         : [],
     }
@@ -193,10 +331,18 @@ function sanityFieldToSchemaField(
 function sanityOfMemberToOfDefinition(
   memberType: SchemaType,
   ancestorNames: ReadonlySet<string>,
-  memo: Map<SchemaType, OfDefinition>,
+  context: ConversionContext,
 ): OfDefinition {
+  // `findBlockType` walks up the `type.type` chain to the base `block`, so
+  // it only detects *whether* this member is a block. A block member's own
+  // marks/styles/lists live on `memberType`, which `resolveBlockOfMember`
+  // reads and compares against the root block to emit only restrictions.
   if (findBlockType(memberType)) {
-    return {type: 'block'}
+    return resolveBlockOfMember(
+      memberType as BlockSchemaType,
+      ancestorNames,
+      context,
+    )
   }
 
   // If this member has fields and isn't already in the ancestor chain,
@@ -221,7 +367,7 @@ function sanityOfMemberToOfDefinition(
   // every later position that reaches the same instance shares the first
   // expansion. Keyed by instance (not name) so that same-named but
   // structurally different inline declarations keep their own shapes.
-  const memoized = memo.get(memberType)
+  const memoized = context.memo.get(memberType)
   if (memoized) {
     return memoized
   }
@@ -233,10 +379,10 @@ function sanityOfMemberToOfDefinition(
     name: memberType.name,
     ...(memberType.title ? {title: memberType.title} : {}),
     fields: (memberType as ObjectSchemaType).fields.map((field) =>
-      sanityFieldToSchemaField(field, nextAncestors, memo),
+      sanityFieldToSchemaField(field, nextAncestors, context),
     ),
   }
-  memo.set(memberType, definition)
+  context.memo.set(memberType, definition)
   return definition
 }
 


### PR DESCRIPTION
Sanity-authored containers with a restricted block member silently inherited the root schema. A code block declaring `marks: {decorators: []}`, `styles: [{value: 'code'}]`, `lists: []` resolved to the full root sub-schema, so `@portabletext/plugin-markdown-shortcuts` and `@portabletext/plugin-character-pair-decorator` fired inside it — `# ` became a heading, `**bold**` became bold, source code silently corrupted.

The plugins are correct. They resolve the schema at the caret with `getPathSubSchema` and no-op when the decorator/style/list/annotation they would produce is absent. The sub-schema they were handed was wrong.

### The bridge

`getPathSubSchema` resolves a container's allowed types through `getSubSchema(schema, of)`, and that `of` comes from the bridge. `sanityOfMemberToOfDefinition` emitted a bare `{type: 'block'}` for every block member, carrying none of the block's enabled styles, decorators, annotations, or lists. `getSubSchema` inherits the root schema for any list an of-member omits (the documented `BlockOfDefinition` contract), so every restricted list silently re-opened to root.

The bug class is wider than the original 8.0.15 report. A reproduction driven straight at the `getSubSchema` seam on `main` shows all five lists (styles, decorators, annotations, lists, inlineObjects) leaking to root; the earlier report only flagged decorators and annotations.

### The fix

A block of-member is now resolved through `resolveBlockOfMember`, which reads the member's own `style`/`listItem` field options and the span's `decorators`/`annotations` and emits each list only when its enabled names differ from the root block's. A member that enables the same set as root is indistinguishable from inheriting root, so it still emits as a bare `{type: 'block'}` and `getSubSchema` inherits root — the existing contract holds. A member that restricts any list emits that list so the restriction survives.

The root block's enabled names ride along on the existing conversion-walk context next to the memo, so the comparison costs nothing extra per member.

### Behavioral delta

Top-level schema conversion is unchanged. Unmodified nested blocks still convert to a bare `{type: 'block'}`, so the existing recursion and cycle tests are byte-identical. Only restricted container block members change shape, gaining the marks, styles, lists, and annotations they always should have carried.

### Known gap: `inlineObjects`

`inlineObjects` is deliberately left to inherit the root. The compiled span shape from Sanity can't distinguish "no inline objects declared" from "inline objects restricted to none", and no current consumer gates on it. Worth re-examining when a consumer needs to restrict inline objects inside a container.