### PR TITLE
fix: resolve container block members from their own schema in `sanitySchemaToPortableTextSchema`

### DIFF
--- a/.changeset/container-block-member-resolution.md
+++ b/.changeset/container-block-member-resolution.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/sanity-bridge': patch
+---
+
+fix: resolve container block members from their own schema in `sanitySchemaToPortableTextSchema`
+
+A container block member now resolves its sub-schema from its own declared styles, decorators, annotations, lists, and inline objects. A code-block line that declares `of: []` no longer inherits the root block's inline objects, and a container that declares a same-named but differently-shaped annotation or inline object (e.g. a `widget` whose fields differ from the root's `widget`) keeps its own shape instead of the root's.

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.test.ts
@@ -15,6 +15,42 @@ import {
 import {describe, expect, test} from 'vitest'
 import {sanitySchemaToPortableTextSchema} from './sanity-schema-to-portable-text-schema'
 
+// The resolved sub-schema for an unmodified nested block member: the bridge
+// emits each block member's own resolved lists, and an unmodified block
+// resolves to Sanity's defaults.
+const defaultBlockOfMember = {
+  type: 'block',
+  styles: [
+    {name: 'normal', title: 'Normal', value: 'normal'},
+    {name: 'h1', title: 'Heading 1', value: 'h1'},
+    {name: 'h2', title: 'Heading 2', value: 'h2'},
+    {name: 'h3', title: 'Heading 3', value: 'h3'},
+    {name: 'h4', title: 'Heading 4', value: 'h4'},
+    {name: 'h5', title: 'Heading 5', value: 'h5'},
+    {name: 'h6', title: 'Heading 6', value: 'h6'},
+    {name: 'blockquote', title: 'Quote', value: 'blockquote'},
+  ],
+  lists: [
+    {name: 'bullet', title: 'Bulleted list', value: 'bullet'},
+    {name: 'number', title: 'Numbered list', value: 'number'},
+  ],
+  decorators: [
+    {name: 'strong', title: 'Strong', value: 'strong'},
+    {name: 'em', title: 'Italic', value: 'em'},
+    {name: 'code', title: 'Code', value: 'code'},
+    {name: 'underline', title: 'Underline', value: 'underline'},
+    {name: 'strike-through', title: 'Strike', value: 'strike-through'},
+  ],
+  annotations: [
+    {
+      name: 'link',
+      title: 'Link',
+      fields: [{name: 'href', title: 'Link', type: 'string'}],
+    },
+  ],
+  inlineObjects: [],
+}
+
 describe(sanitySchemaToPortableTextSchema.name, () => {
   const defaultSchema: Schema = {
     block: {
@@ -385,7 +421,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                         name: 'content',
                         type: 'array',
                         title: 'Content',
-                        of: [{type: 'block'}],
+                        of: [defaultBlockOfMember],
                       },
                     ],
                   },
@@ -480,7 +516,10 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                         name: 'content',
                         type: 'array',
                         title: 'Content',
-                        of: [{type: 'block'}, {type: 'table', title: 'Table'}],
+                        of: [
+                          defaultBlockOfMember,
+                          {type: 'table', title: 'Table'},
+                        ],
                       },
                     ],
                   },
@@ -537,7 +576,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         name: 'input',
         type: 'array',
         title: 'Input',
-        of: [{type: 'block'}, {type: 'aiTask', title: 'Ai Task'}],
+        of: [defaultBlockOfMember, {type: 'aiTask', title: 'Ai Task'}],
       },
     ])
   })
@@ -600,7 +639,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         type: 'array',
         title: 'Content',
         of: [
-          {type: 'block'},
+          defaultBlockOfMember,
           {
             type: 'object',
             name: 'b',
@@ -610,7 +649,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                 name: 'content',
                 type: 'array',
                 title: 'Content',
-                of: [{type: 'block'}, {type: 'a', title: 'A'}],
+                of: [defaultBlockOfMember, {type: 'a', title: 'A'}],
               },
             ],
           },
@@ -625,7 +664,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         type: 'array',
         title: 'Content',
         of: [
-          {type: 'block'},
+          defaultBlockOfMember,
           {
             type: 'object',
             name: 'a',
@@ -635,7 +674,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                 name: 'content',
                 type: 'array',
                 title: 'Content',
-                of: [{type: 'block'}, {type: 'b', title: 'B'}],
+                of: [defaultBlockOfMember, {type: 'b', title: 'B'}],
               },
             ],
           },
@@ -713,7 +752,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         type: 'array',
         title: 'Content',
         of: [
-          {type: 'block'},
+          defaultBlockOfMember,
           {
             type: 'object',
             name: 'b',
@@ -724,7 +763,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                 type: 'array',
                 title: 'Content',
                 of: [
-                  {type: 'block'},
+                  defaultBlockOfMember,
                   {
                     type: 'object',
                     name: 'c',
@@ -734,7 +773,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
                         name: 'content',
                         type: 'array',
                         title: 'Content',
-                        of: [{type: 'block'}, {type: 'a', title: 'A'}],
+                        of: [defaultBlockOfMember, {type: 'a', title: 'A'}],
                       },
                     ],
                   },
@@ -815,7 +854,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         name: 'content',
         type: 'array',
         title: 'Content',
-        of: [{type: 'block'}, cInline],
+        of: [defaultBlockOfMember, cInline],
       },
     ])
     expect(b?.fields).toEqual([
@@ -823,7 +862,7 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
         name: 'content',
         type: 'array',
         title: 'Content',
-        of: [{type: 'block'}, cInline],
+        of: [defaultBlockOfMember, cInline],
       },
     ])
   })
@@ -1090,5 +1129,145 @@ describe(sanitySchemaToPortableTextSchema.name, () => {
       codeLine: {styles: ['normal', 'code'], decorators: []},
       quoteLine: {styles: ['normal', 'blockquote'], decorators: ['em']},
     })
+  })
+
+  test('a container block member that allows no inline objects does not inherit the root inline objects', () => {
+    // The root block allows a `stock-ticker` inline object; the code-block
+    // line declares `of: []`. The line's sub-schema must advertise no
+    // inline objects, otherwise the restriction leaks the root's.
+    const stockTicker = defineType({
+      type: 'object',
+      name: 'stock-ticker',
+      fields: [defineField({name: 'symbol', type: 'string'})],
+    })
+    const codeBlockType = defineType({
+      type: 'object',
+      name: 'code-block',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'lines',
+          of: [
+            defineArrayMember({
+              type: 'block',
+              name: 'block',
+              styles: [{title: 'Code', value: 'code'}],
+              lists: [],
+              marks: {decorators: [], annotations: []},
+              of: [],
+            }),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          name: 'block',
+          of: [{type: 'stock-ticker'}],
+        }),
+        defineArrayMember({type: 'code-block'}),
+      ],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(
+      SanitySchema.compile({
+        types: [portableTextType, codeBlockType, stockTicker],
+      }).get('body'),
+    )
+
+    expect(schema.inlineObjects?.map((object) => object.name)).toEqual([
+      'stock-ticker',
+    ])
+
+    const codeBlock = schema.blockObjects?.find(
+      (bo) => bo.name === 'code-block',
+    )
+    const linesField = codeBlock?.fields?.find(
+      (field) => field.name === 'lines',
+    ) as {of: ReadonlyArray<OfDefinition>} | undefined
+    const subSchema = getSubSchema(schema, linesField?.of ?? [])
+
+    expect(subSchema.inlineObjects.map((object) => object.name)).toEqual([])
+  })
+
+  test('a container inline object that shares a name with the root but differs in shape keeps its own shape', () => {
+    // Root allows inline `widget` with field `a`; the code-block line
+    // allows inline `widget` with field `b`. The name matches but the
+    // shape differs, so the line's sub-schema must keep its own `widget`
+    // (field `b`), not inherit the root's (field `a`).
+    const codeBlockType = defineType({
+      type: 'object',
+      name: 'code-block',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'lines',
+          of: [
+            defineArrayMember({
+              type: 'block',
+              name: 'block',
+              styles: [{title: 'Code', value: 'code'}],
+              lists: [],
+              marks: {decorators: [], annotations: []},
+              of: [
+                {
+                  type: 'object',
+                  name: 'widget',
+                  fields: [{name: 'b', type: 'string'}],
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+    const portableTextType = defineType({
+      type: 'array',
+      name: 'body',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          name: 'block',
+          of: [
+            {
+              type: 'object',
+              name: 'widget',
+              fields: [{name: 'a', type: 'string'}],
+            },
+          ],
+        }),
+        defineArrayMember({type: 'code-block'}),
+      ],
+    })
+
+    const schema = sanitySchemaToPortableTextSchema(
+      SanitySchema.compile({types: [portableTextType, codeBlockType]}).get(
+        'body',
+      ),
+    )
+
+    expect(
+      schema.inlineObjects
+        ?.find((object) => object.name === 'widget')
+        ?.fields.map((field) => field.name),
+    ).toEqual(['a'])
+
+    const codeBlock = schema.blockObjects?.find(
+      (bo) => bo.name === 'code-block',
+    )
+    const linesField = codeBlock?.fields?.find(
+      (field) => field.name === 'lines',
+    ) as {of: ReadonlyArray<OfDefinition>} | undefined
+    const subSchema = getSubSchema(schema, linesField?.of ?? [])
+
+    expect(
+      subSchema.inlineObjects
+        .find((object) => object.name === 'widget')
+        ?.fields.map((field) => field.name),
+    ).toEqual(['b'])
   })
 })

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
@@ -106,23 +106,7 @@ function sanitySchemaTypeToSchema(
   // the walk linear in the size of the compiled schema. Without it, the
   // per-branch ancestor sets below enumerate every simple path through
   // mutually-embedding types, which grows combinatorially.
-  //
-  // The root block's enabled names ride along so a nested `{type: 'block'}`
-  // member can be compared against them: a member that enables the same
-  // marks/styles/lists as the root inherits the root sub-schema (emitted as
-  // a bare `{type: 'block'}`), while a member that restricts any of them is
-  // resolved so the restriction survives in `getSubSchema`.
-  const context: ConversionContext = {
-    memo: new Map<SchemaType, OfDefinition>(),
-    rootBlockNames: {
-      styles: styles.map((style: BlockStyleDefinition) => style.value),
-      decorators: decorators.map(
-        (decorator: BlockDecoratorDefinition) => decorator.value,
-      ),
-      lists: lists.map((list: BlockListDefinition) => list.value),
-      annotations: annotations.map((annotation) => annotation.name),
-    },
-  }
+  const memo = new Map<SchemaType, OfDefinition>()
 
   return {
     block: {
@@ -150,141 +134,114 @@ function sanitySchemaTypeToSchema(
       name: annotation.name,
       title: annotation.title,
       fields: annotation.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set(), context),
+        sanityFieldToSchemaField(field, new Set(), memo),
       ),
     })),
     blockObjects: blockObjectTypes.map((blockObject) => ({
       name: blockObject.name,
       title: blockObject.title,
       fields: blockObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([blockObject.name]), context),
+        sanityFieldToSchemaField(field, new Set([blockObject.name]), memo),
       ),
     })),
     inlineObjects: inlineObjectTypes.map((inlineObject) => ({
       name: inlineObject.name,
       title: inlineObject.title,
       fields: inlineObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([inlineObject.name]), context),
+        sanityFieldToSchemaField(field, new Set([inlineObject.name]), memo),
       ),
     })),
-  }
-}
-
-type ConversionContext = {
-  memo: Map<SchemaType, OfDefinition>
-  rootBlockNames: {
-    styles: ReadonlyArray<string>
-    decorators: ReadonlyArray<string>
-    lists: ReadonlyArray<string>
-    annotations: ReadonlyArray<string>
   }
 }
 
 /**
  * Resolve a container's `{type: 'block'}` `of` member.
  *
- * A nested block declares its sub-schema the same way the root block does:
- * `styles`/`lists` as field options, `decorators`/`annotations` on the
- * span. Each list is emitted only when the member restricts it relative to
- * the root block (the enabled names differ); when the member enables the
- * same set as the root, the list is omitted so `getSubSchema` inherits the
- * root schema (the documented `BlockOfDefinition` contract). Without this, a
- * restricted nested block (e.g. a code-block line that strips marks and
- * styles) would fall back to the root schema and let markdown-shortcuts and
- * character-pair-decorator fire inside the container.
+ * A nested block carries its own resolved sub-schema: `styles`/`lists` as
+ * field options, `decorators`/`annotations` on the span, inline objects as
+ * the non-span `of` members of `children`. Sanity resolves these for every
+ * block (an undeclared list becomes Sanity's defaults, not the root block's
+ * values; a block's inline objects are exactly its own `of`), so there is
+ * nothing to inherit and nothing to merge: emit the member's own resolved
+ * lists and let `getSubSchema` read them directly.
  *
- * `inlineObjects` is intentionally left to inherit the root: the compiled
- * span shape can't distinguish "no inline objects declared" from "inline
- * objects restricted to none", and no current consumer gates on it.
+ * This is what keeps a restricted nested block (a code-block line that
+ * strips marks and styles, or declares `of: []`) from leaking the root's
+ * decorators, styles, or inline objects into the container.
  */
 function resolveBlockOfMember(
   blockType: BlockSchemaType,
   ancestorNames: ReadonlySet<string>,
-  context: ConversionContext,
+  memo: Map<SchemaType, OfDefinition>,
 ): BlockOfDefinition {
-  const root = context.rootBlockNames
-
   const styleList = blockType.fields?.find((field) => field.name === 'style')
     ?.type.options?.list
-  const styles = (Array.isArray(styleList) ? styleList : [])
-    .filter((style: BlockStyleDefinition) => style.value)
-    .map((style: BlockStyleDefinition) => ({
-      name: style.value,
-      title: style.title,
-      value: style.value,
-    }))
-
   const listItemList = blockType.fields?.find(
     (field) => field.name === 'listItem',
   )?.type.options?.list
-  const lists = (Array.isArray(listItemList) ? listItemList : [])
-    .filter((list: BlockListDefinition) => list.value)
-    .map((list: BlockListDefinition) => ({
-      name: list.value,
-      title: list.title,
-      value: list.value,
-    }))
 
-  const spanType = (
+  const childrenOf = (
     blockType.fields?.find((field) => field.name === 'children') as
       | {type: ArraySchemaType}
       | undefined
-  )?.type.of?.find((memberType) => memberType.name === 'span') as
-    | ObjectSchemaType
-    | undefined
+  )?.type.of
+  const spanType = childrenOf?.find(
+    (memberType) => memberType.name === 'span',
+  ) as ObjectSchemaType | undefined
+  const inlineObjectTypes = (
+    Array.isArray(childrenOf) ? childrenOf : []
+  ).filter((memberType) => memberType.name !== 'span') as ObjectSchemaType[]
   const spanDecorators = (
     spanType as unknown as {
       decorators?: ReadonlyArray<BlockDecoratorDefinition>
     }
   )?.decorators
-  const decorators = (Array.isArray(spanDecorators) ? spanDecorators : []).map(
-    (decorator: BlockDecoratorDefinition) => ({
-      name: decorator.value,
-      title: decorator.title,
-      value: decorator.value,
-    }),
-  )
   const spanAnnotations = (spanType as SpanSchemaType | undefined)?.annotations
-  const annotations = (
-    Array.isArray(spanAnnotations) ? spanAnnotations : []
-  ).map((annotation) => ({
-    name: annotation.name,
-    title: annotation.title,
-    fields: annotation.fields.map((field) =>
-      sanityFieldToSchemaField(field, ancestorNames, context),
-    ),
-  }))
 
   return {
     type: 'block',
-    ...(Array.isArray(styleList) && !sameNames(styles, root.styles)
-      ? {styles}
-      : {}),
-    ...(Array.isArray(listItemList) && !sameNames(lists, root.lists)
-      ? {lists}
-      : {}),
-    ...(Array.isArray(spanDecorators) && !sameNames(decorators, root.decorators)
-      ? {decorators}
-      : {}),
-    ...(Array.isArray(spanAnnotations) &&
-    !sameNames(annotations, root.annotations)
-      ? {annotations}
-      : {}),
+    styles: (Array.isArray(styleList) ? styleList : [])
+      .filter((style: BlockStyleDefinition) => style.value)
+      .map((style: BlockStyleDefinition) => ({
+        name: style.value,
+        title: style.title,
+        value: style.value,
+      })),
+    lists: (Array.isArray(listItemList) ? listItemList : [])
+      .filter((list: BlockListDefinition) => list.value)
+      .map((list: BlockListDefinition) => ({
+        name: list.value,
+        title: list.title,
+        value: list.value,
+      })),
+    decorators: (Array.isArray(spanDecorators) ? spanDecorators : []).map(
+      (decorator: BlockDecoratorDefinition) => ({
+        name: decorator.value,
+        title: decorator.title,
+        value: decorator.value,
+      }),
+    ),
+    annotations: (Array.isArray(spanAnnotations) ? spanAnnotations : []).map(
+      (annotation) => ({
+        name: annotation.name,
+        title: annotation.title,
+        fields: annotation.fields.map((field) =>
+          sanityFieldToSchemaField(field, ancestorNames, memo),
+        ),
+      }),
+    ),
+    inlineObjects: inlineObjectTypes.map((inlineObject) => ({
+      name: inlineObject.name,
+      title: inlineObject.title,
+      fields: (inlineObject.fields ?? []).map((field) =>
+        sanityFieldToSchemaField(
+          field,
+          new Set([...ancestorNames, inlineObject.name]),
+          memo,
+        ),
+      ),
+    })),
   }
-}
-
-/**
- * `true` when the resolved members enable exactly the root block's names in
- * the same order, i.e. the nested block does not restrict this list.
- */
-function sameNames(
-  members: ReadonlyArray<{name: string}>,
-  rootNames: ReadonlyArray<string>,
-): boolean {
-  return (
-    members.length === rootNames.length &&
-    members.every((member, index) => member.name === rootNames[index])
-  )
 }
 
 function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
@@ -305,7 +262,7 @@ function sanityFieldToSchemaField(
     type: SchemaType
   },
   ancestorNames: ReadonlySet<string>,
-  context: ConversionContext,
+  memo: Map<SchemaType, OfDefinition>,
 ): FieldDefinition {
   if (field.type.jsonType === 'array') {
     const ofMembers = safeGetOf(field.type)
@@ -315,7 +272,7 @@ function sanityFieldToSchemaField(
       ...(field.type.title ? {title: field.type.title} : {}),
       of: ofMembers
         ? ofMembers.map((member) =>
-            sanityOfMemberToOfDefinition(member, ancestorNames, context),
+            sanityOfMemberToOfDefinition(member, ancestorNames, memo),
           )
         : [],
     }
@@ -331,17 +288,17 @@ function sanityFieldToSchemaField(
 function sanityOfMemberToOfDefinition(
   memberType: SchemaType,
   ancestorNames: ReadonlySet<string>,
-  context: ConversionContext,
+  memo: Map<SchemaType, OfDefinition>,
 ): OfDefinition {
   // `findBlockType` walks up the `type.type` chain to the base `block`, so
   // it only detects *whether* this member is a block. A block member's own
   // marks/styles/lists live on `memberType`, which `resolveBlockOfMember`
-  // reads and compares against the root block to emit only restrictions.
+  // reads to emit the member's own resolved sub-schema.
   if (findBlockType(memberType)) {
     return resolveBlockOfMember(
       memberType as BlockSchemaType,
       ancestorNames,
-      context,
+      memo,
     )
   }
 
@@ -367,7 +324,7 @@ function sanityOfMemberToOfDefinition(
   // every later position that reaches the same instance shares the first
   // expansion. Keyed by instance (not name) so that same-named but
   // structurally different inline declarations keep their own shapes.
-  const memoized = context.memo.get(memberType)
+  const memoized = memo.get(memberType)
   if (memoized) {
     return memoized
   }
@@ -379,10 +336,10 @@ function sanityOfMemberToOfDefinition(
     name: memberType.name,
     ...(memberType.title ? {title: memberType.title} : {}),
     fields: (memberType as ObjectSchemaType).fields.map((field) =>
-      sanityFieldToSchemaField(field, nextAncestors, context),
+      sanityFieldToSchemaField(field, nextAncestors, memo),
     ),
   }
-  context.memo.set(memberType, definition)
+  memo.set(memberType, definition)
   return definition
 }
 


### PR DESCRIPTION
Follow-up to #2817. That PR resolved a container block member's sub-schema by comparing each list against the root block and emitting only the lists that *differed*, leaving the rest to inherit the root via `getSubSchema`. That asked the wrong question, and left two leaks behind.

When converting from Sanity there is nothing to inherit. Every block fully resolves its own lists: an undeclared list becomes Sanity's defaults (not the root block's values), and a block's inline objects are exactly its own `of`. So the container/root distinction the comparison leaned on doesn't exist at the source. Comparing against the root also meant inline objects were never resolved at all (a code-block line declaring `of: []` inherited the root's inline objects), and annotations/inline objects were matched by name, so a container declaring a same-named but differently-shaped entry (a `widget` whose fields differ from the root's `widget`) inherited the root's shape.

`resolveBlockOfMember` now reads the member's own `style`/`listItem` field options, span `decorators`/`annotations`, and inline-object `of` members, and emits all five lists directly. No comparison, no merge: `sameNames`, `sameResolved`, and the root-block lists that were threaded on the conversion context are gone, and the walk is back to threading just the memo. `getSubSchema` reads the populated of-member directly; its inherit-from-root fallback now applies only to hand-authored `defineSchema` schemas that omit a list, which is what that fallback is for.

`of: []` and an omitted `of` both compile to a span-only `children`, so both faithfully resolve to "no inline objects" (Sanity blocks don't inherit inline objects from a root). The effective sub-schema `getSubSchema` returns is unchanged for every previously-passing case; the observable delta is that a container block member's `of` entry is now fully populated instead of a bare `{type: 'block'}`. The recursion and cycle tests assert that populated shape through a shared `defaultBlockOfMember` constant, and the cycle stubs for object members are untouched.

Tests pin the three behaviors: a code-block line with `of: []` resolves to `inlineObjects: []`; a line declaring a `widget` with different fields than the root's `widget` keeps its own field shape; and the existing marks/styles/lists restrictions still resolve at arbitrary container depth.

Branches off `main`; #2817 is merged and released as `@portabletext/sanity-bridge@3.1.3`.
