### PR TITLE
docs: document container sub-schema resolution

### DIFF
--- a/packages/sanity-bridge/README.md
+++ b/packages/sanity-bridge/README.md
@@ -93,6 +93,47 @@ const sanitySchema = Schema.compile({
 const portableTextSchema = sanitySchemaToPortableTextSchema(sanitySchema)
 ```
 
+#### Container sub-schemas
+
+When a block object holds an array field with a nested `{type: 'block'}`
+member (a code block, callout, table cell, ...), the nested block is
+resolved from its own Sanity definition: its styles, decorators,
+annotations, lists, and inline objects come from that block as Sanity
+compiles it, not from the top-level block.
+
+```ts
+const codeBlockType = defineType({
+  type: 'object',
+  name: 'code-block',
+  fields: [
+    defineField({
+      type: 'array',
+      name: 'lines',
+      of: [
+        // A code line: only the `code` style, no marks, no inline objects.
+        {
+          type: 'block',
+          styles: [{title: 'Code', value: 'code'}],
+          lists: [],
+          marks: {decorators: [], annotations: []},
+          of: [],
+        },
+      ],
+    }),
+  ],
+})
+```
+
+In the converted schema the `code-block`'s line carries those restrictions,
+so an editor that gates on the sub-schema offers no decorators, annotations,
+or headings inside it.
+
+Sanity has no notion of a nested block inheriting from an enclosing block, so
+an undeclared property resolves to Sanity's defaults for that block. Declare
+whatever a container should allow on the block member itself. The resulting
+`Schema` follows the resolution rules documented in
+[`@portabletext/schema`](../schema/README.md#containers-and-sub-schemas).
+
 ### Convert Portable Text Schema to Sanity Schema
 
 ```ts

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -30,3 +30,69 @@ import {compileSchema} from '@portabletext/schema'
 
 const schema = compileSchema(schemaDefinition)
 ```
+
+## Containers and sub-schemas
+
+A block object can act as a _container_: one of its fields is an array whose
+`of` includes a `{type: 'block'}` member, which declares the text sub-schema
+allowed inside it. This is how a code block, callout, or table cell restricts
+what can be typed within it.
+
+```ts
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}, {name: 'code'}],
+  styles: [{name: 'normal'}, {name: 'h1'}],
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [
+        {
+          name: 'lines',
+          type: 'array',
+          of: [
+            // A code line: a `code` style only, and no decorators.
+            {type: 'block', styles: [{name: 'code'}], decorators: []},
+          ],
+        },
+      ],
+    },
+  ],
+})
+```
+
+Use `getSubSchema` to resolve what is allowed at a position inside a
+container. It returns a `Schema` you can treat like any top-level one:
+
+```ts
+import {compileSchema, getSubSchema} from '@portabletext/schema'
+
+const schema = compileSchema(schemaDefinition)
+const codeBlock = schema.blockObjects.find((type) => type.name === 'code-block')
+const lines = codeBlock.fields.find((field) => field.name === 'lines')
+
+const subSchema = getSubSchema(schema, lines.of)
+// subSchema.decorators === []                 (the code line forbids decorators)
+// subSchema.styles     === [{name: 'code', ...}] (only the `code` style)
+```
+
+### How a nested block overrides and inherits
+
+Each of `styles`, `decorators`, `annotations`, `lists`, and `inlineObjects`
+resolves independently:
+
+- **Declared** overrides for that property.
+- **Declared empty** (`[]`) overrides to nothing, e.g. `decorators: []`
+  forbids every decorator inside the container.
+- **Absent** inherits from the nearest enclosing container that declares a
+  block, or the root when none does.
+
+There is no merging: a property is either declared here or taken whole from a
+single source. An absent property resolves against the **nearest enclosing
+container** whose block declares it, so a block nested inside a container that
+restricts its own text inherits that restriction rather than the document
+root. It falls back to the root only when no enclosing container declares a
+block of its own (e.g. structural `table` → `row` → `cell` wrappers, where the
+cell's text inherits the document). A nested block never blends multiple
+ancestors; it takes exactly one inherited value. When the `of` has no
+`{type: 'block'}` member at all, the container allows objects only, with no
+text formatting.


### PR DESCRIPTION
The `@portabletext/schema` and `@portabletext/sanity-bridge` READMEs were sparse and predated the container sub-schema work, so the resolution semantics lived only in test names. This documents the consumer-facing contract.

`@portabletext/schema` gains a "Containers and sub-schemas" section: how a block object declares a nested `{type: 'block'}` sub-schema on an array field, how to resolve it with `getSubSchema` (a public export that had no docs), and the per-property rule, a declared property overrides, a declared-empty property replaces (forbids), an absent property inherits from the nearest enclosing container that declares a block (falling back to the root when none does), and there is no merge.

`@portabletext/sanity-bridge` gains a short note that a container block member is resolved from its own Sanity definition (Sanity has no notion of a nested block inheriting from an enclosing block, so an undeclared property is Sanity's defaults), linking back to the schema README for the rules.

Deliberately left out: internals (the memo, compile-time-fill vs read-time fallback, the always-emit history). The READMEs state the contract; the code and tests carry the mechanism. Docs-only, no changeset.

The nearest-enclosing-container inheritance documented here is introduced in #2823; this PR should land together with or after it.
