### PR TITLE
fix: inherit a nested block's sub-schema from its enclosing container

### DIFF
--- a/.changeset/nested-block-container-inheritance.md
+++ b/.changeset/nested-block-container-inheritance.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/schema': patch
+---
+
+fix: inherit a nested block's sub-schema from its enclosing container, not always the root
+
+A `{type: 'block'}` member nested inside a container now inherits any property it doesn't declare (`styles`, `decorators`, `annotations`, `lists`, `inlineObjects`) from the nearest enclosing container's block, falling back to the root only when no enclosing container declares a block of its own. Previously every absent property fell back to the root, so a block nested inside a container that restricts its own text (e.g. a callout limited to `strong`) could end up allowing more than its container. Schemas with single-level containers, or structural nesting where intermediate containers declare no block, are unaffected.

--- a/packages/schema/src/compile-schema.test.ts
+++ b/packages/schema/src/compile-schema.test.ts
@@ -392,7 +392,7 @@ describe(compileSchema.name, () => {
       ])
     })
 
-    test('deeply nested blocks inherit from root, not from intermediate containers', () => {
+    test('a nested block inherits the root when no enclosing container declares its own block', () => {
       expect(
         compileSchema({
           decorators: [{name: 'strong'}],
@@ -458,6 +458,282 @@ describe(compileSchema.name, () => {
                               type: 'array',
                               of: [
                                 {
+                                  type: 'block',
+                                  styles: [
+                                    {
+                                      name: 'normal',
+                                      value: 'normal',
+                                      title: 'Normal',
+                                    },
+                                  ],
+                                  decorators: [
+                                    {name: 'strong', value: 'strong'},
+                                  ],
+                                  annotations: [],
+                                  lists: [],
+                                  inlineObjects: [],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test("a callout nested in a cell inherits the cell's overridden block, not the root", () => {
+      // `table`/`row` are structural and declare no block of their own, so
+      // they pass the root through. The `cell` overrides the root decorators
+      // down to `strong`. A `callout` nested inside the cell omits
+      // decorators, so it inherits the cell's `strong`, not the root's
+      // `strong`/`em`/`code`.
+      expect(
+        compileSchema({
+          decorators: [{name: 'strong'}, {name: 'em'}, {name: 'code'}],
+          blockObjects: [
+            {
+              name: 'table',
+              fields: [
+                {
+                  name: 'rows',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'row',
+                      fields: [
+                        {
+                          name: 'cells',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'object',
+                              name: 'cell',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  type: 'array',
+                                  of: [
+                                    {
+                                      type: 'block',
+                                      decorators: [{name: 'strong'}],
+                                    },
+                                    {
+                                      type: 'object',
+                                      name: 'callout',
+                                      fields: [
+                                        {
+                                          name: 'content',
+                                          type: 'array',
+                                          of: [{type: 'block'}],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'row',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'object',
+                          name: 'cell',
+                          fields: [
+                            {
+                              name: 'content',
+                              type: 'array',
+                              of: [
+                                {
+                                  // The cell overrides the root: `strong` only.
+                                  type: 'block',
+                                  styles: [
+                                    {
+                                      name: 'normal',
+                                      value: 'normal',
+                                      title: 'Normal',
+                                    },
+                                  ],
+                                  decorators: [
+                                    {name: 'strong', value: 'strong'},
+                                  ],
+                                  annotations: [],
+                                  lists: [],
+                                  inlineObjects: [],
+                                },
+                                {
+                                  type: 'object',
+                                  name: 'callout',
+                                  fields: [
+                                    {
+                                      name: 'content',
+                                      type: 'array',
+                                      of: [
+                                        {
+                                          // Inherits the cell's block, not the
+                                          // root (which also allows `em`/`code`).
+                                          type: 'block',
+                                          styles: [
+                                            {
+                                              name: 'normal',
+                                              value: 'normal',
+                                              title: 'Normal',
+                                            },
+                                          ],
+                                          decorators: [
+                                            {name: 'strong', value: 'strong'},
+                                          ],
+                                          annotations: [],
+                                          lists: [],
+                                          inlineObjects: [],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('a nested block inherits the nearest declaring container, not a more distant one', () => {
+      // `outer` declares `[strong, em]`; `inner` (nested in outer) declares
+      // `[strong]`; `leaf` (nested in inner) declares nothing. The leaf block
+      // resolves to `inner`'s `[strong]` (the nearest declaring container),
+      // not `outer`'s `[strong, em]` and not the root's `[strong, em, code]`.
+      expect(
+        compileSchema({
+          decorators: [{name: 'strong'}, {name: 'em'}, {name: 'code'}],
+          blockObjects: [
+            {
+              name: 'outer',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'block',
+                      decorators: [{name: 'strong'}, {name: 'em'}],
+                    },
+                    {
+                      type: 'object',
+                      name: 'inner',
+                      fields: [
+                        {
+                          name: 'content',
+                          type: 'array',
+                          of: [
+                            {type: 'block', decorators: [{name: 'strong'}]},
+                            {
+                              type: 'object',
+                              name: 'leaf',
+                              fields: [
+                                {
+                                  name: 'content',
+                                  type: 'array',
+                                  of: [{type: 'block'}],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).blockObjects,
+      ).toEqual([
+        {
+          name: 'outer',
+          fields: [
+            {
+              name: 'content',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  styles: [{name: 'normal', value: 'normal', title: 'Normal'}],
+                  decorators: [
+                    {name: 'strong', value: 'strong'},
+                    {name: 'em', value: 'em'},
+                  ],
+                  annotations: [],
+                  lists: [],
+                  inlineObjects: [],
+                },
+                {
+                  type: 'object',
+                  name: 'inner',
+                  fields: [
+                    {
+                      name: 'content',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'block',
+                          styles: [
+                            {name: 'normal', value: 'normal', title: 'Normal'},
+                          ],
+                          decorators: [{name: 'strong', value: 'strong'}],
+                          annotations: [],
+                          lists: [],
+                          inlineObjects: [],
+                        },
+                        {
+                          type: 'object',
+                          name: 'leaf',
+                          fields: [
+                            {
+                              name: 'content',
+                              type: 'array',
+                              of: [
+                                {
+                                  // Inherits `inner` (nearest), not `outer`
+                                  // or the root.
                                   type: 'block',
                                   styles: [
                                     {

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -51,12 +51,19 @@ function compileOfMember(
   return member
 }
 
-function compileBlockOfMember(
+/**
+ * Resolve the five sub-schema properties of a block of-member (`styles`,
+ * `decorators`, `annotations`, `lists`, `inlineObjects`): each is the
+ * member's own declaration (overriding) when present, or the inherited
+ * value when absent. The result is also threaded as the inheritance for the
+ * member's sibling containers (see `compileField`), so a nested container
+ * inherits the block of the container that encloses it rather than the root.
+ */
+function resolveBlockInheritance(
   member: BlockOfDefinition,
   inheritance: BlockInheritance,
-): BlockOfDefinition {
+): BlockInheritance {
   return {
-    ...member,
     styles: member.styles
       ? member.styles.map((style) => ({...style, value: style.name}))
       : inheritance.styles,
@@ -90,6 +97,13 @@ function compileBlockOfMember(
   }
 }
 
+function compileBlockOfMember(
+  member: BlockOfDefinition,
+  inheritance: BlockInheritance,
+): BlockOfDefinition {
+  return {...member, ...resolveBlockInheritance(member, inheritance)}
+}
+
 function compileInlineObjectOfMember(
   member: InlineObjectOfDefinition,
   inheritance: BlockInheritance,
@@ -105,9 +119,24 @@ function compileField(
   inheritance: BlockInheritance,
 ): FieldDefinition {
   if (field.type === 'array' && field.of) {
+    // A container's `{type: 'block'}` member defines the text schema at this
+    // position, and its sibling containers inherit that block rather than the
+    // root. The block member itself still resolves against the enclosing
+    // `inheritance` (its own parent container, or the root at the top level).
+    const blockMember = field.of.find(isBlockOfMember)
+    const childInheritance = blockMember
+      ? resolveBlockInheritance(blockMember, inheritance)
+      : inheritance
     return {
       ...field,
-      of: field.of.map((member) => compileOfMember(member, inheritance)),
+      of: field.of.map((member) =>
+        // The block member is `childInheritance` already resolved against the
+        // enclosing `inheritance`; reuse it rather than resolving twice. Its
+        // sibling containers inherit it.
+        member === blockMember
+          ? {...member, ...childInheritance}
+          : compileOfMember(member, childInheritance),
+      ),
     }
   }
   return field


### PR DESCRIPTION
`compileSchema` resolves a container's nested `{type: 'block'}` member by filling any list it doesn't declare (styles, decorators, annotations, lists, inline objects) from an inherited block. Today that inherited block is always the **root**: the inheritance view is captured once from the root and threaded unchanged through the whole `of` walk. So a container that restricts its own text and then nests another container whose block omits a list leaks the root's values into the nested block, the nested block can allow decorators its enclosing container forbade.

This changes the inherited block to the **nearest enclosing container's block**. `compileField` now resolves a container's block member first and threads that resolved block (via an extracted `resolveBlockInheritance`) as the inheritance for the container's sibling members. The block member itself still resolves against its own enclosing inheritance, its parent container, or the root at the top level. It stays single-source: each list is either the member's own declaration or one inherited value, never a merge.

Why this is representable at all: `@portabletext/schema` is inline-always. A nested container is an inline `{type: 'object', name, fields}` node, never a `{type: <name>}` reference to a root object (`compileOfMember` passes references through and never expands them, and the `deeply nested` test nests `table → row → cell → block` entirely inline). So every nested container is a distinct node with a single, unambiguous enclosing block, there's no shared/referenced type that would have more than one parent, and recursion can't arise because you can't author an infinitely nested literal. (The Sanity bridge does produce shared/cycle-stubbed types, but it always emits a block's full lists, so it never relies on this inheritance.)

Net behavior is unchanged for single-level containers and for structural nesting where intermediate containers declare no block of their own, which is every container today: the nearest enclosing block is still the root there, and the existing `deeply nested` test passes unmodified (only renamed to say "when no enclosing container declares its own block"). The behavior changes only when an intermediate container declares its own block; a new test pins that a nested `aside` inside a `callout` whose text is limited to `strong` inherits `strong`, not the root's `strong`/`em`/`code`. `getSubSchema` and the bridge are untouched.
