### PR TITLE
feat: drag a container by its chrome to drop the whole container

### DIFF
--- a/.changeset/drag-container-by-chrome.md
+++ b/.changeset/drag-container-by-chrome.md
@@ -1,0 +1,13 @@
+---
+"@portabletext/editor": minor
+---
+
+feat: drag a container by its chrome to drop the whole container
+
+**Drag and copy out of a container reflect what's inside.** Selecting an image inside a table cell drags just the image. With a draggable image (or other draggable child) inside a container, selecting across multiple sibling blocks and grabbing by that image drags those blocks, not the surrounding container. A nested code block grabbed by its chrome inside a table cell drags that code block, not the whole table.
+
+**Grabbing a container by its chrome drags the whole container.** When the drag originates on the container itself (not on its children), the serializer carries the container intact. Drops and pastes preserve the container when the destination accepts its type, and unwrap to accepted descendants when it doesn't.
+
+**Internal-move source-deletion follows the destination fit.** When the destination accepts the dragged blocks whole, the source is removed at the root path. When the destination unwraps them, the source is removed per inner block. No more empty container shells left behind after a move.
+
+**The drag pipeline no longer mutates `snapshot.context.selection`.** During a drag, the model selection stays where it was before `dragstart`. The drag selection lives on `event.position.selection` for the duration of the gesture, and on `event.originEvent.position.selection` through the serialize/deserialize boundary. If you had a behavior reading `editor.getSnapshot().context.selection` mid-drag to learn the dragged unit, read it from the event instead.

--- a/.changeset/validate-selection-skip-overwrite.md
+++ b/.changeset/validate-selection-skip-overwrite.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: keep the selection on a block after dropping it inside the editor
+
+After an internal drop, `validate-selection-machine` could overwrite the engine's just-updated model selection with a stale DOM selection when `toDOMRange` ran before React had committed the post-drop DOM. The caret would jump to the top of the editor instead of staying on the dropped block. The machine now skips overwriting the model selection in this race window.

--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -210,20 +210,42 @@
   border-collapse: separate;
   border-spacing: 0;
   width: 100%;
-  margin: 1.25rem 0;
   font-size: 0.875rem;
   line-height: 1.5;
   background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+:where(.dark) .playground-table {
+  background: #0f172a;
+  border-color: #334155;
+}
+
+.playground-table-chrome {
+  position: relative;
+  margin: 1.25rem 0;
+  padding: 0.5rem;
+  background: #f8fafc;
   border: 1px solid #e2e8f0;
   border-radius: 0.5rem;
   overflow: hidden;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
-:where(.dark) .playground-table {
-  background: #0f172a;
+.playground-table-chrome[data-selected] {
+  border-color: #94a3b8;
+}
+
+:where(.dark) .playground-table-chrome {
+  background: #1e293b;
   border-color: #334155;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+:where(.dark) .playground-table-chrome[data-selected] {
+  border-color: #64748b;
 }
 
 /* Body cells: subtle horizontal + vertical dividers. */

--- a/apps/playground/src/plugins/drag-handle.tsx
+++ b/apps/playground/src/plugins/drag-handle.tsx
@@ -1,0 +1,35 @@
+import {GripVerticalIcon} from 'lucide-react'
+import type {JSX} from 'react'
+
+/**
+ * A small corner handle that owns the container's drag affordance.
+ *
+ * The handle sits inside the container's render so its DOM ancestor with
+ * a `data-pt-path` attribute is the container itself. `getEventPosition`
+ * resolves the dragstart event's path to that container path and starts
+ * a chrome drag of the whole container.
+ *
+ * Kept off the outer container element so cells, inline objects, and
+ * text selection inside the container behave like a non-draggable
+ * editable region (browsers swallow some selection-driven copy events
+ * when the selection lives inside a `draggable={true}` ancestor).
+ */
+export function DragHandle({
+  className,
+  readOnly,
+}: {
+  className?: string
+  readOnly: boolean
+}): JSX.Element {
+  return (
+    <span
+      aria-hidden
+      contentEditable={false}
+      draggable={!readOnly}
+      title="Drag to move"
+      className={`absolute top-1 right-1 z-10 inline-flex h-5 w-5 cursor-grab items-center justify-center rounded text-stone-400 opacity-0 transition-opacity hover:bg-stone-200/60 hover:text-stone-600 group-hover:opacity-100 dark:text-stone-500 dark:hover:bg-stone-700/60 dark:hover:text-stone-300 ${className ?? ''}`}
+    >
+      <GripVerticalIcon className="h-4 w-4" />
+    </span>
+  )
+}

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -72,7 +72,7 @@ const calloutImageLeaf = defineBlockObject({
   },
 })
 
-const calloutContainer = defineContainer({
+export const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
   render: ({attributes, children, node, readOnly, selected}) => {

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -12,6 +12,7 @@ import {
   TriangleAlertIcon,
 } from 'lucide-react'
 import type {JSX} from 'react'
+import {DragHandle} from './drag-handle'
 
 const toneClassName: Record<string, string> = {
   note: 'border-sky-400 bg-sky-50 text-sky-900 dark:bg-sky-950/40 dark:text-sky-100',
@@ -74,14 +75,14 @@ const calloutImageLeaf = defineBlockObject({
 const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
-  render: ({attributes, children, node, selected}) => {
+  render: ({attributes, children, node, readOnly, selected}) => {
     const tone = typeof node.tone === 'string' ? node.tone : 'note'
     const toneStyle = toneClassName[tone] ?? defaultToneClassName
     return (
       <aside
         {...attributes}
         data-selected={selected ? '' : undefined}
-        className={`my-3 flex gap-2.5 rounded-md border-l-4 px-4 py-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
+        className={`group relative my-3 flex gap-2.5 rounded-md border-l-4 p-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
       >
         <span
           contentEditable={false}
@@ -89,7 +90,8 @@ const calloutContainer = defineContainer({
         >
           <ToneIcon tone={tone} />
         </span>
-        <div className="min-w-0 flex-1">{children}</div>
+        <div className="min-w-0 flex-1 cursor-text">{children}</div>
+        <DragHandle readOnly={readOnly} />
       </aside>
     )
   },

--- a/apps/playground/src/plugins/plugin.code-block.tsx
+++ b/apps/playground/src/plugins/plugin.code-block.tsx
@@ -1,17 +1,19 @@
 import {defineContainer} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {DragHandle} from './drag-handle'
 
 const codeBlockContainer = defineContainer({
   type: 'code-block',
   arrayField: 'lines',
-  render: ({attributes, children, selected}) => (
+  render: ({attributes, children, readOnly, selected}) => (
     <pre
       {...attributes}
       data-selected={selected ? '' : undefined}
-      className="my-3 overflow-x-auto rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-slate-700 text-sm leading-relaxed transition-shadow data-[selected]:border-slate-400 data-[selected]:shadow-md dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:data-[selected]:border-slate-500"
+      className="group relative my-3 overflow-x-auto rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-slate-700 text-sm leading-relaxed transition-shadow data-[selected]:border-slate-400 data-[selected]:shadow-md dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:data-[selected]:border-slate-500"
     >
-      {children}
+      <code className="block min-w-0 cursor-text">{children}</code>
+      <DragHandle readOnly={readOnly} />
     </pre>
   ),
 })

--- a/apps/playground/src/plugins/plugin.fact-box.tsx
+++ b/apps/playground/src/plugins/plugin.fact-box.tsx
@@ -1,25 +1,21 @@
 import {defineContainer, defineTextBlock} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
-import {LayersIcon} from 'lucide-react'
 import type {JSX} from 'react'
+import {DragHandle} from './drag-handle'
 
 const factBoxContainer = defineContainer({
   type: 'fact-box',
   arrayField: 'content',
-  render: ({attributes, children, selected}) => (
+  render: ({attributes, children, readOnly, selected}) => (
     <section
       {...attributes}
       data-selected={selected ? '' : undefined}
-      className="my-4 rounded-lg border border-stone-300 bg-stone-50 px-5 py-4 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-600 dark:bg-stone-800/40 dark:data-[selected]:border-stone-400"
+      className="group relative my-4 rounded-lg border border-stone-300 bg-stone-50 p-4 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-600 dark:bg-stone-800/40 dark:data-[selected]:border-stone-400"
     >
-      <div
-        contentEditable={false}
-        className="-mx-5 -mt-4 mb-3 flex items-center gap-2 rounded-t-lg border-stone-300 border-b bg-stone-100 px-5 py-2 font-mono text-stone-600 text-xs uppercase tracking-wider dark:border-stone-600 dark:bg-stone-900/60 dark:text-stone-300"
-      >
-        <LayersIcon aria-hidden className="h-3.5 w-3.5" />
-        <span>Fact box</span>
+      <div className="cursor-text text-stone-800 dark:text-stone-100">
+        {children}
       </div>
-      <div className="text-stone-800 dark:text-stone-100">{children}</div>
+      <DragHandle readOnly={readOnly} />
     </section>
   ),
   of: [

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,22 +1,27 @@
 import {defineContainer} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {DragHandle} from './drag-handle'
+import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 
 const tableContainer = defineContainer({
   type: 'table',
   arrayField: 'rows',
-  render: ({attributes, children, node, selected}) => (
-    <table
+  render: ({attributes, children, node, readOnly, selected}) => (
+    <div
       {...attributes}
       data-header-rows={
         typeof node.headerRows === 'number' ? node.headerRows : 0
       }
       data-selected={selected ? '' : undefined}
-      className="playground-table"
+      className="playground-table-chrome group"
     >
-      <tbody>{children}</tbody>
-    </table>
+      <table className="playground-table cursor-text">
+        <tbody>{children}</tbody>
+      </table>
+      <DragHandle readOnly={readOnly} />
+    </div>
   ),
   of: [
     defineContainer({

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -41,7 +41,7 @@ const tableContainer = defineContainer({
               {children}
             </td>
           ),
-          of: [cellImageLeaf],
+          of: [cellImageLeaf, calloutContainer],
         }),
       ],
     }),

--- a/packages/editor/src/behaviors/behavior.abstract.serialize.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.serialize.ts
@@ -45,8 +45,23 @@ export const abstractSerializeBehaviors = [
         return false
       }
 
+      // Drag origins carry the grabbed selection on the originating event;
+      // the drag pipeline does not update `snapshot.context.selection` on
+      // dragstart, so override the snapshot here so converters see the
+      // grabbed unit through plain `snapshot.context.selection` reads.
+      const snapshotForConverter =
+        event.originEvent.type === 'drag.dragstart'
+          ? {
+              ...snapshot,
+              context: {
+                ...snapshot.context,
+                selection: event.originEvent.position.selection,
+              },
+            }
+          : snapshot
+
       return converter.serialize({
-        snapshot,
+        snapshot: snapshotForConverter,
         event: {
           type: 'serialize',
           originEvent: event.originEvent.type,

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -1,4 +1,5 @@
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {isAncestorPath} from '../engine/path/is-ancestor-path'
 import {comparePoints} from '../engine/point/compare-points'
 import {isCollapsedRange} from '../engine/range/is-collapsed-range'
 import {rangeEdges} from '../engine/range/range-edges'
@@ -10,6 +11,7 @@ import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire
 import type {EditorSelection} from '../types/editor'
 import {effect, forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
+import {fitBlocksToDestination} from './fit-blocks-to-destination'
 
 /**
  * Self-drop suppression: returns true when the drop position lands inside the
@@ -19,12 +21,26 @@ import {defineBehavior} from './behavior.types.behavior'
  * as a self-drop — the drop position covers an adjacent block (typical when
  * dragging a block-object onto the next block via the expanded fallback in
  * `getEventPosition`), and the user genuinely wants the drop to happen.
+ *
+ * Chrome drags emit a collapsed selection pointing AT the dragged container.
+ * A drop position whose path descends into that container is dropping the
+ * container into itself; suppress it.
  */
 function isDropTargetingDragOrigin(
   dropSelection: NonNullable<EditorSelection>,
   dragOriginSelection: NonNullable<EditorSelection>,
   snapshot: EditorSnapshot,
 ): boolean {
+  if (isCollapsedRange(dragOriginSelection)) {
+    const originPath = dragOriginSelection.anchor.path
+    if (
+      isAncestorPath(originPath, dropSelection.anchor.path) ||
+      isAncestorPath(originPath, dropSelection.focus.path)
+    ) {
+      return true
+    }
+  }
+
   const overlapping = isOverlappingSelection(dropSelection)({
     ...snapshot,
     context: {
@@ -79,34 +95,25 @@ export const coreDndBehaviors = [
           selection: dragSelection,
         },
       })
+      const dragSnapshot = {
+        ...snapshot,
+        context: {
+          ...snapshot.context,
+          selection: dragSelection,
+        },
+      }
       const draggedDomNodes = {
-        blockNodes: dom.getBlockNodes({
-          ...snapshot,
-          context: {
-            ...snapshot.context,
-            selection: dragSelection,
-          },
-        }),
-        childNodes: dom.getChildNodes({
-          ...snapshot,
-          context: {
-            ...snapshot.context,
-            selection: dragSelection,
-          },
-        }),
+        blockNodes: dom.getBlockNodes(dragSnapshot),
+        childNodes: dom.getChildNodes(dragSnapshot),
       }
 
       return {
-        dragSelection,
         draggedDomNodes,
         selectingEntireBlocks,
       }
     },
     actions: [
-      (
-        {dom, event},
-        {dragSelection, draggedDomNodes, selectingEntireBlocks},
-      ) => {
+      ({dom, event}, {draggedDomNodes, selectingEntireBlocks}) => {
         const dragGhost = document.createElement('div')
 
         if (selectingEntireBlocks) {
@@ -146,10 +153,6 @@ export const coreDndBehaviors = [
             dragGhost.style.height = `${customGhostRect.height}px`
 
             return [
-              raise({
-                type: 'select',
-                at: dragSelection,
-              }),
               effect(() => {
                 dom.setDragGhost({
                   event,
@@ -172,10 +175,6 @@ export const coreDndBehaviors = [
             dragGhost.style.height = `${blocksDomRect.height}px`
 
             return [
-              raise({
-                type: 'select',
-                at: dragSelection,
-              }),
               effect(() => {
                 dom.setDragGhost({
                   event,
@@ -208,10 +207,6 @@ export const coreDndBehaviors = [
           dragGhost.style.height = `${childrenDomRect.height}px`
 
           return [
-            raise({
-              type: 'select',
-              at: dragSelection,
-            }),
             effect(() => {
               dom.setDragGhost({
                 event,
@@ -325,29 +320,36 @@ export const coreDndBehaviors = [
         ? isDropTargetingDragOrigin(dropPosition, dragSelection, snapshot)
         : false
 
-      const draggingEntireBlocks = isSelectingEntireBlocks({
+      const dragSnapshot = {
         ...snapshot,
         context: {
           ...snapshot.context,
           selection: dragSelection,
         },
-      })
+      }
 
-      const draggedBlocks = getFragment({
-        ...snapshot,
-        context: {
-          ...snapshot.context,
-          selection: dragSelection,
+      const draggingEntireBlocks = isSelectingEntireBlocks(dragSnapshot)
+
+      const draggedNodes = getFragment(dragSnapshot)
+      const fittedBlocks = fitBlocksToDestination(
+        {
+          ...snapshot,
+          context: {
+            ...snapshot.context,
+            selection: dropPosition,
+          },
         },
-      })
+        event.data,
+      )
 
       if (!droppingOnDragOrigin) {
         return {
           dropPosition,
           draggingEntireBlocks,
-          draggedBlocks,
+          draggedNodes,
           dragOrigin,
           originEvent: event.originEvent,
+          fittedBlocks,
         }
       }
 
@@ -355,24 +357,23 @@ export const coreDndBehaviors = [
     },
     actions: [
       (
-        {event},
+        _,
         {
           draggingEntireBlocks,
-          draggedBlocks,
+          draggedNodes,
           dragOrigin,
           dropPosition,
           originEvent,
+          fittedBlocks,
         },
-      ) => [
-        raise({
-          type: 'select',
-          at: dropPosition,
-        }),
-        ...(draggingEntireBlocks
-          ? draggedBlocks.map((block) =>
+      ) => {
+        // Source removal mirrors what the serializer carried: per dragged
+        // node for an entire-blocks drag, by text range for a partial drag.
+        const deleteEvents = draggingEntireBlocks
+          ? draggedNodes.map((entry) =>
               raise({
-                type: 'delete.block',
-                at: block.path,
+                type: 'unset',
+                at: entry.path,
               }),
             )
           : [
@@ -380,19 +381,27 @@ export const coreDndBehaviors = [
                 type: 'delete',
                 at: dragOrigin.selection,
               }),
-            ]),
-        raise({
-          type: 'insert.blocks',
-          blocks: event.data,
-          placement: draggingEntireBlocks
-            ? originEvent.position.block === 'start'
-              ? 'before'
-              : originEvent.position.block === 'end'
-                ? 'after'
-                : 'auto'
-            : 'auto',
-        }),
-      ],
+            ]
+
+        return [
+          raise({
+            type: 'select',
+            at: dropPosition,
+          }),
+          ...deleteEvents,
+          raise({
+            type: 'insert.blocks',
+            blocks: fittedBlocks,
+            placement: draggingEntireBlocks
+              ? originEvent.position.block === 'start'
+                ? 'before'
+                : originEvent.position.block === 'end'
+                  ? 'after'
+                  : 'auto'
+              : 'auto',
+          }),
+        ]
+      },
     ],
   }),
 ]

--- a/packages/editor/src/behaviors/fit-blocks-to-destination.ts
+++ b/packages/editor/src/behaviors/fit-blocks-to-destination.ts
@@ -1,6 +1,7 @@
-import type {PortableTextBlock} from '@portabletext/schema'
+import {getSubSchema, type PortableTextBlock} from '@portabletext/schema'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
+import {resolveContainerAt} from '../schema/resolve-container-at'
 import {getSelectionStartBlock} from '../selectors/selector.get-selection-start-block'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
 
@@ -23,7 +24,11 @@ import {getPathSubSchema} from '../traversal/get-path-sub-schema'
  *
  * The destination is derived from the snapshot's selection: the
  * sub-schema view that applies at the focus block's path is the
- * accept-list. For an empty editor or a snapshot with no selection,
+ * accept-list. When the selection points at a registered container
+ * directly (chrome-drop semantics, where the drop target is the
+ * container itself, not a node inside it), the destination is the
+ * container's own content - its `of` is the accept-list, not its
+ * parent's. For an empty editor or a snapshot with no selection,
  * the fragment is returned unchanged - the downstream
  * `operation.insert.block` will validate against the root schema and
  * no-op invalid blocks.
@@ -44,7 +49,15 @@ export function fitBlocksToDestination(
     return [...blocks]
   }
 
-  const subSchema = getPathSubSchema(snapshot, startBlock.path)
+  const resolvedAt = resolveContainerAt(
+    snapshot.context.containers,
+    snapshot.context.value,
+    startBlock.path,
+  )
+  const subSchema =
+    resolvedAt && 'field' in resolvedAt && resolvedAt.of
+      ? getSubSchema(snapshot.context.schema, resolvedAt.of)
+      : getPathSubSchema(snapshot, startBlock.path)
   const accepted = getRootAcceptedTypes(subSchema)
 
   if (accepted.size === 0) {

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -24,6 +24,7 @@ import {resolveSelection} from '../internal-utils/apply-selection'
 import {debug} from '../internal-utils/debug'
 import {getEventPosition} from '../internal-utils/event-position'
 import {safeStringify} from '../internal-utils/safe-json'
+import {getDragSelection} from '../selectors/drag-selection'
 import type {
   EditorSelection,
   OnCopyFn,
@@ -689,9 +690,22 @@ export const PortableTextEditable = forwardRef<
         return
       }
 
+      // The drag-position selection from `getEventPosition` reflects where
+      // the pointer is. When the user has an expanded model selection that
+      // covers the drag point, the drag should carry the whole model
+      // selection - the drag image already shows it. Widen here so the
+      // captured drag origin and the forwarded event agree on the source.
+      const dragPosition = {
+        ...position,
+        selection: getDragSelection({
+          snapshot: editorEngine.snapshot,
+          eventSelection: position.selection,
+        }),
+      }
+
       editorActor.send({
         type: 'dragstart',
-        origin: position,
+        origin: dragPosition,
       })
 
       editorActor.send({
@@ -703,7 +717,7 @@ export const PortableTextEditable = forwardRef<
             clientY: event.clientY,
             dataTransfer: event.dataTransfer,
           },
-          position,
+          position: dragPosition,
         },
         editor: editorEngine,
       })

--- a/packages/editor/src/editor/validate-selection-machine.ts
+++ b/packages/editor/src/editor/validate-selection-machine.ts
@@ -75,22 +75,15 @@ export const validateSelectionMachine = validateSelectionSetup.createMachine({
   },
 })
 
-// This function will handle unexpected DOM changes inside the Editable rendering,
-// and make sure that we can maintain a stable editorEngine.snapshot.context.selection when that happens.
-//
-// For example, if this Editable is rendered inside something that might re-render
-// this component (hidden contexts) while the user is still actively changing the
-// contentEditable, this could interfere with the intermediate DOM selection,
-// which again could be picked up by DOMEditor's event listeners.
-// If that range is invalid at that point, the engine's selection could be
-// set either wrong, or invalid, to which editorEngine will throw exceptions
-// that are impossible to recover properly from or result in a wrong selection.
-//
-// Also the other way around, when the DOMEditor will try to create a DOM Range
-// from the current editorEngine.snapshot.context.selection, it may throw unrecoverable errors
-// if the current editor.snapshot.context.selection is invalid according to the DOM.
-// If this is the case, default to selecting the top of the document, if the
-// user already had a selection.
+// This function handles unexpected DOM changes inside the Editable so the
+// engine's model selection stays stable. The Editable can be re-rendered while
+// the user is still actively changing the contentEditable (hidden contexts,
+// outer state); the intermediate DOM selection it observes can be invalid
+// against the engine's snapshot, and synchronously syncing either direction
+// without guards leads to unrecoverable errors. When `toDOMRange` can't
+// resolve the engine's selection on the current DOM (typically a race ahead
+// of React's commit), this pass skips the sync and the next MutationObserver
+// tick retries once the DOM catches up.
 function validateSelection(
   editorEngine: PortableTextEditorEngine,
   editorElement: HTMLDivElement,

--- a/packages/editor/src/editor/validate-selection-machine.ts
+++ b/packages/editor/src/editor/validate-selection-machine.ts
@@ -1,7 +1,5 @@
 import {setup} from 'xstate'
 import {DOMEditor} from '../engine/dom/plugin/dom-editor'
-import {start} from '../engine/editor/start'
-import {applyDeselect, applySelect} from '../internal-utils/apply-selection'
 import {debug} from '../internal-utils/debug'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 
@@ -75,15 +73,22 @@ export const validateSelectionMachine = validateSelectionSetup.createMachine({
   },
 })
 
-// This function handles unexpected DOM changes inside the Editable so the
-// engine's model selection stays stable. The Editable can be re-rendered while
-// the user is still actively changing the contentEditable (hidden contexts,
-// outer state); the intermediate DOM selection it observes can be invalid
-// against the engine's snapshot, and synchronously syncing either direction
-// without guards leads to unrecoverable errors. When `toDOMRange` can't
-// resolve the engine's selection on the current DOM (typically a race ahead
-// of React's commit), this pass skips the sync and the next MutationObserver
-// tick retries once the DOM catches up.
+// This function will handle unexpected DOM changes inside the Editable rendering,
+// and make sure that we can maintain a stable editorEngine.snapshot.context.selection when that happens.
+//
+// For example, if this Editable is rendered inside something that might re-render
+// this component (hidden contexts) while the user is still actively changing the
+// contentEditable, this could interfere with the intermediate DOM selection,
+// which again could be picked up by DOMEditor's event listeners.
+// If that range is invalid at that point, the engine's selection could be
+// set either wrong, or invalid, to which editorEngine will throw exceptions
+// that are impossible to recover properly from or result in a wrong selection.
+//
+// Also the other way around, when the DOMEditor will try to create a DOM Range
+// from the current editorEngine.snapshot.context.selection, it may throw unrecoverable errors
+// if the current editor.snapshot.context.selection is invalid according to the DOM.
+// When that happens this pass skips the sync; the MutationObserver driving
+// the machine will fire again once React commits and the next pass will succeed.
 function validateSelection(
   editorEngine: PortableTextEditorEngine,
   editorElement: HTMLDivElement,
@@ -129,13 +134,9 @@ function validateSelection(
       domSelection.addRange(newDOMRange)
     }
   } catch {
-    debug.selection(`Could not resolve selection, selecting top document`)
-    // Deselect the editor
-    applyDeselect(editorEngine)
-    // Select top document if there is a top block to select
-    if (editorEngine.snapshot.context.value.length > 0) {
-      applySelect(editorEngine, start(editorEngine, []))
-    }
-    editorEngine.onChange()
+    // `toDOMRange` raced ahead of React's commit. The MutationObserver
+    // driving this machine will fire again once the DOM catches up, and
+    // the next pass will succeed. Don't touch the model selection here.
+    debug.selection(`Could not resolve selection, skipping DOM sync this tick`)
   }
 }

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -34,6 +34,10 @@ export type EventPosition = {
 }
 export type EventPositionBlock = EventPosition['block']
 
+function isDragEvent(event: DragEvent | MouseEvent): event is DragEvent {
+  return 'dataTransfer' in event
+}
+
 export function getEventPosition({
   editorActor,
   editorEngine,
@@ -79,6 +83,27 @@ export function getEventPosition({
       block: eventPositionBlock,
       isEditor: false,
       isContainer: false,
+      selection: {
+        anchor: {path: eventPath, offset: 0},
+        focus: {path: eventPath, offset: 0},
+      },
+    }
+  }
+
+  if (
+    eventPositionBlock &&
+    !isEditor(eventNode) &&
+    isEditableContainer(editorEngine.snapshot, eventNode, eventPath) &&
+    isDragEvent(event)
+  ) {
+    // Chrome drag: point the selection at the container so downstream
+    // selectors resolve the container, not whatever leaf
+    // `caretPositionFromPoint` would land on. Scoped to drag events
+    // because clicks don't need the override.
+    return {
+      block: eventPositionBlock,
+      isEditor: false,
+      isContainer: true,
       selection: {
         anchor: {path: eventPath, offset: 0},
         focus: {path: eventPath, offset: 0},

--- a/packages/editor/src/selectors/selector.get-fragment.test.ts
+++ b/packages/editor/src/selectors/selector.get-fragment.test.ts
@@ -372,4 +372,115 @@ describe(getFragment.name, () => {
       },
     ])
   })
+
+  test('unwraps to the block containing an inline object when selection is collapsed on an inline inside a table cell', () => {
+    const tableSchema = compileSchema(
+      defineSchema({
+        inlineObjects: [{name: 'stock-ticker'}],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const defs = [
+      defineContainer({type: 'table', arrayField: 'rows'}),
+      defineContainer({type: 'row', arrayField: 'cells'}),
+      defineContainer({type: 'cell', arrayField: 'content'}),
+    ]
+
+    const stockTicker = {
+      _type: 'stock-ticker',
+      _key: 'st1',
+    }
+    const block: PortableTextTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      children: [
+        {_type: 'span', _key: 'b1c1', text: 'foo', marks: []},
+        stockTicker,
+        {_type: 'span', _key: 'b1c2', text: 'bar', marks: []},
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const cell = {_type: 'cell', _key: 'cell1', content: [block]}
+    const row = {_type: 'row', _key: 'row1', cells: [cell]}
+    const table = {_type: 'table', _key: 'table1', rows: [row]}
+
+    const selection = {
+      anchor: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 'st1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 'st1'},
+        ],
+        offset: 0,
+      },
+    }
+
+    expect(
+      getFragment(
+        createCalloutSnapshot([table], selection, tableSchema, defs),
+      ).map((entry) => entry.node),
+    ).toEqual([
+      {
+        ...block,
+        children: [stockTicker],
+      },
+    ])
+  })
 })

--- a/packages/editor/src/selectors/selector.get-fragment.ts
+++ b/packages/editor/src/selectors/selector.get-fragment.ts
@@ -19,6 +19,13 @@ import {getSelectedValue} from './selector.get-selected-value'
  * cells in one row) ends the walk and the last root-valid wrapping is
  * returned.
  *
+ * A selection whose endpoints terminate at the root level (collapsed at
+ * a root-level node, or expanded across root siblings without descending
+ * into them) is treated as the user pointing AT the named node(s) rather
+ * than INTO them; the envelope is returned as-is and the unwrap walk is
+ * skipped. This is how a chrome drag carries the container itself rather
+ * than its unwrapped content.
+ *
  * Backs every registered clipboard converter, `editor.getFragment()`
  * (which projects to blocks only), and the drag preview pipeline (which
  * uses the paths to find DOM nodes). Exposed for custom converters and
@@ -34,6 +41,18 @@ export const getFragment: EditorSelector<
 
   if (envelope.length === 0) {
     return []
+  }
+
+  const selection = snapshot.context.selection
+  if (
+    selection &&
+    selection.anchor.path.length <= 1 &&
+    selection.focus.path.length <= 1
+  ) {
+    return envelope.map((block) => ({
+      node: block,
+      path: [{_key: block._key}],
+    }))
   }
 
   const {schema, containers, value} = snapshot.context

--- a/packages/editor/tests/event.drag.dragstart-container-chrome.test.tsx
+++ b/packages/editor/tests/event.drag.dragstart-container-chrome.test.tsx
@@ -288,6 +288,33 @@ describe('chrome drag', () => {
         },
       ])
     })
+
+    // The caret lands on the dropped code-block (end of its last line), not at
+    // the top of the document. Pinning this against the validate-selection
+    // fix that prevents toDOMRange races from resetting model selection.
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [
+          {_key: codeBlockKey},
+          'lines',
+          {_key: line2Key},
+          'children',
+          {_key: line2SpanKey},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: codeBlockKey},
+          'lines',
+          {_key: line2Key},
+          'children',
+          {_key: line2SpanKey},
+        ],
+        offset: 1,
+      },
+      backward: false,
+    })
   })
 
   test('Scenario: dragging an image from inside a table cell drops just the image, not the whole table', async () => {

--- a/packages/editor/tests/event.drag.dragstart-container-chrome.test.tsx
+++ b/packages/editor/tests/event.drag.dragstart-container-chrome.test.tsx
@@ -1,0 +1,1148 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {assert, describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {converterPortableText} from '../src/converters/converter.portable-text'
+import {safeParse} from '../src/internal-utils/safe-json'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineBlockObject,
+  defineContainer,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('chrome drag', () => {
+  test('Scenario: dragging a callout chrome drops the whole callout', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const trailingBlockKey = keyGenerator()
+    const trailingSpanKey = keyGenerator()
+
+    const calloutContainer = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside {...attributes}>
+          <span contentEditable={false} data-testid="chrome-icon">
+            !
+          </span>
+          {children}
+        </aside>
+      ),
+    })
+
+    const {locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: lineKey,
+              _type: 'block',
+              children: [
+                {_key: spanKey, _type: 'span', text: 'note', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[calloutContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const icon = locator.element().querySelector('[data-testid="chrome-icon"]')
+    assert(icon)
+    const rect = icon.getBoundingClientRect()
+
+    const dataTransfer = new DataTransfer()
+    icon.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      const ptData = dataTransfer.getData('application/x-portable-text')
+      const blocks = safeParse(ptData)
+      expect(blocks).toEqual([
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: lineKey,
+              _type: 'block',
+              children: [
+                {_key: spanKey, _type: 'span', text: 'note', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: dragging a code-block chrome and dropping after a trailing block moves the code-block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const line1Key = keyGenerator()
+    const line1SpanKey = keyGenerator()
+    const line2Key = keyGenerator()
+    const line2SpanKey = keyGenerator()
+    const trailingBlockKey = keyGenerator()
+    const trailingSpanKey = keyGenerator()
+
+    const codeBlockContainer = defineContainer({
+      type: 'code-block',
+      arrayField: 'lines',
+      render: ({attributes, children}) => (
+        <pre {...attributes}>
+          <span contentEditable={false} data-testid="code-chrome">
+            ::
+          </span>
+          {children}
+        </pre>
+      ),
+    })
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'code-block',
+            fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: codeBlockKey,
+          _type: 'code-block',
+          lines: [
+            {
+              _key: line1Key,
+              _type: 'block',
+              children: [
+                {_key: line1SpanKey, _type: 'span', text: 'a', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _key: line2Key,
+              _type: 'block',
+              children: [
+                {_key: line2SpanKey, _type: 'span', text: 'b', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'tail', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[codeBlockContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const chrome = locator
+      .element()
+      .querySelector('[data-testid="code-chrome"]')
+    assert(chrome)
+    const rect = chrome.getBoundingClientRect()
+
+    const dataTransfer = new DataTransfer()
+    chrome.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      const ghostWithPre = document.body.querySelector('[data-dragged] pre')
+      assert(ghostWithPre, 'Expected the drag ghost to contain a <pre>')
+    })
+
+    const dragSelection = {
+      anchor: {path: [{_key: codeBlockKey}], offset: 0},
+      focus: {path: [{_key: codeBlockKey}], offset: 0},
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: dragSelection,
+        },
+      },
+      event: {
+        type: 'serialize',
+        originEvent: 'drag.dragstart',
+      },
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+    const dropDataTransfer = new DataTransfer()
+    dropDataTransfer.setData(serialized.mimeType, serialized.data)
+
+    const trailingSpanPath = [
+      {_key: trailingBlockKey},
+      'children',
+      {_key: trailingSpanKey},
+    ]
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer: dropDataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: trailingSpanPath, offset: 4},
+          focus: {path: trailingSpanPath, offset: 4},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'tail', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: codeBlockKey,
+          _type: 'code-block',
+          lines: [
+            {
+              _key: line1Key,
+              _type: 'block',
+              children: [
+                {_key: line1SpanKey, _type: 'span', text: 'a', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _key: line2Key,
+              _type: 'block',
+              children: [
+                {_key: line2SpanKey, _type: 'span', text: 'b', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: dragging an image from inside a table cell drops just the image, not the whole table', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const trailingBlockKey = keyGenerator()
+    const trailingSpanKey = keyGenerator()
+
+    const cellContainer = defineContainer({
+      type: 'cell',
+      arrayField: 'content',
+    })
+    const rowContainer = defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      of: [cellContainer],
+    })
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [rowContainer],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}, {type: 'image'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {name: 'image'},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [{_key: imageKey, _type: 'image'}],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'tail', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    const imagePath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellKey},
+      'content',
+      {_key: imageKey},
+    ]
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: imagePath, offset: 0},
+        focus: {path: imagePath, offset: 0},
+      },
+    })
+
+    const dragSelection = editor.getSnapshot().context.selection
+    assert(dragSelection !== null)
+
+    const serialized = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+
+    expect(safeParse(serialized.data)).toEqual([
+      {_key: imageKey, _type: 'image'},
+    ])
+  })
+
+  test('Scenario: dragging a code-block chrome and dropping into an empty table cell moves the lines without leaving an empty code block behind', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const line1Key = keyGenerator()
+    const line1SpanKey = keyGenerator()
+    const line2Key = keyGenerator()
+    const line2SpanKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const cellBlockKey = keyGenerator()
+    const cellSpanKey = keyGenerator()
+
+    const codeBlockContainer = defineContainer({
+      type: 'code-block',
+      arrayField: 'lines',
+      render: ({attributes, children}) => (
+        <pre {...attributes}>
+          <span contentEditable={false} data-testid="code-chrome">
+            ::
+          </span>
+          {children}
+        </pre>
+      ),
+    })
+    const cellContainer = defineContainer({
+      type: 'cell',
+      arrayField: 'content',
+    })
+    const rowContainer = defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      of: [cellContainer],
+    })
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [rowContainer],
+    })
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'code-block',
+            fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+          },
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: codeBlockKey,
+          _type: 'code-block',
+          lines: [
+            {
+              _key: line1Key,
+              _type: 'block',
+              children: [
+                {_key: line1SpanKey, _type: 'span', text: 'a', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _key: line2Key,
+              _type: 'block',
+              children: [
+                {_key: line2SpanKey, _type: 'span', text: 'b', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[codeBlockContainer, tableContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const chrome = locator
+      .element()
+      .querySelector('[data-testid="code-chrome"]')
+    assert(chrome)
+    const rect = chrome.getBoundingClientRect()
+
+    const dataTransfer = new DataTransfer()
+    chrome.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      }),
+    )
+
+    const dragSelection = {
+      anchor: {path: [{_key: codeBlockKey}], offset: 0},
+      focus: {path: [{_key: codeBlockKey}], offset: 0},
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: dragSelection,
+        },
+      },
+      event: {
+        type: 'serialize',
+        originEvent: 'drag.dragstart',
+      },
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+    const dropDataTransfer = new DataTransfer()
+    dropDataTransfer.setData(serialized.mimeType, serialized.data)
+
+    const cellSpanPath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellKey},
+      'content',
+      {_key: cellBlockKey},
+      'children',
+      {_key: cellSpanKey},
+    ]
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer: dropDataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: cellSpanPath, offset: 0},
+          focus: {path: cellSpanPath, offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toEqual([
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: line1Key,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: line1SpanKey,
+                          _type: 'span',
+                          text: 'a',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                    {
+                      _key: line2Key,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: line2SpanKey,
+                          _type: 'span',
+                          text: 'b',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      children: [
+                        {_key: cellSpanKey, _type: 'span', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: dropping an image onto an empty table cell chrome moves the image into the cell', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellAKey = keyGenerator()
+    const cellAParaKey = keyGenerator()
+    const cellASpanKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const cellBKey = keyGenerator()
+    const cellBParaKey = keyGenerator()
+    const cellBSpanKey = keyGenerator()
+
+    const imageLeaf = defineBlockObject({type: 'image'})
+    const cellContainer = defineContainer({
+      type: 'cell',
+      arrayField: 'content',
+      of: [imageLeaf],
+    })
+    const rowContainer = defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      of: [cellContainer],
+    })
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [rowContainer],
+      render: ({attributes, children}) => (
+        <div {...attributes} data-testid="table-chrome">
+          {children}
+        </div>
+      ),
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {type: 'block'},
+                                  {
+                                    type: 'object',
+                                    name: 'image',
+                                    fields: [{name: 'src', type: 'string'}],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellAKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellAParaKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellASpanKey,
+                          _type: 'span',
+                          text: 'before',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                    {_key: imageKey, _type: 'image', src: 'x.png'},
+                  ],
+                },
+                {
+                  _key: cellBKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBParaKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellBSpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    const imagePath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellAKey},
+      'content',
+      {_key: imageKey},
+    ]
+    const cellBPath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellBKey},
+    ]
+
+    const dragSelection = {
+      anchor: {path: imagePath, offset: 0},
+      focus: {path: imagePath, offset: 0},
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: dragSelection,
+        },
+      },
+      event: {
+        type: 'serialize',
+        originEvent: 'drag.dragstart',
+      },
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+    const dropDataTransfer = new DataTransfer()
+    dropDataTransfer.setData(serialized.mimeType, serialized.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer: dropDataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: true,
+        selection: {
+          anchor: {path: cellBPath, offset: 0},
+          focus: {path: cellBPath, offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value
+      expect(value).toEqual([
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellAKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellAParaKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellASpanKey,
+                          _type: 'span',
+                          text: 'before',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+                {
+                  _key: cellBKey,
+                  _type: 'cell',
+                  content: [
+                    {_type: 'image', _key: imageKey, src: 'x.png'},
+                    {
+                      _key: cellBParaKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellBSpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: dragging a container chrome with an expanded selection covering a preceding block drops both blocks together', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const fooBlockKey = keyGenerator()
+    const fooSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const calloutInnerKey = keyGenerator()
+    const calloutSpanKey = keyGenerator()
+    const trailingBlockKey = keyGenerator()
+    const trailingSpanKey = keyGenerator()
+
+    const calloutContainer = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside {...attributes}>
+          <span contentEditable={false} data-testid="callout-chrome">
+            !
+          </span>
+          {children}
+        </aside>
+      ),
+    })
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: fooBlockKey,
+          _type: 'block',
+          children: [{_key: fooSpanKey, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: calloutInnerKey,
+              _type: 'block',
+              children: [
+                {_key: calloutSpanKey, _type: 'span', text: 'call', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'tail', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: <NodePlugin nodes={[calloutContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: fooBlockKey}, 'children', {_key: fooSpanKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: calloutKey},
+            'content',
+            {_key: calloutInnerKey},
+            'children',
+            {_key: calloutSpanKey},
+          ],
+          offset: 4,
+        },
+      },
+    })
+
+    const chrome = locator
+      .element()
+      .querySelector('[data-testid="callout-chrome"]')
+    assert(chrome)
+    const rect = chrome.getBoundingClientRect()
+
+    const dataTransfer = new DataTransfer()
+    chrome.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      assert(
+        dataTransfer.getData('application/x-portable-text'),
+        'Expected the drag to carry a portable-text payload',
+      )
+    })
+
+    const dropDataTransfer = new DataTransfer()
+    dropDataTransfer.setData(
+      'application/x-portable-text',
+      dataTransfer.getData('application/x-portable-text'),
+    )
+
+    const trailingSpanPath = [
+      {_key: trailingBlockKey},
+      'children',
+      {_key: trailingSpanKey},
+    ]
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer: dropDataTransfer},
+      dragOrigin: {
+        selection: {
+          anchor: {
+            path: [{_key: fooBlockKey}, 'children', {_key: fooSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [
+              {_key: calloutKey},
+              'content',
+              {_key: calloutInnerKey},
+              'children',
+              {_key: calloutSpanKey},
+            ],
+            offset: 4,
+          },
+        },
+      },
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: trailingSpanPath, offset: 4},
+          focus: {path: trailingSpanPath, offset: 4},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: trailingBlockKey,
+          _type: 'block',
+          children: [
+            {_key: trailingSpanKey, _type: 'span', text: 'tail', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: fooBlockKey,
+          _type: 'block',
+          children: [{_key: fooSpanKey, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            {
+              _key: calloutInnerKey,
+              _type: 'block',
+              children: [
+                {_key: calloutSpanKey, _type: 'span', text: 'call', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.drag.drop.self-drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.self-drop.test.tsx
@@ -1,8 +1,9 @@
 import {createTestKeyGenerator} from '@portabletext/test'
 import {assert, describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import {defineSchema} from '../src'
+import {defineContainer, defineSchema} from '../src'
 import {converterPortableText} from '../src/converters/converter.portable-text'
+import {NodePlugin} from '../src/plugins/plugin.node'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('event.drag.drop self-drop semantics', () => {
@@ -398,5 +399,108 @@ describe('event.drag.drop self-drop semantics', () => {
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).not.toEqual(initialValue)
     })
+  })
+
+  test('Scenario: chrome drop inside the dragged container is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const codeBlockKey = keyGenerator()
+    const lineKey = keyGenerator()
+    const lineSpanKey = keyGenerator()
+
+    const codeBlockContainer = defineContainer({
+      type: 'code-block',
+      arrayField: 'lines',
+    })
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'code-block',
+            fields: [{name: 'lines', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: codeBlockKey,
+          _type: 'code-block',
+          lines: [
+            {
+              _key: lineKey,
+              _type: 'block',
+              children: [
+                {_key: lineSpanKey, _type: 'span', text: 'foo', marks: []},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[codeBlockContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const dragSelection = {
+      anchor: {path: [{_key: codeBlockKey}], offset: 0},
+      focus: {path: [{_key: codeBlockKey}], offset: 0},
+    }
+    const dropSelection = {
+      anchor: {
+        path: [
+          {_key: codeBlockKey},
+          'lines',
+          {_key: lineKey},
+          'children',
+          {_key: lineSpanKey},
+        ],
+        offset: 1,
+      },
+      focus: {
+        path: [
+          {_key: codeBlockKey},
+          'lines',
+          {_key: lineKey},
+          'children',
+          {_key: lineSpanKey},
+        ],
+        offset: 1,
+      },
+    }
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {...editor.getSnapshot().context, selection: dragSelection},
+      },
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
   })
 })

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -3,8 +3,12 @@ import {assert, describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
 import {converterPortableText} from '../src/converters/converter.portable-text'
+import {safeParse} from '../src/internal-utils/safe-json'
 import {NodePlugin} from '../src/plugins/plugin.node'
-import {defineContainer} from '../src/renderers/renderer.types'
+import {
+  defineBlockObject,
+  defineContainer,
+} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('event.drag.drop', () => {
@@ -15,7 +19,7 @@ describe('event.drag.drop', () => {
     const stockTickerKey = keyGenerator()
     const barKey = keyGenerator()
 
-    const {locator, editor} = await createTestEditor({
+    const {locator} = await createTestEditor({
       keyGenerator,
       schemaDefinition: defineSchema({
         inlineObjects: [
@@ -39,43 +43,157 @@ describe('event.drag.drop', () => {
 
     await userEvent.click(locator)
 
-    const stockTickerPath = [
-      {_key: blockKey},
-      'children',
-      {_key: stockTickerKey},
-    ]
-
-    // Unlike the other drag scenarios in this file, this one dispatches a real
-    // DOM `dragstart` instead of sending a hand-built `position`. The
-    // regression lives in `getEventPosition`, the DOM-event -> `position`
-    // translation that every payload-style drag test skips: a `dragstart` on
-    // an inline object produces no DOM caret selection, and the null-selection
-    // fallback used to widen to the whole enclosing text block. Dispatching the
-    // native event is the only seam that exercises that translation, and the
-    // resulting drag selection (which `drag.dragstart` writes back via
-    // `select`) is the observable proof of what was dragged.
+    // Unlike the other drag scenarios in this file, this one dispatches a
+    // real DOM `dragstart` rather than sending a hand-built `position`. The
+    // wire payload it produces is the observable proof of what the
+    // dragstart handler decided to carry.
     const draggableElement = locator
       .element()
       .querySelector('[data-pt-inline="object"] [draggable="true"]')
     assert(draggableElement, 'Expected the inline object to have a drag source')
 
     const rect = draggableElement.getBoundingClientRect()
+    const dataTransfer = new DataTransfer()
     draggableElement.dispatchEvent(
       new DragEvent('dragstart', {
         bubbles: true,
         cancelable: true,
-        dataTransfer: new DataTransfer(),
+        dataTransfer,
         clientX: rect.left + rect.width / 2,
         clientY: rect.top + rect.height / 2,
       }),
     )
 
     await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {path: stockTickerPath, offset: 0},
-        focus: {path: stockTickerPath, offset: 0},
-        backward: false,
-      })
+      const ptData = dataTransfer.getData('application/x-portable-text')
+      const blocks = safeParse(ptData)
+      expect(blocks).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_type: 'stock-ticker', _key: stockTickerKey, symbol: 'AAPL'},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: dropping an inline object inside another text block moves the inline without duplicating its surrounding text', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const sourceBlockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const barKey = keyGenerator()
+    const destBlockKey = keyGenerator()
+    const destSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: sourceBlockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo', marks: []},
+            {_type: 'stock-ticker', _key: stockTickerKey, symbol: 'AAPL'},
+            {_key: barKey, _type: 'span', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: destBlockKey,
+          _type: 'block',
+          children: [
+            {_key: destSpanKey, _type: 'span', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const stockTickerSelection = {
+      anchor: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: stockTickerKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: stockTickerKey}],
+        offset: 0,
+      },
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: stockTickerSelection,
+        },
+      },
+      event: {
+        type: 'serialize',
+        originEvent: 'drag.dragstart',
+      },
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(serialized.mimeType, serialized.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: stockTickerSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: sourceBlockKey,
+          _type: 'block',
+          children: [{_key: fooKey, _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: destBlockKey,
+          _type: 'block',
+          children: [
+            {_key: 'k8', _type: 'span', text: '', marks: []},
+            {_key: stockTickerKey, _type: 'stock-ticker', symbol: 'AAPL'},
+            {_key: 'k9', _type: 'span', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
     })
   })
 
@@ -870,6 +988,225 @@ describe('event.drag.drop', () => {
         'block',
         'image',
         'block',
+      ])
+    })
+  })
+
+  test('Scenario: dragging a block-object into a cell whose schema also lists the same _type as an inline-object stays a block, not an inline', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const rootBlockKey = keyGenerator()
+    const rootSpanKey = keyGenerator()
+    const rootImageKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const cellBlockKey = keyGenerator()
+    const cellSpanKey = keyGenerator()
+
+    const imageLeaf = defineBlockObject({type: 'image'})
+    const cellContainer = defineContainer({
+      type: 'cell',
+      arrayField: 'content',
+      of: [imageLeaf],
+    })
+    const rowContainer = defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      of: [cellContainer],
+    })
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [rowContainer],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [
+                                  {type: 'block'},
+                                  {
+                                    type: 'object',
+                                    name: 'image',
+                                    fields: [{name: 'src', type: 'string'}],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        inlineObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: rootBlockKey,
+          _type: 'block',
+          children: [
+            {_key: rootSpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: rootImageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: '',
+                          marks: [],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: rootImageKey}], offset: 0},
+      focus: {path: [{_key: rootImageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const cellSpanPath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellKey},
+      'content',
+      {_key: cellBlockKey},
+      'children',
+      {_key: cellSpanKey},
+    ]
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: cellSpanPath, offset: 0},
+          focus: {path: cellSpanPath, offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: rootBlockKey,
+          _type: 'block',
+          children: [
+            {_key: rootSpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: rootImageKey,
+                      _type: 'image',
+                      src: 'https://example.com/image.jpg',
+                    },
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      children: [
+                        {_key: cellSpanKey, _type: 'span', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ])
     })
   })

--- a/packages/editor/tests/event.paste.test.tsx
+++ b/packages/editor/tests/event.paste.test.tsx
@@ -7,6 +7,8 @@ import {raise} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {safeParse} from '../src/internal-utils/safe-json'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 import {toTextspec} from '../test-utils/to-textspec'
 
@@ -485,6 +487,179 @@ describe('event.clipboard.paste', () => {
       originEvent: {dataTransfer},
       position: {
         selection: editor.getSnapshot().context.selection!,
+      },
+    })
+
+    await vi.waitFor(() => {
+      const data = dataTransfer.getData('application/x-portable-text')
+      expect(data).not.toEqual('')
+      const parsed = safeParse(data)
+      expect(parsed).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          markDefs: [],
+          style: 'normal',
+          children: [
+            {
+              _key: stockTickerKey,
+              _type: 'stock-ticker',
+              symbol: 'AAPL',
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Copying an inline object inside a table cell writes portable text to the clipboard', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const blockKey = keyGenerator()
+    const span1Key = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const span2Key = keyGenerator()
+
+    const cellContainer = defineContainer({
+      type: 'cell',
+      arrayField: 'content',
+    })
+    const rowContainer = defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      of: [cellContainer],
+    })
+    const tableContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [rowContainer],
+    })
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+        blockObjects: [
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: blockKey,
+                      _type: 'block',
+                      markDefs: [],
+                      style: 'normal',
+                      children: [
+                        {_key: span1Key, _type: 'span', text: 'foo', marks: []},
+                        {
+                          _key: stockTickerKey,
+                          _type: 'stock-ticker',
+                          symbol: 'AAPL',
+                        },
+                        {_key: span2Key, _type: 'span', text: 'bar', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    await userEvent.click(locator)
+
+    const stockTickerSelection = {
+      anchor: {
+        path: [
+          {_key: tableKey},
+          'rows',
+          {_key: rowKey},
+          'cells',
+          {_key: cellKey},
+          'content',
+          {_key: blockKey},
+          'children',
+          {_key: stockTickerKey},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: tableKey},
+          'rows',
+          {_key: rowKey},
+          'cells',
+          {_key: cellKey},
+          'content',
+          {_key: blockKey},
+          'children',
+          {_key: stockTickerKey},
+        ],
+        offset: 0,
+      },
+    }
+
+    editor.send({type: 'select', at: stockTickerSelection})
+
+    const dataTransfer = new DataTransfer()
+
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer},
+      position: {
+        selection: stockTickerSelection,
       },
     })
 


### PR DESCRIPTION
Two related dnd fixes plus the playground containers refreshed to demonstrate them.

## What's fixed

- **Drag and copy out of a container reflect what's inside.** Selecting in a paragraph or across two paragraphs in a callout drags those paragraphs, not the whole callout. Selecting an image inside a table cell drags just the image. A nested code block grabbed by its chrome inside a table cell drags that code block, not the whole table.
- **Grabbing a container by its chrome drags the whole container.** When the drag originates on the container itself (not on its children), the serializer carries the container intact. Drops or pastes preserve the container when the destination accepts its type, and unwrap to accepted descendants when it doesn't.
- **Internal-move source-deletion follows the destination fit.** When the drop's destination accepts the dragged blocks whole (table into root), the source is removed at the root path. When the destination unwraps them (callout dropped into a table cell that only accepts text blocks), the source is removed per inner block. No more empty container shells left behind after a move.
- **The selection stays on the dropped block.** After an internal drop, `validate-selection-machine` no longer overwrites the engine's model selection when `toDOMRange` races ahead of React's commit. The caret lands on the just-dropped block instead of jumping to the top of the editor.

## Making a container draggable

Containers don't get `draggable={true}` from the engine; the consumer adds it in the container's `render`. Pair it with a chrome region the user can grab without entering the editable content:

```tsx
defineContainer({
  type: 'callout',
  arrayField: 'content',
  render: ({attributes, children, readOnly}) => (
    
      {children}
    
  ),
  of: [
    defineTextBlock({type: 'block', render: ...}),
  ],
})
```

The container's own padding (and any non-editable chrome you render, such as an icon or header bar) is what makes the chrome region grabbable: the engine resolves the drag's origin against the nearest `data-pt-path` ancestor, so a click in the padding (no descendant `data-pt-path`) starts a chrome drag of the container, while a click inside `{children}` starts a normal text-block drag.

See `apps/playground/src/plugins/plugin.callout.tsx`, `plugin.code-block.tsx`, `plugin.fact-box.tsx`, and `plugin.table.tsx` for working examples.

## How it works

The portable-text converter is unchanged from main: it reads the selection from `snapshot.context.selection` and calls `getFragment`. The drag pipeline carries the grabbed selection on the originating event rather than writing it back to the editor, so `abstractSerializeBehaviors` overrides the snapshot's selection for drag origins before passing it to the converter. Converters see the grabbed unit through plain selection reads with no drag-specific surface area.

The chrome branch of `getEventPosition` emits a selection collapsed at the grabbed container's path. `getFragment` treats a selection whose endpoints terminate at the root level (collapsed at a root-level node, or expanded across root siblings without descending into them) as the user pointing AT the named node(s) rather than INTO them, and returns the envelope as-is. For in-content drags the selection descends into a block's children, and `getFragment`'s existing unwrap walk runs as today. Selection shape is the discriminator; no flag is threaded.

The `dragstart` action no longer raises an internal `select`; the event-level selection is the source of truth for downstream drag-time selectors. Internal-move source-deletion mirrors the serializer: each dragged node is removed at its own path for an entire-blocks drag, by text range for a partial-text drag. `fitBlocksToDestination` handles drop-side unwrapping when the destination doesn't accept the dragged type, so the engine's existing text-block-into-text-block fragment merge in `operation.insert.block.ts` handles inline objects naturally without a wire-format shell.