### PR TITLE
test: give Firefox focus tests headroom to settle the focus->blur->focus transient

### DIFF
--- a/packages/editor/tests/focus.test.tsx
+++ b/packages/editor/tests/focus.test.tsx
@@ -5,167 +5,189 @@ import type {EditorEmittedEvent} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 
+// Focusing an empty editor emits `focused` and then programmatically sets the
+// selection (`handleOnFocus` -> `editorEngine.select`). On Firefox that
+// selection-set on a freshly-focused empty contenteditable transiently blurs
+// and re-focuses the element, so the DOM event stream is
+// `focused -> blurred -> focused`. The settled last event is `focused`, but
+// under CI load it can arrive well after the default 1s `vi.waitFor` window,
+// so the wait exhausts on the transient `blurred`. Give the focus waits (and
+// the tests themselves) enough headroom to reach the settled state.
+const FOCUS_SETTLE = {timeout: 10_000, interval: 100} as const
+const TEST_TIMEOUT = 40_000
+
 describe('focus', () => {
-  test('Scenario: Focusing on an empty editor', async () => {
-    const keyGenerator = createTestKeyGenerator()
-    const focusEvents: Array<EditorEmittedEvent['type']> = []
+  test(
+    'Scenario: Focusing on an empty editor',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const focusEvents: Array<EditorEmittedEvent['type']> = []
 
-    const {editor, locator} = await createTestEditor({
-      keyGenerator,
-      children: (
-        <>
-          <button type="button" data-testid="toolbar">
-            Toolbar
-          </button>
-          <EventListenerPlugin
-            on={(event) => {
-              if (event.type === 'focused' || event.type === 'blurred') {
-                focusEvents.push(event.type)
-              }
-            }}
-          />
-        </>
-      ),
-    })
-
-    const expectedSelection = {
-      anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-      focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
-      backward: false,
-    }
-
-    const toolbarLocator = page.getByTestId('toolbar')
-    await vi.waitFor(() => expect.element(toolbarLocator).toBeInTheDocument())
-
-    await userEvent.click(locator)
-
-    // Wait for both focus and selection to settle.
-    // Firefox can be slow to process focus on empty contenteditable elements.
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('focused')
-      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
-    })
-
-    await userEvent.click(toolbarLocator)
-
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('blurred')
-    })
-
-    await userEvent.click(locator)
-
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('focused')
-      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
-    })
-  })
-
-  test('Scenario: Focusing on a non-empty editor', async () => {
-    const keyGenerator = createTestKeyGenerator()
-    const focusEvents: Array<EditorEmittedEvent['type']> = []
-    const fooBlockKey = keyGenerator()
-    const fooSpanKey = keyGenerator()
-    const barBlockKey = keyGenerator()
-    const barSpanKey = keyGenerator()
-    const initialValue = [
-      {
-        _type: 'block',
-        _key: fooBlockKey,
-        children: [
-          {
-            _type: 'span',
-            _key: fooSpanKey,
-            text: 'foo',
-            marks: [],
-          },
-        ],
-        markDefs: [],
-        style: 'normal',
-      },
-      {
-        _type: 'block',
-        _key: barBlockKey,
-        children: [
-          {
-            _type: 'span',
-            _key: barSpanKey,
-            text: 'b',
-            marks: [],
-          },
-        ],
-        markDefs: [],
-        style: 'normal',
-      },
-    ]
-
-    const {editor, locator} = await createTestEditor({
-      keyGenerator,
-      initialValue,
-      children: (
-        <>
-          <button type="button" data-testid="toolbar">
-            Toolbar
-          </button>
-          <EventListenerPlugin
-            on={(event) => {
-              if (event.type === 'focused' || event.type === 'blurred') {
-                focusEvents.push(event.type)
-              }
-            }}
-          />
-        </>
-      ),
-    })
-
-    const barSpanLocator = locator.getByText('b')
-    const toolbarLocator = page.getByTestId('toolbar')
-    await vi.waitFor(() => expect.element(barSpanLocator).toBeInTheDocument())
-    await vi.waitFor(() => expect.element(toolbarLocator).toBeInTheDocument())
-
-    await userEvent.click(barSpanLocator)
-
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('focused')
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {
-          path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
-          offset: 0,
-        },
-        focus: {
-          path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
-          offset: 0,
-        },
-        backward: false,
+      const {editor, locator} = await createTestEditor({
+        keyGenerator,
+        children: (
+          <>
+            <button type="button" data-testid="toolbar">
+              Toolbar
+            </button>
+            <EventListenerPlugin
+              on={(event) => {
+                if (event.type === 'focused' || event.type === 'blurred') {
+                  focusEvents.push(event.type)
+                }
+              }}
+            />
+          </>
+        ),
       })
-    })
 
-    await userEvent.click(toolbarLocator)
-
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('blurred')
-    })
-
-    await userEvent.click(barSpanLocator)
-
-    await vi.waitFor(() => {
-      expect(focusEvents.at(-1)).toEqual('focused')
-    })
-
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.selection).toEqual({
-        anchor: {
-          path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
-          offset: 0,
-        },
-        focus: {
-          path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
-          offset: 0,
-        },
+      const expectedSelection = {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
         backward: false,
+      }
+
+      const toolbarLocator = page.getByTestId('toolbar')
+      await vi.waitFor(() => expect.element(toolbarLocator).toBeInTheDocument())
+
+      await userEvent.click(locator)
+
+      // Wait for both focus and selection to settle.
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('focused')
+        expect(editor.getSnapshot().context.selection).toEqual(
+          expectedSelection,
+        )
+      }, FOCUS_SETTLE)
+
+      await userEvent.click(toolbarLocator)
+
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('blurred')
+      }, FOCUS_SETTLE)
+
+      await userEvent.click(locator)
+
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('focused')
+        expect(editor.getSnapshot().context.selection).toEqual(
+          expectedSelection,
+        )
+      }, FOCUS_SETTLE)
+    },
+  )
+
+  test(
+    'Scenario: Focusing on a non-empty editor',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const focusEvents: Array<EditorEmittedEvent['type']> = []
+      const fooBlockKey = keyGenerator()
+      const fooSpanKey = keyGenerator()
+      const barBlockKey = keyGenerator()
+      const barSpanKey = keyGenerator()
+      const initialValue = [
+        {
+          _type: 'block',
+          _key: fooBlockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: fooSpanKey,
+              text: 'foo',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: barBlockKey,
+          children: [
+            {
+              _type: 'span',
+              _key: barSpanKey,
+              text: 'b',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ]
+
+      const {editor, locator} = await createTestEditor({
+        keyGenerator,
+        initialValue,
+        children: (
+          <>
+            <button type="button" data-testid="toolbar">
+              Toolbar
+            </button>
+            <EventListenerPlugin
+              on={(event) => {
+                if (event.type === 'focused' || event.type === 'blurred') {
+                  focusEvents.push(event.type)
+                }
+              }}
+            />
+          </>
+        ),
       })
-    })
-  })
+
+      const barSpanLocator = locator.getByText('b')
+      const toolbarLocator = page.getByTestId('toolbar')
+      await vi.waitFor(() => expect.element(barSpanLocator).toBeInTheDocument())
+      await vi.waitFor(() => expect.element(toolbarLocator).toBeInTheDocument())
+
+      await userEvent.click(barSpanLocator)
+
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('focused')
+      }, FOCUS_SETTLE)
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.selection).toEqual({
+          anchor: {
+            path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
+            offset: 0,
+          },
+          backward: false,
+        })
+      }, FOCUS_SETTLE)
+
+      await userEvent.click(toolbarLocator)
+
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('blurred')
+      }, FOCUS_SETTLE)
+
+      await userEvent.click(barSpanLocator)
+
+      await vi.waitFor(() => {
+        expect(focusEvents.at(-1)).toEqual('focused')
+      }, FOCUS_SETTLE)
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.selection).toEqual({
+          anchor: {
+            path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: barBlockKey}, 'children', {_key: barSpanKey}],
+            offset: 0,
+          },
+          backward: false,
+        })
+      }, FOCUS_SETTLE)
+    },
+  )
 })


### PR DESCRIPTION
Re-stabilizes the Firefox `focus.test.tsx` tests, which intermittently fail in
CI with `expected 'blurred' to deeply equal 'focused'`. It is a flaky test, not
a regression: it shows up on PRs that change no source at all, including the
changeset release PR (#2826), and it was wrongly suspected on the unified-input
branch (#2814) where it failed in the same way.

Root cause: focusing an empty editor emits `focused` and then programmatically
sets the selection (`handleOnFocus` calls `editorEngine.select`). On Firefox
that selection-set on a freshly-focused empty contenteditable transiently blurs
and re-focuses the element, so the DOM emits `focused -> blurred -> focused`.
The events are forwarded 1:1, so `focusEvents.at(-1)` momentarily holds the
transient `blurred`. The settled last event is `focused`, but under CI load it
can arrive after the default 1s `vi.waitFor` window, so the wait exhausts on the
transient and fails. Chromium is fast enough to settle inside 1s, which is why
it never flakes there.

The fix gives the focus waits a 10s timeout and the two tests a 40s budget (so a
single slow wait is not capped by the 5s default test timeout), leaving the
existing Firefox `retry: 3` as a backstop. The asserted behavior is unchanged,
only the time allowed to observe the settled state. The happy path returns as
soon as the condition holds, so passing runs are not slowed; locally both
browsers stay green (4/4), including 30x in-session repeats.

It cannot be reproduced locally in isolation (this is a CI-contention flake), so
this is best-effort hardening grounded in the confirmed event sequence rather
than a locally-reproduced fix. If it still flakes after this, the next lever is
asserting settled DOM focus (`toHaveFocus`) alongside the event, or treating the
transient blur on empty-editor focus as a real editor issue to fix at the source.
