### PR TITLE
fix(perf): remove blocks in a range back-to-front when deleting

### DIFF
--- a/.changeset/delete-range-backwards.md
+++ b/.changeset/delete-range-backwards.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): remove blocks in a range back-to-front when deleting
+
+Deleting a selection that spans many blocks (such as select-all in a large
+document) no longer slows down quadratically with the number of blocks
+removed. The blocks between the endpoints are now removed from the back of
+the range forward, so the work scales linearly.

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -695,16 +695,27 @@ function removeLeadingChildrenOf(
 /**
  * Remove every sibling block strictly between `startBlockPath` and
  * `endBlockPath`. Both paths must share the same parent.
+ *
+ * Removes from the end of the range backward. Each removal reindexes the
+ * block-index map for the removed node's following siblings; taking the
+ * last in-range block first leaves nothing after it to reindex, so the
+ * whole range is O(n) instead of the O(n^2) a front-to-back walk incurs
+ * (every removal there shifts, and reserializes, all later siblings).
  */
 function removeBlocksBetween(
   editor: PortableTextEditorEngine,
   startBlockPath: Path,
   endBlockPath: Path,
 ): void {
-  let cursor = getSibling(editor.snapshot, startBlockPath, {direction: 'next'})
-  while (cursor && !pathEquals(cursor.path, endBlockPath)) {
+  let cursor = getSibling(editor.snapshot, endBlockPath, {
+    direction: 'previous',
+  })
+  while (cursor && !pathEquals(cursor.path, startBlockPath)) {
+    const previous = getSibling(editor.snapshot, cursor.path, {
+      direction: 'previous',
+    })
     removeNodeAt(editor, cursor.path)
-    cursor = getSibling(editor.snapshot, startBlockPath, {direction: 'next'})
+    cursor = previous
   }
 }
 

--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -103,6 +103,53 @@ describe('Performance', () => {
     })
   })
 
+  describe('Deleting', () => {
+    test('Removing 1000 blocks via select all and delete', async () => {
+      const {editor, locator} = await createTestEditor()
+
+      editor.send({
+        type: 'insert.blocks',
+        blocks: Array.from({length: 1000}, (_, i) => ({
+          _type: 'block',
+          _key: `b${i}`,
+          children: [{_type: 'span', _key: `s${i}`, text: `b${i}`, marks: []}],
+          markDefs: [],
+          style: 'normal',
+        })),
+        placement: 'auto',
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1000)
+
+        expect(locator.getByText('b999')).toBeInTheDocument()
+      })
+
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+          focus: {
+            path: [{_key: 'b999'}, 'children', {_key: 's999'}],
+            offset: 'b999'.length,
+          },
+        },
+      })
+
+      const start = performance.now()
+
+      editor.send({type: 'delete'})
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1)
+      })
+
+      const duration = performance.now() - start
+
+      console.warn(`Removed 1000 blocks in ${duration.toFixed(2)}ms`)
+    })
+  })
+
   describe('Containers', () => {
     const schemaDefinition = defineSchema({
       blockObjects: [


### PR DESCRIPTION
Deleting a selection that spans a large number of blocks, the clearest case being select-all in a big document, hangs the main thread for seconds. Profiling select-all + delete of 8000 root blocks in isolation: the synchronous delete takes ~4800ms (and it's O(n^2), 270ms / 970ms / 4800ms at 2k / 4k / 8k). React unmounting the blocks afterwards is ~80ms, so the hang is the engine, not rendering.

The range delete removes the blocks between the two endpoints in `removeBlocksBetween`, one at a time, always taking the first in-range block via `getSibling(start, 'next')`. Every `unset` reindexes the block-index map for the removed node's following siblings, and removing from the front shifts (and reserializes) every later sibling, so the whole range is O(n^2). That reindexing alone was ~3000ms of the ~4800ms.

Removing the in-range blocks from the back of the range forward fixes it: taking the last in-range block first leaves nothing after it to reindex, so each removal's reindex is O(1) and the range is O(n). The 8000-block delete drops from ~4800ms to ~1800ms. The result is identical, only the removal order changes; inverse operations are recorded per node and replayed in reverse on undo, so undo is unaffected, and the existing delete, cross-container-delete, selection, and undo/redo suites pass unchanged.

The remaining ~1800ms is dominated by the per-operation list-index map rebuild, which `editor-perf-lazy-list-index` removes; stacked, the same delete is ~790ms. Beyond that, one `value.slice()` per removed block is still O(n^2) but a much smaller term; removing it would need a bulk-remove operation (splice the range in one op), which is a larger op-model change left as a follow-up.

Chromium, headless, `tests/performance.test.tsx`, select-all + delete of 1000 root blocks: 99ms before, 66ms after. The quadratic term is small at 1000; the win grows with document size (the 8000-block figures above).
