### PR TITLE
fix(perf): recompute toolbar button state once per microtask, not per editor event

### DIFF
--- a/.changeset/toolbar-coalesce-active-state.md
+++ b/.changeset/toolbar-coalesce-active-state.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/toolbar': patch
+---
+
+fix(perf): recompute toolbar button state once per microtask, not per editor event
+
+Toolbar buttons no longer freeze the editor while recomputing their active
+state during large edits. Deleting or changing a big selection previously
+recomputed every button's active state on every underlying operation, each
+recompute scanning the whole selection; the state now settles once per change.

--- a/packages/toolbar/src/disable-listener.ts
+++ b/packages/toolbar/src/disable-listener.ts
@@ -1,5 +1,6 @@
 import type {Editor} from '@portabletext/editor'
 import {fromCallback, type AnyEventObject} from 'xstate'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 
 export type DisableListenerEvent = {type: 'enable'} | {type: 'disable'}
 
@@ -15,11 +16,11 @@ export const disableListener = fromCallback<
     sendBack({type: 'enable'})
   }
 
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     if (input.editor.getSnapshot().context.readOnly) {
       sendBack({type: 'disable'})
     } else {
       sendBack({type: 'enable'})
     }
-  }).unsubscribe
+  })
 })

--- a/packages/toolbar/src/subscribe-to-editor-change.test.ts
+++ b/packages/toolbar/src/subscribe-to-editor-change.test.ts
@@ -1,0 +1,52 @@
+import type {Editor} from '@portabletext/editor'
+import {describe, expect, test} from 'vitest'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
+
+describe('subscribeToEditorChange', () => {
+  function createEditorStub() {
+    const handlers = new Set<() => void>()
+    const editor = {
+      on: (_type: '*', handler: () => void) => {
+        handlers.add(handler)
+        return {unsubscribe: () => handlers.delete(handler)}
+      },
+    } as unknown as Editor
+    return {
+      editor,
+      emit: () => {
+        for (const handler of handlers) {
+          handler()
+        }
+      },
+    }
+  }
+
+  test('coalesces a synchronous burst into a single trailing call', async () => {
+    const {editor, emit} = createEditorStub()
+    let calls = 0
+    const unsubscribe = subscribeToEditorChange(editor, () => {
+      calls++
+    })
+
+    for (let i = 0; i < 100; i++) {
+      emit()
+    }
+    expect(calls).toBe(0)
+
+    await Promise.resolve()
+    expect(calls).toBe(1)
+
+    for (let i = 0; i < 100; i++) {
+      emit()
+    }
+    await Promise.resolve()
+    expect(calls).toBe(2)
+
+    unsubscribe()
+    for (let i = 0; i < 100; i++) {
+      emit()
+    }
+    await Promise.resolve()
+    expect(calls).toBe(2)
+  })
+})

--- a/packages/toolbar/src/subscribe-to-editor-change.ts
+++ b/packages/toolbar/src/subscribe-to-editor-change.ts
@@ -1,0 +1,44 @@
+import type {Editor} from '@portabletext/editor'
+
+/**
+ * Subscribe to all editor events, coalescing a synchronous burst of events
+ * into a single `listener` call on the next microtask.
+ *
+ * The toolbar's button listeners recompute a selection-dependent selector
+ * (active annotation/decorator/style/list, active style, popover position)
+ * on every editor event. A single user action can emit one event per
+ * underlying operation, so deleting a large selection emits an event per
+ * removed block while the selection is still large. Recomputing each
+ * O(selection) selector once per event is then O(n^2) and blocks the main
+ * thread.
+ *
+ * Only the settled state matters for what the toolbar shows, so coalescing
+ * to the trailing edge runs each selector once per burst instead of once
+ * per event, turning the per-action cost back into a single O(selection)
+ * pass. A pending microtask that fires after unsubscribe is dropped.
+ */
+export function subscribeToEditorChange(
+  editor: Editor,
+  listener: () => void,
+): () => void {
+  let scheduled = false
+  let subscribed = true
+
+  const subscription = editor.on('*', () => {
+    if (scheduled) {
+      return
+    }
+    scheduled = true
+    queueMicrotask(() => {
+      scheduled = false
+      if (subscribed) {
+        listener()
+      }
+    })
+  })
+
+  return () => {
+    subscribed = false
+    subscription.unsubscribe()
+  }
+}

--- a/packages/toolbar/src/use-annotation-button.ts
+++ b/packages/toolbar/src/use-annotation-button.ts
@@ -4,6 +4,7 @@ import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 import {useMutuallyExclusiveAnnotation} from './use-mutually-exclusive-annotation'
 import type {ToolbarAnnotationSchemaType} from './use-toolbar-schema'
 
@@ -23,7 +24,7 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     const snapshot = input.editor.getSnapshot()
 
     if (selectors.isActiveAnnotation(input.schemaType.name)(snapshot)) {
@@ -31,7 +32,7 @@ const activeListener = fromCallback<
     } else {
       sendBack({type: 'set inactive'})
     }
-  }).unsubscribe
+  })
 })
 
 const keyboardShortcutRemove = fromCallback<

--- a/packages/toolbar/src/use-annotation-popover.ts
+++ b/packages/toolbar/src/use-annotation-popover.ts
@@ -11,6 +11,7 @@ import * as React from 'react'
 import type {RefObject} from 'react'
 import {assign, fromCallback, setup, type AnyEventObject} from 'xstate'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 import type {ToolbarAnnotationSchemaType} from './use-toolbar-schema'
 
 type ActiveContext = {
@@ -35,7 +36,7 @@ const activeListener = fromCallback<
   {editor: Editor; schemaTypes: ReadonlyArray<ToolbarAnnotationSchemaType>},
   ActiveListenerEvent
 >(({input, sendBack}) => {
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     const snapshot = input.editor.getSnapshot()
     const activeAnnotations = selectors.getActiveAnnotations(snapshot)
     const focusBlock = selectors.getFocusBlock(snapshot)
@@ -75,7 +76,7 @@ const activeListener = fromCallback<
       }),
       elementRef,
     })
-  }).unsubscribe
+  })
 })
 
 const annotationPopoverMachine = setup({

--- a/packages/toolbar/src/use-decorator-button.ts
+++ b/packages/toolbar/src/use-decorator-button.ts
@@ -7,6 +7,7 @@ import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 import {useDecoratorKeyboardShortcut} from './use-decorator-keyboard-shortcut'
 import {useMutuallyExclusiveDecorator} from './use-mutually-exclusive-decorator'
 import type {ToolbarDecoratorSchemaType} from './use-toolbar-schema'
@@ -27,7 +28,7 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     const snapshot = input.editor.getSnapshot()
 
     if (selectors.isActiveDecorator(input.schemaType.name)(snapshot)) {
@@ -35,7 +36,7 @@ const activeListener = fromCallback<
     } else {
       sendBack({type: 'set inactive'})
     }
-  }).unsubscribe
+  })
 })
 
 const decoratorButtonMachine = setup({

--- a/packages/toolbar/src/use-list-button.ts
+++ b/packages/toolbar/src/use-list-button.ts
@@ -3,6 +3,7 @@ import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 import type {ToolbarListSchemaType} from './use-toolbar-schema'
 
 const activeListener = fromCallback<
@@ -21,7 +22,7 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     const snapshot = input.editor.getSnapshot()
 
     if (selectors.isActiveListItem(input.schemaType.name)(snapshot)) {
@@ -29,7 +30,7 @@ const activeListener = fromCallback<
     } else {
       sendBack({type: 'set inactive'})
     }
-  }).unsubscribe
+  })
 })
 
 const listButtonMachine = setup({

--- a/packages/toolbar/src/use-style-selector.ts
+++ b/packages/toolbar/src/use-style-selector.ts
@@ -7,6 +7,7 @@ import * as selectors from '@portabletext/editor/selectors'
 import {useActor} from '@xstate/react'
 import {assign, fromCallback, setup, type AnyEventObject} from 'xstate'
 import {disableListener, type DisableListenerEvent} from './disable-listener'
+import {subscribeToEditorChange} from './subscribe-to-editor-change'
 import {useStyleKeyboardShortcuts} from './use-style-keyboard-shortcuts'
 import type {ToolbarStyleSchemaType} from './use-toolbar-schema'
 
@@ -24,12 +25,12 @@ const activeListener = fromCallback<
   const activeStyle = selectors.getActiveStyle(input.editor.getSnapshot())
   sendBack({type: 'set active style', style: activeStyle})
 
-  return input.editor.on('*', () => {
+  return subscribeToEditorChange(input.editor, () => {
     const snapshot = input.editor.getSnapshot()
     const activeStyle = selectors.getActiveStyle(snapshot)
 
     sendBack({type: 'set active style', style: activeStyle})
-  }).unsubscribe
+  })
 })
 
 const styleSelectorMachine = setup({


### PR DESCRIPTION
Selecting all and deleting in a large document freezes the main thread. A CPU profile of the deployed editor (select-all + delete) spends the majority of its active time not in the engine but in the toolbar: `editor.on('*')` → `isActiveAnnotation`/`isActiveDecorator`/... → `getSelectedSpans` → `getNodes` over the whole selection → `blockIndexMap.get` per node.

Every toolbar button (annotation, decorator, style, list, the annotation popover, and the shared disabled-state listener) subscribes to `editor.on('*')` and recomputes its active state on every editor event. Those selectors walk the current selection, so each recompute is O(selection). A single user action emits one event per underlying operation, so deleting a large selection emits an event per removed block while the selection is still large. The cost is O(buttons × operations × selection), i.e. quadratic in document size, and it runs synchronously, so the tab hangs.

`subscribeToEditorChange` subscribes to `'*'` the same way but coalesces a synchronous burst of events into a single trailing call on the next microtask. Each selector then runs once per burst instead of once per event, so a delete that emits N operation events recomputes each button once over the settled selection rather than N times over progressively-smaller selections. The settled state is what the toolbar displays, so the trailing call is the only one that matters; a pending microtask that fires after unsubscribe is dropped.

The only observable change is that a button's active state settles one microtask after a change instead of synchronously within the event. The displayed result is unchanged. Each listener still computes its initial state synchronously on mount, so first paint is unaffected. A unit test pins the contract: 100 synchronous events produce exactly one listener call, a second burst produces one more, and no call fires after unsubscribe.

This is the toolbar half of the select-all-delete hang. The engine itself also has O(n²) terms on that path, addressed separately by `editor-perf-delete-range-backwards` (reverse range removal) and `editor-perf-lazy-list-index` (deferred list-index rebuild); this PR is what removes the dominant cost in the profile.
