### PR TITLE
feat: add a `schedule` option to `editor.on` to coalesce event bursts

### DIFF
--- a/.changeset/editor-on-schedule.md
+++ b/.changeset/editor-on-schedule.md
@@ -1,0 +1,25 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: add a `schedule` option to `editor.on` to coalesce event bursts
+
+`editor.on(type, listener, options)` now accepts `{schedule}`:
+
+```ts
+editor.on('*', () => recomputeFromSnapshot(editor.getSnapshot()), {
+  schedule: 'microtask',
+})
+```
+
+With `schedule: 'microtask'`, a synchronous burst of matching events coalesces
+into a single trailing listener call on the next microtask, receiving the last
+event of the burst. This is for listeners that recompute derived state from
+`editor.getSnapshot()` rather than acting on each event: a single user action
+emits one event per underlying operation, so reacting per event runs the
+listener O(operations) times (quadratic when the listener also scans the
+selection). The editor state is never lost, the snapshot is cumulative, only
+the intermediate event objects of the burst are not delivered.
+
+The default, `schedule: 'sync'`, is unchanged: the listener runs synchronously
+for every event. Also exports the `EditorEventListenerOptions` type.

--- a/.changeset/toolbar-schedule-microtask.md
+++ b/.changeset/toolbar-schedule-microtask.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/toolbar': patch
+---
+
+fix(perf): coalesce toolbar editor listeners with `schedule: 'microtask'`
+
+Toolbar buttons no longer freeze the editor while recomputing their active
+state during large edits. Each button listened for every editor event and
+recomputed its active state by scanning the selection, so deleting or changing
+a big selection recomputed every button once per underlying operation. The
+listeners now pass `{schedule: 'microtask'}` to `editor.on`, so a burst of
+events coalesces into a single recompute over the settled state.

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -1,11 +1,13 @@
 import type {PortableTextBlock, SchemaDefinition} from '@portabletext/schema'
-import type {ActorRef, EventObject, Snapshot} from 'xstate'
 import type {Behavior} from './behaviors/behavior.types.behavior'
 import type {ExternalBehaviorEvent} from './behaviors/behavior.types.event'
 import type {EditorDom} from './editor/editor-dom'
 import type {ExternalEditorEvent} from './editor/editor-machine'
 import type {EditorSnapshot} from './editor/editor-snapshot'
-import type {EditorEmittedEvent} from './editor/relay'
+import type {
+  EditorEmittedEvent,
+  EditorEventListenerOptions,
+} from './editor/relay'
 import type {RegistrableNode} from './renderers/renderer.types'
 
 /**
@@ -52,7 +54,13 @@ export type Editor = {
    */
   registerNode: (config: {node: RegistrableNode}) => () => void
   send: (event: EditorEvent) => void
-  on: ActorRef<Snapshot<unknown>, EventObject, EditorEmittedEvent>['on']
+  on: <TType extends EditorEmittedEvent['type'] | '*'>(
+    type: TType,
+    listener: (
+      event: EditorEmittedEvent & (TType extends '*' ? unknown : {type: TType}),
+    ) => void,
+    options?: EditorEventListenerOptions,
+  ) => {unsubscribe: () => void}
   /**
    * Subscribe to editor state changes. The observer's `next` callback fires
    * with the current `EditorSnapshot` on every relevant transition (selection

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -110,26 +110,30 @@ export function createInternalEditor(config: EditorConfig): {
           )
       }
     },
-    on: (event, listener) => {
-      const subscription = relay.on(event, (event) => {
-        switch (event.type) {
-          case 'blurred':
-          case 'done loading':
-          case 'editable':
-          case 'focused':
-          case 'invalid value':
-          case 'loading':
-          case 'mutation':
-          case 'operation':
-          case 'patch':
-          case 'read only':
-          case 'ready':
-          case 'selection':
-          case 'value changed':
-            listener(event)
-            break
-        }
-      })
+    on: (event, listener, options) => {
+      const subscription = relay.on(
+        event,
+        (event) => {
+          switch (event.type) {
+            case 'blurred':
+            case 'done loading':
+            case 'editable':
+            case 'focused':
+            case 'invalid value':
+            case 'loading':
+            case 'mutation':
+            case 'operation':
+            case 'patch':
+            case 'read only':
+            case 'ready':
+            case 'selection':
+            case 'value changed':
+              listener(event)
+              break
+          }
+        },
+        options,
+      )
 
       return subscription
     },

--- a/packages/editor/src/editor/relay.ts
+++ b/packages/editor/src/editor/relay.ts
@@ -104,6 +104,24 @@ export type PatchEvent = {
 type RelayListener = (event: EditorEmittedEvent) => void
 
 /**
+ * @public
+ * Controls when a listener registered with `editor.on(...)` runs.
+ */
+export type EditorEventListenerOptions = {
+  /**
+   * - `'sync'` (default): the listener runs synchronously for every matching
+   *   event, preserving per-event delivery and payloads.
+   * - `'microtask'`: a synchronous burst of matching events coalesces into a
+   *   single trailing listener call on the next microtask, receiving the
+   *   last event of the burst. Intended for listeners that recompute derived
+   *   state from `editor.getSnapshot()` rather than acting on each event;
+   *   editor state is never lost (the snapshot is cumulative), only the
+   *   intermediate event objects of the burst are not delivered.
+   */
+  schedule?: 'sync' | 'microtask'
+}
+
+/**
  * Fans editor events out to consumers (`editor.on(...)`).
  *
  * Guarantees:
@@ -126,6 +144,7 @@ export type Relay = {
     listener: (
       event: EditorEmittedEvent & (TType extends '*' ? unknown : {type: TType}),
     ) => void,
+    options?: EditorEventListenerOptions,
   ) => {unsubscribe: () => void}
   start: () => void
   stop: () => void
@@ -239,16 +258,47 @@ export function createRelay(): Relay {
         drainMailbox()
       }
     },
-    on: (type, listener) => {
-      listeners.set(type, [
-        ...(listeners.get(type) ?? []),
-        listener as RelayListener,
-      ])
+    on: (type, listener, options) => {
+      // `'microtask'` listeners are stored as a coalescing wrapper: `deliver`
+      // calls the wrapper per event (cheap: record the event, schedule once),
+      // and the original listener runs once on the trailing microtask with
+      // the last event. This collapses a burst (e.g. one operation event per
+      // block during a large delete) into a single recompute.
+      let stored: RelayListener
+      let unsubscribed = false
+
+      if (options?.schedule === 'microtask') {
+        let scheduled = false
+        let pendingEvent: EditorEmittedEvent | undefined
+        stored = (event) => {
+          pendingEvent = event
+          if (scheduled) {
+            return
+          }
+          scheduled = true
+          queueMicrotask(() => {
+            scheduled = false
+            if (unsubscribed || status === 'stopped') {
+              return
+            }
+            const event = pendingEvent
+            pendingEvent = undefined
+            if (event !== undefined) {
+              callListener(listener as RelayListener, event)
+            }
+          })
+        }
+      } else {
+        stored = listener as RelayListener
+      }
+
+      listeners.set(type, [...(listeners.get(type) ?? []), stored])
 
       return {
         unsubscribe: () => {
+          unsubscribed = true
           const current = listeners.get(type) ?? []
-          const index = current.indexOf(listener as RelayListener)
+          const index = current.indexOf(stored)
 
           if (index !== -1) {
             listeners.set(type, [

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -41,7 +41,11 @@ export {usePortableTextEditor} from './editor/usePortableTextEditor'
 export {usePortableTextEditorSelection} from './editor/usePortableTextEditorSelection'
 export {defaultKeyGenerator as keyGenerator} from './utils/key-generator'
 export {PortableTextEditor} from './editor/PortableTextEditor'
-export type {EditorEmittedEvent, MutationEvent} from './editor/relay'
+export type {
+  EditorEmittedEvent,
+  EditorEventListenerOptions,
+  MutationEvent,
+} from './editor/relay'
 export {useEditor} from './editor/use-editor'
 export {
   defineBlockObject,

--- a/packages/editor/tests/event.on-schedule.test.tsx
+++ b/packages/editor/tests/event.on-schedule.test.tsx
@@ -1,0 +1,72 @@
+import {describe, expect, test, vi} from 'vitest'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('editor.on schedule option', () => {
+  test("'microtask' coalesces a burst of events into one call; 'sync' does not", async () => {
+    const {editor} = await createTestEditor()
+
+    const blockCount = 200
+    editor.send({
+      type: 'insert.blocks',
+      blocks: Array.from({length: blockCount}, (_, i) => ({
+        _type: 'block',
+        _key: `b${i}`,
+        children: [{_type: 'span', _key: `s${i}`, text: `b${i}`, marks: []}],
+        markDefs: [],
+        style: 'normal',
+      })),
+      placement: 'auto',
+    })
+    await vi.waitFor(() =>
+      expect(editor.getSnapshot().context.value.length).toBe(blockCount),
+    )
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+        focus: {
+          path: [
+            {_key: `b${blockCount - 1}`},
+            'children',
+            {_key: `s${blockCount - 1}`},
+          ],
+          offset: `b${blockCount - 1}`.length,
+        },
+      },
+    })
+
+    let syncCalls = 0
+    let microtaskCalls = 0
+    const syncSubscription = editor.on('*', () => {
+      syncCalls++
+    })
+    const microtaskSubscription = editor.on(
+      '*',
+      () => {
+        microtaskCalls++
+      },
+      {schedule: 'microtask'},
+    )
+
+    editor.send({type: 'delete'})
+
+    // Synchronously after the delete: the sync listener has already fired
+    // once per emitted event, the microtask listener has not fired yet.
+    const syncCallsRightAfterDelete = syncCalls
+    expect(microtaskCalls).toBe(0)
+
+    await vi.waitFor(() =>
+      expect(editor.getSnapshot().context.value.length).toBe(1),
+    )
+    await Promise.resolve()
+
+    syncSubscription.unsubscribe()
+    microtaskSubscription.unsubscribe()
+
+    // The delete emits many events while removing the selection's blocks.
+    expect(syncCallsRightAfterDelete).toBeGreaterThan(10)
+    // The microtask listener collapses that burst to a single trailing call.
+    expect(microtaskCalls).toBe(1)
+  })
+})

--- a/packages/toolbar/src/disable-listener.ts
+++ b/packages/toolbar/src/disable-listener.ts
@@ -15,11 +15,15 @@ export const disableListener = fromCallback<
     sendBack({type: 'enable'})
   }
 
-  return input.editor.on('*', () => {
-    if (input.editor.getSnapshot().context.readOnly) {
-      sendBack({type: 'disable'})
-    } else {
-      sendBack({type: 'enable'})
-    }
-  }).unsubscribe
+  return input.editor.on(
+    '*',
+    () => {
+      if (input.editor.getSnapshot().context.readOnly) {
+        sendBack({type: 'disable'})
+      } else {
+        sendBack({type: 'enable'})
+      }
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })

--- a/packages/toolbar/src/use-annotation-button.ts
+++ b/packages/toolbar/src/use-annotation-button.ts
@@ -23,15 +23,19 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
-    const snapshot = input.editor.getSnapshot()
+  return input.editor.on(
+    '*',
+    () => {
+      const snapshot = input.editor.getSnapshot()
 
-    if (selectors.isActiveAnnotation(input.schemaType.name)(snapshot)) {
-      sendBack({type: 'set active'})
-    } else {
-      sendBack({type: 'set inactive'})
-    }
-  }).unsubscribe
+      if (selectors.isActiveAnnotation(input.schemaType.name)(snapshot)) {
+        sendBack({type: 'set active'})
+      } else {
+        sendBack({type: 'set inactive'})
+      }
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const keyboardShortcutRemove = fromCallback<

--- a/packages/toolbar/src/use-annotation-popover.ts
+++ b/packages/toolbar/src/use-annotation-popover.ts
@@ -35,47 +35,51 @@ const activeListener = fromCallback<
   {editor: Editor; schemaTypes: ReadonlyArray<ToolbarAnnotationSchemaType>},
   ActiveListenerEvent
 >(({input, sendBack}) => {
-  return input.editor.on('*', () => {
-    const snapshot = input.editor.getSnapshot()
-    const activeAnnotations = selectors.getActiveAnnotations(snapshot)
-    const focusBlock = selectors.getFocusBlock(snapshot)
+  return input.editor.on(
+    '*',
+    () => {
+      const snapshot = input.editor.getSnapshot()
+      const activeAnnotations = selectors.getActiveAnnotations(snapshot)
+      const focusBlock = selectors.getFocusBlock(snapshot)
 
-    if (activeAnnotations.length === 0 || !focusBlock) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (activeAnnotations.length === 0 || !focusBlock) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const selectedChildren = input.editor.dom.getChildNodes(snapshot)
-    const firstSelectedChild = selectedChildren.at(0)
+      const selectedChildren = input.editor.dom.getChildNodes(snapshot)
+      const firstSelectedChild = selectedChildren.at(0)
 
-    if (!firstSelectedChild || !(firstSelectedChild instanceof Element)) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!firstSelectedChild || !(firstSelectedChild instanceof Element)) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const elementRef = React.createRef<Element>()
-    elementRef.current = firstSelectedChild
+      const elementRef = React.createRef<Element>()
+      elementRef.current = firstSelectedChild
 
-    sendBack({
-      type: 'set active',
-      annotations: activeAnnotations.flatMap((annotation) => {
-        const schemaType = input.schemaTypes.find(
-          (schemaType) => schemaType.name === annotation._type,
-        )
+      sendBack({
+        type: 'set active',
+        annotations: activeAnnotations.flatMap((annotation) => {
+          const schemaType = input.schemaTypes.find(
+            (schemaType) => schemaType.name === annotation._type,
+          )
 
-        if (!schemaType) {
-          return []
-        }
+          if (!schemaType) {
+            return []
+          }
 
-        return {
-          value: annotation,
-          schemaType,
-          at: [...focusBlock.path, 'markDefs', {_key: annotation._key}],
-        }
-      }),
-      elementRef,
-    })
-  }).unsubscribe
+          return {
+            value: annotation,
+            schemaType,
+            at: [...focusBlock.path, 'markDefs', {_key: annotation._key}],
+          }
+        }),
+        elementRef,
+      })
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const annotationPopoverMachine = setup({

--- a/packages/toolbar/src/use-block-object-popover.ts
+++ b/packages/toolbar/src/use-block-object-popover.ts
@@ -34,53 +34,57 @@ const activeListener = fromCallback<
   {editor: Editor; schemaTypes: ReadonlyArray<ToolbarBlockObjectSchemaType>},
   ActiveListenerEvent
 >(({input, sendBack}) => {
-  return input.editor.on('selection', () => {
-    const snapshot = input.editor.getSnapshot()
+  return input.editor.on(
+    'selection',
+    () => {
+      const snapshot = input.editor.getSnapshot()
 
-    if (!selectors.isSelectionCollapsed(snapshot)) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!selectors.isSelectionCollapsed(snapshot)) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const focusBlockObject = selectors.getFocusBlockObject(snapshot)
+      const focusBlockObject = selectors.getFocusBlockObject(snapshot)
 
-    if (!focusBlockObject) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!focusBlockObject) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const schemaType = input.schemaTypes.find(
-      (schemaType) => schemaType.name === focusBlockObject.node._type,
-    )
+      const schemaType = input.schemaTypes.find(
+        (schemaType) => schemaType.name === focusBlockObject.node._type,
+      )
 
-    if (!schemaType) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!schemaType) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const selectedNodes = input.editor.dom.getBlockNodes(snapshot)
-    const firstSelectedNode = selectedNodes.at(0)
+      const selectedNodes = input.editor.dom.getBlockNodes(snapshot)
+      const firstSelectedNode = selectedNodes.at(0)
 
-    if (!firstSelectedNode || !(firstSelectedNode instanceof Element)) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!firstSelectedNode || !(firstSelectedNode instanceof Element)) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const elementRef = React.createRef<Element>()
-    elementRef.current = firstSelectedNode
+      const elementRef = React.createRef<Element>()
+      elementRef.current = firstSelectedNode
 
-    sendBack({
-      type: 'set active',
-      blockObjects: [
-        {
-          value: focusBlockObject.node,
-          schemaType,
-          at: focusBlockObject.path,
-        },
-      ],
-      elementRef,
-    })
-  }).unsubscribe
+      sendBack({
+        type: 'set active',
+        blockObjects: [
+          {
+            value: focusBlockObject.node,
+            schemaType,
+            at: focusBlockObject.path,
+          },
+        ],
+        elementRef,
+      })
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const blockObjectPopoverMachine = setup({

--- a/packages/toolbar/src/use-decorator-button.ts
+++ b/packages/toolbar/src/use-decorator-button.ts
@@ -27,15 +27,19 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
-    const snapshot = input.editor.getSnapshot()
+  return input.editor.on(
+    '*',
+    () => {
+      const snapshot = input.editor.getSnapshot()
 
-    if (selectors.isActiveDecorator(input.schemaType.name)(snapshot)) {
-      sendBack({type: 'set active'})
-    } else {
-      sendBack({type: 'set inactive'})
-    }
-  }).unsubscribe
+      if (selectors.isActiveDecorator(input.schemaType.name)(snapshot)) {
+        sendBack({type: 'set active'})
+      } else {
+        sendBack({type: 'set inactive'})
+      }
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const decoratorButtonMachine = setup({

--- a/packages/toolbar/src/use-inline-object-popover.ts
+++ b/packages/toolbar/src/use-inline-object-popover.ts
@@ -34,53 +34,57 @@ const activeListener = fromCallback<
   {editor: Editor; schemaTypes: ReadonlyArray<ToolbarInlineObjectSchemaType>},
   ActiveListenerEvent
 >(({input, sendBack}) => {
-  return input.editor.on('selection', () => {
-    const snapshot = input.editor.getSnapshot()
+  return input.editor.on(
+    'selection',
+    () => {
+      const snapshot = input.editor.getSnapshot()
 
-    if (!selectors.isSelectionCollapsed(snapshot)) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!selectors.isSelectionCollapsed(snapshot)) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const focusInlineObject = selectors.getFocusInlineObject(snapshot)
+      const focusInlineObject = selectors.getFocusInlineObject(snapshot)
 
-    if (!focusInlineObject) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!focusInlineObject) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const schemaType = input.schemaTypes.find(
-      (schemaType) => schemaType.name === focusInlineObject.node._type,
-    )
+      const schemaType = input.schemaTypes.find(
+        (schemaType) => schemaType.name === focusInlineObject.node._type,
+      )
 
-    if (!schemaType) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!schemaType) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const selectedNodes = input.editor.dom.getChildNodes(snapshot)
-    const firstSelectedNode = selectedNodes.at(0)
+      const selectedNodes = input.editor.dom.getChildNodes(snapshot)
+      const firstSelectedNode = selectedNodes.at(0)
 
-    if (!firstSelectedNode || !(firstSelectedNode instanceof Element)) {
-      sendBack({type: 'set inactive'})
-      return
-    }
+      if (!firstSelectedNode || !(firstSelectedNode instanceof Element)) {
+        sendBack({type: 'set inactive'})
+        return
+      }
 
-    const elementRef = React.createRef<Element>()
-    elementRef.current = firstSelectedNode
+      const elementRef = React.createRef<Element>()
+      elementRef.current = firstSelectedNode
 
-    sendBack({
-      type: 'set active',
-      inlineObjects: [
-        {
-          value: focusInlineObject.node,
-          schemaType,
-          at: focusInlineObject.path,
-        },
-      ],
-      elementRef,
-    })
-  }).unsubscribe
+      sendBack({
+        type: 'set active',
+        inlineObjects: [
+          {
+            value: focusInlineObject.node,
+            schemaType,
+            at: focusInlineObject.path,
+          },
+        ],
+        elementRef,
+      })
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const inlineObjectPopoverMachine = setup({

--- a/packages/toolbar/src/use-list-button.ts
+++ b/packages/toolbar/src/use-list-button.ts
@@ -21,15 +21,19 @@ const activeListener = fromCallback<
     sendBack({type: 'set inactive'})
   }
 
-  return input.editor.on('*', () => {
-    const snapshot = input.editor.getSnapshot()
+  return input.editor.on(
+    '*',
+    () => {
+      const snapshot = input.editor.getSnapshot()
 
-    if (selectors.isActiveListItem(input.schemaType.name)(snapshot)) {
-      sendBack({type: 'set active'})
-    } else {
-      sendBack({type: 'set inactive'})
-    }
-  }).unsubscribe
+      if (selectors.isActiveListItem(input.schemaType.name)(snapshot)) {
+        sendBack({type: 'set active'})
+      } else {
+        sendBack({type: 'set inactive'})
+      }
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const listButtonMachine = setup({

--- a/packages/toolbar/src/use-style-selector.ts
+++ b/packages/toolbar/src/use-style-selector.ts
@@ -24,12 +24,16 @@ const activeListener = fromCallback<
   const activeStyle = selectors.getActiveStyle(input.editor.getSnapshot())
   sendBack({type: 'set active style', style: activeStyle})
 
-  return input.editor.on('*', () => {
-    const snapshot = input.editor.getSnapshot()
-    const activeStyle = selectors.getActiveStyle(snapshot)
+  return input.editor.on(
+    '*',
+    () => {
+      const snapshot = input.editor.getSnapshot()
+      const activeStyle = selectors.getActiveStyle(snapshot)
 
-    sendBack({type: 'set active style', style: activeStyle})
-  }).unsubscribe
+      sendBack({type: 'set active style', style: activeStyle})
+    },
+    {schedule: 'microtask'},
+  ).unsubscribe
 })
 
 const styleSelectorMachine = setup({


### PR DESCRIPTION
## What

Adds an optional third argument to `editor.on`, and migrates `@portabletext/toolbar` to use it.

```ts
editor.on(type, listener, options?: {schedule?: 'sync' | 'microtask'})
```

```ts
// recompute derived state once per change, not once per operation
editor.on('*', () => recomputeFromSnapshot(editor.getSnapshot()), {
  schedule: 'microtask',
})
```

`schedule: 'sync'` is the default and is unchanged. `schedule: 'microtask'` coalesces a synchronous burst of matching events into a single trailing listener call on the next microtask, delivering the last event of the burst. Also exports `EditorEventListenerOptions`.

## Design notes

The concrete driver is the select-all + delete hang on large documents (EDEX-731). A CPU profile attributes most of the frozen main-thread time not to the engine but to the toolbar: every button subscribes with `editor.on('*')` and recomputes its active state on every editor event, and those selectors (`isActiveAnnotation`/`isActiveDecorator`/...) scan the whole selection. A single user action emits one relay event per underlying operation (the per-op `'operation'` event in particular), so a delete that removes N blocks notifies each button O(N) times while the selection is still large: O(buttons × operations × selection), quadratic and synchronous.

The relay already batches the coarse events (`'mutation'` is debounced, `'selection'` deduped), but `'*'` consumers see the granular per-operation stream, and that granularity is deliberate for consumers that translate each operation to a patch or drive collab. So rather than change what `'*'` delivers, this lets a consumer opt a single subscription into coalesced delivery.

The implementation lives entirely in the relay. A `'microtask'` listener is stored as a coalescing wrapper: `deliver` calls the wrapper per event (record the event, schedule a flush once), and the original listener runs once on the trailing microtask with the last event. Because such listeners recompute from `editor.getSnapshot()`, which the engine mutates cumulatively, no editor state is lost; only the intermediate event objects of the burst are not delivered. A pending flush is dropped on `unsubscribe` and on relay `stop`. Listener-sent events still queue through the existing mailbox; the microtask flush runs after the current synchronous dispatch chain.

The new parameter widens `Editor['on']`, previously aliased to the xstate `ActorRef['on']`, to a dedicated signature carrying `EditorEventListenerOptions`. It is additive and backward compatible: the return shape (`{unsubscribe}`) and the listener signature are unchanged, and omitting `options` preserves today's synchronous, per-event behavior.

Net behavior is unchanged for every existing call site (full unit suite 803 and chromium browser suite 1647 pass without modification). A new test pins the contract and quantifies it: deleting a 200-block selection notifies a `'sync'` `'*'` listener 404 times and a `'microtask'` listener exactly once.

## Commits

1. **`editor.on` `schedule` option** (the primitive, above).
2. **`@portabletext/toolbar` uses it**: every button's `editor.on('*')` (active state) and `editor.on('selection')` (object popovers) listener now passes `{schedule: 'microtask'}`, so each recomputes once per change instead of once per operation. The reformatting noise is prettier moving the calls to their multi-line form for the third argument; the callback bodies are unchanged.

This supersedes #2829, which hand-rolled the same coalescing in a local `subscribeToEditorChange` helper, that PR can be closed. A follow-up (EDEX-1342) carries the same `schedule` knob onto `useEditorSelector` for React selector consumers and explores a value-delivering `subscribeToSelector` primitive.
