### PR TITLE
docs: README pass for isolation-readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,23 @@ For documentation and guides, visit [portabletext.org](https://www.portabletext.
 | [`@portabletext/schema`](./packages/schema/)   | Define and compile Portable Text schemas with full type safety |
 | [`@portabletext/toolbar`](./packages/toolbar/) | React hooks for building toolbars and related UI components    |
 
-## Editor Plugins
+## Editor plugins
 
 | Package                                                                                        | Description                                                               |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | [`@portabletext/plugin-character-pair-decorator`](./packages/plugin-character-pair-decorator/) | Automatically match a pair of characters and decorate the text in between |
-| [`@portabletext/plugin-dnd`](./packages/plugin-dnd/)                                           | Tracks the drop position during drag and drop for custom drop indicators  |
+| [`@portabletext/plugin-dnd`](./packages/plugin-dnd/)                                           | Track the drop position during drag and drop for custom drop indicators   |
 | [`@portabletext/plugin-emoji-picker`](./packages/plugin-emoji-picker/)                         | Easily configure an Emoji Picker for the Portable Text Editor             |
 | [`@portabletext/plugin-input-rule`](./packages/plugin-input-rule/)                             | Easily configure Input Rules in the Portable Text Editor                  |
-| [`@portabletext/plugin-list-index`](./packages/plugin-list-index/)                             | Computes the list index of each list item for custom list rendering       |
-| [`@portabletext/plugin-markdown-shortcuts`](./packages/plugin-markdown-shortcuts/)             | Adds helpful Markdown shortcuts to the editor                             |
-| [`@portabletext/plugin-one-line`](./packages/plugin-one-line/)                                 | Restricts the Portable Text Editor to a single line                       |
-| [`@portabletext/plugin-paste-link`](./packages/plugin-paste-link/)                             | Allows pasting links in the Portable Text Editor                          |
-| [`@portabletext/plugin-sdk-value`](./packages/plugin-sdk-value/)                               | Connects a Portable Text Editor with a Sanity document using the SDK      |
-| [`@portabletext/plugin-typeahead-picker`](./packages/plugin-typeahead-picker/)                 | Generic typeahead picker infrastructure (emoji, mentions, slash commands) |
+| [`@portabletext/plugin-list-index`](./packages/plugin-list-index/)                             | Compute the list index of each list item for custom list rendering        |
+| [`@portabletext/plugin-markdown-shortcuts`](./packages/plugin-markdown-shortcuts/)             | Add helpful Markdown shortcuts to the editor                              |
+| [`@portabletext/plugin-one-line`](./packages/plugin-one-line/)                                 | Restrict the Portable Text Editor to a single line                        |
+| [`@portabletext/plugin-paste-link`](./packages/plugin-paste-link/)                             | Allow pasting links in the Portable Text Editor                           |
+| [`@portabletext/plugin-sdk-value`](./packages/plugin-sdk-value/)                               | Connect a Portable Text Editor with a Sanity document using the SDK       |
+| [`@portabletext/plugin-typeahead-picker`](./packages/plugin-typeahead-picker/)                 | Build typeahead pickers (emoji, mentions, slash commands)                 |
 | [`@portabletext/plugin-typography`](./packages/plugin-typography/)                             | Automatically transform text to typographic variants                      |
 
-## Other Libraries
+## Other libraries
 
 | Package                                                              | Description                                                        |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -38,19 +38,34 @@ For documentation and guides, visit [portabletext.org](https://www.portabletext.
 | [`@portabletext/plugin-markdown-shortcuts`](./packages/plugin-markdown-shortcuts/)             | Adds helpful Markdown shortcuts to the editor                             |
 | [`@portabletext/plugin-one-line`](./packages/plugin-one-line/)                                 | Restricts the Portable Text Editor to a single line                       |
 | [`@portabletext/plugin-paste-link`](./packages/plugin-paste-link/)                             | Allows pasting links in the Portable Text Editor                          |
-| [`@portabletext/plugin-typeahead-picker`](./packages/plugin-typeahead-picker/)                 | Generic typeahead picker infrastructure (emoji, mentions, slash commands) |
 | [`@portabletext/plugin-sdk-value`](./packages/plugin-sdk-value/)                               | Connects a Portable Text Editor with a Sanity document using the SDK      |
+| [`@portabletext/plugin-typeahead-picker`](./packages/plugin-typeahead-picker/)                 | Generic typeahead picker infrastructure (emoji, mentions, slash commands) |
 | [`@portabletext/plugin-typography`](./packages/plugin-typography/)                             | Automatically transform text to typographic variants                      |
 
 ## Other Libraries
 
-| Package                                                              | Description                                              |
-| -------------------------------------------------------------------- | -------------------------------------------------------- |
-| [`@portabletext/html`](./packages/html/)                             | Convert HTML to Portable Text                            |
-| [`@portabletext/block-tools`](./packages/block-tools/)               | Sanity-flavored HTML to Portable Text (wraps html)       |
-| [`@portabletext/markdown`](./packages/markdown/)                     | Convert Portable Text to Markdown and back again         |
-| [`@portabletext/keyboard-shortcuts`](./packages/keyboard-shortcuts/) | Platform-aware keyboard shortcuts                        |
-| [`@portabletext/sanity-bridge`](./packages/sanity-bridge/)           | Convert between Sanity schemas and Portable Text schemas |
-| [`@portabletext/patches`](./packages/patches/)                       | Apply Sanity patches to a value                          |
-| [`@portabletext/test`](./packages/test/)                             | Testing utilities for the Portable Text Editor           |
-| [`racejar`](./packages/racejar/)                                     | A testing framework agnostic Gherkin driver              |
+| Package                                                              | Description                                                        |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`@portabletext/html`](./packages/html/)                             | Convert HTML to Portable Text                                      |
+| [`@portabletext/block-tools`](./packages/block-tools/)               | Sanity-flavored HTML to Portable Text (wraps `@portabletext/html`) |
+| [`@portabletext/markdown`](./packages/markdown/)                     | Convert Portable Text to Markdown and back again                   |
+| [`@portabletext/keyboard-shortcuts`](./packages/keyboard-shortcuts/) | Platform-aware keyboard shortcuts                                  |
+| [`@portabletext/sanity-bridge`](./packages/sanity-bridge/)           | Convert between Sanity schemas and Portable Text schemas           |
+| [`@portabletext/patches`](./packages/patches/)                       | Apply Sanity patches to a value                                    |
+| [`@portabletext/test`](./packages/test/)                             | Testing utilities for the Portable Text Editor                     |
+| [`racejar`](./packages/racejar/)                                     | A testing framework agnostic Gherkin driver                        |
+
+## Contributing
+
+This is a [pnpm](https://pnpm.io/) and [Turborepo](https://turbo.build/) monorepo.
+
+```sh
+pnpm install   # install dependencies
+pnpm build     # build every package
+```
+
+Run `pnpm test` for the test suites and `pnpm check:types`, `pnpm check:lint`, and `pnpm check:format` for the checks CI runs.
+
+## License
+
+[MIT](./LICENSE) © [Sanity.io](https://www.sanity.io/)

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -2,7 +2,7 @@
 
 [![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
 
-## Docs Project Structure
+## Docs project structure
 
 Inside of your Astro + Starlight project, you'll see the following folders and files:
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -2,7 +2,7 @@
 
 [![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
 
-## 🚀 Docs Project Structure
+## Docs Project Structure
 
 Inside of your Astro + Starlight project, you'll see the following folders and files:
 
@@ -28,7 +28,7 @@ Images can be added to `src/assets/` and embedded in Markdown with a relative li
 
 Static assets, like favicons, can be placed in the `public/` directory.
 
-## 🧞 Commands
+## Commands
 
 All commands are run from `apps/docs/`, from a terminal:
 
@@ -103,6 +103,6 @@ export default defineConfig({
 })
 ```
 
-## 👀 Want to learn more?
+## Want to learn more?
 
 Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -11,9 +11,11 @@ Inside of your Astro + Starlight project, you'll see the following folders and f
 ├── public/
 ├── src/
 │   ├── assets/
+│   ├── components/
 │   ├── content/
-│   │   ├── docs/
-│   │   └── config.ts
+│   │   └── docs/
+│   ├── styles/
+│   ├── content.config.ts
 │   └── env.d.ts
 ├── astro.config.mjs
 ├── package.json
@@ -28,16 +30,16 @@ Static assets, like favicons, can be placed in the `public/` directory.
 
 ## 🧞 Commands
 
-All commands are run from the root of the project, from a terminal:
+All commands are run from `apps/docs/`, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+| Command                | Action                                           |
+| :--------------------- | :----------------------------------------------- |
+| `pnpm install`         | Installs dependencies                            |
+| `pnpm dev`             | Starts local dev server at `localhost:4321`      |
+| `pnpm build`           | Build your production site to `./dist/`          |
+| `pnpm preview`         | Preview your build locally, before deploying     |
+| `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `pnpm astro -- --help` | Get help using the Astro CLI                     |
 
 ## Common tasks
 
@@ -48,7 +50,7 @@ We use the [multiple instance](https://starlight-typedoc.vercel.app/guides/multi
 1. Call `createStarlightTypeDocPlugin()` to create a plugin instance and a sidebar group.
 2. Add and configure the plugin in the `plugins` array of the starlight config.
 3. Create a sidebar group.
-4. Create an 'overview' mdx file in content/docs/reference. Use an existing overview, like `toolbar.mdx` as an example.
+4. Create an 'overview' mdx file in content/docs/editor/reference. Use an existing overview, like `editor/reference/toolbar.mdx` as an example.
 
 For steps 1-3, update the `astro.config.mjs`:
 
@@ -89,7 +91,7 @@ export default defineConfig({
             {
               label: 'Toolbar',
               items: [
-                {label: 'Overview', slug: 'reference/toolbar'},
+                {label: 'Overview', slug: 'editor/reference/toolbar'},
                 {...toolbarTypeDocSidebar, badge: 'Generated'},
               ],
             },

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,50 +1,25 @@
-# React + TypeScript + Vite
+# Basic Portable Text Editor example
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A single-file React example showing how to set up [`@portabletext/editor`](../../packages/editor/): a schema with decorators, annotations, styles, lists, a block object (image) and an inline object (stock ticker), the matching render functions, a small toolbar built with `useEditor` and `useEditorSelector`, and a live JSON preview of the Portable Text value.
 
-Currently, two official plugins are available:
+The whole example lives in [`src/App.tsx`](./src/App.tsx).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Run it
 
-## Expanding the ESLint configuration
+From the repository root:
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```sh
+pnpm install
+pnpm --filter example-basic dev
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+Then open the local URL Vite prints (defaults to `http://localhost:5173`).
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
+## What it demonstrates
 
-export default tseslint.config({
-  // Set the react version
-  settings: {react: {version: '18.3'}},
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
-```
+- Defining a schema with `defineSchema` (decorators, annotations, styles, lists, block and inline objects)
+- Render functions: `renderDecorator`, `renderAnnotation`, `renderStyle`, `renderBlock`, `renderChild`
+- A toolbar that toggles marks, styles, and lists using `useEditor` and `useEditorSelector` with selectors from `@portabletext/editor/selectors`
+- Reading the editor value through `EventListenerPlugin` and rendering it as JSON
+
+For a guided walkthrough of the same setup, see [Getting started](https://www.portabletext.org/editor/getting-started/).

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -53,7 +53,7 @@ import type {
 import {EventListenerPlugin} from '@portabletext/editor/plugins'
 ```
 
-### Define the Schema
+### Define the schema
 
 Before you can render the editor, you need a schema. The editor schema configures the types of content rendered by the editor.
 
@@ -358,7 +358,7 @@ The Behavior API is a way of interfacing with the PTE. It allows you to think of
 
 Learn more about the [Behaviors](https://www.portabletext.org/editor/concepts/behavior/) and how to [create your own behaviors](https://www.portabletext.org/editor/guides/create-behavior/) in the documentation.
 
-## Related Packages
+## Related packages
 
 [`@portabletext/toolbar`](../toolbar/) provides React hooks for building toolbars and related UI components.
 
@@ -366,7 +366,7 @@ Learn more about the [Behaviors](https://www.portabletext.org/editor/concepts/be
 
 Extend the editor with [official plugins](../../#editor-plugins).
 
-## End-User Experience
+## End-user experience
 
 In order to provide a robust and consistent end-user experience, the editor is backed by an elaborate E2E test suite generated from a [human-readable Gherkin spec](./gherkin-spec/).
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -9,7 +9,7 @@
 
 > The official editor for editing [Portable Text](https://github.com/portabletext/portabletext) – the JSON based rich text specification for modern content editing platforms.
 
-## Get started with the Portable Text Editor
+## Get started with the Portable Text Editor (PTE)
 
 This library provides you with the building blocks to create a completely custom editor experience built on top of Portable Text. We recommend [checking out the official documentation](https://www.portabletext.org/). The following guide includes the basics to get your started.
 
@@ -349,7 +349,7 @@ This displays the raw Portable Text. To customize how Portable Text renders in y
 
 ## Behavior API
 
-The Behavior API is a way of interfacing with the Portable Text Editor. It allows you to think of and treat the editor as a state machine by:
+The Behavior API is a way of interfacing with the PTE. It allows you to think of and treat the editor as a state machine by:
 
 - Declaratively hooking into editor **events** and defining new behaviors.
 - Imperatively triggering **events**.

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -60,7 +60,7 @@ Before you can render the editor, you need a schema. The editor schema configure
 We'll start with a schema that includes some common rich text elements.
 
 > [!NOTE]
-> This guide includes a limited set of schema types, or rich text elements, to get you started. See the [rendering guide](https://www.portabletext.org/guides/custom-rendering/) for additional examples.
+> This guide includes a limited set of schema types, or rich text elements, to get you started. See the [rendering guide](https://www.portabletext.org/editor/guides/custom-rendering/) for additional examples.
 
 ```tsx
 // App.tsx
@@ -92,7 +92,7 @@ const schemaDefinition = defineSchema({
 })
 ```
 
-Learn more about the different types that exist in schema in the [Portable Text Overview](https://www.portabletext.org/concepts/portabletext/).
+Learn more about the different types that exist in schema in the [Portable Text Overview](https://www.portabletext.org/editor/concepts/portabletext/).
 
 ### Render the editor
 
@@ -208,7 +208,7 @@ const renderDecorator: RenderDecoratorFunction = (props) => {
 
 Update the `PortableTextEditable` with each corresponding function to attach them to the editor.
 
-You may notice that we skipped a few types from the schema. Declare these inline in the configuration, like in the code below. You can learn more about [customizing the render functions](https://www.portabletext.org/guides/custom-rendering/) in the documentation.
+You may notice that we skipped a few types from the schema. Declare these inline in the configuration, like in the code below. You can learn more about [customizing the render functions](https://www.portabletext.org/editor/guides/custom-rendering/) in the documentation.
 
 ```tsx
 <PortableTextEditable
@@ -224,7 +224,7 @@ Before you can see if anything changed, you need a way to interact with the edit
 
 ### Create a toolbar
 
-A toolbar is a collection of UI elements for interacting with the editor. The PTE library gives you the necessary hooks to create a toolbar however you like. Learn more about [creating your own toolbar](https://www.portabletext.org/guides/customize-toolbar/) in the documentation.
+A toolbar is a collection of UI elements for interacting with the editor. The PTE library gives you the necessary hooks to create a toolbar however you like. Learn more about [creating your own toolbar](https://www.portabletext.org/editor/guides/customize-toolbar/) in the documentation.
 
 1. Create a `Toolbar` component in the same file.
 2. Import the `useEditor` hook, and declare an `editor` constant in the component.
@@ -286,7 +286,7 @@ function Toolbar() {
 }
 ```
 
-The `useEditor` hook gives you access to the active editor. `send` lets you send events to the editor. You can view the full list of events in the [Behavior API reference](https://www.portabletext.org/reference/behavior-api/).
+The `useEditor` hook gives you access to the active editor. `send` lets you send events to the editor. You can view the full list of events in the [Behavior API reference](https://www.portabletext.org/editor/reference/behavior-api/).
 
 > [!NOTE]
 > The example above sends a `focus` event after each action. Normally when interacting with a button, the browser removes focus from the text editing area. This event returns focus to the field to prevent interrupting the user.
@@ -333,7 +333,7 @@ function App() {
 // ...
 ```
 
-You can now enter text and interact with the toolbar buttons to toggle the styles and decorators. These are only a small portion of the types of things you can do. Check out the [custom rendering guide](https://www.portabletext.org/guides/custom-rendering/) and the [toolbar customization guide](https://www.portabletext.org/guides/customize-toolbar/) for options.
+You can now enter text and interact with the toolbar buttons to toggle the styles and decorators. These are only a small portion of the types of things you can do. Check out the [custom rendering guide](https://www.portabletext.org/editor/guides/custom-rendering/) and the [toolbar customization guide](https://www.portabletext.org/editor/guides/customize-toolbar/) for options.
 
 ### View the Portable Text data
 
@@ -345,18 +345,18 @@ You can preview the Portable Text from the editor by reading the state. Add the 
 </pre>
 ```
 
-This displays the raw Portable Text. To customize how Portable Text renders in your apps, explore the [collection of serializers](https://www.portabletext.org/integrations/serializers/).
+This displays the raw Portable Text. To customize how Portable Text renders in your apps, explore the [collection of serializers](https://www.portabletext.org/rendering/).
 
 ## Behavior API
 
-The Behavior API is a new way of interfacing with the Portable Text Editor. It allows you to think of and treat the editor as a state machine by:
+The Behavior API is a way of interfacing with the Portable Text Editor. It allows you to think of and treat the editor as a state machine by:
 
 - Declaratively hooking into editor **events** and defining new behaviors.
 - Imperatively triggering **events**.
 - Deriving editor **state** using **pure functions**.
 - Subscribing to **emitted** editor **events**.
 
-Learn more about the [Behaviors](https://www.portabletext.org/concepts/behavior/) and how to [create your own behaviors](https://www.portabletext.org/guides/create-behavior/) in the documentation.
+Learn more about the [Behaviors](https://www.portabletext.org/editor/concepts/behavior/) and how to [create your own behaviors](https://www.portabletext.org/editor/guides/create-behavior/) in the documentation.
 
 ## Related Packages
 

--- a/packages/keyboard-shortcuts/README.md
+++ b/packages/keyboard-shortcuts/README.md
@@ -15,7 +15,7 @@ A TypeScript library for creating platform-aware keyboard shortcuts with automat
 npm install @portabletext/keyboard-shortcuts
 ```
 
-## API Reference
+## API reference
 
 ### `KeyboardEventDefinition`
 
@@ -77,7 +77,7 @@ type KeyboardShortcut<TKeyboardEvent> = {
 - `guard`: Function that determines if a keyboard event matches this shortcut
 - `keys`: Display-friendly key combination for the current platform
 
-### Core Functions
+### Core functions
 
 #### `createKeyboardShortcut(definition)`
 
@@ -137,7 +137,7 @@ const definition = {
 const isMatch = isKeyboardShortcut(definition, keyboardEvent)
 ```
 
-### Common Shortcuts
+### Common shortcuts
 
 The library provides pre-defined shortcuts for common text editing operations:
 
@@ -160,9 +160,9 @@ import {
 } from '@portabletext/keyboard-shortcuts'
 ```
 
-### Usage Examples
+### Usage examples
 
-#### Basic Usage
+#### Basic usage
 
 ```typescript
 import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
@@ -200,7 +200,7 @@ document.addEventListener('keydown', (event) => {
 console.log(saveShortcut.keys.join('+')) // "Ctrl+S" or "⌘+S"
 ```
 
-#### Using Pre-defined Shortcuts
+#### Using pre-defined shortcuts
 
 ```typescript
 import {bold, italic} from '@portabletext/keyboard-shortcuts'
@@ -216,7 +216,7 @@ document.addEventListener('keydown', (event) => {
 })
 ```
 
-#### Multiple Key Combinations
+#### Multiple key combinations
 
 ```typescript
 const deleteShortcut = createKeyboardShortcut({

--- a/packages/keyboard-shortcuts/README.md
+++ b/packages/keyboard-shortcuts/README.md
@@ -119,7 +119,9 @@ const boldShortcut = createKeyboardShortcut({
 // On Apple platforms: ⌘+B
 ```
 
-**Example:**
+#### `isKeyboardShortcut(definition, event)`
+
+Checks whether a keyboard event matches a single `KeyboardEventDefinition`. Returns `true` on a match.
 
 ```typescript
 import {isKeyboardShortcut} from '@portabletext/keyboard-shortcuts'

--- a/packages/patches/README.md
+++ b/packages/patches/README.md
@@ -30,7 +30,7 @@ const result = applyAll({count: 0}, [
 ])
 ```
 
-## Patch Types
+## Patch types
 
 - `set` - Set a value at a path
 - `setIfMissing` - Set a value only if it doesn't exist

--- a/packages/plugin-character-pair-decorator/README.md
+++ b/packages/plugin-character-pair-decorator/README.md
@@ -40,3 +40,17 @@ function App() {
   )
 }
 ```
+
+## Why look up the decorator in the schema?
+
+The `decorator` callback returns the name found in `context.schema`
+(`context.schema.decorators.find((d) => d.name === 'italic')?.name`) instead
+of a hardcoded `'italic'`. That lookup is what makes it schema-aware: if the
+schema has no such decorator the callback returns `undefined` and the pairing
+is skipped, so it never applies a decorator the schema does not declare.
+
+The same gating follows [containers](../schema/README.md#containers-and-sub-schemas),
+because `context.schema` is resolved at the caret: inside a code block whose
+sub-schema declares no decorators the pairing is skipped. Read
+`context.schema` rather than capturing the top-level schema and the plugin
+stays correct at every nesting level.

--- a/packages/plugin-character-pair-decorator/README.md
+++ b/packages/plugin-character-pair-decorator/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-character-pair-decorator`
 
-> ✨ Automatically match a pair of characters and decorate the text in between
+> Automatically match a pair of characters and decorate the text in between
 
 ## Installation
 

--- a/packages/plugin-character-pair-decorator/README.md
+++ b/packages/plugin-character-pair-decorator/README.md
@@ -2,6 +2,14 @@
 
 > ✨ Automatically match a pair of characters and decorate the text in between
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-character-pair-decorator
+```
+
+## Usage
+
 Import the `CharacterPairDecoratorPlugin` React component and place it inside the `EditorProvider` to automatically register the necessary Behaviors:
 
 ```tsx

--- a/packages/plugin-dnd/README.md
+++ b/packages/plugin-dnd/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-dnd`
 
-A helper plugin for tracking the drop position during drag and drop.
+> Track the drop position during drag and drop for custom drop indicators
 
 ## Installation
 

--- a/packages/plugin-dnd/README.md
+++ b/packages/plugin-dnd/README.md
@@ -2,6 +2,14 @@
 
 A helper plugin for tracking the drop position during drag and drop.
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-dnd
+```
+
+## Usage
+
 When a consumer takes over block rendering through the `defineX` pipeline, the engine renders no drop-indicator chrome: where a dragged block would land is deliberately left to the consumer, since drop indication is pointer-driven UI, not document structure. This plugin tracks the position for you, derived from the editor's public `drag.*` behavior events.
 
 ```tsx

--- a/packages/plugin-dnd/package.json
+++ b/packages/plugin-dnd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-dnd",
   "version": "1.0.6",
-  "description": "A helper plugin for tracking the drop position during drag and drop",
+  "description": "Track the drop position during drag and drop for custom drop indicators",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-emoji-picker/README.md
+++ b/packages/plugin-emoji-picker/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-emoji-picker`
 
-> ⚡️ Easily configure an Emoji Picker for the Portable Text Editor
+> Easily configure an Emoji Picker for the Portable Text Editor
 
 ## Installation
 

--- a/packages/plugin-emoji-picker/README.md
+++ b/packages/plugin-emoji-picker/README.md
@@ -2,6 +2,12 @@
 
 > ⚡️ Easily configure an Emoji Picker for the Portable Text Editor
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-emoji-picker
+```
+
 ## Quick Start
 
 The `useEmojiPicker` hook handles the state and logic needed to create an emoji picker for the Portable Text Editor. It manages keyword matching, keyboard navigation, and emoji insertion, but is not concerned with the UI, how the picker is rendered, or how it's positioned in the document.

--- a/packages/plugin-emoji-picker/README.md
+++ b/packages/plugin-emoji-picker/README.md
@@ -8,7 +8,7 @@
 npm install @portabletext/plugin-emoji-picker
 ```
 
-## Quick Start
+## Quick start
 
 The `useEmojiPicker` hook handles the state and logic needed to create an emoji picker for the Portable Text Editor. It manages keyword matching, keyboard navigation, and emoji insertion, but is not concerned with the UI, how the picker is rendered, or how it's positioned in the document.
 
@@ -72,7 +72,7 @@ const matchEmojis = createMatchEmojis({
 })
 ```
 
-## How It Works
+## How it works
 
 The emoji picker activates when users type `:` followed by a keyword (e.g., `:smile` or `:joy`).
 
@@ -82,7 +82,7 @@ The emoji picker activates when users type `:` followed by a keyword (e.g., `:sm
   - `Esc` dismisses the picker
 - **Mouse interactions are opt-in**: Use `onNavigateTo` and `onSelect` to enable hover and click
 
-## API Reference
+## API reference
 
 ### `useEmojiPicker(props)`
 
@@ -99,7 +99,7 @@ The emoji picker activates when users type `:` followed by a keyword (e.g., `:sm
 - `onSelect()`: Select the current match.
 - `onDismiss()`: Dismiss the emoji picker.
 
-## Custom Search Algorithm
+## Custom search algorithm
 
 You can implement a custom search algorithm with your own matching logic and data structures. The only requirement is that your function adheres to the `MatchEmojis` type and returns matches that extend `BaseEmojiMatch`:
 

--- a/packages/plugin-input-rule/README.md
+++ b/packages/plugin-input-rule/README.md
@@ -2,6 +2,14 @@
 
 > Easily configure Input Rules in the Portable Text Editor
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-input-rule
+```
+
+## Why
+
 1. How do you implement undo functionality correctly?
 2. What about smart undo with <kbd>Backspace</kbd>?
 3. Have you considered `insert.text` events that carry more than one character? (Android, anyone?)
@@ -12,7 +20,7 @@ _This is why this plugin exists_. It brings the concept of "Input Rules" to the 
 import type {EditorSchema} from '@portabletext/editor'
 import {raise} from '@portabletext/editor/behaviors'
 import {getPreviousInlineObject} from '@portabletext/editor/selectors'
-import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {defineInputRule, InputRulePlugin} from '@portabletext/plugin-input-rule'
 
 const unorderedListRule = defineInputRule({
   // Listen for a RegExp pattern instead of a raw event
@@ -68,6 +76,11 @@ export function MyMarkdownPlugin() {
 Text transformations are so common that the plugin provides a high-level `defineTextTransformRule` helper to configure them without any boilerplate:
 
 ```tsx
+import {
+  defineTextTransformRule,
+  InputRulePlugin,
+} from '@portabletext/plugin-input-rule'
+
 const emDashRule = defineTextTransformRule({
   on: /--/,
   transform: () => '—',

--- a/packages/plugin-input-rule/README.md
+++ b/packages/plugin-input-rule/README.md
@@ -71,7 +71,7 @@ export function MyMarkdownPlugin() {
 
 > **Tip:** The [`@portabletext/plugin-markdown-shortcuts`](../plugin-markdown-shortcuts/) package is already built using Input Rules and provides common markdown shortcuts out of the box.
 
-## Text Transformation Rules
+## Text transformation rules
 
 Text transformations are so common that the plugin provides a high-level `defineTextTransformRule` helper to configure them without any boilerplate:
 
@@ -93,14 +93,14 @@ export function MyTypographyPlugin() {
 
 In fact, the production-ready [`@portabletext/plugin-typography`](../plugin-typography/) is built on top of Input Rules and comes packed with common text transformations like this.
 
-## Advanced Examples
+## Advanced examples
 
 Input Rules can handle more complex transformations. Here are two advanced examples:
 
 1. **Markdown Link**: Automatically convert `[text](url)` syntax into proper links
 2. **Stock Ticker**: Convert `{SYMBOL}` patterns into stock ticker objects
 
-### Markdown Link Rule
+### Markdown link rule
 
 This example shows how to convert markdown-style link syntax `[text](url)` into proper link annotations:
 
@@ -187,7 +187,7 @@ const markdownLinkRule = defineInputRule({
 })
 ```
 
-### Stock Ticker Rule
+### Stock ticker rule
 
 This example demonstrates how to convert text patterns like `{AAPL}` into custom inline objects:
 

--- a/packages/plugin-input-rule/README.md
+++ b/packages/plugin-input-rule/README.md
@@ -69,7 +69,7 @@ export function MyMarkdownPlugin() {
 }
 ```
 
-> 💡 **Tip:** The [`@portabletext/plugin-markdown-shortcuts`](../plugin-markdown-shortcuts/) package is already built using Input Rules and provides common markdown shortcuts out of the box.
+> **Tip:** The [`@portabletext/plugin-markdown-shortcuts`](../plugin-markdown-shortcuts/) package is already built using Input Rules and provides common markdown shortcuts out of the box.
 
 ## Text Transformation Rules
 

--- a/packages/plugin-input-rule/package.json
+++ b/packages/plugin-input-rule/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-input-rule",
   "version": "5.0.21",
-  "description": "Easily configure input rules in the Portable Text Editor",
+  "description": "Easily configure Input Rules in the Portable Text Editor",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-list-index/README.md
+++ b/packages/plugin-list-index/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-list-index`
 
-A helper plugin for calculating list indices for flat blocks based on `listItem` and `level`.
+> Compute the list index of each list item for custom list rendering
 
 ## Installation
 

--- a/packages/plugin-list-index/README.md
+++ b/packages/plugin-list-index/README.md
@@ -2,6 +2,14 @@
 
 A helper plugin for calculating list indices for flat blocks based on `listItem` and `level`.
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-list-index
+```
+
+## Usage
+
 Portable Text has no nested list structure: a list is a run of flat sibling blocks carrying `listItem` and `level` properties. That makes the 1-based position of an item within its list a _derived_ value: same-type items count up across consecutive blocks on the same level, deeper levels restart at 1, and non-list blocks break the sequence. This plugin derives it for you and keeps it correct as the value changes.
 
 ```tsx

--- a/packages/plugin-list-index/package.json
+++ b/packages/plugin-list-index/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-list-index",
   "version": "1.0.6",
-  "description": "A helper plugin for calculating list indices for flat blocks based on listItem and level",
+  "description": "Compute the list index of each list item for custom list rendering",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-markdown-shortcuts/README.md
+++ b/packages/plugin-markdown-shortcuts/README.md
@@ -2,6 +2,14 @@
 
 > ⬇️ Adds helpful Markdown shortcuts to the editor
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-markdown-shortcuts
+```
+
+## Usage
+
 Import the `MarkdownShortcutsPlugin` React component and place it inside the `EditorProvider` and tell it about your schema:
 
 ```tsx
@@ -14,7 +22,7 @@ import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 
 const schemaDefinition = defineSchema({
   blockObjects: [{name: 'break'}],
-  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}]
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
   decorators: [
     {name: 'em'},
     {name: 'code'},

--- a/packages/plugin-markdown-shortcuts/README.md
+++ b/packages/plugin-markdown-shortcuts/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-markdown-shortcuts`
 
-> Adds helpful Markdown shortcuts to the editor
+> Add helpful Markdown shortcuts to the editor
 
 ## Installation
 

--- a/packages/plugin-markdown-shortcuts/README.md
+++ b/packages/plugin-markdown-shortcuts/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-markdown-shortcuts`
 
-> ⬇️ Adds helpful Markdown shortcuts to the editor
+> Adds helpful Markdown shortcuts to the editor
 
 ## Installation
 

--- a/packages/plugin-markdown-shortcuts/README.md
+++ b/packages/plugin-markdown-shortcuts/README.md
@@ -51,35 +51,36 @@ function App() {
     >
       <PortableTextEditable />
       <MarkdownShortcutsPlugin
-        boldDecorator={({schema}) =>
-          schema.decorators.find((d) => d.name === 'strong')?.name
+        boldDecorator={({context}) =>
+          context.schema.decorators.find((d) => d.name === 'strong')?.name
         }
-        codeDecorator={({schema}) =>
-          schema.decorators.find((d) => d.name === 'code')?.name
+        codeDecorator={({context}) =>
+          context.schema.decorators.find((d) => d.name === 'code')?.name
         }
-        italicDecorator={({schema}) =>
-          schema.decorators.find((d) => d.name === 'em')?.name
+        italicDecorator={({context}) =>
+          context.schema.decorators.find((d) => d.name === 'em')?.name
         }
-        strikeThroughDecorator={({schema}) =>
-          schema.decorators.find((d) => d.name === 'strike-through')?.name
+        strikeThroughDecorator={({context}) =>
+          context.schema.decorators.find((d) => d.name === 'strike-through')
+            ?.name
         }
-        defaultStyle={({schema}) =>
-          schema.styles.find((s) => s.name === 'normal')?.name
+        defaultStyle={({context}) =>
+          context.schema.styles.find((s) => s.name === 'normal')?.name
         }
-        headingStyle={({schema, level}) =>
-          schema.styles.find((s) => s.name === `h${level}`)?.name
+        headingStyle={({context, props}) =>
+          context.schema.styles.find((s) => s.name === `h${props.level}`)?.name
         }
-        blockquoteStyle={({schema}) =>
-          schema.styles.find((s) => s.name === 'blockquote')?.name
+        blockquoteStyle={({context}) =>
+          context.schema.styles.find((s) => s.name === 'blockquote')?.name
         }
-        orderedList={({schema}) =>
-          schema.lists.find((s) => s.name === 'number')?.name
+        orderedList={({context}) =>
+          context.schema.lists.find((s) => s.name === 'number')?.name
         }
-        unorderedList={({schema}) =>
-          schema.lists.find((s) => s.name === 'bullet')?.name
+        unorderedList={({context}) =>
+          context.schema.lists.find((s) => s.name === 'bullet')?.name
         }
-        horizontalRuleObject={({schema}) => {
-          const schemaType = schema.blockObjects.find(
+        horizontalRuleObject={({context}) => {
+          const schemaType = context.schema.blockObjects.find(
             (object) => object.name === 'break',
           )
 
@@ -89,8 +90,8 @@ function App() {
 
           return {_type: schemaType.name}
         }}
-        linkObject={({schema, href}) => {
-          const schemaType = schema.annotations.find(
+        linkObject={({context, props}) => {
+          const schemaType = context.schema.annotations.find(
             (annotation) => annotation.name === 'link',
           )
           const hrefField = schemaType?.fields.find(
@@ -103,7 +104,7 @@ function App() {
 
           return {
             _type: schemaType.name,
-            [hrefField.name]: href,
+            [hrefField.name]: props.href,
           }
         }}
       />
@@ -111,3 +112,22 @@ function App() {
   )
 }
 ```
+
+## Why look up the type in the schema?
+
+Each callback returns the type name as found in `context.schema` (for
+example `context.schema.decorators.find((d) => d.name === 'strong')?.name`)
+instead of a hardcoded `'strong'`. That lookup is what makes the plugin
+schema-aware: when the schema does not define the type, the lookup returns
+`undefined` and the shortcut is skipped, so the plugin never inserts a
+decorator, style, or object the schema does not declare. Hardcoding the
+string would fire the shortcut regardless and produce content the schema
+forbids.
+
+The same gating follows [containers](../schema/README.md#containers-and-sub-schemas),
+because `context.schema` is the schema resolved at the caret, not always the
+top-level one. Inside a code block whose sub-schema declares no decorators, a
+`boldDecorator` that looks up `strong` returns `undefined`, so the shortcut
+is skipped there too. Point each callback at `context.schema` rather than
+capturing the top-level schema and the shortcuts stay correct at every
+nesting level.

--- a/packages/plugin-markdown-shortcuts/package.json
+++ b/packages/plugin-markdown-shortcuts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-markdown-shortcuts",
   "version": "8.0.21",
-  "description": "Adds helpful Markdown shortcuts to the editor",
+  "description": "Add helpful Markdown shortcuts to the editor",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-one-line/README.md
+++ b/packages/plugin-one-line/README.md
@@ -1,6 +1,14 @@
-# One-Line Plugin
+# `@portabletext/plugin-one-line`
 
 > 🤏 Restricts the Portable Text Editor to a single line
+
+## Installation
+
+```sh
+npm install @portabletext/plugin-one-line
+```
+
+## Usage
 
 The plugin blocks `insert.break` events and provides smart handling of other `insert.*` events like `insert.block`.
 

--- a/packages/plugin-one-line/README.md
+++ b/packages/plugin-one-line/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-one-line`
 
-> Restricts the Portable Text Editor to a single line
+> Restrict the Portable Text Editor to a single line
 
 ## Installation
 

--- a/packages/plugin-one-line/README.md
+++ b/packages/plugin-one-line/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-one-line`
 
-> 🤏 Restricts the Portable Text Editor to a single line
+> Restricts the Portable Text Editor to a single line
 
 ## Installation
 

--- a/packages/plugin-one-line/package.json
+++ b/packages/plugin-one-line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-one-line",
   "version": "7.0.21",
-  "description": "🤏 Restricts the Portable Text Editor to a single line",
+  "description": "Restrict the Portable Text Editor to a single line",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-paste-link/README.md
+++ b/packages/plugin-paste-link/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-paste-link`
 
-> Allows pasting links in the Portable Text Editor
+> Allow pasting links in the Portable Text Editor
 
 ## Installation
 

--- a/packages/plugin-paste-link/README.md
+++ b/packages/plugin-paste-link/README.md
@@ -69,6 +69,17 @@ You can customize the link annotation with the `link` prop:
 />
 ```
 
+The `link` callback returns an annotation built from a `context.schema`
+lookup (`context.schema.annotations.find(...)`) instead of a hardcoded type.
+That lookup is what makes paste-link schema-aware: when the schema has no
+matching annotation the callback returns `undefined` and pasting a URL falls
+through to the default paste handling, so the plugin never adds an annotation
+the schema does not declare. Because `context.schema` is resolved at the
+caret, the same gating follows
+[containers](../schema/README.md#containers-and-sub-schemas): the lookup sees
+the container's sub-schema, so a link is only added where that container
+actually allows it.
+
 ## Behaviors
 
 ### Paste URL on selected text

--- a/packages/plugin-paste-link/package.json
+++ b/packages/plugin-paste-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-paste-link",
   "version": "4.0.21",
-  "description": "Allows pasting links in the Portable Text Editor",
+  "description": "Allow pasting links in the Portable Text Editor",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-sdk-value/README.md
+++ b/packages/plugin-sdk-value/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-sdk-value`
 
-> Connects a Portable Text Editor with a Sanity document using the SDK
+> Connect a Portable Text Editor with a Sanity document using the SDK
 
 The SDK Value plugin provides seamless two-way synchronization between a Portable Text Editor instance and a specific field in a Sanity document. This enables real-time collaboration and ensures that changes made through the editor are immediately reflected in the document, and vice versa.
 

--- a/packages/plugin-sdk-value/README.md
+++ b/packages/plugin-sdk-value/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-sdk-value`
 
-> 🔗 Connects a Portable Text Editor with a Sanity document using the SDK
+> Connects a Portable Text Editor with a Sanity document using the SDK
 
 The SDK Value plugin provides seamless two-way synchronization between a Portable Text Editor instance and a specific field in a Sanity document. This enables real-time collaboration and ensures that changes made through the editor are immediately reflected in the document, and vice versa.
 

--- a/packages/plugin-sdk-value/README.md
+++ b/packages/plugin-sdk-value/README.md
@@ -1,8 +1,14 @@
-# SDK Value Plugin
+# `@portabletext/plugin-sdk-value`
 
 > 🔗 Connects a Portable Text Editor with a Sanity document using the SDK
 
 The SDK Value plugin provides seamless two-way synchronization between a Portable Text Editor instance and a specific field in a Sanity document. This enables real-time collaboration and ensures that changes made through the editor are immediately reflected in the document, and vice versa.
+
+## Installation
+
+```sh
+npm install @portabletext/plugin-sdk-value
+```
 
 ## Features
 

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-sdk-value",
   "version": "7.0.21",
-  "description": "Synchronizes the Portable Text Editor value with the Sanity SDK, allowing for two-way editing.",
+  "description": "Connect a Portable Text Editor with a Sanity document using the SDK",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -4,7 +4,7 @@
 
 **Status:** skeleton package, private. Not yet published to npm.
 
-This package will host the schema, container registrations, and behaviors for first-class tables in the Portable Text Editor. The goal is to support tables across standalone PTE, Sanity Studio, and Sanity Canvas with a single shared core.
+This package will host the schema, container registrations, and behaviors for first-class tables in the Portable Text Editor. The goal is to support tables across the standalone Portable Text Editor, Sanity Studio, and Sanity Canvas with a single shared core.
 
 ## Planned API
 

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -1,4 +1,4 @@
-# Table Plugin
+# `@portabletext/plugin-table`
 
 > 📊 Table support for the Portable Text Editor
 

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-table`
 
-> 📊 Table support for the Portable Text Editor
+> Table support for the Portable Text Editor
 
 **Status:** skeleton package, private. Not yet published to npm.
 

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-table`
 
-> Table support for the Portable Text Editor
+> Add table support to the Portable Text Editor
 
 **Status:** skeleton package, private. Not yet published to npm.
 

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -2,7 +2,7 @@
   "name": "@portabletext/plugin-table",
   "version": "0.0.17",
   "private": true,
-  "description": "📊 Table support for the Portable Text Editor",
+  "description": "Add table support to the Portable Text Editor",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-typeahead-picker/README.md
+++ b/packages/plugin-typeahead-picker/README.md
@@ -2,6 +2,12 @@
 
 > Generic typeahead picker infrastructure for the Portable Text Editor
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-typeahead-picker
+```
+
 ## Quick Start
 
 The `useTypeaheadPicker` hook provides the state and logic needed to build typeahead pickers (emoji pickers, mention pickers, slash commands, etc.) for the Portable Text Editor. It manages keyword matching, keyboard navigation, and triggering of actions, but is not concerned with the UI, how the picker is rendered, or how it's positioned in the document.

--- a/packages/plugin-typeahead-picker/README.md
+++ b/packages/plugin-typeahead-picker/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/plugin-typeahead-picker`
 
-> Generic typeahead picker infrastructure for the Portable Text Editor
+> Build typeahead pickers (emoji, mentions, slash commands) for the Portable Text Editor
 
 ## Installation
 
@@ -8,7 +8,7 @@
 npm install @portabletext/plugin-typeahead-picker
 ```
 
-## Quick Start
+## Quick start
 
 The `useTypeaheadPicker` hook provides the state and logic needed to build typeahead pickers (emoji pickers, mention pickers, slash commands, etc.) for the Portable Text Editor. It manages keyword matching, keyboard navigation, and triggering of actions, but is not concerned with the UI, how the picker is rendered, or how it's positioned in the document.
 
@@ -99,7 +99,7 @@ function MyEditor() {
 
 The picker component must be rendered inside `EditorProvider` to access the editor context. Position it as a sibling to `PortableTextEditable` - you'll handle the visual positioning (popover, dropdown, etc.) separately with CSS or a positioning library.
 
-## How It Works
+## How it works
 
 The picker activates when users type the `trigger` pattern (e.g., `:` or `@`). The `keyword` pattern then matches characters typed after the trigger.
 
@@ -224,7 +224,7 @@ The guard is useful for:
 - Avoiding conflicts when another picker or dialog is already open
 - Checking editor state or mode before allowing the picker
 
-## API Reference
+## API reference
 
 ### `defineTypeaheadPicker(config)`
 
@@ -295,11 +295,11 @@ React hook that activates a picker and returns its state.
 | `send(event)`                    | Dispatch events: `{type: 'select'}`, `{type: 'dismiss'}`, `{type: 'navigate to', index}`                     |
 | `snapshot.context.error`         | Error from `getMatches` if it threw/rejected, otherwise `undefined`                                          |
 
-## Async Mode
+## Async mode
 
 When `mode: 'async'` is configured, the picker handles asynchronous `getMatches` functions with loading states and race condition protection.
 
-### Loading States
+### Loading states
 
 Use `snapshot.matches()` to check nested loading states:
 
@@ -331,11 +331,11 @@ function MentionPicker() {
 }
 ```
 
-### Race Condition Handling
+### Race condition handling
 
 When users type quickly, earlier slow requests may complete after later fast requests. The picker automatically ignores stale results to prevent them from overwriting fresh data.
 
-## Error Handling
+## Error handling
 
 If `getMatches` throws or rejects, the error is captured in `snapshot.context.error`. The picker transitions to `'no matches'` state and continues to function.
 
@@ -410,9 +410,9 @@ const commandPicker = defineTypeaheadPicker<CommandMatch>({
 | `event`    | The select event with `match`, `keyword`, and `patternSelection`              |
 | `snapshot` | Current editor snapshot with `context.schema`, `context.keyGenerator()`, etc. |
 
-## Performance Guidelines
+## Performance guidelines
 
-### Match List Size
+### Match list size
 
 Keep your match lists reasonably sized for smooth keyboard navigation:
 
@@ -427,7 +427,7 @@ getMatches: async ({keyword}) => {
 }
 ```
 
-### Debounce Timing
+### Debounce timing
 
 Choose debounce values based on your data source:
 
@@ -458,7 +458,7 @@ const mentionPicker = defineTypeaheadPicker({
 })
 ```
 
-### Memory Considerations
+### Memory considerations
 
 - Avoid storing large datasets in component state
 - For emoji pickers, consider lazy-loading the emoji database
@@ -468,7 +468,7 @@ const mentionPicker = defineTypeaheadPicker({
 
 The picker manages keyboard navigation and selection internally, but you're responsible for the UI semantics.
 
-### Recommended ARIA Attributes
+### Recommended ARIA attributes
 
 ```tsx
 function PickerUI() {
@@ -493,7 +493,7 @@ function PickerUI() {
 }
 ```
 
-### Keyboard Handling
+### Keyboard handling
 
 The following keyboard shortcuts are handled automatically by the picker:
 
@@ -505,7 +505,7 @@ The following keyboard shortcuts are handled automatically by the picker:
 | `Escape`  | Dismiss picker                |
 | `Space`   | Dismiss picker (configurable) |
 
-### Screen Reader Considerations
+### Screen reader considerations
 
 - Announce match count changes with live regions if desired
 - Ensure selected item is visible (scroll into view)

--- a/packages/plugin-typeahead-picker/package.json
+++ b/packages/plugin-typeahead-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@portabletext/plugin-typeahead-picker",
   "version": "6.0.21",
-  "description": "Generic typeahead picker infrastructure for the Portable Text Editor",
+  "description": "Build typeahead pickers (emoji, mentions, slash commands) for the Portable Text Editor",
   "keywords": [
     "portabletext",
     "plugin",

--- a/packages/plugin-typography/README.md
+++ b/packages/plugin-typography/README.md
@@ -46,7 +46,7 @@ function App() {
 }
 ```
 
-## Rules Included
+## Rules included
 
 The plugin includes the following typographic transformation rules:
 
@@ -82,11 +82,11 @@ The plugin includes the following typographic transformation rules:
 | `oneQuarter`       | `1/4` → `¼`                      |
 | `threeQuarters`    | `3/4` → `¾`                      |
 
-## Configuring Rules
+## Configuring rules
 
 The plugin supports flexible configuration through `preset`, `enable`, and `disable` props:
 
-### Using Presets
+### Using presets
 
 The `preset` prop provides quick configuration:
 
@@ -105,7 +105,7 @@ The `preset` prop provides quick configuration:
 <TypographyPlugin preset="none" enable={['emDash', 'ellipsis']} />
 ```
 
-### Enabling Additional Rules
+### Enabling additional rules
 
 Use `enable` to add rules beyond the preset:
 
@@ -117,7 +117,7 @@ Use `enable` to add rules beyond the preset:
 <TypographyPlugin preset="all" disable={['emDash', 'ellipsis']} />
 ```
 
-### Disabling Rules
+### Disabling rules
 
 Use `disable` to remove rules from the preset:
 
@@ -133,7 +133,7 @@ Use `disable` to remove rules from the preset:
 />
 ```
 
-### Combining Options
+### Combining options
 
 All three props work together. The order of operations is:
 
@@ -155,7 +155,7 @@ All three props work together. The order of operations is:
 />
 ```
 
-## Controlling when Text Transformations Run
+## Controlling when text transformations run
 
 The `TypographyPlugin` has an optional `guard` prop that accepts any type of `BehaviorGuard`. Here, you'll have access to the current `EditorSnapshot` as well as information about the current rule being matched.
 
@@ -188,7 +188,7 @@ block the guard sees that container's sub-schema rather than the top-level
 one, which is what lets a guard keyed on the `code` decorator suppress
 transformations inside a code block whose sub-schema defines `code`.
 
-## Using Individual Rules with `InputRulePlugin`
+## Using individual rules with `InputRulePlugin`
 
 All included typographic rules are exported from the plugin. To use them in your own abstraction, import them from this plugin and use them with the `InputRulePlugin`:
 

--- a/packages/plugin-typography/README.md
+++ b/packages/plugin-typography/README.md
@@ -179,6 +179,15 @@ return (
 )
 ```
 
+The `decorators` callback derives its allowed list from `context.schema`
+rather than hardcoding decorator names, so the guard tracks whatever the
+schema actually declares instead of a fixed list that can drift from it.
+Because `context.schema` is resolved at the caret, it also follows
+[containers](../schema/README.md#containers-and-sub-schemas): inside a code
+block the guard sees that container's sub-schema rather than the top-level
+one, which is what lets a guard keyed on the `code` decorator suppress
+transformations inside a code block whose sub-schema defines `code`.
+
 ## Using Individual Rules with `InputRulePlugin`
 
 All included typographic rules are exported from the plugin. To use them in your own abstraction, import them from this plugin and use them with the `InputRulePlugin`:

--- a/packages/plugin-typography/README.md
+++ b/packages/plugin-typography/README.md
@@ -10,6 +10,12 @@ Automatically handles smart undo with <kbd>Backspace</kbd> right after insertion
 
 ![Smart undo with Backspace](./assets/smart-undo-with-backspace.gif)
 
+## Installation
+
+```sh
+npm install @portabletext/plugin-typography
+```
+
 ## Usage
 
 Import the `TypographyPlugin` React component and place it inside the `EditorProvider`:
@@ -153,7 +159,7 @@ All three props work together. The order of operations is:
 
 The `TypographyPlugin` has an optional `guard` prop that accepts any type of `BehaviorGuard`. Here, you'll have access to the current `EditorSnapshot` as well as information about the current rule being matched.
 
-Because disallowing text transformations inside code is a common use case, this plugin ships a built-in `createDecoratorGuard` function. use that to create a `guard` that only allows text transformations inside certain decorators:
+Because disallowing text transformations inside code is a common use case, this plugin ships a built-in `createDecoratorGuard` function. Use that to create a `guard` that only allows text transformations inside certain decorators:
 
 ```tsx
 import {
@@ -175,7 +181,7 @@ return (
 
 ## Using Individual Rules with `InputRulePlugin`
 
-All included typographic rules are exported from the plugin. To use them in your own abstraction, import them from this from plugin and use them with the `InputRulePlugin`:
+All included typographic rules are exported from the plugin. To use them in your own abstraction, import them from this plugin and use them with the `InputRulePlugin`:
 
 ```tsx
 import {InputRulePlugin} from '@portabletext/plugin-input-rule'

--- a/packages/racejar/README.md
+++ b/packages/racejar/README.md
@@ -86,7 +86,7 @@ for (const scenario of feature.scenarios) {
 }
 ```
 
-## Define Steps and Parameter Types
+## Define steps and parameter types
 
 `stepDefinitions` can be defined inline or separately. They are defined using `Given`, `When`, `Then` exported from `racejar`:
 
@@ -106,7 +106,7 @@ import {createParameterType} from 'racejar'
 const parameterTypes = [createParameterType(/* ... */)]
 ```
 
-## Basic Example
+## Basic example
 
 ```ts
 import {Given, Then, When} from 'racejar'
@@ -143,7 +143,7 @@ Feature({
 })
 ```
 
-## Advanced Example
+## Advanced example
 
 The following example is taken from the [`editor`](/packages/editor/) package in this repository. For a full example of how to use `racejar`, head over to [/packages/editor/gherkin-tests/](/packages/editor/gherkin-tests/). The package uses `racejar` to run a [Playwright](https://playwright.dev/) E2E test suite powered by [Vitest Browser Mode](https://vitest.dev/guide/browser/).
 

--- a/packages/sanity-bridge/README.md
+++ b/packages/sanity-bridge/README.md
@@ -13,6 +13,7 @@ npm install @portabletext/sanity-bridge
 ### Convert Sanity Schema to Portable Text Schema
 
 ```ts
+import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
 import {Schema} from '@sanity/schema'
 import {defineField, defineType} from '@sanity/types'
 

--- a/packages/sanity-bridge/README.md
+++ b/packages/sanity-bridge/README.md
@@ -10,7 +10,7 @@ npm install @portabletext/sanity-bridge
 
 ## Usage
 
-### Convert Sanity Schema to Portable Text Schema
+### Convert Sanity schema to Portable Text schema
 
 ```ts
 import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
@@ -135,7 +135,7 @@ whatever a container should allow on the block member itself. The resulting
 `Schema` follows the resolution rules documented in
 [`@portabletext/schema`](../schema/README.md#containers-and-sub-schemas).
 
-### Convert Portable Text Schema to Sanity Schema
+### Convert Portable Text schema to Sanity schema
 
 ```ts
 import {compileSchemaDefinitionToPortableTextMemberSchemaTypes} from '@portabletext/sanity-bridge'

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -10,7 +10,7 @@ npm install @portabletext/schema
 
 ## Usage
 
-### Define a Schema
+### Define a schema
 
 ```ts
 import {defineSchema} from '@portabletext/schema'
@@ -23,7 +23,7 @@ const schemaDefinition = defineSchema({
 })
 ```
 
-### Compile Schema
+### Compile schema
 
 ```ts
 import {compileSchema} from '@portabletext/schema'

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -1,6 +1,12 @@
-# @portabletext/test
+# `@portabletext/test`
 
 Testing utilities for the Portable Text Editor.
+
+## Installation
+
+```sh
+npm install --save-dev @portabletext/test
+```
 
 ## Terse PT
 
@@ -9,6 +15,9 @@ A compact syntax for writing Portable Text in tests, making test data more reada
 ### Parsing Terse PT
 
 ```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator, parseTersePt} from '@portabletext/test'
+
 const tersePt = [
   'h1:Hello, world!',
   '{image}',
@@ -40,6 +49,9 @@ const blocks = parseTersePt(
 ### Producing Terse PT
 
 ```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {getTersePt} from '@portabletext/test'
+
 const blocks = [
   {
     _key: 'k0',

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -72,7 +72,7 @@ const tersePt = getTersePt({
 // ['foo', 'bar']
 ```
 
-## Key Generator
+## Key generator
 
 Generate predictable keys for test fixtures:
 

--- a/packages/toolbar/README.md
+++ b/packages/toolbar/README.md
@@ -1,6 +1,6 @@
 # `@portabletext/toolbar`
 
-Powered by [Behaviors](https://www.portabletext.org/concepts/behavior/) and [State Machines](https://stately.ai/docs/xstate), `@portabletext/toolbar` is a collection of robust React hooks for building toolbars and related UI components
+Powered by [Behaviors](https://www.portabletext.org/editor/concepts/behavior/) and [State Machines](https://stately.ai/docs/xstate), `@portabletext/toolbar` is a collection of robust React hooks for building toolbars and related UI components
 for the Portable Text editor.
 
 Refer to the toolbar in the [Portable Text Playground](../../apps/playground/) for a comprehensive example.
@@ -27,6 +27,7 @@ import {
   useToolbarSchema,
   type ExtendAnnotationSchemaType,
   type ExtendDecoratorSchemaType,
+  type ToolbarDecoratorSchemaType,
 } from '@portabletext/toolbar'
 
 /**

--- a/packages/toolbar/README.md
+++ b/packages/toolbar/README.md
@@ -17,7 +17,7 @@ Refer to the toolbar in the [Portable Text Playground](../../apps/playground/) f
 npm install @portabletext/toolbar
 ```
 
-## Basic Example
+## Basic example
 
 ```tsx
 import {bold, link} from '@portabletext/keyboard-shortcuts'


### PR DESCRIPTION
A pass over every README in the repo (root, editor, and each package/plugin) with one question in mind: does it stand on its own when a reader, or an agent, lands on it cold? Most do. This fixes the ones that did not, in three commits ordered by severity.

The must-fixes were outright defects. `plugin-markdown-shortcuts` had a missing comma after its `annotations` array, so the single code block in the file was invalid JS and threw on copy-paste. `examples/basic` still carried the stock `create-vite` template prose ("React + TypeScript + Vite", an ESLint setup section) and never mentioned that `src/App.tsx` is a complete editor example or how to run it, so the README told you nothing about the example it sits next to. `apps/docs` was the default Starlight template: `npm` commands (the repo is pnpm), a `src/content/config.ts` path that is actually `src/content.config.ts`, and an "add a reference page" walkthrough pointing at the pre-restructure IA (`content/docs/reference`, slug `reference/toolbar`) when the real paths live under `editor/`.

The second commit is stale links. When editor docs moved under `/editor/...`, the `editor` and `toolbar` READMEs kept linking to `/guides/...`, `/concepts/...`, `/reference/...`, and `/integrations/serializers/`. Those resolve today only because `astro.config.mjs` still redirects them; this points them at the canonical paths so they survive a redirect cleanup, and drops the dating "new" from the Behavior API blurb.

The third commit is a consistency pass for isolation-readability. README titles were split between backticked package names and prose ("One-Line Plugin", "SDK Value Plugin", "Table Plugin", and an un-backticked `@portabletext/test`); all now use the backticked package name. Most plugins had no install instruction at all, so each published plugin (and `@portabletext/test`) gains a one-line `## Installation`; the private skeleton `plugin-table` deliberately stays without one. And several runnable snippets omitted their central import and so could not be pasted as-is: `plugin-input-rule` never imported `InputRulePlugin`/`defineTextTransformRule`, `sanity-bridge` called `sanitySchemaToPortableTextSchema` unimported, `toolbar` annotated with an unimported `ToolbarDecoratorSchemaType`, and `test` used `parseTersePt`/`getTersePt`/`compileSchema`/`defineSchema` unimported. As part of the same pass, `isKeyboardShortcut` gets its own heading (it was buried under a second "Example" inside `createKeyboardShortcut`) and two prose typos in `plugin-typography` are fixed.

Docs only, no code or public API touched, no changeset. `pnpm check:format` and `pnpm check:knip` are green. The READMEs left untouched (root, `html`, `block-tools`, `markdown`, `racejar`, `schema`, `plugin-list-index`, `plugin-dnd`, `plugin-paste-link`, `plugin-typeahead-picker`, `plugin-emoji-picker`, `patches`, and the two app skeletons) already read well on their own.