### PR TITLE
refactor: coalesce list-index rebuilds via the editor's buffered `editor.on`

### DIFF
--- a/packages/plugin-list-index/src/plugin.list-index.tsx
+++ b/packages/plugin-list-index/src/plugin.list-index.tsx
@@ -27,29 +27,6 @@ type ListIndexStore = {
 function createListIndexStore(editor: Editor): ListIndexStore {
   let listIndexMap = buildListIndexMap(editor.getSnapshot().context)
   const subscribers = new Map<string, Set<() => void>>()
-  let rebuildScheduled = false
-  let subscribed = false
-
-  function scheduleRebuild() {
-    if (rebuildScheduled) {
-      return
-    }
-
-    rebuildScheduled = true
-
-    // Coalesce per microtask: bulk transactions (value sync, multi-block
-    // inserts) deliver one operation per affected block, and rebuilding per
-    // operation would be O(blocks^2). The map has only React consumers and
-    // they read post-commit, so deferring to the end of the JS turn is
-    // safe; the microtask drains before React's commit.
-    queueMicrotask(() => {
-      rebuildScheduled = false
-
-      if (subscribed) {
-        rebuild()
-      }
-    })
-  }
 
   function rebuild() {
     const previousListIndexMap = listIndexMap
@@ -92,28 +69,35 @@ function createListIndexStore(editor: Editor): ListIndexStore {
       }
     },
     subscribe: () => {
-      subscribed = true
-
       // Operations applied between store creation (render) and subscription
       // (effect) are not observed, so reconcile once up front.
       rebuild()
 
-      const subscription = editor.on('operation', (event) => {
-        // Text ops never change list structure; every other document-changing
-        // op can (including deep edits inside a container), so rebuild. The
-        // rebuild coalesces below and the diff drops no-op changes.
-        if (
-          event.operation.type === 'insert.text' ||
-          event.operation.type === 'remove.text'
-        ) {
-          return
-        }
-
-        scheduleRebuild()
-      })
+      // Buffered microtask delivery coalesces a burst (e.g. one operation per
+      // block during a large delete, insert, or undo) into a single call
+      // carrying the whole burst, so the map rebuilds at most once per burst
+      // instead of once per operation. Text ops never change list structure;
+      // every other document-changing op can (including deep edits inside a
+      // container), so rebuild only when the burst contains one. Inspecting
+      // the whole burst is why this needs `buffer`: deliver-last would drop a
+      // structural op whenever a text op happened to be last in the burst.
+      const subscription = editor.on(
+        'operation',
+        (events) => {
+          if (
+            events.some(
+              (event) =>
+                event.operation.type !== 'insert.text' &&
+                event.operation.type !== 'remove.text',
+            )
+          ) {
+            rebuild()
+          }
+        },
+        {schedule: 'microtask', buffer: true},
+      )
 
       return () => {
-        subscribed = false
         subscription.unsubscribe()
       }
     },
@@ -134,10 +118,11 @@ const ListIndexContext = createContext<ListIndexStore | undefined>(undefined)
  * </EditorProvider>
  * ```
  *
- * The map is rebuilt at most once per editor operation, regardless of how
- * many components read it, and only for operations that can affect list
- * indices. Reads via {@link useListIndex} only re-render when the index at
- * their own path changes.
+ * The map is rebuilt at most once per microtask burst of operations,
+ * regardless of how many operations the burst contains or how many
+ * components read it, and only when the burst contains an operation that can
+ * affect list indices. Reads via {@link useListIndex} only re-render when the
+ * index at their own path changes.
  *
  * @beta
  */


### PR DESCRIPTION
`@portabletext/plugin-list-index` maintains its list-index map by subscribing to `editor.on('operation')` per event and hand-rolling a microtask coalescer (`scheduleRebuild` + a `rebuildScheduled` flag + `queueMicrotask`, with a `subscribed` guard so a queued rebuild does not fire after unsubscribe). It subscribes per event because it must *see* every operation in a burst: it rebuilds only on structural operations and filters out `insert.text`/`remove.text`, so a coalescer that handed it only the last event would miss a structural op whenever a text op was last (`set.selection` is not in the `operation` stream, so the text-op filter is the plugin's only guard against rebuilding on every keystroke).

The editor now provides buffered microtask delivery (stacked PR), so the plugin no longer needs its own coalescer. It subscribes with `{schedule: 'microtask', buffer: true}` and receives the whole burst as one array, rebuilding when the burst contains any non-text operation:

```ts
editor.on(
  'operation',
  (events) => {
    if (events.some((event) =>
      event.operation.type !== 'insert.text' &&
      event.operation.type !== 'remove.text',
    )) {
      rebuild()
    }
  },
  {schedule: 'microtask', buffer: true},
)
```

`buffer` (not plain deliver-last `'microtask'`) is the load-bearing detail: the filter reasons about the whole burst, so a burst ending in a text op must still rebuild for the structural ops earlier in it. The relay now owns the coalescing, the `scheduleRebuild`/`rebuildScheduled`/`subscribed` bookkeeping is gone, and unsubscribe is handled by the subscription.

Behavior is unchanged: the map still rebuilds at most once per microtask burst and only for structural operations, the per-path diff still suppresses no-op re-renders, and all 32 existing plugin tests pass without modification (including "Rebuilds coalesce per microtask" and "Typing inside a list item does not move indices"). No changeset: this is an internal refactor with no observable change, and `updateInternalDependents: always` republishes the plugin against the editor minor that ships `buffer`.

Stacks on #2833. Part of EDEX-1342.
