### PR TITLE
chore(deps): raise the catalog vite floor to ^7.3.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ catalogs:
       specifier: ^8.48.0
       version: 8.48.0
     vite:
-      specifier: ^7.3.1
+      specifier: ^7.3.5
       version: 7.3.5
     vitest:
       specifier: ^4.1.8
@@ -12653,7 +12653,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.25)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -12669,9 +12669,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.25)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@24.12.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
 
   '@vitest/expect@4.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   tailwindcss: ^4.1.18
   typescript: 5.9.3
   typescript-eslint: ^8.48.0
-  vite: ^7.3.1
+  vite: ^7.3.5
   vitest: ^4.1.8
   vitest-browser-react: ^2.2.0
   xstate: ^5.32.1


### PR DESCRIPTION
Now that `vite` is cataloged (#2836), this raises the single catalog entry from `^7.3.1` to `^7.3.5`, the security-patched range Renovate is tracking (issue #14). One line, applied to every workspace at once, which is the payoff of the catalog.

Direct vite consumers (`editor`, `playground`, `racetrack`, `example-basic`) resolve to `7.3.5`. A transitive `@vitejs/plugin-react` peer still pulls `7.3.2` in packages that don't depend on vite directly; that is itself a patched version (the `minimumReleaseAgeExclude` lists `7.3.2 || 7.3.5` as acceptable), so it is not a remaining hole and is left rather than forcing a full `pnpm dedupe` into this diff.

`example-basic` builds clean under `vite v7.3.5`; `pnpm install --frozen-lockfile` stays in sync.
