### PR TITLE
test: raise the test-mode mutation flush cadence to keep typed bursts intact

### DIFF
--- a/packages/editor/src/editor/mutation-batcher.test.ts
+++ b/packages/editor/src/editor/mutation-batcher.test.ts
@@ -6,7 +6,7 @@ import type {EditorActor} from './editor-machine'
 import {createMutationBatcher} from './mutation-batcher'
 import {createRelay} from './relay'
 
-const FLUSH_INTERVAL = 250
+const FLUSH_INTERVAL = 500
 
 function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
   const editorEngine = createEditor() as PortableTextEditorEngine

--- a/packages/editor/src/editor/mutation-batcher.ts
+++ b/packages/editor/src/editor/mutation-batcher.ts
@@ -14,9 +14,16 @@ type PendingMutation = {
 
 const TYPE_DEBOUNCE = 250
 
+// A typed burst splits into two mutations mid-word if this fixed flush cadence
+// fires before the burst finishes typing, so in test mode the interval has to
+// be comfortably longer than a real burst takes to type. It also can't be too
+// long: the interval is the flush path for non-typing pending work, and tests
+// wait on those mutations within a default 1s `waitFor`. 500ms balances both —
+// a burst must take over 500ms to type to split, while non-typing work still
+// flushes well inside 1s. Production never approaches its 1s cadence.
 const FLUSH_INTERVAL =
   // @ts-expect-error - dot notation required for Vite to replace at build time
-  process.env.NODE_ENV === 'test' ? 250 : 1000
+  process.env.NODE_ENV === 'test' ? 500 : 1000
 
 /**
  * Batches `internal.patch` events into debounced `mutation` events.

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -109,12 +109,17 @@ describe('event.mutation', () => {
       ),
     })
 
+    // Each burst flushes into a single mutation: the keystrokes share one undo
+    // step (the key the batcher merges on) and a burst finishes well inside the
+    // batcher's `FLUSH_INTERVAL`, so the fixed flush cadence never fires
+    // mid-burst. Waiting on the settled count (rather than sleeping a fixed
+    // period) lets the first burst flush via its typing debounce before the
+    // second burst opens a fresh undo step.
     await userEvent.type(locator, 'foo')
-    await new Promise((resolve) => setTimeout(resolve, 250))
+    await vi.waitFor(() => expect(mutations).toHaveLength(1))
     await userEvent.type(locator, 'bar')
-    await new Promise((resolve) => setTimeout(resolve, 250))
+    await vi.waitFor(() => expect(mutations).toHaveLength(2))
 
-    expect(mutations).toHaveLength(2)
     expect(mutations[0]!.value).toEqual([
       {
         _type: 'block',


### PR DESCRIPTION
`event.mutation.test.tsx > Scenario: Batching typing mutations` flaked on the Firefox browser job (chromium and webkit were fine), failing through `retry x3` with `expected length 2 but got 3`. It intermittently bounced CI on unrelated PRs.

The scenario types two bursts and asserts two `mutation` events. The batcher flushes pending work on a fixed `FLUSH_INTERVAL` (`mutation-batcher.ts`), and a typed burst is split into two mutations when that cadence fires before the burst finishes typing. Production runs the interval at 1000ms, where a normal burst never approaches it, but test mode ran it at 250ms, so under Firefox CI load a three-character `userEvent.type` burst could exceed 250ms, the interval fired mid-word, and the run saw three mutations.

The fix moves the test-mode interval from 250ms to 500ms. It can't simply match production's 1000ms: the interval is also the flush path for non-typing pending mutations, and several `event.patches` scenarios wait on those within a default 1s `waitFor`, which a 1000ms flush races (I confirmed 1000ms turns three of them red). 500ms balances the two, a burst must now take over 500ms to type before it splits, roughly double the old threshold, while non-typing work still flushes well inside the 1s wait.

This is a margin increase, not a proof of elimination, the original split only manifests under sustained CI load I can't reproduce locally. But doubling the threshold plus Firefox's existing `retry x3` means a failure now requires sustained sub-500ms-per-burst stalls across four attempts, far less likely than the old 250ms boundary. The alternative was deleting the scenario (the batching contract is independently and deterministically pinned by `mutation-batcher.test.ts` with fake timers); keeping it preserves the only real-DOM-typing coverage of batching, with the exact two-mutation count and the `foo`/`foobar` value assertions intact.

```ts
await userEvent.type(locator, 'foo')
await vi.waitFor(() => expect(mutations).toHaveLength(1))
await userEvent.type(locator, 'bar')
await vi.waitFor(() => expect(mutations).toHaveLength(2))
// ...foo / foobar value assertions
```

Verified: `event.mutation` green across many consecutive Firefox runs plus chromium/webkit, `event.patches` back to 88/88, and `mutation-batcher.test.ts` updated to the 500ms constant. The interval change is gated on `NODE_ENV === 'test'`, production stays 1000ms, so there is no consumer-facing change and no changeset.
