### PR TITLE
fix(perf): coalesce `editor.subscribe` notifications to one per microtask burst

### DIFF
--- a/.changeset/coalesce-editor-subscribe.md
+++ b/.changeset/coalesce-editor-subscribe.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): coalesce `editor.subscribe` notifications to one per microtask burst
+
+The editor's actor emits once per applied operation, so a single action that applies many operations (undoing a large delete, inserting many blocks) notified snapshot subscribers once per operation. `useEditorSelector` (and any `editor.subscribe` consumer) therefore re-ran its selector once per operation; a selector that scans the selection became O(operations × selection) and could freeze the main thread on a large undo.
+
+`editor.subscribe` now coalesces a synchronous burst of transitions into a single `next` with the settled snapshot on the next microtask, the same boundary the editor's render already coalesces to. `useEditorSelector` re-runs its selector once per burst instead of once per operation. The snapshot is cumulative, so the delivered value is unchanged; only intermediate per-operation states within a burst are skipped. A consumer that must observe every operation should use `editor.on('operation', ...)`.

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -83,8 +83,15 @@ export type Editor = {
   }
   /**
    * Subscribe to editor state changes. The observer's `next` callback fires
-   * with the current `EditorSnapshot` on every relevant transition (selection
+   * with the current `EditorSnapshot` on relevant transitions (selection
    * updates, content mutations, behavior dispatch, configuration changes).
+   *
+   * Notifications are coalesced: a synchronous burst of transitions (e.g. the
+   * many operations one action applies, like undoing a large delete) delivers
+   * a single `next` with the settled snapshot on the next microtask, rather
+   * than one `next` per transition. The snapshot is cumulative, so only
+   * intermediate per-transition states are skipped. To observe every
+   * operation, use `editor.on('operation', ...)`.
    *
    * The editor has no terminal state and no error path, so `error` and
    * `complete` are part of the observable contract but never fire. They are

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -23,6 +23,7 @@ import {
   type EditorEventListenerOptions,
   type Relay,
 } from './relay'
+import {subscribeCoalesced} from './subscribe-coalesced'
 import {syncMachine, type SyncActor} from './sync-machine'
 
 export function createInternalEditor(config: EditorConfig): {
@@ -159,13 +160,16 @@ export function createInternalEditor(config: EditorConfig): {
       })
     }) as Editor['on'],
     subscribe(observer) {
-      const actorSubscription = editorActor.subscribe({
+      // Coalesce the actor's per-operation emissions to one settled-state
+      // notification per microtask burst (see `subscribeCoalesced`). A single
+      // action that applies many operations (undo of a large delete) then
+      // notifies snapshot subscribers, e.g. `useEditorSelector`, once instead
+      // of once per operation.
+      return subscribeCoalesced(editorActor, {
         next: () => observer.next?.(editor.getSnapshot()),
         error: observer.error,
         complete: observer.complete,
       })
-
-      return {unsubscribe: () => actorSubscription.unsubscribe()}
     },
   }
 

--- a/packages/editor/src/editor/editor-selector.ts
+++ b/packages/editor/src/editor/editor-selector.ts
@@ -41,6 +41,10 @@ export function useEditorSelector<TSelected>(
   selector: EditorSelector<TSelected>,
   compare: (a: TSelected, b: TSelected) => boolean = defaultCompare,
 ) {
+  // The selector re-runs once per microtask burst, not once per operation,
+  // because `editor.subscribe` coalesces the actor's emissions; see
+  // `subscribeCoalesced`.
+  //
   // `useSelector` is typed against xstate's `Subscribable<T>` which has both
   // observer-form and the deprecated function-form `subscribe` overloads.
   // We only expose the modern observer-form; the cast bridges that gap

--- a/packages/editor/src/editor/selection-state-context.tsx
+++ b/packages/editor/src/editor/selection-state-context.tsx
@@ -11,6 +11,7 @@ import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {EditorActorContext} from './editor-actor-context'
 import {getSelectionState, type SelectionState} from './get-selection-state'
+import {subscribeCoalesced} from './subscribe-coalesced'
 
 const emptySet = new Set<string>()
 
@@ -161,19 +162,12 @@ export function SelectionStateProvider({
       }
     }
 
-    let pendingRecompute = false
-
-    const subscription = editorActor.subscribe(() => {
-      // Coalesce bursts of actor updates into one selection-state
-      // recompute per microtask. The microtask drains before React's
-      // commit phase, so subscribers re-render in the same commit as
-      // the actor's state change.
-      if (pendingRecompute) {
-        return
-      }
-      pendingRecompute = true
-      queueMicrotask(() => {
-        pendingRecompute = false
+    // Coalesce bursts of actor updates into one selection-state recompute per
+    // microtask (shared with `editor.subscribe`). The microtask drains before
+    // React's commit phase, so subscribers re-render in the same commit as the
+    // actor's state change.
+    const subscription = subscribeCoalesced(editorActor, {
+      next: () => {
         const newState = computeCurrent()
         if (!selectionStatesEqual(stateRef.current, newState)) {
           stateRef.current = newState
@@ -181,7 +175,7 @@ export function SelectionStateProvider({
             cb()
           }
         }
-      })
+      },
     })
 
     return () => subscription.unsubscribe()

--- a/packages/editor/src/editor/subscribe-coalesced.ts
+++ b/packages/editor/src/editor/subscribe-coalesced.ts
@@ -1,0 +1,67 @@
+type Unsubscribable = {unsubscribe: () => void}
+
+interface SubscribableActor {
+  subscribe(observer: {
+    next?: (value: unknown) => void
+    error?: (error: unknown) => void
+    complete?: () => void
+  }): Unsubscribable
+}
+
+/**
+ * Subscribe to an actor, coalescing a synchronous burst of emissions into a
+ * single trailing-microtask `next` call.
+ *
+ * The editor's actor emits once per applied operation, so a single action
+ * (undoing a large delete, inserting many blocks) emits O(operations) times.
+ * Subscribers that recompute derived state from the settled snapshot, the
+ * public `editor.subscribe`, selection-state, want one notification per burst,
+ * not one per operation; reacting per operation makes a selection-scanning
+ * recompute O(operations × selection) and freezes the main thread.
+ *
+ * Coalescing here, at the snapshot subscription, is the single place that
+ * concern lives: the snapshot is cumulative, so delivering only the settled
+ * state once per burst is sound, and it lands on the same microtask boundary
+ * the editor's render already coalesces to. Consumers that need every
+ * operation (patch generation, the mutation batcher) subscribe to the raw
+ * actor or the `operation` event stream instead.
+ *
+ * `error`/`complete` are forwarded untouched; only `next` is coalesced.
+ */
+export function subscribeCoalesced(
+  actor: SubscribableActor,
+  observer: {
+    next?: () => void
+    error?: (error: unknown) => void
+    complete?: () => void
+  },
+): Unsubscribable {
+  let scheduled = false
+  let active = true
+
+  const subscription = actor.subscribe({
+    next: observer.next
+      ? () => {
+          if (scheduled || !active) {
+            return
+          }
+          scheduled = true
+          queueMicrotask(() => {
+            scheduled = false
+            if (active) {
+              observer.next?.()
+            }
+          })
+        }
+      : undefined,
+    error: observer.error,
+    complete: observer.complete,
+  })
+
+  return {
+    unsubscribe: () => {
+      active = false
+      subscription.unsubscribe()
+    },
+  }
+}

--- a/packages/editor/tests/use-editor-selector.coalesce.test.tsx
+++ b/packages/editor/tests/use-editor-selector.coalesce.test.tsx
@@ -1,0 +1,99 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {useEditor, useEditorSelector} from '../src'
+import {InternalEditorEngineRefPlugin} from '../src/plugins/plugin.internal.editor-engine-ref'
+import {createTestEditor} from '../src/test/vitest'
+import type {PortableTextEditorEngine} from '../src/types/editor-engine'
+
+describe(useEditorSelector.name, () => {
+  test('Scenario: a large undo re-runs a selector a constant number of times, not once per re-inserted block', async () => {
+    const blockCount = 400
+    let selectorRuns = 0
+    let settledLength = -1
+
+    function BlockCountProbe() {
+      const editor = useEditor()
+      settledLength = useEditorSelector(editor, (snapshot) => {
+        selectorRuns += 1
+        return snapshot.context.value.length
+      })
+      return null
+    }
+
+    const engineRef = React.createRef<PortableTextEditorEngine>()
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      children: (
+        <>
+          <InternalEditorEngineRefPlugin ref={engineRef} />
+          <BlockCountProbe />
+        </>
+      ),
+    })
+
+    editor.send({
+      type: 'insert.blocks',
+      blocks: Array.from({length: blockCount}, (_, index) =>
+        block(`b${index}`, `s${index}`),
+      ),
+      placement: 'auto',
+    })
+    await vi.waitFor(() =>
+      expect(editor.getSnapshot().context.value.length).toBe(blockCount),
+    )
+
+    // Drop the insert from history so undo's only step is the delete, whose
+    // inverse re-inserts every block one operation at a time.
+    engineRef.current!.history.undos = []
+    engineRef.current!.history.redos = []
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+        focus: {
+          path: [
+            {_key: `b${blockCount - 1}`},
+            'children',
+            {_key: `s${blockCount - 1}`},
+          ],
+          offset: `b${blockCount - 1}`.length,
+        },
+      },
+    })
+    editor.send({type: 'delete'})
+    await vi.waitFor(() =>
+      expect(editor.getSnapshot().context.value.length).toBe(1),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    // Count only the runs the undo itself causes.
+    selectorRuns = 0
+    editor.send({type: 'history.undo'})
+    await vi.waitFor(() =>
+      expect(editor.getSnapshot().context.value.length).toBe(blockCount),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    // Undo emits once per re-inserted block (~blockCount times). `editor.subscribe`
+    // coalesces the burst, so the selector re-runs a small constant number of
+    // times, not ~blockCount. A loose bound rather than a literal count, so the
+    // assertion absorbs unrelated React re-renders instead of coupling to its
+    // scheduling.
+    expect(selectorRuns).toBeLessThan(20)
+    // It still lands on the settled value.
+    expect(settledLength).toBe(blockCount)
+  })
+})
+
+function block(blockKey: string, spanKey: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: blockKey,
+    children: [{_type: 'span', _key: spanKey, text: blockKey, marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+}


### PR DESCRIPTION
Undoing a large delete (paste ~1000 blocks, select all, delete, undo) froze the main thread for seconds. A CPU trace from `main` spent ~42% of the freeze re-running selectors: `getSelectedSpans` → `getNodes` → `BlockIndexMap.get`.

The cause is that the editor's actor emits **once per applied operation**, while snapshot subscribers want the *settled* state. Undo re-inserts every deleted block, so it emits ~N times. `useEditorSelector` (xstate `useSelector`) re-runs its selector on every emission, and the toolbar's active-state/schema hooks select over the selection. Undo restores the select-all selection, so each of the ~N emissions scans all N blocks: N × O(N) = O(N²). Insert and delete don't hang because they leave a collapsed selection.

#2831/#2833 coalesced the `editor.on` *event* stream, a separate channel, which is why undo still froze on `main`.

The fix puts the coalescing where it belongs, **at the snapshot subscription**, instead of in each consumer. Three places were all reacting to the same per-operation emissions, and `selection-state-context` already hand-rolled its own `queueMicrotask` coalescer for exactly this. A single `subscribeCoalesced` helper collapses a synchronous burst of actor emissions into one trailing-microtask `next`:

- `editor.subscribe` uses it, so every snapshot subscriber (including `useEditorSelector`) is notified once per burst against the settled snapshot.
- `selection-state-context` uses the same helper and **drops its bespoke coalescer**.
- `useEditorSelector` **needs no code change**: it is already a plain `useSelector` and inherits the coalescing through `editor.subscribe` (only a doc comment is added).
- Consumers that need every operation, patch generation, the mutation batcher, the read-only sync, stay on the raw actor or the `operation` event stream.

The blast radius is timing, not value: the snapshot is cumulative, so the delivered value is unchanged, and only the intermediate per-operation states *within a burst* are skipped, on the same microtask boundary the editor's render already coalesces to. A `useEditorSelector` consumer reads the same value it would have read at the end of the burst, one microtask later in the worst case, which is when the editor re-renders anyway. The `editor.subscribe` JSDoc documents the coalescing, and points consumers needing every operation to `editor.on('operation', ...)`.

The full chromium browser suite (176 files, 1656 tests) and the unit suite (808) pass unmodified, including the selection, toolbar, focus, and decorator suites most sensitive to subscription timing. The test pins the contract: a large undo re-runs a `useEditorSelector` selector a small constant number of times (not ~once per re-inserted block) and still lands on the settled value.

Fixes the EDEX-731 large-undo freeze. The engine-side O(N²) terms (#2803 duplicate-key scan, EDEX-1343 bulk op) are real but were not what froze this flow.
