### PR TITLE
chore(playground): give containers a draggable chrome region

### DIFF
--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -210,20 +210,43 @@
   border-collapse: separate;
   border-spacing: 0;
   width: 100%;
-  margin: 1.25rem 0;
   font-size: 0.875rem;
   line-height: 1.5;
   background: #ffffff;
   border: 1px solid #e2e8f0;
-  border-radius: 0.5rem;
+  border-radius: 0.375rem;
   overflow: hidden;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
 :where(.dark) .playground-table {
   background: #0f172a;
   border-color: #334155;
+}
+
+.playground-table-chrome {
+  position: relative;
+  margin: 1.25rem 0;
+  padding: 0.5rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  cursor: grab;
+}
+
+.playground-table-chrome[data-selected] {
+  border-color: #94a3b8;
+}
+
+:where(.dark) .playground-table-chrome {
+  background: #1e293b;
+  border-color: #334155;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+:where(.dark) .playground-table-chrome[data-selected] {
+  border-color: #64748b;
 }
 
 /* Body cells: subtle horizontal + vertical dividers. */

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -71,7 +71,7 @@ const calloutImageLeaf = defineBlockObject({
   },
 })
 
-const calloutContainer = defineContainer({
+export const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
   render: ({attributes, children, node, readOnly, selected}) => {

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -74,14 +74,15 @@ const calloutImageLeaf = defineBlockObject({
 const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
-  render: ({attributes, children, node, selected}) => {
+  render: ({attributes, children, node, readOnly, selected}) => {
     const tone = typeof node.tone === 'string' ? node.tone : 'note'
     const toneStyle = toneClassName[tone] ?? defaultToneClassName
     return (
       <aside
         {...attributes}
+        draggable={!readOnly}
         data-selected={selected ? '' : undefined}
-        className={`my-3 flex gap-2.5 rounded-md border-l-4 px-4 py-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
+        className={`my-3 flex cursor-grab gap-2.5 rounded-md border-l-4 p-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
       >
         <span
           contentEditable={false}
@@ -89,7 +90,9 @@ const calloutContainer = defineContainer({
         >
           <ToneIcon tone={tone} />
         </span>
-        <div className="min-w-0 flex-1">{children}</div>
+        <div draggable={false} className="min-w-0 flex-1 cursor-text">
+          {children}
+        </div>
       </aside>
     )
   },

--- a/apps/playground/src/plugins/plugin.code-block.tsx
+++ b/apps/playground/src/plugins/plugin.code-block.tsx
@@ -5,13 +5,16 @@ import type {JSX} from 'react'
 const codeBlockContainer = defineContainer({
   type: 'code-block',
   arrayField: 'lines',
-  render: ({attributes, children, selected}) => (
+  render: ({attributes, children, readOnly, selected}) => (
     <pre
       {...attributes}
+      draggable={!readOnly}
       data-selected={selected ? '' : undefined}
-      className="my-3 overflow-x-auto rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-slate-700 text-sm leading-relaxed transition-shadow data-[selected]:border-slate-400 data-[selected]:shadow-md dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:data-[selected]:border-slate-500"
+      className="my-3 cursor-grab overflow-x-auto rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-slate-700 text-sm leading-relaxed transition-shadow data-[selected]:border-slate-400 data-[selected]:shadow-md dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200 dark:data-[selected]:border-slate-500"
     >
-      {children}
+      <code draggable={false} className="block min-w-0 cursor-text">
+        {children}
+      </code>
     </pre>
   ),
 })

--- a/apps/playground/src/plugins/plugin.fact-box.tsx
+++ b/apps/playground/src/plugins/plugin.fact-box.tsx
@@ -1,25 +1,23 @@
 import {defineContainer, defineTextBlock} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
-import {LayersIcon} from 'lucide-react'
 import type {JSX} from 'react'
 
 const factBoxContainer = defineContainer({
   type: 'fact-box',
   arrayField: 'content',
-  render: ({attributes, children, selected}) => (
+  render: ({attributes, children, readOnly, selected}) => (
     <section
       {...attributes}
+      draggable={!readOnly}
       data-selected={selected ? '' : undefined}
-      className="my-4 rounded-lg border border-stone-300 bg-stone-50 px-5 py-4 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-600 dark:bg-stone-800/40 dark:data-[selected]:border-stone-400"
+      className="my-4 cursor-grab rounded-lg border border-stone-300 bg-stone-50 p-4 shadow-sm transition-shadow data-[selected]:border-stone-500 data-[selected]:shadow-lg dark:border-stone-600 dark:bg-stone-800/40 dark:data-[selected]:border-stone-400"
     >
       <div
-        contentEditable={false}
-        className="-mx-5 -mt-4 mb-3 flex items-center gap-2 rounded-t-lg border-stone-300 border-b bg-stone-100 px-5 py-2 font-mono text-stone-600 text-xs uppercase tracking-wider dark:border-stone-600 dark:bg-stone-900/60 dark:text-stone-300"
+        draggable={false}
+        className="cursor-text text-stone-800 dark:text-stone-100"
       >
-        <LayersIcon aria-hidden className="h-3.5 w-3.5" />
-        <span>Fact box</span>
+        {children}
       </div>
-      <div className="text-stone-800 dark:text-stone-100">{children}</div>
     </section>
   ),
   of: [

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -6,17 +6,20 @@ import {cellImageLeaf} from './plugin.image'
 const tableContainer = defineContainer({
   type: 'table',
   arrayField: 'rows',
-  render: ({attributes, children, node, selected}) => (
-    <table
+  render: ({attributes, children, node, readOnly, selected}) => (
+    <div
       {...attributes}
+      draggable={!readOnly}
       data-header-rows={
         typeof node.headerRows === 'number' ? node.headerRows : 0
       }
       data-selected={selected ? '' : undefined}
-      className="playground-table"
+      className="playground-table-chrome"
     >
-      <tbody>{children}</tbody>
-    </table>
+      <table draggable={false} className="playground-table cursor-text">
+        <tbody>{children}</tbody>
+      </table>
+    </div>
   ),
   of: [
     defineContainer({

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,6 +1,7 @@
 import {defineContainer} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 
 const tableContainer = defineContainer({
@@ -39,7 +40,7 @@ const tableContainer = defineContainer({
               {children}
             </td>
           ),
-          of: [cellImageLeaf],
+          of: [cellImageLeaf, calloutContainer],
         }),
       ],
     }),


### PR DESCRIPTION
Isolation of the playground changes from #2825 so the cmd+c-on-inline-object-inside-a-table-cell bug can be reproduced against current main without the engine changes from that PR.

Two commits:
- `chore(playground): give containers a draggable chrome region` — slim chrome via container padding + `draggable={!readOnly}` + `cursor-grab` on the outer, `cursor-text` on the children wrapper.
- `chore(playground): accept callouts inside table cells` — positional `of` on cell mirrors schema's `cell.content.of` so containers can nest correctly.

Engine-side chrome-drag does NOT work on this branch — that lives in #2825. This is for isolating the inline-object copy bug.