### PR TITLE
chore(playground): number container lists via `plugin-list-index`

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -22,6 +22,7 @@
     "@portabletext/markdown": "workspace:*",
     "@portabletext/patches": "workspace:*",
     "@portabletext/plugin-emoji-picker": "workspace:*",
+    "@portabletext/plugin-list-index": "workspace:*",
     "@portabletext/plugin-markdown-shortcuts": "workspace:*",
     "@portabletext/plugin-one-line": "workspace:*",
     "@portabletext/plugin-paste-link": "workspace:*",

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -18,6 +18,7 @@ import {
   type RenderStyleFunction,
 } from '@portabletext/editor'
 import {portableTextToMarkdown} from '@portabletext/markdown'
+import {ListIndexProvider} from '@portabletext/plugin-list-index'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {PasteLinkPlugin} from '@portabletext/plugin-paste-link'
@@ -159,54 +160,56 @@ export function Editor(props: {
                 </PortableTextToolbar>
               </FullscreenAwareToolbarWrapper>
             ) : null}
-            <FullscreenAwareContainer>
-              {featureFlags.codeBlockPlugin ? <CodeBlockPlugin /> : null}
-              {featureFlags.calloutPlugin ? <CalloutPlugin /> : null}
-              {featureFlags.factBoxPlugin ? <FactBoxPlugin /> : null}
-              {featureFlags.tablePlugin ? <TablePlugin /> : null}
-              <InlineObjectsPlugin />
-              {featureFlags.emojiPickerPlugin ? <EmojiPickerPlugin /> : null}
-              {featureFlags.mentionPickerPlugin ? (
-                <MentionPickerPlugin />
-              ) : null}
-              {featureFlags.slashCommandPlugin ? (
-                <SlashCommandPickerPlugin />
-              ) : null}
-              {featureFlags.codeEditorPlugin ? <CodeEditorPlugin /> : null}
-              {featureFlags.linkPlugin ? <PasteLinkPlugin /> : null}
-              {featureFlags.imageDeserializerPlugin ? (
-                <ImageDeserializerPlugin />
-              ) : null}
-              {featureFlags.htmlDeserializerPlugin ? (
-                <HtmlDeserializerPlugin />
-              ) : null}
-              {featureFlags.textFileDeserializerPlugin ? (
-                <TextFileDeserializerPlugin />
-              ) : null}
-              {featureFlags.markdownDeserializerPlugin ? (
-                <MarkdownDeserializerPlugin />
-              ) : null}
-              {featureFlags.markdownPlugin ? (
-                <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
-              ) : null}
-              {featureFlags.oneLinePlugin ? <OneLinePlugin /> : null}
-              {featureFlags.typographyPlugin ? (
-                <TypographyPlugin
-                  guard={createDecoratorGuard({
-                    decorators: ({context}) =>
-                      context.schema.decorators.flatMap((decorator) =>
-                        decorator.name === 'code' ? [] : [decorator.name],
-                      ),
-                  })}
+            <ListIndexProvider>
+              <FullscreenAwareContainer>
+                {featureFlags.codeBlockPlugin ? <CodeBlockPlugin /> : null}
+                {featureFlags.calloutPlugin ? <CalloutPlugin /> : null}
+                {featureFlags.factBoxPlugin ? <FactBoxPlugin /> : null}
+                {featureFlags.tablePlugin ? <TablePlugin /> : null}
+                <InlineObjectsPlugin />
+                {featureFlags.emojiPickerPlugin ? <EmojiPickerPlugin /> : null}
+                {featureFlags.mentionPickerPlugin ? (
+                  <MentionPickerPlugin />
+                ) : null}
+                {featureFlags.slashCommandPlugin ? (
+                  <SlashCommandPickerPlugin />
+                ) : null}
+                {featureFlags.codeEditorPlugin ? <CodeEditorPlugin /> : null}
+                {featureFlags.linkPlugin ? <PasteLinkPlugin /> : null}
+                {featureFlags.imageDeserializerPlugin ? (
+                  <ImageDeserializerPlugin />
+                ) : null}
+                {featureFlags.htmlDeserializerPlugin ? (
+                  <HtmlDeserializerPlugin />
+                ) : null}
+                {featureFlags.textFileDeserializerPlugin ? (
+                  <TextFileDeserializerPlugin />
+                ) : null}
+                {featureFlags.markdownDeserializerPlugin ? (
+                  <MarkdownDeserializerPlugin />
+                ) : null}
+                {featureFlags.markdownPlugin ? (
+                  <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
+                ) : null}
+                {featureFlags.oneLinePlugin ? <OneLinePlugin /> : null}
+                {featureFlags.typographyPlugin ? (
+                  <TypographyPlugin
+                    guard={createDecoratorGuard({
+                      decorators: ({context}) =>
+                        context.schema.decorators.flatMap((decorator) =>
+                          decorator.name === 'code' ? [] : [decorator.name],
+                        ),
+                    })}
+                  />
+                ) : null}
+                <FullscreenAwareEditable
+                  rangeDecorations={props.rangeDecorations}
+                  featureFlags={featureFlags}
+                  loading={loading}
                 />
-              ) : null}
-              <FullscreenAwareEditable
-                rangeDecorations={props.rangeDecorations}
-                featureFlags={featureFlags}
-                loading={loading}
-              />
-              <EditorFooter editorRef={props.editorRef} readOnly={readOnly} />
-            </FullscreenAwareContainer>
+                <EditorFooter editorRef={props.editorRef} readOnly={readOnly} />
+              </FullscreenAwareContainer>
+            </ListIndexProvider>
           </EditorProvider>
         </FullscreenProvider>
       </ErrorBoundary>

--- a/apps/playground/src/playground-schema-definition.tsx
+++ b/apps/playground/src/playground-schema-definition.tsx
@@ -304,7 +304,8 @@ export const playgroundSchemaDefinition = defineSchema({
     // ARCHETYPE 3 - selective subsets: ONE-OF in every dimension.
     // Decorators: only strong. Annotations: only comment.
     // Styles: normal + h1 + h2 + h3 + blockquote.
-    // Lists: only bullet (no number - exercises narrowed-list filter).
+    // Lists: bullet + number (narrowing still exercised by the nested
+    // callouts below, which stay bullet-only / empty).
     // Inline objects: only mention.
     // Allows image + nested callout (recursive same-type nesting).
     {
@@ -337,7 +338,10 @@ export const playgroundSchemaDefinition = defineSchema({
                   fields: [{name: 'text', title: 'Text', type: 'string'}],
                 },
               ],
-              lists: [{title: 'Bulleted list', name: 'bullet'}],
+              lists: [
+                {title: 'Bulleted list', name: 'bullet'},
+                {title: 'Numbered list', name: 'number'},
+              ],
               inlineObjects: [
                 {
                   title: 'Mention',
@@ -390,7 +394,7 @@ export const playgroundSchemaDefinition = defineSchema({
     },
     // ARCHETYPE 4 - deep structural nesting + heterogeneous depth.
     // table → row → cell. cell.content allows strong + em decorators,
-    // link annotation, normal style, no lists, no inline objects.
+    // link annotation, normal style, bullet + number lists, no inline objects.
     // PLUS cell.content allows nested callout (different sub-schema
     // than cell). Tests deep traversal AND voting across multiple
     // sub-schemas at different depths.
@@ -447,7 +451,10 @@ export const playgroundSchemaDefinition = defineSchema({
                                   ],
                                 },
                               ],
-                              lists: [],
+                              lists: [
+                                {title: 'Bulleted list', name: 'bullet'},
+                                {title: 'Numbered list', name: 'number'},
+                              ],
                             },
                             {
                               type: 'object',

--- a/apps/playground/src/plugins/list-item-block.tsx
+++ b/apps/playground/src/plugins/list-item-block.tsx
@@ -1,0 +1,31 @@
+import type {TextBlockRenderProps} from '@portabletext/editor'
+import {useListIndex} from '@portabletext/plugin-list-index'
+import type {JSX} from 'react'
+
+/**
+ * Renders a list-item text block inside a container. Containers go through the
+ * `defineTextBlock` pipeline, which emits only `data-pt-*` attributes, so the
+ * playground's pure-CSS list counters in `editor.css` (keyed off
+ * `data-list-item`/`data-level`/`data-list-index`) never fire. This re-emits
+ * those attributes, with the index supplied by `useListIndex` since it is the
+ * one value the consumer cannot derive from `node` alone.
+ */
+export function ListItemBlock(props: {
+  attributes: TextBlockRenderProps['attributes']
+  node: TextBlockRenderProps['node']
+  path: TextBlockRenderProps['path']
+  children: TextBlockRenderProps['children']
+}): JSX.Element {
+  const listIndex = useListIndex(props.path)
+  return (
+    <div
+      {...props.attributes}
+      data-list-item={props.node.listItem}
+      data-level={props.node.level}
+      data-list-index={listIndex}
+      className="my-1"
+    >
+      {props.children}
+    </div>
+  )
+}

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import type {JSX} from 'react'
 import {DragHandle} from './drag-handle'
+import {ListItemBlock} from './list-item-block'
 
 const toneClassName: Record<string, string> = {
   note: 'border-sky-400 bg-sky-50 text-sky-900 dark:bg-sky-950/40 dark:text-sky-100',
@@ -98,12 +99,15 @@ export const calloutContainer = defineContainer({
   of: [
     defineTextBlock({
       type: 'block',
-      render: ({attributes, children, node}) => {
+      render: ({attributes, children, node, path}) => {
         if (node.listItem !== undefined) {
           return (
-            <div {...attributes} className="my-1">
-              {children}
-            </div>
+            <ListItemBlock
+              attributes={attributes}
+              node={node}
+              path={path}
+              children={children}
+            />
           )
         }
 

--- a/apps/playground/src/plugins/plugin.fact-box.tsx
+++ b/apps/playground/src/plugins/plugin.fact-box.tsx
@@ -2,6 +2,7 @@ import {defineContainer, defineTextBlock} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
 import {DragHandle} from './drag-handle'
+import {ListItemBlock} from './list-item-block'
 
 const factBoxContainer = defineContainer({
   type: 'fact-box',
@@ -21,12 +22,15 @@ const factBoxContainer = defineContainer({
   of: [
     defineTextBlock({
       type: 'block',
-      render: ({attributes, children, node}) => {
+      render: ({attributes, children, node, path}) => {
         if (node.listItem !== undefined) {
           return (
-            <div {...attributes} className="my-1">
-              {children}
-            </div>
+            <ListItemBlock
+              attributes={attributes}
+              node={node}
+              path={path}
+              children={children}
+            />
           )
         }
 

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,7 +1,8 @@
-import {defineContainer} from '@portabletext/editor'
+import {defineContainer, defineTextBlock} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
 import {DragHandle} from './drag-handle'
+import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 
@@ -41,7 +42,24 @@ const tableContainer = defineContainer({
               {children}
             </td>
           ),
-          of: [cellImageLeaf, calloutContainer],
+          of: [
+            defineTextBlock({
+              type: 'block',
+              render: ({attributes, children, node, path}) =>
+                node.listItem !== undefined ? (
+                  <ListItemBlock
+                    attributes={attributes}
+                    node={node}
+                    path={path}
+                    children={children}
+                  />
+                ) : (
+                  <div {...attributes}>{children}</div>
+                ),
+            }),
+            cellImageLeaf,
+            calloutContainer,
+          ],
         }),
       ],
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       '@portabletext/plugin-emoji-picker':
         specifier: workspace:*
         version: link:../../packages/plugin-emoji-picker
+      '@portabletext/plugin-list-index':
+        specifier: workspace:*
+        version: link:../../packages/plugin-list-index
       '@portabletext/plugin-markdown-shortcuts':
         specifier: workspace:*
         version: link:../../packages/plugin-markdown-shortcuts
@@ -16676,7 +16679,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@20.19.25)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@27.2.0)(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
Typing a numbered or bulleted list inside a callout or fact-box in the playground produced an unmarked, unindented stack of lines: no number, no bullet, nothing distinguishing item three from a paragraph. Top-level lists render fine, so the breakage was invisible until you put a list inside a container.

The cause is the render pipeline, not the data. The playground draws every list marker with pure-CSS counters in `editor.css`, keyed entirely off three attributes the engine puts on list blocks: `data-list-item`, `data-level`, and `data-list-index`. Top-level blocks get those from the legacy pipeline. The `callout` and `fact-box` containers, however, render their text through `defineTextBlock`, whose new pipeline emits only `data-pt-*` attributes by design. With none of the `data-list-*` attributes present the counters never fired, and the container's `listItem` branch had nothing to show, so it fell back to a bare `<div className="my-1">`.

The fix supplies exactly the one value a consumer cannot derive on its own. `node.listItem` and `node.level` are already on the block; the 1-based position within the list is a derived quantity that depends on sibling order and list breaks, which is what `@portabletext/plugin-list-index` computes (descending containers, numbering each nested array independently). So this mounts `ListIndexProvider` inside `EditorProvider` and routes the container `listItem` branch through a shared `ListItemBlock` that reads `useListIndex(path)` and re-emits the three `data-list-*` attributes onto the wrapper. The existing counter CSS does the rest, rendering numbers (decimal, then lower-alpha, then lower-roman per level) and bullets identically to top-level lists. The numbering, container descent, and restart-at-1 semantics are already pinned in the plugin's own suite (`data-list-index.test.tsx`, "list items nested in a container number within their own array"), so the playground side is pure attribute-spreading glue.

No `counter-reset` scoping was needed even though CSS counters are global in document order. Each list's first item carries `data-list-index='1'`, which fires `counter-set: level-N 1`, and a list run is contiguous siblings: a container is a non-list block that breaks the run, splitting the items around it into separate lists that each reset to 1 at their own start. So a nested list mutating the shared `level-N` counter cannot leak into the outer numbering.

The rendering above only matters where the schema lets a numbered list exist, and it did not: the top-level `callout` content allowed `bullet` only, and `cell` content allowed no lists at all, so callout numbering rendered correctly but could never be created, and cells had no lists of any kind. So the second commit adds `number` to the `callout` and `cell` content list sets, and gives the cell the `defineTextBlock` it lacked (its text blocks were falling through to the engine default, which emits no `data-list-*`), routing cell list items through the same `ListItemBlock`. Cells allow both `bullet` and `number`; bullet needs no extra rendering code, since `ListItemBlock` already spreads `data-list-item` and the counter CSS draws the marker. Callouts nested in table cells are covered transitively through the callout registration.

A root-level global `defineTextBlock` was considered as a way to cover the cell (and any future container) without a per-container override, and rejected. The text-block dispatch resolves a global registration at every position, including the top level, where its `render` would win over the legacy `else` branch. That would pull the playground's top-level blocks off the legacy pipeline and silently drop everything that hangs off `renderBlock`/`renderListItem`/`renderStyle`: the drag-handle chrome, task checkboxes, the style and decorator maps, and the callout/fact-box/table preview fallbacks. The per-cell `defineTextBlock` is the contained equivalent: it shadows nothing and leaves the legacy top-level rendering untouched.

Net behavior for top-level lists is unchanged, and the provider is a single subscription mounted unconditionally, so no feature flag gates it.
