### PR TITLE
fix(perf): skip redundant per-operation sibling scans

### DIFF
--- a/.changeset/block-index-map-lookup.md
+++ b/.changeset/block-index-map-lookup.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): resolve block-index-map child indices via the map, not a linear scan

--- a/.changeset/dedup-scan-cache.md
+++ b/.changeset/dedup-scan-cache.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): scan each sibling group for duplicate keys once instead of per node

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -70,6 +70,7 @@ export function createEditorEngine(
 
   editor.listIndexMap = new Map<string, number>()
   editor.listIndexMapDirty = false
+  editor.verifiedUniqueChildGroups = new Set<string>()
   editor.remotePatches = []
   editor.undoStepId = undefined
 

--- a/packages/editor/src/editor/subscriber.update-value.test.ts
+++ b/packages/editor/src/editor/subscriber.update-value.test.ts
@@ -1,0 +1,164 @@
+import {describe, expect, test} from 'vitest'
+import type {EngineOperation} from '../engine/interfaces/operation'
+import {serializePath} from '../paths/serialize-path'
+import {invalidateVerifiedGroups} from './subscriber.update-value'
+
+/**
+ * `invalidateVerifiedGroups` is the cache-invariant gate the dedup-scan
+ * skip in `normalizeNode` depends on: groups whose direct membership an
+ * operation changes must lose their verdict, and unrelated groups must
+ * keep theirs. The dedup correctness tests prove fixes still apply; this
+ * pins the invariant so a future tweak to the invalidator can't silently
+ * drop the skip without surfacing here.
+ */
+
+const rootGroupId = ''
+const aChildrenGroupId = serializePath([{_key: 'a'}, 'children'])
+const bChildrenGroupId = serializePath([{_key: 'b'}, 'children'])
+
+type Invalidatable = Exclude<
+  EngineOperation,
+  {type: 'set.selection' | 'insert.text' | 'remove.text'}
+>
+
+function withGroups(...ids: ReadonlyArray<string>): Set<string> {
+  return new Set(ids)
+}
+
+function applyInvalidation(
+  groups: Set<string>,
+  operation: Invalidatable,
+): Set<string> {
+  invalidateVerifiedGroups(groups, operation)
+  return groups
+}
+
+describe('invalidateVerifiedGroups', () => {
+  test('drops the group an insert joins, keeps unrelated groups', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'insert',
+      path: [{_key: 'a'}, 'children', 0],
+      node: {_key: 'new', _type: 'span', text: '', marks: []},
+      position: 'before',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(aChildrenGroupId)).toBe(false)
+    expect(groups.has(rootGroupId)).toBe(true)
+    expect(groups.has(bChildrenGroupId)).toBe(true)
+  })
+
+  test('drops the parent group of an unset node', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'unset',
+      path: [{_key: 'a'}, 'children', {_key: 'x'}],
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(aChildrenGroupId)).toBe(false)
+    expect(groups.has(rootGroupId)).toBe(true)
+    expect(groups.has(bChildrenGroupId)).toBe(true)
+  })
+
+  test('drops the field group of an unset whole-field', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'unset',
+      path: [{_key: 'a'}, 'children'],
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(aChildrenGroupId)).toBe(false)
+    expect(groups.has(rootGroupId)).toBe(true)
+    expect(groups.has(bChildrenGroupId)).toBe(true)
+  })
+
+  test('drops the parent group when a `_key` changes', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'set',
+      path: [{_key: 'a'}, 'children', {_key: 'x'}, '_key'],
+      value: 'renamed',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(aChildrenGroupId)).toBe(false)
+    expect(groups.has(rootGroupId)).toBe(true)
+    expect(groups.has(bChildrenGroupId)).toBe(true)
+  })
+
+  test('keeps every group when a deep property changes', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'set',
+      path: [{_key: 'a'}, 'children', {_key: 'x'}, 'text'],
+      value: 'hello',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(rootGroupId)).toBe(true)
+    expect(groups.has(aChildrenGroupId)).toBe(true)
+    expect(groups.has(bChildrenGroupId)).toBe(true)
+  })
+
+  test('clears the cache when a root-level set replaces the whole value', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'set',
+      path: [],
+      value: [],
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.size).toBe(0)
+  })
+
+  test('clears the cache when a numeric segment makes the group id unresolvable', () => {
+    const groups = withGroups(rootGroupId, aChildrenGroupId, bChildrenGroupId)
+    const operation: Invalidatable = {
+      type: 'insert',
+      // `apply-merge-node` emits numeric anchors when prev-children is empty.
+      path: [{_key: 'a'}, 'children', 0, 'children', 0],
+      node: {_key: 'new', _type: 'span', text: '', marks: []},
+      position: 'after',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.size).toBe(0)
+  })
+
+  test("drops a re-inserted subtree's nested groups so a reused key cannot inherit a stale verdict", () => {
+    const replacedChildrenGroupId = serializePath([
+      {_key: 'a'},
+      'children',
+      {_key: 'replaced'},
+      'children',
+    ])
+    const groups = withGroups(
+      rootGroupId,
+      aChildrenGroupId,
+      replacedChildrenGroupId,
+    )
+    const operation: Invalidatable = {
+      type: 'insert',
+      path: [{_key: 'a'}, 'children', 0],
+      node: {
+        _key: 'replaced',
+        _type: 'block',
+        children: [{_key: 'c1', _type: 'span', text: '', marks: []}],
+      },
+      position: 'before',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.has(aChildrenGroupId)).toBe(false)
+    expect(groups.has(replacedChildrenGroupId)).toBe(false)
+    expect(groups.has(rootGroupId)).toBe(true)
+  })
+
+  test('does nothing when the cache is empty (the common batch-of-edits path)', () => {
+    const groups = new Set<string>()
+    const operation: Invalidatable = {
+      type: 'insert',
+      path: [{_key: 'a'}, 'children', 0],
+      node: {_key: 'new', _type: 'span', text: '', marks: []},
+      position: 'before',
+    }
+    applyInvalidation(groups, operation)
+    expect(groups.size).toBe(0)
+  })
+})

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -1,9 +1,159 @@
 import {subscribeToOperations} from '../engine/core/operation-channel'
+import type {Node} from '../engine/interfaces/node'
+import type {EngineOperation} from '../engine/interfaces/operation'
+import type {Path} from '../engine/interfaces/path'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
-import {transformBlockIndexMap} from '../internal-utils/transform-block-index-map'
+import {
+  transformBlockIndexMap,
+  walkKeyedChildrenInValue,
+} from '../internal-utils/transform-block-index-map'
+import {serializePath} from '../paths/serialize-path'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {EditorContext} from './editor-snapshot'
+
+/**
+ * Serialize a sibling-group path to the id `normalizeNode` caches it under,
+ * or return `null` if a node segment is numeric. Numeric segments do appear
+ * on a few paths (`apply-merge-node` emits a numeric anchor when the
+ * previous-children list is empty, and `normalizeNode` emits numeric paths
+ * when fixing up a missing or duplicate `_key`), but the bulk insert/delete
+ * paths this optimization targets are keyed. Resolving a numeric segment to
+ * a keyed id would need a from-root walk (the very O(n) walk this is
+ * avoiding), so the caller clears the whole set instead, which only costs
+ * extra scans the next time `normalizeNode` visits.
+ */
+function groupId(prefix: Path): string | null {
+  for (const segment of prefix) {
+    if (typeof segment === 'number') {
+      return null
+    }
+  }
+  return serializePath(prefix)
+}
+
+/**
+ * Drop the verified-unique verdict for every sibling group whose direct
+ * membership an operation changes, so per-node duplicate-key normalization
+ * re-scans exactly those groups and no others. A group is identified by the
+ * serialized path of its parent node's child array (the root group is `''`).
+ * An operation that introduces a subtree also drops the verdicts for the
+ * groups inside it, so a reused key cannot inherit a stale verdict from a
+ * group that previously held it. Reads only the operation path and node;
+ * never walks the value from the root.
+ */
+export function invalidateVerifiedGroups(
+  groups: Set<string>,
+  operation: Exclude<
+    EngineOperation,
+    {type: 'set.selection' | 'insert.text' | 'remove.text'}
+  >,
+): void {
+  // Nothing is verified yet (the common case during a batch of edits, whose
+  // normalization is deferred), so there is nothing to invalidate. Skips the
+  // per-operation path serialization entirely on the hot insert path.
+  if (groups.size === 0) {
+    return
+  }
+
+  // Whole-value replacement (`set []`/`unset []`): every group is rebuilt.
+  if (operation.path.length === 0) {
+    groups.clear()
+    return
+  }
+
+  const drop = (prefix: Path): boolean => {
+    const id = groupId(prefix)
+    if (id === null) {
+      groups.clear()
+      return false
+    }
+    groups.delete(id)
+    return true
+  }
+
+  const dropSubtreeGroups = (node: Node, nodePath: Path): void => {
+    walkKeyedChildrenInValue(node, nodePath, (childPath) => {
+      const id = groupId(childPath.slice(0, -1))
+      if (id !== null) {
+        groups.delete(id)
+      }
+    })
+  }
+
+  const path = operation.path
+  const lastSegment = path[path.length - 1]
+
+  if (operation.type === 'insert') {
+    // The node joins the group containing the reference sibling.
+    const groupPath = path.slice(0, -1)
+    if (drop(groupPath) && operation.node._key !== undefined) {
+      dropSubtreeGroups(operation.node, [
+        ...groupPath,
+        {_key: operation.node._key},
+      ])
+    }
+    return
+  }
+
+  if (operation.type === 'unset') {
+    if (typeof lastSegment === 'string' && lastSegment !== '_key') {
+      // Unsetting a whole child-array field empties that field's group.
+      drop(path)
+      return
+    }
+    // Unsetting a node, or its `_key`, changes the node's own group.
+    const nodePath = lastSegment === '_key' ? path.slice(0, -1) : path
+    drop(nodePath.slice(0, -1))
+    return
+  }
+
+  // `set`
+  if (
+    typeof lastSegment === 'number' ||
+    isKeyedSegment(lastSegment) ||
+    lastSegment === '_key'
+  ) {
+    // Node replacement, or a `_key` change: the node's group changes.
+    const nodePath = lastSegment === '_key' ? path.slice(0, -1) : path
+    if (drop(nodePath.slice(0, -1)) && lastSegment !== '_key') {
+      const replacement = operation.value
+      if (
+        replacement !== null &&
+        typeof replacement === 'object' &&
+        !Array.isArray(replacement)
+      ) {
+        const replacementKey = (replacement as Node)._key
+        if (replacementKey !== undefined) {
+          dropSubtreeGroups(replacement as Node, [
+            ...nodePath.slice(0, -1),
+            {_key: replacementKey},
+          ])
+        }
+      }
+    }
+    return
+  }
+
+  if (typeof lastSegment === 'string') {
+    if (Array.isArray(operation.value)) {
+      // Replacing a child array rebuilds that field's group.
+      if (drop(path)) {
+        for (const child of operation.value as ReadonlyArray<Node>) {
+          if (child && child._key !== undefined) {
+            dropSubtreeGroups(child, [...path, {_key: child._key}])
+          }
+        }
+      }
+      return
+    }
+    // A plain property whose value may carry keyed nodes: re-verify all.
+    if (operation.value !== null && typeof operation.value === 'object') {
+      groups.clear()
+    }
+  }
+}
 
 /**
  * Keeps `blockIndexMap` in sync with the value, transforming it
@@ -15,6 +165,10 @@ import type {EditorContext} from './editor-snapshot'
  * on read (`getListIndexMap`) instead of per operation. List-item
  * numbering depends on block adjacency that any structural op can disturb
  * non-locally, so any structural op marks it dirty.
+ *
+ * `verifiedUniqueChildGroups` is invalidated per structural op so per-node
+ * duplicate-key normalization can skip groups whose membership is unchanged
+ * (see `invalidateVerifiedGroups`).
  */
 export function subscribeUpdateValue(
   context: Pick<EditorContext, 'keyGenerator' | 'schema'>,
@@ -66,6 +220,8 @@ export function subscribeUpdateValue(
     // than reason about which paths matter. The map is rebuilt lazily the
     // next time the renderer reads it.
     editor.listIndexMapDirty = true
+
+    invalidateVerifiedGroups(editor.verifiedUniqueChildGroups, operation)
   })
 
   return () => {

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -11,6 +11,7 @@ import {debug} from '../../internal-utils/debug'
 import {isEqualMarkDefs} from '../../internal-utils/equality'
 import {setNodeProperties} from '../../internal-utils/set-node-properties'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
 import {getChildren} from '../../traversal/get-children'
 import {getNode} from '../../traversal/get-node'
@@ -169,37 +170,71 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Fix duplicate _key among siblings
   if (path.length > 0 && nodeRecord['_key'] !== undefined) {
     const parent = getParent(editor.snapshot, path)
-    const siblings = parent
-      ? getChildren(editor.snapshot, parent.path)
-      : editor.snapshot.context.value.map((child, index) => ({
-          node: child,
-          path: [{_key: child._key}],
-          index,
-        }))
-
-    const siblingList = [...siblings]
     const key = nodeRecord['_key'] as string
+    // The child array holding this node is the field segment right after
+    // the parent's path. Read it straight off the parent node rather than
+    // re-resolving children from the root through the schema; fall back to
+    // `getChildren` only if that field isn't a plain array.
+    const childFieldName = parent
+      ? (path[parent.path.length] as string)
+      : undefined
+    const rawSiblings =
+      parent && typeof childFieldName === 'string'
+        ? (parent.node as Record<string, unknown>)[childFieldName]
+        : undefined
+    const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
+      ? editor.snapshot.context.value
+      : Array.isArray(rawSiblings)
+        ? (rawSiblings as ReadonlyArray<{_key?: string}>)
+        : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
 
-    // Find all siblings with this key
-    let firstIndex = -1
-    for (let i = 0; i < siblingList.length; i++) {
-      if (siblingList[i]!.node._key === key) {
-        if (firstIndex === -1) {
-          firstIndex = i
-        } else {
-          // Found a duplicate: rename the later occurrence
+    // A group of zero or one child can't hold a duplicate key, so it needs
+    // neither a scan nor a cache entry: re-checking it is already O(1). This
+    // is the common shape for container fields (a row's single cell, a
+    // cell's single content block) and single-span text blocks, so only
+    // genuinely multi-child groups ever cost a serialized id.
+    if (siblingNodes.length > 1) {
+      // Identify the group by its serialized path (the root group is `''`).
+      // The verdict survives edits elsewhere in the tree: it is dropped only
+      // when the op stream sees this group's own membership change (see
+      // `subscribeUpdateValue`). Verifying a group is O(siblings); caching
+      // the verdict keeps a bulk insert of n pre-keyed siblings at O(n)
+      // instead of O(n^2).
+      const groupId =
+        parent && typeof childFieldName === 'string'
+          ? serializePath([...parent.path, childFieldName])
+          : ''
+
+      if (!editor.verifiedUniqueChildGroups.has(groupId)) {
+        const seenKeys = new Set<string>()
+        let groupIsUnique = true
+        let duplicateIndexOfKey = -1
+
+        for (let index = 0; index < siblingNodes.length; index++) {
+          const siblingKey = siblingNodes[index]?._key
+          if (siblingKey === undefined) {
+            continue
+          }
+          if (seenKeys.has(siblingKey)) {
+            groupIsUnique = false
+            // The second occurrence of this node's own key is the one the
+            // previous per-node implementation renamed; preserve that so
+            // generated keys land on the same node.
+            if (siblingKey === key && duplicateIndexOfKey === -1) {
+              duplicateIndexOfKey = index
+            }
+          } else {
+            seenKeys.add(siblingKey)
+          }
+        }
+
+        if (duplicateIndexOfKey !== -1) {
           const newKey = editor.snapshot.context.keyGenerator()
           debug.normalization('Fixing duplicate key on node')
-          const dupParentPath = parent ? parent.path : []
           const numericPath: Path =
-            dupParentPath.length === 0
-              ? [i]
-              : [
-                  ...dupParentPath,
-                  getChildFieldName(editor.snapshot.context, parent!.path) ??
-                    'children',
-                  i,
-                ]
+            parent && typeof childFieldName === 'string'
+              ? [...parent.path, childFieldName, duplicateIndexOfKey]
+              : [duplicateIndexOfKey]
           editor.apply({
             type: 'set',
             path: [...numericPath, '_key'],
@@ -211,6 +246,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
             },
           })
           return
+        }
+
+        if (groupIsUnique) {
+          editor.verifiedUniqueChildGroups.add(groupId)
         }
       }
     }

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -19,6 +19,7 @@ function createBareEditor(value: Array<PortableTextBlock>): Editor {
   editor.containers = new Map()
   editor.blockIndexMap = new Map()
   editor.listIndexMap = new Map()
+  editor.verifiedUniqueChildGroups = new Set()
   editor.snapshot = {
     blockIndexMap: editor.blockIndexMap,
     context: {

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -320,7 +320,7 @@ function pruneSubtreeAtPath(
  * array-valued field; for each entry with a `_key`, recurses. Mirrors
  * `getNodeChildren` shape but without requiring container resolution.
  */
-function walkKeyedChildrenInValue(
+export function walkKeyedChildrenInValue(
   node: Node,
   nodePath: Path,
   visit: (childPath: Path) => void,

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -43,13 +43,11 @@ export function transformBlockIndexMap(
     case 'set.selection':
       return
     case 'insert': {
-      const lastSegment = op.path[op.path.length - 1]
-      // Resolve the anchor index (the path's last segment addresses an
-      // existing sibling for keyed paths, or a literal index for numeric).
-      const anchorIndex =
-        typeof lastSegment === 'number'
-          ? lastSegment
-          : resolveChildIndexInValue(beforeValue, op.path)
+      // Resolve the anchor index. The path's last segment addresses an
+      // existing sibling (keyed) or is a literal index (numeric); for keyed
+      // paths the map already holds the index (it reflects `beforeValue` here,
+      // before this op mutates it), so this is O(1) instead of a linear scan.
+      const anchorIndex = childIndexFromMap(map, beforeValue, op.path)
       if (anchorIndex < 0) {
         // The anchor doesn't exist in `beforeValue`, so the operation
         // cannot have changed the tree.
@@ -88,10 +86,7 @@ export function transformBlockIndexMap(
         }
         return
       }
-      const removeIndex =
-        typeof lastSegment === 'number'
-          ? lastSegment
-          : resolveChildIndexInValue(beforeValue, op.path)
+      const removeIndex = childIndexFromMap(map, beforeValue, op.path)
       pruneSubtreeAtPath(map, beforeValue, op.path)
       if (removeIndex >= 0) {
         const siblingContext = resolveSiblingContext(
@@ -149,7 +144,7 @@ export function transformBlockIndexMap(
       // Last segment is keyed or numeric (full node replacement). The
       // replacement may carry a different `_key` than the path
       // addresses, so locate the new node by index instead of by key.
-      const childIndex = resolveChildIndexInValue(beforeValue, op.path)
+      const childIndex = childIndexFromMap(map, beforeValue, op.path)
       pruneSubtreeAtPath(map, beforeValue, op.path)
       if (childIndex >= 0) {
         addSubtree(map, context, afterValue, [
@@ -167,6 +162,42 @@ export function transformBlockIndexMap(
  * value. Used when an op's path ends in a `KeyedSegment` instead of a
  * numeric index. Returns `-1` if not resolvable.
  */
+/**
+ * Resolve a child index for `path`'s last segment. Numeric last segments are
+ * the index directly; for keyed segments the block-index map holds it, and the
+ * map reflects `beforeValue` at the call sites (before this operation mutates
+ * the map), so it is an O(1) lookup instead of the linear scan in
+ * `resolveChildIndexInValue`. A numeric path segment can't form the map's keyed
+ * id, and a map miss falls back to the scan; the oracle/fuzz tests pin
+ * equivalence.
+ */
+function childIndexFromMap(
+  map: ReadonlyMap<string, number>,
+  beforeValue: ReadonlyArray<Node>,
+  path: Path,
+): number {
+  const last = path[path.length - 1]
+  if (typeof last === 'number') {
+    return last
+  }
+  if (isKeyedSegment(last)) {
+    let keyed = true
+    for (let i = 0; i < path.length - 1; i++) {
+      if (typeof path[i] === 'number') {
+        keyed = false
+        break
+      }
+    }
+    if (keyed) {
+      const index = map.get(serializePath(path))
+      if (index !== undefined) {
+        return index
+      }
+    }
+  }
+  return resolveChildIndexInValue(beforeValue, path)
+}
+
 function resolveChildIndexInValue(
   value: ReadonlyArray<Node>,
   path: Path,

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -52,6 +52,19 @@ export interface PortableTextEditorEngine extends DOMEditor {
    * per render, regardless of how many operations a batch applied.
    */
   listIndexMapDirty: boolean
+  /**
+   * Serialized paths of sibling groups (a node's keyed child array, or the
+   * root value array as `''`) whose children have been verified to carry no
+   * duplicate `_key`s. Per-node duplicate-key normalization skips groups
+   * listed here. The op stream removes a group only when an operation
+   * changes that group's own direct membership (insert/remove/re-key/replace
+   * of a direct child), so an edit deep inside one group never forces a
+   * re-scan of its ancestors, and an operation that introduces a subtree
+   * also removes that subtree's groups so a reused key can't inherit a stale
+   * verdict. Works identically at every depth; the root is just the group
+   * with the empty path.
+   */
+  verifiedUniqueChildGroups: Set<string>
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
 


### PR DESCRIPTION
Two per-operation scans of the sibling group, the same anti-pattern in two places, were the largest remaining engine `send` cost on bulk-insert and undo-of-delete paths. This PR makes both lookups skip the scan when the answer is already known.

Normalizing a freshly-inserted block (`normalizeNode`) scanned the whole sibling array for duplicate keys once per node, O(n^2) over a group of n. The scan now caches its verdict: `editor.verifiedUniqueChildGroups` records every sibling group already verified to hold unique keys, and `normalizeNode` skips the scan for a listed group. The op stream invalidates a group only when an operation changes that group's own direct membership, so re-inserting n blocks scans the root group once instead of n times. Duplicate keys are still detected and fixed identically; the dedup tests pass unchanged.

`transformBlockIndexMap`, which keeps the block-index map in sync per operation, resolved each op's child index with a linear `findIndex`. For the shapes the editor actually emits (a paste appending blocks, or a back-to-front bulk delete) the addressed node sits at the end of its group, so every op scanned the whole group. The map already holds every keyed path's index and still reflects `beforeValue` at each resolution call site, so the lookup is now O(1). It falls back to the linear scan when a path segment is numeric (which can't form the map's keyed id) or the map misses, so an unmaintained or stale map (the bare engine in `operation-channel.test.ts`, for instance) still resolves correctly. The oracle and fuzz tests in `transform-block-index-map.test.ts` pin that the transformed map equals one rebuilt fresh from `afterValue`, so the resolved indices are identical to before.

A third per-insert scan was prototyped and deliberately dropped: the key-collision check in `applyOperation` (`children.some(...)` per insert). Unlike the index lookup it returns a boolean, so a map miss is indistinguishable from "no collision" and there is no safe O(1) fallback. In an editor whose block-index map isn't maintained per operation it would miss a real collision and emit a corrupted `beforeValue` (which `operation-channel.test.ts` catches), so the collision check keeps its linear scan.

Net behavior is unchanged: both fixes preserve identical results (dedup behavior, map contents) and the full suite is green (809 unit, 1666 chromium).

Engine `send` time, chromium, medians of 3 runs, bare editor:

| N | insert (before to after) | undo (before to after) | delete (before to after) |
|---|---|---|---|
| 1,000 | 70 to 53ms (24%) | 35 to 20ms (43%) | 35 to 30ms (14%) |
| 4,000 | 500 to 314ms (37%) | 271 to 103ms (62%) | 244 to 188ms (23%) |
| 8,000 | 1388 to 695ms (50%) | 920 to 237ms (74%) | 735 to 672ms (9%) |