### PR TITLE
chore(renovate): require dashboard approval for `@sanity/*` updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,9 +42,6 @@
       "description": "Ensure internal and important packages open a PRs right away, without waiting for manual approval",
       "matchPackageNames": [
         "@portabletext/*",
-        "@sanity/schema",
-        "@sanity/types",
-        "@sanity/diff-match-patch",
         "react",
         "rxjs",
         "slate",


### PR DESCRIPTION
`@sanity/schema`, `@sanity/types`, and `@sanity/diff-match-patch` sat in the "open PRs right away, without waiting for manual approval" packageRule (`dependencyDashboardApproval: false`, weekday schedule), so Renovate auto-opened PRs for them. They're no longer important enough to justify jumping the queue.

Removing the three `@sanity/*` entries lets them fall back to the repo's `:dependencyDashboardApproval` default: their updates now collect in the dependency dashboard and only become PRs once approved there, like ordinary dependencies. `@portabletext/*`, `react`, `rxjs`, `slate*`, and `typescript` keep the immediate-PR behavior.

No version or lockfile change; this only affects when Renovate surfaces future `@sanity/*` updates.