### PR TITLE
refactor(sanity-bridge): extract createPortableTextMemberSchemaTypesFromOf

### DIFF
--- a/packages/sanity-bridge/src/portable-text-member-schema-types.test.ts
+++ b/packages/sanity-bridge/src/portable-text-member-schema-types.test.ts
@@ -1,0 +1,119 @@
+import {Schema as SanitySchema} from '@sanity/schema'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type ArraySchemaType,
+  type PortableTextBlock,
+  type SchemaType,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+import {
+  createPortableTextMemberSchemaTypes,
+  createPortableTextMemberSchemaTypesFromOf,
+} from './portable-text-member-schema-types'
+
+function compile(types: ReadonlyArray<unknown>) {
+  return SanitySchema.compile({
+    name: 'test',
+    types: types as Parameters<typeof SanitySchema.compile>[0]['types'],
+  }).get('content') as ArraySchemaType<PortableTextBlock>
+}
+
+describe(createPortableTextMemberSchemaTypesFromOf.name, () => {
+  test('called with the root `of`, produces the same shape as the public entry point', () => {
+    const root = compile([
+      defineType({
+        name: 'content',
+        type: 'array',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'image',
+            fields: [defineField({name: 'src', type: 'string'})],
+          }),
+        ],
+      }),
+    ])
+
+    expect(
+      createPortableTextMemberSchemaTypesFromOf(root, root.of ?? []),
+    ).toEqual(createPortableTextMemberSchemaTypes(root))
+  })
+
+  test('called with a non-root `of`, buckets that `of` -- not the root', () => {
+    // The root carries `image` as a block object; the foreign `of` we
+    // pass instead carries `caption`. The result must reflect the
+    // foreign `of` (caption), not the root (image).
+    const root = compile([
+      defineType({
+        name: 'content',
+        type: 'array',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'image',
+            fields: [defineField({name: 'src', type: 'string'})],
+          }),
+        ],
+      }),
+    ])
+
+    const foreignOf = compile([
+      defineType({
+        name: 'content',
+        type: 'array',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'caption',
+            fields: [defineField({name: 'text', type: 'string'})],
+          }),
+        ],
+      }),
+    ]).of as ReadonlyArray<SchemaType>
+
+    const result = createPortableTextMemberSchemaTypesFromOf(root, foreignOf)
+
+    expect(result.blockObjects.map((t) => t.name)).toEqual(['caption'])
+  })
+
+  test('`portableText` always points at the root, even when bucketizing a non-root `of`', () => {
+    const root = compile([
+      defineType({
+        name: 'content',
+        type: 'array',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'image',
+            fields: [defineField({name: 'src', type: 'string'})],
+          }),
+        ],
+      }),
+    ])
+
+    const foreignOf = compile([
+      defineType({
+        name: 'content',
+        type: 'array',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'caption',
+            fields: [defineField({name: 'text', type: 'string'})],
+          }),
+        ],
+      }),
+    ]).of as ReadonlyArray<SchemaType>
+
+    expect(
+      createPortableTextMemberSchemaTypesFromOf(root, foreignOf).portableText,
+    ).toBe(root)
+  })
+})

--- a/packages/sanity-bridge/src/portable-text-member-schema-types.ts
+++ b/packages/sanity-bridge/src/portable-text-member-schema-types.ts
@@ -37,9 +37,30 @@ export function createPortableTextMemberSchemaTypes(
   if (!portableTextType) {
     throw new Error("Parameter 'portabletextType' missing (required)")
   }
-  const blockType = portableTextType.of?.find(findBlockType) as
-    | BlockSchemaType
-    | undefined
+  return createPortableTextMemberSchemaTypesFromOf(
+    portableTextType,
+    portableTextType.of ?? [],
+  )
+}
+
+/**
+ * Bucketize an `of` array into the `PortableTextMemberSchemaTypes` shape.
+ *
+ * The root entry point ({@link createPortableTextMemberSchemaTypes}) calls
+ * this with the root's own `of`. Path-aware resolution calls it with the
+ * enclosing container's `of` — yielding the same shape sourced from the
+ * container's sub-schema instead of root. Mirrors the fractal structure
+ * of `@portabletext/schema`'s `getSubSchema`, where everything is a
+ * schema view and containers produce schema views.
+ *
+ * `rootPortableTextType` is threaded through because the result's
+ * `portableText` back-reference always points at root.
+ */
+export function createPortableTextMemberSchemaTypesFromOf(
+  rootPortableTextType: ArraySchemaType<PortableTextBlock>,
+  of: ReadonlyArray<SchemaType>,
+): PortableTextMemberSchemaTypes {
+  const blockType = of.find(findBlockType) as BlockSchemaType | undefined
   if (!blockType) {
     throw new Error('Block type is not defined in this schema (required)')
   }
@@ -64,7 +85,7 @@ export function createPortableTextMemberSchemaTypes(
   const inlineObjectTypes = (ofType.filter(
     (memberType) => memberType.name !== 'span',
   ) || []) as ObjectSchemaType[]
-  const blockObjectTypes = (portableTextType.of?.filter(
+  const blockObjectTypes = (of.filter(
     (field) => field.name !== blockType.name,
   ) || []) as ObjectSchemaType[]
 
@@ -74,7 +95,7 @@ export function createPortableTextMemberSchemaTypes(
     lists: resolveEnabledListItems(blockType),
     block: blockType,
     span: spanType,
-    portableText: portableTextType,
+    portableText: rootPortableTextType,
     inlineObjects: inlineObjectTypes,
     blockObjects: blockObjectTypes,
     annotations: (spanType as SpanSchemaType).annotations,


### PR DESCRIPTION
Factor the bucketization core of `createPortableTextMemberSchemaTypes` into a module-internal helper keyed on an `of` array. The root entry point is now the helper invoked with the root's own `of`; path-aware resolution (a follow-up in the same package) will invoke it with an enclosing container's `of`, producing the same shape sourced from the container's sub-schema instead of root.

## Why this shape

Mirrors `@portabletext/schema`'s `getSubSchema`, where everything is a `Schema` and containers produce Schemas. A code-block's interior is itself a Schema; a callout's interior is itself a Schema. PTE composes this into `getPathSubSchema`:

```ts
export function getPathSubSchema(snapshot, path) {
  const enclosing = getEnclosingContainer(snapshot, path)
  if (!enclosing) return snapshot.context.schema
  return getSubSchema(snapshot.context.schema, enclosing.of)
}
```

This PR sets up the Sanity side onto the same shape. The follow-up resolver, also in `@portabletext/sanity-bridge`, walks the runtime value + Sanity `ArraySchemaType` along a `path` and invokes the helper with the enclosing container's `of`. `PortableTextMemberSchemaTypes` returned at any depth carries the root `portableText` back-reference; the buckets get sourced from the right `of` at that depth.

## Scope

- Helper is module-internal — exported from its source file so the follow-up resolver can import it, **not** re-exported from `index.ts`. No public API change.
- `createPortableTextMemberSchemaTypes` signature unchanged, delegates to the helper with `portableTextType.of`. No behavior change for existing consumers.
- No changeset.

## Verification

- `pnpm --filter @portabletext/sanity-bridge test:unit` — 25/25 passing.
- `pnpm --filter @portabletext/sanity-bridge check:types` — clean.
- `pnpm --filter @portabletext/sanity-bridge check:lint` — clean.
- `pnpm --filter @portabletext/sanity-bridge build` — clean.

Each test was retroactively verified by breaking the implementation:

- Test 1 (delegation) fails when the public entry point passes a wrong `of` to the helper.
- Test 2 (back-reference) fails when the helper writes a wrong value to `portableText`.
- Test 3 (buckets) fails when bucket logic regresses.

## Out of scope

- The path-aware resolver itself. Spec at `/specs/sanity-bridge-path-aware-member-schema-types.md`; follow-up PRs cover that step and the Studio integration.