### PR TITLE
chore(renovate): drop the Slate package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,22 +40,9 @@
     },
     {
       "description": "Ensure internal and important packages open a PRs right away, without waiting for manual approval",
-      "matchPackageNames": [
-        "@portabletext/*",
-        "react",
-        "rxjs",
-        "slate",
-        "slate-dom",
-        "slate-react",
-        "typescript"
-      ],
+      "matchPackageNames": ["@portabletext/*", "react", "rxjs", "typescript"],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"]
-    },
-    {
-      "description": "Group Slate packages",
-      "matchPackageNames": ["/slate/"],
-      "groupName": "slate"
     },
     {
       "description": "Group Tailwind packages",


### PR DESCRIPTION
Slate was removed from the codebase (`refactor: remove "slate" from the codebase`), so nothing depends on `slate`, `slate-dom`, or `slate-react` anymore (confirmed: no `package.json` references them). Their two renovate rules are now dead config:

- the `slate`, `slate-dom`, `slate-react` entries in the "open PRs right away" package list, and
- the "Group Slate packages" grouping rule (`matchPackageNames: ["/slate/"]`).

This removes both. Config-only, no version or lockfile change; JSON validated. Follows #2853 (the `@sanity/*` approval change), which is where this loose thread was first noticed.