### PR TITLE
feat(sanity-bridge): add getSanitySubSchema walk

### DIFF
--- a/.changeset/sanity-bridge-get-sanity-sub-schema.md
+++ b/.changeset/sanity-bridge-get-sanity-sub-schema.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/sanity-bridge": minor
+---
+
+feat: add `getSanitySubSchema` walk
+
+`getSanitySubSchema(rootPortableTextType, value, path)` returns the `PortableTextMemberSchemaTypes` view that applies at `path`. Sanity-side counterpart to `@portabletext/schema`'s `getSubSchema`. Walks the path against the Portable Text value to find the nearest container ancestor (or the root) and bucketizes its `of` declaration into the same shape as `createPortableTextMemberSchemaTypes`.
+
+Studio integrations rendering Portable Text at container depth can resolve their schema view per-position instead of always reading from the root. `path`s that traverse only text blocks and their span children, stale `_key` references, and unregistered `_type`s all fall back to the root bucketization.

--- a/packages/sanity-bridge/src/get-sanity-sub-schema.integration.test.ts
+++ b/packages/sanity-bridge/src/get-sanity-sub-schema.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Studio-shaped integration suite for `getSanitySubSchema`.
+ *
+ * Mirrors the realistic lookup shapes Sanity Studio's render callbacks
+ * perform: `schemaTypes.blockObjects.find((t) => t.name === block._type)`,
+ * `schemaTypes.decorators.find((t) => t.value === schemaType.value)`,
+ * and so on. The fixtures set up the scenarios where today's flat-bucket
+ * provider misresolves (container-only types, positional override), plus
+ * the safety floor (root invariant, stale-path fallback) that guarantees
+ * existing root-only consumers see no behavioral change.
+ */
+
+import {Schema as SanitySchema} from '@sanity/schema'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type ArraySchemaType,
+  type PortableTextBlock,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+import {getSanitySubSchema} from './get-sanity-sub-schema'
+import {createPortableTextMemberSchemaTypes} from './portable-text-member-schema-types'
+
+function compile(
+  types: ReadonlyArray<unknown>,
+): ArraySchemaType<PortableTextBlock> {
+  return SanitySchema.compile({
+    name: 'test',
+    types: types as Parameters<typeof SanitySchema.compile>[0]['types'],
+  }).get('content') as ArraySchemaType<PortableTextBlock>
+}
+
+describe('getSanitySubSchema (Studio-shaped integration)', () => {
+  describe('container-only types at depth', () => {
+    // Code-block declares its own inline-object (`codeAnnotation`) and
+    // decorator (`hex`) that are only registered inside the code-block's
+    // `lines.of`, not at root. Today's flat-bucket provider misses these.
+    const codeBlockSchema = compile([
+      defineType({
+        type: 'object',
+        name: 'codeAnnotation',
+        fields: [defineField({type: 'string', name: 'note'})],
+      }),
+      defineType({
+        type: 'object',
+        name: 'code-block',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'lines',
+            of: [
+              defineArrayMember({
+                type: 'block',
+                name: 'block',
+                styles: [{title: 'Code', value: 'code'}],
+                lists: [],
+                marks: {
+                  decorators: [{title: 'Hex', value: 'hex'}],
+                  annotations: [],
+                },
+                of: [defineArrayMember({type: 'codeAnnotation'})],
+              }),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({type: 'block', name: 'block'}),
+          defineArrayMember({type: 'code-block'}),
+        ],
+      }),
+    ])
+
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'code-block',
+        _key: 'cb1',
+        lines: [
+          {
+            _type: 'block',
+            _key: 'line1',
+            style: 'code',
+            children: [
+              {_type: 'span', _key: 's1', text: 'foo', marks: ['hex']},
+              {_type: 'codeAnnotation', _key: 'ca1', note: 'inline'},
+            ],
+            markDefs: [],
+          },
+        ],
+      } as unknown as PortableTextBlock,
+    ]
+
+    test('inline-object registered only inside the container resolves at container depth', () => {
+      const schemaTypes = getSanitySubSchema(codeBlockSchema, value, [
+        {_key: 'cb1'},
+        'lines',
+        {_key: 'line1'},
+        'children',
+        {_key: 'ca1'},
+      ])
+
+      // Studio's `InlineObject.tsx` does:
+      //   schemaTypes.inlineObjects.find((t) => t.name === inline._type)
+      expect(
+        schemaTypes.inlineObjects.find((t) => t.name === 'codeAnnotation')
+          ?.name,
+      ).toEqual('codeAnnotation')
+    })
+
+    test('the same inline-object does NOT resolve against the root bucket', () => {
+      const rootSchemaTypes =
+        createPortableTextMemberSchemaTypes(codeBlockSchema)
+
+      expect(
+        rootSchemaTypes.inlineObjects.find((t) => t.name === 'codeAnnotation'),
+      ).toEqual(undefined)
+    })
+
+    test('decorator registered only inside the container resolves at container depth', () => {
+      const schemaTypes = getSanitySubSchema(codeBlockSchema, value, [
+        {_key: 'cb1'},
+        'lines',
+        {_key: 'line1'},
+        'children',
+        {_key: 's1'},
+      ])
+
+      // Studio's `Decorator.tsx` does:
+      //   schemaTypes.decorators.find((d) => d.value === schemaType.value)
+      expect(
+        schemaTypes.decorators.find((d) => d.value === 'hex')?.value,
+      ).toEqual('hex')
+    })
+
+    test('the same decorator does NOT resolve against the root bucket', () => {
+      const rootSchemaTypes =
+        createPortableTextMemberSchemaTypes(codeBlockSchema)
+
+      expect(rootSchemaTypes.decorators.find((d) => d.value === 'hex')).toEqual(
+        undefined,
+      )
+    })
+  })
+
+  describe('positional override (same `_type` registered under different parents)', () => {
+    // `calloutCard` registered as a block-object at root AND inside a
+    // `callout` container's `content.of`. The two registrations point at
+    // the same compiled type today (Sanity globally interns by name), so
+    // the discriminating fact is which BUCKET resolves: at depth, only
+    // `calloutCard` is in the bucket; at root, both `callout` and
+    // `calloutCard` are.
+    const positionalSchema = compile([
+      defineType({
+        type: 'object',
+        name: 'calloutCard',
+        fields: [defineField({type: 'string', name: 'rootField'})],
+      }),
+      defineType({
+        type: 'object',
+        name: 'callout',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'content',
+            of: [
+              defineArrayMember({type: 'block', name: 'block'}),
+              defineArrayMember({type: 'calloutCard'}),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({type: 'block', name: 'block'}),
+          defineArrayMember({type: 'callout'}),
+          defineArrayMember({type: 'calloutCard'}),
+        ],
+      }),
+    ])
+
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {_type: 'calloutCard', _key: 'rootCard'} as unknown as PortableTextBlock,
+      {
+        _type: 'callout',
+        _key: 'callout1',
+        content: [{_type: 'calloutCard', _key: 'nestedCard'}],
+      } as unknown as PortableTextBlock,
+    ]
+
+    test('block-object at root resolves against the root bucket containing both callout and calloutCard', () => {
+      const schemaTypes = getSanitySubSchema(positionalSchema, value, [
+        {_key: 'rootCard'},
+      ])
+
+      expect(schemaTypes.blockObjects.map((t) => t.name).sort()).toEqual([
+        'callout',
+        'calloutCard',
+      ])
+    })
+
+    test('block-object nested inside a container resolves against the container bucket containing only calloutCard', () => {
+      const schemaTypes = getSanitySubSchema(positionalSchema, value, [
+        {_key: 'callout1'},
+        'content',
+        {_key: 'nestedCard'},
+      ])
+
+      expect(schemaTypes.blockObjects.map((t) => t.name).sort()).toEqual([
+        'calloutCard',
+      ])
+    })
+  })
+
+  describe('safety floor: root-only consumers unchanged', () => {
+    const codeBlockSchema = compile([
+      defineType({
+        type: 'object',
+        name: 'code-block',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'lines',
+            of: [
+              defineArrayMember({
+                type: 'block',
+                name: 'block',
+                styles: [{title: 'Code', value: 'code'}],
+                lists: [],
+                marks: {decorators: [], annotations: []},
+                of: [],
+              }),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({type: 'block', name: 'block'}),
+          defineArrayMember({type: 'code-block'}),
+        ],
+      }),
+    ])
+
+    test('empty path returns the root bucketization (fractal invariant at depth zero)', () => {
+      expect(getSanitySubSchema(codeBlockSchema, [], [])).toEqual(
+        createPortableTextMemberSchemaTypes(codeBlockSchema),
+      )
+    })
+
+    test('top-level keyed path returns the root bucketization', () => {
+      const value: ReadonlyArray<PortableTextBlock> = [
+        {
+          _type: 'code-block',
+          _key: 'cb1',
+          lines: [],
+        } as unknown as PortableTextBlock,
+      ]
+
+      expect(
+        getSanitySubSchema(codeBlockSchema, value, [{_key: 'cb1'}]),
+      ).toEqual(createPortableTextMemberSchemaTypes(codeBlockSchema))
+    })
+
+    test('span path inside a root text block returns the root bucketization', () => {
+      const value: ReadonlyArray<PortableTextBlock> = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'x'}],
+        } as unknown as PortableTextBlock,
+      ]
+
+      expect(
+        getSanitySubSchema(codeBlockSchema, value, [
+          {_key: 'b1'},
+          'children',
+          {_key: 's1'},
+        ]),
+      ).toEqual(createPortableTextMemberSchemaTypes(codeBlockSchema))
+    })
+
+    test('stale `_key` reference falls back to the root bucketization without throwing', () => {
+      const value: ReadonlyArray<PortableTextBlock> = [
+        {
+          _type: 'code-block',
+          _key: 'cb1',
+          lines: [],
+        } as unknown as PortableTextBlock,
+      ]
+
+      expect(
+        getSanitySubSchema(codeBlockSchema, value, [
+          {_key: 'gone'},
+          'lines',
+          {_key: 'line1'},
+        ]),
+      ).toEqual(createPortableTextMemberSchemaTypes(codeBlockSchema))
+    })
+
+    test('unregistered `_type` along the walk falls back to the root bucketization', () => {
+      const value: ReadonlyArray<PortableTextBlock> = [
+        {
+          _type: 'unknown-type',
+          _key: 'u1',
+          children: [],
+        } as unknown as PortableTextBlock,
+      ]
+
+      expect(
+        getSanitySubSchema(codeBlockSchema, value, [
+          {_key: 'u1'},
+          'children',
+          {_key: 'x'},
+        ]),
+      ).toEqual(createPortableTextMemberSchemaTypes(codeBlockSchema))
+    })
+  })
+})

--- a/packages/sanity-bridge/src/get-sanity-sub-schema.test.ts
+++ b/packages/sanity-bridge/src/get-sanity-sub-schema.test.ts
@@ -1,0 +1,241 @@
+import {Schema as SanitySchema} from '@sanity/schema'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type ArraySchemaType,
+  type PortableTextBlock,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+import {getSanitySubSchema} from './get-sanity-sub-schema'
+import {createPortableTextMemberSchemaTypesFromOf} from './portable-text-member-schema-types'
+
+function compile(
+  types: ReadonlyArray<unknown>,
+): ArraySchemaType<PortableTextBlock> {
+  return SanitySchema.compile({
+    name: 'test',
+    types: types as Parameters<typeof SanitySchema.compile>[0]['types'],
+  }).get('content') as ArraySchemaType<PortableTextBlock>
+}
+
+describe(getSanitySubSchema.name, () => {
+  const codeBlockRoot = compile([
+    defineType({
+      type: 'object',
+      name: 'code-block',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'lines',
+          of: [
+            defineArrayMember({
+              type: 'block',
+              name: 'block',
+              styles: [{title: 'Code', value: 'code'}],
+              lists: [],
+              marks: {decorators: [], annotations: []},
+              of: [],
+            }),
+          ],
+        }),
+      ],
+    }),
+    defineType({
+      type: 'array',
+      name: 'content',
+      of: [
+        defineArrayMember({type: 'block', name: 'block'}),
+        defineArrayMember({type: 'code-block'}),
+      ],
+    }),
+  ])
+
+  test('empty path returns the root bucketization', () => {
+    expect(getSanitySubSchema(codeBlockRoot, [], [])).toEqual(
+      createPortableTextMemberSchemaTypesFromOf(
+        codeBlockRoot,
+        codeBlockRoot.of ?? [],
+      ),
+    )
+  })
+
+  test('top-level keyed path returns the root bucketization (target is at root)', () => {
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'code-block',
+        _key: 'cb1',
+        lines: [],
+      } as unknown as PortableTextBlock,
+    ]
+    expect(getSanitySubSchema(codeBlockRoot, value, [{_key: 'cb1'}])).toEqual(
+      createPortableTextMemberSchemaTypesFromOf(
+        codeBlockRoot,
+        codeBlockRoot.of ?? [],
+      ),
+    )
+  })
+
+  test('child of a depth-1 block returns that block child `of` bucketization', () => {
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'code-block',
+        _key: 'cb1',
+        lines: [{_type: 'block', _key: 'line1', style: 'code', children: []}],
+      } as unknown as PortableTextBlock,
+    ]
+    const result = getSanitySubSchema(codeBlockRoot, value, [
+      {_key: 'cb1'},
+      'lines',
+      {_key: 'line1'},
+    ])
+
+    // code-block's `lines.of` is just `[block]` — no block-objects.
+    expect(result.blockObjects).toEqual([])
+    // `portableText` is the root array type, carries form-builder
+    // context regardless of depth.
+    expect(result.portableText).toBe(codeBlockRoot)
+  })
+
+  test('depth-2 walk: code-block nested inside callout resolves to code-block child `of` bucketization', () => {
+    const calloutNested = compile([
+      defineType({
+        type: 'object',
+        name: 'code-block',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'lines',
+            of: [
+              defineArrayMember({
+                type: 'block',
+                name: 'block',
+                styles: [{title: 'Code', value: 'code'}],
+                lists: [],
+                marks: {decorators: [], annotations: []},
+                of: [],
+              }),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'object',
+        name: 'callout',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'content',
+            of: [
+              defineArrayMember({type: 'block', name: 'block'}),
+              defineArrayMember({type: 'code-block'}),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({type: 'block', name: 'block'}),
+          defineArrayMember({type: 'callout'}),
+        ],
+      }),
+    ])
+
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'callout',
+        _key: 'callout1',
+        content: [
+          {
+            _type: 'code-block',
+            _key: 'cb1',
+            lines: [
+              {_type: 'block', _key: 'line1', style: 'code', children: []},
+            ],
+          },
+        ],
+      } as unknown as PortableTextBlock,
+    ]
+
+    const result = getSanitySubSchema(calloutNested, value, [
+      {_key: 'callout1'},
+      'content',
+      {_key: 'cb1'},
+      'lines',
+      {_key: 'line1'},
+    ])
+
+    // Code-block's `lines.of` has no block-objects — discriminates
+    // from the callout-level bucketization (which DOES include
+    // code-block as a block-object).
+    expect(result.blockObjects).toEqual([])
+  })
+
+  test('missing key in value falls back to root bucketization', () => {
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'code-block',
+        _key: 'cb1',
+        lines: [],
+      } as unknown as PortableTextBlock,
+    ]
+    const result = getSanitySubSchema(codeBlockRoot, value, [
+      {_key: 'gone'},
+      'lines',
+      {_key: 'line1'},
+    ])
+
+    expect(result).toEqual(
+      createPortableTextMemberSchemaTypesFromOf(
+        codeBlockRoot,
+        codeBlockRoot.of ?? [],
+      ),
+    )
+  })
+
+  test('span path falls back to the root bucketization (text block `children.of` is not Portable-Text-shaped)', () => {
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: 'x'}],
+      } as unknown as PortableTextBlock,
+    ]
+    const result = getSanitySubSchema(codeBlockRoot, value, [
+      {_key: 'b1'},
+      'children',
+      {_key: 's1'},
+    ])
+
+    expect(result).toEqual(
+      createPortableTextMemberSchemaTypesFromOf(
+        codeBlockRoot,
+        codeBlockRoot.of ?? [],
+      ),
+    )
+  })
+
+  test('unregistered `_type` along the walk falls back to root bucketization', () => {
+    const value: ReadonlyArray<PortableTextBlock> = [
+      {
+        _type: 'unknown-block-object',
+        _key: 'unknown1',
+        children: [{_type: 'span', _key: 's1', text: 'x'}],
+      } as unknown as PortableTextBlock,
+    ]
+    const result = getSanitySubSchema(codeBlockRoot, value, [
+      {_key: 'unknown1'},
+      'children',
+      {_key: 's1'},
+    ])
+
+    expect(result).toEqual(
+      createPortableTextMemberSchemaTypesFromOf(
+        codeBlockRoot,
+        codeBlockRoot.of ?? [],
+      ),
+    )
+  })
+})

--- a/packages/sanity-bridge/src/get-sanity-sub-schema.ts
+++ b/packages/sanity-bridge/src/get-sanity-sub-schema.ts
@@ -1,0 +1,197 @@
+import {
+  isArraySchemaType,
+  isKeySegment,
+  type ArraySchemaType,
+  type Path,
+  type PortableTextBlock,
+  type SchemaType,
+} from '@sanity/types'
+import {
+  createPortableTextMemberSchemaTypesFromOf,
+  type PortableTextMemberSchemaTypes,
+} from './portable-text-member-schema-types'
+
+/**
+ * Resolve the {@link PortableTextMemberSchemaTypes} view at `path`
+ * against `value`. Walks `path` to find the nearest Portable-Text-
+ * shaped ancestor — a container's child array, or the root — and
+ * bucketizes its `of` declaration into the same shape as
+ * {@link createPortableTextMemberSchemaTypes}.
+ *
+ * Sanity-side counterpart to `@portabletext/schema`'s `getSubSchema`,
+ * composed with the same walk that PTE's `getPathSubSchema` performs.
+ * The two functions answer the same question — "what's the schema
+ * here?" — in their respective type universes: `@portabletext/schema`
+ * operates over the PTE `Schema` shape; this one over Sanity's
+ * `SchemaType`. Same algorithm, different inputs.
+ *
+ * The walk is structured against the raw Sanity `ArraySchemaType` and
+ * value tree directly, without consulting PTE's runtime `Containers`
+ * map, so it can run from anywhere a Studio integration sits.
+ *
+ * A "Portable-Text-shaped" `of` is an array declaration that includes
+ * a `{type: 'block'}` member. Text blocks' `children` field carries a
+ * span-content `of` (no block member) and is not Portable-Text-shaped;
+ * descending into it would not yield a `PortableTextMemberSchemaTypes`
+ * view. The walk therefore tracks the deepest PT-shaped `of` it has
+ * traversed and returns its bucketization. When `path` traverses no
+ * containers (or is empty), returns the root bucketization.
+ *
+ * Falls back to the root bucketization when:
+ * - `path` traverses only text blocks and their span children,
+ * - any segment along the walk can't be resolved against the value, or
+ * - any member along the walk has no child array field.
+ *
+ * @public
+ */
+export function getSanitySubSchema(
+  rootPortableTextType: ArraySchemaType<PortableTextBlock>,
+  value: ReadonlyArray<PortableTextBlock>,
+  path: Path,
+): PortableTextMemberSchemaTypes {
+  const enclosingOf = resolveEnclosingOf(rootPortableTextType, value, path)
+  return createPortableTextMemberSchemaTypesFromOf(
+    rootPortableTextType,
+    enclosingOf ?? rootPortableTextType.of ?? [],
+  )
+}
+
+/**
+ * Walk `path` and return the deepest Portable-Text-shaped `of`
+ * traversed (the `of` of the nearest container ancestor). Returns
+ * `undefined` when the walk traverses no containers — the root `of`
+ * is the answer.
+ */
+function resolveEnclosingOf(
+  rootPortableTextType: ArraySchemaType<PortableTextBlock>,
+  value: ReadonlyArray<PortableTextBlock>,
+  path: Path,
+): ReadonlyArray<SchemaType> | undefined {
+  const parentKeyedIndex = findParentKeyedIndex(path)
+  if (parentKeyedIndex < 0) {
+    return undefined
+  }
+
+  let currentOf: ReadonlyArray<SchemaType> = rootPortableTextType.of ?? []
+  let currentChildren: ReadonlyArray<PortableTextBlock> = value
+  let containerOf: ReadonlyArray<SchemaType> | undefined
+
+  for (let segmentIndex = 0; segmentIndex <= parentKeyedIndex; segmentIndex++) {
+    const segment = path[segmentIndex]!
+    if (typeof segment === 'string') {
+      continue
+    }
+
+    let childNode: PortableTextBlock | undefined
+    if (isKeySegment(segment)) {
+      childNode = currentChildren.find((child) => child._key === segment._key)
+    } else if (typeof segment === 'number') {
+      childNode = currentChildren.at(segment)
+    } else {
+      return containerOf
+    }
+    if (!childNode) {
+      return containerOf
+    }
+
+    const member = currentOf.find((entry) => entry.name === childNode._type)
+    if (!member) {
+      return containerOf
+    }
+
+    const childField = findChildArrayField(member)
+    if (!childField) {
+      // Terminal member (no editable children).
+      return containerOf
+    }
+
+    const nextOf = safeGetOf(childField.type) ?? []
+    if (isPortableTextShaped(nextOf)) {
+      containerOf = nextOf
+    }
+    currentOf = nextOf
+    const rawChildren = (childNode as Record<string, unknown>)[childField.name]
+    currentChildren = Array.isArray(rawChildren)
+      ? (rawChildren as ReadonlyArray<PortableTextBlock>)
+      : []
+  }
+
+  return containerOf
+}
+
+/**
+ * A Portable-Text-shaped `of` carries a member whose root type name
+ * is `'block'` — the same membership test
+ * {@link createPortableTextMemberSchemaTypesFromOf} uses to find the
+ * block type. Span-content arrays (text block `children.of`) don't
+ * qualify because their members are spans, not blocks.
+ */
+function isPortableTextShaped(of: ReadonlyArray<SchemaType>): boolean {
+  return of.some((entry) => walkToRoot(entry).name === 'block')
+}
+
+function walkToRoot(type: SchemaType): SchemaType {
+  return type.type ? walkToRoot(type.type) : type
+}
+
+/**
+ * Locate the parent of the target node in `path`. The result is the
+ * index of the last-but-one keyed segment. When `path` has only one
+ * keyed segment, the parent is the root (returns `-1`).
+ */
+function findParentKeyedIndex(path: Path): number {
+  let lastKeyedIndex = -1
+  let parentKeyedIndex = -1
+  for (let index = 0; index < path.length; index++) {
+    const segment = path[index]
+    if (segment !== undefined && isKeySegment(segment)) {
+      parentKeyedIndex = lastKeyedIndex
+      lastKeyedIndex = index
+    }
+  }
+  return parentKeyedIndex
+}
+
+/**
+ * Find the (single) array field on a member type. Text blocks carry
+ * `children`; block-objects carry their own array field by
+ * construction. Other field types (string `style`, string `listItem`,
+ * object `markDefs`, etc.) are skipped. Members without a `fields`
+ * array (string members, primitive type aliases) yield `undefined`.
+ */
+function findChildArrayField(
+  member: SchemaType,
+): {name: string; type: ArraySchemaType} | undefined {
+  const fields = (
+    member as {fields?: ReadonlyArray<{name: string; type: SchemaType}>}
+  ).fields
+  if (!fields) {
+    return undefined
+  }
+  for (const field of fields) {
+    if (isArraySchemaType(field.type)) {
+      return {name: field.name, type: field.type}
+    }
+  }
+  return undefined
+}
+
+/**
+ * Read the `of` array off a Sanity `SchemaType` if it carries one.
+ * Mirrors the local helper in `sanity-schema-to-portable-text-schema.ts`.
+ * Sanity schema getters can throw on partially-compiled types; the
+ * try/catch keeps the walk robust at edges.
+ */
+function safeGetOf(
+  schemaType: SchemaType,
+): ReadonlyArray<SchemaType> | undefined {
+  try {
+    if (schemaType.jsonType === 'array') {
+      const arrayOf = (schemaType as ArraySchemaType).of
+      return Array.isArray(arrayOf) ? arrayOf : undefined
+    }
+  } catch {
+    // Sanity schema getters can throw — ignore
+  }
+  return undefined
+}

--- a/packages/sanity-bridge/src/index.ts
+++ b/packages/sanity-bridge/src/index.ts
@@ -2,4 +2,5 @@ export {
   createPortableTextMemberSchemaTypes,
   type PortableTextMemberSchemaTypes,
 } from './portable-text-member-schema-types'
+export {getSanitySubSchema} from './get-sanity-sub-schema'
 export {sanitySchemaToPortableTextSchema} from './sanity-schema-to-portable-text-schema'


### PR DESCRIPTION
Sanity-side counterpart to `@portabletext/schema`'s `getSubSchema`. Walks a path against a Portable Text value tree to find the nearest Portable-Text-shaped ancestor (a container's child array, or the root) and bucketizes its `of` declaration into a `PortableTextMemberSchemaTypes` view.

Same algorithm PTE's `getPathSubSchema` performs internally — `getEnclosingContainer` walk plus `getSubSchema` bucketization — composed into one function on the Sanity-typed side. `PortableTextMemberSchemaTypes` is Sanity-typed because Studio's form-builder integration needs the actual `ObjectSchemaType` references for `i18nTitleKey`, `options`, validation, etc.; translating to PTE `Schema` mid-walk would throw those away.

The walk runs against raw Sanity `ArraySchemaType` and value tree directly, without consulting PTE's runtime `Containers` map. The Sanity provider integration that consumes this lives in `@sanity/sanity` and doesn't carry a PTE editor reference; keeping the resolver runtime-free lets it run from wherever the provider sits.

A "Portable-Text-shaped" `of` is an array declaration whose members include a type whose root name is `block` — the same membership test `createPortableTextMemberSchemaTypesFromOf` uses to find the block type. Text blocks' `children` field carries a span-content `of` (no block member) and is not Portable-Text-shaped; the walk falls through it. Span paths therefore resolve to the enclosing container's bucketization, or to the root.

Naming follows the bridge's universe-first convention (`sanitySchemaToPortableTextSchema`): `getSanitySubSchema` reads as "give me the Sanity-typed sub-schema view" without colliding with `@portabletext/schema`'s same-named function (different universe, different return type).

Ships with a Studio-shaped integration suite that mimics the exact lookup patterns Sanity Studio's render callbacks perform (`schemaTypes.inlineObjects.find(t => t.name === ...)`, `schemaTypes.decorators.find(d => d.value === ...)`, `schemaTypes.blockObjects.map(t => t.name)`) and exercises the scenarios where today's flat-bucket provider misresolves:

- **Container-only types at depth.** Inline-objects and decorators registered only inside a container resolve at container depth; the same lookups against the root bucket return `undefined`.
- **Positional override across parents.** Block-objects registered both at root and inside a container resolve against the parent-specific bucket — root has `[callout, calloutCard]`, the container's depth has only `[calloutCard]`.
- **Safety floor.** Empty path, top-level keyed path, span path, stale `_key` reference, and unregistered `_type` all fall back to the root bucketization (structural equality to `createPortableTextMemberSchemaTypes(root)`). Existing root-only consumers see no behavioral change.

Step 2 of `/specs/sanity-bridge-path-aware-member-schema-types.md`. Step 3 (Studio's `PortableTextMemberSchemaTypesProvider` path-aware update) follows in `@sanity/sanity`.