### PR TITLE
test(sanity-bridge): benchmark getSanitySubSchema

### DIFF
--- a/packages/sanity-bridge/package.json
+++ b/packages/sanity-bridge/package.json
@@ -40,6 +40,7 @@
     "dev": "pkg-utils watch",
     "lint:fix": "biome lint --write .",
     "prepublishOnly": "turbo run build",
+    "test:bench": "vitest bench --run",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest watch"
   },

--- a/packages/sanity-bridge/src/get-sanity-sub-schema.bench.ts
+++ b/packages/sanity-bridge/src/get-sanity-sub-schema.bench.ts
@@ -1,0 +1,192 @@
+/**
+ * Micro-benchmark for `getSanitySubSchema` to establish a baseline cost
+ * per call and catch regressions on the path-walk + bucketization.
+ *
+ * Studio's `Compositor.tsx` calls `getSanitySubSchema` inside each of
+ * three render callbacks (block / inline / annotation). The callbacks
+ * fire once per rendered node — so the per-call cost is multiplied by
+ * the number of nodes the editor re-renders on each commit. The
+ * scenarios below cover the realistic shapes:
+ *
+ * - Root-level block in a small document (10 blocks, depth-1 path).
+ * - Root-level block in a large document (500 blocks, depth-1 path).
+ *   Heaviest realistic doc; stresses the root-level `.find()` over many
+ *   siblings.
+ * - Depth-2 path inside a container (callout > code-block > line). The
+ *   nested-container case the function is designed for.
+ * - Depth-3 path. Edge case (rare in practice).
+ * - Stale-path fallback in a large document. The `.find()` walk fails
+ *   over many siblings, then the function returns the root
+ *   bucketization.
+ */
+
+import {Schema as SanitySchema} from '@sanity/schema'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type ArraySchemaType,
+  type PortableTextBlock,
+} from '@sanity/types'
+import {bench, describe} from 'vitest'
+import {getSanitySubSchema} from './get-sanity-sub-schema'
+
+function compile(
+  types: ReadonlyArray<unknown>,
+): ArraySchemaType<PortableTextBlock> {
+  return SanitySchema.compile({
+    name: 'test',
+    types: types as Parameters<typeof SanitySchema.compile>[0]['types'],
+  }).get('content') as ArraySchemaType<PortableTextBlock>
+}
+
+const flatSchema = compile([
+  defineType({
+    type: 'object',
+    name: 'image',
+    fields: [defineField({type: 'string', name: 'alt'})],
+  }),
+  defineType({
+    type: 'array',
+    name: 'content',
+    of: [
+      defineArrayMember({type: 'block', name: 'block'}),
+      defineArrayMember({type: 'image'}),
+    ],
+  }),
+])
+
+const nestedSchema = compile([
+  defineType({
+    type: 'object',
+    name: 'code-block',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'lines',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            name: 'block',
+            styles: [{title: 'Code', value: 'code'}],
+            lists: [],
+            marks: {decorators: [], annotations: []},
+            of: [],
+          }),
+        ],
+      }),
+    ],
+  }),
+  defineType({
+    type: 'object',
+    name: 'callout',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({type: 'block', name: 'block'}),
+          defineArrayMember({type: 'code-block'}),
+        ],
+      }),
+    ],
+  }),
+  defineType({
+    type: 'array',
+    name: 'content',
+    of: [
+      defineArrayMember({type: 'block', name: 'block'}),
+      defineArrayMember({type: 'callout'}),
+    ],
+  }),
+])
+
+function buildFlatDoc(blockCount: number): ReadonlyArray<PortableTextBlock> {
+  const blocks: PortableTextBlock[] = []
+  for (let index = 0; index < blockCount; index++) {
+    blocks.push({
+      _type: 'block',
+      _key: `b${index}`,
+      children: [{_type: 'span', _key: `s${index}`, text: `block ${index}`}],
+      markDefs: [],
+    } as unknown as PortableTextBlock)
+  }
+  return blocks
+}
+
+function buildNestedDoc(blockCount: number): ReadonlyArray<PortableTextBlock> {
+  // Half the blocks are callouts containing a code-block containing a
+  // line; the rest are plain text blocks.
+  const blocks: PortableTextBlock[] = []
+  for (let index = 0; index < blockCount; index++) {
+    if (index % 2 === 0) {
+      blocks.push({
+        _type: 'block',
+        _key: `b${index}`,
+        children: [{_type: 'span', _key: `s${index}`, text: `block ${index}`}],
+        markDefs: [],
+      } as unknown as PortableTextBlock)
+    } else {
+      blocks.push({
+        _type: 'callout',
+        _key: `b${index}`,
+        content: [
+          {
+            _type: 'code-block',
+            _key: `cb${index}`,
+            lines: [
+              {
+                _type: 'block',
+                _key: `line${index}`,
+                style: 'code',
+                children: [{_type: 'span', _key: `s${index}`, text: 'code'}],
+                markDefs: [],
+              },
+            ],
+          },
+        ],
+      } as unknown as PortableTextBlock)
+    }
+  }
+  return blocks
+}
+
+describe('getSanitySubSchema', () => {
+  const smallFlat = buildFlatDoc(10)
+  const largeFlat = buildFlatDoc(500)
+  const largeNested = buildNestedDoc(500)
+
+  bench('depth-1 path, 10-block doc', () => {
+    getSanitySubSchema(flatSchema, smallFlat, [{_key: 'b5'}])
+  })
+
+  bench('depth-1 path, 500-block doc', () => {
+    getSanitySubSchema(flatSchema, largeFlat, [{_key: 'b250'}])
+  })
+
+  bench('depth-2 path, 500-block doc (callout > code-block)', () => {
+    getSanitySubSchema(nestedSchema, largeNested, [
+      {_key: 'b249'},
+      'content',
+      {_key: 'cb249'},
+    ])
+  })
+
+  bench('depth-3 path, 500-block doc (callout > code-block > line)', () => {
+    getSanitySubSchema(nestedSchema, largeNested, [
+      {_key: 'b249'},
+      'content',
+      {_key: 'cb249'},
+      'lines',
+      {_key: 'line249'},
+    ])
+  })
+
+  bench('stale `_key` fallback, 500-block doc', () => {
+    getSanitySubSchema(flatSchema, largeFlat, [{_key: 'gone'}])
+  })
+
+  bench('root case (empty path)', () => {
+    getSanitySubSchema(flatSchema, largeFlat, [])
+  })
+})


### PR DESCRIPTION
Establishes a baseline per-call cost for `getSanitySubSchema` and a regression check for the path-walk + bucketization.

Sanity Studio's `Compositor.tsx` calls `getSanitySubSchema` inside three render callbacks (block / inline / annotation), so the per-call cost is multiplied by the number of nodes the editor re-renders on each commit. The six scenarios cover root + depth-1 / depth-2 / depth-3 paths against small and large documents (10 vs 500 blocks), plus the stale-path fallback.

Baseline numbers from local hardware (vitest 4.1.8, Node 22):

| Scenario | Mean | Calls/sec |
|---|---|---|
| Root case (empty path) | 0.3 µs | 4.0M/s |
| Depth-1 path, 10-block doc | 0.2 µs | 4.2M/s |
| Depth-1 path, 500-block doc | 0.2 µs | 4.3M/s |
| Depth-2 path, 500-block doc | 2.4 µs | 424K/s |
| Depth-3 path, 500-block doc | 1.8 µs | 551K/s |
| Stale `_key` fallback, 500-block doc | 0.3 µs | 3.7M/s |

The root + depth-1 cases are virtually identical: the `.find()` over 500 siblings is dominated by string compares which JS optimizes hard. Each container hop adds ~1–2 µs (member resolution + child-field lookup, not the value walk).

For Studio's hot path — 3 callbacks × N nodes per commit at depth-2 — that's ~6N µs per commit. A 500-block doc fully re-rendering is ~3 ms; a single-block re-render is ~6 µs. Comfortably within frame budget for any realistic interaction.

Run via `pnpm --filter @portabletext/sanity-bridge test:bench`. Vitest's default `vitest run` ignores `*.bench.ts` files, so unit tests are unaffected.