### PR TITLE
fix: gate span `data-child-*` on the pipeline, not container nesting

### DIFF
--- a/.changeset/data-child-pipeline-gate.md
+++ b/.changeset/data-child-pipeline-gate.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: gate span `data-child-*` on the pipeline, not container nesting
+
+Spans rendered through the new pipeline (a `defineX` text-block registration, or any descendant of a container) no longer emit the legacy `data-child-key`/`data-child-name`/`data-child-type` attributes. Previously they appeared on top-level spans even when the text block was rendered through a catch-all registration, inconsistent with `data-slate-*`, which the new pipeline already omitted. Spans in the legacy pipeline (no `defineX` registration) are unchanged and still carry them.

--- a/packages/editor/src/editor/render.text.tsx
+++ b/packages/editor/src/editor/render.text.tsx
@@ -1,15 +1,15 @@
 import {useContext} from 'react'
 import type {Editable} from '../engine/react/components/editable'
-import {ParentContainerContext} from './parent-container-context'
+import {NewPipelineContext} from './new-pipeline-context'
 
 export type RenderTextProps = Parameters<
   NonNullable<React.ComponentProps<typeof Editable>['renderText']>
 >[0]
 
 export function RenderText(props: RenderTextProps) {
-  const parentContainer = useContext(ParentContainerContext)
+  const isInNewPipeline = useContext(NewPipelineContext)
 
-  if (parentContainer) {
+  if (isInNewPipeline) {
     const {'data-slate-node': _sn, ...rest} =
       props.attributes as typeof props.attributes & {
         'data-slate-node'?: string

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -703,4 +703,86 @@ describe('DOM structure', () => {
       expect(paragraph!.hasAttribute('data-slate-node')).toEqual(false)
     })
   })
+
+  test('9. root text block rendered via `defineTextBlock` catch-all omits `data-slate-*`/`data-child-*` on spans and inline objects', async () => {
+    await createTestEditor({
+      schemaDefinition: defineSchema({
+        inlineObjects: [{name: 'stock-ticker'}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello ', marks: []},
+            {_key: 'i0', _type: 'stock-ticker'},
+            {_key: 's1', _type: 'span', text: ' world', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineTextBlock({
+              type: '*',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+            }),
+          ]}
+        />
+      ),
+    })
+    await vi.waitFor(() => {
+      const el = document.querySelector('[data-slate-editor]')
+      expect(el).not.toEqual(null)
+      expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
+        [
+          '<div',
+          ' data-pt-path="[_key==&quot;b0&quot;]"',
+          ' data-pt-block="text">',
+          '<span',
+          ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
+          ' data-pt-inline="span">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
+          'hello ',
+          '</span>',
+          '</span>',
+          '</span>',
+          '<span',
+          ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;i0&quot;]"',
+          ' contenteditable="false"',
+          ' data-pt-inline="object">',
+          '<span',
+          ' data-pt-spacer="true"',
+          ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
+          '<span>',
+          '<span data-pt-marks="true">',
+          '<span data-pt-zero-width="true">',
+          '\uFEFF',
+          '</span>',
+          '</span>',
+          '</span>',
+          '</span>',
+          '<span contenteditable="false">',
+          '[stock-ticker: i0]',
+          '</span>',
+          '</span>',
+          '<span',
+          ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s1&quot;]"',
+          ' data-pt-inline="span">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
+          ' world',
+          '</span>',
+          '</span>',
+          '</span>',
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
 })


### PR DESCRIPTION
Studio's clean-break Portable Text input renders every block through `defineX` catch-all registrations, yet its top-level spans were still emitting the legacy `data-child-key`/`data-child-name`/`data-child-type` attributes, while spans inside a container (e.g. a table cell) were clean. Same span, two DOM shapes depending on nesting. That inconsistency is the bug.

## Diagnosis

`data-child-*` is legacy back-compat DOM, meant to be suppressed in the new pipeline alongside `data-slate-*`. `RenderText` (`render.text.tsx`) gated it on `ParentContainerContext` ("inside a container?"), while every other legacy-DOM site gates on `NewPipelineContext` ("in a `registerNode` subtree?"). These agree everywhere except a top-level text block rendered through a `defineTextBlock` catch-all: `isInNewPipelineForChild` returns `true` for it (`editor.textBlocks.has('*')`), so `text.tsx` correctly dropped `data-slate-node`, but `ParentContainerContext` is still undefined at the top level, so `RenderText` emitted `data-child-*`. Studio's clean break registers exactly that catch-all, so every top-level span leaked.

## The fix

Gate `RenderText` on `NewPipelineContext`, like every other legacy-DOM emission site. The branch logic is unchanged; only the context it reads changes. A span in any new-pipeline subtree (catch-all text block or container descendant) now omits `data-child-*`, matching the `data-slate-*` it already lacked. The legacy pipeline (no `defineX` registration) is untouched.

Scoped to spans. Inline objects emit `data-child-*` from a separate site (`RenderInlineObject`), but its default path runs only in the legacy pipeline: a new-pipeline *unregistered* inline object is intercepted earlier in `render.element.tsx`, which already renders a clean `data-pt-*`-only placeholder, and registered inline objects inherit the clean shape. So there was no inline-object leak to fix.

The test lives in `dom-structure.test.tsx`, the home for full-DOM assertions. Test 9 (new) is the new-pipeline twin of test 2 (its legacy counterpart): the same root block with spans and an inline object, rendered through a catch-all, asserting the whole subtree is `data-pt-*` only, no `data-slate-*`, no `data-child-*`. Green on chromium, firefox, and webkit.

## Blast radius

The only observable change is that spans in new-pipeline subtrees lose `data-child-*`, which they should never have had alongside the `data-slate-*` they already lacked. The legacy pipeline still emits the full back-compat shape. The full browser suite passes (the 8 failures are the known firefox-focus and webkit-headless flakes, green on re-run); the regression sweep across dom-structure, container, render, inline, annotation, and decorator tests is green.
