### PR TITLE
docs: clarify that ParentContainerContext is not a pipeline gate

### DIFF
--- a/packages/editor/src/editor/parent-container-context.ts
+++ b/packages/editor/src/editor/parent-container-context.ts
@@ -6,12 +6,17 @@ import type {ContainerConfig} from '../renderers/renderer.types'
  * config down the render tree. Undefined at the root level (top-level
  * elements have no parent container).
  *
- * Consumers use this to:
- *   - Check whether they're nested inside a container (truthiness check),
- *     which gates the editing-/pt-attribute split in the render pipeline.
- *   - Look up positional overrides via `parent.container.of` - a child
- *     `_type` declared inside parent's `of` is rendered using that
- *     positional registration instead of the global one.
+ * Used to look up positional overrides via `parent.container.of` -
+ * a child `_type` declared inside the parent's `of` is rendered using
+ * that positional registration instead of the global one.
+ *
+ * Not a pipeline gate. Whether the current render position emits the
+ * new-pipeline DOM shape (clean `data-pt-*`) or the legacy shape
+ * (`data-slate-*` + `data-child-*`) is governed by `NewPipelineContext`.
+ * A top-level catch-all `defineTextBlock` puts a render position inside
+ * the new pipeline without any parent container — reading this
+ * context's truthiness as a pipeline gate produces a stale answer for
+ * top-level catch-all subtrees.
  */
 export const ParentContainerContext = createContext<
   ContainerConfig | undefined


### PR DESCRIPTION
PR #2859 removed the last reader using `ParentContainerContext`'s truthiness to gate between the new-pipeline (clean `data-pt-*`) and legacy (`data-slate-*` + `data-child-*`) DOM shapes. `NewPipelineContext` is the sole gate now. The "Consumers use this to:" bullet still claimed the legacy-DOM-gate job, which is now stale.

Drops the stale bullet. Names the symmetry: `NewPipelineContext` governs the pipeline shape, this context governs positional-override lookup, and a top-level catch-all `defineTextBlock` is the case where their answers diverge — exactly the bug PR #2859 fixed.

Documentation only. No behavior change.