### PR TITLE
fix: select a dragged inline object at its destination

### DIFF
--- a/.changeset/drop-inline-object-selection.md
+++ b/.changeset/drop-inline-object-selection.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/editor": patch
+---
+
+fix: select a dragged inline object at its destination instead of the caret after it
+
+Dragging an inline object to a new position now leaves that object selected, the same as inserting one. Previously the caret was placed on the span immediately following the dropped object.

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -5,6 +5,7 @@ import {isCollapsedRange} from '../engine/range/is-collapsed-range'
 import {rangeEdges} from '../engine/range/range-edges'
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
 import {getDragSelection} from '../selectors/drag-selection'
+import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
 import {getFragment} from '../selectors/selector.get-fragment'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
@@ -330,6 +331,12 @@ export const coreDndBehaviors = [
 
       const draggingEntireBlocks = isSelectingEntireBlocks(dragSnapshot)
 
+      // A collapsed drag on a single inline object: the moved object keeps its
+      // `_key`, so it can be re-selected at the destination after the move.
+      const movedInlineObjectKey = draggingEntireBlocks
+        ? undefined
+        : getFocusInlineObject(dragSnapshot)?.node._key
+
       const draggedNodes = getFragment(dragSnapshot)
       const fittedBlocks = fitBlocksToDestination(
         {
@@ -350,6 +357,7 @@ export const coreDndBehaviors = [
           dragOrigin,
           originEvent: event.originEvent,
           fittedBlocks,
+          movedInlineObjectKey,
         }
       }
 
@@ -365,8 +373,26 @@ export const coreDndBehaviors = [
           dropPosition,
           originEvent,
           fittedBlocks,
+          movedInlineObjectKey,
         },
       ) => {
+        // The dropped object lives in the drop position's block, keyed by its
+        // preserved `_key`. Re-selecting it keeps the moved inline object
+        // selected, mirroring inserting an inline object, instead of leaving
+        // the caret on the span that follows it.
+        const movedInlineObjectSelection = movedInlineObjectKey
+          ? (() => {
+              const objectPath = [
+                ...dropPosition.anchor.path.slice(0, -2),
+                'children' as const,
+                {_key: movedInlineObjectKey},
+              ]
+              return {
+                anchor: {path: objectPath, offset: 0},
+                focus: {path: objectPath, offset: 0},
+              }
+            })()
+          : undefined
         // Source removal mirrors what the serializer carried: per dragged
         // node for an entire-blocks drag, by text range for a partial drag.
         const deleteEvents = draggingEntireBlocks
@@ -399,7 +425,11 @@ export const coreDndBehaviors = [
                   ? 'after'
                   : 'auto'
               : 'auto',
+            select: movedInlineObjectSelection ? 'none' : undefined,
           }),
+          ...(movedInlineObjectSelection
+            ? [raise({type: 'select', at: movedInlineObjectSelection})]
+            : []),
         ]
       },
     ],

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -332,10 +332,13 @@ export const coreDndBehaviors = [
       const draggingEntireBlocks = isSelectingEntireBlocks(dragSnapshot)
 
       // A collapsed drag on a single inline object: the moved object keeps its
-      // `_key`, so it can be re-selected at the destination after the move.
-      const movedInlineObjectKey = draggingEntireBlocks
-        ? undefined
-        : getFocusInlineObject(dragSnapshot)?.node._key
+      // `_key`, so it can be re-selected at the destination after the move. A
+      // text-range drag ending on an inline object is excluded by the
+      // collapsed-range guard so we don't mistake it for a single-object drag.
+      const movedInlineObjectKey =
+        !draggingEntireBlocks && isCollapsedRange(dragSelection)
+          ? getFocusInlineObject(dragSnapshot)?.node._key
+          : undefined
 
       const draggedNodes = getFragment(dragSnapshot)
       const fittedBlocks = fitBlocksToDestination(
@@ -380,18 +383,18 @@ export const coreDndBehaviors = [
         // preserved `_key`. Re-selecting it keeps the moved inline object
         // selected, mirroring inserting an inline object, instead of leaving
         // the caret on the span that follows it.
-        const movedInlineObjectSelection = movedInlineObjectKey
-          ? (() => {
-              const objectPath = [
-                ...dropPosition.anchor.path.slice(0, -2),
-                'children' as const,
-                {_key: movedInlineObjectKey},
-              ]
-              return {
-                anchor: {path: objectPath, offset: 0},
-                focus: {path: objectPath, offset: 0},
-              }
-            })()
+        const movedInlineObjectPath = movedInlineObjectKey
+          ? [
+              ...dropPosition.anchor.path.slice(0, -2),
+              'children' as const,
+              {_key: movedInlineObjectKey},
+            ]
+          : undefined
+        const movedInlineObjectSelection = movedInlineObjectPath
+          ? {
+              anchor: {path: movedInlineObjectPath, offset: 0},
+              focus: {path: movedInlineObjectPath, offset: 0},
+            }
           : undefined
         // Source removal mirrors what the serializer carried: per dragged
         // node for an entire-blocks drag, by text range for a partial drag.

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -197,6 +197,113 @@ describe('event.drag.drop', () => {
     })
   })
 
+  test('Scenario: dropping an inline object selects it at the destination, not the caret after it', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const sourceBlockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const barKey = keyGenerator()
+    const destBlockKey = keyGenerator()
+    const destSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: sourceBlockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo', marks: []},
+            {_type: 'stock-ticker', _key: stockTickerKey, symbol: 'AAPL'},
+            {_key: barKey, _type: 'span', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: destBlockKey,
+          _type: 'block',
+          children: [
+            {_key: destSpanKey, _type: 'span', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const stockTickerSelection = {
+      anchor: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: stockTickerKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: stockTickerKey}],
+        offset: 0,
+      },
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: stockTickerSelection,
+        },
+      },
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(serialized.mimeType, serialized.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: stockTickerSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+        },
+      },
+    })
+
+    // The moved inline object keeps its `_key`. After the drop, the selection
+    // should be collapsed on the object itself (path ending at the object's
+    // key), mirroring what inserting an inline object does, not on the span
+    // that follows it.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: destBlockKey}, 'children', {_key: stockTickerKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: destBlockKey}, 'children', {_key: stockTickerKey}],
+          offset: 0,
+        },
+        backward: false,
+      })
+    })
+  })
+
   test('Scenario: Dragging inline object', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -304,6 +304,114 @@ describe('event.drag.drop', () => {
     })
   })
 
+  test('Scenario: dropping a text range ending on an inline object preserves the default destination selection', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const sourceBlockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const barKey = keyGenerator()
+    const destBlockKey = keyGenerator()
+    const destSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: sourceBlockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo', marks: []},
+            {_type: 'stock-ticker', _key: stockTickerKey, symbol: 'AAPL'},
+            {_key: barKey, _type: 'span', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: destBlockKey,
+          _type: 'block',
+          children: [
+            {_key: destSpanKey, _type: 'span', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    // A text range spanning "foo" through the inline object — the focus
+    // lands on the inline object but the drag is a range, not a single
+    // object move.
+    const rangeSelection = {
+      anchor: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: fooKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: sourceBlockKey}, 'children', {_key: stockTickerKey}],
+        offset: 0,
+      },
+    }
+
+    const serialized = converterPortableText.serialize({
+      snapshot: {
+        ...editor.getSnapshot(),
+        context: {
+          ...editor.getSnapshot().context,
+          selection: rangeSelection,
+        },
+      },
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (serialized.type === 'serialization.failure') {
+      assert.fail(serialized.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(serialized.mimeType, serialized.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: rangeSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+            offset: 0,
+          },
+        },
+      },
+    })
+
+    // The drop should keep `insert.blocks`' default selection at the start of
+    // the destination span, not collapse onto the moved inline object's path.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: destBlockKey}, 'children', {_key: destSpanKey}],
+          offset: 0,
+        },
+        backward: false,
+      })
+    })
+  })
+
   test('Scenario: Dragging inline object', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()


### PR DESCRIPTION
Dragging an inline object to a new position left the caret on the span immediately *after* the dropped object instead of selecting the object. Inserting an inline object selects it (pinned by `event.insert.inline-object.test.tsx`, you press ArrowRight to land after it), so a drag-move landing one step further right is an inconsistency, and the reported papercut: you move a mention and the caret is sitting just past it rather than on it.

The dnd move runs through the `deserialization.success` handler in `behavior.core.dnd.ts`, which raises `insert.blocks` with no `select`. That falls back to `insert.blocks`' default, the start of the content following the inserted fragment, which for an inline object is the next span. `insert.blocks`' `start`/`end` can't fix this either: the fitted fragment leads with an empty span, so neither edge lands on the object.

So the handler now special-cases the one case that's wrong. When the drag is a single inline object (`getFocusInlineObject` on the drag selection, the moved object keeps its `_key`), it inserts with `select: 'none'` and then re-selects the object at the drop block:

```ts
const objectPath = [...dropPosition.anchor.path.slice(0, -2), 'children', {_key}]
raise({type: 'select', at: {anchor: {path: objectPath, offset: 0}, focus: {path: objectPath, offset: 0}}})
```

`dropPosition.anchor.path.slice(0, -2)` is the drop block's path (works at any container depth: it strips the trailing `'children', {_key: span}`). Drags of text ranges and entire blocks are untouched, they keep `insert.blocks`' default selection, so this only changes the inline-object case.

Pinned by a new scenario in `event.drag.drop.test.tsx` that drops an inline object and asserts the post-drop selection is collapsed on the moved object's own path. It fails on `main` (selection lands on the following span) and passes here; green on chromium/firefox/webkit. The existing drag/self-drop suites stay green.

Regression note, in the interest of honesty: the post-drop selection was never test-covered, so it drifted silently when dnd was rebuilt around `insert.blocks`. I didn't run a commit-level bisect because the drag test harness and event shapes predate the current APIs, so an automated bisect across the range isn't clean. The fix is justified by consistency with insert and is pinned going forward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX fix in DnD selection with explicit guards for range and block drags; covered by new tests.
> 
> **Overview**
> **Drag-and-drop** for a **single inline object** (collapsed selection) now leaves that object **selected** at the drop site, matching **insert inline object** behavior. Previously **`insert.blocks`** defaulted to the caret on the **span after** the dropped object.
> 
> The **`deserialization.success`** handler in **`behavior.core.dnd.ts`** detects this case via **`getFocusInlineObject`** and a collapsed drag selection (text-range drags that end on an inline object are excluded). It inserts with **`select: 'none'`**, then raises **`select`** on the moved object’s path using its preserved **`_key`** under the drop block.
> 
> Two drag-drop tests lock in the new selection and confirm **partial text-range** drops still use the default destination caret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb2fec54a4e9238eb03696d6bed242638c7b75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->