### PR TITLE
chore(renovate): prune inert and stale package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,19 +28,13 @@
     {
       "matchFileNames": ["packages/editor/package.json"],
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["react", "rxjs"],
+      "matchPackageNames": ["react"],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
     },
     {
-      "matchFileNames": ["packages/editor/package.json"],
-      "matchPackageNames": ["racejar"],
-      "rangeStrategy": "bump",
-      "semanticCommitType": "chore"
-    },
-    {
       "description": "Ensure internal and important packages open a PRs right away, without waiting for manual approval",
-      "matchPackageNames": ["@portabletext/*", "react", "rxjs", "typescript"],
+      "matchPackageNames": ["@portabletext/*", "react", "typescript"],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"]
     },
@@ -53,11 +47,6 @@
       "description": "Group XState packages",
       "matchPackageNames": ["/xstate/"],
       "groupName": "xstate"
-    },
-    {
-      "description": "Group @portabletext/plugin-* packages",
-      "matchPackageNames": ["@portabletext/plugin-*"],
-      "groupName": "portabletext-plugins"
     },
     {
       "description": "Group Cucumber packages",


### PR DESCRIPTION
Prunes Renovate `packageRules` that no longer match anything, so the config reflects the current workspace.

- **`rxjs`** is no longer a dependency anywhere, but it was still in the editor `devDependencies` range-strategy rule and the "open PRs right away" list. Removed from both (`react`, `typescript` stay).
- **`racejar` rule** (bump `racejar` in `packages/editor/package.json`) can never fire: editor depends on it via `workspace:*`, and Renovate doesn't update workspace-protocol deps. Removed.
- **`@portabletext/plugin-*` group** is inert for the same reason: every reference to those packages in the workspace is `workspace:*`/`workspace:^`, so there's never an update to group. Removed.

Kept deliberately: the `packages/racejar/package.json` entry in the published-package range rule (racejar is published, so its own dependency ranges still get the `bump` strategy), and the tailwind / xstate / jsdom / cucumber groups (real third-party deps that do get updated).

Verified each removal against the workspace: `rxjs` appears in no `package.json`; all `@portabletext/plugin-*` and the editor `racejar` references are `workspace:` protocol. No behavioral change beyond dropping rules that matched nothing. Config-only; JSON validated.
