### PR TITLE
fix: align the decorator-pair selection guard with `plugin-input-rule`

### DIFF
--- a/.changeset/character-pair-input-rule-guard.md
+++ b/.changeset/character-pair-input-rule-guard.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-character-pair-decorator': patch
+---
+
+fix: align the decorator-pair selection guard with `plugin-input-rule`
+
+The detection of whether the caret has moved away from a just-applied character-pair decoration now matches `@portabletext/plugin-input-rule`: it compares block key and offset and falls back to a raw selection comparison when the caret lands somewhere block offsets can't be computed (such as an inline object). As a result the plugin no longer depends on `remeda`.

--- a/packages/plugin-character-pair-decorator/package.json
+++ b/packages/plugin-character-pair-decorator/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@xstate/react": "catalog:",
-    "remeda": "catalog:",
     "xstate": "catalog:"
   },
   "devDependencies": {

--- a/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
+++ b/packages/plugin-character-pair-decorator/src/plugin.character-pair-decorator.ts
@@ -1,9 +1,13 @@
-import type {BlockOffset, Editor, EditorContext} from '@portabletext/editor'
+import type {
+  BlockOffset,
+  Editor,
+  EditorContext,
+  EditorSelection,
+} from '@portabletext/editor'
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, effect, raise} from '@portabletext/editor/behaviors'
 import * as utils from '@portabletext/editor/utils'
 import {useActorRef} from '@xstate/react'
-import {isDeepEqual} from 'remeda'
 import {
   assign,
   fromCallback,
@@ -53,6 +57,7 @@ type DecoratorPairEvent =
         anchor: BlockOffset
         focus: BlockOffset
       }
+      selection: EditorSelection
     }
   | {
       type: 'delete.backward'
@@ -99,7 +104,7 @@ const selectionListenerCallback: CallbackLogicFunction<
   // behavior events.
   const subscription = input.editor.on('selection', (event) => {
     if (!event.selection) {
-      sendBack({type: 'selection', blockOffsets: undefined})
+      sendBack({type: 'selection', blockOffsets: undefined, selection: null})
       return
     }
 
@@ -114,11 +119,19 @@ const selectionListenerCallback: CallbackLogicFunction<
     })
 
     if (!anchor || !focus) {
-      sendBack({type: 'selection', blockOffsets: undefined})
+      sendBack({
+        type: 'selection',
+        blockOffsets: undefined,
+        selection: event.selection,
+      })
       return
     }
 
-    sendBack({type: 'selection', blockOffsets: {anchor, focus}})
+    sendBack({
+      type: 'selection',
+      blockOffsets: {anchor, focus},
+      selection: event.selection,
+    })
   })
 
   return () => subscription.unsubscribe()
@@ -163,6 +176,7 @@ const decoratorPairMachine = setup({
       }) => string | undefined
       editor: Editor
       offsetAfterDecorator?: BlockOffset
+      endSelection: EditorSelection
       pair: {char: string; amount: number}
     },
     input: {} as {
@@ -191,6 +205,7 @@ const decoratorPairMachine = setup({
   context: ({input}) => ({
     decorator: input.decorator,
     editor: input.editor,
+    endSelection: null,
     pair: input.pair,
   }),
   initial: 'idle',
@@ -211,6 +226,8 @@ const decoratorPairMachine = setup({
           target: 'decorator added',
           actions: assign({
             offsetAfterDecorator: ({event}) => event.blockOffset,
+            endSelection: ({context}) =>
+              context.editor.getSnapshot().context.selection,
           }),
         },
       },
@@ -235,15 +252,41 @@ const decoratorPairMachine = setup({
         'selection': {
           target: 'idle',
           guard: ({context, event}) => {
-            const selectionChanged = !isDeepEqual(
-              {
-                anchor: context.offsetAfterDecorator,
-                focus: context.offsetAfterDecorator,
-              },
-              event.blockOffsets,
-            )
+            const offsetAfterDecorator = context.offsetAfterDecorator
 
-            return selectionChanged
+            if (event.blockOffsets && offsetAfterDecorator) {
+              // Block offsets are compared rather than raw selection points
+              // because they normalize away span-level differences (e.g. the
+              // cursor at the same position but in a different span after
+              // normalization).
+              const decoratorBlock = offsetAfterDecorator.path.at(-1)
+              const anchorBlock = event.blockOffsets.anchor.path.at(-1)
+              const focusBlock = event.blockOffsets.focus.path.at(-1)
+
+              if (
+                !utils.isKeyedSegment(decoratorBlock) ||
+                !utils.isKeyedSegment(anchorBlock) ||
+                !utils.isKeyedSegment(focusBlock)
+              ) {
+                return false
+              }
+
+              const anchorChanged =
+                decoratorBlock._key !== anchorBlock._key ||
+                offsetAfterDecorator.offset !== event.blockOffsets.anchor.offset
+              const focusChanged =
+                decoratorBlock._key !== focusBlock._key ||
+                offsetAfterDecorator.offset !== event.blockOffsets.focus.offset
+
+              return anchorChanged || focusChanged
+            }
+
+            // Block offsets can't be computed when the cursor is on an inline
+            // object, so fall back to comparing the raw selections.
+            return !utils.isEqualSelections(
+              context.endSelection,
+              event.selection,
+            )
           },
         },
         'delete.backward': {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -744,9 +744,6 @@ importers:
       '@xstate/react':
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1)
-      remeda:
-        specifier: 'catalog:'
-        version: 2.32.0
       xstate:
         specifier: 'catalog:'
         version: 5.32.1
@@ -16679,7 +16676,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@types/node@20.19.25)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@27.2.0)(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
`@portabletext/plugin-character-pair-decorator` and `@portabletext/plugin-input-rule` are built on the same state machine: an idle state, an active state that listens for `selection` and `delete.backward` (raising `history.undo` for smart-undo on Backspace), and a guard that returns to idle once the caret leaves the just-applied transformation. Their selection-change guards had drifted apart.

`plugin-input-rule`'s guard compares block key and offset (normalizing away span-level differences) and falls back to `isEqualSelections(endSelection, currentSelection)` when block offsets can't be computed, which happens when the caret lands on an inline object. The decorator-pair guard instead ran a bespoke deep equality over the `{anchor, focus}` block offsets, via `remeda`'s `isDeepEqual`, and treated "offsets unavailable" as "selection changed", with no raw-selection fallback.

This aligns the decorator-pair guard with `plugin-input-rule`: it compares each block offset's keyed block segment and offset through `isKeyedSegment`, and falls back to `isEqualSelections` otherwise. To support the fallback, the `selection` event now carries the raw selection and the machine tracks `endSelection` captured after the decoration.

Net behavior is unchanged for the common in-text caret (the plugin's browser suite, backspace + sub-schema, drives that path and stays green); the fallback only refines the inline-object case. Because the comparison now uses the editor's public `isEqualSelections`/`isKeyedSegment` utils, `remeda` is no longer needed and is dropped from the package's dependencies, it was the only package pulling `remeda` into a published install (the editor, `block-tools`, and `@portabletext/html` each vendor a local deep-equal in their `equality.ts` to avoid it).

Side note for the catalog: with this merged, `remeda` is no longer a runtime dependency of any published package (only `apps/playground` still uses it), so it should move from the default catalog to `catalogs.tooling` in #2867.
