### PR TITLE
chore: patch node-fetch@2 false-positive premature close breaking releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
       "@types/react": "$@types/react",
       "@types/react-dom": "$@types/react-dom",
       "@types/react-is": "$@types/react-is"
+    },
+    "patchedDependencies": {
+      "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch"
     }
   }
 }

--- a/patches/node-fetch@2.7.0.patch
+++ b/patches/node-fetch@2.7.0.patch
@@ -1,0 +1,39 @@
+diff --git a/lib/index.es.js b/lib/index.es.js
+index aae9799c1a8798d5899ffed6deda4c98b7007b48..ef123d67e2d89775ba8542c96dc7a6372f10ea3a 100644
+--- a/lib/index.es.js
++++ b/lib/index.es.js
+@@ -1740,7 +1740,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 				// if a data listener is still present we didn't end cleanly
+ 				const hasDataListener = socket && socket.listenerCount('data') > 0;
+ 
+-				if (hasDataListener && !hadError) {
++				if (hasDataListener && !hadError && !response.complete) {
+ 					const err = new Error('Premature close');
+ 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+ 					errorCallback(err);
+diff --git a/lib/index.js b/lib/index.js
+index 567ff5da58e83683bec0ea9e86221041ddf9435f..580872b1135530f3744f94f998a78dd0c3b8d307 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1744,7 +1744,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 				// if a data listener is still present we didn't end cleanly
+ 				const hasDataListener = socket && socket.listenerCount('data') > 0;
+ 
+-				if (hasDataListener && !hadError) {
++				if (hasDataListener && !hadError && !response.complete) {
+ 					const err = new Error('Premature close');
+ 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+ 					errorCallback(err);
+diff --git a/lib/index.mjs b/lib/index.mjs
+index 2863dd9c318754a77c6bfb57ec5e7db8759abd8b..8a491b962fa6f44e27d22244ee2377521b21d68e 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -1738,7 +1738,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 				// if a data listener is still present we didn't end cleanly
+ 				const hasDataListener = socket && socket.listenerCount('data') > 0;
+ 
+-				if (hasDataListener && !hadError) {
++				if (hasDataListener && !hadError && !response.complete) {
+ 					const err = new Error('Premature close');
+ 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+ 					errorCallback(err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,11 @@ overrides:
   '@types/react-dom': ^19.2.3
   '@types/react-is': ^19.2.0
 
+patchedDependencies:
+  node-fetch@2.7.0:
+    hash: b0d5cc14560f7561e59b22f6ce0c4264b42472f44800c61d491f2f774d06c486
+    path: patches/node-fetch@2.7.0.patch
+
 importers:
 
   .:
@@ -9069,7 +9074,7 @@ snapshots:
   '@changesets/get-github-info@0.7.0':
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(patch_hash=b0d5cc14560f7561e59b22f6ce0c4264b42472f44800c61d491f2f774d06c486)
     transitivePeerDependencies:
       - encoding
 
@@ -15049,7 +15054,7 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(patch_hash=b0d5cc14560f7561e59b22f6ce0c4264b42472f44800c61d491f2f774d06c486):
     dependencies:
       whatwg-url: 5.0.0
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}


### PR DESCRIPTION
The Release workflow's `changesets` job has been failing in the `@changesets/cli version` step while generating changelog entries ([run](https://github.com/portabletext/editor/actions/runs/28359058951/job/84009024598)):

```
FetchError: Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
code: ERR_STREAM_PREMATURE_CLOSE
  at node-fetch@2.7.0/lib/index.js:400 (Gunzip)
```

`@changesets/changelog-github` → `@changesets/get-github-info` queries the GitHub GraphQL API through `node-fetch@2.7.0` (the only `node-fetch@2` consumer in the tree). A Node security release, the *"fix response queue poisoning in `http.Agent`"* change shipped across **all** maintained lines (22.23.0 included), altered keep-alive socket-reuse timing: the response stream's `close` fires after the socket is returned to the agent and marked free, so `node-fetch@2`'s end detector sees the agent's guard `data` listener and raises a false-positive premature close on a cleanly completed, gzipped response.

References: node-fetch#1767, nodejs/node#63989, changesets#2115.

This is why the earlier Node-22 pin (portabletext/.github#16) didn't help, the regression is in every maintained line, not Node 24 specifically. Reverting to a pre-regression patch would reintroduce the security fix it shipped with, and upgrading changesets doesn't help (`get-github-info@0.8.0` still depends on `node-fetch@2`).

So this patches `node-fetch@2.7.0` with the fix from the upstream thread: guard the premature-close error with `!response.complete`, so a response the runtime already marked complete isn't reported as prematurely closed. It's the same change `node-fetch@3` already carries, applied via `pnpm patch` (`patches/node-fetch@2.7.0.patch`, three identical call sites across `lib/index.js`/`.es.js`/`.mjs`). Verified `pnpm install --frozen-lockfile` applies it and the installed copy carries the guard.

Release-tooling only; no published code or dependency-range changes, so no changeset.

Cross-repo note: every PT repo releasing through the shared `changesets.yml` hits this. The same `pnpm patch` is the per-repo fix; alternatively, once a Node line carrying the upstream fix lands on the Actions runners, bumping the workflow's Node pin would fix them all at once and this patch could be dropped.

---

**Vercel deploys (second commit).** The new `patchedDependencies` entry surfaced a latent version drift. Vercel installs this pnpm-10 repo with its bundled **pnpm 9** (old-project default; it ignores `"packageManager": "pnpm@10.25.0"` unless the project sets `ENABLE_EXPERIMENTAL_COREPACK=1`), and a `corepack enable` in the install command doesn't override it because Vercel's pnpm 9 sits ahead of the corepack shim on PATH. pnpm 9 then rejects the lockfile on frozen install, not over the dependency graph (identical) but over the patch entry: the patch is recorded with pnpm 10's hash, which pnpm 9 computes differently (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`).

The root `vercel.json` installs with `--no-frozen-lockfile`, so pnpm 9 re-derives the patch metadata and applies the version-agnostic patch file; resolved versions don't change, only the version-mismatch guard is relaxed on an otherwise-correct lockfile. The cleaner fix is to set `ENABLE_EXPERIMENTAL_COREPACK=1` on the Vercel project so it uses the repo's pnpm 10, after which this can return to `--frozen-lockfile`.
