### PR TITLE
fix: write a `text`-named field on an inline object during value sync

### DIFF
--- a/.changeset/inline-object-text-field-sync.md
+++ b/.changeset/inline-object-text-field-sync.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: write a `text`-named field on an inline object during value sync
+
+An inline object with a custom field named `text` now picks up changes to that
+field when the editor receives an updated value. Previously the change was
+dropped: the editor reconciled the field as if it were span text, so the new
+value never reached the inline object even though the incoming value carried it.

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -1002,14 +1002,21 @@ function updateBlock({
             oldBlockChild,
           )
 
-          const {text: _text, ...childProps} =
-            currentBlockChild as unknown as Record<string, unknown>
-
-          applySetNode(slateEditor, childProps, path)
-
           const isSpanNode =
             isSpan({schema: context.schema}, currentBlockChild) &&
             isSpan({schema: context.schema}, oldBlockChild)
+
+          const childProps = {
+            ...(currentBlockChild as unknown as Record<string, unknown>),
+          }
+
+          // A span's `text` is applied below via text operations. On an
+          // inline object `text` is an ordinary field and is written here.
+          if (isSpanNode) {
+            delete childProps['text']
+          }
+
+          applySetNode(slateEditor, childProps, path)
 
           if (isSpanNode && isTextChanged) {
             if (oldBlockChild.text.length > 0) {

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1572,4 +1572,62 @@ describe('event.update value', () => {
       expect(editor.getSnapshot().context.value).toEqual(newValue)
     })
   })
+
+  test("Scenario: Updating an inline object's `text` field", async () => {
+    const schemaDefinition = defineSchema({
+      inlineObjects: [
+        {name: 'inlineNote', fields: [{name: 'text', type: 'string'}]},
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [
+            {_key: 's1', _type: 'span', text: '', marks: []},
+            {_key: 'n1', _type: 'inlineNote', text: ''},
+            {_key: 's2', _type: 'span', text: '', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [
+            {_key: 's1', _type: 'span', text: '', marks: []},
+            {_key: 'n1', _type: 'inlineNote', text: 'hello'},
+            {_key: 's2', _type: 'span', text: '', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b1',
+          _type: 'block',
+          children: [
+            {_key: 's1', _type: 'span', text: '', marks: []},
+            {_key: 'n1', _type: 'inlineNote', text: 'hello'},
+            {_key: 's2', _type: 'span', text: '', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Backport of #2871 to the 6.x line.

An inline object with a custom field named `text` would not pick up edits to that field. You could open the inline object, set its `text`, and the change would persist to the document, but the editor's own value never reflected it: the field came back empty, and serializing the editor (a drag, a copy) produced the inline object without its `text`. Renaming the field to anything else (`caption`, `note`) made it sync correctly, which is what pinned it to the field name.

This is a regression introduced in `@portabletext/editor@6.6.1` (#2431, "fix: allow unsetting `text` prop on spans"). Before that, the child reconcile set the full child including `text` via `applySetNode`, so an inline object's `text` field synced. #2431 added a strip to let a span *unset* its text, but stripped `text` unconditionally for every child:

```ts
const {text: _text, ...childProps} = currentBlockChild as ...
applySetNode(slateEditor, childProps, path)
// ...later, only for spans:
if (isSpanNode && isTextChanged) { /* insert_text */ }
```

On an inline object, `text` is an ordinary field, not span text, so it was removed and then never re-applied (the `insert_text` branch is span-only). The equality check correctly reported the child as changed, so the sync ran; only the apply step dropped the field.

The fix strips `text` only when the child is a span. On a non-span child it flows through `applySetNode` like any other property:

```ts
const childProps = {...(currentBlockChild as ... Record<string, unknown>)}
if (isSpanNode) {
  delete childProps['text']
}
applySetNode(slateEditor, childProps, path)
```

Net behavior is unchanged for spans (their `text` still routes through `insert_text`) and for inline objects without a `text` field. The only observable delta is the fix.

Pinned by a new case in `tests/event.update-value.test.tsx` that sends an `update value` event changing an inline object's `text` from `''` to `'hello'` and asserts the editor's value reflects it. Verified red on the unpatched 6.x code (the field stays `''`) and green with the fix; the full update-value suite stays green (26 tests).
