### PR TITLE
chore(deps): self-declare `@sanity/pkg-utils` in every package, drop it from the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,6 @@
       "pnpm format:staged"
     ]
   },
-  "dependencies": {
-    "@sanity/pkg-utils": "^10.2.1"
-  },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
     "@changesets/changelog-github": "^0.5.2",

--- a/packages/plugin-character-pair-decorator/package.json
+++ b/packages/plugin-character-pair-decorator/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:*",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@vitejs/plugin-react": "catalog:tooling",

--- a/packages/plugin-dnd/package.json
+++ b/packages/plugin-dnd/package.json
@@ -53,6 +53,7 @@
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:^",
     "@portabletext/test": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@types/react-dom": "catalog:tooling",

--- a/packages/plugin-list-index/package.json
+++ b/packages/plugin-list-index/package.json
@@ -52,6 +52,7 @@
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:^",
     "@portabletext/test": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@types/react-dom": "catalog:tooling",

--- a/packages/plugin-markdown-shortcuts/package.json
+++ b/packages/plugin-markdown-shortcuts/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@vitejs/plugin-react": "catalog:tooling",

--- a/packages/plugin-one-line/package.json
+++ b/packages/plugin-one-line/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "babel-plugin-react-compiler": "catalog:tooling",

--- a/packages/plugin-paste-link/package.json
+++ b/packages/plugin-paste-link/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@vitejs/plugin-react": "catalog:tooling",

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -68,6 +68,7 @@
     "@portabletext/patches": "workspace:^",
     "@portabletext/schema": "workspace:^",
     "@portabletext/test": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/sdk-react": "^2.13.0",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "babel-plugin-react-compiler": "catalog:tooling",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,10 +110,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@sanity/pkg-utils':
-        specifier: ^10.2.1
-        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -755,6 +751,9 @@ importers:
       '@portabletext/schema':
         specifier: workspace:*
         version: link:../schema
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -806,6 +805,9 @@ importers:
       '@portabletext/test':
         specifier: workspace:^
         version: link:../test
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -985,6 +987,9 @@ importers:
       '@portabletext/test':
         specifier: workspace:^
         version: link:../test
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -1043,6 +1048,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -1088,6 +1096,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -1118,6 +1129,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -1185,6 +1199,9 @@ importers:
       '@portabletext/test':
         specifier: workspace:^
         version: link:../test
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/sdk-react':
         specifier: ^2.13.0
         version: 2.13.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.1)
@@ -1242,6 +1259,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0


### PR DESCRIPTION
The Renovate dashboard shows `fix(deps): update dependency @sanity/pkg-utils ...`. Unlike the other `fix` tooling entries (those are a stale dashboard, they flip to `chore` once Renovate re-runs against the merged `tooling` catalog), this one is genuinely `fix`, and chasing it down surfaced a workspace inconsistency.

The root `package.json` listed `@sanity/pkg-utils` under `dependencies` with a literal `^10.2.1`. It was acting as the hoisted-binary provider for eight plugin packages, `plugin-character-pair-decorator`, `plugin-dnd`, `plugin-list-index`, `plugin-markdown-shortcuts`, `plugin-one-line`, `plugin-paste-link`, `plugin-sdk-value`, `plugin-table`, that run `pkg-utils build` without declaring the dependency themselves: pnpm puts the root `node_modules/.bin` on `PATH` for every workspace script, so those packages resolved the binary from the root. The other fifteen packages already declare it as `catalog:tooling`.

Because the root reference sat in `dependencies`, the shared preset `sanity-io/renovate-config:semantic-commit-type` classified it as `fix(deps)`, so each bump opened a spurious patch release. (It's also why knip never flagged the root copy as unused, it saw those plugins' `pkg-utils build` invocations resolving to it.)

This makes the eight freeloaders declare `@sanity/pkg-utils: catalog:tooling` like the rest, then drops it from the root entirely. Every package now resolves its own binary, there's no root dependency for Renovate to misclassify, and the `tooling` catalog is the single version source.

Verified: clean `pnpm build` 27/27 (each package's `pkg-utils build` resolves its own copy with the root provider gone), `pnpm install --frozen-lockfile` in sync, `check:knip` and `check:format` green. No published runtime dependency changes, so no changeset.
