### PR TITLE
fix: return a path that identifies the node from `getNode`

### DIFF
--- a/.changeset/get-node-strips-trailing-field-segments.md
+++ b/.changeset/get-node-strips-trailing-field-segments.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: return a path that identifies the node from `getNode`
+
+`getNode(snapshot, path)` follows a path through the editor value and returns the deepest node it reaches. When the input path ended on a field-name string — e.g. `[{_key: 'image1'}, 'caption']` pointing into a block object's primitive field — the walker still resolved to the block but returned the input path verbatim, including the trailing field name. The contract was lying: `entry.path` didn't identify `entry.node`, and `getNode(snapshot, entry.path)` round-tripped to a different shape than the input had implied.
+
+The walker now strips trailing field-name segments from the returned path. `getNode` always returns a path that resolves back to the same node — `getNode(snapshot, entry.path).node === entry.node`.

--- a/packages/editor/src/traversal/get-node.test.ts
+++ b/packages/editor/src/traversal/get-node.test.ts
@@ -267,3 +267,51 @@ describe(getNode.name, () => {
     ).toBeUndefined()
   })
 })
+
+describe(`${getNode.name} strips trailing field-name segments`, () => {
+  const testbed = createNodeTraversalTestbed()
+
+  test('block-object path with trailing primitive field returns the block path', () => {
+    // `image` is a block object. A path that points into a primitive
+    // field of the block resolves to the block node itself; the
+    // returned path identifies the block, not the field.
+    const entry = getNode(testbed.snapshot, [{_key: 'k4'}, 'caption'])
+    expect(entry?.node).toBe(testbed.image)
+    expect(entry?.path).toEqual([{_key: 'k4'}])
+  })
+
+  test('span path with trailing `text` returns the span path', () => {
+    // `span1` has a primitive `text` field. A path that points into
+    // it resolves to the span itself.
+    const entry = getNode(testbed.snapshot, [
+      {_key: 'k3'},
+      'children',
+      {_key: 'k0'},
+      'text',
+    ])
+    expect(entry?.node).toBe(testbed.span1)
+    expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k0'}])
+  })
+
+  test('inline-object path with trailing primitive field returns the inline-object path', () => {
+    // `stockTicker1` is an inline object. A path that points into
+    // any field of it resolves to the inline object itself.
+    const entry = getNode(testbed.snapshot, [
+      {_key: 'k3'},
+      'children',
+      {_key: 'k1'},
+      'symbol',
+    ])
+    expect(entry?.node).toBe(testbed.stockTicker1)
+    expect(entry?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k1'}])
+  })
+
+  test('returned path round-trips through `getNode`', () => {
+    // A second `getNode` call against the returned path resolves to
+    // the same node — the path is a stable identifier.
+    const first = getNode(testbed.snapshot, [{_key: 'k4'}, 'caption'])
+    const second = getNode(testbed.snapshot, first?.path ?? [])
+    expect(second?.node).toBe(testbed.image)
+    expect(second?.path).toEqual([{_key: 'k4'}])
+  })
+})

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -14,8 +14,11 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * field name strings are skipped (they're structural), and numbers
  * are resolved by index.
  *
- * The returned path is always fully keyed, even if the input path
- * contained numeric indices.
+ * The returned `path` always identifies the returned node: it's fully
+ * keyed (numeric indices are converted to `KeyedSegment`s) and any
+ * trailing field-name segments in the input — e.g. `[{_key},'caption']`
+ * pointing into an object node's primitive field — are stripped so
+ * that `getNode(snapshot, entry.path).node === entry.node`.
  *
  * @beta
  */
@@ -96,6 +99,19 @@ export function getNode(
 
   if (!node) {
     return undefined
+  }
+
+  // Strip trailing field-name segments. The walker pushes every string
+  // segment onto `resolvedPath` unconditionally, but a string segment
+  // that follows the deepest reached node is a field reference inside
+  // the node, not part of the node's path. Returning the input path
+  // verbatim would mean `entry.path` doesn't identify `entry.node`,
+  // which breaks every reasonable composition.
+  while (
+    resolvedPath.length > 0 &&
+    typeof resolvedPath[resolvedPath.length - 1] === 'string'
+  ) {
+    resolvedPath.pop()
   }
 
   return {node, path: resolvedPath}


### PR DESCRIPTION
`getNode(snapshot, path)` walks a path through the editor value and returns the deepest node it reaches. Two parts of the contract were lying:

- When the input path ended on a field-name string — e.g. `[{_key: 'image1'}, 'caption']` pointing into a block object's primitive field — the walker still resolved to the block but returned the input path verbatim, including the trailing field name. `entry.path` didn't identify `entry.node`, and downstream composition (`isBlock(entry.path)`, `getEnclosingBlock(entry.path)`) misclassified the entry because it saw the field-suffixed path instead of the node's path.
- When the input path crossed into a sidecar field that isn't the node's structural child array — e.g. `[{_key: 'block1'}, 'markDefs', {_key: 'mark1'}]` reaching an annotation on a text block — the walker continued looking up keyed segments against the wrong child list (the block's `children` instead of its `markDefs`) and silently returned `undefined`. The behavior was mechanism-incidental: if a span happened to share a `_key` with a markDef, `getNode` would have returned that span.

Both cases now resolve to the deepest node reachable through the schema's structural descent. The walker consults the field name produced by each `getNodeChildren` and only descends when the next string segment matches; otherwise the rest of the path is treated as suffix. Trailing field-name segments are stripped from the returned path. `getNode(snapshot, entry.path).node === entry.node` for every returned entry.

Generalizes naturally to any sidecar shape — a container whose configured `arrayField` is `'markDefs'` still descends into it (because its `getNodeChildren` returns `fieldName: 'markDefs'`), while a text block at the same path doesn't. The schema decides what's structural.

### What to review

`packages/editor/src/traversal/get-node.ts` — the walker tracks `currentFieldName` from each descent. String segments are accepted only when they match; otherwise the loop breaks. The trailing-strip handles tail field names not matched against a descent.

`packages/editor/src/traversal/get-node.test.ts` — six new test cases:

- Block-object path with a trailing primitive field (`[{_key: 'image'}, 'caption']`) returns the block path.
- Span path with trailing `'text'` returns the span path.
- Inline-object path with a trailing field returns the inline-object path.
- Round-trip: feeding the returned path back into `getNode` resolves to the same node.
- Annotation path (`[{block}, 'markDefs', {ann}]`) resolves to the enclosing text block.
- Annotation path with a trailing field returns the text block.

`packages/editor/src/traversal/node-traversal-testbed.ts` — added `markDefs` to `textBlock1` so annotation cases are testable in the shared testbed.

Each branch discriminated by break-and-restore.

### Testing

- 26/26 `get-node.test.ts` pass.
- 827/827 editor unit tests pass.
- biome lint + prettier format + tsc + react-compiler all green.
- Caller audit done by hand: `behavior.abstract.annotation.ts` already strips `markDefs/{_key}` from `event.at` before calling `getNode`, so it doesn't depend on the annotation-path-returns-undefined behavior. Selection-point construction at `util.block-offset.ts:32` builds `[...blockPath, 'children', {_key: span._key}]` — no trailing `'text'` — so engine selection points already match the new contract.

### Why this exists

Surfaced reviewing sanity-io/sanity#13338 — Studio's depth-agnostic PT hooks classifier was inventing workarounds (`endsOnKeyedSegment` guard + trailing-string strip in `getEnclosingBlock` fallback) for the trailing-string half of this bug. Christian's "what happens if `getNode` is called with an annotation path?" probe surfaced the second half (the sidecar miss). Both halves are the same root cause: the walker wasn't honoring the schema's structural-field contract. Once this lands and releases, the classifier's workarounds become unnecessary, and #2879's `getAnnotation` composes cleanly with `getNode` because every path now resolves to *something* (the annotation via `getAnnotation`, or the enclosing block via `getNode`).