### PR TITLE
fix: validate `getSibling`'s `blockIndexMap` index against the value

### DIFF
--- a/.changeset/get-sibling-value-index.md
+++ b/.changeset/get-sibling-value-index.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: validate `getSibling`'s `blockIndexMap` index against the value
+
+`getSibling` still uses the block index map as an O(1) fast path, but now validates the index it returns against the resolved sibling list and falls back to a value scan when the map is missing or stale, an as-yet-unkeyed node, or a snapshot that pairs the live map with a pre-apply value. Previously it trusted the map blindly and returned `undefined` (reporting no sibling where one exists) or, when the map disagreed with the value, the wrong neighbour. This matches how `getNode`, `getChildren`, and `getAncestors` already treat the map.

--- a/packages/editor/src/traversal/get-sibling.test.ts
+++ b/packages/editor/src/traversal/get-sibling.test.ts
@@ -292,4 +292,34 @@ describe(getSibling.name, () => {
     expect(entry?.node).toBe(testbed.codeLine1)
     expect(entry?.path).toEqual([{_key: 'k11'}, 'code', {_key: 'k8'}])
   })
+
+  test('resolves the sibling from the value when the blockIndexMap misses', () => {
+    // getNode/getChildren/getAncestors linear-scan the value when
+    // blockIndexMap misses (unkeyed transient nodes) or disagrees with it (a
+    // textPatch snapshot pairs the live map with a pre-apply value).
+    // getSibling must be equally robust: an empty map stands in for either
+    // case, and the sibling still lives in the value.
+    const snapshot = {
+      context: testbed.snapshot.context,
+      blockIndexMap: new Map<string, number>(),
+    }
+
+    const next = getSibling(snapshot, [{_key: 'k3'}], {direction: 'next'})
+    expect(next?.node).toBe(testbed.image)
+    expect(next?.path).toEqual([{_key: 'k4'}])
+
+    const previous = getSibling(snapshot, [{_key: 'k4'}], {
+      direction: 'previous',
+    })
+    expect(previous?.node).toBe(testbed.textBlock1)
+    expect(previous?.path).toEqual([{_key: 'k3'}])
+
+    const nestedSpan = getSibling(
+      snapshot,
+      [{_key: 'k3'}, 'children', {_key: 'k0'}],
+      {direction: 'next'},
+    )
+    expect(nestedSpan?.node).toBe(testbed.stockTicker1)
+    expect(nestedSpan?.path).toEqual([{_key: 'k3'}, 'children', {_key: 'k1'}])
+  })
 })

--- a/packages/editor/src/traversal/get-sibling.ts
+++ b/packages/editor/src/traversal/get-sibling.ts
@@ -59,9 +59,28 @@ export function getSibling(
   const parent = parentPath(path)
   const children = getChildren(snapshot, parent)
 
-  const currentIndex = snapshot.blockIndexMap.get(serializePath(path))
+  // Prefer the O(1) `blockIndexMap` lookup, but validate it against the
+  // resolved children before trusting it. The map can miss (an unkeyed
+  // transient node) or disagree with the traversed value (a snapshot that
+  // pairs the live map with a pre-apply value, e.g. `textPatch`); only then
+  // fall back to an O(n) scan of `children`, which is value-derived and the
+  // source of truth. Mirrors the fast-path-then-scan in `getNode`/
+  // `getChildren`.
+  let currentIndex = snapshot.blockIndexMap.get(serializePath(path)) ?? -1
+  const mappedSegment = children[currentIndex]?.path.at(-1)
 
-  if (currentIndex === undefined) {
+  if (
+    !(isKeyedSegment(mappedSegment) && mappedSegment._key === lastSegment._key)
+  ) {
+    currentIndex = children.findIndex((child) => {
+      const childSegment = child.path.at(-1)
+      return (
+        isKeyedSegment(childSegment) && childSegment._key === lastSegment._key
+      )
+    })
+  }
+
+  if (currentIndex === -1) {
     return undefined
   }
 


### PR DESCRIPTION
Found by the traversal audit that followed the `getNode` path-contract fix (#2876, EDEX-1425), same family: a util over-trusting `blockIndexMap` without the value fallback the rest of the traversal layer carries.

`getSibling` looked up the current node's index with `blockIndexMap.get(serializePath(path))` and trusted it blindly, then indexed the value-derived sibling array (from `getChildren`) with it. `blockIndexMap` can **miss** (an unkeyed transient node) or **disagree** with the traversed value (a snapshot that pairs the live map with a pre-apply value, e.g. `textPatch`):

- On a **miss**, the lookup returned `undefined`, so `getSibling` reported *no sibling* where one exists.
- On a **disagreement**, the stale map index pointed at the wrong slot in the value-derived array, returning the *wrong* sibling.

`getNode`, `getChildren`, and `getAncestors` all take the map as a **fast path** and fall back to a value scan when it misses or disagrees; `getSibling` was the lone holdout trusting it unconditionally. It now validates the mapped index against the resolved `children` (does the child at that index carry the path's last keyed `_key`?) and scans only when it doesn't.

The O(1) lookup is preserved in the common case; the O(n) scan runs only on the stale-map snapshots. `children` was already materialized by `getChildren` (itself O(n)) to return the sibling node + path, so the fast path adds no asymptotic cost over what the function already did.

TDD: the new test (`resolves the sibling from the value when the blockIndexMap misses`) pairs the testbed value with an empty map and asserts next/previous/nested-span siblings still resolve. It fails on `main` (returns `undefined`) and passes with the fix; the existing 21 cases are unchanged.

Net behavior is unchanged when the map and value agree. `816` editor unit tests pass; types, lint, knip green.
