### PR TITLE
feat: add `getAnnotation` to `@portabletext/editor/traversal`

### DIFF
--- a/.changeset/add-get-annotation.md
+++ b/.changeset/add-get-annotation.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: add `getAnnotation` to `@portabletext/editor/traversal`
+
+`getAnnotation(snapshot, path)` resolves a path of the shape
+`[..., {_key: block}, 'markDefs', {_key: annotation}, ...]` to the
+annotation node on the enclosing text block. Annotations live in
+`markDefs` alongside `children` rather than inside the value tree, so
+they aren't reachable through `getNode`. The walker is schema-aware:
+a container whose own array field happens to be named `markDefs` does
+not resolve to an annotation.

--- a/packages/editor/src/traversal/get-annotation.test.ts
+++ b/packages/editor/src/traversal/get-annotation.test.ts
@@ -1,0 +1,210 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {buildIndexMaps} from '../internal-utils/build-index-maps'
+import {defineContainer} from '../renderers/renderer.types'
+import {getAnnotation} from './get-annotation'
+import {resolveTestbedContainers} from './node-traversal-testbed'
+
+function createAnnotationTestbed() {
+  const keyGenerator = createTestKeyGenerator()
+
+  const link1 = {_key: 'mark1', _type: 'link', href: 'https://a'}
+  const link2 = {_key: 'mark2', _type: 'link', href: 'https://b'}
+  const span1 = {
+    _key: keyGenerator(),
+    _type: 'span',
+    text: 'linked',
+    marks: ['mark1'],
+  }
+  const textBlock = {
+    _key: keyGenerator(),
+    _type: 'block',
+    children: [span1],
+    markDefs: [link1, link2],
+  }
+
+  const nestedLink = {_key: 'nested-mark', _type: 'link', href: 'https://c'}
+  const nestedSpan = {
+    _key: keyGenerator(),
+    _type: 'span',
+    text: 'nested',
+    marks: ['nested-mark'],
+  }
+  const nestedBlock = {
+    _key: keyGenerator(),
+    _type: 'block',
+    children: [nestedSpan],
+    markDefs: [nestedLink],
+  }
+  const weirdContainer = {
+    _key: keyGenerator(),
+    _type: 'weird-container',
+    markDefs: [nestedBlock],
+  }
+
+  const schema = compileSchema(
+    defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      blockObjects: [
+        {
+          name: 'weird-container',
+          fields: [
+            {
+              name: 'markDefs',
+              type: 'array',
+              of: [{type: 'block'}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+  const weirdContainerDef = defineContainer({
+    type: 'weird-container',
+    arrayField: 'markDefs',
+  })
+
+  const value = [textBlock, weirdContainer]
+  const containers = resolveTestbedContainers(schema, [weirdContainerDef])
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps(
+    {schema, containers, value},
+    {blockIndexMap, listIndexMap: new Map<string, number>()},
+  )
+
+  const snapshot = {
+    context: {schema, containers, value},
+    blockIndexMap,
+  }
+
+  return {
+    snapshot,
+    textBlock,
+    link1,
+    link2,
+    weirdContainer,
+    nestedBlock,
+    nestedLink,
+  }
+}
+
+describe(getAnnotation.name, () => {
+  const testbed = createAnnotationTestbed()
+
+  test('empty path', () => {
+    expect(getAnnotation(testbed.snapshot, [])).toBeUndefined()
+  })
+
+  test('path without markDefs', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [{_key: testbed.textBlock._key}]),
+    ).toBeUndefined()
+  })
+
+  test('annotation by key', () => {
+    const entry = getAnnotation(testbed.snapshot, [
+      {_key: testbed.textBlock._key},
+      'markDefs',
+      {_key: 'mark1'},
+    ])
+    expect(entry).toEqual({
+      node: testbed.link1,
+      path: [{_key: testbed.textBlock._key}, 'markDefs', {_key: 'mark1'}],
+    })
+  })
+
+  test('second annotation by key', () => {
+    const entry = getAnnotation(testbed.snapshot, [
+      {_key: testbed.textBlock._key},
+      'markDefs',
+      {_key: 'mark2'},
+    ])
+    expect(entry?.node).toBe(testbed.link2)
+  })
+
+  test('annotation with trailing field segment', () => {
+    const entry = getAnnotation(testbed.snapshot, [
+      {_key: testbed.textBlock._key},
+      'markDefs',
+      {_key: 'mark1'},
+      'href',
+    ])
+    expect(entry?.node).toBe(testbed.link1)
+    expect(entry?.path).toEqual([
+      {_key: testbed.textBlock._key},
+      'markDefs',
+      {_key: 'mark1'},
+    ])
+  })
+
+  test('annotation key not found', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [
+        {_key: testbed.textBlock._key},
+        'markDefs',
+        {_key: 'nonexistent'},
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('markDefs followed by a string segment', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [
+        {_key: testbed.textBlock._key},
+        'markDefs',
+        'href',
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('markDefs as the final segment', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [
+        {_key: testbed.textBlock._key},
+        'markDefs',
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('markDefs on a container with a markDefs-named array field', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [
+        {_key: testbed.weirdContainer._key},
+        'markDefs',
+        {_key: testbed.nestedBlock._key},
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('block path does not exist', () => {
+    expect(
+      getAnnotation(testbed.snapshot, [
+        {_key: 'nonexistent'},
+        'markDefs',
+        {_key: 'mark1'},
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('annotation on a text block inside a container with markDefs-named array field', () => {
+    const entry = getAnnotation(testbed.snapshot, [
+      {_key: testbed.weirdContainer._key},
+      'markDefs',
+      {_key: testbed.nestedBlock._key},
+      'markDefs',
+      {_key: testbed.nestedLink._key},
+    ])
+    expect(entry).toEqual({
+      node: testbed.nestedLink,
+      path: [
+        {_key: testbed.weirdContainer._key},
+        'markDefs',
+        {_key: testbed.nestedBlock._key},
+        'markDefs',
+        {_key: testbed.nestedLink._key},
+      ],
+    })
+  })
+})

--- a/packages/editor/src/traversal/get-annotation.ts
+++ b/packages/editor/src/traversal/get-annotation.ts
@@ -1,0 +1,58 @@
+import type {PortableTextObject} from '@portabletext/schema'
+import type {Path} from '../engine/interfaces/path'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+import {getTextBlock} from './get-text-block'
+import type {TraversalSnapshot} from './traversal-snapshot'
+
+/**
+ * Get the annotation at a given path.
+ *
+ * Annotations live in `markDefs` on a text block, alongside `children`
+ * rather than inside it, so they aren't reachable through `getNode`.
+ * `getAnnotation` resolves a path of the shape
+ * `[..., {_key: block}, 'markDefs', {_key: annotation}, ...]` to the
+ * annotation node on the enclosing text block.
+ *
+ * @beta
+ */
+export function getAnnotation(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): {node: PortableTextObject; path: Path} | undefined {
+  // A path may cross multiple `'markDefs'` segments if a consumer
+  // registers a container whose array field is named `markDefs`. Try
+  // each position and pick the one whose prefix resolves to a text
+  // block.
+  for (let i = 0; i < path.length - 1; i++) {
+    if (path[i] !== 'markDefs') {
+      continue
+    }
+
+    const annotationSegment = path[i + 1]
+
+    if (!isKeyedSegment(annotationSegment)) {
+      continue
+    }
+
+    const block = getTextBlock(snapshot, path.slice(0, i))
+
+    if (!block) {
+      continue
+    }
+
+    const annotation = block.node.markDefs?.find(
+      (markDef) => markDef._key === annotationSegment._key,
+    )
+
+    if (!annotation) {
+      return undefined
+    }
+
+    return {
+      node: annotation,
+      path: [...block.path, 'markDefs', {_key: annotation._key}],
+    }
+  }
+
+  return undefined
+}

--- a/packages/editor/src/traversal/index.ts
+++ b/packages/editor/src/traversal/index.ts
@@ -1,5 +1,6 @@
 export {getAncestor} from './get-ancestor'
 export {getAncestors} from './get-ancestors'
+export {getAnnotation} from './get-annotation'
 export {getBlock, isBlock} from './is-block'
 export {getChildren} from './get-children'
 export {getContainerChildren} from './get-container-children'


### PR DESCRIPTION
Annotations live in a text block's `markDefs` array, alongside `children` rather than inside it. They aren't reachable through `getNode`, which only descends into the value tree's child structure.

`getAnnotation(snapshot, path) -> {node, path} | undefined` resolves an annotation path schema-aware. It walks the path looking for a `'markDefs'` segment followed by a keyed segment whose preceding prefix resolves to a text block, then looks up the annotation by `_key` on that block's `markDefs`. Paths into a container whose own array field happens to be named `markDefs` return undefined, since that segment doesn't address an annotation. Trailing segments after the annotation's keyed segment are tolerated.

Mirrors the shape of the other schema-aware getters in this module (`getSpan`, `getTextBlock`, `getBlock`): one path argument, one resolved entry out.