### PR TITLE
fix: stop `getNode` at sidecar field boundaries

### DIFF
--- a/.changeset/get-node-honor-schema-fields.md
+++ b/.changeset/get-node-honor-schema-fields.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stop `getNode` at sidecar field boundaries
+
+`getNode(snapshot, path)` walks a path through the editor value. When the path crossed into a sidecar field that isn't the node's structural child array — e.g. `[{_key: 'block1'}, 'markDefs', {_key: 'mark1'}]` digging into an annotation on a text block — the walker kept looking up keyed segments against the wrong child list. It silently returned `undefined` only because the markDef `_key` didn't happen to collide with a span `_key`; if it did, `getNode` would have returned the unrelated span.
+
+The walker now consults the field name produced by each `getNodeChildren` and only descends into a string segment that matches. Paths that try to dig past the sidecar boundary return `undefined` explicitly (use `getAnnotation` to resolve an annotation node). Paths that end on a trailing field name on a valid node continue to return the node with that name stripped from `entry.path`.
+
+The schema decides what's structural: a text block descends into `children`, a container descends into its configured `arrayField` — including `'markDefs'` if a consumer registers a container with that name, which the previous string-name behavior couldn't distinguish from a real annotation path.

--- a/packages/editor/src/traversal/get-node.test.ts
+++ b/packages/editor/src/traversal/get-node.test.ts
@@ -314,4 +314,59 @@ describe(`${getNode.name} strips trailing field-name segments`, () => {
     expect(second?.node).toBe(testbed.image)
     expect(second?.path).toEqual([{_key: 'k4'}])
   })
+
+  test('annotation path returns undefined (use getAnnotation instead)', () => {
+    // `markDefs` is a sidecar field on a text block: annotations live
+    // alongside `children`, not inside the value tree's descent. A path
+    // that digs into `markDefs` past the field name can't be resolved
+    // by `getNode` — use `getAnnotation`.
+    expect(
+      getNode(testbed.snapshot, [{_key: 'k3'}, 'markDefs', {_key: 'mark1'}]),
+    ).toBeUndefined()
+  })
+
+  test('annotation path with trailing field returns undefined', () => {
+    expect(
+      getNode(testbed.snapshot, [
+        {_key: 'k3'},
+        'markDefs',
+        {_key: 'mark1'},
+        'href',
+      ]),
+    ).toBeUndefined()
+  })
+
+  test('descends into a container whose array field is named markDefs', () => {
+    // A container registered with `arrayField: 'markDefs'` makes
+    // `'markDefs'` a structural field. The walker consults each
+    // descent's field name (not a hardcoded list), so the path
+    // resolves to the child inside the container.
+    const child = {_key: 'm0', _type: 'note'}
+    const containerBlock = {
+      _key: 'b0',
+      _type: 'sidebar',
+      markDefs: [child],
+    }
+    const snapshot = {
+      ...testbed.snapshot,
+      context: {
+        ...testbed.snapshot.context,
+        value: [containerBlock],
+        containers: new Map([
+          [
+            'sidebar',
+            {
+              kind: 'container' as const,
+              type: 'sidebar',
+              field: {name: 'markDefs', of: [{name: 'note'}]} as never,
+            },
+          ],
+        ]),
+      },
+      blockIndexMap: new Map([['[_key=="b0"]', 0]]),
+    }
+    const entry = getNode(snapshot, [{_key: 'b0'}, 'markDefs', {_key: 'm0'}])
+    expect(entry?.node).toBe(child)
+    expect(entry?.path).toEqual([{_key: 'b0'}, 'markDefs', {_key: 'm0'}])
+  })
 })

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -11,14 +11,21 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  *
  * The path can be either keyed (KeyedSegment + field name strings) or
  * indexed (numbers). Keyed segments are resolved by matching `_key`,
- * field name strings are skipped (they're structural), and numbers
- * are resolved by index.
+ * field name strings name a structural descent into the previous
+ * node's children, and numbers are resolved by index.
  *
  * The returned `path` always identifies the returned node: it's fully
  * keyed (numeric indices are converted to `KeyedSegment`s) and any
- * trailing field-name segments in the input — e.g. `[{_key},'caption']`
- * pointing into an object node's primitive field — are stripped so
- * that `getNode(snapshot, entry.path).node === entry.node`.
+ * trailing segments in the input that point outside the value tree —
+ * e.g. an object node's primitive field, or an annotation reached via
+ * `'markDefs'` on a text block — are stripped so that
+ * `getNode(snapshot, entry.path).node === entry.node`.
+ *
+ * The walk stops when a string segment names a field that isn't the
+ * current node's structural child array. Annotations live in
+ * `markDefs` on a text block, alongside `children` rather than inside
+ * it, so `getNode` resolves an annotation path to the enclosing text
+ * block. Use `getAnnotation` to resolve the annotation itself.
  *
  * @beta
  */
@@ -32,6 +39,7 @@ export function getNode(
 
   const {context, blockIndexMap} = snapshot
   let currentChildren: Array<Node> = context.value
+  let currentFieldName: string | undefined
   let node: Node | undefined
   let currentParent: RegisteredContainer | undefined
   const resolvedPath: Path = []
@@ -40,8 +48,27 @@ export function getNode(
     const segment = path[i]
 
     if (typeof segment === 'string') {
-      resolvedPath.push(segment)
-      continue
+      // A string segment names a structural descent. If it matches the
+      // field name produced by the previous node's `getNodeChildren`,
+      // it's part of the value-tree descent — push it and continue.
+      // Otherwise the string names a sidecar field (markDefs on a text
+      // block, a primitive field on an object). If the input keeps
+      // digging past it with more keyed/numeric segments, the caller
+      // wanted a node inside the sidecar and `getNode` can't reach it
+      // (use `getAnnotation` for annotations); return undefined.
+      // Otherwise the rest is just trailing field names — let the loop
+      // exit and the post-loop strip remove them.
+      if (currentFieldName !== undefined && segment === currentFieldName) {
+        resolvedPath.push(segment)
+        continue
+      }
+      for (let j = i + 1; j < path.length; j++) {
+        const s = path[j]
+        if (isKeyedSegment(s) || typeof s === 'number') {
+          return undefined
+        }
+      }
+      break
     }
 
     if (isKeyedSegment(segment)) {
@@ -93,7 +120,10 @@ export function getNode(
       }
 
       currentChildren = next.children
+      currentFieldName = next.fieldName
       currentParent = next.parent
+    } else {
+      currentFieldName = undefined
     }
   }
 
@@ -101,12 +131,11 @@ export function getNode(
     return undefined
   }
 
-  // Strip trailing field-name segments. The walker pushes every string
-  // segment onto `resolvedPath` unconditionally, but a string segment
-  // that follows the deepest reached node is a field reference inside
-  // the node, not part of the node's path. Returning the input path
-  // verbatim would mean `entry.path` doesn't identify `entry.node`,
-  // which breaks every reasonable composition.
+  // Strip trailing field-name segments. The walker may have pushed
+  // matching field names during structural descent; if the deepest
+  // reached keyed segment was the last keyed segment in the input,
+  // any further field names that followed are part of the input but
+  // don't identify the returned node.
   while (
     resolvedPath.length > 0 &&
     typeof resolvedPath[resolvedPath.length - 1] === 'string'

--- a/packages/editor/src/traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/traversal/node-traversal-testbed.ts
@@ -96,13 +96,20 @@ export function resolveTestbedContainers(
 export function createNodeTraversalTestbed() {
   const keyGenerator = createTestKeyGenerator()
 
-  const span1 = {_key: keyGenerator(), _type: 'span', text: 'hello '}
+  const link1 = {_key: 'mark1', _type: 'link', href: 'https://a'}
+  const span1 = {
+    _key: keyGenerator(),
+    _type: 'span',
+    text: 'hello ',
+    marks: ['mark1'],
+  }
   const stockTicker1 = {_key: keyGenerator(), _type: 'stock-ticker'}
   const span2 = {_key: keyGenerator(), _type: 'span', text: ' world'}
   const textBlock1 = {
     _key: keyGenerator(),
     _type: 'block',
     children: [span1, stockTicker1, span2],
+    markDefs: [link1],
   }
 
   const image = {_key: keyGenerator(), _type: 'image'}
@@ -198,6 +205,7 @@ export function createNodeTraversalTestbed() {
 
   const schema = compileSchema(
     defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
       inlineObjects: [{name: 'stock-ticker'}],
       blockObjects: [
         {name: 'image'},
@@ -277,6 +285,7 @@ export function createNodeTraversalTestbed() {
     context,
     snapshot,
     textBlock1,
+    link1,
     span1,
     stockTicker1,
     span2,


### PR DESCRIPTION
Follow-up to #2876.

When the input path crossed into a sidecar field that isn't the node's structural child array — e.g. `[{_key: 'block1'}, 'markDefs', {_key: 'mark1'}]` digging into an annotation on a text block — the walker kept looking up keyed segments against the wrong child list. It silently returned `undefined` only because the markDef `_key` didn't happen to collide with a span `_key`; if it did, `getNode` would have returned the unrelated span.

The walker now consults the field name produced by each `getNodeChildren` and only descends into a string segment that matches. Paths that try to dig past the sidecar boundary return `undefined` explicitly (use `getAnnotation` to resolve an annotation node). Paths that end on a trailing field name on a valid node continue to return the node with that name stripped from `entry.path` (the #2876 behavior).

The schema decides what's structural: a text block descends into `children`, a container descends into its configured `arrayField` — including `'markDefs'` if a consumer registers a container with that name, which the previous string-name behavior couldn't distinguish from a real annotation path.

### What to review

`packages/editor/src/traversal/get-node.ts` — the walker tracks `currentFieldName` from each `getNodeChildren` descent. String segments are accepted when they match; otherwise the loop checks for further keyed/numeric segments and returns `undefined` if any exist (path tried to dig past a sidecar boundary). Otherwise it breaks and the post-loop strip removes the trailing string.

`packages/editor/src/traversal/get-node.test.ts` — three new cases:
- Annotation path `[{block},'markDefs',{ann}]` → `undefined`.
- Annotation path with trailing field `[{block},'markDefs',{ann},'href']` → `undefined`.
- Container registered with `arrayField:'markDefs'` resolves `[{containerBlock},'markDefs',{child}]` to the child.

Each branch discriminated by break-and-restore.

### Testing

- 27/27 `get-node.test.ts` pass.
- biome lint + prettier format + tsc all green locally; CI sweep.
- Caller audit: `apply-operation.ts` set/unset handlers route markDef paths through `findBlockSegment + applyAll` because `getNode` returns `undefined` for them — preserved (the first PR attempt broke this by returning the block; corrected here). `behavior.abstract.annotation.ts` strips `markDefs/{_key}` from `event.at` before calling `getNode`, unaffected. Selection-point construction at `util.block-offset.ts:32` builds `[...blockPath, 'children', {_key}]` — no trailing `'text'` — unaffected.

### Why this exists

Christian asked while reviewing #2879: "what happens if `getNode` is called with an annotation path?" The honest answer was "returns `undefined` for mechanism-incidental reasons" — the walker happens to fall through to a child array that doesn't contain the markDef key, but if keys collided across `children` and `markDefs`, or if a consumer registered a container with `arrayField:'markDefs'`, the walker would have returned wrong results silently. The fix isn't a special-case for `markDefs`; it's the walker honoring the schema's structural-field contract.

Once this and #2879 land, sanity-io/sanity#13338's `classifyEditorPath` workarounds (`endsOnKeyedSegment` guard, trailing-string strip in `getEnclosingBlock` fallback, the markDefs tail-scan) all become removable. The classifier collapses to composing `getAnnotation` + `getNode` + `isBlock`/`isInline`.