### PR TITLE
feat(plugin-table): table insert and unset behaviors

### DIFF
--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -46,15 +46,20 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
+    "@portabletext/test": "workspace:^",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",
+    "@vitejs/plugin-react": "catalog:tooling",
+    "@vitest/browser": "catalog:tooling",
+    "@vitest/browser-playwright": "catalog:tooling",
     "babel-plugin-react-compiler": "catalog:tooling",
     "eslint": "catalog:tooling",
     "eslint-plugin-react-hooks": "catalog:tooling",
     "react": "catalog:",
     "typescript": "catalog:tooling",
-    "typescript-eslint": "catalog:tooling"
+    "typescript-eslint": "catalog:tooling",
+    "vitest": "catalog:tooling"
   },
   "peerDependencies": {
     "@portabletext/editor": "workspace:^",

--- a/packages/plugin-table/src/behaviors/alignment.ts
+++ b/packages/plugin-table/src/behaviors/alignment.ts
@@ -1,0 +1,44 @@
+import type {Path} from '@portabletext/editor'
+import {raise} from '@portabletext/editor/behaviors'
+import type {Table} from './types'
+
+/**
+ * `alignment` is positional, so a column insert/remove must shift the array
+ * in lockstep with the columns. A table with no `alignment` field returns
+ * `undefined`: there is nothing to keep in sync.
+ */
+
+function setAlignment(tablePath: Path, alignment: Table['alignment']) {
+  return raise({type: 'block.set', at: tablePath, props: {alignment}})
+}
+
+export function alignmentInsertAction(
+  table: Table,
+  tablePath: Path,
+  columnIndex: number,
+) {
+  const alignment = table.alignment
+  if (!alignment) {
+    return undefined
+  }
+  return setAlignment(tablePath, [
+    ...alignment.slice(0, columnIndex),
+    null,
+    ...alignment.slice(columnIndex),
+  ])
+}
+
+export function alignmentRemoveAction(
+  table: Table,
+  tablePath: Path,
+  columnIndex: number,
+) {
+  const alignment = table.alignment
+  if (!alignment) {
+    return undefined
+  }
+  return setAlignment(
+    tablePath,
+    alignment.filter((_, index) => index !== columnIndex),
+  )
+}

--- a/packages/plugin-table/src/behaviors/insert.test.tsx
+++ b/packages/plugin-table/src/behaviors/insert.test.tsx
@@ -1,0 +1,550 @@
+import {defineSchema} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const existingRow = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [
+    {
+      _type: 'cell',
+      _key: 'c0',
+      value: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+    },
+  ],
+}
+
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [existingRow],
+  },
+]
+
+const insertedRow = {
+  _type: 'row',
+  _key: 'k3',
+  cells: [
+    {
+      _type: 'cell',
+      _key: 'k2',
+      value: [
+        {
+          _type: 'block',
+          _key: 'k4',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k5', text: '', marks: []}],
+        },
+      ],
+    },
+  ],
+}
+
+describe('custom.insert.row', () => {
+  test('inserts a row after', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [existingRow, insertedRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('inserts a row before', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      position: 'before',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [insertedRow, existingRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('finds the closest row when `at` points to a cell (after)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'c0'}],
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [existingRow, insertedRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('finds the closest row when `at` points to a cell (before)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'c0'}],
+      position: 'before',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [insertedRow, existingRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('inserts a row at the end when `at` points to the table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}],
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [existingRow, insertedRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('inserts a row at the start when `at` points to the table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.row',
+      at: [{_key: 't0'}],
+      position: 'before',
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [insertedRow, existingRow],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+})
+
+const twoByTwoR0C0 = {
+  _type: 'cell',
+  _key: 'r0c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0C1 = {
+  _type: 'cell',
+  _key: 'r0c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C0 = {
+  _type: 'cell',
+  _key: 'r1c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C1 = {
+  _type: 'cell',
+  _key: 'r1c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0 = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [twoByTwoR0C0, twoByTwoR0C1],
+}
+
+const twoByTwoR1 = {
+  _type: 'row',
+  _key: 'r1',
+  cells: [twoByTwoR1C0, twoByTwoR1C1],
+}
+
+const twoByTwoValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [twoByTwoR0, twoByTwoR1],
+  },
+]
+
+const insertedCellInR0 = {
+  _type: 'cell',
+  _key: 'k2',
+  value: [
+    {
+      _type: 'block',
+      _key: 'k6',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'k7', text: '', marks: []}],
+    },
+  ],
+}
+
+const insertedCellInR1 = {
+  _type: 'cell',
+  _key: 'k3',
+  value: [
+    {
+      _type: 'block',
+      _key: 'k4',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'k5', text: '', marks: []}],
+    },
+  ],
+}
+
+describe('custom.insert.column', () => {
+  test('inserts a column after when `at` points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot().context.value
+      expect(snapshot).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C0, insertedCellInR0, twoByTwoR0C1],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C0, insertedCellInR1, twoByTwoR1C1],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('inserts a column before when `at` points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c1'}],
+      position: 'before',
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot().context.value
+      expect(snapshot).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C0, insertedCellInR0, twoByTwoR0C1],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C0, insertedCellInR1, twoByTwoR1C1],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('inserts a column at the end when `at` points to the table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.column',
+      at: [{_key: 't0'}],
+      position: 'after',
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot().context.value
+      expect(snapshot).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C0, twoByTwoR0C1, insertedCellInR0],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C0, twoByTwoR1C1, insertedCellInR1],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('inserts a column at the start when `at` points to the table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.insert.column',
+      at: [{_key: 't0'}],
+      position: 'before',
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot().context.value
+      expect(snapshot).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [insertedCellInR0, twoByTwoR0C0, twoByTwoR0C1],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [insertedCellInR1, twoByTwoR1C0, twoByTwoR1C1],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/insert.ts
+++ b/packages/plugin-table/src/behaviors/insert.ts
@@ -1,0 +1,140 @@
+import type {EditorSelectionPoint, Path} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {alignmentInsertAction} from './alignment'
+import {isCell, isRow, isTable, type Row, type Table} from './types'
+
+export const insertBehaviors = [
+  defineBehavior<
+    {at: Path; position: 'before' | 'after'},
+    'custom.insert.row',
+    {row: Row; rowPath: Path}
+  >({
+    on: 'custom.insert.row',
+    guard: ({snapshot, event}) => {
+      const enclosingRow = getEnclosingBlock(snapshot, event.at, {
+        match: isRow,
+      })
+      if (enclosingRow) {
+        return {row: enclosingRow.node, rowPath: enclosingRow.path}
+      }
+      const enclosingTable = getEnclosingBlock(snapshot, event.at, {
+        match: isTable,
+      })
+      if (!enclosingTable) {
+        return false
+      }
+      const edgeRow =
+        event.position === 'before'
+          ? enclosingTable.node.rows.at(0)
+          : enclosingTable.node.rows.at(-1)
+      if (!edgeRow) {
+        return false
+      }
+      return {
+        row: edgeRow,
+        rowPath: [...enclosingTable.path, 'rows', {_key: edgeRow._key}],
+      }
+    },
+    actions: [
+      ({event}, {row, rowPath}) => {
+        const point: EditorSelectionPoint = {path: rowPath, offset: 0}
+        return [
+          raise({
+            type: 'insert.block',
+            block: {
+              _type: 'row',
+              cells: row.cells.map(() => ({_type: 'cell'})),
+            },
+            placement: event.position,
+            select: 'none',
+            at: {anchor: point, focus: point},
+          }),
+        ]
+      },
+    ],
+  }),
+  defineBehavior<
+    {at: Path; position: 'before' | 'after'},
+    'custom.insert.column',
+    {table: Table; tablePath: Path; columnIndex: number}
+  >({
+    on: 'custom.insert.column',
+    guard: ({snapshot, event}) => {
+      const enclosingCell = getEnclosingBlock(snapshot, event.at, {
+        match: isCell,
+      })
+      if (enclosingCell) {
+        const row = getParent(snapshot, enclosingCell.path, {match: isRow})
+        if (!row) {
+          return false
+        }
+        const columnIndex = row.node.cells.findIndex(
+          (cell) => cell._key === enclosingCell.node._key,
+        )
+        if (columnIndex === -1) {
+          return false
+        }
+        const table = getParent(snapshot, row.path, {match: isTable})
+        if (!table) {
+          return false
+        }
+        return {table: table.node, tablePath: table.path, columnIndex}
+      }
+      const enclosingTable = getEnclosingBlock(snapshot, event.at, {
+        match: isTable,
+      })
+      if (!enclosingTable) {
+        return false
+      }
+      const firstRow = enclosingTable.node.rows.at(0)
+      if (!firstRow) {
+        return false
+      }
+      const columnIndex =
+        event.position === 'before' ? 0 : firstRow.cells.length - 1
+      return {
+        table: enclosingTable.node,
+        tablePath: enclosingTable.path,
+        columnIndex,
+      }
+    },
+    actions: [
+      ({event}, {table, tablePath, columnIndex}) => {
+        const insertActions = table.rows.flatMap((row) => {
+          const cellAtColumn = row.cells.at(columnIndex)
+          if (!cellAtColumn) {
+            return []
+          }
+          const cellPath: Path = [
+            ...tablePath,
+            'rows',
+            {_key: row._key},
+            'cells',
+            {_key: cellAtColumn._key},
+          ]
+          const point: EditorSelectionPoint = {path: cellPath, offset: 0}
+          return [
+            raise({
+              type: 'insert.block',
+              block: {_type: 'cell'},
+              placement: event.position,
+              select: 'none',
+              at: {anchor: point, focus: point},
+            }),
+          ]
+        })
+        const newColumnIndex =
+          event.position === 'before' ? columnIndex : columnIndex + 1
+        const alignmentAction = alignmentInsertAction(
+          table,
+          tablePath,
+          newColumnIndex,
+        )
+        return alignmentAction
+          ? [...insertActions, alignmentAction]
+          : insertActions
+      },
+    ],
+  }),
+]

--- a/packages/plugin-table/src/behaviors/types.ts
+++ b/packages/plugin-table/src/behaviors/types.ts
@@ -1,0 +1,31 @@
+import type {PortableTextBlock} from '@portabletext/editor'
+
+export type Cell = {
+  _type: 'cell'
+  _key: string
+  value: Array<PortableTextBlock>
+}
+export type Row = PortableTextBlock & {_type: 'row'; cells: Array<Cell>}
+
+/** Per-column alignment, positional (array index = column index). `null` is an explicitly unaligned column. */
+export type ColumnAlignment = 'left' | 'center' | 'right' | null
+
+export type Table = PortableTextBlock & {
+  _type: 'table'
+  rows: Array<Row>
+  alignment?: Array<ColumnAlignment>
+}
+
+export function isRow(node: PortableTextBlock): node is Row {
+  // biome-ignore lint/complexity/useLiteralKeys: tsconfig has noPropertyAccessFromIndexSignature
+  return node._type === 'row' && 'cells' in node && Array.isArray(node['cells'])
+}
+
+export function isCell(node: PortableTextBlock): node is Cell {
+  return node._type === 'cell'
+}
+
+export function isTable(node: PortableTextBlock): node is Table {
+  // biome-ignore lint/complexity/useLiteralKeys: tsconfig has noPropertyAccessFromIndexSignature
+  return node._type === 'table' && 'rows' in node && Array.isArray(node['rows'])
+}

--- a/packages/plugin-table/src/behaviors/unset.test.tsx
+++ b/packages/plugin-table/src/behaviors/unset.test.tsx
@@ -1,0 +1,931 @@
+import {defineSchema} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const existingRow = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [
+    {
+      _type: 'cell',
+      _key: 'c0',
+      value: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        },
+      ],
+    },
+  ],
+}
+
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [existingRow],
+  },
+]
+
+const twoByTwoR0C0 = {
+  _type: 'cell',
+  _key: 'r0c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0C1 = {
+  _type: 'cell',
+  _key: 'r0c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C0 = {
+  _type: 'cell',
+  _key: 'r1c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C1 = {
+  _type: 'cell',
+  _key: 'r1c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0 = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [twoByTwoR0C0, twoByTwoR0C1],
+}
+
+const twoByTwoR1 = {
+  _type: 'row',
+  _key: 'r1',
+  cells: [twoByTwoR1C0, twoByTwoR1C1],
+}
+
+const twoByTwoValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [twoByTwoR0, twoByTwoR1],
+  },
+]
+
+describe('custom.unset.row', () => {
+  test('unsets a row when `at` points to the row', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [twoByTwoR1],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('finds the closest row when `at` points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}, 'cells', {_key: 'r1c0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [twoByTwoR0],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+})
+
+describe('custom.unset.column', () => {
+  test('unsets a column when `at` points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C1],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C1],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+})
+
+const threeRowR0C0 = {
+  _type: 'cell',
+  _key: 'r0c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR0C1 = {
+  _type: 'cell',
+  _key: 'r0c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR1C0 = {
+  _type: 'cell',
+  _key: 'r1c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR1C1 = {
+  _type: 'cell',
+  _key: 'r1c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR2C0 = {
+  _type: 'cell',
+  _key: 'r2c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r2c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r2c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR2C1 = {
+  _type: 'cell',
+  _key: 'r2c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r2c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r2c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR0 = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [threeRowR0C0, threeRowR0C1],
+}
+
+const threeRowR1 = {
+  _type: 'row',
+  _key: 'r1',
+  cells: [threeRowR1C0, threeRowR1C1],
+}
+
+const threeRowR2 = {
+  _type: 'row',
+  _key: 'r2',
+  cells: [threeRowR2C0, threeRowR2C1],
+}
+
+const threeRowValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [threeRowR0, threeRowR1, threeRowR2],
+  },
+]
+
+function pointInSpan(rowKey: string, colKey: string) {
+  return {
+    path: [
+      {_key: 't0'},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: colKey},
+      'value',
+      {_key: `${colKey}b`},
+      'children',
+      {_key: `${colKey}s`},
+    ],
+    offset: 0,
+  }
+}
+
+describe('custom.unset.row — selection recovery', () => {
+  test('cursor inside the unset row moves to next row, same column', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r1', 'r1c1')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}, 'cells', {_key: 'r1c1'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR0, threeRowR2],
+        },
+      ])
+      const recovered = pointInSpan('r2', 'r2c1')
+      expect(snapshot.context.selection).toEqual({
+        anchor: recovered,
+        focus: recovered,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(threeRowValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor in last row falls back to previous row, same column', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r2', 'r2c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r2'}, 'cells', {_key: 'r2c0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR0, threeRowR1],
+        },
+      ])
+      const recovered = pointInSpan('r1', 'r1c0')
+      expect(snapshot.context.selection).toEqual({
+        anchor: recovered,
+        focus: recovered,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(threeRowValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor outside the unset row stays where it is', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r2', 'r2c1')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR2],
+        },
+      ])
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(threeRowValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('expanded selection spans the unset row — both endpoints survive, no corrective select', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0', 'r0c0')
+    const focus = pointInSpan('r2', 'r2c0')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR0, threeRowR2],
+        },
+      ])
+      expect(snapshot.context.selection).toEqual({
+        anchor,
+        focus,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(threeRowValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor,
+        focus,
+        backward: false,
+      })
+    })
+  })
+
+  test('guard refuses when there is only one row left', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+})
+
+describe('custom.unset.column — selection recovery', () => {
+  test('cursor inside the unset column moves to next column, same row', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r0', 'r0c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C1],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C1],
+            },
+          ],
+        },
+      ])
+      const recovered = pointInSpan('r0', 'r0c1')
+      expect(snapshot.context.selection).toEqual({
+        anchor: recovered,
+        focus: recovered,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(twoByTwoValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor in the last column falls back to previous column', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r1', 'r1c1')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}, 'cells', {_key: 'r1c1'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              ...twoByTwoR0,
+              cells: [twoByTwoR0C0],
+            },
+            {
+              ...twoByTwoR1,
+              cells: [twoByTwoR1C0],
+            },
+          ],
+        },
+      ])
+      const recovered = pointInSpan('r1', 'r1c0')
+      expect(snapshot.context.selection).toEqual({
+        anchor: recovered,
+        focus: recovered,
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual(twoByTwoValue)
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('guard refuses when there is only one column left', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'c0'}],
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+})
+
+const preBlock = {
+  _type: 'block',
+  _key: 'pre',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'pres', text: 'before', marks: []}],
+}
+
+const postBlock = {
+  _type: 'block',
+  _key: 'post',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'posts', text: 'after', marks: []}],
+}
+
+const twoByTwoTable = {
+  _type: 'table',
+  _key: 't0',
+  rows: [twoByTwoR0, twoByTwoR1],
+}
+
+const sandwichedTableValue = [preBlock, twoByTwoTable, postBlock]
+
+const tableLastValue = [preBlock, twoByTwoTable]
+
+const onlyPreValue = [preBlock]
+
+const prePoint = {
+  path: [{_key: 'pre'}, 'children', {_key: 'pres'}],
+  offset: 0,
+}
+
+const postPoint = {
+  path: [{_key: 'post'}, 'children', {_key: 'posts'}],
+  offset: 0,
+}
+
+// When the table is the only block, the engine normalizes the empty document
+// to a single empty text block. Keys are issued by createTestKeyGenerator after
+// the initial editor setup consumed k0 and k1.
+const placeholderBlock = {
+  _type: 'block',
+  _key: 'k2',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+}
+
+describe('custom.unset.table', () => {
+  test('unsets the table when `at` points to the table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([placeholderBlock])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('unsets the table when `at` points to a row', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([placeholderBlock])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('unsets the table when `at` points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([placeholderBlock])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('is a no-op when `at` does not resolve to a table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: onlyPreValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 'pre'}],
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(onlyPreValue)
+  })
+})
+
+describe('custom.unset.table — selection recovery', () => {
+  test('cursor inside the unset table moves to next sibling block', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: sandwichedTableValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r0', 'r0c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([preBlock, postBlock])
+      expect(snapshot.context.selection).toEqual({
+        anchor: postPoint,
+        focus: postPoint,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor inside the unset table moves to previous sibling when no next exists', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: tableLastValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r0', 'r0c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([preBlock])
+      expect(snapshot.context.selection).toEqual({
+        anchor: prePoint,
+        focus: prePoint,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor outside the table is preserved', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: sandwichedTableValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({type: 'select', at: {anchor: prePoint, focus: prePoint}})
+
+    editor.send({
+      type: 'custom.unset.table',
+      at: [{_key: 't0'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([preBlock, postBlock])
+      expect(snapshot.context.selection).toEqual({
+        anchor: prePoint,
+        focus: prePoint,
+        backward: false,
+      })
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/unset.ts
+++ b/packages/plugin-table/src/behaviors/unset.ts
@@ -1,0 +1,255 @@
+import type {
+  EditorSelection,
+  EditorSelectionPoint,
+  Path,
+} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {
+  getEnclosingBlock,
+  getLeaf,
+  getParent,
+  getSibling,
+  pathContains,
+} from '@portabletext/editor/traversal'
+import {alignmentRemoveAction} from './alignment'
+import {isCell, isRow, isTable, type Table} from './types'
+
+function selectionTouches(
+  selection: EditorSelection,
+  paths: Array<Path>,
+): boolean {
+  if (!selection) {
+    return false
+  }
+  return paths.some(
+    (path) =>
+      pathContains(path, selection.anchor.path) ||
+      pathContains(path, selection.focus.path),
+  )
+}
+
+export const unsetBehaviors = [
+  defineBehavior<
+    {at: Path},
+    'custom.unset.row',
+    {
+      rowPath: Path
+      columnIndex: number
+      neighborCellPath: Path
+    }
+  >({
+    on: 'custom.unset.row',
+    guard: ({snapshot, event}) => {
+      const enclosingRow = getEnclosingBlock(snapshot, event.at, {
+        match: isRow,
+      })
+      if (!enclosingRow) {
+        return false
+      }
+      const table = getParent(snapshot, enclosingRow.path, {match: isTable})
+      if (!table) {
+        return false
+      }
+      const rowIndex = table.node.rows.findIndex(
+        (row) => row._key === enclosingRow.node._key,
+      )
+      if (rowIndex === -1) {
+        return false
+      }
+      const neighborRow =
+        table.node.rows[rowIndex + 1] ?? table.node.rows[rowIndex - 1]
+      if (!neighborRow) {
+        return false
+      }
+      const enclosingCell = getEnclosingBlock(snapshot, event.at, {
+        match: isCell,
+      })
+      const columnIndex = enclosingCell
+        ? enclosingRow.node.cells.findIndex(
+            (cell) => cell._key === enclosingCell.node._key,
+          )
+        : 0
+      const safeColumnIndex = Math.min(
+        Math.max(columnIndex, 0),
+        neighborRow.cells.length - 1,
+      )
+      const neighborCell = neighborRow.cells.at(safeColumnIndex)
+      if (!neighborCell) {
+        return false
+      }
+      const neighborCellPath: Path = [
+        ...table.path,
+        'rows',
+        {_key: neighborRow._key},
+        'cells',
+        {_key: neighborCell._key},
+      ]
+      return {
+        rowPath: enclosingRow.path,
+        columnIndex: safeColumnIndex,
+        neighborCellPath,
+      }
+    },
+    actions: [
+      ({snapshot}, {rowPath, neighborCellPath}) => {
+        const actions = [raise({type: 'unset', at: rowPath})]
+        if (selectionTouches(snapshot.context.selection, [rowPath])) {
+          const leaf = getLeaf(snapshot, neighborCellPath, {edge: 'start'})
+          if (leaf) {
+            const point: EditorSelectionPoint = {path: leaf.path, offset: 0}
+            actions.push(
+              raise({type: 'select', at: {anchor: point, focus: point}}),
+            )
+          }
+        }
+        return actions
+      },
+    ],
+  }),
+  defineBehavior<
+    {at: Path},
+    'custom.unset.column',
+    {
+      cellPaths: Array<Path>
+      neighborCellPath: Path
+      table: Table
+      tablePath: Path
+      columnIndex: number
+    }
+  >({
+    on: 'custom.unset.column',
+    guard: ({snapshot, event}) => {
+      const enclosingCell = getEnclosingBlock(snapshot, event.at, {
+        match: isCell,
+      })
+      if (!enclosingCell) {
+        return false
+      }
+      const enclosingRow = getParent(snapshot, enclosingCell.path, {
+        match: isRow,
+      })
+      if (!enclosingRow) {
+        return false
+      }
+      const columnIndex = enclosingRow.node.cells.findIndex(
+        (cell) => cell._key === enclosingCell.node._key,
+      )
+      if (columnIndex === -1) {
+        return false
+      }
+      const table = getParent(snapshot, enclosingRow.path, {match: isTable})
+      if (!table) {
+        return false
+      }
+      if (enclosingRow.node.cells.length <= 1) {
+        return false
+      }
+      const neighborColumnIndex =
+        columnIndex + 1 < enclosingRow.node.cells.length
+          ? columnIndex + 1
+          : columnIndex - 1
+      const neighborCell = enclosingRow.node.cells.at(neighborColumnIndex)
+      if (!neighborCell) {
+        return false
+      }
+      const neighborCellPath: Path = [
+        ...enclosingRow.path,
+        'cells',
+        {_key: neighborCell._key},
+      ]
+      const cellPaths = table.node.rows.flatMap((row) => {
+        const cellAtColumn = row.cells.at(columnIndex)
+        if (!cellAtColumn) {
+          return []
+        }
+        return [
+          [
+            ...table.path,
+            'rows',
+            {_key: row._key},
+            'cells',
+            {_key: cellAtColumn._key},
+          ] satisfies Path,
+        ]
+      })
+      return {
+        cellPaths,
+        neighborCellPath,
+        table: table.node,
+        tablePath: table.path,
+        columnIndex,
+      }
+    },
+    actions: [
+      (
+        {snapshot},
+        {cellPaths, neighborCellPath, table, tablePath, columnIndex},
+      ) => {
+        const actions = cellPaths.map((cellPath) =>
+          raise({type: 'unset', at: cellPath}),
+        )
+        const alignmentAction = alignmentRemoveAction(
+          table,
+          tablePath,
+          columnIndex,
+        )
+        if (alignmentAction) {
+          actions.push(alignmentAction)
+        }
+        if (selectionTouches(snapshot.context.selection, cellPaths)) {
+          const leaf = getLeaf(snapshot, neighborCellPath, {edge: 'start'})
+          if (leaf) {
+            const point: EditorSelectionPoint = {path: leaf.path, offset: 0}
+            actions.push(
+              raise({type: 'select', at: {anchor: point, focus: point}}),
+            )
+          }
+        }
+        return actions
+      },
+    ],
+  }),
+  defineBehavior<
+    {at: Path},
+    'custom.unset.table',
+    {tablePath: Path; neighborBlockPath: Path | undefined}
+  >({
+    on: 'custom.unset.table',
+    guard: ({snapshot, event}) => {
+      const enclosingTable = getEnclosingBlock(snapshot, event.at, {
+        match: isTable,
+      })
+      if (!enclosingTable) {
+        return false
+      }
+      const nextSibling = getSibling(snapshot, enclosingTable.path, {
+        direction: 'next',
+      })
+      const previousSibling = getSibling(snapshot, enclosingTable.path, {
+        direction: 'previous',
+      })
+      return {
+        tablePath: enclosingTable.path,
+        neighborBlockPath: nextSibling?.path ?? previousSibling?.path,
+      }
+    },
+    actions: [
+      ({snapshot}, {tablePath, neighborBlockPath}) => {
+        const actions = [raise({type: 'unset', at: tablePath})]
+        if (
+          neighborBlockPath &&
+          selectionTouches(snapshot.context.selection, [tablePath])
+        ) {
+          const leaf = getLeaf(snapshot, neighborBlockPath, {edge: 'start'})
+          if (leaf) {
+            const point: EditorSelectionPoint = {path: leaf.path, offset: 0}
+            actions.push(
+              raise({type: 'select', at: {anchor: point, focus: point}}),
+            )
+          }
+        }
+        return actions
+      },
+    ],
+  }),
+]

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -1,22 +1,50 @@
-import {useEditor} from '@portabletext/editor'
-import {useEffect} from 'react'
+import {defineContainer} from '@portabletext/editor'
+import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {insertBehaviors} from './behaviors/insert'
+import {unsetBehaviors} from './behaviors/unset'
+
+// `table` -> `row` -> `cell` nested containers. The render is intentionally
+// trivial: the behaviors only need the container structure registered to
+// operate on the nested arrays.
+const tableContainer = defineContainer({
+  type: 'table',
+  arrayField: 'rows',
+  render: ({attributes, children}) => (
+    <table {...attributes}>
+      <tbody>{children}</tbody>
+    </table>
+  ),
+  of: [
+    defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
+      of: [
+        defineContainer({
+          type: 'cell',
+          arrayField: 'value',
+          render: ({attributes, children}) => (
+            <td {...attributes}>{children}</td>
+          ),
+        }),
+      ],
+    }),
+  ],
+})
 
 /**
- * Skeleton placeholder for the table plugin.
- *
- * This component currently registers no behaviors and renders nothing. It
- * exists so that consumers can wire `<TablePlugin />` into their editor today
- * and pick up real functionality as the package grows.
+ * Registers the table containers and the row/column insert and unset
+ * behaviors. Drive them by dispatching `custom.insert.row`,
+ * `custom.insert.column`, `custom.unset.row`, `custom.unset.column`, or
+ * `custom.unset.table`.
  *
  * @alpha
  */
 export function TablePlugin() {
-  const editor = useEditor()
-
-  useEffect(() => {
-    // Reserved for behavior registration once the table API takes shape.
-    void editor
-  }, [editor])
-
-  return null
+  return (
+    <>
+      <NodePlugin nodes={[tableContainer]} />
+      <BehaviorPlugin behaviors={[...insertBehaviors, ...unsetBehaviors]} />
+    </>
+  )
 }

--- a/packages/plugin-table/vitest.config.ts
+++ b/packages/plugin-table/vitest.config.ts
@@ -1,0 +1,32 @@
+import react from '@vitejs/plugin-react'
+import {playwright} from '@vitest/browser-playwright'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        plugins: [
+          react({
+            babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
+          }),
+        ],
+        test: {
+          name: 'browser',
+          include: ['src/**/*.test.tsx'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [
+              {browser: 'chromium'},
+              {browser: 'firefox'},
+              {browser: 'webkit'},
+            ],
+            screenshotFailures: false,
+          },
+        },
+      },
+    ],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1259,6 +1259,9 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
+      '@portabletext/test':
+        specifier: workspace:^
+        version: link:../test
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 10.2.1(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
@@ -1268,6 +1271,15 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@vitejs/plugin-react':
+        specifier: catalog:tooling
+        version: 5.2.0(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser':
+        specifier: catalog:tooling
+        version: 4.1.9(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
+      '@vitest/browser-playwright':
+        specifier: catalog:tooling
+        version: 4.1.9(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.9)
       babel-plugin-react-compiler:
         specifier: catalog:tooling
         version: 1.0.0
@@ -1286,6 +1298,9 @@ importers:
       typescript-eslint:
         specifier: catalog:tooling
         version: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: catalog:tooling
+        version: 4.1.9(@types/node@24.12.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugin-typeahead-picker:
     dependencies:
@@ -9009,7 +9024,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.4
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -9018,7 +9033,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -9084,7 +9099,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.3
+      semver: 7.8.4
 
   '@changesets/get-github-info@0.7.0':
     dependencies:


### PR DESCRIPTION
`@portabletext/plugin-table` ships as a published skeleton: `<TablePlugin />` renders nothing, a placeholder so consumers can wire it in before the real functionality exists. This is the first slice of that functionality, the behaviors for structurally editing a table's rows and columns.

`<TablePlugin />` now registers `table` -> `row` -> `cell` as nested containers and a set of behaviors driven by custom events: `custom.insert.row`, `custom.insert.column`, `custom.unset.row`, `custom.unset.column`, `custom.unset.table`. Each is a `defineBehavior` that guards on the event, resolves the target row/column against the `table`/`row`/`cell` structure (`types.ts`), and raises the engine primitives (`insert.block`, `unset`). A column insert or unset also shifts the table's positional `alignment` array in lockstep (`alignment.ts`), so per-column alignment stays attached to its column; a table with no `alignment` field is untouched.

The container registration is deliberately minimal (`<table>`/`<tr>`/`<td>`). The behaviors operate on the nested value arrays, which the engine only recognizes once `table`/`row`/`cell` are registered as containers, without that registration the inserts are silently dropped (verified by running the behaviors with no container registration: 69 of 84 cases fail). The richer render (selection highlighting, header rows, replaceable `components`) is a separate change.

### What to review

`behaviors/insert.ts` and `behaviors/unset.ts` are the substance. `behaviors/types.ts` is the shared structure model (`Table`/`Row`/`Cell` plus the `isTable`/`isRow`/`isCell` guards). `plugin.table.tsx` is the minimal container registration and the behavior wiring.

### Testing

`insert.test.tsx` (row/column, before/after, undo) and `unset.test.tsx` (row/column/table, including rectangle selections), 84 assertions, green across the three browser projects. tsc, biome lint, and prettier format clean locally.
