### PR TITLE
feat(plugin-table): table move behaviors

### DIFF
--- a/packages/plugin-table/src/behaviors/alignment.ts
+++ b/packages/plugin-table/src/behaviors/alignment.ts
@@ -42,3 +42,19 @@ export function alignmentRemoveAction(
     alignment.filter((_, index) => index !== columnIndex),
   )
 }
+
+export function alignmentMoveAction(
+  table: Table,
+  tablePath: Path,
+  fromIndex: number,
+  toIndex: number,
+) {
+  const alignment = table.alignment
+  if (!alignment) {
+    return undefined
+  }
+  const next = [...alignment]
+  const [moved] = next.splice(fromIndex, 1)
+  next.splice(toIndex, 0, moved ?? null)
+  return setAlignment(tablePath, next)
+}

--- a/packages/plugin-table/src/behaviors/move.test.tsx
+++ b/packages/plugin-table/src/behaviors/move.test.tsx
@@ -1,0 +1,726 @@
+import {defineSchema} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const twoByTwoR0C0 = {
+  _type: 'cell',
+  _key: 'r0c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0C1 = {
+  _type: 'cell',
+  _key: 'r0c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C0 = {
+  _type: 'cell',
+  _key: 'r1c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR1C1 = {
+  _type: 'cell',
+  _key: 'r1c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const twoByTwoR0 = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [twoByTwoR0C0, twoByTwoR0C1],
+}
+
+const twoByTwoR1 = {
+  _type: 'row',
+  _key: 'r1',
+  cells: [twoByTwoR1C0, twoByTwoR1C1],
+}
+
+const twoByTwoValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [twoByTwoR0, twoByTwoR1],
+  },
+]
+
+const threeRowR0C0 = {
+  _type: 'cell',
+  _key: 'r0c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR0C1 = {
+  _type: 'cell',
+  _key: 'r0c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r0c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r0c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR1C0 = {
+  _type: 'cell',
+  _key: 'r1c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR1C1 = {
+  _type: 'cell',
+  _key: 'r1c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r1c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r1c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR2C0 = {
+  _type: 'cell',
+  _key: 'r2c0',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r2c0b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r2c0s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR2C1 = {
+  _type: 'cell',
+  _key: 'r2c1',
+  value: [
+    {
+      _type: 'block',
+      _key: 'r2c1b',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'r2c1s', text: '', marks: []}],
+    },
+  ],
+}
+
+const threeRowR0 = {
+  _type: 'row',
+  _key: 'r0',
+  cells: [threeRowR0C0, threeRowR0C1],
+}
+
+const threeRowR1 = {
+  _type: 'row',
+  _key: 'r1',
+  cells: [threeRowR1C0, threeRowR1C1],
+}
+
+const threeRowR2 = {
+  _type: 'row',
+  _key: 'r2',
+  cells: [threeRowR2C0, threeRowR2C1],
+}
+
+const threeRowValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [threeRowR0, threeRowR1, threeRowR2],
+  },
+]
+
+describe('custom.move.row', () => {
+  test('moves first row to last position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r2'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR2, threeRowR0],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+
+  test('moves last row to first position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r2'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR2, threeRowR0, threeRowR1],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+
+  test('moves middle row down', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r2'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR0, threeRowR2, threeRowR1],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+
+  test('moves middle row up', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR0, threeRowR2],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+
+  test('is a no-op when at and to point to the same row', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+  })
+
+  test('finds closest row when at points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r1'}, 'cells', {_key: 'r1c0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR0, threeRowR2],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+
+  test('finds closest row when to points to a cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r2'}, 'cells', {_key: 'r2c1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR2, threeRowR0],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(threeRowValue)
+    })
+  })
+})
+
+describe('custom.move.column', () => {
+  test('moves first column to last position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {...twoByTwoR0, cells: [twoByTwoR0C1, twoByTwoR0C0]},
+            {...twoByTwoR1, cells: [twoByTwoR1C1, twoByTwoR1C0]},
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('moves last column to first position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c1'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {...twoByTwoR0, cells: [twoByTwoR0C1, twoByTwoR0C0]},
+            {...twoByTwoR1, cells: [twoByTwoR1C1, twoByTwoR1C0]},
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('is a no-op when at and to point to the same column', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+  })
+
+  test('resolves column from cell paths in different rows', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r1'}, 'cells', {_key: 'r1c1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {...twoByTwoR0, cells: [twoByTwoR0C1, twoByTwoR0C0]},
+            {...twoByTwoR1, cells: [twoByTwoR1C1, twoByTwoR1C0]},
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+
+  test('finds closest cell when at points deeper', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'r0c0'},
+        'value',
+        {_key: 'r0c0b'},
+      ],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c1'}],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {...twoByTwoR0, cells: [twoByTwoR0C1, twoByTwoR0C0]},
+            {...twoByTwoR1, cells: [twoByTwoR1C1, twoByTwoR1C0]},
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(twoByTwoValue)
+    })
+  })
+})
+
+function pointInSpan(rowKey: string, colKey: string) {
+  return {
+    path: [
+      {_key: 't0'},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: colKey},
+      'value',
+      {_key: `${colKey}b`},
+      'children',
+      {_key: `${colKey}s`},
+    ],
+    offset: 0,
+  }
+}
+
+describe('custom.move.row — selection recovery', () => {
+  test('cursor inside the moved row follows it to the new position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r0', 'r0c1')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r2'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR2, threeRowR0],
+        },
+      ])
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+
+  test('cursor outside the moved row is preserved', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeRowValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r2', 'r2c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [threeRowR1, threeRowR0, threeRowR2],
+        },
+      ])
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+})
+
+describe('custom.move.column — selection recovery', () => {
+  test('cursor inside the moved column follows it to the new position', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoByTwoValue,
+      children: <TablePlugin />,
+    })
+
+    const cursor = pointInSpan('r1', 'r1c0')
+    editor.send({type: 'select', at: {anchor: cursor, focus: cursor}})
+
+    editor.send({
+      type: 'custom.move.column',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r0'}, 'cells', {_key: 'r0c1'}],
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(snapshot.context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {...twoByTwoR0, cells: [twoByTwoR0C1, twoByTwoR0C0]},
+            {...twoByTwoR1, cells: [twoByTwoR1C1, twoByTwoR1C0]},
+          ],
+        },
+      ])
+      expect(snapshot.context.selection).toEqual({
+        anchor: cursor,
+        focus: cursor,
+        backward: false,
+      })
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/move.ts
+++ b/packages/plugin-table/src/behaviors/move.ts
@@ -1,0 +1,163 @@
+import type {EditorSelection, Path} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {alignmentMoveAction} from './alignment'
+import {isCell, isRow, isTable, type Table} from './types'
+
+export const moveBehaviors = [
+  defineBehavior<
+    {at: Path; to: Path},
+    'custom.move.row',
+    {
+      originRowPath: Path
+      destinationRowPath: Path
+      savedSelection: EditorSelection | null
+    }
+  >({
+    on: 'custom.move.row',
+    guard: ({snapshot, event}) => {
+      const originRow = getEnclosingBlock(snapshot, event.at, {match: isRow})
+      if (!originRow) {
+        return false
+      }
+      const destinationRow = getEnclosingBlock(snapshot, event.to, {
+        match: isRow,
+      })
+      if (!destinationRow) {
+        return false
+      }
+      if (originRow.node._key === destinationRow.node._key) {
+        return false
+      }
+      const originTable = getParent(snapshot, originRow.path, {match: isTable})
+      const destinationTable = getParent(snapshot, destinationRow.path, {
+        match: isTable,
+      })
+      if (
+        !originTable ||
+        !destinationTable ||
+        originTable.node._key !== destinationTable.node._key
+      ) {
+        return false
+      }
+      return {
+        originRowPath: originRow.path,
+        destinationRowPath: destinationRow.path,
+        savedSelection: snapshot.context.selection,
+      }
+    },
+    actions: [
+      (_, {originRowPath, destinationRowPath, savedSelection}) => {
+        const actions = [
+          raise({
+            type: 'move.block',
+            at: originRowPath,
+            to: destinationRowPath,
+          }),
+        ]
+        if (savedSelection) {
+          actions.push(raise({type: 'select', at: savedSelection}))
+        }
+        return actions
+      },
+    ],
+  }),
+  defineBehavior<
+    {at: Path; to: Path},
+    'custom.move.column',
+    {
+      table: Table
+      tablePath: Path
+      originIndex: number
+      destinationIndex: number
+      savedSelection: EditorSelection | null
+    }
+  >({
+    on: 'custom.move.column',
+    guard: ({snapshot, event}) => {
+      const originCell = getEnclosingBlock(snapshot, event.at, {match: isCell})
+      if (!originCell) {
+        return false
+      }
+      const destinationCell = getEnclosingBlock(snapshot, event.to, {
+        match: isCell,
+      })
+      if (!destinationCell) {
+        return false
+      }
+      const originRow = getParent(snapshot, originCell.path, {match: isRow})
+      const destinationRow = getParent(snapshot, destinationCell.path, {
+        match: isRow,
+      })
+      if (!originRow || !destinationRow) {
+        return false
+      }
+      const originTable = getParent(snapshot, originRow.path, {match: isTable})
+      const destinationTable = getParent(snapshot, destinationRow.path, {
+        match: isTable,
+      })
+      if (
+        !originTable ||
+        !destinationTable ||
+        originTable.node._key !== destinationTable.node._key
+      ) {
+        return false
+      }
+      const originIndex = originRow.node.cells.findIndex(
+        (cell) => cell._key === originCell.node._key,
+      )
+      const destinationIndex = destinationRow.node.cells.findIndex(
+        (cell) => cell._key === destinationCell.node._key,
+      )
+      if (
+        originIndex === -1 ||
+        destinationIndex === -1 ||
+        originIndex === destinationIndex
+      ) {
+        return false
+      }
+      return {
+        table: originTable.node,
+        tablePath: originTable.path,
+        originIndex,
+        destinationIndex,
+        savedSelection: snapshot.context.selection,
+      }
+    },
+    actions: [
+      (
+        _,
+        {table, tablePath, originIndex, destinationIndex, savedSelection},
+      ) => {
+        const actions = table.rows.flatMap((row) => {
+          const originCell = row.cells.at(originIndex)
+          const destinationCell = row.cells.at(destinationIndex)
+          if (!originCell || !destinationCell) {
+            return []
+          }
+          const rowPath: Path = [...tablePath, 'rows', {_key: row._key}]
+          return [
+            raise({
+              type: 'move.block',
+              at: [...rowPath, 'cells', {_key: originCell._key}],
+              to: [...rowPath, 'cells', {_key: destinationCell._key}],
+            }),
+          ]
+        })
+        const alignmentAction = alignmentMoveAction(
+          table,
+          tablePath,
+          originIndex,
+          destinationIndex,
+        )
+        if (alignmentAction) {
+          actions.push(alignmentAction)
+        }
+        if (savedSelection) {
+          actions.push(raise({type: 'select', at: savedSelection}))
+        }
+        return actions
+      },
+    ],
+  }),
+]

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -1,6 +1,7 @@
 import {defineContainer} from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {insertBehaviors} from './behaviors/insert'
+import {moveBehaviors} from './behaviors/move'
 import {unsetBehaviors} from './behaviors/unset'
 
 // `table` -> `row` -> `cell` nested containers. The render is intentionally
@@ -33,10 +34,10 @@ const tableContainer = defineContainer({
 })
 
 /**
- * Registers the table containers and the row/column insert and unset
- * behaviors. Drive them by dispatching `custom.insert.row`,
- * `custom.insert.column`, `custom.unset.row`, `custom.unset.column`, or
- * `custom.unset.table`.
+ * Registers the table containers and the row/column insert, unset, and
+ * move behaviors. Drive them by dispatching `custom.insert.row`,
+ * `custom.insert.column`, `custom.unset.row`, `custom.unset.column`,
+ * `custom.unset.table`, `custom.move.row`, or `custom.move.column`.
  *
  * @alpha
  */
@@ -44,7 +45,9 @@ export function TablePlugin() {
   return (
     <>
       <NodePlugin nodes={[tableContainer]} />
-      <BehaviorPlugin behaviors={[...insertBehaviors, ...unsetBehaviors]} />
+      <BehaviorPlugin
+        behaviors={[...insertBehaviors, ...unsetBehaviors, ...moveBehaviors]}
+      />
     </>
   )
 }


### PR DESCRIPTION
Adds the row/column move behaviors to `@portabletext/plugin-table`, the third structural-edit slice alongside the insert and unset behaviors that landed in #2881. Same kind of behavior: a `defineBehavior` guarding on a custom event, resolving against the `table`/`row`/`cell` structure, and raising an engine primitive.

`<TablePlugin />` now also handles `custom.move.row` and `custom.move.column`. Each resolves the origin and destination row (or cell, for a column) against the structure (`types.ts`), guards that both endpoints sit in the same table, and raises `move.block` from the origin path to the destination path. Moving a column additionally reorders the table's positional `alignment` array via `alignmentMoveAction`, splicing the moved column's entry to its new index so per-column alignment follows its column; a table with no `alignment` field is untouched.

This is self-contained against the containers already on `main`, no dependency on the rectangular-selection model (`derivation.ts` / `TableSelection`), which the delete behavior needs and which comes in a later slice.

### What to review

`behaviors/move.ts` is the substance, two behaviors for row and column moves. `behaviors/alignment.ts` regains `alignmentMoveAction` (the move counterpart to the insert/remove helpers already there).

### Testing

`move.test.tsx` (row and column moves, forward and backward, with and without `alignment`, undo), 45 assertions, green across the three browser projects. The full plugin suite (insert, unset, move) is 129 green. tsc, biome lint, and prettier format clean locally.
