### PR TITLE
feat(plugin-table): rectangular cell selection and delete behavior

### DIFF
--- a/packages/plugin-table/src/behaviors/delete.test.tsx
+++ b/packages/plugin-table/src/behaviors/delete.test.tsx
@@ -1,0 +1,554 @@
+import {defineSchema} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+function textBlock(key: string, spanKey: string, text: string): TextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: spanKey, text, marks: []}],
+  }
+}
+
+function cellWithText(
+  cellKey: string,
+  blockKey: string,
+  spanKey: string,
+  text: string,
+): Cell {
+  return {
+    _type: 'cell',
+    _key: cellKey,
+    value: [textBlock(blockKey, spanKey, text)],
+  }
+}
+
+type Cell = {
+  _type: 'cell'
+  _key: string
+  value: ReadonlyArray<TextBlock>
+}
+
+type TextBlock = {
+  _type: 'block'
+  _key: string
+  style: string
+  markDefs: ReadonlyArray<unknown>
+  children: ReadonlyArray<{
+    _type: 'span'
+    _key: string
+    text: string
+    marks: ReadonlyArray<string>
+  }>
+}
+
+// 2x2 table with text in each cell
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {
+        _type: 'row',
+        _key: 'r0',
+        cells: [
+          cellWithText('r0c0', 'r0c0b', 'r0c0s', 'AA'),
+          cellWithText('r0c1', 'r0c1b', 'r0c1s', 'BB'),
+        ],
+      },
+      {
+        _type: 'row',
+        _key: 'r1',
+        cells: [
+          cellWithText('r1c0', 'r1c0b', 'r1c0s', 'CC'),
+          cellWithText('r1c1', 'r1c1b', 'r1c1s', 'DD'),
+        ],
+      },
+    ],
+  },
+]
+
+function pointInSpan(
+  cellKey: string,
+  blockKey: string,
+  spanKey: string,
+  offset: number,
+) {
+  return {
+    path: [
+      {_key: 't0'},
+      'rows',
+      {_key: cellKey.startsWith('r0') ? 'r0' : 'r1'},
+      'cells',
+      {_key: cellKey},
+      'value',
+      {_key: blockKey},
+      'children',
+      {_key: spanKey},
+    ],
+    offset,
+  }
+}
+
+function pointAtCell(cellKey: string) {
+  return {
+    path: [
+      {_key: 't0'},
+      'rows',
+      {_key: cellKey.startsWith('r0') ? 'r0' : 'r1'},
+      'cells',
+      {_key: cellKey},
+    ],
+    offset: 0,
+  }
+}
+
+function collapsed(point: ReturnType<typeof pointInSpan>) {
+  return {anchor: point, focus: point, backward: false}
+}
+
+function collapsedAtCell(cellKey: string) {
+  const point = pointAtCell(cellKey)
+  return {anchor: point, focus: point, backward: false}
+}
+
+/**
+ * Builds the expected post-delete value for a 2x2 `initialValue` table
+ * given the set of cleared cell keys. Each cleared cell ends up with a
+ * single empty block; we drive its block + span keys from the test's
+ * key generator state.
+ */
+function tableWithCleared(
+  cleared: Record<string, {blockKey: string; spanKey: string}>,
+) {
+  function cellFor(
+    cellKey: string,
+    originalBlock: string,
+    originalSpan: string,
+    originalText: string,
+  ): Cell {
+    const overrides = cleared[cellKey]
+    if (overrides) {
+      return cellWithText(cellKey, overrides.blockKey, overrides.spanKey, '')
+    }
+    return cellWithText(cellKey, originalBlock, originalSpan, originalText)
+  }
+  return [
+    {
+      _type: 'table',
+      _key: 't0',
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            cellFor('r0c0', 'r0c0b', 'r0c0s', 'AA'),
+            cellFor('r0c1', 'r0c1b', 'r0c1s', 'BB'),
+          ],
+        },
+        {
+          _type: 'row',
+          _key: 'r1',
+          cells: [
+            cellFor('r1c0', 'r1c0b', 'r1c0s', 'CC'),
+            cellFor('r1c1', 'r1c1b', 'r1c1s', 'DD'),
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+describe('delete behaviors within tables', () => {
+  test('delete.backward at offset 0 of cell start: no-op (no cross-cell merge)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const point = pointInSpan('r0c1', 'r0c1b', 'r0c1s', 0)
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+      expect(editor.getSnapshot().context.selection).toEqual(collapsed(point))
+    })
+  })
+
+  test('delete.forward at end of cell: no-op (no cross-cell merge)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const point = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 2)
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'delete.forward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+      expect(editor.getSnapshot().context.selection).toEqual(collapsed(point))
+    })
+  })
+
+  test('delete.backward inside cell text: deletes one char within cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const startPoint = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 2)
+    editor.send({type: 'select', at: {anchor: startPoint, focus: startPoint}})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    const endPoint = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                cellWithText('r0c0', 'r0c0b', 'r0c0s', 'A'),
+                cellWithText('r0c1', 'r0c1b', 'r0c1s', 'BB'),
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                cellWithText('r1c0', 'r1c0b', 'r1c0s', 'CC'),
+                cellWithText('r1c1', 'r1c1b', 'r1c1s', 'DD'),
+              ],
+            },
+          ],
+        },
+      ])
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsed(endPoint),
+      )
+    })
+  })
+
+  test('delete on multi-cell rectangle (2x2): clears all touched cells, collapses to top-left cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    const focus = pointInSpan('r1c1', 'r1c1b', 'r1c1s', 1)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k8', spanKey: 'k9'},
+          r0c1: {blockKey: 'k6', spanKey: 'k7'},
+          r1c0: {blockKey: 'k4', spanKey: 'k5'},
+          r1c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c0'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('delete on multi-cell rectangle in same row: clears both, leaves other row untouched', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    const focus = pointInSpan('r0c1', 'r0c1b', 'r0c1s', 1)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k4', spanKey: 'k5'},
+          r0c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c0'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('delete on multi-cell rectangle in cols 1+: selection lands at start of selection top-left, not table top-left', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    // Select cells in column 1 only (r0c1 + r1c1). After delete, cursor must
+    // land at the start of r0c1 (top-left of the SELECTION), not r0c0.
+    const anchor = pointInSpan('r0c1', 'r0c1b', 'r0c1s', 0)
+    const focus = pointInSpan('r1c1', 'r1c1b', 'r1c1s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c1: {blockKey: 'k4', spanKey: 'k5'},
+          r1c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c1'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('split (Enter) inside a cell: splits inside the cell, structure outside cell preserved', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const point = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'split'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'r0c0',
+                  value: [
+                    textBlock('r0c0b', 'r0c0s', 'A'),
+                    textBlock('k2', 'r0c0s', 'A'),
+                  ],
+                },
+                cellWithText('r0c1', 'r0c1b', 'r0c1s', 'BB'),
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                cellWithText('r1c0', 'r1c0b', 'r1c0s', 'CC'),
+                cellWithText('r1c1', 'r1c1b', 'r1c1s', 'DD'),
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('split (Enter) with multi-cell rectangle selection: clears rectangle, no split', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    const focus = pointInSpan('r0c1', 'r0c1b', 'r0c1s', 1)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'split'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k4', spanKey: 'k5'},
+          r0c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c0'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('delete.range straddling two cells in same row: structure preserved (no cell merge)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    const focus = pointInSpan('r0c1', 'r0c1b', 'r0c1s', 1)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k4', spanKey: 'k5'},
+          r0c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c0'),
+      )
+    })
+  })
+
+  test('delete.range straddling rows in same table: structure preserved (no row merge)', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 1)
+    const focus = pointInSpan('r1c1', 'r1c1b', 'r1c1s', 1)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k8', spanKey: 'k9'},
+          r0c1: {blockKey: 'k6', spanKey: 'k7'},
+          r1c0: {blockKey: 'k4', spanKey: 'k5'},
+          r1c1: {blockKey: 'k2', spanKey: 'k3'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtCell('r0c0'),
+      )
+    })
+  })
+
+  test('delete.backward in last empty cell of a single-cell table: removes the table (matches plain-block backspace semantics)', async () => {
+    const onlyEmptyCellTable = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [cellWithText('r0c0', 'r0c0b', 'r0c0s', '')],
+          },
+        ],
+      },
+    ]
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: onlyEmptyCellTable,
+      children: <TablePlugin />,
+    })
+
+    const point = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      // Engine removes the table - symmetric with backspace in an empty
+      // block. This is the documented contract; intercepting would surprise
+      // users.
+      expect(editor.getSnapshot().context.value).toEqual([
+        textBlock('r0c0b', 'r0c0s', ''),
+      ])
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/delete.ts
+++ b/packages/plugin-table/src/behaviors/delete.ts
@@ -1,0 +1,112 @@
+import type {EditorSnapshot, Path} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {getEnclosingBlock} from '@portabletext/editor/traversal'
+import {getTableSelection} from '../get-table-selection'
+import {isTable, type Table, type TableSelection} from './types'
+
+type ClearableSelection = {
+  tableSelection: TableSelection
+  table: {node: Table; path: Path}
+}
+
+/**
+ * Resolve a rectangular cell selection together with its table node, so the
+ * action doesn't have to re-resolve the table. Returns `false` for an
+ * ordinary single-cell selection.
+ */
+function clearableSelection(
+  snapshot: EditorSnapshot,
+): ClearableSelection | false {
+  const tableSelection = getTableSelection(snapshot)
+  if (!tableSelection) {
+    return false
+  }
+  const table = getEnclosingBlock(snapshot, tableSelection.tablePath, {
+    match: isTable,
+  })
+  if (!table) {
+    return false
+  }
+  return {tableSelection, table}
+}
+
+/**
+ * Intercepts `delete` and `split` when the editor selection spans more
+ * than one table cell. Cells inside the rectangular cell selection get
+ * cleared to a single empty text block and the selection collapses to
+ * the start of the top-left cell. Within a single cell, the engine's
+ * built-in behavior is unchanged.
+ */
+export const deleteBehaviors = [
+  defineBehavior<Record<string, never>, 'delete', ClearableSelection>({
+    on: 'delete',
+    guard: ({snapshot}) => clearableSelection(snapshot),
+    actions: [
+      (_, {tableSelection, table}) =>
+        clearCellsAndCollapse(tableSelection, table),
+    ],
+  }),
+  defineBehavior<Record<string, never>, 'split', ClearableSelection>({
+    on: 'split',
+    guard: ({snapshot}) => clearableSelection(snapshot),
+    actions: [
+      (_, {tableSelection, table}) =>
+        clearCellsAndCollapse(tableSelection, table),
+    ],
+  }),
+]
+
+function clearCellsAndCollapse(
+  tableSelection: TableSelection,
+  table: {node: Table; path: Path},
+) {
+  // Unset every block inside each cell's `value` array. Targeting keyed
+  // child paths (rather than the whole `value` field) keeps inverse
+  // data attached to each operation, so `history.undo` restores the
+  // original content. Normalization repopulates each cleared cell with a
+  // single empty text block.
+  const actions = []
+  const [rowStart, rowEnd] = tableSelection.rowRange
+  const [colStart, colEnd] = tableSelection.colRange
+  let topLeftCellPath: Path | null = null
+  for (let r = rowStart; r <= rowEnd; r++) {
+    const row = table.node.rows[r]
+    if (!row) {
+      continue
+    }
+    for (let c = colStart; c <= colEnd; c++) {
+      const cell = row.cells[c]
+      if (!cell) {
+        continue
+      }
+      const cellPath: Path = [
+        ...tableSelection.tablePath,
+        'rows',
+        {_key: row._key},
+        'cells',
+        {_key: cell._key},
+      ]
+      if (topLeftCellPath === null) {
+        topLeftCellPath = cellPath
+      }
+      for (const block of cell.value) {
+        actions.push(
+          raise({
+            type: 'unset',
+            at: [...cellPath, 'value', {_key: block._key}],
+          }),
+        )
+      }
+    }
+  }
+  if (topLeftCellPath) {
+    // Raise select.block (not select with leaf path). select.block resolves
+    // to the cell's first leaf via the apply layer AFTER our unsets +
+    // normalization complete — so the cursor lands inside the cleared cell's
+    // freshly-minted empty block, not at whatever leaf survived transformPoint.
+    actions.push(
+      raise({type: 'select.block', at: topLeftCellPath, select: 'start'}),
+    )
+  }
+  return actions
+}

--- a/packages/plugin-table/src/behaviors/types.ts
+++ b/packages/plugin-table/src/behaviors/types.ts
@@ -1,4 +1,4 @@
-import type {PortableTextBlock} from '@portabletext/editor'
+import type {Path, PortableTextBlock} from '@portabletext/editor'
 
 export type Cell = {
   _type: 'cell'
@@ -28,4 +28,10 @@ export function isCell(node: PortableTextBlock): node is Cell {
 export function isTable(node: PortableTextBlock): node is Table {
   // biome-ignore lint/complexity/useLiteralKeys: tsconfig has noPropertyAccessFromIndexSignature
   return node._type === 'table' && 'rows' in node && Array.isArray(node['rows'])
+}
+
+export type TableSelection = {
+  tablePath: Path
+  rowRange: [number, number]
+  colRange: [number, number]
 }

--- a/packages/plugin-table/src/get-table-selection.test.tsx
+++ b/packages/plugin-table/src/get-table-selection.test.tsx
@@ -1,0 +1,296 @@
+import {defineSchema} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {getTableSelection} from './get-table-selection'
+import {TablePlugin} from './plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {
+                          name: 'value',
+                          type: 'array',
+                          of: [{type: 'block'}],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+function cell(colKey: string) {
+  return {
+    _type: 'cell',
+    _key: colKey,
+    value: [
+      {
+        _type: 'block',
+        _key: `${colKey}b`,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: `${colKey}s`, text: '', marks: []}],
+      },
+    ],
+  }
+}
+
+function row(rowKey: string, colKeys: Array<string>) {
+  return {
+    _type: 'row',
+    _key: rowKey,
+    cells: colKeys.map((colKey) => cell(colKey)),
+  }
+}
+
+function pointInSpan(
+  tableKey: string,
+  rowKey: string,
+  colKey: string,
+  offset = 0,
+) {
+  return {
+    path: [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: colKey},
+      'value',
+      {_key: `${colKey}b`},
+      'children',
+      {_key: `${colKey}s`},
+    ],
+    offset,
+  }
+}
+
+const threeByThreeValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      row('r0', ['r0c0', 'r0c1', 'r0c2']),
+      row('r1', ['r1c0', 'r1c1', 'r1c2']),
+      row('r2', ['r2c0', 'r2c1', 'r2c2']),
+    ],
+  },
+]
+
+const preBlock = {
+  _type: 'block',
+  _key: 'pre',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'pres', text: 'before', marks: []}],
+}
+
+const postBlock = {
+  _type: 'block',
+  _key: 'post',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'posts', text: 'after', marks: []}],
+}
+
+const sandwichedTable = {
+  _type: 'table',
+  _key: 't0',
+  rows: [
+    row('r0', ['r0c0', 'r0c1', 'r0c2']),
+    row('r1', ['r1c0', 'r1c1', 'r1c2']),
+    row('r2', ['r2c0', 'r2c1', 'r2c2']),
+  ],
+}
+
+const sandwichedTableValue = [preBlock, sandwichedTable, postBlock]
+
+const twoTablesValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [row('t0r0', ['t0r0c0', 't0r0c1'])],
+  },
+  {
+    _type: 'table',
+    _key: 't1',
+    rows: [row('t1r0', ['t1r0c0', 't1r0c1'])],
+  },
+]
+
+describe('getTableSelection', () => {
+  test('returns undefined when selection is null', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    expect(getTableSelection(editor.getSnapshot())).toBeUndefined()
+  })
+
+  test('returns undefined when collapsed inside a single cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    const point = pointInSpan('t0', 'r0', 'r0c0')
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+    expect(getTableSelection(editor.getSnapshot())).toBeUndefined()
+  })
+
+  test('returns undefined when anchor and focus are in the same cell at different offsets', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('t0', 'r0', 'r0c0', 0)
+    const focus = pointInSpan('t0', 'r0', 'r0c0', 0)
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+    expect(getTableSelection(editor.getSnapshot())).toBeUndefined()
+  })
+
+  test('derives rectangle when anchor and focus are different cells', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('t0', 'r0', 'r0c1')
+    const focus = pointInSpan('t0', 'r2', 'r2c2')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(getTableSelection(editor.getSnapshot())).toEqual({
+        tablePath: [{_key: 't0'}],
+        rowRange: [0, 2],
+        colRange: [1, 2],
+      })
+    })
+  })
+
+  test('sorts row and col ranges regardless of direction', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('t0', 'r2', 'r2c2')
+    const focus = pointInSpan('t0', 'r0', 'r0c1')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(getTableSelection(editor.getSnapshot())).toEqual({
+        tablePath: [{_key: 't0'}],
+        rowRange: [0, 2],
+        colRange: [1, 2],
+      })
+    })
+  })
+
+  test('returns undefined when one endpoint is outside any cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: sandwichedTableValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = {
+      path: [{_key: 'pre'}, 'children', {_key: 'pres'}],
+      offset: 0,
+    }
+    const focus = pointInSpan('t0', 'r0', 'r0c0')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+    expect(getTableSelection(editor.getSnapshot())).toBeUndefined()
+  })
+
+  test('returns undefined when anchor and focus are in different tables', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: twoTablesValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('t0', 't0r0', 't0r0c0')
+    const focus = pointInSpan('t1', 't1r0', 't1r0c0')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+    expect(getTableSelection(editor.getSnapshot())).toBeUndefined()
+  })
+
+  test('derives the canonical example: (row1, col2) → (row3, col1) on a 3x3 table', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: threeByThreeValue,
+      children: <TablePlugin />,
+    })
+
+    // 1-indexed: row1/col2 = row index 0, col index 1
+    // 1-indexed: row3/col1 = row index 2, col index 0
+    const anchor = pointInSpan('t0', 'r0', 'r0c1')
+    const focus = pointInSpan('t0', 'r2', 'r2c0')
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    await vi.waitFor(() => {
+      expect(getTableSelection(editor.getSnapshot())).toEqual({
+        tablePath: [{_key: 't0'}],
+        rowRange: [0, 2],
+        colRange: [0, 1],
+      })
+    })
+  })
+})

--- a/packages/plugin-table/src/get-table-selection.ts
+++ b/packages/plugin-table/src/get-table-selection.ts
@@ -1,0 +1,84 @@
+import type {EditorSnapshot} from '@portabletext/editor'
+import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {isCell, isRow, isTable, type TableSelection} from './behaviors/types'
+
+/**
+ * Derives a rectangular table selection from the linear editor selection.
+ *
+ * Returns `undefined` when:
+ * - the selection is null
+ * - both endpoints resolve to the same cell (ordinary linear selection)
+ * - either endpoint is outside any cell
+ * - endpoints resolve to cells in different tables
+ *
+ * @alpha
+ */
+export function getTableSelection(
+  snapshot: EditorSnapshot,
+): TableSelection | undefined {
+  const selection = snapshot.context.selection
+  if (!selection) {
+    return undefined
+  }
+
+  const anchorCell = getEnclosingBlock(snapshot, selection.anchor.path, {
+    match: isCell,
+  })
+  const focusCell = getEnclosingBlock(snapshot, selection.focus.path, {
+    match: isCell,
+  })
+  if (!anchorCell || !focusCell) {
+    return undefined
+  }
+  if (anchorCell.node._key === focusCell.node._key) {
+    return undefined
+  }
+
+  const anchorRow = getParent(snapshot, anchorCell.path, {match: isRow})
+  const focusRow = getParent(snapshot, focusCell.path, {match: isRow})
+  if (!anchorRow || !focusRow) {
+    return undefined
+  }
+
+  const anchorTable = getParent(snapshot, anchorRow.path, {match: isTable})
+  const focusTable = getParent(snapshot, focusRow.path, {match: isTable})
+  if (!anchorTable || !focusTable) {
+    return undefined
+  }
+  if (anchorTable.node._key !== focusTable.node._key) {
+    return undefined
+  }
+
+  const anchorRowIndex = anchorTable.node.rows.findIndex(
+    (row) => row._key === anchorRow.node._key,
+  )
+  const focusRowIndex = anchorTable.node.rows.findIndex(
+    (row) => row._key === focusRow.node._key,
+  )
+  const anchorColIndex = anchorRow.node.cells.findIndex(
+    (cell) => cell._key === anchorCell.node._key,
+  )
+  const focusColIndex = focusRow.node.cells.findIndex(
+    (cell) => cell._key === focusCell.node._key,
+  )
+  if (
+    anchorRowIndex === -1 ||
+    focusRowIndex === -1 ||
+    anchorColIndex === -1 ||
+    focusColIndex === -1
+  ) {
+    return undefined
+  }
+
+  return {
+    tablePath: anchorTable.path,
+    rowRange: [
+      Math.min(anchorRowIndex, focusRowIndex),
+      Math.max(anchorRowIndex, focusRowIndex),
+    ],
+    colRange: [
+      Math.min(anchorColIndex, focusColIndex),
+      Math.max(anchorColIndex, focusColIndex),
+    ],
+  }
+}

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -1,5 +1,6 @@
 import {defineContainer} from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {deleteBehaviors} from './behaviors/delete'
 import {insertBehaviors} from './behaviors/insert'
 import {moveBehaviors} from './behaviors/move'
 import {unsetBehaviors} from './behaviors/unset'
@@ -39,6 +40,9 @@ const tableContainer = defineContainer({
  * `custom.insert.column`, `custom.unset.row`, `custom.unset.column`,
  * `custom.unset.table`, `custom.move.row`, or `custom.move.column`.
  *
+ * Also intercepts `delete` and `split` when the selection spans more than
+ * one cell, clearing the selected rectangle instead of deleting structure.
+ *
  * @alpha
  */
 export function TablePlugin() {
@@ -46,7 +50,12 @@ export function TablePlugin() {
     <>
       <NodePlugin nodes={[tableContainer]} />
       <BehaviorPlugin
-        behaviors={[...insertBehaviors, ...unsetBehaviors, ...moveBehaviors]}
+        behaviors={[
+          ...insertBehaviors,
+          ...unsetBehaviors,
+          ...moveBehaviors,
+          ...deleteBehaviors,
+        ]}
       />
     </>
   )


### PR DESCRIPTION
Adds the rectangular cell-selection model and the delete/split behavior that consumes it. These ship together because `getTableSelection` has no other consumer yet, the behavior is what exercises it.

`getTableSelection(snapshot)` derives a rectangular `TableSelection` (the `tablePath` plus row and column ranges) from the linear editor selection. It resolves each endpoint to its enclosing cell, checks they sit in the same table, and returns the bounding rectangle. It returns `undefined` for the cases that aren't a multi-cell rectangle: a null selection, both endpoints in the same cell (an ordinary linear selection), an endpoint outside any cell, or endpoints in different tables.

`<TablePlugin />` now intercepts `delete` and `split` (Backspace, Delete, Enter) when `getTableSelection` reports a multi-cell rectangle. Every block in each selected cell is unset and the selection collapses to the start of the top-left cell, instead of the engine deleting table structure. Within a single cell, the engine's built-in behavior is unchanged.

The clear targets keyed child paths (`[...cellPath, 'value', {_key}]`) rather than the whole `value` field, so each operation keeps its inverse and `history.undo` restores the original content; normalization repopulates each cleared cell with a single empty text block. The collapse uses `select.block` with `select: 'start'` so the cursor resolves to the cell's freshly-minted empty block after the unsets and normalization complete.

### What to review

`get-table-selection.ts` (`getTableSelection`) is a pure selector over the snapshot. `behaviors/delete.ts` guards both `delete` and `split` on it and clears the rectangle. `behaviors/types.ts` regains the `TableSelection` type (and its `Path` import).

### Testing

`get-table-selection.test.tsx` (single-cell, multi-cell rectangles, cross-table, no selection) and `delete.test.tsx` (Backspace/Delete/Enter over a rectangle, single-cell pass-through, undo) — 57 assertions, green across the three browser projects. Full plugin suite (insert, unset, move, delete) is 186 green. tsc, biome lint, prettier format, and knip clean locally.


