### PR TITLE
fix: scope `editor.dom.getSelectionRect` to the editor

### DIFF
--- a/.changeset/editor-dom-selection-rect.md
+++ b/.changeset/editor-dom-selection-rect.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: scope `editor.dom.getSelectionRect` to the editor
+
+`editor.dom.getSelectionRect` now returns the rect of the passed snapshot's selection. Previously, when focus sat outside the editor or another Portable Text editor was mounted on the page, it could return the rect of an unrelated element.

--- a/packages/editor/src/editor/editor-dom.ts
+++ b/packages/editor/src/editor/editor-dom.ts
@@ -1,8 +1,10 @@
 import type {BehaviorEvent} from '../behaviors/behavior.types.event'
 import {getDomNode} from '../dom-traversal/get-dom-node'
+import {DOMEditor} from '../engine/dom/plugin/dom-editor'
 import type {Path} from '../engine/interfaces/path'
 import {isAncestorPath} from '../engine/path/is-ancestor-path'
 import {rangeEdges} from '../engine/range/range-edges'
+import {resolveSelection} from '../internal-utils/apply-selection'
 import {getSelectionEndBlock, getSelectionStartBlock} from '../selectors'
 import {getFragment} from '../selectors/selector.get-fragment'
 import {getNodes} from '../traversal/get-nodes'
@@ -14,6 +16,10 @@ export type EditorDom = {
   getBlockNodes: (snapshot: EditorSnapshot) => Array<Node>
   getChildNodes: (snapshot: EditorSnapshot) => Array<Node>
   getEditorElement: () => Element | undefined
+  /**
+   * The bounding rect of the snapshot's selection. A collapsed selection gives
+   * a caret rect.
+   */
   getSelectionRect: (snapshot: EditorSnapshot) => DOMRect | null
   getStartBlockElement: (snapshot: EditorSnapshot) => Element | null
   getEndBlockElement: (snapshot: EditorSnapshot) => Element | null
@@ -42,7 +48,7 @@ export function createEditorDom(
     getBlockNodes: (snapshot) => getBlockNodes(editorEngine, snapshot),
     getChildNodes: (snapshot) => getChildNodes(editorEngine, snapshot),
     getEditorElement: () => getEditorElement(editorEngine),
-    getSelectionRect: (snapshot) => getSelectionRect(snapshot),
+    getSelectionRect: (snapshot) => getSelectionRect(editorEngine, snapshot),
     getStartBlockElement: (snapshot) =>
       getStartBlockElement(editorEngine, snapshot),
     getEndBlockElement: (snapshot) =>
@@ -127,21 +133,29 @@ function getEditorElement(editorEngine: PortableTextEditorEngine) {
   return getDomNode(editorEngine, [])
 }
 
-function getSelectionRect(snapshot: EditorSnapshot) {
-  if (!snapshot.context.selection) {
+function getSelectionRect(
+  editorEngine: PortableTextEditorEngine,
+  snapshot: EditorSnapshot,
+): DOMRect | null {
+  const selection = snapshot.context.selection
+
+  if (!selection) {
     return null
   }
 
   try {
-    const selection = window.getSelection()
+    const engineRange = resolveSelection({snapshot}, selection)
 
-    if (!selection) {
+    if (!engineRange) {
       return null
     }
 
-    const range = selection.getRangeAt(0)
-    return range.getBoundingClientRect()
+    return DOMEditor.toDOMRange(
+      editorEngine,
+      engineRange,
+    ).getBoundingClientRect()
   } catch {
+    // `toDOMRange` throws when the selection isn't rendered (unmounted, virtualized).
     return null
   }
 }

--- a/packages/editor/tests/editor-dom-selection-rect.test.tsx
+++ b/packages/editor/tests/editor-dom-selection-rect.test.tsx
@@ -1,0 +1,84 @@
+import {describe, expect, test} from 'vitest'
+import {defineSchema, type EditorSnapshot} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'b1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's1', text: 'line one', marks: []}],
+  },
+  {
+    _type: 'block',
+    _key: 'b2',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's2', text: 'line two', marks: []}],
+  },
+]
+
+function withCaret(
+  snapshot: EditorSnapshot,
+  blockKey: string,
+  spanKey: string,
+): EditorSnapshot {
+  const point = {
+    path: [{_key: blockKey}, 'children', {_key: spanKey}],
+    offset: 0,
+  }
+  return {
+    ...snapshot,
+    context: {...snapshot.context, selection: {anchor: point, focus: point}},
+  }
+}
+
+describe('editor.dom.getSelectionRect', () => {
+  test("returns a rect for the snapshot's selection, lower for a lower block", async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+    const snapshot = editor.getSnapshot()
+
+    const rectTop = editor.dom.getSelectionRect(withCaret(snapshot, 'b1', 's1'))
+    const rectBottom = editor.dom.getSelectionRect(
+      withCaret(snapshot, 'b2', 's2'),
+    )
+
+    expect(rectTop).not.toBeNull()
+    expect(rectBottom).not.toBeNull()
+    expect(Number.isFinite(rectTop!.top)).toBe(true)
+    // b2 sits below b1, so its caret rect is lower on the page.
+    expect(rectBottom!.top).toBeGreaterThan(rectTop!.top)
+  })
+
+  test('returns null when the snapshot has no selection', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+    const snapshot = editor.getSnapshot()
+
+    expect(
+      editor.dom.getSelectionRect({
+        ...snapshot,
+        context: {...snapshot.context, selection: null},
+      }),
+    ).toBeNull()
+  })
+
+  test('returns null when the selection does not resolve', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    expect(
+      editor.dom.getSelectionRect(
+        withCaret(editor.getSnapshot(), 'does-not-exist', 'x'),
+      ),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
`editor.dom.getSelectionRect(snapshot)` returned a rect for the wrong element whenever the editor didn't own the document selection. It read `window.getSelection().getRangeAt(0)`, which is document-global: with focus outside the editor, or a second Portable Text editor mounted on the page, the browser's active selection is somewhere else entirely and `getSelectionRect` handed back that element's rect. The `snapshot` argument was dead weight, only null-checked, then ignored in favour of the live DOM.

It now maps the snapshot's own selection to a rect: `resolveSelection` resolves the keyed selection against the snapshot's value and schema, and `DOMEditor.toDOMRange(...).getBoundingClientRect()` reads its geometry. That scopes the result to this editor and makes `snapshot` load-bearing. The signature is unchanged, and the range whose rect you want is expressed the way the sibling `dom` methods already take theirs, through the snapshot's selection (`getBlockNodes`/`getChildNodes` read `snapshot.context.selection` too). A caret rect is a snapshot with a collapsed selection.

`getSelectionRect` has no callers inside the editor, so the change is inert internally. The pinning is a browser test with two stacked blocks that asserts the lower block's caret rect sits below the upper one's, and that an absent or unresolvable selection returns `null`. The gherkin delete suite, which drives the same `toDOMRange`-to-rect path through `findCurrentLineRange`, stays green.

The one behaviour it stops reflecting is a transient divergence between the DOM selection and the model, mid-IME composition where the DOM leads. Nothing consumed that.
