### PR TITLE
feat(plugin-table): keyboard navigation between cells

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,6 +26,7 @@
     "@portabletext/plugin-markdown-shortcuts": "workspace:*",
     "@portabletext/plugin-one-line": "workspace:*",
     "@portabletext/plugin-paste-link": "workspace:*",
+    "@portabletext/plugin-table": "workspace:*",
     "@portabletext/plugin-typeahead-picker": "workspace:*",
     "@portabletext/plugin-typography": "workspace:*",
     "@portabletext/react": "catalog:tooling",

--- a/apps/playground/src/playground-schema-definition.tsx
+++ b/apps/playground/src/playground-schema-definition.tsx
@@ -426,7 +426,7 @@ export const playgroundSchemaDefinition = defineSchema({
                       name: 'cell',
                       fields: [
                         {
-                          name: 'content',
+                          name: 'value',
                           title: 'Content',
                           type: 'array',
                           of: [

--- a/apps/playground/src/plugins/plugin.markdown-deserializer.tsx
+++ b/apps/playground/src/plugins/plugin.markdown-deserializer.tsx
@@ -57,27 +57,6 @@ export function MarkdownDeserializerPlugin() {
                   lines,
                 }
               },
-              // The default md→pt table emits cells with field name `value`,
-              // but the playground's cell schema uses `content`. Rename.
-              table: ({context, value}) => {
-                const rows = value.rows.map((row) => ({
-                  _type: 'row',
-                  _key: row._key,
-                  cells: row.cells.map((cell) => ({
-                    _type: 'cell',
-                    _key: cell._key,
-                    content: cell.value,
-                  })),
-                }))
-                return {
-                  _type: 'table',
-                  _key: context.keyGenerator(),
-                  ...(value.headerRows !== undefined
-                    ? {headerRows: value.headerRows}
-                    : {}),
-                  rows,
-                }
-              },
               // The playground has a void `break` block-object in place of a
               // dedicated horizontal-rule type - map onto it.
               horizontalRule: ({context}) => ({

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,5 +1,6 @@
 import {defineContainer, defineTextBlock} from '@portabletext/editor'
-import {NodePlugin} from '@portabletext/editor/plugins'
+import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {tableBehaviors} from '@portabletext/plugin-table'
 import type {JSX} from 'react'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
@@ -36,7 +37,7 @@ const tableContainer = defineContainer({
       of: [
         defineContainer({
           type: 'cell',
-          arrayField: 'content',
+          arrayField: 'value',
           render: ({attributes, children, selected}) => (
             <td {...attributes} data-selected={selected ? '' : undefined}>
               {children}
@@ -67,5 +68,10 @@ const tableContainer = defineContainer({
 })
 
 export function TablePlugin(): JSX.Element {
-  return <NodePlugin nodes={[tableContainer]} />
+  return (
+    <>
+      <NodePlugin nodes={[tableContainer]} />
+      <BehaviorPlugin behaviors={tableBehaviors} />
+    </>
+  )
 }

--- a/apps/playground/src/previews/markdown-options.ts
+++ b/apps/playground/src/previews/markdown-options.ts
@@ -1,13 +1,12 @@
 import {
   DefaultCalloutRenderer,
   DefaultHorizontalRuleRenderer,
+  DefaultTableRenderer,
   type PortableTextRenderers,
   type PortableTextTypeRenderer,
 } from '@portabletext/markdown'
 
 type Block = {_type: string; children?: Array<{_type: string; text?: string}>}
-type Cell = {_type: 'cell'; content: Array<Block>}
-type Row = {_type: 'row'; cells: Array<Cell>}
 
 export const markdownOptions: Partial<PortableTextRenderers> = {
   types: {
@@ -44,52 +43,7 @@ export const markdownOptions: Partial<PortableTextRenderers> = {
 
     'callout': DefaultCalloutRenderer,
 
-    // Adapter from playground's `cell.content` shape to the package's
-    // built-in table renderer (which expects `cell.value`). Collapses
-    // each cell to a single line of inline-rendered text since markdown
-    // tables do not support multi-line cells.
-    'table': (({value, renderNode}) => {
-      const tableValue = value as {headerRows?: number; rows?: Array<Row>}
-      const rows = tableValue.rows ?? []
-      if (rows.length === 0 || rows[0]?.cells.length === 0) {
-        return ''
-      }
-      const headerRows = tableValue.headerRows ?? 0
-      const renderCell = (cell: Cell): string => {
-        return cell.content
-          .map((block, index) =>
-            renderNode({
-              node: block,
-              index,
-              isInline: false,
-              renderNode,
-            }),
-          )
-          .join(' ')
-          .replace(/\s+/g, ' ')
-          .trim()
-      }
-      const lines: Array<string> = []
-      for (let i = 0; i < headerRows; i++) {
-        const row = rows[i]
-        if (!row) {
-          continue
-        }
-        lines.push(`| ${row.cells.map(renderCell).join(' | ')} |`)
-      }
-      if (headerRows > 0) {
-        const sep = rows[0]!.cells.map(() => ' --- ').join('|')
-        lines.push(`|${sep}|`)
-      }
-      for (let i = headerRows; i < rows.length; i++) {
-        const row = rows[i]
-        if (!row) {
-          continue
-        }
-        lines.push(`| ${row.cells.map(renderCell).join(' | ')} |`)
-      }
-      return lines.join('\n')
-    }) satisfies PortableTextTypeRenderer,
+    'table': DefaultTableRenderer,
 
     // No native markdown for fact-box. Render inner content as a
     // collapsible `<details>` block so the preview still surfaces the

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -44,6 +44,9 @@
     "lint:fix": "biome lint --write .",
     "prepublishOnly": "turbo run build"
   },
+  "dependencies": {
+    "@portabletext/keyboard-shortcuts": "workspace:^"
+  },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
     "@portabletext/test": "workspace:^",

--- a/packages/plugin-table/src/behaviors/insert.ts
+++ b/packages/plugin-table/src/behaviors/insert.ts
@@ -1,8 +1,9 @@
 import type {EditorSelectionPoint, Path} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
-import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {getEnclosingBlock} from '@portabletext/editor/traversal'
+import {resolveCell} from '../resolve-cell'
 import {alignmentInsertAction} from './alignment'
-import {isCell, isRow, isTable, type Row, type Table} from './types'
+import {isRow, isTable, type Row, type Table} from './types'
 
 export const insertBehaviors = [
   defineBehavior<
@@ -61,25 +62,19 @@ export const insertBehaviors = [
   >({
     on: 'custom.insert.column',
     guard: ({snapshot, event}) => {
-      const enclosingCell = getEnclosingBlock(snapshot, event.at, {
-        match: isCell,
-      })
-      if (enclosingCell) {
-        const row = getParent(snapshot, enclosingCell.path, {match: isRow})
-        if (!row) {
-          return false
-        }
-        const columnIndex = row.node.cells.findIndex(
-          (cell) => cell._key === enclosingCell.node._key,
+      const resolved = resolveCell(snapshot, event.at)
+      if (resolved) {
+        const columnIndex = resolved.row.node.cells.findIndex(
+          (cell) => cell._key === resolved.cell.node._key,
         )
         if (columnIndex === -1) {
           return false
         }
-        const table = getParent(snapshot, row.path, {match: isTable})
-        if (!table) {
-          return false
+        return {
+          table: resolved.table.node,
+          tablePath: resolved.table.path,
+          columnIndex,
         }
-        return {table: table.node, tablePath: table.path, columnIndex}
       }
       const enclosingTable = getEnclosingBlock(snapshot, event.at, {
         match: isTable,

--- a/packages/plugin-table/src/behaviors/nav.test.tsx
+++ b/packages/plugin-table/src/behaviors/nav.test.tsx
@@ -1,0 +1,286 @@
+import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {getEnclosingBlock} from '@portabletext/editor/traversal'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {afterAll, beforeAll, describe, expect, test} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {TablePlugin} from '../plugin.table'
+import {isCell} from './types'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const cell = (key: string, text: string) => ({
+  _type: 'cell',
+  _key: key,
+  value: [
+    {
+      _type: 'block',
+      _key: `b-${key}`,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: `s-${key}`, text, marks: []}],
+    },
+  ],
+})
+
+// 2x2 grid: c00 c01 / c10 c11
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {_type: 'row', _key: 'r0', cells: [cell('c00', 'A'), cell('c01', 'B')]},
+      {_type: 'row', _key: 'r1', cells: [cell('c10', 'C'), cell('c11', 'D')]},
+    ],
+  },
+]
+
+// Same grid, but the left column holds text long enough to wrap across several
+// visual lines once the cell width is constrained (see the `beforeAll` style).
+const longText =
+  'lorem ipsum dolor sit amet consectetur adipiscing elit '.repeat(4)
+const wrappedValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {
+        _type: 'row',
+        _key: 'r0',
+        cells: [cell('c00', longText), cell('c01', 'B')],
+      },
+      {
+        _type: 'row',
+        _key: 'r1',
+        cells: [cell('c10', longText), cell('c11', 'D')],
+      },
+    ],
+  },
+]
+
+function spanPath(cellKey: string) {
+  const rowKey = cellKey.startsWith('c0') ? 'r0' : 'r1'
+  return [
+    {_key: 't0'},
+    'rows',
+    {_key: rowKey},
+    'cells',
+    {_key: cellKey},
+    'value',
+    {_key: `b-${cellKey}`},
+    'children',
+    {_key: `s-${cellKey}`},
+  ]
+}
+
+function focusCellKey(snapshot: EditorSnapshot): string | undefined {
+  const focus = snapshot.context.selection?.focus.path
+  if (!focus) {
+    return undefined
+  }
+  return getEnclosingBlock(snapshot, focus, {match: isCell})?.node._key
+}
+
+function focusBlockKey(snapshot: EditorSnapshot): string | undefined {
+  const focus = snapshot.context.selection?.focus.path
+  if (!focus) {
+    return undefined
+  }
+  return getEnclosingBlock(snapshot, focus)?.node._key
+}
+
+async function navFrom(
+  cellKey: string,
+  offset: number,
+  key: string,
+  value: typeof initialValue = initialValue,
+) {
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: value,
+    children: <TablePlugin />,
+  })
+  await userEvent.click(locator)
+  const point = {path: spanPath(cellKey), offset}
+  editor.send({type: 'select', at: {anchor: point, focus: point}})
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await userEvent.keyboard(`{${key}}`)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  return focusCellKey(editor.getSnapshot())
+}
+
+describe('table keyboard navigation', () => {
+  test('Tab moves to the next cell in the row', async () => {
+    expect(await navFrom('c00', 1, 'Tab')).toEqual('c01')
+  })
+
+  test('Tab wraps to the first cell of the next row', async () => {
+    expect(await navFrom('c01', 1, 'Tab')).toEqual('c10')
+  })
+
+  test('Tab at the last cell does not move (passes through)', async () => {
+    expect(await navFrom('c11', 1, 'Tab')).toEqual('c11')
+  })
+
+  test('Shift+Tab moves to the previous cell', async () => {
+    expect(await navFrom('c01', 1, 'Shift>}{Tab}{/Shift')).toEqual('c00')
+  })
+
+  test('Shift+Tab wraps to the last cell of the previous row', async () => {
+    expect(await navFrom('c10', 1, 'Shift>}{Tab}{/Shift')).toEqual('c01')
+  })
+
+  test('Shift+Tab at the first cell does not move (passes through)', async () => {
+    expect(await navFrom('c00', 1, 'Shift>}{Tab}{/Shift')).toEqual('c00')
+  })
+
+  test('ArrowDown moves to the cell directly below (same column)', async () => {
+    expect(await navFrom('c01', 1, 'ArrowDown')).toEqual('c11')
+  })
+
+  test('ArrowDown in the bottom row does not move (passes through)', async () => {
+    expect(await navFrom('c10', 1, 'ArrowDown')).toEqual('c10')
+  })
+
+  test('ArrowUp moves to the cell directly above (same column)', async () => {
+    expect(await navFrom('c10', 0, 'ArrowUp')).toEqual('c00')
+  })
+
+  test('ArrowUp in the top row does not move (passes through)', async () => {
+    expect(await navFrom('c00', 0, 'ArrowUp')).toEqual('c00')
+  })
+
+  test('ArrowUp lands in the last block of the cell above', async () => {
+    const value = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c00',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'c00-b0',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'c00-s0', text: 'top', marks: []},
+                    ],
+                  },
+                  {
+                    _type: 'block',
+                    _key: 'c00-b1',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: 'c00-s1',
+                        text: 'bottom',
+                        marks: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+              cell('c01', 'B'),
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', 'C'), cell('c11', 'D')],
+          },
+        ],
+      },
+    ]
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: value,
+      children: <TablePlugin />,
+    })
+    await userEvent.click(locator)
+    const point = {path: spanPath('c10'), offset: 0}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await userEvent.keyboard('{ArrowUp}')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(focusBlockKey(editor.getSnapshot())).toEqual('c00-b1')
+  })
+})
+
+describe('table keyboard navigation across a wrapped cell', () => {
+  let wrapStyle: HTMLStyleElement
+
+  beforeAll(() => {
+    wrapStyle = document.createElement('style')
+    wrapStyle.textContent =
+      'table{table-layout:fixed;width:80px}td,td *{word-break:break-all}'
+    document.head.append(wrapStyle)
+  })
+
+  afterAll(() => {
+    wrapStyle.remove()
+  })
+
+  test('ArrowDown from the last visual line crosses to the cell below', async () => {
+    expect(
+      await navFrom('c00', longText.length, 'ArrowDown', wrappedValue),
+    ).toEqual('c10')
+  })
+
+  test('ArrowDown from an earlier line stays in the cell (passes through)', async () => {
+    expect(await navFrom('c00', 0, 'ArrowDown', wrappedValue)).toEqual('c00')
+  })
+
+  test('ArrowUp from the first visual line crosses to the cell above', async () => {
+    expect(await navFrom('c10', 0, 'ArrowUp', wrappedValue)).toEqual('c00')
+  })
+
+  test('ArrowUp from a later line stays in the cell (passes through)', async () => {
+    expect(
+      await navFrom('c10', longText.length, 'ArrowUp', wrappedValue),
+    ).toEqual('c10')
+  })
+})

--- a/packages/plugin-table/src/behaviors/nav.ts
+++ b/packages/plugin-table/src/behaviors/nav.ts
@@ -1,0 +1,290 @@
+import type {EditorSelection, EditorSnapshot, Path} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {isSelectionCollapsed} from '@portabletext/editor/selectors'
+import {
+  getBlock,
+  getChildren,
+  getEnclosingBlock,
+  getFirstChild,
+  getLastChild,
+} from '@portabletext/editor/traversal'
+import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
+import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
+import {resolveCell} from '../resolve-cell'
+
+type Dom = {getSelectionRect: (snapshot: EditorSnapshot) => DOMRect | null}
+type Entry = {path: Path}
+
+const tab = createKeyboardShortcut({
+  default: [{key: 'Tab', alt: false, ctrl: false, meta: false, shift: false}],
+})
+const shiftTab = createKeyboardShortcut({
+  default: [{key: 'Tab', alt: false, ctrl: false, meta: false, shift: true}],
+})
+const arrowDown = createKeyboardShortcut({
+  default: [
+    {key: 'ArrowDown', alt: false, ctrl: false, meta: false, shift: false},
+  ],
+})
+const arrowUp = createKeyboardShortcut({
+  default: [
+    {key: 'ArrowUp', alt: false, ctrl: false, meta: false, shift: false},
+  ],
+})
+
+export const navBehaviors = [
+  // Tab: move to the start of the next cell, wrapping to the first cell of the
+  // next row. At the last cell the guard fails, so Tab falls through to the
+  // editor default and is not overwritten.
+  defineBehavior({
+    on: 'keyboard.keydown',
+    guard: ({snapshot, event}) => {
+      if (!tab.guard(event.originEvent)) {
+        return false
+      }
+      const position = resolveFocusCell(snapshot)
+      if (!position) {
+        return false
+      }
+      const cells = getChildren(snapshot, position.row.path)
+      const nextRow = adjacentRow(snapshot, position.table, position.row, 1)
+      const target =
+        cells[indexOf(cells, position.cell) + 1] ??
+        (nextRow && getFirstChild(snapshot, nextRow.path))
+      const at = target && cellStart(snapshot, target.path)
+      return at ? {at} : false
+    },
+    actions: [(_, {at}) => [raise({type: 'select', at})]],
+  }),
+
+  // Shift+Tab: move to the start of the previous cell, wrapping to the last
+  // cell of the previous row. At the first cell it falls through.
+  defineBehavior({
+    on: 'keyboard.keydown',
+    guard: ({snapshot, event}) => {
+      if (!shiftTab.guard(event.originEvent)) {
+        return false
+      }
+      const position = resolveFocusCell(snapshot)
+      if (!position) {
+        return false
+      }
+      const cells = getChildren(snapshot, position.row.path)
+      const columnIndex = indexOf(cells, position.cell)
+      const previousRow = adjacentRow(
+        snapshot,
+        position.table,
+        position.row,
+        -1,
+      )
+      const target =
+        (columnIndex > 0 ? cells[columnIndex - 1] : undefined) ??
+        (previousRow && getLastChild(snapshot, previousRow.path))
+      const at = target && cellStart(snapshot, target.path)
+      return at ? {at} : false
+    },
+    actions: [(_, {at}) => [raise({type: 'select', at})]],
+  }),
+
+  // ArrowDown: when the caret is in the last block of a cell, move to the cell
+  // directly below (same column). Otherwise fall through so the caret moves
+  // within the cell.
+  defineBehavior({
+    on: 'keyboard.keydown',
+    guard: ({snapshot, event, dom}) => {
+      if (!arrowDown.guard(event.originEvent)) {
+        return false
+      }
+      const position = resolveFocusCell(snapshot)
+      if (!position || !focusAtCellEdge(snapshot, position.cell.path, 'last')) {
+        return false
+      }
+      if (!focusOnVisualEdge(snapshot, dom, 'last')) {
+        return false
+      }
+      const rowBelow = adjacentRow(snapshot, position.table, position.row, 1)
+      const target =
+        rowBelow &&
+        sameColumnCell(snapshot, position.cell, position.row, rowBelow)
+      const at = target && cellStart(snapshot, target.path)
+      return at ? {at} : false
+    },
+    actions: [(_, {at}) => [raise({type: 'select', at})]],
+  }),
+
+  // ArrowUp: when the caret is in the first block of a cell, move to the cell
+  // directly above (same column). Otherwise fall through.
+  defineBehavior({
+    on: 'keyboard.keydown',
+    guard: ({snapshot, event, dom}) => {
+      if (!arrowUp.guard(event.originEvent)) {
+        return false
+      }
+      const position = resolveFocusCell(snapshot)
+      if (
+        !position ||
+        !focusAtCellEdge(snapshot, position.cell.path, 'first')
+      ) {
+        return false
+      }
+      if (!focusOnVisualEdge(snapshot, dom, 'first')) {
+        return false
+      }
+      const rowAbove = adjacentRow(snapshot, position.table, position.row, -1)
+      const target =
+        rowAbove &&
+        sameColumnCell(snapshot, position.cell, position.row, rowAbove)
+      const at = target && cellEnd(snapshot, target.path)
+      return at ? {at} : false
+    },
+    actions: [(_, {at}) => [raise({type: 'select', at})]],
+  }),
+]
+
+/**
+ * The table cell the collapsed selection focus sits in, with its enclosing row
+ * and table. Returns `undefined` when the focus isn't inside a cell.
+ */
+function resolveFocusCell(snapshot: EditorSnapshot) {
+  const selection = snapshot.context.selection
+  if (!selection || !isSelectionCollapsed(snapshot)) {
+    return undefined
+  }
+  return resolveCell(snapshot, selection.focus.path)
+}
+
+/** A collapsed selection at the start of the cell's first block. */
+function cellStart(
+  snapshot: EditorSnapshot,
+  cellPath: Path,
+): EditorSelection | undefined {
+  const firstChild = getFirstChild(snapshot, cellPath)
+  const firstBlock = firstChild && getBlock(snapshot, firstChild.path)
+  if (!firstBlock) {
+    return undefined
+  }
+  const point = getBlockStartPoint({
+    context: snapshot.context,
+    block: firstBlock,
+  })
+  return {anchor: point, focus: point}
+}
+
+/** A collapsed selection at the end of the cell's last block. */
+function cellEnd(
+  snapshot: EditorSnapshot,
+  cellPath: Path,
+): EditorSelection | undefined {
+  const lastChild = getLastChild(snapshot, cellPath)
+  const lastBlock = lastChild && getBlock(snapshot, lastChild.path)
+  if (!lastBlock) {
+    return undefined
+  }
+  const point = getBlockEndPoint({context: snapshot.context, block: lastBlock})
+  return {anchor: point, focus: point}
+}
+
+/** Whether the focus sits in the cell's first (or last) block. */
+function focusAtCellEdge(
+  snapshot: EditorSnapshot,
+  cellPath: Path,
+  edge: 'first' | 'last',
+): boolean {
+  const selection = snapshot.context.selection
+  if (!selection) {
+    return false
+  }
+  const focusBlock = getEnclosingBlock(snapshot, selection.focus.path)
+  const edgeBlock =
+    edge === 'first'
+      ? getFirstChild(snapshot, cellPath)
+      : getLastChild(snapshot, cellPath)
+  return (
+    !!focusBlock &&
+    !!edgeBlock &&
+    getKey(focusBlock.path) === getKey(edgeBlock.path)
+  )
+}
+
+/**
+ * Whether the caret sits on the first (or last) visual line of its block. The
+ * caret's client rect and the block edge point's rect share a vertical band
+ * when they render on the same line. Returns `false` when either rect can't be
+ * measured, e.g. the selection isn't currently rendered.
+ */
+function focusOnVisualEdge(
+  snapshot: EditorSnapshot,
+  dom: Dom,
+  edge: 'first' | 'last',
+): boolean {
+  const selection = snapshot.context.selection
+  if (!selection) {
+    return false
+  }
+  const focusBlock = getEnclosingBlock(snapshot, selection.focus.path)
+  if (!focusBlock) {
+    return false
+  }
+  const edgePoint =
+    edge === 'first'
+      ? getBlockStartPoint({context: snapshot.context, block: focusBlock})
+      : getBlockEndPoint({context: snapshot.context, block: focusBlock})
+  const caretRect = dom.getSelectionRect(snapshot)
+  const edgeRect = dom.getSelectionRect({
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      selection: {anchor: edgePoint, focus: edgePoint},
+    },
+  })
+  return !!caretRect && !!edgeRect && sameLine(caretRect, edgeRect)
+}
+
+/** The row `offset` positions above (-1) or below (+1) `row` in `table`. */
+function adjacentRow(
+  snapshot: EditorSnapshot,
+  table: Entry,
+  row: Entry,
+  offset: 1 | -1,
+): Entry | undefined {
+  const rows = getChildren(snapshot, table.path)
+  const index = indexOf(rows, row) + offset
+  return index >= 0 ? rows[index] : undefined
+}
+
+/** The cell in `adjacentRow` sharing `cell`'s column, clamped to the row width. */
+function sameColumnCell(
+  snapshot: EditorSnapshot,
+  cell: Entry,
+  row: Entry,
+  adjacentRow: Entry,
+): Entry | undefined {
+  const columnIndex = indexOf(getChildren(snapshot, row.path), cell)
+  const cells = getChildren(snapshot, adjacentRow.path)
+  return cells[Math.min(columnIndex, cells.length - 1)]
+}
+
+/** Whether two client rects share a vertical band, i.e. render on one line. */
+function sameLine(first: DOMRect, second: DOMRect): boolean {
+  return withinBand(first, second) && withinBand(second, first)
+}
+
+function withinBand(rect: DOMRect, compareRect: DOMRect): boolean {
+  const middle = (compareRect.top + compareRect.bottom) / 2
+  return rect.top <= middle && rect.bottom >= middle
+}
+
+/** The index of `entry` among `entries`, matched by keyed path segment. */
+function indexOf(entries: Array<Entry>, entry: Entry): number {
+  return entries.findIndex(
+    (candidate) => getKey(candidate.path) === getKey(entry.path),
+  )
+}
+
+/** The `_key` of a path's last keyed segment. */
+function getKey(path: Path): string | undefined {
+  const segment = path.at(-1)
+  return typeof segment === 'object' && segment !== null && '_key' in segment
+    ? segment._key
+    : undefined
+}

--- a/packages/plugin-table/src/get-table-selection.ts
+++ b/packages/plugin-table/src/get-table-selection.ts
@@ -1,6 +1,6 @@
 import type {EditorSnapshot} from '@portabletext/editor'
-import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
-import {isCell, isRow, isTable, type TableSelection} from './behaviors/types'
+import type {TableSelection} from './behaviors/types'
+import {resolveCell} from './resolve-cell'
 
 /**
  * Derives a rectangular table selection from the linear editor selection.
@@ -21,45 +21,29 @@ export function getTableSelection(
     return undefined
   }
 
-  const anchorCell = getEnclosingBlock(snapshot, selection.anchor.path, {
-    match: isCell,
-  })
-  const focusCell = getEnclosingBlock(snapshot, selection.focus.path, {
-    match: isCell,
-  })
-  if (!anchorCell || !focusCell) {
+  const anchor = resolveCell(snapshot, selection.anchor.path)
+  const focus = resolveCell(snapshot, selection.focus.path)
+  if (!anchor || !focus) {
     return undefined
   }
-  if (anchorCell.node._key === focusCell.node._key) {
+  if (anchor.cell.node._key === focus.cell.node._key) {
     return undefined
   }
-
-  const anchorRow = getParent(snapshot, anchorCell.path, {match: isRow})
-  const focusRow = getParent(snapshot, focusCell.path, {match: isRow})
-  if (!anchorRow || !focusRow) {
+  if (anchor.table.node._key !== focus.table.node._key) {
     return undefined
   }
 
-  const anchorTable = getParent(snapshot, anchorRow.path, {match: isTable})
-  const focusTable = getParent(snapshot, focusRow.path, {match: isTable})
-  if (!anchorTable || !focusTable) {
-    return undefined
-  }
-  if (anchorTable.node._key !== focusTable.node._key) {
-    return undefined
-  }
-
-  const anchorRowIndex = anchorTable.node.rows.findIndex(
-    (row) => row._key === anchorRow.node._key,
+  const anchorRowIndex = anchor.table.node.rows.findIndex(
+    (row) => row._key === anchor.row.node._key,
   )
-  const focusRowIndex = anchorTable.node.rows.findIndex(
-    (row) => row._key === focusRow.node._key,
+  const focusRowIndex = anchor.table.node.rows.findIndex(
+    (row) => row._key === focus.row.node._key,
   )
-  const anchorColIndex = anchorRow.node.cells.findIndex(
-    (cell) => cell._key === anchorCell.node._key,
+  const anchorColIndex = anchor.row.node.cells.findIndex(
+    (cell) => cell._key === anchor.cell.node._key,
   )
-  const focusColIndex = focusRow.node.cells.findIndex(
-    (cell) => cell._key === focusCell.node._key,
+  const focusColIndex = focus.row.node.cells.findIndex(
+    (cell) => cell._key === focus.cell.node._key,
   )
   if (
     anchorRowIndex === -1 ||
@@ -71,7 +55,7 @@ export function getTableSelection(
   }
 
   return {
-    tablePath: anchorTable.path,
+    tablePath: anchor.table.path,
     rowRange: [
       Math.min(anchorRowIndex, focusRowIndex),
       Math.max(anchorRowIndex, focusRowIndex),

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -52,15 +52,22 @@ export function TablePlugin() {
   return (
     <>
       <NodePlugin nodes={[tableContainer]} />
-      <BehaviorPlugin
-        behaviors={[
-          ...insertBehaviors,
-          ...unsetBehaviors,
-          ...moveBehaviors,
-          ...deleteBehaviors,
-          ...navBehaviors,
-        ]}
-      />
+      <BehaviorPlugin behaviors={tableBehaviors} />
     </>
   )
 }
+
+/**
+ * The table behaviors, split out so a consumer that brings its own table
+ * render (its own `NodePlugin` containers) can add them with a
+ * `<BehaviorPlugin behaviors={tableBehaviors} />` instead of `TablePlugin`.
+ *
+ * @alpha
+ */
+export const tableBehaviors = [
+  ...insertBehaviors,
+  ...unsetBehaviors,
+  ...moveBehaviors,
+  ...deleteBehaviors,
+  ...navBehaviors,
+]

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -3,6 +3,7 @@ import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {deleteBehaviors} from './behaviors/delete'
 import {insertBehaviors} from './behaviors/insert'
 import {moveBehaviors} from './behaviors/move'
+import {navBehaviors} from './behaviors/nav'
 import {unsetBehaviors} from './behaviors/unset'
 
 // `table` -> `row` -> `cell` nested containers. The render is intentionally
@@ -41,7 +42,9 @@ const tableContainer = defineContainer({
  * `custom.unset.table`, `custom.move.row`, or `custom.move.column`.
  *
  * Also intercepts `delete` and `split` when the selection spans more than
- * one cell, clearing the selected rectangle instead of deleting structure.
+ * one cell, clearing the selected rectangle instead of deleting structure,
+ * and `Tab` / `Shift+Tab` / `ArrowUp` / `ArrowDown` to move the caret
+ * between cells.
  *
  * @alpha
  */
@@ -55,6 +58,7 @@ export function TablePlugin() {
           ...unsetBehaviors,
           ...moveBehaviors,
           ...deleteBehaviors,
+          ...navBehaviors,
         ]}
       />
     </>

--- a/packages/plugin-table/src/resolve-cell.ts
+++ b/packages/plugin-table/src/resolve-cell.ts
@@ -1,0 +1,33 @@
+import type {EditorSnapshot, Path} from '@portabletext/editor'
+import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {
+  isCell,
+  isRow,
+  isTable,
+  type Cell,
+  type Row,
+  type Table,
+} from './behaviors/types'
+
+/**
+ * Resolves the table cell enclosing `path`, together with its row and table.
+ * Returns `undefined` when `path` isn't inside a cell.
+ */
+export function resolveCell(
+  snapshot: EditorSnapshot,
+  path: Path,
+):
+  | {
+      cell: {node: Cell; path: Path}
+      row: {node: Row; path: Path}
+      table: {node: Table; path: Path}
+    }
+  | undefined {
+  const cell = getEnclosingBlock(snapshot, path, {match: isCell})
+  const row = cell && getParent(snapshot, cell.path, {match: isRow})
+  const table = row && getParent(snapshot, row.path, {match: isTable})
+  if (!cell || !row || !table) {
+    return undefined
+  }
+  return {cell, row, table}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@portabletext/plugin-paste-link':
         specifier: workspace:*
         version: link:../../packages/plugin-paste-link
+      '@portabletext/plugin-table':
+        specifier: workspace:*
+        version: link:../../packages/plugin-table
       '@portabletext/plugin-typeahead-picker':
         specifier: workspace:*
         version: link:../../packages/plugin-typeahead-picker

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1255,6 +1255,10 @@ importers:
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
 
   packages/plugin-table:
+    dependencies:
+      '@portabletext/keyboard-shortcuts':
+        specifier: workspace:^
+        version: link:../keyboard-shortcuts
     devDependencies:
       '@portabletext/editor':
         specifier: workspace:*


### PR DESCRIPTION
Adds keyboard navigation between cells to `@portabletext/plugin-table`, so the caret moves around a table the way you'd expect.

`<TablePlugin />` now registers `keyboard.keydown` behaviors:

- **Tab / Shift+Tab** move to the next / previous cell, wrapping from the end of a row to the start of the next (and back). At the last cell (Tab) or the first cell (Shift+Tab) the guard fails and the key falls through to the editor default, so neither is overwritten at the table boundary.
- **ArrowDown / ArrowUp** move to the cell directly below / above in the same column, but only when the caret is on the last / first visual line of the cell. Otherwise the guard fails and the arrow moves within the cell as usual. At the table's bottom / top edge they pass through.

The caret lands at the start of the target cell. Enter (a newline in the cell) and Escape are left to the default behavior.

The vertical arrows are line-aware, not just block-aware. The guard first checks the caret is in the cell's last (or first) block by model traversal, then confirms it's on that block's last (or first) *visual* line by comparing the caret's client rect with the block edge point's rect via `editor.dom.getSelectionRect`: sharing a vertical band means the same rendered line (the same mutual-band test the engine uses for line-unit deletes). This is what distinguishes "move to the next line inside a wrapped cell" from "cross to the next cell", whether the cell spans lines through multiple blocks or one wrapped block. `nav.test.tsx` covers both: the 2x2 single-line grid for every key and boundary, plus a width-constrained wrapped cell where ArrowDown/Up cross only from the last/first line.

Keys are matched with `@portabletext/keyboard-shortcuts`, and the enclosing cell / row / table are resolved through the traversal utilities. The first commit extracts the cell -> row -> table walk that `nav`, `get-table-selection`, and `insert` were each repeating into a shared `resolveCell(snapshot, path)`; the existing `get-table-selection` and `insert` tests pin that it's behavior-preserving.

The behaviors are also exported as `tableBehaviors`, so a consumer that brings its own table render (its own `NodePlugin` containers) can add them with `<BehaviorPlugin behaviors={tableBehaviors} />` instead of the batteries-included `TablePlugin`. That's how the last commit wires this into the playground so it's testable by hand: it keeps the playground's rich table render (images and callouts in cells, list items, header-row styling, 100% width) and drives it with `tableBehaviors`. It also renames the playground's table cell field `content` -> `value` to match the plugin and the `@portabletext/markdown` canonical shape, which lets the two markdown adapter shims that only bridged `content` vs `value` go away (pt->md uses the built-in `DefaultTableRenderer`, md->pt drops its rename override).
