### PR TITLE
fix: honor table `headerRows: 0` in Markdown serialization

### DIFF
--- a/.changeset/markdown-table-header-rows.md
+++ b/.changeset/markdown-table-header-rows.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: honor table `headerRows: 0` in Markdown serialization
+
+`portableTextToMarkdown` now respects a table's `headerRows` field. A table with `headerRows: 0` serializes with an empty Markdown header row and every row in the body, instead of silently promoting the first row to the header. `markdownToPortableText` reads an all-empty header row back as `headerRows: 0` (dropping the empty header), so a headerless table round-trips. Tables with `headerRows` of 1 or more are unchanged, the first row is the header; because GFM allows a single header row, values above 1 still flatten to one header on export while the extra rows stay on the Portable Text side.

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -49,12 +49,15 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
 }
 
 /**
- * Renders a Portable Text table block-object back to Markdown. Because
- * GFM allows exactly one header row, the first row is always emitted as
- * the header, followed by the delimiter row, followed by the remaining
- * rows as body rows. The PT `headerRows` field is informational on the
- * Portable Text side and is ignored on the way out so that the emitted
- * Markdown is always a valid GFM table.
+ * Renders a Portable Text table block-object back to Markdown.
+ *
+ * The PT `headerRows` field decides the header. `headerRows === 0` is an
+ * explicit headerless table: GFM has no headerless form, so an empty header
+ * row is emitted and every row goes in the body (that empty header reads back
+ * as `headerRows: 0` via `markdownToPortableText`). Any other value
+ * (`undefined` or `>= 1`) promotes `rows[0]` to the header. GFM allows exactly
+ * one header row, so header rows beyond the first flatten into the body,
+ * lossy, but the extra rows stay on the Portable Text side.
  *
  * Asymmetric tables (rows of varying cell counts) are widened to match
  * the row with the most cells. Narrower rows are padded with empty cells
@@ -119,16 +122,16 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
     0,
   )
 
-  const renderRow = (cells: typeof headerRow.cells): string => {
-    const texts = cells.map((cell) => escapeTableCell(getCellText(cell.value)))
-    while (texts.length < columnCount) {
-      texts.push('')
+  const renderCells = (texts: Array<string>): string => {
+    const padded = [...texts]
+    while (padded.length < columnCount) {
+      padded.push('')
     }
-    return `| ${texts.join(' | ')} |`
+    return `| ${padded.join(' | ')} |`
   }
 
-  // First row is the header, padded to the table's column count
-  lines.push(renderRow(headerRow.cells))
+  const renderRow = (cells: typeof headerRow.cells): string =>
+    renderCells(cells.map((cell) => escapeTableCell(getCellText(cell.value))))
 
   // Delimiter row, sized to the column count. Each cell's colons encode the
   // column's alignment as defined by `value.alignment[columnIndex]`.
@@ -145,13 +148,26 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
     }
     return ' --- '
   })
-  lines.push(`|${separators.join('|')}|`)
+  const delimiter = `|${separators.join('|')}|`
 
-  // Remaining rows are the body
-  for (let i = 1; i < rows.length; i++) {
-    const row = rows.at(i)
-    if (row) {
+  if (value.headerRows === 0) {
+    // Explicit headerless table: emit an empty header row and keep every row
+    // in the body.
+    lines.push(renderCells([]))
+    lines.push(delimiter)
+    for (const row of rows) {
       lines.push(renderRow(row.cells))
+    }
+  } else {
+    // `rows[0]` is the header. Header rows beyond the first flatten into the
+    // body (GFM has a single header row).
+    lines.push(renderRow(headerRow.cells))
+    lines.push(delimiter)
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows.at(i)
+      if (row) {
+        lines.push(renderRow(row.cells))
+      }
     }
   }
 

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -3357,6 +3357,99 @@ describe(markdownToPortableText.name, () => {
       },
     })
 
+    test('empty header row reads back as headerRows 0 with only the body rows', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '|  |  |',
+        '| --- | --- |',
+        '| Cell 1 | Cell 2 |',
+        '| Cell 3 | Cell 4 |',
+      ].join('\n')
+      expect(
+        markdownToPortableText(markdown, getTableTestOptions(keyGenerator)),
+      ).toEqual([
+        {
+          _key: 'k20',
+          _type: 'table',
+          headerRows: 0,
+          rows: [
+            {
+              _key: 'k12',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k8',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'k6',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k7', text: 'Cell 1', marks: []},
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'k11',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'k9',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k10', text: 'Cell 2', marks: []},
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k19',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k15',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'k13',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k14', text: 'Cell 3', marks: []},
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'k18',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'k16',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k17', text: 'Cell 4', marks: []},
+                      ],
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
     test('simple table', () => {
       const keyGenerator = createTestKeyGenerator()
       const markdown = [

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1530,15 +1530,16 @@ describe(portableTextToMarkdown.name, () => {
         ).toBe(markdownOut)
       })
 
-      test('headerRows 0 promotes the first row to header', () => {
+      test('headerRows 0 emits an empty header row and keeps every row in the body', () => {
         const table = portableText.at(0)
         if (!table) {
           throw new Error('expected a table block')
         }
         const withZeroHeaderRows = [{...table, headerRows: 0}]
         const markdownOut = [
-          '| Cell 1 | Cell 2 |',
+          '|  |  |',
           '| --- | --- |',
+          '| Cell 1 | Cell 2 |',
           '| Cell 3 | Cell 4 |',
         ].join('\n')
 

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -1,6 +1,7 @@
 import {alert} from '@mdit/plugin-alert'
 import {
   isSpan,
+  isTextBlock,
   type PortableTextBlock,
   type PortableTextObject,
   type PortableTextTextBlock,
@@ -205,6 +206,28 @@ export function extractAlignmentFromStyleAttr(
 }
 
 /**
+ * A table row is empty when every cell holds only blank spans, no non-empty
+ * text, no inline objects, no non-text blocks. Used to detect a headerless
+ * GFM table: `portableTextToMarkdown` emits an empty header row for
+ * `headerRows: 0`, and an empty header must round-trip back to
+ * `headerRows: 0` rather than a phantom header row.
+ */
+function isEmptyTableRow(
+  cells: Array<{value: Array<PortableTextBlock>}>,
+  context: {schema: Schema},
+): boolean {
+  return cells.every((cell) =>
+    cell.value.every(
+      (block) =>
+        isTextBlock(context, block) &&
+        block.children.every(
+          (child) => isSpan(context, child) && (child.text ?? '').trim() === '',
+        ),
+    ),
+  )
+}
+
+/**
  * Flattens a table structure by lifting all blocks from all cells.
  */
 function flattenTable(
@@ -362,6 +385,7 @@ export function markdownToPortableText(
       }>
     }>
     headerRows: number
+    emptyHeaderDropped: boolean
     alignment: Array<'left' | 'center' | 'right' | null>
   } | null = null
   let currentTableRow: Array<{
@@ -1118,7 +1142,12 @@ export function markdownToPortableText(
       // Tables
       case 'table_open':
         flushBlock()
-        currentTable = {rows: [], headerRows: 0, alignment: []}
+        currentTable = {
+          rows: [],
+          headerRows: 0,
+          emptyHeaderDropped: false,
+          alignment: [],
+        }
         break
 
       case 'table_close': {
@@ -1139,7 +1168,9 @@ export function markdownToPortableText(
               headerRows:
                 currentTable.headerRows > 0
                   ? currentTable.headerRows
-                  : undefined,
+                  : currentTable.emptyHeaderDropped
+                    ? 0
+                    : undefined,
               alignment: hasAlignment ? currentTable.alignment : undefined,
             },
             isInline: false,
@@ -1182,13 +1213,26 @@ export function markdownToPortableText(
 
       case 'tr_close':
         if (currentTable && currentTableRow) {
-          currentTable.rows.push({
-            _key: consolidatedOptions.keyGenerator(),
-            _type: 'row',
-            cells: currentTableRow,
-          })
-          if (inTableHead) {
-            currentTable.headerRows++
+          if (
+            inTableHead &&
+            isEmptyTableRow(currentTableRow, {
+              schema: consolidatedOptions.schema,
+            })
+          ) {
+            // An all-empty header row means "no header": drop it and leave
+            // `headerRows` at 0 (recorded so `table_close` emits an explicit
+            // 0, not `undefined`), so `portableTextToMarkdown`'s headerless
+            // output round-trips back to `headerRows: 0`.
+            currentTable.emptyHeaderDropped = true
+          } else {
+            currentTable.rows.push({
+              _key: consolidatedOptions.keyGenerator(),
+              _type: 'row',
+              cells: currentTableRow,
+            })
+            if (inTableHead) {
+              currentTable.headerRows++
+            }
           }
         }
         currentTableRow = null


### PR DESCRIPTION
`portableTextToMarkdown` ignored a table's `headerRows` field and always promoted `rows[0]` to the GFM header. A headerless table (`headerRows: 0`) lost that fact on export, `rows[0]` was reinterpreted as the header, and the round-trip back through `markdownToPortableText` returned `headerRows: 1`.

**pt→md** (`DefaultTableRenderer`): `headerRows === 0` now emits an empty header row (padded to the column count) plus the delimiter, with every row in the body. Any other value (`undefined` or `>= 1`) still promotes `rows[0]`. GFM allows a single header row, so header rows beyond the first flatten into the body (lossy, and the extra rows stay on the Portable Text side).

**md→pt**: an all-empty header row is dropped and recorded as an explicit `headerRows: 0` (distinct from the pre-existing no-header `undefined` fallback); a non-empty header stays `headerRows: 1`. Markdown only ever emits 0 or 1, so a headerless table round-trips cleanly with no phantom empty header row.

Round-trips: `0 → empty-header md → 0`; `1 → header md → 1`; `>= 2 → single-header md → 1` (lossy on export, `> 1` preserved in the PT source, documented).

`headerRows` stays `number`, so this is a serialization-behavior change, not an API break. The existing `portable-text-to-markdown` "`headerRows: 0` promotes the first row" test flips (now asserts the empty header + full body), and a new `markdown-to-portable-text` test pins the empty-header read-back to `headerRows: 0` with only the body rows (full-literal `toEqual`, deterministic keys). All 292 markdown-package tests pass; types/lint/build/knip/format green.

Out of scope (follow-up): the ticket notes `@portabletext/plugin-table`'s header feature should adopt the same `headerRows: number`. Happy to file that separately.
