### PR TITLE
feat(playground): table editing chrome to match the design prototype

### DIFF
--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -208,9 +208,26 @@
 .playground-table-chrome {
   position: relative;
   margin: 20px 0;
-  /* Top gutter holds the column handles; right/bottom lanes are reserved for
-     the add-column / add-row extend bars so the table never shifts. */
-  padding: 20px 20px 20px 0;
+}
+
+/* Horizontal scroll under a wide table: lighter thumb, gap from the table edge. */
+.table-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(28, 31, 36, 0.22) transparent;
+}
+.table-scroll::-webkit-scrollbar {
+  height: 6px;
+}
+.table-scroll::-webkit-scrollbar-track {
+  margin-top: 8px;
+  background: transparent;
+}
+.table-scroll::-webkit-scrollbar-thumb {
+  background: rgba(28, 31, 36, 0.22);
+  border-radius: 3px;
+}
+.table-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(28, 31, 36, 0.35);
 }
 
 .playground-table {

--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -208,8 +208,9 @@
 .playground-table-chrome {
   position: relative;
   margin: 20px 0;
-  /* Top gutter holds the column handles; the table is flush on the left. */
-  padding: 20px 0 0 0;
+  /* Top gutter holds the column handles; right/bottom lanes are reserved for
+     the add-column / add-row extend bars so the table never shifts. */
+  padding: 20px 20px 20px 0;
 }
 
 .playground-table {

--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -201,128 +201,60 @@
 }
 
 /**
- * Playground table styling.
- *
- * `data-header-rows` carries the table's headerRows count; CSS targets
- * the first N rows via `tr:nth-child(-n+N)` to highlight headers.
+ * Table styling — matches the design prototype (pte-tables-phases branch).
+ * `data-header-rows` (0/1) marks whether the first row is a header.
  */
+.playground-table-chrome {
+  position: relative;
+  margin: 20px 0;
+}
+
 .playground-table {
+  width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  width: 100%;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.375rem;
-  overflow: hidden;
+  table-layout: fixed;
+  background: #fff;
+  border: 1px solid #e3e4e8;
+  border-radius: 6px;
+}
+
+.playground-table td {
+  padding: 8px 12px;
+  vertical-align: top;
+  color: #1c1f24;
+  border-bottom: 1px solid #e3e4e8;
+  border-right: 1px solid #e3e4e8;
+  word-break: break-word;
+}
+
+/* Clean outer edges: last column/row drop their outer grid line. */
+.playground-table tr td:last-child {
+  border-right: none;
+}
+.playground-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Header row: darker base + semibold (IX11), no size/case change. */
+.playground-table[data-header-rows]:not([data-header-rows='0'])
+  tr:first-child
+  td {
+  background: #f6f6f8;
+  font-weight: 600;
 }
 
 :where(.dark) .playground-table {
   background: #0f172a;
   border-color: #334155;
 }
-
-.playground-table-chrome {
-  position: relative;
-  margin: 1.25rem 0;
-  padding: 0.5rem;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.5rem;
-  overflow: hidden;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-}
-
-.playground-table-chrome[data-selected] {
-  border-color: #94a3b8;
-}
-
-:where(.dark) .playground-table-chrome {
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-}
-
-:where(.dark) .playground-table-chrome[data-selected] {
-  border-color: #64748b;
-}
-
-/* Body cells: subtle horizontal + vertical dividers. */
-.playground-table td {
-  padding: 0.625rem 0.875rem;
-  vertical-align: top;
-  min-width: 8rem;
-  color: #1e293b;
-  border-bottom: 1px solid #f1f5f9;
-  border-right: 1px solid #f1f5f9;
-}
-
 :where(.dark) .playground-table td {
   color: #e2e8f0;
-  border-bottom-color: #1e293b;
-  border-right-color: #1e293b;
+  border-color: #334155;
 }
-
-/* Last cell in each row drops its right border so the table edge stays clean. */
-.playground-table tr td:last-child {
-  border-right: none;
-}
-
-/* Last row drops its bottom border so the table edge is clean. */
-.playground-table tr:last-child td {
-  border-bottom: none;
-}
-
-/**
- * Header rows: bg tinted indigo to clearly differentiate from body, with
- * uppercase + tracking on the cell content. The bottom of the header band
- * has a slightly stronger divider to mark the body boundary.
- */
-.playground-table[data-header-rows='1'] tr:nth-child(1) td,
-.playground-table[data-header-rows='2'] tr:nth-child(-n + 2) td,
-.playground-table[data-header-rows='3'] tr:nth-child(-n + 3) td {
-  background: #f1f5f9;
-  color: #475569;
-  font-weight: 600;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-
-:where(.dark) .playground-table[data-header-rows='1'] tr:nth-child(1) td,
-:where(.dark) .playground-table[data-header-rows='2'] tr:nth-child(-n + 2) td,
-:where(.dark) .playground-table[data-header-rows='3'] tr:nth-child(-n + 3) td {
+:where(.dark)
+  .playground-table[data-header-rows]:not([data-header-rows='0'])
+  tr:first-child
+  td {
   background: #1e293b;
-  color: #94a3b8;
-}
-
-/* Last header row gets a slightly heavier divider to mark the body boundary. */
-.playground-table[data-header-rows='1'] tr:nth-child(1) td,
-.playground-table[data-header-rows='2'] tr:nth-child(2) td,
-.playground-table[data-header-rows='3'] tr:nth-child(3) td {
-  border-bottom: 1px solid #cbd5e1;
-}
-
-:where(.dark) .playground-table[data-header-rows='1'] tr:nth-child(1) td,
-:where(.dark) .playground-table[data-header-rows='2'] tr:nth-child(2) td,
-:where(.dark) .playground-table[data-header-rows='3'] tr:nth-child(3) td {
-  border-bottom-color: #475569;
-}
-
-/**
- * Selection cue: `data-selected` is set on the cell whose content currently
- * holds the editor selection. Subtle inset-ring highlight only on that cell
- * - the row and table cascades aren't styled (they were too noisy when the
- * caret was inside a single cell).
- */
-.playground-table td[data-selected] {
-  box-shadow: inset 0 0 0 2px #3b82f6;
-  border-radius: 0;
-}
-
-:where(.dark) .playground-table td[data-selected] {
-  box-shadow: inset 0 0 0 2px #60a5fa;
 }

--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -208,6 +208,8 @@
 .playground-table-chrome {
   position: relative;
   margin: 20px 0;
+  /* Top gutter holds the column handles; the table is flush on the left. */
+  padding: 20px 0 0 0;
 }
 
 .playground-table {

--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -201,8 +201,9 @@
 }
 
 /**
- * Table styling — matches the design prototype (pte-tables-phases branch).
- * `data-header-rows` (0/1) marks whether the first row is a header.
+ * Table layout only. Cell borders, header base, selection outline/overlay and
+ * corner radii are inline per cell (see `table-cell-style.ts`), matching the
+ * design prototype.
  */
 .playground-table-chrome {
   position: relative;
@@ -214,47 +215,13 @@
   border-collapse: separate;
   border-spacing: 0;
   table-layout: fixed;
-  background: #fff;
-  border: 1px solid #e3e4e8;
-  border-radius: 6px;
 }
 
-.playground-table td {
-  padding: 8px 12px;
-  vertical-align: top;
-  color: #1c1f24;
-  border-bottom: 1px solid #e3e4e8;
-  border-right: 1px solid #e3e4e8;
-  word-break: break-word;
+/* While a multi-cell range is active, the blue rectangle overlay stands in for
+   the selection, so hide the native text-selection highlight. */
+.playground-table[data-cell-range] ::selection {
+  background: transparent;
 }
-
-/* Clean outer edges: last column/row drop their outer grid line. */
-.playground-table tr td:last-child {
-  border-right: none;
-}
-.playground-table tr:last-child td {
-  border-bottom: none;
-}
-
-/* Header row: darker base + semibold (IX11), no size/case change. */
-.playground-table[data-header-rows]:not([data-header-rows='0'])
-  tr:first-child
-  td {
-  background: #f6f6f8;
-  font-weight: 600;
-}
-
-:where(.dark) .playground-table {
-  background: #0f172a;
-  border-color: #334155;
-}
-:where(.dark) .playground-table td {
-  color: #e2e8f0;
-  border-color: #334155;
-}
-:where(.dark)
-  .playground-table[data-header-rows]:not([data-header-rows='0'])
-  tr:first-child
-  td {
-  background: #1e293b;
+.playground-table[data-cell-range] ::-moz-selection {
+  background: transparent;
 }

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -35,7 +35,7 @@ import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 import {cellStyle, type CellRange} from './table-cell-style'
-import {TableChrome, type HoverCell} from './table-chrome'
+import {TableChrome, TableTrashLayer, type HoverCell} from './table-chrome'
 import {useTableMetrics} from './table-metrics'
 
 const tableContainer = defineContainer({
@@ -195,6 +195,25 @@ function TableContainer({
     }
   }
 
+  const deleteRow = (index: number) => {
+    const snapshot = editor.getSnapshot()
+    const row = getChildren(snapshot, path).at(index)
+    const cell = row && getChildren(snapshot, row.path).at(0)
+    const insideCell = cell && getFirstChild(snapshot, cell.path)
+    if (insideCell) {
+      editor.send({type: 'custom.unset.row', at: insideCell.path})
+    }
+  }
+  const deleteCol = (index: number) => {
+    const snapshot = editor.getSnapshot()
+    const firstRow = getChildren(snapshot, path).at(0)
+    const cell = firstRow && getChildren(snapshot, firstRow.path).at(index)
+    const insideCell = cell && getFirstChild(snapshot, cell.path)
+    if (insideCell) {
+      editor.send({type: 'custom.unset.column', at: insideCell.path})
+    }
+  }
+
   const onMouseMove = (event: ReactMouseEvent) => {
     const rect = tableRef.current?.getBoundingClientRect()
     if (!rect || !metrics) {
@@ -245,6 +264,16 @@ function TableContainer({
         onSelectCol={selectCol}
         onInsertRow={insertRow}
         onInsertCol={insertCol}
+      />
+      <TableTrashLayer
+        tableRef={tableRef}
+        metrics={metrics}
+        selectedRow={selectedRow}
+        selectedCol={selectedCol}
+        canDeleteRow={rowCount > 1}
+        canDeleteCol={columnCount > 1}
+        onDeleteRow={deleteRow}
+        onDeleteCol={deleteCol}
       />
     </div>
   )

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -14,6 +14,7 @@ import {
   getEnclosingBlock,
   getFirstChild,
   getParent,
+  getText,
 } from '@portabletext/editor/traversal'
 import {getBlockStartPoint, isEqualPaths} from '@portabletext/editor/utils'
 import {
@@ -25,6 +26,8 @@ import {
   type TableSelection,
 } from '@portabletext/plugin-table'
 import {
+  createContext,
+  useContext,
   useMemo,
   useRef,
   useState,
@@ -36,12 +39,22 @@ import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 import {cellStyle, type CellRange} from './table-cell-style'
 import {
+  ReorderGhost,
   TableChrome,
   TableMenu,
   TableTrashLayer,
   type HoverCell,
 } from './table-chrome'
+import {useTableDragReorder} from './table-drag'
 import {useTableMetrics} from './table-metrics'
+import {reorderIndex} from './table-reorder'
+
+// The source row/column dims while it's being drag-reordered; cells read this
+// to know whether they're part of the lifted row/column.
+const TableDragContext = createContext<{
+  kind: 'row' | 'column'
+  index: number
+} | null>(null)
 
 const tableContainer = defineContainer({
   type: 'table',
@@ -248,6 +261,89 @@ function TableContainer({
     }
   }
 
+  const commitRowDrag = (from: number, insertBefore: number) => {
+    const finalIndex = reorderIndex(from, insertBefore)
+    if (finalIndex === from) {
+      return
+    }
+    const snapshot = editor.getSnapshot()
+    const rows = getChildren(snapshot, path)
+    const origin = rows.at(from)
+    const destination = rows.at(finalIndex)
+    if (origin && destination) {
+      editor.send({
+        type: 'custom.move.row',
+        at: origin.path,
+        to: destination.path,
+      })
+    }
+  }
+  const commitColDrag = (from: number, insertBefore: number) => {
+    const finalIndex = reorderIndex(from, insertBefore)
+    if (finalIndex === from) {
+      return
+    }
+    const snapshot = editor.getSnapshot()
+    const firstRow = getChildren(snapshot, path).at(0)
+    const cells = firstRow ? getChildren(snapshot, firstRow.path) : []
+    const origin = cells.at(from)
+    const destination = cells.at(finalIndex)
+    if (origin && destination) {
+      editor.send({
+        type: 'custom.move.column',
+        at: origin.path,
+        to: destination.path,
+      })
+    }
+  }
+
+  const {drag, onHandlePointerDown} = useTableDragReorder({
+    tableRef,
+    metrics,
+    onCommitRow: commitRowDrag,
+    onCommitCol: commitColDrag,
+    onSelectRow: selectRow,
+    onSelectCol: selectCol,
+  })
+
+  // Primitive projections keep the memos below ref-stable across pointermoves
+  // (the drag object changes identity on every move) while matching the
+  // dependencies the React Compiler infers.
+  const activeDragKind = drag?.active ? drag.kind : null
+  const activeDragIndex = drag?.active ? drag.index : null
+  const dragKind = drag?.kind ?? null
+  const dragIndex = drag?.index ?? null
+
+  const dragContextValue = useMemo(
+    () =>
+      activeDragKind !== null && activeDragIndex !== null
+        ? {kind: activeDragKind, index: activeDragIndex}
+        : null,
+    [activeDragKind, activeDragIndex],
+  )
+
+  // The lifted row/column's cell texts, for the drag ghost.
+  const ghostCellTexts = useMemo(() => {
+    if (dragKind === null || dragIndex === null) {
+      return null
+    }
+    const snapshot = editor.getSnapshot()
+    const rows = getChildren(snapshot, path)
+    if (dragKind === 'row') {
+      const row = rows.at(dragIndex)
+      if (!row) {
+        return null
+      }
+      return getChildren(snapshot, row.path).map(
+        (cell) => getText(snapshot, cell.path) ?? '',
+      )
+    }
+    return rows.map((row) => {
+      const cell = getChildren(snapshot, row.path).at(dragIndex)
+      return cell ? (getText(snapshot, cell.path) ?? '') : ''
+    })
+  }, [dragKind, dragIndex, editor, path])
+
   const onMouseMove = (event: ReactMouseEvent) => {
     const rect = tableRef.current?.getBoundingClientRect()
     if (!rect || !metrics) {
@@ -286,7 +382,11 @@ function TableContainer({
             <col key={index} />
           ))}
         </colgroup>
-        <tbody>{children}</tbody>
+        <tbody>
+          <TableDragContext.Provider value={dragContextValue}>
+            {children}
+          </TableDragContext.Provider>
+        </tbody>
       </table>
       <TableChrome
         metrics={metrics}
@@ -294,10 +394,16 @@ function TableContainer({
         hoverCell={hoverCell}
         selectedRow={selectedRow}
         selectedCol={selectedCol}
-        onSelectRow={selectRow}
-        onSelectCol={selectCol}
+        onHandlePointerDown={onHandlePointerDown}
+        drag={drag}
         onInsertRow={insertRow}
         onInsertCol={insertCol}
+      />
+      <ReorderGhost
+        drag={drag}
+        metrics={metrics}
+        hasHeader={hasHeader}
+        cellTexts={ghostCellTexts}
       />
       {metrics ? (
         <TableMenu
@@ -408,12 +514,19 @@ function TableCell({
     },
     isEqualCellDescriptor,
   )
+  const dragContext = useContext(TableDragContext)
+  const dimmed =
+    descriptor !== null &&
+    dragContext !== null &&
+    (dragContext.kind === 'row'
+      ? descriptor.rowIdx === dragContext.index
+      : descriptor.colIdx === dragContext.index)
   const style = useMemo(
     () => (descriptor ? cellStyle(descriptor) : undefined),
     [descriptor],
   )
   return (
-    <td {...attributes} style={style}>
+    <td {...attributes} style={dimmed ? {...style, opacity: 0.35} : style}>
       {children}
     </td>
   )

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -161,6 +161,40 @@ function TableContainer({
       selectCells(first.path, last.path)
     }
   }
+  // The plugin's insert behaviors resolve `at` via `getEnclosingBlock`, so a
+  // path inside the reference cell (its first block) is all they need.
+  const insertRow = (boundary: number) => {
+    const snapshot = editor.getSnapshot()
+    const rows = getChildren(snapshot, path)
+    const referenceRow = rows.at(Math.min(boundary, rows.length - 1))
+    const referenceCell =
+      referenceRow && getChildren(snapshot, referenceRow.path).at(0)
+    const insideCell =
+      referenceCell && getFirstChild(snapshot, referenceCell.path)
+    if (insideCell) {
+      editor.send({
+        type: 'custom.insert.row',
+        at: insideCell.path,
+        position: boundary < rows.length ? 'before' : 'after',
+      })
+    }
+  }
+  const insertCol = (boundary: number) => {
+    const snapshot = editor.getSnapshot()
+    const firstRow = getChildren(snapshot, path).at(0)
+    const cells = firstRow ? getChildren(snapshot, firstRow.path) : []
+    const referenceCell = cells.at(Math.min(boundary, cells.length - 1))
+    const insideCell =
+      referenceCell && getFirstChild(snapshot, referenceCell.path)
+    if (insideCell) {
+      editor.send({
+        type: 'custom.insert.column',
+        at: insideCell.path,
+        position: boundary < cells.length ? 'before' : 'after',
+      })
+    }
+  }
+
   const onMouseMove = (event: ReactMouseEvent) => {
     const rect = tableRef.current?.getBoundingClientRect()
     if (!rect || !metrics) {
@@ -209,6 +243,8 @@ function TableContainer({
         selectedCol={selectedCol}
         onSelectRow={selectRow}
         onSelectCol={selectCol}
+        onInsertRow={insertRow}
+        onInsertCol={insertCol}
       />
     </div>
   )

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -4,23 +4,39 @@ import {
   useEditor,
   useEditorSelector,
   type ContainerRenderProps,
+  type EditorSnapshot,
+  type Path,
 } from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
-import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
-import {isEqualPaths} from '@portabletext/editor/utils'
+import {
+  getBlock,
+  getChildren,
+  getEnclosingBlock,
+  getFirstChild,
+  getParent,
+} from '@portabletext/editor/traversal'
+import {getBlockStartPoint, isEqualPaths} from '@portabletext/editor/utils'
 import {
   getTableSelection,
   isCell,
   isRow,
   isTable,
   tableBehaviors,
+  type TableSelection,
 } from '@portabletext/plugin-table'
-import {useMemo, type JSX} from 'react'
-import {DragHandle} from './drag-handle'
+import {
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
 import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 import {cellStyle, type CellRange} from './table-cell-style'
+import {TableChrome, type HoverCell} from './table-chrome'
+import {useTableMetrics} from './table-metrics'
 
 const tableContainer = defineContainer({
   type: 'table',
@@ -78,25 +94,105 @@ function TableContainer({
   children,
   node,
   path,
-  readOnly,
-  selected,
 }: ContainerRenderProps): JSX.Element {
   const editor = useEditor()
   const table = isTable(node) ? node : undefined
+  const rowCount = table?.rows.length ?? 0
   const columnCount = table?.rows[0]?.cells.length ?? 0
-  const hasCellRange = useEditorSelector(editor, (snapshot) => {
-    const selection = getTableSelection(snapshot)
-    return selection ? isEqualPaths(selection.tablePath, path) : false
-  })
+  const tableRef = useRef<HTMLTableElement>(null)
+  const metrics = useTableMetrics(tableRef, `${rowCount}x${columnCount}`)
+  const [active, setActive] = useState(false)
+  const [hoverCell, setHoverCell] = useState<HoverCell>(null)
+
+  const tableSelection = useEditorSelector(
+    editor,
+    (snapshot) => {
+      const selection = getTableSelection(snapshot)
+      return selection && isEqualPaths(selection.tablePath, path)
+        ? selection
+        : null
+    },
+    isEqualTableSelection,
+  )
+  const hasCellRange = tableSelection !== null
+  // A selected row/column is a range spanning exactly one row/column edge to
+  // edge; that's when its handle shows as selected.
+  const selectedRow =
+    tableSelection &&
+    tableSelection.rowRange[0] === tableSelection.rowRange[1] &&
+    tableSelection.colRange[0] === 0 &&
+    tableSelection.colRange[1] === columnCount - 1
+      ? tableSelection.rowRange[0]
+      : null
+  const selectedCol =
+    tableSelection &&
+    tableSelection.colRange[0] === tableSelection.colRange[1] &&
+    tableSelection.rowRange[0] === 0 &&
+    tableSelection.rowRange[1] === rowCount - 1
+      ? tableSelection.colRange[0]
+      : null
+
+  const selectCells = (anchorCellPath: Path, focusCellPath: Path) => {
+    const snapshot = editor.getSnapshot()
+    const anchor = cellStartPoint(snapshot, anchorCellPath)
+    const focus = cellStartPoint(snapshot, focusCellPath)
+    if (anchor && focus) {
+      editor.send({type: 'select', at: {anchor, focus}})
+    }
+  }
+  const selectRow = (index: number) => {
+    const snapshot = editor.getSnapshot()
+    const row = getChildren(snapshot, path).at(index)
+    const cells = row ? getChildren(snapshot, row.path) : []
+    const first = cells.at(0)
+    const last = cells.at(-1)
+    if (first && last) {
+      selectCells(first.path, last.path)
+    }
+  }
+  const selectCol = (index: number) => {
+    const snapshot = editor.getSnapshot()
+    const rows = getChildren(snapshot, path)
+    const firstRow = rows.at(0)
+    const lastRow = rows.at(-1)
+    const first = firstRow && getChildren(snapshot, firstRow.path).at(index)
+    const last = lastRow && getChildren(snapshot, lastRow.path).at(index)
+    if (first && last) {
+      selectCells(first.path, last.path)
+    }
+  }
+  const onMouseMove = (event: ReactMouseEvent) => {
+    const rect = tableRef.current?.getBoundingClientRect()
+    if (!rect || !metrics) {
+      return
+    }
+    const relY = event.clientY - rect.top
+    const relX = event.clientX - rect.left
+    const row = metrics.rows.findIndex(
+      (r) => relY >= r.top && relY < r.top + r.height,
+    )
+    const col = metrics.cols.findIndex(
+      (c) => relX >= c.left && relX < c.left + c.width,
+    )
+    setHoverCell(row >= 0 && col >= 0 ? {row, col} : null)
+  }
+
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: mouse events only reveal the hover chrome; all interaction lives on the chrome's buttons
     <div
       {...attributes}
-      data-selected={selected ? '' : undefined}
       className="playground-table-chrome group"
+      onMouseEnter={() => setActive(true)}
+      onMouseLeave={() => {
+        setActive(false)
+        setHoverCell(null)
+      }}
     >
       <table
+        ref={tableRef}
         className="playground-table cursor-text"
         data-cell-range={hasCellRange ? '' : undefined}
+        onMouseMove={onMouseMove}
       >
         <colgroup>
           {Array.from({length: columnCount}, (_, index) => (
@@ -105,8 +201,45 @@ function TableContainer({
         </colgroup>
         <tbody>{children}</tbody>
       </table>
-      <DragHandle readOnly={readOnly} />
+      <TableChrome
+        metrics={metrics}
+        active={active}
+        hoverCell={hoverCell}
+        selectedRow={selectedRow}
+        selectedCol={selectedCol}
+        onSelectRow={selectRow}
+        onSelectCol={selectCol}
+      />
     </div>
+  )
+}
+
+/** The point at the start of a cell's first block. */
+function cellStartPoint(snapshot: EditorSnapshot, cellPath: Path) {
+  const firstChild = getFirstChild(snapshot, cellPath)
+  const block = firstChild && getBlock(snapshot, firstChild.path)
+  if (!block) {
+    return null
+  }
+  return getBlockStartPoint({context: snapshot.context, block})
+}
+
+function isEqualTableSelection(
+  a: TableSelection | null,
+  b: TableSelection | null,
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  return (
+    a.rowRange[0] === b.rowRange[0] &&
+    a.rowRange[1] === b.rowRange[1] &&
+    a.colRange[0] === b.colRange[0] &&
+    a.colRange[1] === b.colRange[1] &&
+    isEqualPaths(a.tablePath, b.tablePath)
   )
 }
 

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -438,7 +438,9 @@ function TableContainer({
             className="playground-table cursor-text"
             data-cell-range={hasCellRange ? '' : undefined}
           >
-            <colgroup>
+            {/* Leafless subtrees derail the engine's DOM-point
+                normalization; mark them non-editable so it skips them. */}
+            <colgroup contentEditable={false}>
               {Array.from({length: columnCount}, (_, index) => (
                 <col key={index} />
               ))}

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -35,7 +35,12 @@ import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 import {cellStyle, type CellRange} from './table-cell-style'
-import {TableChrome, TableTrashLayer, type HoverCell} from './table-chrome'
+import {
+  TableChrome,
+  TableMenu,
+  TableTrashLayer,
+  type HoverCell,
+} from './table-chrome'
 import {useTableMetrics} from './table-metrics'
 
 const tableContainer = defineContainer({
@@ -195,6 +200,35 @@ function TableContainer({
     }
   }
 
+  const hasHeader = (Number(table?.headerRows) || 0) >= 1
+  const toggleHeader = () => {
+    editor.send({
+      type: 'block.set',
+      at: path,
+      props: {headerRows: hasHeader ? 0 : 1},
+    })
+  }
+  const selectTable = () => {
+    const snapshot = editor.getSnapshot()
+    const rows = getChildren(snapshot, path)
+    const firstRow = rows.at(0)
+    const lastRow = rows.at(-1)
+    const first = firstRow && getChildren(snapshot, firstRow.path).at(0)
+    const last = lastRow && getChildren(snapshot, lastRow.path).at(-1)
+    if (first && last) {
+      selectCells(first.path, last.path)
+    }
+  }
+  const deleteTable = () => {
+    const snapshot = editor.getSnapshot()
+    const firstRow = getChildren(snapshot, path).at(0)
+    const cell = firstRow && getChildren(snapshot, firstRow.path).at(0)
+    const insideCell = cell && getFirstChild(snapshot, cell.path)
+    if (insideCell) {
+      editor.send({type: 'custom.unset.table', at: insideCell.path})
+    }
+  }
+
   const deleteRow = (index: number) => {
     const snapshot = editor.getSnapshot()
     const row = getChildren(snapshot, path).at(index)
@@ -265,6 +299,18 @@ function TableContainer({
         onInsertRow={insertRow}
         onInsertCol={insertCol}
       />
+      {metrics ? (
+        <TableMenu
+          metrics={metrics}
+          active={active}
+          handlers={{
+            hasHeader,
+            onToggleHeader: toggleHeader,
+            onSelectTable: selectTable,
+            onDeleteTable: deleteTable,
+          }}
+        />
+      ) : null}
       <TableTrashLayer
         tableRef={tableRef}
         metrics={metrics}

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -39,6 +39,7 @@ import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 import {cellStyle, type CellRange} from './table-cell-style'
 import {
+  EXTEND_LANE,
   ReorderGhost,
   TableChrome,
   TableMenu,
@@ -365,14 +366,35 @@ function TableContainer({
     }
     const relY = event.clientY - rect.top
     const relX = event.clientX - rect.left
-    const row = metrics.rows.findIndex(
+    let row = metrics.rows.findIndex(
       (candidate) =>
         relY >= candidate.top && relY < candidate.top + candidate.height,
     )
-    const col = metrics.cols.findIndex(
+    let col = metrics.cols.findIndex(
       (candidate) =>
         relX >= candidate.left && relX < candidate.left + candidate.width,
     )
+    // The extend lanes below/right of the table count as their edge
+    // row/column, so the add bars are reachable directly (approaching from
+    // outside the table) instead of only via the last row/column's cells.
+    const lastRow = metrics.rows.at(-1)
+    if (
+      row === -1 &&
+      lastRow &&
+      relY >= lastRow.top &&
+      relY <= metrics.height + EXTEND_LANE
+    ) {
+      row = metrics.rows.length - 1
+    }
+    const lastCol = metrics.cols.at(-1)
+    if (
+      col === -1 &&
+      lastCol &&
+      relX >= lastCol.left &&
+      relX <= metrics.width + EXTEND_LANE
+    ) {
+      col = metrics.cols.length - 1
+    }
     setHoverCell(row >= 0 && col >= 0 ? {row, col} : null)
   }
 

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,15 +1,26 @@
 import {
   defineContainer,
   defineTextBlock,
+  useEditor,
+  useEditorSelector,
   type ContainerRenderProps,
 } from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
-import {isTable, tableBehaviors} from '@portabletext/plugin-table'
-import type {JSX} from 'react'
+import {getEnclosingBlock, getParent} from '@portabletext/editor/traversal'
+import {isEqualPaths} from '@portabletext/editor/utils'
+import {
+  getTableSelection,
+  isCell,
+  isRow,
+  isTable,
+  tableBehaviors,
+} from '@portabletext/plugin-table'
+import {useMemo, type JSX} from 'react'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
+import {cellStyle, type CellRange} from './table-cell-style'
 
 const tableContainer = defineContainer({
   type: 'table',
@@ -28,11 +39,7 @@ const tableContainer = defineContainer({
         defineContainer({
           type: 'cell',
           arrayField: 'value',
-          render: ({attributes, children, selected}) => (
-            <td {...attributes} data-selected={selected ? '' : undefined}>
-              {children}
-            </td>
-          ),
+          render: (props) => <TableCell {...props} />,
           of: [
             defineTextBlock({
               type: 'block',
@@ -70,12 +77,17 @@ function TableContainer({
   attributes,
   children,
   node,
+  path,
   readOnly,
   selected,
 }: ContainerRenderProps): JSX.Element {
+  const editor = useEditor()
   const table = isTable(node) ? node : undefined
-  const headerRows = Number(table?.headerRows) || 0
   const columnCount = table?.rows[0]?.cells.length ?? 0
+  const hasCellRange = useEditorSelector(editor, (snapshot) => {
+    const selection = getTableSelection(snapshot)
+    return selection ? isEqualPaths(selection.tablePath, path) : false
+  })
   return (
     <div
       {...attributes}
@@ -84,7 +96,7 @@ function TableContainer({
     >
       <table
         className="playground-table cursor-text"
-        data-header-rows={headerRows}
+        data-cell-range={hasCellRange ? '' : undefined}
       >
         <colgroup>
           {Array.from({length: columnCount}, (_, index) => (
@@ -96,4 +108,99 @@ function TableContainer({
       <DragHandle readOnly={readOnly} />
     </div>
   )
+}
+
+type CellDescriptor = {
+  rowIdx: number
+  colIdx: number
+  rowCount: number
+  colCount: number
+  isHeader: boolean
+  range: CellRange | null
+}
+
+// Cells read the derived `getTableSelection` (a rectangle) and draw the grey
+// grid + blue selection outline + overlay per cell. Position and header state
+// come from resolving the cell -> row -> table by path.
+function TableCell({
+  attributes,
+  children,
+  path,
+}: ContainerRenderProps): JSX.Element {
+  const editor = useEditor()
+  const descriptor = useEditorSelector(
+    editor,
+    (snapshot): CellDescriptor | null => {
+      const cell = getEnclosingBlock(snapshot, path, {match: isCell})
+      const row = cell && getParent(snapshot, cell.path, {match: isRow})
+      const table = row && getParent(snapshot, row.path, {match: isTable})
+      if (!cell || !row || !table) {
+        return null
+      }
+      const rowIdx = table.node.rows.findIndex(
+        (candidate) => candidate._key === row.node._key,
+      )
+      const colIdx = row.node.cells.findIndex(
+        (candidate) => candidate._key === cell.node._key,
+      )
+      const selection = getTableSelection(snapshot)
+      const range =
+        selection && isEqualPaths(selection.tablePath, table.path)
+          ? {
+              r0: selection.rowRange[0],
+              r1: selection.rowRange[1],
+              c0: selection.colRange[0],
+              c1: selection.colRange[1],
+            }
+          : null
+      return {
+        rowIdx,
+        colIdx,
+        rowCount: table.node.rows.length,
+        colCount: table.node.rows[0]?.cells.length ?? 0,
+        isHeader: (Number(table.node.headerRows) || 0) >= 1 && rowIdx === 0,
+        range,
+      }
+    },
+    isEqualCellDescriptor,
+  )
+  const style = useMemo(
+    () => (descriptor ? cellStyle(descriptor) : undefined),
+    [descriptor],
+  )
+  return (
+    <td {...attributes} style={style}>
+      {children}
+    </td>
+  )
+}
+
+function isEqualCellDescriptor(
+  a: CellDescriptor | null,
+  b: CellDescriptor | null,
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  return (
+    a.rowIdx === b.rowIdx &&
+    a.colIdx === b.colIdx &&
+    a.rowCount === b.rowCount &&
+    a.colCount === b.colCount &&
+    a.isHeader === b.isHeader &&
+    isEqualCellRange(a.range, b.range)
+  )
+}
+
+function isEqualCellRange(a: CellRange | null, b: CellRange | null): boolean {
+  if (a === b) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  return a.r0 === b.r0 && a.r1 === b.r1 && a.c0 === b.c0 && a.c1 === b.c1
 }

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,6 +1,10 @@
-import {defineContainer, defineTextBlock} from '@portabletext/editor'
+import {
+  defineContainer,
+  defineTextBlock,
+  type ContainerRenderProps,
+} from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
-import {tableBehaviors} from '@portabletext/plugin-table'
+import {isTable, tableBehaviors} from '@portabletext/plugin-table'
 import type {JSX} from 'react'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
@@ -10,21 +14,7 @@ import {cellImageLeaf} from './plugin.image'
 const tableContainer = defineContainer({
   type: 'table',
   arrayField: 'rows',
-  render: ({attributes, children, node, readOnly, selected}) => (
-    <div
-      {...attributes}
-      data-header-rows={
-        typeof node.headerRows === 'number' ? node.headerRows : 0
-      }
-      data-selected={selected ? '' : undefined}
-      className="playground-table-chrome group"
-    >
-      <table className="playground-table cursor-text">
-        <tbody>{children}</tbody>
-      </table>
-      <DragHandle readOnly={readOnly} />
-    </div>
-  ),
+  render: (props) => <TableContainer {...props} />,
   of: [
     defineContainer({
       type: 'row',
@@ -73,5 +63,37 @@ export function TablePlugin(): JSX.Element {
       <NodePlugin nodes={[tableContainer]} />
       <BehaviorPlugin behaviors={tableBehaviors} />
     </>
+  )
+}
+
+function TableContainer({
+  attributes,
+  children,
+  node,
+  readOnly,
+  selected,
+}: ContainerRenderProps): JSX.Element {
+  const table = isTable(node) ? node : undefined
+  const headerRows = Number(table?.headerRows) || 0
+  const columnCount = table?.rows[0]?.cells.length ?? 0
+  return (
+    <div
+      {...attributes}
+      data-selected={selected ? '' : undefined}
+      className="playground-table-chrome group"
+    >
+      <table
+        className="playground-table cursor-text"
+        data-header-rows={headerRows}
+      >
+        <colgroup>
+          {Array.from({length: columnCount}, (_, index) => (
+            <col key={index} />
+          ))}
+        </colgroup>
+        <tbody>{children}</tbody>
+      </table>
+      <DragHandle readOnly={readOnly} />
+    </div>
   )
 }

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -27,6 +27,7 @@ import {
 } from '@portabletext/plugin-table'
 import {
   createContext,
+  useCallback,
   useContext,
   useMemo,
   useRef,
@@ -165,14 +166,17 @@ function TableContainer({
       ? tableSelection.colRange[0]
       : null
 
-  const selectCells = (anchorCellPath: Path, focusCellPath: Path) => {
-    const snapshot = editor.getSnapshot()
-    const anchor = cellStartPoint(snapshot, anchorCellPath)
-    const focus = cellStartPoint(snapshot, focusCellPath)
-    if (anchor && focus) {
-      editor.send({type: 'select', at: {anchor, focus}})
-    }
-  }
+  const selectCells = useCallback(
+    (anchorCellPath: Path, focusCellPath: Path) => {
+      const snapshot = editor.getSnapshot()
+      const anchor = cellStartPoint(snapshot, anchorCellPath)
+      const focus = cellStartPoint(snapshot, focusCellPath)
+      if (anchor && focus) {
+        editor.send({type: 'select', at: {anchor, focus}})
+      }
+    },
+    [editor],
+  )
   const selectRow = (index: number) => {
     const snapshot = editor.getSnapshot()
     const row = getChildren(snapshot, path).at(index)
@@ -236,7 +240,7 @@ function TableContainer({
       props: {headerRows: hasHeader ? 0 : 1},
     })
   }
-  const selectTable = () => {
+  const selectTable = useCallback(() => {
     const snapshot = editor.getSnapshot()
     const rows = getChildren(snapshot, path)
     const firstRow = rows.at(0)
@@ -246,7 +250,7 @@ function TableContainer({
     if (first && last) {
       selectCells(first.path, last.path)
     }
-  }
+  }, [editor, path, selectCells])
   const deleteTable = () => {
     const snapshot = editor.getSnapshot()
     const firstRow = getChildren(snapshot, path).at(0)
@@ -419,6 +423,7 @@ function TableContainer({
         }}
       >
         <div
+          className="playground-table-inner"
           style={{
             position: 'relative',
             // Gutters: top for the column handles, right/bottom lanes for the

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -42,11 +42,18 @@ import {
   ReorderGhost,
   TableChrome,
   TableMenu,
+  TableScrollFade,
   TableTrashLayer,
   type HoverCell,
 } from './table-chrome'
 import {useTableDragReorder} from './table-drag'
 import {useTableMetrics} from './table-metrics'
+import {
+  MIN_COL_PX,
+  SCROLL_PADDING_BOTTOM,
+  useScrollFade,
+  useTableHorizontalLayout,
+} from './table-overflow'
 import {reorderIndex} from './table-reorder'
 
 // The source row/column dims while it's being drag-reordered; cells read this
@@ -118,7 +125,14 @@ function TableContainer({
   const rowCount = table?.rows.length ?? 0
   const columnCount = table?.rows[0]?.cells.length ?? 0
   const tableRef = useRef<HTMLTableElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const metrics = useTableMetrics(tableRef, `${rowCount}x${columnCount}`)
+  const scrollWide = useTableHorizontalLayout(
+    scrollRef,
+    columnCount,
+    `${rowCount}x${columnCount}`,
+  )
+  const fade = useScrollFade(scrollRef, `${rowCount}x${columnCount}`)
   const [active, setActive] = useState(false)
   const [hoverCell, setHoverCell] = useState<HoverCell>(null)
 
@@ -352,10 +366,12 @@ function TableContainer({
     const relY = event.clientY - rect.top
     const relX = event.clientX - rect.left
     const row = metrics.rows.findIndex(
-      (r) => relY >= r.top && relY < r.top + r.height,
+      (candidate) =>
+        relY >= candidate.top && relY < candidate.top + candidate.height,
     )
     const col = metrics.cols.findIndex(
-      (c) => relX >= c.left && relX < c.left + c.width,
+      (candidate) =>
+        relX >= candidate.left && relX < candidate.left + candidate.width,
     )
     setHoverCell(row >= 0 && col >= 0 ? {row, col} : null)
   }
@@ -370,53 +386,72 @@ function TableContainer({
         setActive(false)
         setHoverCell(null)
       }}
+      onMouseMove={onMouseMove}
     >
-      <table
-        ref={tableRef}
-        className="playground-table cursor-text"
-        data-cell-range={hasCellRange ? '' : undefined}
-        onMouseMove={onMouseMove}
+      <div
+        ref={scrollRef}
+        className="table-scroll"
+        style={{
+          overflowX: scrollWide ? 'auto' : undefined,
+          paddingBottom: scrollWide ? SCROLL_PADDING_BOTTOM : undefined,
+        }}
       >
-        <colgroup>
-          {Array.from({length: columnCount}, (_, index) => (
-            <col key={index} />
-          ))}
-        </colgroup>
-        <tbody>
-          <TableDragContext.Provider value={dragContextValue}>
-            {children}
-          </TableDragContext.Provider>
-        </tbody>
-      </table>
-      <TableChrome
-        metrics={metrics}
-        active={active}
-        hoverCell={hoverCell}
-        selectedRow={selectedRow}
-        selectedCol={selectedCol}
-        onHandlePointerDown={onHandlePointerDown}
-        drag={drag}
-        onInsertRow={insertRow}
-        onInsertCol={insertCol}
-      />
+        <div
+          style={{
+            position: 'relative',
+            // Gutters: top for the column handles, right/bottom lanes for the
+            // extend bars. The chrome is absolute in here so it scrolls with
+            // the table.
+            padding: '20px 20px 20px 0',
+            width: scrollWide ? columnCount * MIN_COL_PX + 20 : undefined,
+          }}
+        >
+          <table
+            ref={tableRef}
+            className="playground-table cursor-text"
+            data-cell-range={hasCellRange ? '' : undefined}
+          >
+            <colgroup>
+              {Array.from({length: columnCount}, (_, index) => (
+                <col key={index} />
+              ))}
+            </colgroup>
+            <tbody>
+              <TableDragContext.Provider value={dragContextValue}>
+                {children}
+              </TableDragContext.Provider>
+            </tbody>
+          </table>
+          <TableChrome
+            metrics={metrics}
+            active={active}
+            hoverCell={hoverCell}
+            selectedRow={selectedRow}
+            selectedCol={selectedCol}
+            onHandlePointerDown={onHandlePointerDown}
+            drag={drag}
+            onInsertRow={insertRow}
+            onInsertCol={insertCol}
+          />
+        </div>
+      </div>
       <ReorderGhost
         drag={drag}
         metrics={metrics}
         hasHeader={hasHeader}
         cellTexts={ghostCellTexts}
       />
-      {metrics ? (
-        <TableMenu
-          metrics={metrics}
-          active={active}
-          handlers={{
-            hasHeader,
-            onToggleHeader: toggleHeader,
-            onSelectTable: selectTable,
-            onDeleteTable: deleteTable,
-          }}
-        />
-      ) : null}
+      <TableMenu
+        right={scrollWide ? 0 : 20}
+        active={active}
+        handlers={{
+          hasHeader,
+          onToggleHeader: toggleHeader,
+          onSelectTable: selectTable,
+          onDeleteTable: deleteTable,
+        }}
+      />
+      <TableScrollFade left={fade.left} right={fade.right} />
       <TableTrashLayer
         tableRef={tableRef}
         metrics={metrics}

--- a/apps/playground/src/plugins/table-cell-style.ts
+++ b/apps/playground/src/plugins/table-cell-style.ts
@@ -3,21 +3,17 @@ import type {CSSProperties} from 'react'
 // Visual tokens from the design prototype (constants.js on pte-tables-phases).
 export const BLUE = '#556bfc'
 export const BORDER = '#e3e4e8'
-export const SELECTION_BORDER = 1.5
-export const FG = '#1c1f24'
-export const HEADER_BG = '#f6f6f8'
-export const SELECTED_BG = 'rgba(85, 107, 252, 0.06)'
-export const CELL_PADDING = '8px 12px'
-export const TABLE_RADIUS = 6
+const SELECTION_BORDER = 1.5
+const FG = '#1c1f24'
+const HEADER_BG = '#f6f6f8'
+const SELECTED_BG = 'rgba(85, 107, 252, 0.06)'
+const CELL_PADDING = '8px 12px'
+const TABLE_RADIUS = 6
 
 export type CellRange = {r0: number; r1: number; c0: number; c1: number}
 
 /** Which edges of the selection rectangle this cell sits on (for the outline). */
-export function cellRangeEdges(
-  row: number,
-  col: number,
-  range: CellRange | null,
-) {
+function cellRangeEdges(row: number, col: number, range: CellRange | null) {
   if (
     !range ||
     row < range.r0 ||
@@ -43,7 +39,9 @@ function cornerRadius(
   colCount: number,
 ): CSSProperties {
   const style: CSSProperties = {}
-  if (rowIdx === 0 && colIdx === 0) style.borderTopLeftRadius = TABLE_RADIUS
+  if (rowIdx === 0 && colIdx === 0) {
+    style.borderTopLeftRadius = TABLE_RADIUS
+  }
   if (rowIdx === 0 && colIdx === colCount - 1) {
     style.borderTopRightRadius = TABLE_RADIUS
   }
@@ -126,8 +124,12 @@ export function cellStyle({
   }
 
   if (showOverlay) {
-    if (!outline.bottom) borderBottom = 'none'
-    if (!outline.right) borderRight = 'none'
+    if (!outline.bottom) {
+      borderBottom = 'none'
+    }
+    if (!outline.right) {
+      borderRight = 'none'
+    }
     if (!outline.bottom && rowIdx < rowCount - 1) {
       shadows.push(`inset 0 -1px 0 0 ${BORDER}`)
     }

--- a/apps/playground/src/plugins/table-cell-style.ts
+++ b/apps/playground/src/plugins/table-cell-style.ts
@@ -1,0 +1,161 @@
+import type {CSSProperties} from 'react'
+
+// Visual tokens from the design prototype (constants.js on pte-tables-phases).
+export const BLUE = '#556bfc'
+export const BORDER = '#e3e4e8'
+export const SELECTION_BORDER = 1.5
+export const FG = '#1c1f24'
+export const HEADER_BG = '#f6f6f8'
+export const SELECTED_BG = 'rgba(85, 107, 252, 0.06)'
+export const CELL_PADDING = '8px 12px'
+export const TABLE_RADIUS = 6
+
+export type CellRange = {r0: number; r1: number; c0: number; c1: number}
+
+/** Which edges of the selection rectangle this cell sits on (for the outline). */
+export function cellRangeEdges(
+  row: number,
+  col: number,
+  range: CellRange | null,
+) {
+  if (
+    !range ||
+    row < range.r0 ||
+    row > range.r1 ||
+    col < range.c0 ||
+    col > range.c1
+  ) {
+    return {top: false, bottom: false, left: false, right: false, inside: false}
+  }
+  return {
+    top: row === range.r0,
+    bottom: row === range.r1,
+    left: col === range.c0,
+    right: col === range.c1,
+    inside: true,
+  }
+}
+
+function cornerRadius(
+  rowIdx: number,
+  colIdx: number,
+  rowCount: number,
+  colCount: number,
+): CSSProperties {
+  const style: CSSProperties = {}
+  if (rowIdx === 0 && colIdx === 0) style.borderTopLeftRadius = TABLE_RADIUS
+  if (rowIdx === 0 && colIdx === colCount - 1) {
+    style.borderTopRightRadius = TABLE_RADIUS
+  }
+  if (rowIdx === rowCount - 1 && colIdx === 0) {
+    style.borderBottomLeftRadius = TABLE_RADIUS
+  }
+  if (rowIdx === rowCount - 1 && colIdx === colCount - 1) {
+    style.borderBottomRightRadius = TABLE_RADIUS
+  }
+  return style
+}
+
+// The grey grid line just above/left of the selection's top/left edge is
+// suppressed so it doesn't double up with the blue outline drawn by the
+// bordering cell.
+function suppressRightGrid(
+  rowIdx: number,
+  colIdx: number,
+  range: CellRange | null,
+): boolean {
+  return (
+    !!range &&
+    colIdx + 1 === range.c0 &&
+    rowIdx >= range.r0 &&
+    rowIdx <= range.r1
+  )
+}
+
+function suppressBottomGrid(
+  rowIdx: number,
+  colIdx: number,
+  range: CellRange | null,
+): boolean {
+  return (
+    !!range &&
+    rowIdx + 1 === range.r0 &&
+    colIdx >= range.c0 &&
+    colIdx <= range.c1
+  )
+}
+
+/**
+ * The inline style for one cell: grey grid borders, blue selection outline on
+ * the selection-rectangle edges, corner radii on the table corners, header
+ * base, and the light-blue overlay on selected cells. Faithful to the branch's
+ * `cellGridAndSelectionStyle` / `cellCornerRadius`, scoped to a single range.
+ */
+export function cellStyle({
+  rowIdx,
+  colIdx,
+  rowCount,
+  colCount,
+  isHeader,
+  range,
+}: {
+  rowIdx: number
+  colIdx: number
+  rowCount: number
+  colCount: number
+  isHeader: boolean
+  range: CellRange | null
+}): CSSProperties {
+  const outline = cellRangeEdges(rowIdx, colIdx, range)
+  const showOverlay = outline.inside
+
+  const gridSide = `1px solid ${BORDER}`
+  const selSide = `${SELECTION_BORDER}px solid ${BLUE}`
+  const shadows: Array<string> = []
+
+  const borderTop = outline.top ? selSide : rowIdx === 0 ? gridSide : 'none'
+  const borderLeft = outline.left ? selSide : colIdx === 0 ? gridSide : 'none'
+  let borderBottom = outline.bottom ? selSide : gridSide
+  let borderRight = outline.right ? selSide : gridSide
+
+  if (!outline.right && suppressRightGrid(rowIdx, colIdx, range)) {
+    borderRight = 'none'
+  }
+  if (!outline.bottom && suppressBottomGrid(rowIdx, colIdx, range)) {
+    borderBottom = 'none'
+  }
+
+  if (showOverlay) {
+    if (!outline.bottom) borderBottom = 'none'
+    if (!outline.right) borderRight = 'none'
+    if (!outline.bottom && rowIdx < rowCount - 1) {
+      shadows.push(`inset 0 -1px 0 0 ${BORDER}`)
+    }
+    if (!outline.right && colIdx < colCount - 1) {
+      shadows.push(`inset -1px 0 0 0 ${BORDER}`)
+    }
+  }
+
+  let background = isHeader ? HEADER_BG : '#fff'
+  if (showOverlay) {
+    background = isHeader
+      ? `linear-gradient(${SELECTED_BG}, ${SELECTED_BG}), ${HEADER_BG}`
+      : SELECTED_BG
+  }
+
+  return {
+    ...cornerRadius(rowIdx, colIdx, rowCount, colCount),
+    borderTop,
+    borderLeft,
+    borderBottom,
+    borderRight,
+    boxShadow: shadows.length > 0 ? shadows.join(', ') : undefined,
+    padding: CELL_PADDING,
+    verticalAlign: 'top',
+    background,
+    fontWeight: isHeader ? 600 : 400,
+    color: FG,
+    wordBreak: 'break-word',
+    ...(showOverlay ? {position: 'relative', zIndex: 1} : {}),
+  }
+}

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -1,4 +1,12 @@
-import {useState, type JSX} from 'react'
+import {Trash2Icon} from 'lucide-react'
+import {
+  useCallback,
+  useLayoutEffect,
+  useState,
+  type JSX,
+  type RefObject,
+} from 'react'
+import {createPortal} from 'react-dom'
 import {BLUE, BORDER} from './table-cell-style'
 import {snapPx, type TableMetrics} from './table-metrics'
 
@@ -30,6 +38,10 @@ const EXTEND_BAR_BG = '#fafafb'
 const EXTEND_BAR_BG_HOVER = '#f0f1f3'
 const EXTEND_ICON = '#6e7484'
 const EXTEND_ICON_HOVER = '#5c5f69'
+const TRASH_SIZE = 26
+const TRASH_GAP = 8
+/** Above the toolbar and field chrome; delete must stay clickable. */
+const TRASH_Z_INDEX = 10050
 
 type BoundaryHover = {kind: 'row' | 'column'; index: number} | null
 
@@ -478,5 +490,150 @@ function DragDots({
         />
       ))}
     </div>
+  )
+}
+
+type TrashLayout = {
+  row: {left: number; top: number} | null
+  col: {left: number; top: number} | null
+}
+
+/**
+ * Row/column delete buttons in a top-level portal so they are never clipped
+ * by the editable's scrollport. Fixed-positioned from the live table rect,
+ * re-measured on resize and any scroll.
+ */
+export function TableTrashLayer({
+  tableRef,
+  metrics,
+  selectedRow,
+  selectedCol,
+  canDeleteRow,
+  canDeleteCol,
+  onDeleteRow,
+  onDeleteCol,
+}: {
+  tableRef: RefObject<HTMLTableElement | null>
+  metrics: TableMetrics | null
+  selectedRow: number | null
+  selectedCol: number | null
+  canDeleteRow: boolean
+  canDeleteCol: boolean
+  onDeleteRow: (index: number) => void
+  onDeleteCol: (index: number) => void
+}): JSX.Element | null {
+  const [layout, setLayout] = useState<TrashLayout | null>(null)
+
+  const measure = useCallback(() => {
+    const table = tableRef.current
+    if (!table || !metrics) {
+      setLayout(null)
+      return
+    }
+    const rect = table.getBoundingClientRect()
+    const next: TrashLayout = {row: null, col: null}
+    if (selectedRow !== null && canDeleteRow && metrics.rows[selectedRow]) {
+      const row = metrics.rows[selectedRow]
+      const handleLeft = rect.left - HANDLE_BTN_ROW.w / 2
+      next.row = {
+        left: handleLeft - TRASH_GAP - TRASH_SIZE,
+        top: rect.top + row.centerY,
+      }
+    }
+    if (selectedCol !== null && canDeleteCol && metrics.cols[selectedCol]) {
+      const col = metrics.cols[selectedCol]
+      next.col = {
+        left: rect.left + col.centerX,
+        top: rect.top - HANDLE_BTN_COL.h / 2 - TRASH_GAP - TRASH_SIZE,
+      }
+    }
+    setLayout(next)
+  }, [tableRef, metrics, selectedRow, selectedCol, canDeleteRow, canDeleteCol])
+
+  useLayoutEffect(() => {
+    measure()
+    window.addEventListener('resize', measure)
+    window.addEventListener('scroll', measure, true)
+    return () => {
+      window.removeEventListener('resize', measure)
+      window.removeEventListener('scroll', measure, true)
+    }
+  }, [measure])
+
+  if (!layout || (!layout.row && !layout.col)) {
+    return null
+  }
+
+  return createPortal(
+    <>
+      {layout.row && selectedRow !== null ? (
+        <TrashButton
+          label="Delete row"
+          left={layout.row.left}
+          top={layout.row.top}
+          transform="translate(0, -50%)"
+          onClick={() => onDeleteRow(selectedRow)}
+        />
+      ) : null}
+      {layout.col && selectedCol !== null ? (
+        <TrashButton
+          label="Delete column"
+          left={layout.col.left}
+          top={layout.col.top}
+          transform="translate(-50%, 0)"
+          onClick={() => onDeleteCol(selectedCol)}
+        />
+      ) : null}
+    </>,
+    document.body,
+  )
+}
+
+function TrashButton({
+  label,
+  left,
+  top,
+  transform,
+  onClick,
+}: {
+  label: string
+  left: number
+  top: number
+  transform: string
+  onClick: () => void
+}): JSX.Element {
+  const [hovered, setHovered] = useState(false)
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        onClick()
+      }}
+      style={{
+        position: 'fixed',
+        left,
+        top,
+        transform,
+        width: TRASH_SIZE,
+        height: TRASH_SIZE,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: hovered ? '#c0303a' : '#1c1f24',
+        color: '#fff',
+        border: 'none',
+        borderRadius: 4,
+        padding: 0,
+        cursor: 'pointer',
+        zIndex: TRASH_Z_INDEX,
+        transition: 'background 100ms ease',
+      }}
+    >
+      <Trash2Icon aria-hidden="true" size={14} />
+    </button>
   )
 }

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -5,10 +5,12 @@ import {
   useRef,
   useState,
   type JSX,
+  type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from 'react'
 import {createPortal} from 'react-dom'
 import {BLUE, BORDER} from './table-cell-style'
+import type {DragState} from './table-drag'
 import {snapPx, type TableMetrics} from './table-metrics'
 
 // Top gutter holds the column handles + table menu. No left gutter: the table
@@ -78,8 +80,8 @@ export function TableChrome({
   hoverCell,
   selectedRow,
   selectedCol,
-  onSelectRow,
-  onSelectCol,
+  onHandlePointerDown,
+  drag,
   onInsertRow,
   onInsertCol,
 }: {
@@ -88,8 +90,12 @@ export function TableChrome({
   hoverCell: HoverCell
   selectedRow: number | null
   selectedCol: number | null
-  onSelectRow: (index: number) => void
-  onSelectCol: (index: number) => void
+  onHandlePointerDown: (
+    kind: 'row' | 'column',
+    index: number,
+    event: ReactPointerEvent<HTMLButtonElement>,
+  ) => void
+  drag: DragState | null
   onInsertRow: (boundary: number) => void
   onInsertCol: (boundary: number) => void
 }): JSX.Element | null {
@@ -97,13 +103,14 @@ export function TableChrome({
   if (!metrics) {
     return null
   }
+  const dragging = Boolean(drag?.active)
   const lastRow = metrics.rows.length - 1
   const lastCol = metrics.cols.length - 1
   return (
     <>
       <ExtendBar
         label="Add row at end"
-        visible={active && hoverCell?.row === lastRow}
+        visible={active && !dragging && hoverCell?.row === lastRow}
         style={{
           left: GUTTER_LEFT,
           top: GUTTER_TOP + metrics.height + EXTEND_GAP,
@@ -114,7 +121,7 @@ export function TableChrome({
       />
       <ExtendBar
         label="Add column at end"
-        visible={active && hoverCell?.col === lastCol}
+        visible={active && !dragging && hoverCell?.col === lastCol}
         style={{
           left: GUTTER_LEFT + metrics.width + EXTEND_GAP,
           top: GUTTER_TOP,
@@ -132,7 +139,8 @@ export function TableChrome({
           active={active}
           cellHot={hoverCell?.col === index}
           selected={selectedCol === index}
-          onSelect={() => onSelectCol(index)}
+          dragging={dragging && drag?.kind === 'column'}
+          onPointerDown={(event) => onHandlePointerDown('column', index, event)}
         />
       ))}
       {metrics.rows.map((row, index) => (
@@ -144,9 +152,17 @@ export function TableChrome({
           active={active}
           cellHot={hoverCell?.row === index}
           selected={selectedRow === index}
-          onSelect={() => onSelectRow(index)}
+          dragging={dragging && drag?.kind === 'row'}
+          onPointerDown={(event) => onHandlePointerDown('row', index, event)}
         />
       ))}
+      {drag?.active ? (
+        <ReorderInsertLine
+          metrics={metrics}
+          kind={drag.kind}
+          insertIndex={drag.insertIndex}
+        />
+      ) : null}
       {/* Internal boundaries only (between columns/rows); the edges are handled
           by the extend bars, matching the default prototype variant. */}
       {Array.from({length: Math.max(metrics.cols.length - 1, 0)}, (_, k) => {
@@ -156,7 +172,7 @@ export function TableChrome({
             key={`col-boundary-${index}`}
             x={GUTTER_LEFT + colBorderX(metrics, index)}
             y={GUTTER_TOP}
-            visible={active}
+            visible={active && !dragging}
             hot={boundary?.kind === 'column' && boundary.index === index}
             onEnter={() => setBoundary({kind: 'column', index})}
             onLeave={() => setBoundary(null)}
@@ -171,7 +187,7 @@ export function TableChrome({
             key={`row-boundary-${index}`}
             x={GUTTER_LEFT}
             y={GUTTER_TOP + rowBorderY(metrics, index)}
-            visible={active}
+            visible={active && !dragging}
             hot={boundary?.kind === 'row' && boundary.index === index}
             onEnter={() => setBoundary({kind: 'row', index})}
             onLeave={() => setBoundary(null)}
@@ -384,7 +400,8 @@ function Handle({
   active,
   cellHot,
   selected,
-  onSelect,
+  dragging,
+  onPointerDown,
 }: {
   kind: 'row' | 'column'
   x: number
@@ -392,7 +409,8 @@ function Handle({
   active: boolean
   cellHot: boolean
   selected: boolean
-  onSelect: () => void
+  dragging: boolean
+  onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
 }): JSX.Element {
   const [hot, setHot] = useState(false)
   const isColumn = kind === 'column'
@@ -409,10 +427,7 @@ function Handle({
       tabIndex={lit ? 0 : -1}
       onMouseEnter={() => setHot(true)}
       onMouseLeave={() => setHot(false)}
-      onPointerDown={(event) => {
-        event.preventDefault()
-        onSelect()
-      }}
+      onPointerDown={onPointerDown}
       style={{
         position: 'absolute',
         left: x,
@@ -426,7 +441,7 @@ function Handle({
         pointerEvents: lit ? 'auto' : 'none',
         opacity: lit ? 1 : 0,
         transition: 'opacity 100ms ease',
-        cursor: showExpanded ? 'grab' : 'pointer',
+        cursor: dragging ? 'grabbing' : showExpanded ? 'grab' : 'pointer',
         zIndex: 5,
         border: 'none',
         background: 'transparent',
@@ -899,5 +914,162 @@ function ToggleSwitch({checked}: {checked: boolean}): JSX.Element {
         }}
       />
     </span>
+  )
+}
+
+/** IX15: insertion line while dragging to reorder. */
+function ReorderInsertLine({
+  metrics,
+  kind,
+  insertIndex,
+}: {
+  metrics: TableMetrics
+  kind: 'row' | 'column'
+  insertIndex: number
+}): JSX.Element {
+  if (kind === 'column') {
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          left: GUTTER_LEFT + colBorderX(metrics, insertIndex),
+          top: GUTTER_TOP,
+          width: INSERT_GUIDE,
+          height: metrics.height,
+          transform: 'translateX(-50%)',
+          background: BLUE,
+          pointerEvents: 'none',
+          zIndex: 12,
+        }}
+      />
+    )
+  }
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: GUTTER_LEFT,
+        top: GUTTER_TOP + rowBorderY(metrics, insertIndex),
+        width: metrics.width,
+        height: INSERT_GUIDE,
+        transform: 'translateY(-50%)',
+        background: BLUE,
+        pointerEvents: 'none',
+        zIndex: 12,
+      }}
+    />
+  )
+}
+
+const GHOST_SHADOW =
+  '0 10px 32px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.06)'
+
+/** IX15: the lifted row/column follows the pointer as a solid preview. */
+export function ReorderGhost({
+  drag,
+  metrics,
+  hasHeader,
+  cellTexts,
+}: {
+  drag: DragState | null
+  metrics: TableMetrics | null
+  hasHeader: boolean
+  cellTexts: Array<string> | null
+}): JSX.Element | null {
+  if (!drag?.active || !metrics || !cellTexts) {
+    return null
+  }
+  const left = drag.clientX - drag.grabOffsetX
+  const top = drag.clientY - drag.grabOffsetY
+
+  if (drag.kind === 'row') {
+    const rowMetrics = metrics.rows[drag.index]
+    if (!rowMetrics) {
+      return null
+    }
+    const isHeader = hasHeader && drag.index === 0
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          left,
+          top,
+          width: metrics.width,
+          height: rowMetrics.height,
+          display: 'flex',
+          pointerEvents: 'none',
+          zIndex: 10000,
+          borderRadius: 6,
+          border: `1px solid ${BORDER}`,
+          background: isHeader ? '#f6f6f8' : '#fff',
+          boxShadow: GHOST_SHADOW,
+          overflow: 'hidden',
+          fontWeight: isHeader ? 600 : 400,
+        }}
+      >
+        {metrics.cols.map((col, index) => (
+          <div
+            key={index}
+            style={{
+              width: col.width,
+              padding: '8px 12px',
+              borderRight:
+                index < metrics.cols.length - 1
+                  ? `1px solid ${BORDER}`
+                  : 'none',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {cellTexts[index]}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  const colMetrics = metrics.cols[drag.index]
+  if (!colMetrics) {
+    return null
+  }
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left,
+        top,
+        width: colMetrics.width,
+        height: metrics.height,
+        display: 'flex',
+        flexDirection: 'column',
+        pointerEvents: 'none',
+        zIndex: 10000,
+        borderRadius: 6,
+        border: `1px solid ${BORDER}`,
+        background: '#fff',
+        boxShadow: GHOST_SHADOW,
+        overflow: 'hidden',
+      }}
+    >
+      {metrics.rows.map((row, index) => (
+        <div
+          key={index}
+          style={{
+            height: row.height,
+            padding: '8px 12px',
+            borderBottom:
+              index < metrics.rows.length - 1 ? `1px solid ${BORDER}` : 'none',
+            background: hasHeader && index === 0 ? '#f6f6f8' : undefined,
+            fontWeight: hasHeader && index === 0 ? 600 : 400,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {cellTexts[index]}
+        </div>
+      ))}
+    </div>
   )
 }

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -109,7 +109,18 @@ export function TableChrome({
   const lastRow = metrics.rows.length - 1
   const lastCol = metrics.cols.length - 1
   return (
-    <>
+    // Chrome inside the contentEditable must be marked non-editable, or the
+    // engine's DOM-point normalization treats it as content: an element-level
+    // selection endpoint after the table then descends into a chrome button
+    // instead of resolving to the table's last leaf.
+    <div
+      contentEditable={false}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+      }}
+    >
       <ExtendBar
         label="Add row at end"
         visible={active && !dragging && hoverCell?.row === lastRow}
@@ -200,7 +211,7 @@ export function TableChrome({
       {active && boundary ? (
         <InsertGuideline metrics={metrics} hovered={boundary} />
       ) : null}
-    </>
+    </div>
   )
 }
 
@@ -750,6 +761,7 @@ export function TableMenu({
       <button
         ref={triggerRef}
         type="button"
+        contentEditable={false}
         aria-label="Table options"
         aria-haspopup="menu"
         aria-expanded={open}
@@ -993,6 +1005,7 @@ export function ReorderGhost({
     const isHeader = hasHeader && drag.index === 0
     return (
       <div
+        contentEditable={false}
         style={{
           position: 'fixed',
           left,
@@ -1038,6 +1051,7 @@ export function ReorderGhost({
   }
   return (
     <div
+      contentEditable={false}
       style={{
         position: 'fixed',
         left,
@@ -1100,6 +1114,7 @@ export function TableScrollFade({
     <>
       {left ? (
         <div
+          contentEditable={false}
           aria-hidden="true"
           style={{
             ...fadeBase,
@@ -1111,6 +1126,7 @@ export function TableScrollFade({
       ) : null}
       {right ? (
         <div
+          contentEditable={false}
           aria-hidden="true"
           style={{
             ...fadeBase,

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -121,6 +121,23 @@ export function TableChrome({
         pointerEvents: 'none',
       }}
     >
+      {/* The gutter is chrome territory, but structurally it is padding on
+          an editable-context div, so browsers hit-test carets into it with
+          divergent heuristics (some resolve to the table's document-order
+          end). Swallow its clicks like every other chrome element does. */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: GUTTER_LEFT,
+          width: metrics.width,
+          height: GUTTER_TOP,
+          pointerEvents: 'auto',
+        }}
+        onPointerDown={(event) => {
+          event.preventDefault()
+        }}
+      />
       <ExtendBar
         label="Add row at end"
         visible={active && !dragging && hoverCell?.row === lastRow}

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -37,6 +37,8 @@ const GRID_LINE_HALF = 0.5
 const INSERT_GUIDE = 1.5
 const EXTEND_SIZE = 17
 const EXTEND_GAP = 3
+/** The reserved add-row / add-column lane: bar + gap. */
+export const EXTEND_LANE = EXTEND_SIZE + EXTEND_GAP
 const EXTEND_BAR_BG = '#fafafb'
 const EXTEND_BAR_BG_HOVER = '#f0f1f3'
 const EXTEND_ICON = '#6e7484'

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -1,0 +1,189 @@
+import {useState, type JSX} from 'react'
+import {BLUE, BORDER} from './table-cell-style'
+import type {TableMetrics} from './table-metrics'
+
+// Top gutter holds the column handles + table menu. No left gutter: the table
+// is flush and the row handles overhang into the editable's own padding.
+export const GUTTER_TOP = 20
+export const GUTTER_LEFT = 0
+
+const HANDLE_REST_ROW = {w: 3, h: 16}
+const HANDLE_REST_COL = {w: 16, h: 3}
+const HANDLE_BTN_ROW = {w: 12, h: 16}
+const HANDLE_BTN_COL = {w: 16, h: 12}
+const HANDLE_BTN_PAD = 3
+const HANDLE_REST_BG = '#bbbdc9'
+const HANDLE_HIT = 24
+const HANDLE_EXPANDED_SHADOW = `inset 0 0 0 0.5px rgba(255,255,255,0.9), 0 0 0 1px ${BORDER}`
+const HANDLE_EXPANDED_SHADOW_SELECTED =
+  'inset 0 0 0 0.5px rgba(255,255,255,0.9), 0 0 0 1px #fff'
+const HANDLE_DOT = 2
+const HANDLE_DOT_GAP = 2
+
+export type HoverCell = {row: number; col: number} | null
+
+export function TableChrome({
+  metrics,
+  active,
+  hoverCell,
+  selectedRow,
+  selectedCol,
+  onSelectRow,
+  onSelectCol,
+}: {
+  metrics: TableMetrics | null
+  active: boolean
+  hoverCell: HoverCell
+  selectedRow: number | null
+  selectedCol: number | null
+  onSelectRow: (index: number) => void
+  onSelectCol: (index: number) => void
+}): JSX.Element | null {
+  if (!metrics) {
+    return null
+  }
+  return (
+    <>
+      {metrics.cols.map((col, index) => (
+        <Handle
+          key={`col-${index}`}
+          kind="column"
+          x={GUTTER_LEFT + col.centerX}
+          y={GUTTER_TOP}
+          active={active}
+          cellHot={hoverCell?.col === index}
+          selected={selectedCol === index}
+          onSelect={() => onSelectCol(index)}
+        />
+      ))}
+      {metrics.rows.map((row, index) => (
+        <Handle
+          key={`row-${index}`}
+          kind="row"
+          x={GUTTER_LEFT}
+          y={GUTTER_TOP + row.centerY}
+          active={active}
+          cellHot={hoverCell?.row === index}
+          selected={selectedRow === index}
+          onSelect={() => onSelectRow(index)}
+        />
+      ))}
+    </>
+  )
+}
+
+function Handle({
+  kind,
+  x,
+  y,
+  active,
+  cellHot,
+  selected,
+  onSelect,
+}: {
+  kind: 'row' | 'column'
+  x: number
+  y: number
+  active: boolean
+  cellHot: boolean
+  selected: boolean
+  onSelect: () => void
+}): JSX.Element {
+  const [hot, setHot] = useState(false)
+  const isColumn = kind === 'column'
+  const rest = isColumn ? HANDLE_REST_COL : HANDLE_REST_ROW
+  const btn = isColumn ? HANDLE_BTN_COL : HANDLE_BTN_ROW
+  const showRest = cellHot && !hot && !selected
+  const showExpanded = hot || selected
+  const lit = active && (cellHot || hot || selected)
+
+  return (
+    <div
+      role="button"
+      aria-label={isColumn ? 'Column handle' : 'Row handle'}
+      onMouseEnter={() => setHot(true)}
+      onMouseLeave={() => setHot(false)}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        onSelect()
+      }}
+      style={{
+        position: 'absolute',
+        left: x,
+        top: y,
+        transform: 'translate(-50%, -50%)',
+        width: HANDLE_HIT,
+        height: HANDLE_HIT,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: lit ? 'auto' : 'none',
+        opacity: lit ? 1 : 0,
+        transition: 'opacity 100ms ease',
+        cursor: showExpanded ? 'grab' : 'pointer',
+        zIndex: 5,
+      }}
+    >
+      <div
+        style={{
+          width: showExpanded ? btn.w : rest.w,
+          height: showExpanded ? btn.h : rest.h,
+          boxSizing: 'border-box',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: showExpanded ? 4 : 3,
+          padding: showExpanded ? HANDLE_BTN_PAD : 0,
+          ...(showExpanded
+            ? {
+                background: selected ? BLUE : '#fff',
+                boxShadow: selected
+                  ? HANDLE_EXPANDED_SHADOW_SELECTED
+                  : HANDLE_EXPANDED_SHADOW,
+              }
+            : showRest
+              ? {
+                  background: HANDLE_REST_BG,
+                  boxShadow: 'inset 0 0 0 0.5px rgba(255,255,255,0.7)',
+                }
+              : {background: 'transparent'}),
+        }}
+      >
+        {showExpanded ? (
+          <DragDots isColumn={isColumn} selected={selected} />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function DragDots({
+  isColumn,
+  selected,
+}: {
+  isColumn: boolean
+  selected: boolean
+}): JSX.Element {
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${isColumn ? 3 : 2}, ${HANDLE_DOT}px)`,
+        gap: HANDLE_DOT_GAP,
+      }}
+    >
+      {Array.from({length: 6}, (_, index) => (
+        <div
+          key={index}
+          style={{
+            width: HANDLE_DOT,
+            height: HANDLE_DOT,
+            borderRadius: '50%',
+            background: selected ? '#fff' : '#8a8f99',
+          }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -1,7 +1,8 @@
-import {Trash2Icon} from 'lucide-react'
+import {EllipsisIcon, PanelTopIcon, TableIcon, Trash2Icon} from 'lucide-react'
 import {
   useCallback,
   useLayoutEffect,
+  useRef,
   useState,
   type JSX,
   type RefObject,
@@ -638,5 +639,265 @@ function TrashButton({
     >
       <Trash2Icon aria-hidden="true" size={14} />
     </button>
+  )
+}
+
+const MENU_BTN = 25
+const MENU_MIN_WIDTH = 200
+const MENU_Z_INDEX = 10100
+const MENU_ABOVE_GAP = 2
+
+export type TableMenuHandlers = {
+  hasHeader: boolean
+  onToggleHeader: () => void
+  onSelectTable: () => void
+  onDeleteTable: () => void
+}
+
+/**
+ * The table-level `...` menu: trigger tight to the table's top edge, top-right,
+ * fading in on table hover; dropdown portaled to document.body so it never
+ * clips or scrolls the editable.
+ */
+export function TableMenu({
+  metrics,
+  active,
+  handlers,
+}: {
+  metrics: TableMetrics
+  active: boolean
+  handlers: TableMenuHandlers
+}): JSX.Element {
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false)
+  const [hovered, setHovered] = useState(false)
+  const [menuPos, setMenuPos] = useState<{left: number; top: number} | null>(
+    null,
+  )
+
+  const syncMenuPos = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) {
+      return
+    }
+    setMenuPos({left: rect.right - MENU_MIN_WIDTH, top: rect.bottom + 6})
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+    syncMenuPos()
+    window.addEventListener('resize', syncMenuPos)
+    window.addEventListener('scroll', syncMenuPos, true)
+    return () => {
+      window.removeEventListener('resize', syncMenuPos)
+      window.removeEventListener('scroll', syncMenuPos, true)
+    }
+  }, [open, syncMenuPos])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (
+        target instanceof Node &&
+        (menuRef.current?.contains(target) ||
+          triggerRef.current?.contains(target))
+      ) {
+        return
+      }
+      setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const visible = active || open
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Table options"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        tabIndex={visible ? 0 : -1}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onPointerDown={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          setOpen((wasOpen) => !wasOpen)
+        }}
+        style={{
+          position: 'absolute',
+          left: GUTTER_LEFT + metrics.width - MENU_BTN,
+          top: GUTTER_TOP - MENU_BTN - MENU_ABOVE_GAP,
+          width: MENU_BTN,
+          height: MENU_BTN,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          border: 'none',
+          borderRadius: 3,
+          padding: 0,
+          background: open ? '#f0f1f3' : hovered ? '#f6f6f8' : 'transparent',
+          color: '#1c1f24',
+          cursor: 'pointer',
+          pointerEvents: visible ? 'auto' : 'none',
+          opacity: visible ? 1 : 0,
+          transition: 'opacity 100ms ease, background 100ms ease',
+          zIndex: 6,
+        }}
+      >
+        <EllipsisIcon aria-hidden="true" size={20} />
+      </button>
+      {open && menuPos
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="menu"
+              style={{
+                position: 'fixed',
+                left: menuPos.left,
+                top: menuPos.top,
+                width: MENU_MIN_WIDTH,
+                background: '#fff',
+                border: '1px solid #e4e6ea',
+                borderRadius: 6,
+                padding: 5,
+                zIndex: MENU_Z_INDEX,
+              }}
+            >
+              <MenuRow
+                label="Header row"
+                icon={<PanelTopIcon aria-hidden="true" size={16} />}
+                trailing={<ToggleSwitch checked={handlers.hasHeader} />}
+                onClick={handlers.onToggleHeader}
+              />
+              <MenuRow
+                label="Select table"
+                icon={<TableIcon aria-hidden="true" size={16} />}
+                onClick={() => {
+                  setOpen(false)
+                  handlers.onSelectTable()
+                }}
+              />
+              <MenuRow
+                label="Delete table"
+                icon={<Trash2Icon aria-hidden="true" size={16} />}
+                destructive
+                onClick={() => {
+                  setOpen(false)
+                  handlers.onDeleteTable()
+                }}
+              />
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  )
+}
+
+function MenuRow({
+  label,
+  icon,
+  trailing,
+  destructive,
+  onClick,
+}: {
+  label: string
+  icon: JSX.Element
+  trailing?: JSX.Element
+  destructive?: boolean
+  onClick: () => void
+}): JSX.Element {
+  const [hovered, setHovered] = useState(false)
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      // Act on click but keep DOM focus in the editable; a focus steal here
+      // leaves the editor caret-less after the menu (or the table) unmounts.
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        width: '100%',
+        padding: '8px 10px',
+        border: 'none',
+        background: hovered ? '#f4f4f6' : 'transparent',
+        cursor: 'pointer',
+        borderRadius: 4,
+        textAlign: 'left',
+        fontSize: 13,
+        color: destructive ? '#c0303a' : '#1c1f24',
+      }}
+    >
+      <span
+        style={{
+          width: 21,
+          height: 21,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </span>
+      <span style={{flex: 1, whiteSpace: 'nowrap'}}>{label}</span>
+      {trailing}
+    </button>
+  )
+}
+
+function ToggleSwitch({checked}: {checked: boolean}): JSX.Element {
+  return (
+    // The row button carries the label and click; the switch is decorative.
+    <span
+      aria-hidden="true"
+      style={{
+        width: 28,
+        height: 16,
+        borderRadius: 8,
+        padding: 2,
+        background: checked ? '#1c1f24' : '#d3d4d8',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: checked ? 'flex-end' : 'flex-start',
+        flexShrink: 0,
+        transition: 'background 100ms ease',
+      }}
+    >
+      <span
+        style={{
+          width: 12,
+          height: 12,
+          borderRadius: '50%',
+          background: '#fff',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
+        }}
+      />
+    </span>
   )
 }

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -675,11 +675,12 @@ export type TableMenuHandlers = {
  * clips or scrolls the editable.
  */
 export function TableMenu({
-  metrics,
+  right,
   active,
   handlers,
 }: {
-  metrics: TableMetrics
+  /** Distance from the wrapper's right edge; pins the trigger to the scrollport when the table overflows. */
+  right: number
   active: boolean
   handlers: TableMenuHandlers
 }): JSX.Element {
@@ -760,7 +761,7 @@ export function TableMenu({
         }}
         style={{
           position: 'absolute',
-          left: GUTTER_LEFT + metrics.width - MENU_BTN,
+          right,
           top: GUTTER_TOP - MENU_BTN - MENU_ABOVE_GAP,
           width: MENU_BTN,
           height: MENU_BTN,
@@ -1071,5 +1072,52 @@ export function ReorderGhost({
         </div>
       ))}
     </div>
+  )
+}
+
+/** Left/right fade hints over the scrollport edges when the table overflows. */
+export function TableScrollFade({
+  left,
+  right,
+}: {
+  left: boolean
+  right: boolean
+}): JSX.Element | null {
+  if (!left && !right) {
+    return null
+  }
+  const fadeBase = {
+    position: 'absolute' as const,
+    top: GUTTER_TOP,
+    bottom: EXTEND_SIZE + EXTEND_GAP + 12,
+    width: 36,
+    pointerEvents: 'none' as const,
+    zIndex: 7,
+  }
+  return (
+    <>
+      {left ? (
+        <div
+          aria-hidden="true"
+          style={{
+            ...fadeBase,
+            left: 0,
+            background:
+              'linear-gradient(to right, #ffffff 0%, rgba(255,255,255,0) 100%)',
+          }}
+        />
+      ) : null}
+      {right ? (
+        <div
+          aria-hidden="true"
+          style={{
+            ...fadeBase,
+            right: 0,
+            background:
+              'linear-gradient(to left, #ffffff 0%, rgba(255,255,255,0) 100%)',
+          }}
+        />
+      ) : null}
+    </>
   )
 }

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -1,11 +1,11 @@
 import {useState, type JSX} from 'react'
 import {BLUE, BORDER} from './table-cell-style'
-import type {TableMetrics} from './table-metrics'
+import {snapPx, type TableMetrics} from './table-metrics'
 
 // Top gutter holds the column handles + table menu. No left gutter: the table
 // is flush and the row handles overhang into the editable's own padding.
-export const GUTTER_TOP = 20
-export const GUTTER_LEFT = 0
+const GUTTER_TOP = 20
+const GUTTER_LEFT = 0
 
 const HANDLE_REST_ROW = {w: 3, h: 16}
 const HANDLE_REST_COL = {w: 16, h: 3}
@@ -19,6 +19,37 @@ const HANDLE_EXPANDED_SHADOW_SELECTED =
   'inset 0 0 0 0.5px rgba(255,255,255,0.9), 0 0 0 1px #fff'
 const HANDLE_DOT = 2
 const HANDLE_DOT_GAP = 2
+const HANDLE_GREY = '#c1c4ca'
+const BOUNDARY_DOT = 4
+const BOUNDARY_PLUS = 17
+const GRID_LINE_HALF = 0.5
+const INSERT_GUIDE = 1.5
+
+type BoundaryHover = {kind: 'row' | 'column'; index: number} | null
+
+/** Vertical grid line at a column insert boundary (relative to the table). */
+function colBorderX(metrics: TableMetrics, index: number): number {
+  const {cols, width} = metrics
+  if (index <= 0) {
+    return snapPx((cols[0]?.left ?? 0) + GRID_LINE_HALF)
+  }
+  if (index >= cols.length) {
+    return snapPx(width - GRID_LINE_HALF)
+  }
+  return snapPx(cols[index].left - GRID_LINE_HALF)
+}
+
+/** Horizontal grid line at a row insert boundary (relative to the table). */
+function rowBorderY(metrics: TableMetrics, index: number): number {
+  const {rows, height} = metrics
+  if (index <= 0) {
+    return snapPx(GRID_LINE_HALF)
+  }
+  if (index >= rows.length) {
+    return snapPx(height - GRID_LINE_HALF)
+  }
+  return snapPx(rows[index].top - GRID_LINE_HALF)
+}
 
 export type HoverCell = {row: number; col: number} | null
 
@@ -30,6 +61,8 @@ export function TableChrome({
   selectedCol,
   onSelectRow,
   onSelectCol,
+  onInsertRow,
+  onInsertCol,
 }: {
   metrics: TableMetrics | null
   active: boolean
@@ -38,7 +71,10 @@ export function TableChrome({
   selectedCol: number | null
   onSelectRow: (index: number) => void
   onSelectCol: (index: number) => void
+  onInsertRow: (boundary: number) => void
+  onInsertCol: (boundary: number) => void
 }): JSX.Element | null {
+  const [boundary, setBoundary] = useState<BoundaryHover>(null)
   if (!metrics) {
     return null
   }
@@ -68,7 +104,174 @@ export function TableChrome({
           onSelect={() => onSelectRow(index)}
         />
       ))}
+      {/* Internal boundaries only (between columns/rows); the edges are handled
+          by the extend bars, matching the default prototype variant. */}
+      {Array.from({length: Math.max(metrics.cols.length - 1, 0)}, (_, k) => {
+        const index = k + 1
+        return (
+          <BoundaryControl
+            key={`col-boundary-${index}`}
+            x={GUTTER_LEFT + colBorderX(metrics, index)}
+            y={GUTTER_TOP}
+            visible={active}
+            hot={boundary?.kind === 'column' && boundary.index === index}
+            onEnter={() => setBoundary({kind: 'column', index})}
+            onLeave={() => setBoundary(null)}
+            onInsert={() => onInsertCol(index)}
+          />
+        )
+      })}
+      {Array.from({length: Math.max(metrics.rows.length - 1, 0)}, (_, k) => {
+        const index = k + 1
+        return (
+          <BoundaryControl
+            key={`row-boundary-${index}`}
+            x={GUTTER_LEFT}
+            y={GUTTER_TOP + rowBorderY(metrics, index)}
+            visible={active}
+            hot={boundary?.kind === 'row' && boundary.index === index}
+            onEnter={() => setBoundary({kind: 'row', index})}
+            onLeave={() => setBoundary(null)}
+            onInsert={() => onInsertRow(index)}
+          />
+        )
+      })}
+      {active && boundary ? (
+        <InsertGuideline metrics={metrics} hovered={boundary} />
+      ) : null}
     </>
+  )
+}
+
+function BoundaryControl({
+  x,
+  y,
+  visible,
+  hot,
+  onEnter,
+  onLeave,
+  onInsert,
+}: {
+  x: number
+  y: number
+  visible: boolean
+  hot: boolean
+  onEnter: () => void
+  onLeave: () => void
+  onInsert: () => void
+}): JSX.Element {
+  const hit = 20
+  return (
+    <button
+      type="button"
+      aria-label="Insert here"
+      tabIndex={visible ? 0 : -1}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        onInsert()
+      }}
+      style={{
+        position: 'absolute',
+        left: x - hit / 2,
+        top: y - hit / 2,
+        width: hit,
+        height: hit,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: visible ? 'auto' : 'none',
+        cursor: 'pointer',
+        zIndex: 6,
+        border: 'none',
+        background: 'transparent',
+        padding: 0,
+      }}
+    >
+      {hot ? (
+        <div
+          style={{
+            width: BOUNDARY_PLUS,
+            height: BOUNDARY_PLUS,
+            borderRadius: '50%',
+            background: BLUE,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: '0 1px 4px rgba(85,107,252,0.4)',
+          }}
+        >
+          <svg
+            aria-hidden="true"
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+          >
+            <path
+              d="M5 1v8M1 5h8"
+              stroke="#fff"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </div>
+      ) : (
+        <div
+          style={{
+            width: BOUNDARY_DOT,
+            height: BOUNDARY_DOT,
+            borderRadius: '50%',
+            background: HANDLE_GREY,
+            opacity: visible ? 1 : 0,
+            transition: 'opacity 100ms ease',
+          }}
+        />
+      )}
+    </button>
+  )
+}
+
+function InsertGuideline({
+  metrics,
+  hovered,
+}: {
+  metrics: TableMetrics
+  hovered: NonNullable<BoundaryHover>
+}): JSX.Element {
+  if (hovered.kind === 'column') {
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          left: GUTTER_LEFT + colBorderX(metrics, hovered.index),
+          top: GUTTER_TOP,
+          width: INSERT_GUIDE,
+          height: metrics.height,
+          transform: 'translateX(-50%)',
+          background: BLUE,
+          pointerEvents: 'none',
+          zIndex: 3,
+        }}
+      />
+    )
+  }
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: GUTTER_LEFT,
+        top: GUTTER_TOP + rowBorderY(metrics, hovered.index),
+        width: metrics.width,
+        height: INSERT_GUIDE,
+        transform: 'translateY(-50%)',
+        background: BLUE,
+        pointerEvents: 'none',
+        zIndex: 3,
+      }}
+    />
   )
 }
 
@@ -98,9 +301,10 @@ function Handle({
   const lit = active && (cellHot || hot || selected)
 
   return (
-    <div
-      role="button"
+    <button
+      type="button"
       aria-label={isColumn ? 'Column handle' : 'Row handle'}
+      tabIndex={lit ? 0 : -1}
       onMouseEnter={() => setHot(true)}
       onMouseLeave={() => setHot(false)}
       onPointerDown={(event) => {
@@ -122,6 +326,9 @@ function Handle({
         transition: 'opacity 100ms ease',
         cursor: showExpanded ? 'grab' : 'pointer',
         zIndex: 5,
+        border: 'none',
+        background: 'transparent',
+        padding: 0,
       }}
     >
       <div
@@ -153,7 +360,7 @@ function Handle({
           <DragDots isColumn={isColumn} selected={selected} />
         ) : null}
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -202,7 +202,10 @@ function ExtendBar({
       type="button"
       aria-label={label}
       tabIndex={visible ? 0 : -1}
-      onClick={onClick}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        onClick()
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -24,6 +24,12 @@ const BOUNDARY_DOT = 4
 const BOUNDARY_PLUS = 17
 const GRID_LINE_HALF = 0.5
 const INSERT_GUIDE = 1.5
+const EXTEND_SIZE = 17
+const EXTEND_GAP = 3
+const EXTEND_BAR_BG = '#fafafb'
+const EXTEND_BAR_BG_HOVER = '#f0f1f3'
+const EXTEND_ICON = '#6e7484'
+const EXTEND_ICON_HOVER = '#5c5f69'
 
 type BoundaryHover = {kind: 'row' | 'column'; index: number} | null
 
@@ -78,8 +84,32 @@ export function TableChrome({
   if (!metrics) {
     return null
   }
+  const lastRow = metrics.rows.length - 1
+  const lastCol = metrics.cols.length - 1
   return (
     <>
+      <ExtendBar
+        label="Add row at end"
+        visible={active && hoverCell?.row === lastRow}
+        style={{
+          left: GUTTER_LEFT,
+          top: GUTTER_TOP + metrics.height + EXTEND_GAP,
+          width: metrics.width,
+          height: EXTEND_SIZE,
+        }}
+        onClick={() => onInsertRow(metrics.rows.length)}
+      />
+      <ExtendBar
+        label="Add column at end"
+        visible={active && hoverCell?.col === lastCol}
+        style={{
+          left: GUTTER_LEFT + metrics.width + EXTEND_GAP,
+          top: GUTTER_TOP,
+          width: EXTEND_SIZE,
+          height: metrics.height,
+        }}
+        onClick={() => onInsertCol(metrics.cols.length)}
+      />
       {metrics.cols.map((col, index) => (
         <Handle
           key={`col-${index}`}
@@ -140,6 +170,62 @@ export function TableChrome({
         <InsertGuideline metrics={metrics} hovered={boundary} />
       ) : null}
     </>
+  )
+}
+
+function ExtendBar({
+  label,
+  visible,
+  style,
+  onClick,
+}: {
+  label: string
+  visible: boolean
+  style: {left: number; top: number; width: number; height: number}
+  onClick: () => void
+}): JSX.Element {
+  const [hovered, setHovered] = useState(false)
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      tabIndex={visible ? 0 : -1}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        position: 'absolute',
+        ...style,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: 'none',
+        borderRadius: 3,
+        padding: 0,
+        pointerEvents: visible ? 'auto' : 'none',
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 100ms ease, background 100ms ease',
+        background: hovered ? EXTEND_BAR_BG_HOVER : EXTEND_BAR_BG,
+        color: hovered ? EXTEND_ICON_HOVER : EXTEND_ICON,
+        cursor: 'pointer',
+        zIndex: 1,
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M7 2.5v9M2.5 7h9"
+          stroke="currentColor"
+          strokeWidth="1.15"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
   )
 }
 

--- a/apps/playground/src/plugins/table-defaults.ts
+++ b/apps/playground/src/plugins/table-defaults.ts
@@ -1,0 +1,24 @@
+/**
+ * The fields of a freshly inserted table: 3x3 with one header row, matching
+ * the design prototype's insert. Used by both the toolbar button and the
+ * slash command.
+ */
+export function defaultTableValue() {
+  return {
+    headerRows: 1,
+    rows: Array.from({length: 3}, () => ({
+      _type: 'row',
+      cells: Array.from({length: 3}, () => ({
+        _type: 'cell',
+        value: [
+          {
+            _type: 'block',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', text: '', marks: []}],
+          },
+        ],
+      })),
+    })),
+  }
+}

--- a/apps/playground/src/plugins/table-drag.ts
+++ b/apps/playground/src/plugins/table-drag.ts
@@ -1,0 +1,190 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react'
+import type {TableMetrics} from './table-metrics'
+import {
+  computeColInsertIndex,
+  computeGhostGrabOffset,
+  computeRowInsertIndex,
+  DRAG_THRESHOLD_PX,
+} from './table-reorder'
+
+export type DragState = {
+  kind: 'row' | 'column'
+  index: number
+  startX: number
+  startY: number
+  clientX: number
+  clientY: number
+  grabOffsetX: number
+  grabOffsetY: number
+  active: boolean
+  insertIndex: number
+  pointerId: number
+}
+
+/**
+ * Pointer-driven row/column reorder from a handle (IX15, B5). Below the 4px
+ * threshold a pointer-up is a click and selects; past it the drag tracks the
+ * nearest insert boundary and commits on drop.
+ */
+export function useTableDragReorder({
+  tableRef,
+  metrics,
+  onCommitRow,
+  onCommitCol,
+  onSelectRow,
+  onSelectCol,
+}: {
+  tableRef: RefObject<HTMLTableElement | null>
+  metrics: TableMetrics | null
+  onCommitRow: (from: number, insertBefore: number) => void
+  onCommitCol: (from: number, insertBefore: number) => void
+  onSelectRow: (index: number) => void
+  onSelectCol: (index: number) => void
+}): {
+  drag: DragState | null
+  onHandlePointerDown: (
+    kind: 'row' | 'column',
+    index: number,
+    event: ReactPointerEvent<HTMLButtonElement>,
+  ) => void
+  isDragging: boolean
+} {
+  const sessionRef = useRef<DragState | null>(null)
+  const [drag, setDrag] = useState<DragState | null>(null)
+
+  const endSession = useCallback(() => {
+    sessionRef.current = null
+    setDrag(null)
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }, [])
+
+  const onHandlePointerDown = useCallback(
+    (
+      kind: 'row' | 'column',
+      index: number,
+      event: ReactPointerEvent<HTMLButtonElement>,
+    ) => {
+      if (event.button !== 0) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+
+      const target = event.currentTarget
+      target.setPointerCapture(event.pointerId)
+
+      const tableRect = tableRef.current?.getBoundingClientRect() ?? null
+      const {grabOffsetX, grabOffsetY} = computeGhostGrabOffset(
+        kind,
+        index,
+        event.clientX,
+        event.clientY,
+        tableRect,
+        metrics,
+      )
+
+      sessionRef.current = {
+        kind,
+        index,
+        startX: event.clientX,
+        startY: event.clientY,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        grabOffsetX,
+        grabOffsetY,
+        active: false,
+        insertIndex: index,
+        pointerId: event.pointerId,
+      }
+      setDrag({...sessionRef.current})
+      document.body.style.userSelect = 'none'
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const session = sessionRef.current
+        if (!session || moveEvent.pointerId !== session.pointerId) {
+          return
+        }
+        const dx = moveEvent.clientX - session.startX
+        const dy = moveEvent.clientY - session.startY
+        const active = session.active || Math.hypot(dx, dy) >= DRAG_THRESHOLD_PX
+
+        const table = tableRef.current
+        let insertIndex = session.insertIndex
+        if (active && table && metrics) {
+          const rect = table.getBoundingClientRect()
+          insertIndex =
+            session.kind === 'row'
+              ? computeRowInsertIndex(moveEvent.clientY, rect, metrics.rows)
+              : computeColInsertIndex(moveEvent.clientX, rect, metrics.cols)
+        }
+
+        sessionRef.current = {
+          ...session,
+          active,
+          clientX: moveEvent.clientX,
+          clientY: moveEvent.clientY,
+          insertIndex,
+        }
+        setDrag({...sessionRef.current})
+
+        if (active) {
+          document.body.style.cursor = 'grabbing'
+        }
+      }
+
+      const onUp = (upEvent: PointerEvent) => {
+        const session = sessionRef.current
+        if (!session || upEvent.pointerId !== session.pointerId) {
+          return
+        }
+        try {
+          target.releasePointerCapture(session.pointerId)
+        } catch {
+          // already released
+        }
+
+        if (session.active) {
+          if (session.kind === 'row') {
+            onCommitRow(session.index, session.insertIndex)
+          } else {
+            onCommitCol(session.index, session.insertIndex)
+          }
+        } else if (session.kind === 'row') {
+          onSelectRow(session.index)
+        } else {
+          onSelectCol(session.index)
+        }
+
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
+        window.removeEventListener('pointercancel', onUp)
+        endSession()
+      }
+
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+      window.addEventListener('pointercancel', onUp)
+    },
+    [
+      tableRef,
+      metrics,
+      onCommitRow,
+      onCommitCol,
+      onSelectRow,
+      onSelectCol,
+      endSession,
+    ],
+  )
+
+  useEffect(() => () => endSession(), [endSession])
+
+  return {drag, onHandlePointerDown, isDragging: Boolean(drag?.active)}
+}

--- a/apps/playground/src/plugins/table-metrics.ts
+++ b/apps/playground/src/plugins/table-metrics.ts
@@ -1,0 +1,74 @@
+import {useLayoutEffect, useState, type RefObject} from 'react'
+
+/** Round to device pixels so 1px borders and small dots stay crisp. */
+export function snapPx(px: number): number {
+  if (typeof window === 'undefined') {
+    return px
+  }
+  const dpr = window.devicePixelRatio || 1
+  return Math.round(px * dpr) / dpr
+}
+
+export type TableMetrics = {
+  width: number
+  height: number
+  rows: Array<{top: number; height: number; centerY: number}>
+  cols: Array<{left: number; width: number; centerX: number}>
+}
+
+/**
+ * Measures row centers and column centers relative to the `<table>` box so
+ * chrome can be pinned to the real border lines (not a guessed CSS grid).
+ * Ported from the design prototype's `useTableMetrics`.
+ */
+export function useTableMetrics(
+  tableRef: RefObject<HTMLTableElement | null>,
+  revision: string,
+): TableMetrics | null {
+  const [metrics, setMetrics] = useState<TableMetrics | null>(null)
+
+  useLayoutEffect(() => {
+    const table = tableRef.current
+    if (!table) {
+      return
+    }
+
+    const measure = () => {
+      const rect = table.getBoundingClientRect()
+      const trs = [...table.querySelectorAll('tbody tr')]
+      const firstRowCells = trs[0]?.querySelectorAll('td') ?? []
+
+      const rows = trs.map((tr) => {
+        const r = tr.getBoundingClientRect()
+        const top = snapPx(r.top - rect.top)
+        const height = snapPx(r.height)
+        return {top, height, centerY: snapPx(top + height / 2)}
+      })
+
+      const cols = [...firstRowCells].map((td) => {
+        const c = td.getBoundingClientRect()
+        const left = snapPx(c.left - rect.left)
+        const width = snapPx(c.width)
+        return {left, width, centerX: snapPx(left + width / 2)}
+      })
+
+      setMetrics({
+        width: snapPx(rect.width),
+        height: snapPx(rect.height),
+        rows,
+        cols,
+      })
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(table)
+    window.addEventListener('resize', measure)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [tableRef, revision])
+
+  return metrics
+}

--- a/apps/playground/src/plugins/table-overflow.ts
+++ b/apps/playground/src/plugins/table-overflow.ts
@@ -1,0 +1,105 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type RefObject,
+} from 'react'
+
+/** Min width per column before the table scrolls horizontally (IX10). */
+export const MIN_COL_PX = 140
+export const SCROLL_PADDING_BOTTOM = 12
+
+const EDGE_EPSILON = 2
+
+/**
+ * Hybrid column width (IX10): columns share the width equally while the field
+ * fits; fixed min column width plus horizontal scroll inside the table
+ * container once `colCount x MIN_COL_PX` exceeds the scrollport.
+ */
+export function useTableHorizontalLayout(
+  scrollRef: RefObject<HTMLDivElement | null>,
+  colCount: number,
+  revision: string,
+): boolean {
+  const [enforceMinColumnWidth, setEnforceMinColumnWidth] = useState(false)
+
+  const measure = useCallback(() => {
+    const element = scrollRef.current
+    if (!element || colCount < 1) {
+      setEnforceMinColumnWidth(false)
+      return
+    }
+    const minTableWidth = colCount * MIN_COL_PX
+    const next = minTableWidth > element.clientWidth + EDGE_EPSILON
+    setEnforceMinColumnWidth((prev) => (prev === next ? prev : next))
+  }, [scrollRef, colCount])
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current
+    if (!element) {
+      return
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    if (element.firstElementChild) {
+      observer.observe(element.firstElementChild)
+    }
+    return () => {
+      window.removeEventListener('resize', measure)
+      observer.disconnect()
+    }
+  }, [scrollRef, measure, revision])
+
+  return enforceMinColumnWidth
+}
+
+/** Left/right fade hints when the horizontal scrollport overflows. */
+export function useScrollFade(
+  scrollRef: RefObject<HTMLDivElement | null>,
+  revision: string,
+): {left: boolean; right: boolean} {
+  const [fade, setFade] = useState({left: false, right: false})
+
+  const measure = useCallback(() => {
+    const element = scrollRef.current
+    if (!element) {
+      setFade({left: false, right: false})
+      return
+    }
+    const {scrollLeft, scrollWidth, clientWidth} = element
+    const overflows = scrollWidth > clientWidth + EDGE_EPSILON
+    setFade((prev) => {
+      const next = {
+        left: overflows && scrollLeft > EDGE_EPSILON,
+        right:
+          overflows && scrollLeft + clientWidth < scrollWidth - EDGE_EPSILON,
+      }
+      return prev.left === next.left && prev.right === next.right ? prev : next
+    })
+  }, [scrollRef])
+
+  useEffect(() => {
+    const element = scrollRef.current
+    if (!element) {
+      return
+    }
+    measure()
+    element.addEventListener('scroll', measure, {passive: true})
+    window.addEventListener('resize', measure)
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    if (element.firstElementChild) {
+      observer.observe(element.firstElementChild)
+    }
+    return () => {
+      element.removeEventListener('scroll', measure)
+      window.removeEventListener('resize', measure)
+      observer.disconnect()
+    }
+  }, [scrollRef, measure, revision])
+
+  return fade
+}

--- a/apps/playground/src/plugins/table-reorder.ts
+++ b/apps/playground/src/plugins/table-reorder.ts
@@ -1,0 +1,93 @@
+import type {TableMetrics} from './table-metrics'
+
+/** B5: movement before drag; below threshold, pointer-up = select only. */
+export const DRAG_THRESHOLD_PX = 4
+
+/** Pointer offset from ghost top-left, keeps the cursor anchored where the handle was grabbed. */
+export function computeGhostGrabOffset(
+  kind: 'row' | 'column',
+  index: number,
+  clientX: number,
+  clientY: number,
+  tableRect: DOMRect | null,
+  metrics: TableMetrics | null,
+): {grabOffsetX: number; grabOffsetY: number} {
+  if (!tableRect || !metrics) {
+    return {grabOffsetX: 0, grabOffsetY: 0}
+  }
+  if (kind === 'row') {
+    const rowMetrics = metrics.rows[index]
+    if (!rowMetrics) {
+      return {grabOffsetX: 0, grabOffsetY: 0}
+    }
+    return {
+      grabOffsetX: clientX - tableRect.left,
+      grabOffsetY: clientY - (tableRect.top + rowMetrics.top),
+    }
+  }
+  const colMetrics = metrics.cols[index]
+  if (!colMetrics) {
+    return {grabOffsetX: 0, grabOffsetY: 0}
+  }
+  return {
+    grabOffsetX: clientX - (tableRect.left + colMetrics.left),
+    grabOffsetY: clientY - tableRect.top,
+  }
+}
+
+/** The row boundary (0..rows.length) nearest to the pointer. */
+export function computeRowInsertIndex(
+  clientY: number,
+  tableRect: DOMRect,
+  rows: TableMetrics['rows'],
+): number {
+  if (rows.length === 0) {
+    return 0
+  }
+  const y = clientY - tableRect.top
+  const lastRow = rows[rows.length - 1]
+  const boundaries = [
+    ...rows.map((row) => row.top),
+    lastRow.top + lastRow.height,
+  ]
+  return nearestBoundary(y, boundaries)
+}
+
+/** The column boundary (0..cols.length) nearest to the pointer. */
+export function computeColInsertIndex(
+  clientX: number,
+  tableRect: DOMRect,
+  cols: TableMetrics['cols'],
+): number {
+  if (cols.length === 0) {
+    return 0
+  }
+  const x = clientX - tableRect.left
+  const lastCol = cols[cols.length - 1]
+  const boundaries = [
+    ...cols.map((col) => col.left),
+    lastCol.left + lastCol.width,
+  ]
+  return nearestBoundary(x, boundaries)
+}
+
+function nearestBoundary(position: number, boundaries: Array<number>): number {
+  let nearest = 0
+  let best = Number.POSITIVE_INFINITY
+  boundaries.forEach((boundary, index) => {
+    const distance = Math.abs(position - boundary)
+    if (distance < best) {
+      best = distance
+      nearest = index
+    }
+  })
+  return nearest
+}
+
+/** The final index of the item after dropping it before `insertBefore`. */
+export function reorderIndex(from: number, insertBefore: number): number {
+  if (insertBefore === from || insertBefore === from + 1) {
+    return from
+  }
+  return insertBefore > from ? insertBefore - 1 : insertBefore
+}

--- a/apps/playground/src/slash-command-picker.tsx
+++ b/apps/playground/src/slash-command-picker.tsx
@@ -36,7 +36,7 @@ type CommandMatch = {
   icon: JSX.Element
   keywords: string[]
   action:
-    | {type: 'insert.block'; block: {_type: string}}
+    | {type: 'insert.block'; block: {_type: string; [key: string]: unknown}}
     | {type: 'style.toggle'; style: string}
     | {type: 'list item.toggle'; listItem: string}
 }
@@ -161,7 +161,24 @@ const commands: CommandMatch[] = [
     keywords: ['table', 'grid', 'rows', 'columns'],
     action: {
       type: 'insert.block',
-      block: {_type: 'table'},
+      block: {
+        _type: 'table',
+        headerRows: 1,
+        rows: Array.from({length: 3}, () => ({
+          _type: 'row',
+          cells: Array.from({length: 3}, () => ({
+            _type: 'cell',
+            value: [
+              {
+                _type: 'block',
+                style: 'normal',
+                markDefs: [],
+                children: [{_type: 'span', text: '', marks: []}],
+              },
+            ],
+          })),
+        })),
+      },
     },
   },
   {

--- a/apps/playground/src/slash-command-picker.tsx
+++ b/apps/playground/src/slash-command-picker.tsx
@@ -22,6 +22,7 @@ import {
   TextQuoteIcon,
 } from 'lucide-react'
 import {useEffect, useRef, useState, type JSX} from 'react'
+import {defaultTableValue} from './plugins/table-defaults'
 import {Button} from './primitives/button'
 import {Dialog} from './primitives/dialog'
 import type {FieldOption} from './primitives/fields'
@@ -161,24 +162,7 @@ const commands: CommandMatch[] = [
     keywords: ['table', 'grid', 'rows', 'columns'],
     action: {
       type: 'insert.block',
-      block: {
-        _type: 'table',
-        headerRows: 1,
-        rows: Array.from({length: 3}, () => ({
-          _type: 'row',
-          cells: Array.from({length: 3}, () => ({
-            _type: 'cell',
-            value: [
-              {
-                _type: 'block',
-                style: 'normal',
-                markDefs: [],
-                children: [{_type: 'span', text: '', marks: []}],
-              },
-            ],
-          })),
-        })),
-      },
+      block: {_type: 'table', ...defaultTableValue()},
     },
   },
   {
@@ -226,8 +210,16 @@ const slashCommandPicker = defineTypeaheadPicker<CommandMatch>({
         const blockObjectSchema = snapshot.context.schema.blockObjects.find(
           (blockObject) => blockObject.name === blockType,
         )
+        // A command that carries a complete block inserts it directly; the
+        // dialog is for commands that only name a type whose fields need
+        // filling.
+        const prefilled = Object.keys(event.match.action.block).length > 1
 
-        if (blockObjectSchema && blockObjectSchema.fields.length > 0) {
+        if (
+          !prefilled &&
+          blockObjectSchema &&
+          blockObjectSchema.fields.length > 0
+        ) {
           const extendedSchema = extendBlockObject(blockObjectSchema)
 
           return [

--- a/apps/playground/src/toolbar/button.block-object.tsx
+++ b/apps/playground/src/toolbar/button.block-object.tsx
@@ -1,6 +1,8 @@
+import {useEditor} from '@portabletext/editor'
 import {useApplicableSchema, useBlockObjectButton} from '@portabletext/toolbar'
 import type {ToolbarBlockObjectSchemaType} from '@portabletext/toolbar'
 import {TooltipTrigger} from 'react-aria-components'
+import {defaultTableValue} from '../plugins/table-defaults'
 import {Button} from '../primitives/button'
 import {Dialog} from '../primitives/dialog'
 import type {FieldOption} from '../primitives/fields'
@@ -15,6 +17,39 @@ export function BlockObjectButton(props: {
 }) {
   const {snapshot, send} = useBlockObjectButton(props)
   const applicable = useApplicableSchema()
+  const editor = useEditor()
+
+  if (props.schemaType.name === 'table') {
+    // Tables skip the field dialog: every insert wants the same 3x3 shape
+    // with one header row, so the button inserts it directly.
+    return (
+      <TooltipTrigger>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={
+            !applicable.blockObjects.has(props.schemaType.name) ||
+            snapshot.matches('disabled')
+          }
+          onPress={() => {
+            editor.send({
+              type: 'insert.block object',
+              blockObject: {
+                name: props.schemaType.name,
+                value: defaultTableValue(),
+              },
+              placement: 'auto',
+            })
+            editor.send({type: 'focus'})
+          }}
+        >
+          <Icon icon={props.schemaType.icon} fallback={null} />
+          {props.schemaType.title}
+        </Button>
+        <Tooltip>Insert {props.schemaType.title}</Tooltip>
+      </TooltipTrigger>
+    )
+  }
 
   return (
     <Dialog

--- a/apps/playground/src/toolbar/form.insert-block-object.tsx
+++ b/apps/playground/src/toolbar/form.insert-block-object.tsx
@@ -32,7 +32,23 @@ export function InsertBlockObjectForm(
         const formDataValues = Object.fromEntries(formData)
         const {placement, ...formValue} = FormDataSchema.parse(formDataValues)
 
-        const value = {...(props.defaultValues ?? {}), ...formValue}
+        // `FormData` values are all strings; coerce `number` fields back to
+        // numbers so e.g. a table's `headerRows` is stored as `1`, not `"1"`.
+        const numberFields = new Set(
+          props.fields
+            .filter((field) => field.type === 'number')
+            .map((field) => field.name),
+        )
+        const value: {[key: string]: unknown} = {...(props.defaultValues ?? {})}
+        for (const [key, fieldValue] of Object.entries(formValue)) {
+          if (numberFields.has(key) && typeof fieldValue === 'string') {
+            if (fieldValue !== '') {
+              value[key] = Number(fieldValue)
+            }
+          } else {
+            value[key] = fieldValue
+          }
+        }
 
         props.onSubmit({
           value,

--- a/apps/playground/src/toolbar/portable-text-toolbar.tsx
+++ b/apps/playground/src/toolbar/portable-text-toolbar.tsx
@@ -329,27 +329,12 @@ export const extendBlockObject = ((blockObject) => {
   }
 
   if (blockObject.name === 'table') {
-    const emptyCell = () => ({
-      _type: 'cell',
-      content: [
-        {
-          _type: 'block',
-          style: 'normal',
-          children: [{_type: 'span', text: '', marks: []}],
-          markDefs: [],
-        },
-      ],
-    })
-    const emptyRow = () => ({
-      _type: 'row',
-      cells: [emptyCell(), emptyCell(), emptyCell()],
-    })
+    // No `defaultValues`: tables never open the field dialog, both the
+    // toolbar button and the slash command insert the shared 3x3 default
+    // directly.
     return {
       ...blockObject,
       icon: TableIcon,
-      defaultValues: {
-        rows: [emptyRow(), emptyRow()],
-      },
     }
   }
 

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -60,6 +60,10 @@ export default defineConfig({
         __dirname,
         '../../packages/plugin-paste-link/src',
       ),
+      '@portabletext/plugin-table': path.resolve(
+        __dirname,
+        '../../packages/plugin-table/src',
+      ),
       '@portabletext/plugin-typeahead-picker': path.resolve(
         __dirname,
         '../../packages/plugin-typeahead-picker/src',

--- a/packages/plugin-table/src/behaviors/types.ts
+++ b/packages/plugin-table/src/behaviors/types.ts
@@ -1,15 +1,30 @@
 import type {Path, PortableTextBlock} from '@portabletext/editor'
 
+/**
+ * @alpha
+ */
 export type Cell = {
   _type: 'cell'
   _key: string
   value: Array<PortableTextBlock>
 }
+
+/**
+ * @alpha
+ */
 export type Row = PortableTextBlock & {_type: 'row'; cells: Array<Cell>}
 
-/** Per-column alignment, positional (array index = column index). `null` is an explicitly unaligned column. */
+/**
+ * Per-column alignment, positional (array index = column index). `null` is an
+ * explicitly unaligned column.
+ *
+ * @alpha
+ */
 export type ColumnAlignment = 'left' | 'center' | 'right' | null
 
+/**
+ * @alpha
+ */
 export type Table = PortableTextBlock & {
   _type: 'table'
   rows: Array<Row>
@@ -18,20 +33,32 @@ export type Table = PortableTextBlock & {
   headerRows?: number
 }
 
+/**
+ * @alpha
+ */
 export function isRow(node: PortableTextBlock): node is Row {
   // biome-ignore lint/complexity/useLiteralKeys: tsconfig has noPropertyAccessFromIndexSignature
   return node._type === 'row' && 'cells' in node && Array.isArray(node['cells'])
 }
 
+/**
+ * @alpha
+ */
 export function isCell(node: PortableTextBlock): node is Cell {
   return node._type === 'cell'
 }
 
+/**
+ * @alpha
+ */
 export function isTable(node: PortableTextBlock): node is Table {
   // biome-ignore lint/complexity/useLiteralKeys: tsconfig has noPropertyAccessFromIndexSignature
   return node._type === 'table' && 'rows' in node && Array.isArray(node['rows'])
 }
 
+/**
+ * @alpha
+ */
 export type TableSelection = {
   tablePath: Path
   rowRange: [number, number]

--- a/packages/plugin-table/src/index.ts
+++ b/packages/plugin-table/src/index.ts
@@ -1,1 +1,3 @@
 export * from './plugin.table'
+export * from './behaviors/types'
+export {getTableSelection} from './get-table-selection'


### PR DESCRIPTION
Builds the playground table to 1:1 parity with the `pte-tables-phases` design prototype (`sanity-labs/tables-design-prototype`), as a top-notch playground example rather than a shipped plugin surface. Tracked under EDEX-1467; the branch code is the source of truth, and where its draft `decisions.md` disagrees with the code, the code wins (caught: `HEADER_BG`, the Studio left inset, B1 insertion focus).

`@portabletext/plugin-table` stays headless: it contributes the structural behaviors and the derived `getTableSelection`, and now exports its types + `getTableSelection` so a consumer that owns the render can read table structure and selection. Everything visual and interactive lives in the playground, plain React + CSS, no `@sanity/ui`. Structural selection (row / column / whole table / sweep range) is expressed as a cell-spanning editor selection and drawn from the one derived `getTableSelection`; the prototype's pure modules (geometry, reorder math, border lines) are ported as typed modules.

The full chrome, matched to the prototype's default (`phase`) variant:

- Render + header row (`headerRows`, default 3x3 header-on), branch tokens for grid / padding / corners.
- Selection visuals: `1.5px #556bfc` outline + `rgba(85,107,252,0.06)` overlay per cell, native `::selection` suppressed while a range is active. Sweep-drag, shift-click, and shift+arrow ranges all come from the browser's native selection machinery, no custom range mechanism.
- Row/column handles (rest / hover 6-dot / selected blue): click selects, drag reorders with a solid ghost + insertion line (4px click-vs-drag threshold per B5), source dims to 35%.
- Boundary insert dots + guideline between rows/columns; add-row / add-column extend bars in reserved lanes (reachable from the lanes themselves, a deliberate superset of the prototype's cell-hover reveal).
- Trash delete on row/column selection (portaled, never clipped; last row/column protected per B4).
- Table `...` menu: header-row switch, select table, delete table.
- Horizontal overflow: equal column share until 140px/column, then containerized scroll with edge fades; menu pins to the scrollport, chrome scrolls with the table.

One focus rule governs all chrome: interactive chrome never takes DOM focus (preventDefault on pointerdown), so the editor caret survives every menu/bar/handle interaction, including table deletion.

Remaining under EDEX-1467, out of this PR's scope: rich cell content (EDEX-1476, low priority) and x-preserving arrow nav (EDEX-1466, needs a core primitive and ships separately).
