### PR TITLE
fix(perf): resolve the `unset` selection fallback's nearest spans without a document scan

### DIFF
--- a/.changeset/unset-fallback-neighbor-query.md
+++ b/.changeset/unset-fallback-neighbor-query.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): resolve the `unset` selection fallback's nearest spans without a document scan
+
+Backspacing through empty blocks, and any other edit that removes the
+node the selection sits in, no longer slows down with document size.
+Previously each such removal scanned the document from the start to
+find the nearest span; in large documents this made deleting empty
+lines feel sluggish (~267ms per backspace at 8,000 blocks, now ~20ms).
+
+One narrow behavioral fix rides along: when the removed node was
+addressed by a numeric path, the fallback previously moved the
+selection to the document's first span; it now moves it to the actual
+nearest span.

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -3,26 +3,23 @@ import {
   set as setPatchHelper,
   unset as unsetPatchHelper,
 } from '@portabletext/patches'
-import type {PortableTextBlock, PortableTextSpan} from '@portabletext/schema'
-import {isSpan} from '@portabletext/schema'
+import type {PortableTextBlock} from '@portabletext/schema'
+import {findNearestSpans} from '../../internal-utils/find-nearest-spans'
 import {getValue} from '../../internal-utils/get-value'
 import {safeStringify} from '../../internal-utils/safe-json'
 import {serializePath} from '../../paths/serialize-path'
 import {getNode} from '../../traversal/get-node'
-import {getNodes} from '../../traversal/get-nodes'
 import type {EditorSelection} from '../../types/editor'
 import type {KeyedSegment} from '../../types/paths'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import type {Editor} from '../interfaces/editor'
-import type {Node, NodeEntry} from '../interfaces/node'
+import type {Node} from '../interfaces/node'
 import type {EngineOperation} from '../interfaces/operation'
 import type {Path} from '../interfaces/path'
 import type {Range} from '../interfaces/range'
 import {commonPath} from '../path/common-path'
-import {comparePaths} from '../path/compare-paths'
 import {isSiblingPath} from '../path/is-sibling-path'
 import {parentPath} from '../path/parent-path'
-import {pathEquals} from '../path/path-equals'
 import {transformPoint} from '../point/transform-point'
 import {isBackwardRange} from '../range/is-backward-range'
 import {isRange} from '../range/is-range'
@@ -257,9 +254,9 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
       const lastSegment = path[path.length - 1]
       if (isKeyedSegment(lastSegment) || typeof lastSegment === 'number') {
         // Transform the selection BEFORE removing the node from the tree.
-        // comparePaths needs the node in the tree to resolve document order
-        // for keyed segments. After removal, it falls back to string
-        // comparison of _key values which may give wrong ordering.
+        // `findNearestSpans` anchors on the removed node's position, so the
+        // node must still be in the tree (and in `blockIndexMap`) to resolve
+        // document order for keyed segments.
         if (editor.snapshot.context.selection) {
           let selection: EditorSelection = {
             ...editor.snapshot.context.selection,
@@ -271,41 +268,32 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
             if (selection != null && result != null) {
               selection[key] = result
             } else {
-              let prev: NodeEntry<PortableTextSpan> | undefined
-              let next: NodeEntry<PortableTextSpan> | undefined
-
-              for (const {node: n, path: p} of getNodes(editor.snapshot)) {
-                if (!isSpan({schema: editor.snapshot.context.schema}, n)) {
-                  continue
-                }
-                if (pathEquals(p, path)) {
-                  continue
-                }
-                if (comparePaths(p, path, editor.snapshot.context) === -1) {
-                  prev = [n, p]
-                } else {
-                  next = [n, p]
-                  break
-                }
-              }
+              // The point sat inside the removed subtree; move it to
+              // the span nearest to the removed node in document
+              // order.
+              const {previousSpan, nextSpan} = findNearestSpans(
+                editor.snapshot,
+                path,
+              )
 
               let preferNext = false
-              if (prev && next) {
-                if (isSiblingPath(prev[1], path)) {
+              if (previousSpan && nextSpan) {
+                if (isSiblingPath(previousSpan.path, path)) {
                   preferNext = false
-                } else if (pathEquals(next[1], path)) {
-                  preferNext = true
                 } else {
                   preferNext =
-                    commonPath(prev[1], path).length <
-                    commonPath(next[1], path).length
+                    commonPath(previousSpan.path, path).length <
+                    commonPath(nextSpan.path, path).length
                 }
               }
 
-              if (prev && !preferNext) {
-                selection![key] = {path: prev[1], offset: prev[0].text.length}
-              } else if (next) {
-                selection![key] = {path: next[1], offset: 0}
+              if (previousSpan && !preferNext) {
+                selection![key] = {
+                  path: previousSpan.path,
+                  offset: previousSpan.node.text.length,
+                }
+              } else if (nextSpan) {
+                selection![key] = {path: nextSpan.path, offset: 0}
               } else {
                 selection = null
               }

--- a/packages/editor/src/internal-utils/find-nearest-spans.test.ts
+++ b/packages/editor/src/internal-utils/find-nearest-spans.test.ts
@@ -1,0 +1,242 @@
+import {compileSchema, defineSchema, isSpan} from '@portabletext/schema'
+import {describe, expect, test} from 'vitest'
+import type {Path} from '../engine/interfaces/path'
+import {comparePaths} from '../engine/path/compare-paths'
+import {pathEquals} from '../engine/path/path-equals'
+import {serializePath} from '../paths/serialize-path'
+import {getNodes} from '../traversal/get-nodes'
+import {createNodeTraversalTestbed} from '../traversal/node-traversal-testbed'
+import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
+import {buildIndexMaps} from './build-index-maps'
+import {findNearestSpans, type SpanEntry} from './find-nearest-spans'
+
+describe(findNearestSpans.name, () => {
+  const testbed = createNodeTraversalTestbed()
+
+  test('Scenario: Equals the document scan for every node path in the testbed', () => {
+    for (const {path} of getNodes(testbed.snapshot)) {
+      expect(
+        findNearestSpans(testbed.snapshot, path),
+        `path ${serializePath(path)}`,
+      ).toEqual(referenceNearestSpans(testbed.snapshot, path))
+    }
+  })
+
+  test('Scenario: Removing a block object between text blocks', () => {
+    // `image` sits between `textBlock1` (ending in `span2`) and
+    // `textBlock2` (starting with `span3`).
+    expect(
+      findNearestSpans(testbed.snapshot, [{_key: testbed.image._key}]),
+    ).toEqual({
+      previousSpan: {
+        node: testbed.span2,
+        path: [
+          {_key: testbed.textBlock1._key},
+          'children',
+          {_key: testbed.span2._key},
+        ],
+      },
+      nextSpan: {
+        node: testbed.span3,
+        path: [
+          {_key: testbed.textBlock2._key},
+          'children',
+          {_key: testbed.span3._key},
+        ],
+      },
+    })
+  })
+
+  test('Scenario: Removing the first block yields its own descendant as next', () => {
+    // Descendants of the removed node come after it in document order,
+    // matching the document scan the fallback used before.
+    expect(
+      findNearestSpans(testbed.snapshot, [{_key: testbed.textBlock1._key}]),
+    ).toEqual({
+      previousSpan: undefined,
+      nextSpan: {
+        node: testbed.span1,
+        path: [
+          {_key: testbed.textBlock1._key},
+          'children',
+          {_key: testbed.span1._key},
+        ],
+      },
+    })
+  })
+
+  test('Scenario: Removing a nested cell block reaches across container boundaries', () => {
+    // `cellBlock3` lives in `cell2`; the previous span is in `cell1`'s
+    // last block, the next span is `cellBlock3`'s own descendant.
+    expect(
+      findNearestSpans(testbed.snapshot, [
+        {_key: testbed.table._key},
+        'rows',
+        {_key: testbed.row1._key},
+        'cells',
+        {_key: testbed.cell2._key},
+        'content',
+        {_key: testbed.cellBlock3._key},
+      ]),
+    ).toEqual({
+      previousSpan: {
+        node: testbed.cellSpan2,
+        path: [
+          {_key: testbed.table._key},
+          'rows',
+          {_key: testbed.row1._key},
+          'cells',
+          {_key: testbed.cell1._key},
+          'content',
+          {_key: testbed.cellBlock2._key},
+          'children',
+          {_key: testbed.cellSpan2._key},
+        ],
+      },
+      nextSpan: {
+        node: testbed.cellSpan3,
+        path: [
+          {_key: testbed.table._key},
+          'rows',
+          {_key: testbed.row1._key},
+          'cells',
+          {_key: testbed.cell2._key},
+          'content',
+          {_key: testbed.cellBlock3._key},
+          'children',
+          {_key: testbed.cellSpan3._key},
+        ],
+      },
+    })
+  })
+
+  test('Scenario: Numeric root path', () => {
+    // `unset` op paths may address root children by index. The
+    // document scan this replaced degenerated here (`comparePaths`
+    // can't order keyed paths against a numeric segment, so every span
+    // compared as "after" and the first span in the document won);
+    // `findNearestSpans` resolves the true document-order neighbors.
+    expect(findNearestSpans(testbed.snapshot, [1])).toEqual({
+      previousSpan: {
+        node: testbed.span2,
+        path: [
+          {_key: testbed.textBlock1._key},
+          'children',
+          {_key: testbed.span2._key},
+        ],
+      },
+      nextSpan: {
+        node: testbed.span3,
+        path: [
+          {_key: testbed.textBlock2._key},
+          'children',
+          {_key: testbed.span3._key},
+        ],
+      },
+    })
+  })
+
+  test('Scenario: Only block objects between the removed node and the nearest spans', () => {
+    // The walk hops over span-less siblings in both directions until it
+    // reaches a subtree that holds a span.
+    const snapshot = createObjectRunSnapshot()
+
+    expect(findNearestSpans(snapshot, [{_key: 'image2'}])).toEqual(
+      referenceNearestSpans(snapshot, [{_key: 'image2'}]),
+    )
+    expect(findNearestSpans(snapshot, [{_key: 'image2'}])).toEqual({
+      previousSpan: {
+        node: {_key: 'span1', _type: 'span', text: 'before', marks: []},
+        path: [{_key: 'block1'}, 'children', {_key: 'span1'}],
+      },
+      nextSpan: {
+        node: {_key: 'span2', _type: 'span', text: 'after', marks: []},
+        path: [{_key: 'block2'}, 'children', {_key: 'span2'}],
+      },
+    })
+  })
+
+  test('Scenario: Document without spans', () => {
+    const snapshot = createSpanlessSnapshot()
+
+    expect(findNearestSpans(snapshot, [{_key: 'image2'}])).toEqual({
+      previousSpan: undefined,
+      nextSpan: undefined,
+    })
+  })
+})
+
+/**
+ * Keep-in-sync: the document-scan implementation that
+ * `findNearestSpans` replaced in `applyOperation`'s `unset` case,
+ * kept as the oracle.
+ */
+function referenceNearestSpans(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): {
+  previousSpan: SpanEntry | undefined
+  nextSpan: SpanEntry | undefined
+} {
+  let previousSpan: SpanEntry | undefined
+  let nextSpan: SpanEntry | undefined
+
+  for (const {node, path: nodePath} of getNodes(snapshot)) {
+    if (!isSpan({schema: snapshot.context.schema}, node)) {
+      continue
+    }
+    if (pathEquals(nodePath, path)) {
+      continue
+    }
+    if (comparePaths(nodePath, path, snapshot.context) === -1) {
+      previousSpan = {node, path: nodePath}
+    } else {
+      nextSpan = {node, path: nodePath}
+      break
+    }
+  }
+
+  return {previousSpan, nextSpan}
+}
+
+function createObjectRunSnapshot(): TraversalSnapshot {
+  const schema = compileSchema(defineSchema({blockObjects: [{name: 'image'}]}))
+  const value = [
+    {
+      _key: 'block1',
+      _type: 'block',
+      children: [{_key: 'span1', _type: 'span', text: 'before', marks: []}],
+    },
+    {_key: 'image1', _type: 'image'},
+    {_key: 'image2', _type: 'image'},
+    {_key: 'image3', _type: 'image'},
+    {
+      _key: 'block2',
+      _type: 'block',
+      children: [{_key: 'span2', _type: 'span', text: 'after', marks: []}],
+    },
+  ]
+  const blockIndexMap = new Map<string, number>()
+  const listIndexMap = new Map<string, number>()
+  const containers = new Map()
+
+  buildIndexMaps({schema, value, containers}, {blockIndexMap, listIndexMap})
+
+  return {context: {schema, containers, value}, blockIndexMap}
+}
+
+function createSpanlessSnapshot(): TraversalSnapshot {
+  const schema = compileSchema(defineSchema({blockObjects: [{name: 'image'}]}))
+  const value = [
+    {_key: 'image1', _type: 'image'},
+    {_key: 'image2', _type: 'image'},
+    {_key: 'image3', _type: 'image'},
+  ]
+  const blockIndexMap = new Map<string, number>()
+  const listIndexMap = new Map<string, number>()
+  const containers = new Map()
+
+  buildIndexMaps({schema, value, containers}, {blockIndexMap, listIndexMap})
+
+  return {context: {schema, containers, value}, blockIndexMap}
+}

--- a/packages/editor/src/internal-utils/find-nearest-spans.ts
+++ b/packages/editor/src/internal-utils/find-nearest-spans.ts
@@ -1,0 +1,218 @@
+import type {PortableTextSpan} from '@portabletext/schema'
+import {isSpan} from '@portabletext/schema'
+import type {Path} from '../engine/interfaces/path'
+import {serializePath} from '../paths/serialize-path'
+import {getChildren} from '../traversal/get-children'
+import {getNodes} from '../traversal/get-nodes'
+import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+
+export type SpanEntry = {
+  node: PortableTextSpan
+  path: Path
+}
+
+/**
+ * Find the spans nearest to `path` in document order: the last span
+ * strictly before it (`previousSpan`) and the first span strictly after
+ * it (`nextSpan`). `path` itself is never returned, but its descendants
+ * come after it in document order, so they are `nextSpan` candidates.
+ *
+ * Anchored replacement for scanning the whole document with `getNodes`
+ * from the start: walks outward from `path` level by level (siblings
+ * through `getChildren`, the position within them through
+ * `blockIndexMap`), descending only into sibling subtrees between
+ * `path` and the answer. Equivalence with the document scan is pinned
+ * by the oracle test in `find-nearest-spans.test.ts`.
+ */
+export function findNearestSpans(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): {
+  previousSpan: SpanEntry | undefined
+  nextSpan: SpanEntry | undefined
+} {
+  return {
+    previousSpan: findPreviousSpan(snapshot, path),
+    nextSpan: findNextSpan(snapshot, path),
+  }
+}
+
+function findNextSpan(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): SpanEntry | undefined {
+  // Descendants of `path` come first in document order after `path`
+  // itself, so the node's own subtree is the nearest place a next span
+  // can live.
+  const descendantSpan = firstSpanIn(snapshot, path)
+  if (descendantSpan) {
+    return descendantSpan
+  }
+
+  let currentPath = path
+  while (currentPath.length > 0) {
+    const parentPath = nodeParentPath(currentPath)
+    const siblings = getChildren(snapshot, parentPath)
+    const index = childIndex(snapshot, siblings, currentPath)
+
+    if (index !== -1) {
+      for (
+        let siblingIndex = index + 1;
+        siblingIndex < siblings.length;
+        siblingIndex++
+      ) {
+        const sibling = siblings[siblingIndex]!
+        if (isSpan({schema: snapshot.context.schema}, sibling.node)) {
+          return {node: sibling.node, path: sibling.path}
+        }
+        const siblingDescendantSpan = firstSpanIn(snapshot, sibling.path)
+        if (siblingDescendantSpan) {
+          return siblingDescendantSpan
+        }
+      }
+    }
+
+    currentPath = parentPath
+  }
+
+  return undefined
+}
+
+function findPreviousSpan(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): SpanEntry | undefined {
+  // Ancestors of `path` precede it in document order but are never
+  // spans (spans are leaves), so the nearest previous span lives in a
+  // preceding sibling's subtree at some ancestor level.
+  let currentPath = path
+  while (currentPath.length > 0) {
+    const parentPath = nodeParentPath(currentPath)
+    const siblings = getChildren(snapshot, parentPath)
+    const index = childIndex(snapshot, siblings, currentPath)
+
+    if (index !== -1) {
+      for (let siblingIndex = index - 1; siblingIndex >= 0; siblingIndex--) {
+        const sibling = siblings[siblingIndex]!
+        // A sibling's descendants come after the sibling itself in
+        // document order, so the subtree's last span wins over the
+        // sibling.
+        const siblingDescendantSpan = lastSpanIn(snapshot, sibling.path)
+        if (siblingDescendantSpan) {
+          return siblingDescendantSpan
+        }
+        if (isSpan({schema: snapshot.context.schema}, sibling.node)) {
+          return {node: sibling.node, path: sibling.path}
+        }
+      }
+    }
+
+    currentPath = parentPath
+  }
+
+  return undefined
+}
+
+/**
+ * First span inside the subtree at `path`, in document order. Bounded
+ * by the subtree size.
+ */
+function firstSpanIn(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): SpanEntry | undefined {
+  for (const entry of getNodes(snapshot, {
+    at: path,
+    match: (node) => isSpan({schema: snapshot.context.schema}, node),
+  })) {
+    return entry as SpanEntry
+  }
+  return undefined
+}
+
+/**
+ * Last span inside the subtree at `path`, in document order. Spans are
+ * leaves, so the first span yielded by a reverse pre-order traversal
+ * (which visits later subtrees entirely before earlier ones) is the
+ * document-order-last span. Bounded by the subtree size.
+ */
+function lastSpanIn(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): SpanEntry | undefined {
+  for (const entry of getNodes(snapshot, {
+    at: path,
+    match: (node) => isSpan({schema: snapshot.context.schema}, node),
+    reverse: true,
+  })) {
+    return entry as SpanEntry
+  }
+  return undefined
+}
+
+/**
+ * The path of the sibling-array level containing `path`'s last
+ * segment: strips the trailing keyed/numeric segment and the run of
+ * field-name segments before it (`[block, 'children', span]` →
+ * `[block]`).
+ */
+function nodeParentPath(path: Path): Path {
+  let end = path.length - 1
+  while (end > 0 && typeof path[end - 1] === 'string') {
+    end--
+  }
+  return path.slice(0, end)
+}
+
+/**
+ * The index of `childPath`'s node within `siblings`. Resolves keyed
+ * segments through `blockIndexMap` (O(1), verified against the sibling
+ * array) with a linear fallback for misses and paths the map can't key
+ * (numeric segments).
+ *
+ * Not built on `getSibling` (`traversal/get-sibling.ts`) deliberately:
+ * its `match` tests the sibling node itself, while this walk needs
+ * "is a span or contains one" and would still have to re-descend the
+ * matched sibling to extract the span entry.
+ */
+function childIndex(
+  snapshot: TraversalSnapshot,
+  siblings: Array<{node: {_key?: string}; path: Path}>,
+  childPath: Path,
+): number {
+  const lastSegment = childPath[childPath.length - 1]
+
+  if (typeof lastSegment === 'number') {
+    return lastSegment < siblings.length ? lastSegment : -1
+  }
+
+  if (!isKeyedSegment(lastSegment)) {
+    return -1
+  }
+
+  let fullyKeyed = true
+  for (
+    let segmentIndex = 0;
+    segmentIndex < childPath.length - 1;
+    segmentIndex++
+  ) {
+    const segment = childPath[segmentIndex]
+    if (typeof segment !== 'string' && !isKeyedSegment(segment)) {
+      fullyKeyed = false
+      break
+    }
+  }
+
+  if (fullyKeyed) {
+    const mapIndex = snapshot.blockIndexMap.get(serializePath(childPath))
+    if (
+      mapIndex !== undefined &&
+      siblings[mapIndex]?.node._key === lastSegment._key
+    ) {
+      return mapIndex
+    }
+  }
+
+  return siblings.findIndex((sibling) => sibling.node._key === lastSegment._key)
+}

--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -148,6 +148,72 @@ describe('Performance', () => {
 
       console.warn(`Removed 1000 blocks in ${duration.toFixed(2)}ms`)
     })
+
+    test('Backspacing through 20 empty blocks in a 1000-block document', async () => {
+      const {editor, locator} = await createTestEditor()
+
+      editor.send({
+        type: 'insert.blocks',
+        blocks: Array.from({length: 1000}, (_, i) => ({
+          _type: 'block',
+          _key: `b${i}`,
+          children: [{_type: 'span', _key: `s${i}`, text: `b${i}`, marks: []}],
+          markDefs: [],
+          style: 'normal',
+        })),
+        placement: 'auto',
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1000)
+
+        expect(locator.getByText('b999')).toBeInTheDocument()
+      })
+
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: 'b500'}, 'children', {_key: 's500'}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: 'b500'}, 'children', {_key: 's500'}],
+            offset: 0,
+          },
+        },
+      })
+
+      // Splitting a collapsed selection repeatedly leaves a run of
+      // empty blocks. Backspacing through them merges each one back,
+      // which discards the empty span the selection sits in and
+      // exercises the `unset` selection fallback on every merge.
+      for (let breakIndex = 0; breakIndex < 20; breakIndex++) {
+        editor.send({type: 'insert.break'})
+        await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+      }
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1020)
+      })
+
+      const start = performance.now()
+
+      for (let backspaceIndex = 0; backspaceIndex < 20; backspaceIndex++) {
+        editor.send({type: 'delete.backward', unit: 'character'})
+        await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+      }
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1000)
+      })
+
+      const duration = performance.now() - start
+
+      console.warn(
+        `Backspaced through 20 empty blocks in ${duration.toFixed(2)}ms`,
+      )
+    })
   })
 
   describe('Containers', () => {


### PR DESCRIPTION
Backspacing through empty lines in a large document was sluggish: at 8,000 blocks each backspace burned ~267ms of main thread, and the cost grew linearly with document size. This came out of the hot-path review as the single worst per-keystroke number in the editor (plain typing is ~14ms at the same scale).

The cost sits in `applyOperation`'s `unset` case. When an `unset` removes the node a selection point sits in, `transformPoint` returns `null` and the code falls back to relocating the point to the nearest span. That fallback iterated `getNodes(editor.snapshot)` from the document start with a `comparePaths` (which serializes paths for `blockIndexMap` lookups) per span: O(n) per selection point. A backspace that merges an empty block discards the empty span the selection sits in, so the everyday delete-empty-lines gesture triggered the fallback on every keystroke, twice (anchor + focus).

`findNearestSpans` (`internal-utils/find-nearest-spans.ts`) answers the same query anchored at the removed path instead: walk outward level by level, resolving siblings through `getChildren` and the position within them through `blockIndexMap` (verified, with a linear fallback for misses and numeric segments), descending only into sibling subtrees between the path and the answer. The removed node's own subtree is checked first for the next span, because descendants follow their ancestor in document order, which is exactly what the document scan yielded. Two invariants carry the design: the fallback runs before the node is removed (the existing transform-before-removal ordering), so the anchor always resolves; and spans are leaves, so the document-order-last span of a subtree is the first match of a reverse pre-order traversal. Typical cost is O(depth); it degenerates to a cheap hop across span-less siblings.

Equivalence with the old scan is pinned by an oracle test that sweeps every node path of the traversal testbed (containers, inline objects, span-less blocks, empty spans) against the scan kept as a reference implementation, plus explicit full-value cases for block-object removal, first-block removal (next span is the removed node's own descendant), and cross-container cell removal. The `preferNext` tie-break is untouched; its `pathEquals(next, path)` branch was dropped because it was provably dead in the old code too (the scan skipped `path` itself).

One semantic note worth flagging: for `unset` paths addressed numerically, the old scan degenerated, `comparePaths` cannot order a keyed path against a numeric segment, so every span compared as "after" and the selection jumped to the document's first span. The fallback now resolves the true document-order neighbors. The numeric-path test pins the new behavior with explicit expected values.

Everything else is unchanged: 835 unit and 1685 chromium tests pass. Backspacing through empty blocks (chromium, medians of 3): 1k blocks 11.8 to 2.6ms per backspace, 8k 267 to 19.5ms (13.7x). Non-empty merges at 8k: 55 to 36ms. The residual ~20ms at 8k is the per-block selector fan-out tracked separately (EDEX-1485). A second commit adds a backspace-through-empty-blocks baseline to the performance test file alongside the existing insert/remove baselines.
