### PR TITLE
fix: verify `getSibling`'s mapped index against the tree and fall back to a scan

### DIFF
--- a/.changeset/get-sibling-map-fallback.md
+++ b/.changeset/get-sibling-map-fallback.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve `getSibling` when `blockIndexMap` misses or disagrees with the tree
+
+`getSibling` previously returned `undefined` for siblings the tree
+plainly has when the anchor's path was absent from the block-index
+map, and could return the wrong sibling when the map was stale. It now
+verifies the mapped position against the tree and falls back to a
+linear scan, matching `getNode` and `getChildren`. Paths addressing
+the anchor by numeric index now resolve instead of returning
+`undefined`.

--- a/packages/editor/src/traversal/get-sibling.test.ts
+++ b/packages/editor/src/traversal/get-sibling.test.ts
@@ -292,4 +292,57 @@ describe(getSibling.name, () => {
     expect(entry?.node).toBe(testbed.codeLine1)
     expect(entry?.path).toEqual([{_key: 'k11'}, 'code', {_key: 'k8'}])
   })
+
+  test('numeric last segment resolves as a literal index', () => {
+    const entry = getSibling(testbed.snapshot, [1], {direction: 'next'})
+    expect(entry?.node).toBe(testbed.textBlock2)
+    expect(entry?.path).toEqual([{_key: testbed.textBlock2._key}])
+  })
+
+  test('out-of-range numeric last segment returns undefined', () => {
+    expect(
+      getSibling(testbed.snapshot, [99], {direction: 'next'}),
+    ).toBeUndefined()
+  })
+
+  test('resolves the anchor when `blockIndexMap` misses', () => {
+    // An unmaintained map (e.g. a bare engine) must not hide siblings
+    // the tree plainly has; mirrors the `getNode`/`getChildren`
+    // fallback.
+    const snapshot = {
+      context: testbed.snapshot.context,
+      blockIndexMap: new Map<string, number>(),
+    }
+
+    const entry = getSibling(snapshot, [{_key: 'k3'}], {direction: 'next'})
+    expect(entry?.node).toBe(testbed.image)
+    expect(entry?.path).toEqual([{_key: 'k4'}])
+  })
+
+  test('resolves the anchor when `blockIndexMap` disagrees with the tree', () => {
+    // A stale map (snapshots pairing a live map with a pre-apply
+    // value) previously returned the wrong sibling without
+    // verification.
+    const snapshot = {
+      context: testbed.snapshot.context,
+      blockIndexMap: new Map<string, number>([['[_key=="k3"]', 2]]),
+    }
+
+    const entry = getSibling(snapshot, [{_key: 'k3'}], {direction: 'next'})
+    expect(entry?.node).toBe(testbed.image)
+    expect(entry?.path).toEqual([{_key: 'k4'}])
+  })
+
+  test('`match` still applies under a map miss', () => {
+    const snapshot = {
+      context: testbed.snapshot.context,
+      blockIndexMap: new Map<string, number>(),
+    }
+
+    const entry = getSibling(snapshot, [{_key: 'k3'}], {
+      direction: 'next',
+      match: (node) => node._type === 'block',
+    })
+    expect(entry?.node).toBe(testbed.textBlock2)
+  })
 })

--- a/packages/editor/src/traversal/get-sibling.ts
+++ b/packages/editor/src/traversal/get-sibling.ts
@@ -52,17 +52,40 @@ export function getSibling(
 
   const lastSegment = path.at(-1)
 
-  if (!isKeyedSegment(lastSegment)) {
+  if (!isKeyedSegment(lastSegment) && typeof lastSegment !== 'number') {
     return undefined
   }
 
   const parent = parentPath(path)
   const children = getChildren(snapshot, parent)
 
-  const currentIndex = snapshot.blockIndexMap.get(serializePath(path))
+  let currentIndex: number
 
-  if (currentIndex === undefined) {
-    return undefined
+  if (typeof lastSegment === 'number') {
+    if (lastSegment < 0 || lastSegment >= children.length) {
+      return undefined
+    }
+    currentIndex = lastSegment
+  } else {
+    const mappedIndex = snapshot.blockIndexMap.get(serializePath(path))
+
+    if (
+      mappedIndex !== undefined &&
+      children[mappedIndex]?.node._key === lastSegment._key
+    ) {
+      currentIndex = mappedIndex
+    } else {
+      // The map can miss (unkeyed transient nodes, unmaintained maps) or
+      // disagree with the traversed value (snapshots that pair the live map
+      // with a pre-apply value). Fall back to a linear scan in both cases,
+      // mirroring `getNode` and `getChildren`.
+      currentIndex = children.findIndex(
+        (child) => child.node._key === lastSegment._key,
+      )
+      if (currentIndex === -1) {
+        return undefined
+      }
+    }
   }
 
   if (!match) {


### PR DESCRIPTION
`getSibling` resolves its anchor's position with a bare `blockIndexMap.get(serializePath(path))`, which leaves three holes: a map miss returns `undefined` even when the tree plainly has the sibling, a stale map silently returns the *wrong* sibling because the mapped index is never verified against the tree, and a numeric last segment always returns `undefined`. Its siblings `getNode` and `getChildren` already follow the house pattern (map lookup, verify against the tree, linear fallback) and document why maps legitimately miss (unkeyed transient nodes from remote patches) or disagree (snapshots pairing the live map with a pre-apply value); `getSibling` predates the pattern.

The fix mirrors that pattern exactly: the mapped index is accepted only when the child at that position carries the path's `_key`, otherwise the anchor is located with a linear `findIndex`; numeric last segments resolve as literal, bounds-checked indices. Four new tests pin the holes (map miss, map disagreement, `match` under a miss, numeric anchor) and were verified to fail on the previous implementation; a fifth pins the out-of-range numeric boundary.

Net behavior is unchanged whenever the map is current, which every editor-maintained snapshot guarantees; all 22 existing `getSibling` tests pass unmodified, and the full suite is green (834 unit, 1684 chromium). The deltas only surface for unmaintained or stale maps and numeric paths, where the old answers (`undefined`, or a mis-indexed sibling) were wrong.

Extracted from the EDEX-1484 discussion: `findNearestSpans` (#2893) hand-rolled its sibling walk partly because `getSibling` lacked this fallback. #2893 does not depend on this PR, but once both land, the hand-rolled walk's why-not comment can drop two of its three reasons.
