### PR TITLE
chore: make `reactCompilerOptions.sources` serializable for pkg-utils 10.8

### DIFF
--- a/packages/editor/package.config.ts
+++ b/packages/editor/package.config.ts
@@ -68,6 +68,42 @@ const UN_EXCLUDED_SLATE_PATHS = [
   ...TIER_3_PATHS,
 ]
 
+/**
+ * Everything under `src/` except `src/engine/` is compiled. Expressed as
+ * data, not a function: pkg-utils runs babel in a parallel worker pool
+ * (`@rollup/plugin-babel`'s `parallel: true`), which requires plugin
+ * options to be structured-cloneable, so `sources` must be an array of
+ * substrings (`filename.indexOf(entry) !== -1`), not a predicate.
+ *
+ * The trailing slash on directory entries keeps `/src/engine/` from
+ * matching `/src/engine-plugins/`. Keep in sync with the actual top-level
+ * directories of `src/`: a new directory must be added here or the
+ * compiler will silently skip it.
+ */
+const COMPILED_SOURCES = [
+  '/src/behaviors/',
+  '/src/converters/',
+  '/src/dom-traversal/',
+  '/src/editor/',
+  '/src/engine-plugins/',
+  '/src/internal-utils/',
+  '/src/operations/',
+  '/src/paths/',
+  '/src/plugins/',
+  '/src/priority/',
+  '/src/renderers/',
+  '/src/schema/',
+  '/src/selectors/',
+  '/src/test/',
+  '/src/traversal/',
+  '/src/types/',
+  '/src/utils/',
+  '/src/editor.ts',
+  '/src/index.ts',
+  '/src/type-utils.ts',
+  ...UN_EXCLUDED_SLATE_PATHS,
+]
+
 export default defineConfig({
   define: {
     __DEV__: false,
@@ -94,12 +130,7 @@ export default defineConfig({
   babel: {reactCompiler: true},
   reactCompilerOptions: {
     target: '19',
-    sources: (filename: string) => {
-      if (!filename.includes('/src/engine/')) {
-        return true
-      }
-      return UN_EXCLUDED_SLATE_PATHS.some((path) => filename.endsWith(path))
-    },
+    sources: COMPILED_SOURCES,
   },
   dts: 'rolldown',
 })


### PR DESCRIPTION
Prep for the `@sanity/pkg-utils` 10.8 bump (#2891), needed on `main` first because of how bundle-stats baselines work.

pkg-utils 10.8 runs babel through `@rollup/plugin-babel@7`'s parallel worker pool (`parallel: true`, unconditional, no config escape hatch), which requires plugin options to be structured-cloneable. The editor's `reactCompilerOptions.sources` was a predicate function (the tiered `src/engine/` un-exclusion filter), so `@portabletext/editor#build` fails under 10.8 with `Cannot use "parallel" mode because the "plugins" option is not serializable` (surfacing in CI as a downstream esbuild service crash). The other packages' configs are plain JSON and were unaffected.

`babel-plugin-react-compiler` accepts `sources` as an array of substrings (`isFilePartOfSources`: `filename.indexOf(entry) !== -1`), which is serializable. The predicate is re-expressed as data: every non-engine top-level `src/` directory (trailing slash keeps `/src/engine/` from matching `/src/engine-plugins/`), the root-level modules, plus the existing `UN_EXCLUDED_SLATE_PATHS` tier allowlist.

**Compilation coverage is unchanged and pinned by measurement**: 39 `react/compiler-runtime` memo-cache call sites per build, per-file identical, across all four combinations of {pkg-utils 10.2.1, 10.8.2} × {function, array}. The array form is version-agnostic (same `babel-plugin-react-compiler@1.0.0` does the matching), so this lands safely on main ahead of the bump.

The keep-in-sync cost is named in a comment: a new top-level `src/` directory must be added to `COMPILED_SOURCES` or the compiler silently skips it.

**Why main first**: `rexxars/bundle-stats` checks out and builds the PR's *base ref* for its size comparison, using the head's installed dependencies. On #2891 that means building main's function-config with 10.8 installed → the same serializability crash, unfixable from the PR itself. Once this merges, #2891 rebases clean (I'll drop the equivalent commit currently sitting on its branch).

Worth an upstream issue on `@sanity/pkg-utils` (hard-enabled `parallel: true` breaks any function-valued babel/react-compiler option, with no knob), your call whether to file it.
