### PR TITLE
refactor: remove dead branch in `blockOffsetToSpanSelectionPoint`

### DIFF
--- a/packages/editor/src/utils/util.block-offset.ts
+++ b/packages/editor/src/utils/util.block-offset.ts
@@ -57,12 +57,10 @@ export function blockOffsetToSpanSelectionPoint({
     }
 
     if (offsetLeft === 0 && selectionPoint && !skippedInlineObject) {
-      if (skippedInlineObject) {
-        selectionPoint = {
-          path: [...blockPath, 'children', {_key: child._key}],
-          offset: 0,
-        }
-      }
+      // A boundary offset stays at the end of the previous span unless an
+      // inline object was skipped, in which case falling through to the
+      // `offsetLeft <= child.text.length` branch lands the point at the
+      // start of this span instead.
       break
     }
 


### PR DESCRIPTION
The backward branch of `blockOffsetToSpanSelectionPoint` guards `if (offsetLeft === 0 && selectionPoint && !skippedInlineObject)` and immediately checks `if (skippedInlineObject)` inside it, which can never be true. The behavior the dead branch reached for already happens via fall-through: when an inline object was skipped, the `offsetLeft <= child.text.length` branch assigns the point to the start of the current span. The replacement comment records that fall-through so the next reader doesn't reconstruct it.

Net behavior unchanged: 13 block-offset unit tests, the input-rule suite (82) and the character-pair-decorator suite pass unmodified. Noticed while comparing the plugins' span-offset searches with `findNearestSpans` (#2893).