### PR TITLE
feat(editor): add `editor.dom.getPointAtCoordinates`

### DIFF
--- a/.changeset/editor-dom-point-at-coordinates.md
+++ b/.changeset/editor-dom-point-at-coordinates.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: add `editor.dom.getPointAtCoordinates`
+
+Pass viewport coordinates (for example a pointer event's `clientX`/`clientY`) and get back where a click at those coordinates would place the caret, as an editor selection point, or `null` when the coordinates don't hit the editor's content:
+
+```ts
+const point = editor.dom.getPointAtCoordinates({
+  x: event.clientX,
+  y: event.clientY,
+})
+// {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3}
+```
+
+It's the counterpart of `editor.dom.getSelectionRect`: that one turns a selection into pixels, this one turns pixels back into a point. Behavior guards and actions get it on their `dom` argument.

--- a/packages/editor/src/editor/editor-dom.ts
+++ b/packages/editor/src/editor/editor-dom.ts
@@ -5,10 +5,12 @@ import type {Path} from '../engine/interfaces/path'
 import {isAncestorPath} from '../engine/path/is-ancestor-path'
 import {rangeEdges} from '../engine/range/range-edges'
 import {resolveSelection} from '../internal-utils/apply-selection'
+import {getPointAtCoordinates} from '../internal-utils/point-at-coordinates'
 import {getSelectionEndBlock, getSelectionStartBlock} from '../selectors'
 import {getFragment} from '../selectors/selector.get-fragment'
 import {getNodes} from '../traversal/get-nodes'
 import type {PickFromUnion} from '../type-utils'
+import type {EditorSelectionPoint} from '../types/editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorSnapshot} from './editor-snapshot'
 
@@ -21,6 +23,17 @@ export type EditorDom = {
    * a caret rect.
    */
   getSelectionRect: (snapshot: EditorSnapshot) => DOMRect | null
+  /**
+   * Resolves viewport (client) coordinates to the editor point where a click
+   * at those coordinates would place the caret. The browser snaps to the
+   * nearest position within the element at the coordinates. Returns `null`
+   * when the coordinates don't resolve to a position inside the editor's
+   * content.
+   */
+  getPointAtCoordinates: (coordinates: {
+    x: number
+    y: number
+  }) => EditorSelectionPoint | null
   getStartBlockElement: (snapshot: EditorSnapshot) => Element | null
   getEndBlockElement: (snapshot: EditorSnapshot) => Element | null
   /**
@@ -49,6 +62,8 @@ export function createEditorDom(
     getChildNodes: (snapshot) => getChildNodes(editorEngine, snapshot),
     getEditorElement: () => getEditorElement(editorEngine),
     getSelectionRect: (snapshot) => getSelectionRect(editorEngine, snapshot),
+    getPointAtCoordinates: (coordinates) =>
+      getPointAtCoordinates(editorEngine, coordinates),
     getStartBlockElement: (snapshot) =>
       getStartBlockElement(editorEngine, snapshot),
     getEndBlockElement: (snapshot) =>

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -16,6 +16,7 @@ import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {isSelectionCollapsed} from '../utils/util.is-selection-collapsed'
+import {getPointAtCoordinates} from './point-at-coordinates'
 
 export type EventPosition = {
   block: 'start' | 'end'
@@ -303,48 +304,11 @@ function getSelectionFromEvent(
     return undefined
   }
 
-  const window = DOMEditor.getWindow(editor)
-
-  let domRange: Range | undefined
-
-  if (window.document.caretPositionFromPoint !== undefined) {
-    const position = window.document.caretPositionFromPoint(
-      event.clientX,
-      event.clientY,
-    )
-
-    if (position) {
-      try {
-        domRange = window.document.createRange()
-        domRange.setStart(position.offsetNode, position.offset)
-        domRange.setEnd(position.offsetNode, position.offset)
-      } catch {}
-    }
-  } else if (window.document.caretRangeFromPoint !== undefined) {
-    // Use WebKit-proprietary fallback method
-    domRange =
-      window.document.caretRangeFromPoint(event.clientX, event.clientY) ??
-      undefined
-  } else {
-    console.warn(
-      'Neither caretPositionFromPoint nor caretRangeFromPoint is supported',
-    )
-    return undefined
-  }
-
-  if (!domRange) {
-    return undefined
-  }
-
-  try {
-    return DOMEditor.toEditorSelection(editor, domRange, {
-      exactMatch: false,
-      // It can still throw even with this option set to true
-      suppressThrow: false,
-    })
-  } catch {
-    return undefined
-  }
+  const point = getPointAtCoordinates(editor, {
+    x: event.clientX,
+    y: event.clientY,
+  })
+  return point ? {anchor: point, focus: point} : undefined
 }
 
 function isEventContainer(

--- a/packages/editor/src/internal-utils/point-at-coordinates.ts
+++ b/packages/editor/src/internal-utils/point-at-coordinates.ts
@@ -1,0 +1,61 @@
+import {DOMEditor} from '../engine/dom/plugin/dom-editor'
+import type {EditorSelectionPoint} from '../types/editor'
+import type {PortableTextEditorEngine} from '../types/editor-engine'
+
+/**
+ * Resolves viewport (client) coordinates to the editor point where a click
+ * at those coordinates would place the caret. Returns `null` when the
+ * coordinates don't resolve to a position inside the editor's content.
+ */
+export function getPointAtCoordinates(
+  editorEngine: PortableTextEditorEngine,
+  coordinates: {x: number; y: number},
+): EditorSelectionPoint | null {
+  let domRange: Range | undefined
+
+  try {
+    const window = DOMEditor.getWindow(editorEngine)
+
+    if (window.document.caretPositionFromPoint !== undefined) {
+      const position = window.document.caretPositionFromPoint(
+        coordinates.x,
+        coordinates.y,
+      )
+
+      if (position) {
+        try {
+          domRange = window.document.createRange()
+          domRange.setStart(position.offsetNode, position.offset)
+          domRange.setEnd(position.offsetNode, position.offset)
+        } catch {
+          // The browser can report a position that `setStart`/`setEnd` reject.
+        }
+      }
+    } else if (window.document.caretRangeFromPoint !== undefined) {
+      // WebKit doesn't support `caretPositionFromPoint`.
+      domRange =
+        window.document.caretRangeFromPoint(coordinates.x, coordinates.y) ??
+        undefined
+    }
+  } catch {
+    // `getWindow` throws when the editor isn't mounted.
+    return null
+  }
+
+  if (!domRange) {
+    return null
+  }
+
+  try {
+    const selection = DOMEditor.toEditorSelection(editorEngine, domRange, {
+      exactMatch: false,
+      // It can still throw even with this option set to true
+      suppressThrow: false,
+    })
+    return selection?.focus ?? null
+  } catch {
+    // `toEditorSelection` throws when the DOM position doesn't map into the
+    // editor's content.
+    return null
+  }
+}

--- a/packages/editor/tests/editor-dom-point-at-coordinates.test.tsx
+++ b/packages/editor/tests/editor-dom-point-at-coordinates.test.tsx
@@ -1,0 +1,68 @@
+import {describe, expect, test} from 'vitest'
+import {defineSchema, type EditorSnapshot} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'b1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's1', text: 'line one', marks: []}],
+  },
+  {
+    _type: 'block',
+    _key: 'b2',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's2', text: 'line two', marks: []}],
+  },
+]
+
+function withCaret(
+  snapshot: EditorSnapshot,
+  blockKey: string,
+  spanKey: string,
+  offset: number,
+): EditorSnapshot {
+  const point = {
+    path: [{_key: blockKey}, 'children', {_key: spanKey}],
+    offset,
+  }
+  return {
+    ...snapshot,
+    context: {...snapshot.context, selection: {anchor: point, focus: point}},
+  }
+}
+
+describe('editor.dom.getPointAtCoordinates', () => {
+  test('round-trips with getSelectionRect (pixels back to the same point)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+    const snapshot = editor.getSnapshot()
+
+    const rect = editor.dom.getSelectionRect(withCaret(snapshot, 'b2', 's2', 3))
+    expect(rect).not.toBeNull()
+
+    const point = editor.dom.getPointAtCoordinates({
+      x: rect!.left,
+      y: rect!.top + rect!.height / 2,
+    })
+
+    expect(point).toEqual({
+      path: [{_key: 'b2'}, 'children', {_key: 's2'}],
+      offset: 3,
+    })
+  })
+
+  test('returns null for coordinates outside the editor', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    expect(editor.dom.getPointAtCoordinates({x: -1000, y: -1000})).toBeNull()
+  })
+})

--- a/packages/plugin-table/src/behaviors/nav.test.tsx
+++ b/packages/plugin-table/src/behaviors/nav.test.tsx
@@ -325,3 +325,38 @@ describe('table keyboard navigation across a wrapped cell', () => {
     })
   })
 })
+
+describe('table keyboard navigation preserves the caret column', () => {
+  // Identical text in the stacked cells, so the x of a given offset in one
+  // cell is exactly the x of the same offset in the other.
+  const columnValue = [
+    {
+      _type: 'table',
+      _key: 't0',
+      rows: [
+        {_type: 'row', _key: 'r0', cells: [cell('c00', 'abcdef')]},
+        {_type: 'row', _key: 'r1', cells: [cell('c10', 'abcdef')]},
+      ],
+    },
+  ]
+
+  test('ArrowDown lands at the same column in the cell below', async () => {
+    const editor = await navFrom('c00', 3, 'ArrowDown', columnValue)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: spanPath('c10'),
+        offset: 3,
+      })
+    })
+  })
+
+  test('ArrowUp lands at the same column in the cell above', async () => {
+    const editor = await navFrom('c10', 2, 'ArrowUp', columnValue)
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: spanPath('c00'),
+        offset: 2,
+      })
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/nav.test.tsx
+++ b/packages/plugin-table/src/behaviors/nav.test.tsx
@@ -2,7 +2,7 @@ import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {getEnclosingBlock} from '@portabletext/editor/traversal'
 import {createTestKeyGenerator} from '@portabletext/test'
-import {afterAll, beforeAll, describe, expect, test} from 'vitest'
+import {afterAll, beforeAll, describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {TablePlugin} from '../plugin.table'
 import {isCell} from './types'
@@ -122,6 +122,7 @@ function focusBlockKey(snapshot: EditorSnapshot): string | undefined {
   return getEnclosingBlock(snapshot, focus)?.node._key
 }
 
+/** Places the caret at `offset` in `cellKey`, presses `key`, returns the editor. */
 async function navFrom(
   cellKey: string,
   offset: number,
@@ -137,51 +138,82 @@ async function navFrom(
   await userEvent.click(locator)
   const point = {path: spanPath(cellKey), offset}
   editor.send({type: 'select', at: {anchor: point, focus: point}})
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+  })
   await userEvent.keyboard(`{${key}}`)
-  await new Promise((resolve) => setTimeout(resolve, 50))
-  return focusCellKey(editor.getSnapshot())
+  return editor
 }
 
 describe('table keyboard navigation', () => {
   test('Tab moves to the next cell in the row', async () => {
-    expect(await navFrom('c00', 1, 'Tab')).toEqual('c01')
+    const editor = await navFrom('c00', 1, 'Tab')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c01')
+    })
   })
 
   test('Tab wraps to the first cell of the next row', async () => {
-    expect(await navFrom('c01', 1, 'Tab')).toEqual('c10')
+    const editor = await navFrom('c01', 1, 'Tab')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c10')
+    })
   })
 
   test('Tab at the last cell does not move (passes through)', async () => {
-    expect(await navFrom('c11', 1, 'Tab')).toEqual('c11')
+    const editor = await navFrom('c11', 1, 'Tab')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c11')
+    })
   })
 
   test('Shift+Tab moves to the previous cell', async () => {
-    expect(await navFrom('c01', 1, 'Shift>}{Tab}{/Shift')).toEqual('c00')
+    const editor = await navFrom('c01', 1, 'Shift>}{Tab}{/Shift')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('Shift+Tab wraps to the last cell of the previous row', async () => {
-    expect(await navFrom('c10', 1, 'Shift>}{Tab}{/Shift')).toEqual('c01')
+    const editor = await navFrom('c10', 1, 'Shift>}{Tab}{/Shift')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c01')
+    })
   })
 
   test('Shift+Tab at the first cell does not move (passes through)', async () => {
-    expect(await navFrom('c00', 1, 'Shift>}{Tab}{/Shift')).toEqual('c00')
+    const editor = await navFrom('c00', 1, 'Shift>}{Tab}{/Shift')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('ArrowDown moves to the cell directly below (same column)', async () => {
-    expect(await navFrom('c01', 1, 'ArrowDown')).toEqual('c11')
+    const editor = await navFrom('c01', 1, 'ArrowDown')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c11')
+    })
   })
 
   test('ArrowDown in the bottom row does not move (passes through)', async () => {
-    expect(await navFrom('c10', 1, 'ArrowDown')).toEqual('c10')
+    const editor = await navFrom('c10', 1, 'ArrowDown')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c10')
+    })
   })
 
   test('ArrowUp moves to the cell directly above (same column)', async () => {
-    expect(await navFrom('c10', 0, 'ArrowUp')).toEqual('c00')
+    const editor = await navFrom('c10', 0, 'ArrowUp')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('ArrowUp in the top row does not move (passes through)', async () => {
-    expect(await navFrom('c00', 0, 'ArrowUp')).toEqual('c00')
+    const editor = await navFrom('c00', 0, 'ArrowUp')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('ArrowUp lands in the last block of the cell above', async () => {
@@ -234,19 +266,10 @@ describe('table keyboard navigation', () => {
         ],
       },
     ]
-    const {editor, locator} = await createTestEditor({
-      keyGenerator: createTestKeyGenerator(),
-      schemaDefinition,
-      initialValue: value,
-      children: <TablePlugin />,
+    const editor = await navFrom('c10', 0, 'ArrowUp', value)
+    await vi.waitFor(() => {
+      expect(focusBlockKey(editor.getSnapshot())).toEqual('c00-b1')
     })
-    await userEvent.click(locator)
-    const point = {path: spanPath('c10'), offset: 0}
-    editor.send({type: 'select', at: {anchor: point, focus: point}})
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    await userEvent.keyboard('{ArrowUp}')
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    expect(focusBlockKey(editor.getSnapshot())).toEqual('c00-b1')
   })
 })
 
@@ -265,22 +288,40 @@ describe('table keyboard navigation across a wrapped cell', () => {
   })
 
   test('ArrowDown from the last visual line crosses to the cell below', async () => {
-    expect(
-      await navFrom('c00', longText.length, 'ArrowDown', wrappedValue),
-    ).toEqual('c10')
+    const editor = await navFrom(
+      'c00',
+      longText.length,
+      'ArrowDown',
+      wrappedValue,
+    )
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c10')
+    })
   })
 
   test('ArrowDown from an earlier line stays in the cell (passes through)', async () => {
-    expect(await navFrom('c00', 0, 'ArrowDown', wrappedValue)).toEqual('c00')
+    const editor = await navFrom('c00', 0, 'ArrowDown', wrappedValue)
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('ArrowUp from the first visual line crosses to the cell above', async () => {
-    expect(await navFrom('c10', 0, 'ArrowUp', wrappedValue)).toEqual('c00')
+    const editor = await navFrom('c10', 0, 'ArrowUp', wrappedValue)
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+    })
   })
 
   test('ArrowUp from a later line stays in the cell (passes through)', async () => {
-    expect(
-      await navFrom('c10', longText.length, 'ArrowUp', wrappedValue),
-    ).toEqual('c10')
+    const editor = await navFrom(
+      'c10',
+      longText.length,
+      'ArrowUp',
+      wrappedValue,
+    )
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c10')
+    })
   })
 })

--- a/packages/plugin-table/src/behaviors/nav.ts
+++ b/packages/plugin-table/src/behaviors/nav.ts
@@ -1,4 +1,9 @@
-import type {EditorSelection, EditorSnapshot, Path} from '@portabletext/editor'
+import type {
+  EditorSelection,
+  EditorSelectionPoint,
+  EditorSnapshot,
+  Path,
+} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {isSelectionCollapsed} from '@portabletext/editor/selectors'
 import {
@@ -12,7 +17,13 @@ import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
 import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
 import {resolveCell} from '../resolve-cell'
 
-type Dom = {getSelectionRect: (snapshot: EditorSnapshot) => DOMRect | null}
+type Dom = {
+  getSelectionRect: (snapshot: EditorSnapshot) => DOMRect | null
+  getPointAtCoordinates: (coordinates: {
+    x: number
+    y: number
+  }) => EditorSelectionPoint | null
+}
 type Entry = {path: Path}
 
 const tab = createKeyboardShortcut({
@@ -106,7 +117,8 @@ export const navBehaviors = [
       const target =
         rowBelow &&
         sameColumnCell(snapshot, position.cell, position.row, rowBelow)
-      const at = target && cellStart(snapshot, target.path)
+      const at =
+        target && cellEntrySelection(snapshot, dom, target.path, 'first')
       return at ? {at} : false
     },
     actions: [(_, {at}) => [raise({type: 'select', at})]],
@@ -134,7 +146,8 @@ export const navBehaviors = [
       const target =
         rowAbove &&
         sameColumnCell(snapshot, position.cell, position.row, rowAbove)
-      const at = target && cellEnd(snapshot, target.path)
+      const at =
+        target && cellEntrySelection(snapshot, dom, target.path, 'last')
       return at ? {at} : false
     },
     actions: [(_, {at}) => [raise({type: 'select', at})]],
@@ -181,6 +194,44 @@ function cellEnd(
     return undefined
   }
   const point = getBlockEndPoint({context: snapshot.context, block: lastBlock})
+  return {anchor: point, focus: point}
+}
+
+/**
+ * A collapsed selection in the cell, at the caret's current x where possible:
+ * hit-tests the caret's x on the cell's first (or last) line and uses the
+ * resolved point when it lands inside the cell. Falls back to the start (or
+ * end) of the cell, e.g. when the cell is narrower than the caret's x.
+ */
+function cellEntrySelection(
+  snapshot: EditorSnapshot,
+  dom: Dom,
+  cellPath: Path,
+  edge: 'first' | 'last',
+): EditorSelection | undefined {
+  const fallback =
+    edge === 'first'
+      ? cellStart(snapshot, cellPath)
+      : cellEnd(snapshot, cellPath)
+  if (!fallback) {
+    return undefined
+  }
+  const caretRect = dom.getSelectionRect(snapshot)
+  const entryLineRect = dom.getSelectionRect({
+    ...snapshot,
+    context: {...snapshot.context, selection: fallback},
+  })
+  if (!caretRect || !entryLineRect) {
+    return fallback
+  }
+  const point = dom.getPointAtCoordinates({
+    x: caretRect.left,
+    y: entryLineRect.top + entryLineRect.height / 2,
+  })
+  const resolved = point && resolveCell(snapshot, point.path)
+  if (!resolved || getKey(resolved.cell.path) !== getKey(cellPath)) {
+    return fallback
+  }
   return {anchor: point, focus: point}
 }
 


### PR DESCRIPTION
Arrow-navigating between table cells drops the caret at the target cell's start (going down) or end (going up), regardless of where the caret was horizontally, so walking down a column of cells zig-zags instead of tracking the column, the way native vertical caret movement does within a block.

Fixing that needs the one question the model can't answer: "what editor point sits at these pixel coordinates?" The editor already answers it internally for drag-and-drop (`getSelectionFromEvent` in `event-position.ts`: `caretPositionFromPoint`, with the WebKit-proprietary `caretRangeFromPoint` fallback, mapped back through the engine), but nothing outside core can do that mapping. The first commit extracts it as `editor.dom.getPointAtCoordinates({x, y})` returning `EditorSelectionPoint | null`, and refactors the DnD path onto it, so core dogfoods the primitive from day one.

The method is the deliberate inverse of `editor.dom.getSelectionRect`: that one is model to pixels (a selection's client rect), this one is pixels to model, taking client coordinates so the pair composes directly. A test pins the round-trip, a caret's rect fed back in resolves to the exact same `{path, offset}`, across all three browsers (webkit exercises the fallback branch). Unlike the snapshot-based `dom` methods it takes no `snapshot`, deliberately: a hit-test interrogates live layout and cannot be parameterized by a snapshot. It returns `null` for unmappable coordinates, and since the browser snaps to the nearest position within the hit element, the semantics are "the point a click there would produce", not strict containment. Design decisions and the considered-and-rejected list are recorded on EDEX-1466.

The second commit is the consumer: the table plugin's ArrowDown/ArrowUp guards now hit-test the caret's x on the target cell's entry line (the first block's first line arriving from above, the last block's last line from below) and land there when the resolved point is inside the target cell, falling back to the previous cell-edge behavior when the hit-test misses (a narrower cell, a border hit, an unmeasurable rect). Tests use identical text in stacked cells so the assertion is exact: the landing offset must equal the departing offset. All 15 pre-existing nav tests pass unchanged, they assert landing cells, not offsets, and the fallback preserves the old landing for every case where the hit-test can't improve on it.

Tab/Shift+Tab deliberately keep landing at the cell start: tab-order semantics, not spatial movement.
