### PR TITLE
fix: only rewrite the DOM selection when it disagrees with the model

### DIFF
--- a/.changeset/selection-validation-equivalent-ranges.md
+++ b/.changeset/selection-validation-equivalent-ranges.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep equivalent DOM selections intact during selection validation
+
+Sweeping a text selection across table cells could log "DOM range out of sync, validating selection" and collapse the selection mid-drag. The validator now recognizes when the browser's selection is an equivalent representation of the editor's selection and leaves it alone instead of rewriting it.

--- a/packages/editor/src/editor/validate-selection-machine.ts
+++ b/packages/editor/src/editor/validate-selection-machine.ts
@@ -2,6 +2,7 @@ import {setup} from 'xstate'
 import {DOMEditor} from '../engine/dom/plugin/dom-editor'
 import {debug} from '../internal-utils/debug'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {isEqualSelections} from '../utils/util.is-equal-selections'
 
 const validateSelectionSetup = setup({
   types: {
@@ -117,22 +118,39 @@ function validateSelection(
   if (!domSelection || domSelection.rangeCount === 0) {
     return
   }
-  const existingDOMRange = domSelection.getRangeAt(0)
   try {
+    const domEditorSelection = DOMEditor.toEditorSelection(
+      editorEngine,
+      domSelection,
+      {
+        exactMatch: false,
+        suppressThrow: true,
+      },
+    )
+
+    if (
+      domEditorSelection &&
+      isEqualSelections(
+        domEditorSelection,
+        editorEngine.snapshot.context.selection,
+      )
+    ) {
+      // The DOM selection already means what the model selection says, even
+      // when the browser represents it differently (element-level endpoints
+      // during a sweep across table cells, for example). Rewriting it would
+      // reset an in-progress native drag.
+      return
+    }
+
     const newDOMRange = DOMEditor.toDOMRange(
       editorEngine,
       editorEngine.snapshot.context.selection,
     )
-    if (
-      newDOMRange.startOffset !== existingDOMRange.startOffset ||
-      newDOMRange.endOffset !== existingDOMRange.endOffset
-    ) {
-      debug.selection('DOM range out of sync, validating selection')
-      // Remove all ranges temporary
-      domSelection?.removeAllRanges()
-      // Set the correct range
-      domSelection.addRange(newDOMRange)
-    }
+    debug.selection('DOM range out of sync, validating selection')
+    // Remove all ranges temporary
+    domSelection.removeAllRanges()
+    // Set the correct range
+    domSelection.addRange(newDOMRange)
   } catch {
     // `toDOMRange` raced ahead of React's commit. The MutationObserver
     // driving this machine will fire again once the DOM catches up, and

--- a/packages/editor/tests/selection-validation.test.tsx
+++ b/packages/editor/tests/selection-validation.test.tsx
@@ -1,0 +1,98 @@
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'b1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+  },
+]
+
+const anchor = {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0}
+const focus = {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3}
+
+function findTextNode(root: Node, text: string): Node | null {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  while (walker.nextNode()) {
+    if (walker.currentNode.textContent === text) {
+      return walker.currentNode
+    }
+  }
+  return null
+}
+
+/**
+ * The MutationObserver driving selection validation fires on childList
+ * mutations. Its callback is queued as a microtask before this function's
+ * continuation, so awaiting once lets the validation pass run first.
+ */
+async function triggerSelectionValidation(editorElement: Element) {
+  editorElement.appendChild(document.createComment('mutation'))
+  await Promise.resolve()
+}
+
+describe('selection validation', () => {
+  test('leaves an equivalent DOM selection representation alone', async () => {
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: {anchor, focus}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(focus)
+    })
+
+    const editorElement = locator.element()
+    const textNode = findTextNode(editorElement, 'foo')
+    const parent = textNode?.parentNode
+    expect(parent).not.toBeNull()
+    const index = Array.prototype.indexOf.call(parent!.childNodes, textNode)
+
+    // The same selection ("foo", offsets 0..3) expressed with element-level
+    // endpoints, the way browsers represent a selection swept across table
+    // cells.
+    window.getSelection()?.setBaseAndExtent(parent!, index, parent!, index + 1)
+
+    await triggerSelectionValidation(editorElement)
+
+    const domSelection = window.getSelection()
+    expect(domSelection?.anchorNode).toBe(parent)
+    expect(domSelection?.anchorOffset).toBe(index)
+    expect(domSelection?.focusNode).toBe(parent)
+    expect(domSelection?.focusOffset).toBe(index + 1)
+    expect(editor.getSnapshot().context.selection?.focus).toEqual(focus)
+  })
+
+  test('rewrites a DOM selection that means something else', async () => {
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: {anchor, focus}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(focus)
+    })
+
+    const editorElement = locator.element()
+    const textNode = findTextNode(editorElement, 'foo')
+    const parent = textNode?.parentNode
+    expect(parent).not.toBeNull()
+
+    // A collapsed selection at the block start disagrees with the model's
+    // 0..3 range.
+    window.getSelection()?.setBaseAndExtent(parent!, 0, parent!, 0)
+
+    await triggerSelectionValidation(editorElement)
+
+    const domSelection = window.getSelection()
+    expect(domSelection?.focusNode).toBe(textNode)
+    expect(domSelection?.focusOffset).toBe(3)
+  })
+})


### PR DESCRIPTION
Sweeping a text selection across table cells easily logs `pte:selection DOM range out of sync, validating selection` and then collapses the selection back to the anchor mid-drag, so a cell-range selection in a table breaks under the user's cursor. The event log shows the drag producing a stream of correct cross-cell `select` events, then the warning twice, then a collapsed selection at the anchor.

The diagnosis is in `validateSelection` (`validate-selection-machine.ts`), which runs on every DOM mutation. It compared the model's canonical DOM range against the live DOM range by `startOffset`/`endOffset` alone, ignoring the containers. During a sweep across table cells the browser legitimately represents the selection with element-level endpoints (`<tr>`/`<td>` with child indexes, the same representation the engine's own Firefox table compat exists for), while `toDOMRange(model)` produces text-node endpoints with character offsets. Same logical selection, numerically different offsets, so validation misfired on essentially every table sweep. The "fix" it then applied, `removeAllRanges()` + `addRange()`, resets the browser's drag base mid-drag (collapsing the sweep) and destroys backwardness, since a `Range` carries no direction.

The validator now asks the only question that matters: does the live DOM selection mean what the model says? It maps the DOM selection back through `toEditorSelection` and compares editor selections with `isEqualSelections`. Equivalent representations are left alone; the DOM is rewritten only on genuine disagreement. Passing the `DOMSelection` itself rather than `getRangeAt(0)` also routes Firefox's multi-range table selections through the engine's existing compat, and preserves direction on the comparison path.

Two tests pin the contract in `selection-validation.test.tsx`, both driven through the real MutationObserver rather than internals: one expresses the same selection with element-level endpoints and asserts it survives validation untouched (red on the old comparison, verified), one asserts a DOM selection that genuinely disagrees with the model is still rewritten to the canonical range. Green on chromium, firefox, and webkit.

Net behavior only changes in the narrow case where the DOM selection and the model selection are equivalent but differently represented: previously the DOM selection was rewritten (breaking active drags), now it is left alone. Genuine desyncs are rewritten exactly as before. The full chromium editor browser suite passes (1687/1689, the one failure is `undo-redo-collaboration.test.tsx`, which passes isolated both with and without this change, a pre-existing full-suite flake).
