### PR TITLE
fix: skip leafless subtrees when normalizing DOM points

### DIFF
--- a/.changeset/normalize-dom-point-leafless-subtrees.md
+++ b/.changeset/normalize-dom-point-leafless-subtrees.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: selection mapping no longer dead-ends in leafless subtrees
+
+Selecting across a table rendered with a `<colgroup>` (for example via triple-click, or clicking near the table's edges) could silently fail to update the editor's selection, leaving it stale or collapsed while the screen showed a larger selection. DOM positions that normalize into an element holding no editable content now skip to the nearest sibling with content instead, so element-level selections map to what they visually cover.

--- a/packages/editor/src/engine/dom/utils/dom.ts
+++ b/packages/editor/src/engine/dom/utils/dom.ts
@@ -160,12 +160,16 @@ const getEditableChildAndIndex = (
   let triedForward = false
   let triedBackward = false
 
-  // While the child is a comment node, or an element node with no children,
-  // keep iterating to find a sibling non-void, non-comment node.
+  // While the child is a comment node, an element node with no children, or
+  // an element whose subtree holds no editable content (a leafless subtree
+  // like a table's <colgroup> would otherwise dead-end the descent), keep
+  // iterating to find a sibling with editable content.
   while (
     isDOMComment(child) ||
     (isDOMElement(child) && child.childNodes.length === 0) ||
-    (isDOMElement(child) && child.getAttribute('contenteditable') === 'false')
+    (isDOMElement(child) &&
+      child.getAttribute('contenteditable') === 'false') ||
+    (isDOMElement(child) && !hasEditableContent(child))
   ) {
     if (triedForward && triedBackward) {
       break
@@ -205,6 +209,21 @@ const getEditableChild = (
 ): DOMNode => {
   const [child] = getEditableChildAndIndex(parent, index, direction)
   return child
+}
+
+/**
+ * Whether an element's subtree holds anything a DOM point can resolve to:
+ * text, or a rendered block/inline object.
+ */
+const hasEditableContent = (element: DOMElement): boolean => {
+  if (element.textContent !== '') {
+    return true
+  }
+  return (
+    element.querySelector(
+      '[data-pt-block="object"], [data-pt-inline="object"]',
+    ) !== null
+  )
 }
 
 /**

--- a/packages/editor/tests/selection-sync-leafless-subtree.test.tsx
+++ b/packages/editor/tests/selection-sync-leafless-subtree.test.tsx
@@ -1,0 +1,179 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+// The <colgroup> renders no text and no leaves: a DOM point normalized into
+// it can resolve to nothing.
+const tableContainer = defineContainer({
+  type: 'table',
+  arrayField: 'rows',
+  render: ({attributes, children}) => (
+    <table data-testid="table" {...attributes}>
+      <colgroup>
+        <col />
+        <col />
+      </colgroup>
+      <tbody>{children}</tbody>
+    </table>
+  ),
+  of: [
+    defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
+      of: [
+        defineContainer({
+          type: 'cell',
+          arrayField: 'value',
+          render: ({attributes, children}) => (
+            <td {...attributes}>{children}</td>
+          ),
+        }),
+      ],
+    }),
+  ],
+})
+
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {
+        _type: 'row',
+        _key: 'r0',
+        cells: [
+          {
+            _type: 'cell',
+            _key: 'c0',
+            value: [
+              {
+                _type: 'block',
+                _key: 'b0',
+                style: 'normal',
+                markDefs: [],
+                children: [{_type: 'span', _key: 's0', text: 'A', marks: []}],
+              },
+            ],
+          },
+          {
+            _type: 'cell',
+            _key: 'c1',
+            value: [
+              {
+                _type: 'block',
+                _key: 'b1',
+                style: 'normal',
+                markDefs: [],
+                children: [{_type: 'span', _key: 's1', text: 'B', marks: []}],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+function cellSpanPath(cellKey: string, blockKey: string, spanKey: string) {
+  return [
+    {_key: 't0'},
+    'rows',
+    {_key: 'r0'},
+    'cells',
+    {_key: cellKey},
+    'value',
+    {_key: blockKey},
+    'children',
+    {_key: spanKey},
+  ]
+}
+
+describe('selection sync across leafless subtrees', () => {
+  test('an element-level range over the table maps to a full-table selection', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+    await userEvent.click(locator)
+
+    // The range a triple-click produces: element-level endpoints spanning the
+    // whole <table>, offset 0 sits before the <colgroup>.
+    const table = locator.element().querySelector('[data-testid="table"]')
+    expect(table).not.toBeNull()
+    window
+      .getSelection()
+      ?.setBaseAndExtent(table!, 0, table!, table!.childNodes.length)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: cellSpanPath('c0', 'b0', 's0'), offset: 0},
+        focus: {path: cellSpanPath('c1', 'b1', 's1'), offset: 1},
+        backward: false,
+      })
+    })
+  })
+
+  test('a collapsed element-level point before the colgroup maps to the first cell', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+    await userEvent.click(locator)
+
+    const table = locator.element().querySelector('[data-testid="table"]')
+    expect(table).not.toBeNull()
+    window.getSelection()?.setBaseAndExtent(table!, 0, table!, 0)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: cellSpanPath('c0', 'b0', 's0'), offset: 0},
+        focus: {path: cellSpanPath('c0', 'b0', 's0'), offset: 0},
+        backward: false,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Triple-clicking a table in the playground shows a whole-table selection on screen while the editor's model keeps a stale collapsed caret, so Delete and typing act on something other than what's visibly selected. Clicking near the table's edges similarly parks carets that never map into the model (EDEX-1118 reported the same family from the deployed playground in June: typing after such a click injects content into the last cell, then below the table).

The diagnosis: `getEditableChildAndIndex` treats any element with children as content. A table's `<colgroup>` has children (the `<col>`s) but no editable content, so `normalizeDOMPoint`'s descent walks into it and dead-ends: the resulting point on a `<col>` resolves to nothing in `toSelectionPoint`, `suppressThrow: true` swallows the failure, and the whole `selectionchange` sync silently skips, leaving the model stale. Any leafless subtree inside a container render triggers it; `<colgroup>` is just the canonical case every table renders.

The fix extends the child-seeking skip condition: elements whose subtree holds no editable content (no text, no rendered block/inline object) are skipped with backtracking, exactly as `contenteditable="false"` elements already are. The predicate is deliberately conservative: zero-width leaves keep matching through their text content and void objects through their rendered attributes, so void-adjacent positions behave exactly as before.

Two tests pin it on a container table rendered with a plain `<colgroup>` (no attribute tricks), both driven through the real `selectionchange` sync: an element-level range spanning the table must map to first-cell start to last-cell end, and a collapsed element-level point before the colgroup must map into the first cell. Both fail without the fix (one maps wrong, one maps to `null`), verified red. Green on chromium, firefox, and webkit; the full chromium editor browser suite passes 1690/1690.

Follows #2898 in the same subsystem: that one stopped the validator from destroying equivalent DOM selections, this one makes the mapping produce the right answer in the first place. The remaining piece of the cluster is EDEX-1512 (canonicalizing collapsed carets parked on structural elements).
