### PR TITLE
fix(perf): notify render selectors only when their inputs can have changed

### DIFF
--- a/.changeset/segment-selector-channels.md
+++ b/.changeset/segment-selector-channels.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): notify render selectors only when their inputs can have changed
+
+Typing and moving the caret in large documents no longer pay a cost
+proportional to the block count. Previously every editor change
+re-ran an internal selector for every rendered block and span; in a
+document with thousands of blocks this made each keystroke and caret
+move noticeably sluggish. Rendered output is unchanged.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -70,6 +70,7 @@ export function createEditorEngine(
 
   editor.listIndexMap = new Map<string, number>()
   editor.listIndexMapDirty = false
+  editor.selectorChannelsPending = {registrations: false, listIndex: false}
   editor.verifiedUniqueChildGroups = new Set<string>()
   editor.remotePatches = []
   editor.undoStepId = undefined

--- a/packages/editor/src/editor/register-node-on-engine.ts
+++ b/packages/editor/src/editor/register-node-on-engine.ts
@@ -39,7 +39,7 @@ export function registerNodeOnEngine(
     engine.containers = containers
     engine.snapshot.context.containers = buildPublicContainers(containers)
     normalize(engine, {force: true})
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'textBlock') {
@@ -49,7 +49,7 @@ export function registerNodeOnEngine(
     const textBlocks = new Map(engine.textBlocks)
     textBlocks.set(node.type, resolveTextBlockConfig(node))
     engine.textBlocks = textBlocks
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'span') {
@@ -59,7 +59,7 @@ export function registerNodeOnEngine(
     const spans = new Map(engine.spans)
     spans.set(node.type, {span: node})
     engine.spans = spans
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'blockObject') {
@@ -69,7 +69,7 @@ export function registerNodeOnEngine(
     const blockObjects = new Map(engine.blockObjects)
     blockObjects.set(node.type, {blockObject: node})
     engine.blockObjects = blockObjects
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   // inlineObject
@@ -79,7 +79,7 @@ export function registerNodeOnEngine(
   const inlineObjects = new Map(engine.inlineObjects)
   inlineObjects.set(node.type, {inlineObject: node})
   engine.inlineObjects = inlineObjects
-  engine.onChange()
+  notifyRegistrationsChanged(engine)
 }
 
 /**
@@ -97,33 +97,44 @@ export function unregisterNodeOnEngine(
     engine.containers = containers
     engine.snapshot.context.containers = buildPublicContainers(containers)
     normalize(engine, {force: true})
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'textBlock') {
     const textBlocks = new Map(engine.textBlocks)
     textBlocks.delete(node.type)
     engine.textBlocks = textBlocks
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'span') {
     const spans = new Map(engine.spans)
     spans.delete(node.type)
     engine.spans = spans
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   if (node.kind === 'blockObject') {
     const blockObjects = new Map(engine.blockObjects)
     blockObjects.delete(node.type)
     engine.blockObjects = blockObjects
-    engine.onChange()
+    notifyRegistrationsChanged(engine)
     return
   }
   // inlineObject
   const inlineObjects = new Map(engine.inlineObjects)
   inlineObjects.delete(node.type)
   engine.inlineObjects = inlineObjects
+  notifyRegistrationsChanged(engine)
+}
+
+/**
+ * The registration maps are mutated only in this module, so the React
+ * layer's 'registrations' selector channel is armed here alone. The
+ * pending flag is consumed by the `onContextChange` dispatch, so it
+ * survives notifications that fire before the React layer is wired.
+ */
+function notifyRegistrationsChanged(engine: PortableTextEditorEngine): void {
+  engine.selectorChannelsPending.registrations = true
   engine.onChange()
 }

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -6,7 +6,7 @@ import {isTextBlock} from '@portabletext/schema'
 import {useCallback, useContext, useMemo, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
-import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
+import {useRegistrationsSelector} from '../engine/react/hooks/use-engine-selector'
 import {useEngineStatic} from '../engine/react/hooks/use-engine-static'
 import {serializePath} from '../paths/serialize-path'
 import type {
@@ -78,7 +78,7 @@ export function RenderElement(props: {
     globalInlineObjectCatchAll,
     textBlockConfig,
     textBlockCatchAll,
-  ] = useEngineSelector(
+  ] = useRegistrationsSelector(
     useCallback(
       (engine) =>
         [

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@portabletext/schema'
 import {useCallback, useContext} from 'react'
 import type {Path} from '../engine/interfaces/path'
-import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
+import {useRegistrationsSelector} from '../engine/react/hooks/use-engine-selector'
 import type {SpanConfig} from '../renderers/renderer.types'
 import {findInlinePositionalOverride} from './find-positional-override'
 import {ParentTextBlockContext} from './parent-text-block-context'
@@ -28,7 +28,7 @@ export function useSpanConfig(
 ): SpanConfig | undefined {
   const parentTextBlock = useContext(ParentTextBlockContext)
   const positional = findInlinePositionalOverride(parentTextBlock, node._type)
-  const [globalSpan, globalSpanCatchAll] = useEngineSelector(
+  const [globalSpan, globalSpanCatchAll] = useRegistrationsSelector(
     useCallback(
       (engine) =>
         [engine.spans.get(node._type), engine.spans.get('*')] as const,

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -5,7 +5,7 @@ import type {
 import {useRef, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
-import {useEngineSelector} from '../engine/react/hooks/use-engine-selector'
+import {useListIndexSelector} from '../engine/react/hooks/use-engine-selector'
 import {getListIndexMap} from '../internal-utils/build-index-maps'
 import {serializePath} from '../paths/serialize-path'
 import type {
@@ -45,7 +45,7 @@ export function RenderTextBlock(props: {
   const selected = useIsSelectedContainer(serializedPath)
   const focused = useIsFocusedContainer(serializedPath)
   const dropPosition = useElementDropPosition(props.path)
-  const listIndex = useEngineSelector((editor) =>
+  const listIndex = useListIndexSelector((editor) =>
     getListIndexMap(editor).get(serializedPath),
   )
   const subSchema = useBlockSubSchema(props.path)

--- a/packages/editor/src/editor/subscriber.update-value.ts
+++ b/packages/editor/src/editor/subscriber.update-value.ts
@@ -220,6 +220,7 @@ export function subscribeUpdateValue(
     // than reason about which paths matter. The map is rebuilt lazily the
     // next time the renderer reads it.
     editor.listIndexMapDirty = true
+    editor.selectorChannelsPending.listIndex = true
 
     invalidateVerifiedGroups(editor.verifiedUniqueChildGroups, operation)
   })

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -73,7 +73,6 @@ import {useAndroidInputManager} from '../hooks/android-input-manager/use-android
 import useChildren from '../hooks/use-children'
 import {DecorateContext, useDecorateContext} from '../hooks/use-decorations'
 import {useEngine} from '../hooks/use-engine'
-import {useFlushDeferredSelectorsOnRender} from '../hooks/use-engine-selector'
 import {useIsomorphicLayoutEffect} from '../hooks/use-isomorphic-layout-effect'
 import {ReadOnlyContext} from '../hooks/use-read-only'
 import {useTrackUserInput} from '../hooks/use-track-user-input'
@@ -1026,8 +1025,6 @@ export const Editable = forwardRef(
 
     const decorations = decorate([editor as any, []])
     const decorateContext = useDecorateContext(decorate)
-
-    useFlushDeferredSelectorsOnRender()
 
     return (
       <ReadOnlyContext.Provider value={readOnly}>

--- a/packages/editor/src/engine/react/components/engine.tsx
+++ b/packages/editor/src/engine/react/components/engine.tsx
@@ -18,7 +18,15 @@ export const Engine = (props: {editor: Editor; children: React.ReactNode}) => {
   const {selectorContext, onChange: handleSelectorChange} = useSelectorContext()
 
   const onContextChange = useCallback(() => {
-    handleSelectorChange()
+    // Consume the channel flags armed where the corresponding state
+    // mutated, so channel-scoped selectors only run when their inputs
+    // could have changed.
+    const pending = editor.selectorChannelsPending
+    const registrations = pending.registrations
+    const listIndex = pending.listIndex
+    pending.registrations = false
+    pending.listIndex = false
+    handleSelectorChange({registrations, listIndex})
   }, [editor, handleSelectorChange])
 
   useEffect(() => {

--- a/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
+++ b/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
@@ -7,35 +7,65 @@ import {useIsomorphicLayoutEffect} from './use-isomorphic-layout-effect'
 type Callback = () => void
 
 /**
+ * Which editor state a selector depends on, so the notify dispatch can
+ * skip listeners whose inputs cannot have changed. 'registrations'
+ * fires only when a renderer registration map is swapped
+ * (`register-node-on-engine.ts`, the sole mutation site); 'listIndex'
+ * fires only when a flush contained a structural operation (the same
+ * signal that invalidates `listIndexMap`). Omitted means every editor
+ * change, the previous behavior for all listeners.
+ */
+type EngineSelectorChannel = 'registrations' | 'listIndex'
+
+/**
  * A React context for sharing the editor selector context in a way to control
  * re-renders.
  */
 
 export const EngineSelectorContext = createContext<{
-  addEventListener: (callback: Callback) => () => void
+  addEventListener: (
+    callback: Callback,
+    channel?: EngineSelectorChannel,
+  ) => () => void
   flushDeferred: () => void
 }>({} as any)
 
 const refEquality = (a: any, b: any) => a === b
 
 /**
- * Use redux style selectors to prevent re-rendering on every keystroke.
- *
- * Bear in mind re-rendering can only prevented if the returned value is a value
- * type or for reference types (e.g. objects and arrays) add a custom equality
- * function.
- *
- * If `selector` is memoized using `useCallback`, then it will only be called
- * when it or the editor state changes. Otherwise, `selector` will be called
- * every time the component renders.
- *
- * @example
- * const isSelectionActive = useEngineSelector(editor => Boolean(editor.snapshot.context.selection))
+ * `useEngineSelector` scoped to the 'registrations' channel: the
+ * selector re-runs on its component's renders and when a renderer
+ * registration map is swapped, not on document or selection changes.
+ * Only for selectors that read the registration maps
+ * (`engine.containers/spans/textBlocks/blockObjects/inlineObjects`)
+ * exclusively; those maps are mutated only in
+ * `register-node-on-engine.ts`, which arms this channel.
  */
-
-export function useEngineSelector<T>(
+export function useRegistrationsSelector<T>(
   selector: (editor: Editor) => T,
   equalityFn: (a: T | null, b: T) => boolean = refEquality,
+): T {
+  return useChannelSelector(selector, equalityFn, 'registrations')
+}
+
+/**
+ * `useEngineSelector` scoped to the 'listIndex' channel: the selector
+ * re-runs on its component's renders and when a flush contained a
+ * structural operation (the same signal that invalidates
+ * `listIndexMap`), not on text or selection changes. Only for
+ * selectors that read `getListIndexMap`.
+ */
+export function useListIndexSelector<T>(
+  selector: (editor: Editor) => T,
+  equalityFn: (a: T | null, b: T) => boolean = refEquality,
+): T {
+  return useChannelSelector(selector, equalityFn, 'listIndex')
+}
+
+function useChannelSelector<T>(
+  selector: (editor: Editor) => T,
+  equalityFn: (a: T | null, b: T) => boolean,
+  channel: EngineSelectorChannel,
 ): T {
   const context = useContext(EngineSelectorContext)
   if (!context) {
@@ -56,26 +86,46 @@ export function useEngineSelector<T>(
   )
 
   useIsomorphicLayoutEffect(() => {
-    const unsubscribe = addEventListener(update)
+    const unsubscribe = addEventListener(update, channel)
     update()
     return unsubscribe
-  }, [addEventListener, update])
+  }, [addEventListener, update, channel])
 
   return selectedState
 }
 
 /**
- * Create selector context with editor updating on every editor change
+ * Create selector context with editor updating on every editor change.
+ *
+ * Listeners live in per-channel sets so a change only reaches the
+ * selectors whose inputs it can affect: with thousands of blocks each
+ * holding channel-scoped subscriptions, notifying all of them on every
+ * keystroke and selection move dominated per-event cost.
  */
 export function useSelectorContext() {
   const eventListeners = useRef(new Set<Callback>())
+  const registrationListeners = useRef(new Set<Callback>())
+  const listIndexListeners = useRef(new Set<Callback>())
   const deferredEventListeners = useRef(new Set<Callback>())
 
-  const onChange = useCallback(() => {
-    eventListeners.current.forEach((listener) => {
-      listener()
-    })
-  }, [])
+  const onChange = useCallback(
+    (changed: {registrations: boolean; listIndex: boolean}) => {
+      eventListeners.current.forEach((listener) => {
+        listener()
+      })
+      if (changed.registrations) {
+        registrationListeners.current.forEach((listener) => {
+          listener()
+        })
+      }
+      if (changed.listIndex) {
+        listIndexListeners.current.forEach((listener) => {
+          listener()
+        })
+      }
+    },
+    [],
+  )
 
   const flushDeferred = useCallback(() => {
     deferredEventListeners.current.forEach((listener) => {
@@ -84,13 +134,22 @@ export function useSelectorContext() {
     deferredEventListeners.current.clear()
   }, [])
 
-  const addEventListener = useCallback((callbackProp: Callback) => {
-    eventListeners.current.add(callbackProp)
+  const addEventListener = useCallback(
+    (callbackProp: Callback, channel?: EngineSelectorChannel) => {
+      const listeners =
+        channel === 'registrations'
+          ? registrationListeners.current
+          : channel === 'listIndex'
+            ? listIndexListeners.current
+            : eventListeners.current
+      listeners.add(callbackProp)
 
-    return () => {
-      eventListeners.current.delete(callbackProp)
-    }
-  }, [])
+      return () => {
+        listeners.delete(callbackProp)
+      }
+    },
+    [],
+  )
 
   const selectorContext = useMemo(
     () => ({

--- a/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
+++ b/packages/editor/src/engine/react/hooks/use-engine-selector.tsx
@@ -27,7 +27,6 @@ export const EngineSelectorContext = createContext<{
     callback: Callback,
     channel?: EngineSelectorChannel,
   ) => () => void
-  flushDeferred: () => void
 }>({} as any)
 
 const refEquality = (a: any, b: any) => a === b
@@ -106,7 +105,6 @@ export function useSelectorContext() {
   const eventListeners = useRef(new Set<Callback>())
   const registrationListeners = useRef(new Set<Callback>())
   const listIndexListeners = useRef(new Set<Callback>())
-  const deferredEventListeners = useRef(new Set<Callback>())
 
   const onChange = useCallback(
     (changed: {registrations: boolean; listIndex: boolean}) => {
@@ -126,13 +124,6 @@ export function useSelectorContext() {
     },
     [],
   )
-
-  const flushDeferred = useCallback(() => {
-    deferredEventListeners.current.forEach((listener) => {
-      listener()
-    })
-    deferredEventListeners.current.clear()
-  }, [])
 
   const addEventListener = useCallback(
     (callbackProp: Callback, channel?: EngineSelectorChannel) => {
@@ -154,15 +145,9 @@ export function useSelectorContext() {
   const selectorContext = useMemo(
     () => ({
       addEventListener,
-      flushDeferred,
     }),
-    [addEventListener, flushDeferred],
+    [addEventListener],
   )
 
   return {selectorContext, onChange}
-}
-
-export function useFlushDeferredSelectorsOnRender() {
-  const {flushDeferred} = useContext(EngineSelectorContext)
-  useIsomorphicLayoutEffect(flushDeferred)
 }

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -53,6 +53,16 @@ export interface PortableTextEditorEngine extends DOMEditor {
    */
   listIndexMapDirty: boolean
   /**
+   * Per-notify pending flags for the segmented selector channels
+   * (`EngineSelectorChannel`). Set where the corresponding state mutates
+   * (registration map swaps in `register-node-on-engine.ts`, list-index
+   * invalidation in the update-value subscriber) and consumed by the
+   * React layer's `onContextChange` dispatch. Separate from
+   * `listIndexMapDirty`, which any read clears via `getListIndexMap`;
+   * these are cleared only when the notification is delivered.
+   */
+  selectorChannelsPending: {registrations: boolean; listIndex: boolean}
+  /**
    * Serialized paths of sibling groups (a node's keyed child array, or the
    * root value array as `''`) whose children have been verified to carry no
    * duplicate `_key`s. Per-node duplicate-key normalization skips groups

--- a/packages/editor/tests/engine-selector-channels.test.tsx
+++ b/packages/editor/tests/engine-selector-channels.test.tsx
@@ -1,0 +1,120 @@
+import {useContext, useEffect, useMemo, useState} from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {defineBlockObject} from '../src'
+import type {Editor} from '../src/engine/interfaces/editor'
+import {
+  EngineSelectorContext,
+  useListIndexSelector,
+  useRegistrationsSelector,
+} from '../src/engine/react/hooks/use-engine-selector'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {createTestEditor} from '../src/test/vitest'
+
+const selectorRuns = {default: 0, registrations: 0, listIndex: 0}
+
+// Module-level selectors have stable identities, so they only run on
+// mount and when their channel is notified, never on unrelated renders.
+function registrationsSelector(_engine: Editor) {
+  selectorRuns.registrations++
+  return null
+}
+
+function listIndexSelector(_engine: Editor) {
+  selectorRuns.listIndex++
+  return null
+}
+
+let mountLateNodePlugin: (() => void) | undefined
+
+function ChannelProbe() {
+  // The every-change set has no selector hook anymore (`useEngine` is
+  // its only production subscriber), so the probe subscribes a raw
+  // listener to pin that unscoped listeners still fire per change.
+  const {addEventListener} = useContext(EngineSelectorContext)
+  useEffect(
+    () =>
+      addEventListener(() => {
+        selectorRuns.default++
+      }),
+    [addEventListener],
+  )
+  useRegistrationsSelector(registrationsSelector)
+  useListIndexSelector(listIndexSelector)
+
+  const [latePluginMounted, setLatePluginMounted] = useState(false)
+  mountLateNodePlugin = () => setLatePluginMounted(true)
+  const lateNodes = useMemo(
+    () => [defineBlockObject({type: 'late-object'})],
+    [],
+  )
+
+  return latePluginMounted ? <NodePlugin nodes={lateNodes} /> : null
+}
+
+describe('engine selector channels', () => {
+  test('Scenario: Text and selection ops leave channel-scoped selectors alone', async () => {
+    const {editor} = await createTestEditor({children: <ChannelProbe />})
+
+    editor.send({
+      type: 'insert.blocks',
+      placement: 'auto',
+      blocks: Array.from({length: 3}, (_, index) => ({
+        _type: 'block',
+        _key: `b${index}`,
+        children: [
+          {_type: 'span', _key: `s${index}`, text: `b${index}`, marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      })),
+    })
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 2},
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const afterSetup = {...selectorRuns}
+
+    editor.send({type: 'insert.text', text: 'x'})
+    await vi.waitFor(() => {
+      expect(selectorRuns.default).toBeGreaterThan(afterSetup.default)
+    })
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Typing and moving the caret cannot change registration maps or
+    // list indices, so those selectors must not have run.
+    expect(selectorRuns.registrations).toBe(afterSetup.registrations)
+    expect(selectorRuns.listIndex).toBe(afterSetup.listIndex)
+
+    const afterTyping = {...selectorRuns}
+
+    // A structural op (block split) can shift list indices.
+    editor.send({type: 'insert.break'})
+    await vi.waitFor(() => {
+      expect(selectorRuns.listIndex).toBeGreaterThan(afterTyping.listIndex)
+    })
+    expect(selectorRuns.registrations).toBe(afterTyping.registrations)
+
+    const afterBreak = {...selectorRuns}
+
+    // Registering a renderer arms the registrations channel.
+    mountLateNodePlugin?.()
+    await vi.waitFor(() => {
+      expect(selectorRuns.registrations).toBeGreaterThan(
+        afterBreak.registrations,
+      )
+    })
+  })
+})


### PR DESCRIPTION
Typing and moving the caret in a large document paid a per-event cost proportional to the block count: at 8,000 blocks, ~11ms of every keystroke and collapsed caret move, ~85% of the per-event cost, went into notifying selector subscriptions that could not possibly have new results. This came out of the hot-path review as the dominant remaining per-keystroke term after #2893.

The mechanism: every rendered element holds a registration-map selector (`render.element.tsx`), every span another (`render.leaf-config.tsx`), and every text block a `listIndex` selector (`render.text-block.tsx`), all registered in `useSelectorContext`'s single listener `Set`, 24,002 listeners at 8k blocks, and `onChange` fired them all, twice per user event (content flush + selection flush). None of them can change on a text or selection op: the registration maps are swapped only in `register-node-on-engine.ts`, and list indices only shift when a flush contained a structural operation.

Listeners now live in per-channel sets, and the channel is encoded in the hook name rather than a parameter: `useRegistrationsSelector` fires only when a registration map was swapped, `useListIndexSelector` only when a flush armed the same structural signal that invalidates `listIndexMap`, and the generic `useEngineSelector` hook is deleted outright: after the migration it had no consumers left, and the every-change listener set remains only for `useEngine`, which re-renders the editable root per change by design. Named hooks keep the dependency invariant at the declaration site instead of a stringly channel argument a call site could pair with the wrong selector (the default channel holds ~2 listeners at runtime, so the per-keystroke fan-out is gone rather than reduced). The channels are armed through `editor.selectorChannelsPending` flags set at the mutation sites and consumed by the `onContextChange` dispatch. Two design points worth calling out: the flags are deliberately separate from `listIndexMapDirty`, because any `getListIndexMap` read clears that flag, so a mid-flush read (a behavior guard, for instance) could swallow the notification; and because the flags are consumed at dispatch rather than fired-and-forgotten, they survive registration `onChange` calls that happen before the React layer has wired `onContextChange`, delivering on the next dispatch instead of never.

Selector semantics are unchanged: a channel-scoped selector still re-runs on every render of its own component (unmemoized selectors keep their per-render behavior) and whenever its channel fires. The only removed runs are notifications whose flush provably could not have changed the selector's inputs. The channel-count test pins this from both sides, text and selection ops leave 'registrations'/'listIndex' selectors unrun, a block split runs 'listIndex', and a late-mounted `NodePlugin` runs 'registrations', and was verified to fail on the single-set implementation. The full suite is green (841 unit, 1690 chromium) with the dynamic-registration suites untouched.

The ticket's optional second step (coalescing the two per-event flush notifications into one microtask) is deliberately skipped: with the fan-out segmented, the double fire reaches ~2 listeners and there is nothing left to coalesce.

Engine send time at 8k blocks (chromium, medians of 3, bare editor): typing 11.3 to 2.2ms per keystroke (5.1x), collapsed caret moves 9.6 to 1.8ms (5.4x), Enter 18.9 to 8.8ms, Backspace 17.7 to 8.5ms. Per-keystroke cost is now near-flat in document size (typing 0.8ms at 1k vs 2.2ms at 8k); the residual structural-event cost is the `listIndex` channel itself plus the `useChildren` rebuild tracked in EDEX-1488.




A second commit removes dead machinery found while answering "what still uses the every-change set": `deferredEventListeners`/`flushDeferred`/`useFlushDeferredSelectorsOnRender` had no writer anywhere, so the editable flushed a permanently empty set on every render. Net behavior unchanged.