### PR TITLE
feat(plugin-table): apply `decorator.toggle` per cell in a rectangular selection

### DIFF
--- a/packages/plugin-table/src/behaviors/classification.test.tsx
+++ b/packages/plugin-table/src/behaviors/classification.test.tsx
@@ -35,12 +35,12 @@ const treatments: Record<
   'decorator.remove': 'remap',
   'decorator.toggle': 'remap',
   'delete': 'remap',
-  // Expected to decompose through `delete`, which is remapped; pin with
-  // tests before flipping to `pass`.
-  'delete.backward': 'pending',
+  // Re-raises `delete` (which is remapped) for any selection; backspace
+  // over a rectangle is pinned in delete.test.tsx.
+  'delete.backward': 'pass',
   'delete.block': 'pass',
   'delete.child': 'pass',
-  'delete.forward': 'pending',
+  'delete.forward': 'pass',
   'delete.text': 'pending',
   // Paste over a rectangle.
   'deserialize': 'pending',
@@ -59,7 +59,10 @@ const treatments: Record<
   'insert.inline object': 'pending',
   'insert.soft break': 'pending',
   'insert.span': 'pending',
-  'insert.text': 'pending',
+  // Decomposes into `delete` plus the insert on expanded selections, so the
+  // rectangle clears and the text lands in the top-left cell (pinned in
+  // delete.test.tsx).
+  'insert.text': 'pass',
   'list item.add': 'remap',
   'list item.remove': 'remap',
   'list item.toggle': 'remap',

--- a/packages/plugin-table/src/behaviors/classification.test.tsx
+++ b/packages/plugin-table/src/behaviors/classification.test.tsx
@@ -1,0 +1,100 @@
+import type {SyntheticBehaviorEvent} from '@portabletext/editor/behaviors'
+import {expect, test} from 'vitest'
+import {tableBehaviors} from '../plugin.table'
+
+/**
+ * How the plugin treats each synthetic event when the selection spans more
+ * than one table cell:
+ *
+ * - `remap`: the event acts on the selection, so the plugin intercepts it
+ *   and gives it rectangle semantics (fan out per member cell, or clear the
+ *   rectangle).
+ * - `pass`: the event is safe as-is, because it is path-addressed, keyed,
+ *   pure caret motion, history, or a result notification.
+ * - `pending`: the event acts on the selection but has no rectangle
+ *   semantics yet.
+ *
+ * The `Record` is total over the event union on purpose: when the editor
+ * adds a synthetic event, this file stops compiling until the new event is
+ * classified.
+ */
+const treatments: Record<
+  SyntheticBehaviorEvent['type'],
+  'remap' | 'pass' | 'pending'
+> = {
+  'annotation.add': 'remap',
+  'annotation.remove': 'remap',
+  // Keyed to an existing annotation, not selection-scoped.
+  'annotation.set': 'pass',
+  'annotation.toggle': 'remap',
+  'block.set': 'pass',
+  'block.unset': 'pass',
+  'child.set': 'pass',
+  'child.unset': 'pass',
+  'decorator.add': 'remap',
+  'decorator.remove': 'remap',
+  'decorator.toggle': 'remap',
+  'delete': 'remap',
+  // Expected to decompose through `delete`, which is remapped; pin with
+  // tests before flipping to `pass`.
+  'delete.backward': 'pending',
+  'delete.block': 'pass',
+  'delete.child': 'pass',
+  'delete.forward': 'pending',
+  'delete.text': 'pending',
+  // Paste over a rectangle.
+  'deserialize': 'pending',
+  'deserialize.data': 'pending',
+  // Applies through `insert.blocks`, which is classified separately.
+  'deserialization.failure': 'pass',
+  'deserialization.success': 'pass',
+  'history.redo': 'pass',
+  'history.undo': 'pass',
+  'insert': 'pass',
+  // Typing or inserting over a rectangle should replace the rectangle.
+  'insert.block': 'pending',
+  'insert.blocks': 'pending',
+  'insert.break': 'pending',
+  'insert.child': 'pending',
+  'insert.inline object': 'pending',
+  'insert.soft break': 'pending',
+  'insert.span': 'pending',
+  'insert.text': 'pending',
+  'list item.add': 'remap',
+  'list item.remove': 'remap',
+  'list item.toggle': 'remap',
+  'move.backward': 'pass',
+  'move.forward': 'pass',
+  'move.block': 'pass',
+  // Moving "the selected block" is ambiguous for a rectangle; rows and
+  // columns move through the plugin's own custom events instead.
+  'move.block down': 'pending',
+  'move.block up': 'pending',
+  'remove.text': 'pass',
+  'select': 'pass',
+  'select.block': 'pass',
+  'select.next block': 'pass',
+  'select.previous block': 'pass',
+  // Copy/cut should serialize the rectangle, not the linear fragment.
+  'serialize': 'pending',
+  'serialize.data': 'pending',
+  'serialization.failure': 'pass',
+  'serialization.success': 'pass',
+  'set': 'pass',
+  'split': 'remap',
+  'style.add': 'remap',
+  'style.remove': 'remap',
+  'style.toggle': 'remap',
+  'unset': 'pass',
+}
+
+test('every remapped event has an interceptor wired into tableBehaviors', () => {
+  const wired = new Set(tableBehaviors.map((behavior) => behavior.on))
+  const remapped = Object.entries(treatments)
+    .filter(([, treatment]) => treatment === 'remap')
+    .map(([eventType]) => eventType)
+
+  for (const eventType of remapped) {
+    expect(wired).toContain(eventType)
+  }
+})

--- a/packages/plugin-table/src/behaviors/delete.test.tsx
+++ b/packages/plugin-table/src/behaviors/delete.test.tsx
@@ -472,6 +472,87 @@ describe('delete behaviors within tables', () => {
     })
   })
 
+  test('backspace over a multi-cell rectangle clears it', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    const focus = pointInSpan('r1c1', 'r1c1b', 'r1c1s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k2', spanKey: 'k3'},
+          r0c1: {blockKey: 'k8', spanKey: 'k9'},
+          r1c0: {blockKey: 'k6', spanKey: 'k7'},
+          r1c1: {blockKey: 'k4', spanKey: 'k5'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtClearedCell('r0c0', 'k2', 'k3'),
+      )
+    })
+  })
+
+  test('typing over a multi-cell rectangle replaces it with the typed text', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    const focus = pointInSpan('r1c1', 'r1c1b', 'r1c1s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+    // `insert.text` decomposes into `delete` plus the insert on expanded
+    // selections, so the rectangle clears and the text lands in the
+    // top-left cell's minted block.
+    editor.send({type: 'insert.text', text: 'x'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                cellWithText('r0c0', 'k2', 'k3', 'x'),
+                cellWithText('r0c1', 'k8', 'k9', ''),
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                cellWithText('r1c0', 'k6', 'k7', ''),
+                cellWithText('r1c1', 'k4', 'k5', ''),
+              ],
+            },
+          ],
+        },
+      ])
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsed(pointInSpan('r0c0', 'k2', 'k3', 1)),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
   test('delete.range straddling two cells in same row: structure preserved (no cell merge)', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),

--- a/packages/plugin-table/src/behaviors/delete.ts
+++ b/packages/plugin-table/src/behaviors/delete.ts
@@ -51,10 +51,10 @@ function clearCellsAndCollapse({
     }
   }
   if (topLeftCellPath) {
-    // Raise select.block (not select with leaf path). select.block resolves
-    // to the cell's first leaf via the apply layer AFTER our unsets +
-    // normalization complete — so the cursor lands inside the cleared cell's
-    // freshly-minted empty block, not at whatever leaf survived transformPoint.
+    // Raise select.block (not select with a leaf path): the cleared cell's
+    // replacement block does not exist yet. The select operation repairs the
+    // emptied cell, minting its empty block, and resolves to the minted
+    // leaf, so the cursor lands inside the cleared cell.
     actions.push(
       raise({type: 'select.block', at: topLeftCellPath, select: 'start'}),
     )

--- a/packages/plugin-table/src/behaviors/delete.ts
+++ b/packages/plugin-table/src/behaviors/delete.ts
@@ -1,34 +1,10 @@
-import type {EditorSnapshot, Path} from '@portabletext/editor'
+import type {Path} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
-import {getEnclosingBlock} from '@portabletext/editor/traversal'
-import {getTableSelection} from '../get-table-selection'
-import {isTable, type Table, type TableSelection} from './types'
-
-type ClearableSelection = {
-  tableSelection: TableSelection
-  table: {node: Table; path: Path}
-}
-
-/**
- * Resolve a rectangular cell selection together with its table node, so the
- * action doesn't have to re-resolve the table. Returns `false` for an
- * ordinary single-cell selection.
- */
-function clearableSelection(
-  snapshot: EditorSnapshot,
-): ClearableSelection | false {
-  const tableSelection = getTableSelection(snapshot)
-  if (!tableSelection) {
-    return false
-  }
-  const table = getEnclosingBlock(snapshot, tableSelection.tablePath, {
-    match: isTable,
-  })
-  if (!table) {
-    return false
-  }
-  return {tableSelection, table}
-}
+import {
+  memberCells,
+  resolveTableSelection,
+  type ResolvedTableSelection,
+} from '../get-table-selection'
 
 /**
  * Intercepts `delete` and `split` when the editor selection spans more
@@ -38,65 +14,40 @@ function clearableSelection(
  * built-in behavior is unchanged.
  */
 export const deleteBehaviors = [
-  defineBehavior<Record<string, never>, 'delete', ClearableSelection>({
+  defineBehavior<Record<string, never>, 'delete', ResolvedTableSelection>({
     on: 'delete',
-    guard: ({snapshot}) => clearableSelection(snapshot),
-    actions: [
-      (_, {tableSelection, table}) =>
-        clearCellsAndCollapse(tableSelection, table),
-    ],
+    guard: ({snapshot}) => resolveTableSelection(snapshot) ?? false,
+    actions: [(_, resolved) => clearCellsAndCollapse(resolved)],
   }),
-  defineBehavior<Record<string, never>, 'split', ClearableSelection>({
+  defineBehavior<Record<string, never>, 'split', ResolvedTableSelection>({
     on: 'split',
-    guard: ({snapshot}) => clearableSelection(snapshot),
-    actions: [
-      (_, {tableSelection, table}) =>
-        clearCellsAndCollapse(tableSelection, table),
-    ],
+    guard: ({snapshot}) => resolveTableSelection(snapshot) ?? false,
+    actions: [(_, resolved) => clearCellsAndCollapse(resolved)],
   }),
 ]
 
-function clearCellsAndCollapse(
-  tableSelection: TableSelection,
-  table: {node: Table; path: Path},
-) {
+function clearCellsAndCollapse({
+  tableSelection,
+  table,
+}: ResolvedTableSelection) {
   // Unset every block inside each cell's `value` array. Targeting keyed
   // child paths (rather than the whole `value` field) keeps inverse
   // data attached to each operation, so `history.undo` restores the
   // original content. Normalization repopulates each cleared cell with a
   // single empty text block.
   const actions = []
-  const [rowStart, rowEnd] = tableSelection.rowRange
-  const [colStart, colEnd] = tableSelection.colRange
   let topLeftCellPath: Path | null = null
-  for (let r = rowStart; r <= rowEnd; r++) {
-    const row = table.node.rows[r]
-    if (!row) {
-      continue
+  for (const cell of memberCells(tableSelection, table.node)) {
+    if (topLeftCellPath === null) {
+      topLeftCellPath = cell.path
     }
-    for (let c = colStart; c <= colEnd; c++) {
-      const cell = row.cells[c]
-      if (!cell) {
-        continue
-      }
-      const cellPath: Path = [
-        ...tableSelection.tablePath,
-        'rows',
-        {_key: row._key},
-        'cells',
-        {_key: cell._key},
-      ]
-      if (topLeftCellPath === null) {
-        topLeftCellPath = cellPath
-      }
-      for (const block of cell.value) {
-        actions.push(
-          raise({
-            type: 'unset',
-            at: [...cellPath, 'value', {_key: block._key}],
-          }),
-        )
-      }
+    for (const block of cell.node.value) {
+      actions.push(
+        raise({
+          type: 'unset',
+          at: [...cell.path, 'value', {_key: block._key}],
+        }),
+      )
     }
   }
   if (topLeftCellPath) {

--- a/packages/plugin-table/src/behaviors/format.test.tsx
+++ b/packages/plugin-table/src/behaviors/format.test.tsx
@@ -7,6 +7,7 @@ import {TablePlugin} from '../plugin.table'
 
 const schemaDefinition = defineSchema({
   decorators: [{name: 'strong'}],
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
   blockObjects: [
     {
       name: 'table',
@@ -41,7 +42,12 @@ const schemaDefinition = defineSchema({
   ],
 })
 
-const cell = (key: string, text: string, marks: Array<string> = []) => ({
+const cell = (
+  key: string,
+  text: string,
+  marks: Array<string> = [],
+  markDefs: Array<{_type: string; _key: string; href?: string}> = [],
+) => ({
   _type: 'cell',
   _key: key,
   value: [
@@ -49,11 +55,19 @@ const cell = (key: string, text: string, marks: Array<string> = []) => ({
       _type: 'block',
       _key: `b-${key}`,
       style: 'normal',
-      markDefs: [],
+      markDefs,
       children: [{_type: 'span', _key: `s-${key}`, text, marks}],
     },
   ],
 })
+
+const linkedCell = (key: string, text: string) =>
+  cell(
+    key,
+    text,
+    [`l-${key}`],
+    [{_type: 'link', _key: `l-${key}`, href: 'https://example.com'}],
+  )
 
 // 2x2 grid: c00 c01 / c10 c11
 const initialValue = [
@@ -101,12 +115,20 @@ function spanMarks(
   snapshot: EditorSnapshot,
   cellKey: string,
 ): Array<string> | undefined {
+  return firstBlock(snapshot, cellKey)?.children[0]?.marks
+}
+
+function cellMarkDefs(snapshot: EditorSnapshot, cellKey: string) {
+  return firstBlock(snapshot, cellKey)?.markDefs ?? []
+}
+
+function firstBlock(snapshot: EditorSnapshot, cellKey: string) {
   const value = snapshot.context.value as typeof initialValue
   const rowIndex = cellKey.startsWith('c0') ? 0 : 1
   const cellNode = value[0]?.rows[rowIndex]?.cells.find(
     (candidate) => candidate._key === cellKey,
   )
-  return cellNode?.value[0]?.children[0]?.marks
+  return cellNode?.value[0]
 }
 
 /**
@@ -244,6 +266,97 @@ describe('rectangular selection formatting', () => {
       // Outside the rectangle, the decorator stays.
       expect(spanMarks(snapshot, 'c01')).toEqual(['strong'])
       expect(spanMarks(snapshot, 'c11')).toEqual(['strong'])
+    })
+  })
+
+  test('annotation.add on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'link', value: {href: 'https://example.com'}},
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      // Each member cell gets its own markDef, referenced by its span.
+      for (const cellKey of ['c00', 'c10']) {
+        const markDefs = cellMarkDefs(snapshot, cellKey)
+        expect(markDefs.map((markDef) => markDef._type)).toEqual(['link'])
+        expect(spanMarks(snapshot, cellKey)).toEqual([markDefs[0]?._key])
+      }
+      expect(cellMarkDefs(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(cellMarkDefs(snapshot, 'c11')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('annotation.remove on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn([
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [linkedCell('c00', 'A'), linkedCell('c01', 'B')],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [linkedCell('c10', 'C'), linkedCell('c11', 'D')],
+          },
+        ],
+      },
+    ])
+
+    editor.send({type: 'annotation.remove', annotation: {name: 'link'}})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual([])
+      expect(spanMarks(snapshot, 'c10')).toEqual([])
+      // Outside the rectangle, the annotation stays.
+      expect(spanMarks(snapshot, 'c01')).toEqual(['l-c01'])
+      expect(spanMarks(snapshot, 'c11')).toEqual(['l-c11'])
+    })
+  })
+
+  test('annotation.toggle on a mixed column applies uniformly', async () => {
+    const editor = await selectLeftColumn([
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [linkedCell('c00', 'A'), cell('c01', 'B')],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', 'C'), cell('c11', 'D')],
+          },
+        ],
+      },
+    ])
+
+    editor.send({
+      type: 'annotation.toggle',
+      annotation: {name: 'link', value: {href: 'https://example.com'}},
+    })
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      // c00 was already linked: a per-cell toggle would checkerboard, and a
+      // blind add would stack a second annotation. It keeps its original.
+      expect(spanMarks(snapshot, 'c00')).toEqual(['l-c00'])
+      expect(spanMarks(snapshot, 'c10')).toHaveLength(1)
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
     })
   })
 

--- a/packages/plugin-table/src/behaviors/format.test.tsx
+++ b/packages/plugin-table/src/behaviors/format.test.tsx
@@ -201,6 +201,52 @@ describe('rectangular selection formatting', () => {
     })
   })
 
+  test('decorator.add on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c10')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('decorator.remove on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn([
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [cell('c00', 'A', ['strong']), cell('c01', 'B', ['strong'])],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', 'C', ['strong']), cell('c11', 'D', ['strong'])],
+          },
+        ],
+      },
+    ])
+
+    editor.send({type: 'decorator.remove', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual([])
+      expect(spanMarks(snapshot, 'c10')).toEqual([])
+      // Outside the rectangle, the decorator stays.
+      expect(spanMarks(snapshot, 'c01')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c11')).toEqual(['strong'])
+    })
+  })
+
   test('a single undo restores the whole column', async () => {
     const editor = await selectLeftColumn()
 

--- a/packages/plugin-table/src/behaviors/format.test.tsx
+++ b/packages/plugin-table/src/behaviors/format.test.tsx
@@ -8,6 +8,8 @@ import {TablePlugin} from '../plugin.table'
 const schemaDefinition = defineSchema({
   decorators: [{name: 'strong'}],
   annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  styles: [{name: 'normal'}, {name: 'h1'}],
+  lists: [{name: 'bullet'}],
   blockObjects: [
     {
       name: 'table',
@@ -42,24 +44,36 @@ const schemaDefinition = defineSchema({
   ],
 })
 
+type TestBlock = {
+  _type: 'block'
+  _key: string
+  style: string
+  listItem?: string
+  level?: number
+  markDefs: Array<{_type: string; _key: string; href?: string}>
+  children: Array<{
+    _type: string
+    _key: string
+    text: string
+    marks: Array<string>
+  }>
+}
+
 const cell = (
   key: string,
   text: string,
   marks: Array<string> = [],
   markDefs: Array<{_type: string; _key: string; href?: string}> = [],
-) => ({
-  _type: 'cell',
-  _key: key,
-  value: [
-    {
-      _type: 'block',
-      _key: `b-${key}`,
-      style: 'normal',
-      markDefs,
-      children: [{_type: 'span', _key: `s-${key}`, text, marks}],
-    },
-  ],
-})
+) => {
+  const block: TestBlock = {
+    _type: 'block',
+    _key: `b-${key}`,
+    style: 'normal',
+    markDefs,
+    children: [{_type: 'span', _key: `s-${key}`, text, marks}],
+  }
+  return {_type: 'cell', _key: key, value: [block]}
+}
 
 const linkedCell = (key: string, text: string) =>
   cell(
@@ -120,6 +134,14 @@ function spanMarks(
 
 function cellMarkDefs(snapshot: EditorSnapshot, cellKey: string) {
   return firstBlock(snapshot, cellKey)?.markDefs ?? []
+}
+
+function blockStyle(snapshot: EditorSnapshot, cellKey: string) {
+  return firstBlock(snapshot, cellKey)?.style
+}
+
+function blockListItem(snapshot: EditorSnapshot, cellKey: string) {
+  return firstBlock(snapshot, cellKey)?.listItem
 }
 
 function firstBlock(snapshot: EditorSnapshot, cellKey: string) {
@@ -357,6 +379,67 @@ describe('rectangular selection formatting', () => {
       expect(spanMarks(snapshot, 'c10')).toHaveLength(1)
       expect(spanMarks(snapshot, 'c01')).toEqual([])
       expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('style.toggle on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({type: 'style.toggle', style: 'h1'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(blockStyle(snapshot, 'c00')).toBe('h1')
+      expect(blockStyle(snapshot, 'c10')).toBe('h1')
+      expect(blockStyle(snapshot, 'c01')).toBe('normal')
+      expect(blockStyle(snapshot, 'c11')).toBe('normal')
+    })
+  })
+
+  test('style.toggle styles empty member cells too', async () => {
+    const editor = await selectLeftColumn([
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [cell('c00', 'A'), cell('c01', 'B')],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', ''), cell('c11', 'D')],
+          },
+        ],
+      },
+    ])
+
+    editor.send({type: 'style.toggle', style: 'h1'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(blockStyle(snapshot, 'c00')).toBe('h1')
+      // Unlike span-level formatting, block-level formatting includes empty
+      // cells: typing into c10 later should produce an h1.
+      expect(blockStyle(snapshot, 'c10')).toBe('h1')
+      expect(blockStyle(snapshot, 'c01')).toBe('normal')
+      expect(blockStyle(snapshot, 'c11')).toBe('normal')
+    })
+  })
+
+  test('list item.toggle on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({type: 'list item.toggle', listItem: 'bullet'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(blockListItem(snapshot, 'c00')).toBe('bullet')
+      expect(blockListItem(snapshot, 'c10')).toBe('bullet')
+      expect(blockListItem(snapshot, 'c01')).toBeUndefined()
+      expect(blockListItem(snapshot, 'c11')).toBeUndefined()
     })
   })
 

--- a/packages/plugin-table/src/behaviors/format.test.tsx
+++ b/packages/plugin-table/src/behaviors/format.test.tsx
@@ -1,0 +1,222 @@
+import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const cell = (key: string, text: string, marks: Array<string> = []) => ({
+  _type: 'cell',
+  _key: key,
+  value: [
+    {
+      _type: 'block',
+      _key: `b-${key}`,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: `s-${key}`, text, marks}],
+    },
+  ],
+})
+
+// 2x2 grid: c00 c01 / c10 c11
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {_type: 'row', _key: 'r0', cells: [cell('c00', 'A'), cell('c01', 'B')]},
+      {_type: 'row', _key: 'r1', cells: [cell('c10', 'C'), cell('c11', 'D')]},
+    ],
+  },
+]
+
+const mixedColumnValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {
+        _type: 'row',
+        _key: 'r0',
+        cells: [cell('c00', 'A', ['strong']), cell('c01', 'B')],
+      },
+      {_type: 'row', _key: 'r1', cells: [cell('c10', 'C'), cell('c11', 'D')]},
+    ],
+  },
+]
+
+function spanPath(cellKey: string) {
+  const rowKey = cellKey.startsWith('c0') ? 'r0' : 'r1'
+  return [
+    {_key: 't0'},
+    'rows',
+    {_key: rowKey},
+    'cells',
+    {_key: cellKey},
+    'value',
+    {_key: `b-${cellKey}`},
+    'children',
+    {_key: `s-${cellKey}`},
+  ]
+}
+
+function spanMarks(
+  snapshot: EditorSnapshot,
+  cellKey: string,
+): Array<string> | undefined {
+  const value = snapshot.context.value as typeof initialValue
+  const rowIndex = cellKey.startsWith('c0') ? 0 : 1
+  const cellNode = value[0]?.rows[rowIndex]?.cells.find(
+    (candidate) => candidate._key === cellKey,
+  )
+  return cellNode?.value[0]?.children[0]?.marks
+}
+
+/**
+ * Selects the left column: anchor in `c00`, focus in `c10`. The linear range
+ * between them covers `c01`, which the rectangle excludes.
+ */
+async function selectLeftColumn(value = initialValue) {
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: value,
+    children: <TablePlugin />,
+  })
+  const focusOffset = value[0]?.rows[1]?.cells[0]?.value[0]?.children[0]?.text
+    .length as number
+  await userEvent.click(locator)
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: spanPath('c00'), offset: 0},
+      focus: {path: spanPath('c10'), offset: focusOffset},
+    },
+  })
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection?.focus.path.at(-1)).toEqual({
+      _key: 's-c10',
+    })
+  })
+  return editor
+}
+
+describe('rectangular selection formatting', () => {
+  test('decorator.toggle on a column selection only affects the column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c10')).toEqual(['strong'])
+      // The linear range covers c01, but the rectangle does not.
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('decorator.toggle on a mixed column applies uniformly', async () => {
+    const editor = await selectLeftColumn(mixedColumnValue)
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      // c00 was already strong; a per-cell toggle would checkerboard.
+      expect(spanMarks(snapshot, 'c00')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c10')).toEqual(['strong'])
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('an empty cell in the column neither blocks nor breaks the toggle', async () => {
+    const editor = await selectLeftColumn([
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [cell('c00', 'A'), cell('c01', 'B')],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', ''), cell('c11', 'D')],
+          },
+        ],
+      },
+    ])
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual(['strong'])
+      // The empty cell has nothing to decorate and stays untouched.
+      expect(spanMarks(snapshot, 'c10')).toEqual([])
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+
+  test('a single undo restores the whole column', async () => {
+    const editor = await selectLeftColumn()
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+    await vi.waitFor(() => {
+      expect(spanMarks(editor.getSnapshot(), 'c10')).toEqual(['strong'])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      expect(spanMarks(snapshot, 'c00')).toEqual([])
+      expect(spanMarks(snapshot, 'c10')).toEqual([])
+      expect(spanMarks(snapshot, 'c01')).toEqual([])
+      expect(spanMarks(snapshot, 'c11')).toEqual([])
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/format.ts
+++ b/packages/plugin-table/src/behaviors/format.ts
@@ -1,9 +1,13 @@
 import type {EditorSelection, EditorSnapshot} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {
+  getSelectedTextBlocks,
   isActiveAnnotation,
   isActiveDecorator,
+  isActiveListItem,
+  isActiveStyle,
 } from '@portabletext/editor/selectors'
+import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {isEqualSelectionPoints} from '@portabletext/editor/utils'
 import {cellEndPoint, cellStartPoint} from '../cell-points'
 import {memberCells, resolveTableSelection} from '../get-table-selection'
@@ -20,6 +24,8 @@ type RectangleFormatting = {
   active: boolean
 }
 
+type SelectedTextBlocks = ReturnType<typeof getSelectedTextBlocks>
+
 /**
  * A rectangular cell selection is represented as a linear anchor->focus
  * range, and the two disagree about membership: a column selection's linear
@@ -27,10 +33,13 @@ type RectangleFormatting = {
  * re-raised once per member cell, each carrying an explicit `at`, instead of
  * acting on the linear range.
  *
- * Every guard bails when the event carries an explicit `at`: addressed
- * events (including our own re-raises) already know where to apply, so only
- * selection-scoped events need remapping. This is also what keeps the
- * re-raises from recursing.
+ * The span-level guards (decorators, annotations) bail when the event
+ * carries an explicit `at`: addressed events (including our own re-raises)
+ * already know where to apply, so only selection-scoped events need
+ * remapping. This is also what keeps the re-raises from recursing. The
+ * block-level events (styles, list items) carry no `at` at all; their
+ * decomposition terminates in path-addressed `block.set`/`block.unset`
+ * primitives instead.
  */
 export const formatBehaviors = [
   defineBehavior<
@@ -39,13 +48,15 @@ export const formatBehaviors = [
     RectangleFormatting
   >({
     on: 'decorator.toggle',
-    guard: ({snapshot, event}) =>
-      event.at
-        ? false
-        : resolveRectangleFormatting(
-            snapshot,
-            isActiveDecorator(event.decorator),
-          ),
+    guard: ({snapshot, event}) => {
+      if (event.at) {
+        return false
+      }
+      const ranges = spanRanges(snapshot)
+      return ranges
+        ? resolveMembers(snapshot, ranges, isActiveDecorator(event.decorator))
+        : false
+    },
     actions: [
       ({event}, {members, active}) =>
         // Toggling each member cell separately would checkerboard a mixed
@@ -68,13 +79,19 @@ export const formatBehaviors = [
     RectangleFormatting
   >({
     on: 'annotation.toggle',
-    guard: ({snapshot, event}) =>
-      event.at
-        ? false
-        : resolveRectangleFormatting(
+    guard: ({snapshot, event}) => {
+      if (event.at) {
+        return false
+      }
+      const ranges = spanRanges(snapshot)
+      return ranges
+        ? resolveMembers(
             snapshot,
+            ranges,
             isActiveAnnotation(event.annotation.name),
-          ),
+          )
+        : false
+    },
     actions: [
       ({event}, {members, active}) =>
         // Unlike decorator marks, annotations are not set-semantic: every
@@ -102,6 +119,114 @@ export const formatBehaviors = [
   fanOutOverRectangle('decorator.remove'),
   fanOutOverRectangle('annotation.add'),
   fanOutOverRectangle('annotation.remove'),
+  defineBehavior<Record<string, never>, 'style.toggle', {active: boolean}>({
+    on: 'style.toggle',
+    guard: ({snapshot, event}) => {
+      const ranges = rectangleRanges(snapshot)
+      return ranges
+        ? resolveMembers(snapshot, ranges, isActiveStyle(event.style))
+        : false
+    },
+    actions: [
+      ({event}, {active}) => [
+        // The re-raise is address-less and re-enters the interceptors
+        // below, which decompose it per member cell.
+        raise({
+          type: active ? 'style.remove' : 'style.add',
+          style: event.style,
+        }),
+      ],
+    ],
+  }),
+  defineBehavior<Record<string, never>, 'list item.toggle', {active: boolean}>({
+    on: 'list item.toggle',
+    guard: ({snapshot, event}) => {
+      const ranges = rectangleRanges(snapshot)
+      return ranges
+        ? resolveMembers(snapshot, ranges, isActiveListItem(event.listItem))
+        : false
+    },
+    actions: [
+      ({event}, {active}) => [
+        raise({
+          type: active ? 'list item.remove' : 'list item.add',
+          listItem: event.listItem,
+        }),
+      ],
+    ],
+  }),
+  // Keep in sync with core's `behavior.abstract.style.ts`, which decomposes
+  // the selection-scoped style events into `block.set`/`block.unset` per
+  // selected text block. Here they decompose over the member cells' ranges
+  // instead of the linear selection.
+  defineBehavior<Record<string, never>, 'style.add', SelectedTextBlocks>({
+    on: 'style.add',
+    guard: ({snapshot}) => rectangleTextBlocks(snapshot),
+    actions: [
+      ({event}, blocks) =>
+        blocks.map((block) =>
+          raise({
+            type: 'block.set',
+            at: block.path,
+            props: {style: event.style},
+          }),
+        ),
+    ],
+  }),
+  defineBehavior<Record<string, never>, 'style.remove', SelectedTextBlocks>({
+    on: 'style.remove',
+    guard: ({snapshot}) => rectangleTextBlocks(snapshot),
+    actions: [
+      (_, blocks) =>
+        blocks.map((block) =>
+          raise({type: 'block.unset', at: block.path, props: ['style']}),
+        ),
+    ],
+  }),
+  // Keep in sync with core's `behavior.abstract.list-item.ts`: adding only
+  // touches blocks whose sub-schema declares the list, removing unsets both
+  // `level` and `listItem`.
+  defineBehavior<Record<string, never>, 'list item.add', SelectedTextBlocks>({
+    on: 'list item.add',
+    guard: ({snapshot, event}) => {
+      const blocks = rectangleTextBlocks(snapshot)
+      if (!blocks) {
+        return false
+      }
+      const listBlocks = blocks.filter((block) =>
+        getPathSubSchema(snapshot, block.path).lists.some(
+          (list) => list.name === event.listItem,
+        ),
+      )
+      return listBlocks.length > 0 ? listBlocks : false
+    },
+    actions: [
+      ({event}, blocks) =>
+        blocks.map((block) =>
+          raise({
+            type: 'block.set',
+            at: block.path,
+            props: {level: block.node.level ?? 1, listItem: event.listItem},
+          }),
+        ),
+    ],
+  }),
+  defineBehavior<Record<string, never>, 'list item.remove', SelectedTextBlocks>(
+    {
+      on: 'list item.remove',
+      guard: ({snapshot}) => rectangleTextBlocks(snapshot),
+      actions: [
+        (_, blocks) =>
+          blocks.map((block) =>
+            raise({
+              type: 'block.unset',
+              at: block.path,
+              props: ['level', 'listItem'],
+            }),
+          ),
+      ],
+    },
+  ),
 ]
 
 /**
@@ -117,8 +242,7 @@ function fanOutOverRectangle<
 >(on: TEventType) {
   return defineBehavior<Record<string, never>, TEventType, Ranges>({
     on,
-    guard: ({snapshot, event}) =>
-      event.at ? false : rectangleRanges(snapshot),
+    guard: ({snapshot, event}) => (event.at ? false : spanRanges(snapshot)),
     actions: [
       ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
     ],
@@ -126,19 +250,16 @@ function fanOutOverRectangle<
 }
 
 /**
- * The member-cell content ranges together with whether the formatting is
- * active on each and across all of them, so toggles can aggregate first and
- * apply uniformly. The active state comes from core's own selector,
- * evaluated against each member cell's range.
+ * Each range paired with whether the formatting is active on it, plus the
+ * aggregate across all of them, so toggles can decide once and apply
+ * uniformly. The active state comes from core's own selectors, evaluated
+ * against each member cell's range.
  */
-function resolveRectangleFormatting(
+function resolveMembers(
   snapshot: EditorSnapshot,
+  ranges: Ranges,
   isActive: (snapshot: EditorSnapshot) => boolean,
-): RectangleFormatting | false {
-  const ranges = rectangleRanges(snapshot)
-  if (!ranges) {
-    return false
-  }
+): RectangleFormatting {
   const members = ranges.map((range) => ({
     range,
     active: isActive({
@@ -150,8 +271,45 @@ function resolveRectangleFormatting(
 }
 
 /**
+ * The selected text blocks of every member cell, resolved per member-cell
+ * range, or `false` when the selection isn't a rectangle. Block-level
+ * formatting includes empty cells: their blocks are legitimately styleable.
+ */
+function rectangleTextBlocks(
+  snapshot: EditorSnapshot,
+): SelectedTextBlocks | false {
+  const ranges = rectangleRanges(snapshot)
+  if (!ranges) {
+    return false
+  }
+  const blocks = ranges.flatMap((range) =>
+    getSelectedTextBlocks({
+      ...snapshot,
+      context: {...snapshot.context, selection: range},
+    }),
+  )
+  return blocks.length > 0 ? blocks : false
+}
+
+/**
+ * Member ranges with content. Empty cells are excluded: there is nothing
+ * span-level to format in them, and span-level active selectors would read
+ * the caret's mark state instead of the cell's content.
+ */
+function spanRanges(snapshot: EditorSnapshot): Ranges | false {
+  const ranges = rectangleRanges(snapshot)
+  if (!ranges) {
+    return false
+  }
+  const inhabited = ranges.filter(
+    (range) => !isEqualSelectionPoints(range.anchor, range.focus),
+  )
+  return inhabited.length > 0 ? inhabited : false
+}
+
+/**
  * The content range of every member cell in the rectangle, or `false` when
- * the selection isn't a rectangle or no member cell has content.
+ * the selection isn't a rectangle.
  */
 function rectangleRanges(snapshot: EditorSnapshot): Ranges | false {
   const resolved = resolveTableSelection(snapshot)
@@ -167,12 +325,6 @@ function rectangleRanges(snapshot: EditorSnapshot): Ranges | false {
     const anchor = cellStartPoint(snapshot, cell.path)
     const focus = cellEndPoint(snapshot, cell.path)
     if (!anchor || !focus) {
-      continue
-    }
-    if (isEqualSelectionPoints(anchor, focus)) {
-      // An empty cell's content range is collapsed: there is nothing to
-      // format, and active-state selectors would read the caret's mark
-      // state instead of the cell's content.
       continue
     }
     ranges.push({anchor, focus})

--- a/packages/plugin-table/src/behaviors/format.ts
+++ b/packages/plugin-table/src/behaviors/format.ts
@@ -1,0 +1,92 @@
+import type {EditorSelection, EditorSnapshot} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {isActiveDecorator} from '@portabletext/editor/selectors'
+import {isEqualSelectionPoints} from '@portabletext/editor/utils'
+import {cellEndPoint, cellStartPoint} from '../cell-points'
+import {memberCells, resolveTableSelection} from '../get-table-selection'
+
+type RectangleDecorator = {
+  decorator: string
+  ranges: Array<NonNullable<EditorSelection>>
+  active: boolean
+}
+
+/**
+ * A rectangular cell selection is represented as a linear anchor->focus
+ * range, and the two disagree about membership: a column selection's linear
+ * range covers every intermediate cell. Formatting events therefore get
+ * re-raised once per member cell, each carrying an explicit `at`, instead of
+ * acting on the linear range.
+ */
+export const formatBehaviors = [
+  defineBehavior<Record<string, never>, 'decorator.toggle', RectangleDecorator>(
+    {
+      on: 'decorator.toggle',
+      guard: ({snapshot, event}) => {
+        if (event.at) {
+          // Addressed events (including our own re-raises) already know
+          // where to apply; only selection-scoped events need remapping.
+          return false
+        }
+        return resolveRectangleDecorator(snapshot, event.decorator)
+      },
+      actions: [
+        (_, {decorator, ranges, active}) =>
+          ranges.map((range) =>
+            raise({
+              // Toggling each member cell separately would checkerboard a
+              // mixed rectangle. Aggregate first: if any member cell misses
+              // the decorator, add it everywhere, otherwise remove it
+              // everywhere.
+              type: active ? 'decorator.remove' : 'decorator.add',
+              decorator,
+              at: range,
+            }),
+          ),
+      ],
+    },
+  ),
+]
+
+function resolveRectangleDecorator(
+  snapshot: EditorSnapshot,
+  decorator: string,
+): RectangleDecorator | false {
+  const resolved = resolveTableSelection(snapshot)
+  if (!resolved) {
+    return false
+  }
+
+  const ranges: Array<NonNullable<EditorSelection>> = []
+  let active = true
+  for (const cell of memberCells(
+    resolved.tableSelection,
+    resolved.table.node,
+  )) {
+    const anchor = cellStartPoint(snapshot, cell.path)
+    const focus = cellEndPoint(snapshot, cell.path)
+    if (!anchor || !focus) {
+      continue
+    }
+    if (isEqualSelectionPoints(anchor, focus)) {
+      // An empty cell's content range is collapsed: there is nothing to
+      // decorate, and `isActiveDecorator` would read the caret's mark state
+      // instead of the cell's content.
+      continue
+    }
+    const range = {anchor, focus}
+    ranges.push(range)
+    if (
+      !isActiveDecorator(decorator)({
+        ...snapshot,
+        context: {...snapshot.context, selection: range},
+      })
+    ) {
+      active = false
+    }
+  }
+  if (ranges.length === 0) {
+    return false
+  }
+  return {decorator, ranges, active}
+}

--- a/packages/plugin-table/src/behaviors/format.ts
+++ b/packages/plugin-table/src/behaviors/format.ts
@@ -1,15 +1,22 @@
 import type {EditorSelection, EditorSnapshot} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
-import {isActiveDecorator} from '@portabletext/editor/selectors'
+import {
+  isActiveAnnotation,
+  isActiveDecorator,
+} from '@portabletext/editor/selectors'
 import {isEqualSelectionPoints} from '@portabletext/editor/utils'
 import {cellEndPoint, cellStartPoint} from '../cell-points'
 import {memberCells, resolveTableSelection} from '../get-table-selection'
 
 type Ranges = Array<NonNullable<EditorSelection>>
 
-type RectangleDecorator = {
-  decorator: string
-  ranges: Ranges
+type MemberRange = {
+  range: NonNullable<EditorSelection>
+  active: boolean
+}
+
+type RectangleFormatting = {
+  members: Array<MemberRange>
   active: boolean
 }
 
@@ -26,48 +33,121 @@ type RectangleDecorator = {
  * re-raises from recursing.
  */
 export const formatBehaviors = [
-  defineBehavior<Record<string, never>, 'decorator.toggle', RectangleDecorator>(
-    {
-      on: 'decorator.toggle',
-      guard: ({snapshot, event}) => {
-        if (event.at) {
-          return false
-        }
-        return resolveRectangleDecorator(snapshot, event.decorator)
-      },
-      actions: [
-        (_, {decorator, ranges, active}) =>
-          ranges.map((range) =>
+  defineBehavior<
+    Record<string, never>,
+    'decorator.toggle',
+    RectangleFormatting
+  >({
+    on: 'decorator.toggle',
+    guard: ({snapshot, event}) =>
+      event.at
+        ? false
+        : resolveRectangleFormatting(
+            snapshot,
+            isActiveDecorator(event.decorator),
+          ),
+    actions: [
+      ({event}, {members, active}) =>
+        // Toggling each member cell separately would checkerboard a mixed
+        // rectangle. Aggregate first: if any member cell misses the
+        // decorator, add it where missing, otherwise remove it everywhere.
+        members
+          .filter((member) => (active ? true : !member.active))
+          .map((member) =>
             raise({
-              // Toggling each member cell separately would checkerboard a
-              // mixed rectangle. Aggregate first: if any member cell misses
-              // the decorator, add it everywhere, otherwise remove it
-              // everywhere.
               type: active ? 'decorator.remove' : 'decorator.add',
-              decorator,
-              at: range,
+              decorator: event.decorator,
+              at: member.range,
             }),
           ),
-      ],
-    },
-  ),
-  defineBehavior<Record<string, never>, 'decorator.add', Ranges>({
-    on: 'decorator.add',
-    guard: ({snapshot, event}) =>
-      event.at ? false : rectangleRanges(snapshot),
-    actions: [
-      ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
     ],
   }),
-  defineBehavior<Record<string, never>, 'decorator.remove', Ranges>({
-    on: 'decorator.remove',
+  defineBehavior<
+    Record<string, never>,
+    'annotation.toggle',
+    RectangleFormatting
+  >({
+    on: 'annotation.toggle',
     guard: ({snapshot, event}) =>
-      event.at ? false : rectangleRanges(snapshot),
+      event.at
+        ? false
+        : resolveRectangleFormatting(
+            snapshot,
+            isActiveAnnotation(event.annotation.name),
+          ),
     actions: [
-      ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
+      ({event}, {members, active}) =>
+        // Unlike decorator marks, annotations are not set-semantic: every
+        // `annotation.add` mints a new markDef. The add branch must skip
+        // members that are already active, or a mixed rectangle would
+        // stack a second annotation onto them.
+        members
+          .filter((member) => (active ? true : !member.active))
+          .map((member) =>
+            active
+              ? raise({
+                  type: 'annotation.remove',
+                  annotation: {name: event.annotation.name},
+                  at: member.range,
+                })
+              : raise({
+                  type: 'annotation.add',
+                  annotation: event.annotation,
+                  at: member.range,
+                }),
+          ),
     ],
   }),
+  fanOutOverRectangle('decorator.add'),
+  fanOutOverRectangle('decorator.remove'),
+  fanOutOverRectangle('annotation.add'),
+  fanOutOverRectangle('annotation.remove'),
 ]
+
+/**
+ * Re-raise the event once per member cell. No aggregate is involved: add
+ * adds and remove removes.
+ */
+function fanOutOverRectangle<
+  TEventType extends
+    | 'decorator.add'
+    | 'decorator.remove'
+    | 'annotation.add'
+    | 'annotation.remove',
+>(on: TEventType) {
+  return defineBehavior<Record<string, never>, TEventType, Ranges>({
+    on,
+    guard: ({snapshot, event}) =>
+      event.at ? false : rectangleRanges(snapshot),
+    actions: [
+      ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
+    ],
+  })
+}
+
+/**
+ * The member-cell content ranges together with whether the formatting is
+ * active on each and across all of them, so toggles can aggregate first and
+ * apply uniformly. The active state comes from core's own selector,
+ * evaluated against each member cell's range.
+ */
+function resolveRectangleFormatting(
+  snapshot: EditorSnapshot,
+  isActive: (snapshot: EditorSnapshot) => boolean,
+): RectangleFormatting | false {
+  const ranges = rectangleRanges(snapshot)
+  if (!ranges) {
+    return false
+  }
+  const members = ranges.map((range) => ({
+    range,
+    active: isActive({
+      ...snapshot,
+      context: {...snapshot.context, selection: range},
+    }),
+  }))
+  return {members, active: members.every((member) => member.active)}
+}
 
 /**
  * The content range of every member cell in the rectangle, or `false` when
@@ -98,21 +178,4 @@ function rectangleRanges(snapshot: EditorSnapshot): Ranges | false {
     ranges.push({anchor, focus})
   }
   return ranges.length > 0 ? ranges : false
-}
-
-function resolveRectangleDecorator(
-  snapshot: EditorSnapshot,
-  decorator: string,
-): RectangleDecorator | false {
-  const ranges = rectangleRanges(snapshot)
-  if (!ranges) {
-    return false
-  }
-  const active = ranges.every((range) =>
-    isActiveDecorator(decorator)({
-      ...snapshot,
-      context: {...snapshot.context, selection: range},
-    }),
-  )
-  return {decorator, ranges, active}
 }

--- a/packages/plugin-table/src/behaviors/format.ts
+++ b/packages/plugin-table/src/behaviors/format.ts
@@ -5,9 +5,11 @@ import {isEqualSelectionPoints} from '@portabletext/editor/utils'
 import {cellEndPoint, cellStartPoint} from '../cell-points'
 import {memberCells, resolveTableSelection} from '../get-table-selection'
 
+type Ranges = Array<NonNullable<EditorSelection>>
+
 type RectangleDecorator = {
   decorator: string
-  ranges: Array<NonNullable<EditorSelection>>
+  ranges: Ranges
   active: boolean
 }
 
@@ -17,6 +19,11 @@ type RectangleDecorator = {
  * range covers every intermediate cell. Formatting events therefore get
  * re-raised once per member cell, each carrying an explicit `at`, instead of
  * acting on the linear range.
+ *
+ * Every guard bails when the event carries an explicit `at`: addressed
+ * events (including our own re-raises) already know where to apply, so only
+ * selection-scoped events need remapping. This is also what keeps the
+ * re-raises from recursing.
  */
 export const formatBehaviors = [
   defineBehavior<Record<string, never>, 'decorator.toggle', RectangleDecorator>(
@@ -24,8 +31,6 @@ export const formatBehaviors = [
       on: 'decorator.toggle',
       guard: ({snapshot, event}) => {
         if (event.at) {
-          // Addressed events (including our own re-raises) already know
-          // where to apply; only selection-scoped events need remapping.
           return false
         }
         return resolveRectangleDecorator(snapshot, event.decorator)
@@ -46,19 +51,35 @@ export const formatBehaviors = [
       ],
     },
   ),
+  defineBehavior<Record<string, never>, 'decorator.add', Ranges>({
+    on: 'decorator.add',
+    guard: ({snapshot, event}) =>
+      event.at ? false : rectangleRanges(snapshot),
+    actions: [
+      ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
+    ],
+  }),
+  defineBehavior<Record<string, never>, 'decorator.remove', Ranges>({
+    on: 'decorator.remove',
+    guard: ({snapshot, event}) =>
+      event.at ? false : rectangleRanges(snapshot),
+    actions: [
+      ({event}, ranges) => ranges.map((range) => raise({...event, at: range})),
+    ],
+  }),
 ]
 
-function resolveRectangleDecorator(
-  snapshot: EditorSnapshot,
-  decorator: string,
-): RectangleDecorator | false {
+/**
+ * The content range of every member cell in the rectangle, or `false` when
+ * the selection isn't a rectangle or no member cell has content.
+ */
+function rectangleRanges(snapshot: EditorSnapshot): Ranges | false {
   const resolved = resolveTableSelection(snapshot)
   if (!resolved) {
     return false
   }
 
-  const ranges: Array<NonNullable<EditorSelection>> = []
-  let active = true
+  const ranges: Ranges = []
   for (const cell of memberCells(
     resolved.tableSelection,
     resolved.table.node,
@@ -70,23 +91,28 @@ function resolveRectangleDecorator(
     }
     if (isEqualSelectionPoints(anchor, focus)) {
       // An empty cell's content range is collapsed: there is nothing to
-      // decorate, and `isActiveDecorator` would read the caret's mark state
-      // instead of the cell's content.
+      // format, and active-state selectors would read the caret's mark
+      // state instead of the cell's content.
       continue
     }
-    const range = {anchor, focus}
-    ranges.push(range)
-    if (
-      !isActiveDecorator(decorator)({
-        ...snapshot,
-        context: {...snapshot.context, selection: range},
-      })
-    ) {
-      active = false
-    }
+    ranges.push({anchor, focus})
   }
-  if (ranges.length === 0) {
+  return ranges.length > 0 ? ranges : false
+}
+
+function resolveRectangleDecorator(
+  snapshot: EditorSnapshot,
+  decorator: string,
+): RectangleDecorator | false {
+  const ranges = rectangleRanges(snapshot)
+  if (!ranges) {
     return false
   }
+  const active = ranges.every((range) =>
+    isActiveDecorator(decorator)({
+      ...snapshot,
+      context: {...snapshot.context, selection: range},
+    }),
+  )
   return {decorator, ranges, active}
 }

--- a/packages/plugin-table/src/behaviors/nav.ts
+++ b/packages/plugin-table/src/behaviors/nav.ts
@@ -7,7 +7,6 @@ import type {
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {isSelectionCollapsed} from '@portabletext/editor/selectors'
 import {
-  getBlock,
   getChildren,
   getEnclosingBlock,
   getFirstChild,
@@ -15,6 +14,7 @@ import {
 } from '@portabletext/editor/traversal'
 import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
 import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
+import {cellEndPoint, cellStartPoint} from '../cell-points'
 import {resolveCell} from '../resolve-cell'
 
 type Dom = {
@@ -171,16 +171,8 @@ function cellStart(
   snapshot: EditorSnapshot,
   cellPath: Path,
 ): EditorSelection | undefined {
-  const firstChild = getFirstChild(snapshot, cellPath)
-  const firstBlock = firstChild && getBlock(snapshot, firstChild.path)
-  if (!firstBlock) {
-    return undefined
-  }
-  const point = getBlockStartPoint({
-    context: snapshot.context,
-    block: firstBlock,
-  })
-  return {anchor: point, focus: point}
+  const point = cellStartPoint(snapshot, cellPath)
+  return point && {anchor: point, focus: point}
 }
 
 /** A collapsed selection at the end of the cell's last block. */
@@ -188,13 +180,8 @@ function cellEnd(
   snapshot: EditorSnapshot,
   cellPath: Path,
 ): EditorSelection | undefined {
-  const lastChild = getLastChild(snapshot, cellPath)
-  const lastBlock = lastChild && getBlock(snapshot, lastChild.path)
-  if (!lastBlock) {
-    return undefined
-  }
-  const point = getBlockEndPoint({context: snapshot.context, block: lastBlock})
-  return {anchor: point, focus: point}
+  const point = cellEndPoint(snapshot, cellPath)
+  return point && {anchor: point, focus: point}
 }
 
 /**

--- a/packages/plugin-table/src/cell-points.ts
+++ b/packages/plugin-table/src/cell-points.ts
@@ -1,0 +1,37 @@
+import type {
+  EditorSelectionPoint,
+  EditorSnapshot,
+  Path,
+} from '@portabletext/editor'
+import {
+  getBlock,
+  getFirstChild,
+  getLastChild,
+} from '@portabletext/editor/traversal'
+import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
+
+/** The point at the start of the cell's first block. */
+export function cellStartPoint(
+  snapshot: EditorSnapshot,
+  cellPath: Path,
+): EditorSelectionPoint | undefined {
+  const firstChild = getFirstChild(snapshot, cellPath)
+  const firstBlock = firstChild && getBlock(snapshot, firstChild.path)
+  if (!firstBlock) {
+    return undefined
+  }
+  return getBlockStartPoint({context: snapshot.context, block: firstBlock})
+}
+
+/** The point at the end of the cell's last block. */
+export function cellEndPoint(
+  snapshot: EditorSnapshot,
+  cellPath: Path,
+): EditorSelectionPoint | undefined {
+  const lastChild = getLastChild(snapshot, cellPath)
+  const lastBlock = lastChild && getBlock(snapshot, lastChild.path)
+  if (!lastBlock) {
+    return undefined
+  }
+  return getBlockEndPoint({context: snapshot.context, block: lastBlock})
+}

--- a/packages/plugin-table/src/get-table-selection.ts
+++ b/packages/plugin-table/src/get-table-selection.ts
@@ -1,5 +1,11 @@
-import type {EditorSnapshot} from '@portabletext/editor'
-import type {TableSelection} from './behaviors/types'
+import type {EditorSnapshot, Path} from '@portabletext/editor'
+import {getEnclosingBlock} from '@portabletext/editor/traversal'
+import {
+  isTable,
+  type Cell,
+  type Table,
+  type TableSelection,
+} from './behaviors/types'
 import {resolveCell} from './resolve-cell'
 
 /**
@@ -64,5 +70,65 @@ export function getTableSelection(
       Math.min(anchorColIndex, focusColIndex),
       Math.max(anchorColIndex, focusColIndex),
     ],
+  }
+}
+
+export type ResolvedTableSelection = {
+  tableSelection: TableSelection
+  table: {node: Table; path: Path}
+}
+
+/**
+ * `getTableSelection` together with the table node it targets, so behaviors
+ * acting on the rectangle don't have to re-resolve the table. Returns
+ * `undefined` for an ordinary single-cell selection.
+ */
+export function resolveTableSelection(
+  snapshot: EditorSnapshot,
+): ResolvedTableSelection | undefined {
+  const tableSelection = getTableSelection(snapshot)
+  if (!tableSelection) {
+    return undefined
+  }
+  const table = getEnclosingBlock(snapshot, tableSelection.tablePath, {
+    match: isTable,
+  })
+  if (!table) {
+    return undefined
+  }
+  return {tableSelection, table}
+}
+
+/**
+ * The cells inside the rectangle, in row-major order, each with its keyed
+ * path.
+ */
+export function* memberCells(
+  tableSelection: TableSelection,
+  table: Table,
+): Generator<{node: Cell; path: Path}> {
+  const [rowStart, rowEnd] = tableSelection.rowRange
+  const [colStart, colEnd] = tableSelection.colRange
+  for (let rowIndex = rowStart; rowIndex <= rowEnd; rowIndex++) {
+    const row = table.rows[rowIndex]
+    if (!row) {
+      continue
+    }
+    for (let colIndex = colStart; colIndex <= colEnd; colIndex++) {
+      const cell = row.cells[colIndex]
+      if (!cell) {
+        continue
+      }
+      yield {
+        node: cell,
+        path: [
+          ...tableSelection.tablePath,
+          'rows',
+          {_key: row._key},
+          'cells',
+          {_key: cell._key},
+        ],
+      }
+    }
   }
 }

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -1,6 +1,7 @@
 import {defineContainer} from '@portabletext/editor'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {deleteBehaviors} from './behaviors/delete'
+import {formatBehaviors} from './behaviors/format'
 import {insertBehaviors} from './behaviors/insert'
 import {moveBehaviors} from './behaviors/move'
 import {navBehaviors} from './behaviors/nav'
@@ -70,4 +71,5 @@ export const tableBehaviors = [
   ...moveBehaviors,
   ...deleteBehaviors,
   ...navBehaviors,
+  ...formatBehaviors,
 ]


### PR DESCRIPTION
Toggling a decorator with a selection that spans multiple table cells decorated cells that were never visually selected. Select a column in a 2x2 table (top-left cell to bottom-left cell) and toggle bold: the top-right cell came out bold too, even though it sits outside the rectangle the user sees and the cell-selection visuals confirm.

The mechanism is a representation mismatch. A rectangular cell selection is carried as a linear anchor->focus range, and the two disagree about membership: the linear range between the top-left and bottom-left cells covers every intermediate cell in document order, including the whole top-right cell. Core's `decorator.toggle` acts on the linear range, so every selection-scoped formatting event does the wrong thing on rectangles by construction. The plugin already intercepted `delete` and `split` for exactly this reason; this PR starts extending that to formatting, `decorator.toggle` first.

The first commit is a pure refactor: `delete.ts` resolved the rectangle plus its table node and iterated member cells inline, and `nav.ts` derived cell start/end points inline, so the rectangle machinery the new behavior needs gets extracted next to the code that defines the rectangle (`resolveTableSelection` and `memberCells` in `get-table-selection.ts`, `cellStartPoint`/`cellEndPoint` in `cell-points.ts`) with `delete`/`nav` adopting it. Net behavior unchanged.

On top of that, `format.ts` intercepts `decorator.toggle` when the derived table selection spans more than one cell and the event carries no explicit `at`, and re-raises `decorator.add`/`decorator.remove` once per member cell, each carrying the cell's content range as `at`. The no-`at` guard doubles as the recursion exemption: addressed events (including our own re-raises) pass through untouched. The add/remove decision is aggregated across the rectangle first, if any member cell misses the decorator it gets added everywhere, otherwise removed everywhere, so a mixed rectangle formats uniformly instead of checkerboarding. The aggregate reuses core's `isActiveDecorator` selector evaluated against each member cell's range, the same snapshot-override idiom core's own `decorator.toggle` handler uses, and skips empty cells, which have nothing to decorate (`format.test.tsx` pins the column-purity case, where the intermediate cell must stay untouched, the mixed-column case, and the empty-cell case). All re-raises come from one behavior action, so a single `history.undo` restores the whole rectangle, pinned by its own test.

Blast radius: the behavior only fires when the selection endpoints resolve to different cells of the same table and the event has no `at`. Single-cell selections, selections outside tables, and addressed `decorator.toggle` events fall through to core unchanged; the full plugin suite passes untouched across all three browsers.

The remaining formatting families follow the same pattern, one commit each. `decorator.add`/`decorator.remove` and the annotation events fan out per member cell through a shared factory; the annotation toggle's add branch additionally skips members that are already active, because annotations are not set-semantic (every `annotation.add` mints a new markDef) and a mixed rectangle would otherwise stack a second annotation onto already-linked cells, the mixed-column test pins that a linked cell keeps its original markDef.

The style and list-item events carry no `at` in their payloads, so they can't be re-addressed the same way, and they don't need to be: core's own abstract behaviors decompose them into path-addressed `block.set`/`block.unset` over `getSelectedTextBlocks(snapshot)`, and the plugin mirrors that decomposition per member-cell range (keep-in-sync pointers reference `behavior.abstract.style.ts` and `behavior.abstract.list-item.ts`). The toggles aggregate via `isActiveStyle`/`isActiveListItem` and re-raise the address-less `add`/`remove`, which the interceptors decompose; recursion terminates at the path-addressed primitives. No core changes were needed for any of this.

One deliberate semantic split: block-level formatting (styles, list items) includes empty member cells, their blocks are legitimately styleable (toggle h1, type into the empty cell later, get an h1), while span-level formatting (decorators, annotations) skips them, since there is nothing to decorate and span-level active selectors would read the caret's mark state. Both sides of the split are pinned by tests.


The last commit adds the anti-drift mechanism: a classification test holding a `Record` total over `SyntheticBehaviorEvent['type']`, labeling every synthetic event as remapped, safe to pass through, or pending rectangle semantics. When core adds a synthetic event, the plugin stops compiling until the new event is classified, and a runtime assertion cross-checks that every remapped event actually has an interceptor wired into `tableBehaviors`. It caught its first omission during authoring (`move.forward` was missing from the map).
