### PR TITLE
feat(plugin-table): rectangle-aware clipboard (copy, cut, paste)

### DIFF
--- a/packages/plugin-table/src/behaviors/classification.test.tsx
+++ b/packages/plugin-table/src/behaviors/classification.test.tsx
@@ -42,16 +42,20 @@ const treatments: Record<
   'delete.child': 'pass',
   'delete.forward': 'pass',
   'delete.text': 'pending',
-  // Paste over a rectangle.
-  'deserialize': 'pending',
-  'deserialize.data': 'pending',
+  // MIME negotiation only; the application is `insert.blocks`, classified
+  // separately. The paste gesture itself is safe: `clipboard.paste`
+  // decomposes into `delete` (remapped) plus the forwarded paste, pinned in
+  // delete.test.tsx.
+  'deserialize': 'pass',
+  'deserialize.data': 'pass',
   // Applies through `insert.blocks`, which is classified separately.
   'deserialization.failure': 'pass',
   'deserialization.success': 'pass',
   'history.redo': 'pass',
   'history.undo': 'pass',
   'insert': 'pass',
-  // Typing or inserting over a rectangle should replace the rectangle.
+  // Inserting over a rectangle should replace the rectangle; these are not
+  // yet verified to decompose through `delete`.
   'insert.block': 'pending',
   'insert.blocks': 'pending',
   'insert.break': 'pending',

--- a/packages/plugin-table/src/behaviors/classification.test.tsx
+++ b/packages/plugin-table/src/behaviors/classification.test.tsx
@@ -78,9 +78,10 @@ const treatments: Record<
   'select.block': 'pass',
   'select.next block': 'pass',
   'select.previous block': 'pass',
-  // Copy/cut should serialize the rectangle, not the linear fragment.
-  'serialize': 'pending',
-  'serialize.data': 'pending',
+  // The fan-out into per-MIME `serialize.data` events carries no selection;
+  // the interception happens at `serialize.data`.
+  'serialize': 'pass',
+  'serialize.data': 'remap',
   'serialization.failure': 'pass',
   'serialization.success': 'pass',
   'set': 'pass',

--- a/packages/plugin-table/src/behaviors/delete.test.tsx
+++ b/packages/plugin-table/src/behaviors/delete.test.tsx
@@ -553,6 +553,99 @@ describe('delete behaviors within tables', () => {
     })
   })
 
+  test('pasting over a column selection replaces the column only', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    const focus = pointInSpan('r1c0', 'r1c0b', 'r1c0s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    // `clipboard.paste` on an expanded selection decomposes into `delete`
+    // plus the forwarded paste, so the rectangle clears and the pasted
+    // content lands in the top-left cell's minted block.
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'X')
+    editor.send({
+      type: 'clipboard.paste',
+      originEvent: {dataTransfer},
+      position: {
+        selection: {anchor, focus},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [
+                cellWithText('r0c0', 'k2', 'k3', 'X'),
+                cellWithText('r0c1', 'r0c1b', 'r0c1s', 'BB'),
+              ],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                cellWithText('r1c0', 'k4', 'k5', ''),
+                cellWithText('r1c1', 'r1c1b', 'r1c1s', 'DD'),
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('pasting multi-line text over a rectangle lands inside the cell', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    const focus = pointInSpan('r1c0', 'r1c0b', 'r1c0s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+
+    const dataTransfer = new DataTransfer()
+    // A blank line separates paragraphs; a single newline is a soft break.
+    dataTransfer.setData('text/plain', 'one\n\ntwo')
+    editor.send({
+      type: 'clipboard.paste',
+      originEvent: {dataTransfer},
+      position: {
+        selection: {anchor, focus},
+      },
+    })
+
+    await vi.waitFor(() => {
+      const value = editor.getSnapshot().context.value as typeof initialValue
+      const anchorCell = value[0]?.rows[0]?.cells[0]
+      // Both pasted blocks belong to the cell; the table is not split.
+      expect(value).toHaveLength(1)
+      expect(anchorCell?.value.map((block) => block.children[0]?.text)).toEqual(
+        ['one', 'two'],
+      )
+    })
+  })
+
   test('delete.range straddling two cells in same row: structure preserved (no cell merge)', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),

--- a/packages/plugin-table/src/behaviors/serialize.test.tsx
+++ b/packages/plugin-table/src/behaviors/serialize.test.tsx
@@ -1,0 +1,304 @@
+import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const cell = (key: string, text: string) => ({
+  _type: 'cell',
+  _key: key,
+  value: [
+    {
+      _type: 'block',
+      _key: `b-${key}`,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: `s-${key}`, text, marks: []}],
+    },
+  ],
+})
+
+// 2x2 grid: c00 c01 / c10 c11
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {_type: 'row', _key: 'r0', cells: [cell('c00', 'A'), cell('c01', 'B')]},
+      {_type: 'row', _key: 'r1', cells: [cell('c10', 'C'), cell('c11', 'D')]},
+    ],
+  },
+]
+
+function spanPath(cellKey: string) {
+  const rowKey = cellKey.startsWith('c0') ? 'r0' : 'r1'
+  return [
+    {_key: 't0'},
+    'rows',
+    {_key: rowKey},
+    'cells',
+    {_key: cellKey},
+    'value',
+    {_key: `b-${cellKey}`},
+    'children',
+    {_key: `s-${cellKey}`},
+  ]
+}
+
+const leftColumnSelection = {
+  anchor: {path: spanPath('c00'), offset: 0},
+  focus: {path: spanPath('c10'), offset: 1},
+}
+
+function value(snapshot: EditorSnapshot) {
+  return snapshot.context.value as typeof initialValue
+}
+
+/**
+ * Selects the left column: anchor in `c00`, focus in `c10`. The linear range
+ * between them covers `c01`, which the rectangle excludes.
+ */
+async function selectLeftColumn() {
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue,
+    children: <TablePlugin />,
+  })
+  await userEvent.click(locator)
+  editor.send({type: 'select', at: leftColumnSelection})
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+  })
+  return editor
+}
+
+describe('rectangular selection copy/cut', () => {
+  test('copying a column selection serializes only the column', async () => {
+    const editor = await selectLeftColumn()
+    const dataTransfer = new DataTransfer()
+
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer},
+      position: {selection: leftColumnSelection},
+    })
+
+    await vi.waitFor(() => {
+      // The linear fragment would include c01 (`B`).
+      expect(
+        JSON.parse(dataTransfer.getData('application/x-portable-text')),
+      ).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {_type: 'row', _key: 'r0', cells: [cell('c00', 'A')]},
+            {_type: 'row', _key: 'r1', cells: [cell('c10', 'C')]},
+          ],
+        },
+      ])
+      // The core markdown converter renders tables as fenced JSON unless
+      // the app registers `DefaultTableRenderer` (the playground does). The
+      // concern here is rectangle scoping, so parse the fence and assert
+      // the same rectangle-only table.
+      const markdown = dataTransfer.getData('text/markdown')
+      expect(
+        JSON.parse(markdown.replace(/^```json\n/, '').replace(/\n```$/, '')),
+      ).toEqual({
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {_type: 'row', _key: 'r0', cells: [cell('c00', 'A')]},
+          {_type: 'row', _key: 'r1', cells: [cell('c10', 'C')]},
+        ],
+      })
+    })
+  })
+
+  test('slicing keeps header rows and alignment positional', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          headerRows: 1,
+          alignment: ['left', 'right'],
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [cell('c00', 'A'), cell('c01', 'B')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ],
+      children: <TablePlugin />,
+    })
+    await userEvent.click(locator)
+
+    // Right column (c01 -> c11): the header row is included, the left
+    // column's alignment entry is not.
+    const rightColumnSelection = {
+      anchor: {path: spanPath('c01'), offset: 0},
+      focus: {path: spanPath('c11'), offset: 1},
+    }
+    editor.send({type: 'select', at: rightColumnSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    const columnTransfer = new DataTransfer()
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer: columnTransfer},
+      position: {selection: rightColumnSelection},
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        JSON.parse(columnTransfer.getData('application/x-portable-text')),
+      ).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          headerRows: 1,
+          alignment: ['right'],
+          rows: [
+            {_type: 'row', _key: 'r0', cells: [cell('c01', 'B')]},
+            {_type: 'row', _key: 'r1', cells: [cell('c11', 'D')]},
+          ],
+        },
+      ])
+    })
+
+    // Bottom row (c10 -> c11): the header row is excluded, so the copy
+    // carries no header rows.
+    const bottomRowSelection = {
+      anchor: {path: spanPath('c10'), offset: 0},
+      focus: {path: spanPath('c11'), offset: 1},
+    }
+    editor.send({type: 'select', at: bottomRowSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.path.at(-1)).toEqual(
+        {_key: 's-c11'},
+      )
+    })
+
+    const rowTransfer = new DataTransfer()
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer: rowTransfer},
+      position: {selection: bottomRowSelection},
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        JSON.parse(rowTransfer.getData('application/x-portable-text')),
+      ).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          headerRows: 0,
+          alignment: ['left', 'right'],
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('cutting a column selection serializes the column and clears it', async () => {
+    const editor = await selectLeftColumn()
+    const dataTransfer = new DataTransfer()
+
+    editor.send({
+      type: 'clipboard.cut',
+      originEvent: {dataTransfer},
+      position: {selection: leftColumnSelection},
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        JSON.parse(dataTransfer.getData('application/x-portable-text')),
+      ).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {_type: 'row', _key: 'r0', cells: [cell('c00', 'A')]},
+            {_type: 'row', _key: 'r1', cells: [cell('c10', 'C')]},
+          ],
+        },
+      ])
+      // The column cells cleared; the rest of the table is untouched.
+      const snapshot = editor.getSnapshot()
+      expect(
+        value(snapshot)[0]?.rows[0]?.cells[0]?.value[0]?.children[0]?.text,
+      ).toBe('')
+      expect(
+        value(snapshot)[0]?.rows[1]?.cells[0]?.value[0]?.children[0]?.text,
+      ).toBe('')
+      expect(
+        value(snapshot)[0]?.rows[0]?.cells[1]?.value[0]?.children[0]?.text,
+      ).toBe('B')
+      expect(
+        value(snapshot)[0]?.rows[1]?.cells[1]?.value[0]?.children[0]?.text,
+      ).toBe('D')
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/serialize.ts
+++ b/packages/plugin-table/src/behaviors/serialize.ts
@@ -1,0 +1,118 @@
+import type {EditorSnapshot, Path} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {cellEndPoint, cellStartPoint} from '../cell-points'
+import {resolveTableSelection} from '../get-table-selection'
+import type {Cell, Row, Table, TableSelection} from './types'
+
+type SerializeDataResult = ReturnType<
+  EditorSnapshot['context']['converters'][number]['serialize']
+>
+
+/**
+ * Copying or cutting a rectangular cell selection must serialize the
+ * rectangle, not the linear fragment between its corners, which covers
+ * cells outside a column selection by construction. The interception calls
+ * the same converter core would call, but against a snapshot whose value is
+ * a synthetic table sliced to the rectangle and whose selection spans it
+ * leaf-to-leaf, the same snapshot-override idiom core's own `serialize.data`
+ * behavior uses for drag origins. The rectangle clear on cut comes from the
+ * `delete` that `clipboard.cut` raises after `serialize`.
+ */
+export const serializeBehaviors = [
+  defineBehavior<Record<string, never>, 'serialize.data', SerializeDataResult>({
+    on: 'serialize.data',
+    guard: ({snapshot, event}) => {
+      if (
+        event.originEvent.type !== 'clipboard.copy' &&
+        event.originEvent.type !== 'clipboard.cut'
+      ) {
+        // Drag origins carry a grabbed selection that differs from the
+        // editor selection the rectangle is derived from.
+        return false
+      }
+      const resolved = resolveTableSelection(snapshot)
+      if (!resolved) {
+        return false
+      }
+      const converter = snapshot.context.converters.find(
+        (candidate) => candidate.mimeType === event.mimeType,
+      )
+      if (!converter) {
+        return false
+      }
+
+      const rectangle = sliceTable(resolved.table.node, resolved.tableSelection)
+      const firstRow = rectangle.rows[0]
+      const lastRow = rectangle.rows[rectangle.rows.length - 1]
+      const firstCell = firstRow?.cells[0]
+      const lastCell = lastRow?.cells[lastRow.cells.length - 1]
+      if (!firstRow || !lastRow || !firstCell || !lastCell) {
+        return false
+      }
+
+      const doctoredSnapshot = {
+        ...snapshot,
+        context: {...snapshot.context, value: [rectangle]},
+      }
+      const anchor = cellStartPoint(
+        doctoredSnapshot,
+        cellPath(rectangle, firstRow, firstCell),
+      )
+      const focus = cellEndPoint(
+        doctoredSnapshot,
+        cellPath(rectangle, lastRow, lastCell),
+      )
+      if (!anchor || !focus) {
+        return false
+      }
+
+      return converter.serialize({
+        snapshot: {
+          ...doctoredSnapshot,
+          context: {
+            ...doctoredSnapshot.context,
+            selection: {anchor, focus},
+          },
+        },
+        event: {type: 'serialize', originEvent: event.originEvent.type},
+      })
+    },
+    actions: [
+      ({event}, serialization) => [
+        raise({...serialization, originEvent: event.originEvent}),
+      ],
+    ],
+  }),
+]
+
+function sliceTable(table: Table, tableSelection: TableSelection): Table {
+  const [rowStart, rowEnd] = tableSelection.rowRange
+  const [colStart, colEnd] = tableSelection.colRange
+  const sliced: Table = {
+    ...table,
+    rows: table.rows.slice(rowStart, rowEnd + 1).map((row) => ({
+      ...row,
+      cells: row.cells.slice(colStart, colEnd + 1),
+    })),
+  }
+  if (typeof table.headerRows === 'number') {
+    // Header rows only survive when the rectangle includes them.
+    sliced.headerRows =
+      rowStart === 0 ? Math.min(table.headerRows, sliced.rows.length) : 0
+  }
+  if (table.alignment) {
+    // Alignment is positional per column.
+    sliced.alignment = table.alignment.slice(colStart, colEnd + 1)
+  }
+  return sliced
+}
+
+function cellPath(table: Table, row: Row, cell: Cell): Path {
+  return [
+    {_key: table._key},
+    'rows',
+    {_key: row._key},
+    'cells',
+    {_key: cell._key},
+  ]
+}

--- a/packages/plugin-table/src/behaviors/types.ts
+++ b/packages/plugin-table/src/behaviors/types.ts
@@ -14,6 +14,8 @@ export type Table = PortableTextBlock & {
   _type: 'table'
   rows: Array<Row>
   alignment?: Array<ColumnAlignment>
+  /** Number of leading rows that are header rows. */
+  headerRows?: number
 }
 
 export function isRow(node: PortableTextBlock): node is Row {

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -5,6 +5,7 @@ import {formatBehaviors} from './behaviors/format'
 import {insertBehaviors} from './behaviors/insert'
 import {moveBehaviors} from './behaviors/move'
 import {navBehaviors} from './behaviors/nav'
+import {serializeBehaviors} from './behaviors/serialize'
 import {unsetBehaviors} from './behaviors/unset'
 
 // `table` -> `row` -> `cell` nested containers. The render is intentionally
@@ -72,4 +73,5 @@ export const tableBehaviors = [
   ...deleteBehaviors,
   ...navBehaviors,
   ...formatBehaviors,
+  ...serializeBehaviors,
 ]


### PR DESCRIPTION
Copying a rectangular cell selection put the wrong cells on the clipboard: the clipboard pipeline serializes the linear fragment between the selection's corners, which covers cells outside a column selection by construction. Copy the left column of a 2x2 table and the top-right cell comes along.

The interception point is `serialize.data`, not `serialize`: the fan-out into per-MIME events carries no selection, the data events are where converters read one (`getFragment(snapshot)` on the linear selection). The plugin behavior guards on a rectangle plus a `clipboard.copy`/`clipboard.cut` origin, then calls the same converter core's abstract behavior would call, but against a doctored snapshot: `context.value` replaced with a synthetic table sliced to the rectangle (keys preserved, so paths stay valid) and `context.selection` spanning it leaf-to-leaf. This is the snapshot-override idiom core's own `serialize.data` behavior already uses for drag origins. One behavior covers every MIME type generically, and plugin-before-abstract ordering means the linear version never fires for these origins. Drag origins are excluded deliberately: the drag pipeline carries a grabbed selection that differs from the editor selection the rectangle derives from.

One known ceiling, deliberately accepted: this is a terminal handler, invisible to any `serialize` behaviors an app registers itself. A composition-friendly alternative, addressing the serialize events with a subject override and re-raising, was prototyped in #2905 and paused while the API shape settles; this shape is intentionally local to the plugin so it can be deleted wholesale when that lands.

Slicing adjusts the table's positional fields, pinned by their own test: `headerRows` survives only when the rectangle includes row 0, clamped to the rectangle's height, and `alignment` is sliced by the column range (a rectangle from column 1 onward would otherwise inherit column 0's alignment). `headerRows` joins the plugin's `Table` type; the parity branch already carries the same field, so that rebase dedupes trivially.

Cut needed no new mechanism: core's `clipboard.cut` raises `serialize` then `delete`, and the plugin's existing rectangle clear intercepts the delete. The cut test pins the full composition: rectangle on the clipboard, member cells cleared, out-of-rectangle cells untouched, one undo restores everything.

One rendering note: the core markdown converter renders tables as fenced JSON, because `@portabletext/markdown`'s default renderer map is deliberately empty ('table' is not a core Portable Text type) and GFM output requires the app to register the package's `DefaultTableRenderer`, which the playground does. The tests parse the fence and assert the rectangle, since the plugin's contract is the fragment, not the rendering.

`serialize.data` flips to `remap` and `serialize` to `pass` in the classification map; the map's wiring cross-check picks up the new behavior automatically. Single-cell selections never trigger any of this, copying text within one cell stays a plain linear copy.

The second commit pins paste, which needed no plugin code at all: `clipboard.paste` on an expanded selection decomposes into `delete` plus the forwarded paste, so the rectangle clears through the existing interception, the select-time container repair collapses the caret into the top-left cell, and the pasted content lands there, single-block and multi-block (both paragraphs inside the cell, table not split), each pinned with one undo restoring everything. `deserialize`/`deserialize.data` flip to `pass` (MIME plumbing; the selection consumer is `insert.blocks`, which stays honestly `pending`).

Stacked on #2901 (uses its shared rectangle resolution and cell-point helpers); retargets to main when that merges.
