### PR TITLE
feat(plugin-table): distribute a pasted table fragment over the target cells

### DIFF
--- a/packages/plugin-table/src/behaviors/paste.test.tsx
+++ b/packages/plugin-table/src/behaviors/paste.test.tsx
@@ -1,0 +1,431 @@
+import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {TablePlugin} from '../plugin.table'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const cell = (key: string, text: string) => ({
+  _type: 'cell',
+  _key: key,
+  value: [
+    {
+      _type: 'block',
+      _key: `b-${key}`,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: `s-${key}`, text, marks: []}],
+    },
+  ],
+})
+
+// 2x2 grid: c00 c01 / c10 c11
+const initialValue = [
+  {
+    _type: 'table',
+    _key: 't0',
+    rows: [
+      {_type: 'row', _key: 'r0', cells: [cell('c00', 'A'), cell('c01', 'B')]},
+      {_type: 'row', _key: 'r1', cells: [cell('c10', 'C'), cell('c11', 'D')]},
+    ],
+  },
+]
+
+function spanPath(cellKey: string) {
+  const rowKey = cellKey.startsWith('c0') ? 'r0' : 'r1'
+  return [
+    {_key: 't0'},
+    'rows',
+    {_key: rowKey},
+    'cells',
+    {_key: cellKey},
+    'value',
+    {_key: `b-${cellKey}`},
+    'children',
+    {_key: `s-${cellKey}`},
+  ]
+}
+
+/** A one-column, two-row table fragment (`P` over `Q`) copied "elsewhere". */
+const columnFragment = [
+  {
+    _type: 'table',
+    _key: 'x-t',
+    rows: [
+      {_type: 'row', _key: 'x-r0', cells: [cell('x-c0', 'P')]},
+      {_type: 'row', _key: 'x-r1', cells: [cell('x-c1', 'Q')]},
+    ],
+  },
+]
+
+function pasteFragment(
+  editor: {send: (event: never) => void},
+  fragment: unknown,
+  selection: unknown,
+) {
+  const dataTransfer = new DataTransfer()
+  dataTransfer.setData('application/x-portable-text', JSON.stringify(fragment))
+  ;(editor.send as (event: unknown) => void)({
+    type: 'clipboard.paste',
+    originEvent: {dataTransfer},
+    position: {selection},
+  })
+}
+
+async function createEditor(value = initialValue) {
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: value,
+    children: <TablePlugin />,
+  })
+  await userEvent.click(locator)
+  return editor
+}
+
+function value(snapshot: EditorSnapshot) {
+  return snapshot.context.value as typeof initialValue
+}
+
+function pastedCell(
+  cellKey: string,
+  blockKey: string,
+  spanKey: string,
+  text: string,
+) {
+  return {
+    _type: 'cell',
+    _key: cellKey,
+    value: [
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: spanKey, text, marks: []}],
+      },
+    ],
+  }
+}
+
+describe('pasting a table fragment into a table', () => {
+  test('distributes over a target rectangle from its top-left', async () => {
+    const editor = await createEditor()
+    const rightColumn = {
+      anchor: {path: spanPath('c01'), offset: 0},
+      focus: {path: spanPath('c11'), offset: 1},
+    }
+    editor.send({type: 'select', at: rightColumn})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    pasteFragment(editor, columnFragment, rightColumn)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [cell('c00', 'A'), pastedCell('c01', 'k2', 'k3', 'P')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), pastedCell('c11', 'k4', 'k5', 'Q')],
+            },
+          ],
+        },
+      ])
+      // The pasted rectangle becomes the selection.
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [
+            {_key: 't0'},
+            'rows',
+            {_key: 'r0'},
+            'cells',
+            {_key: 'c01'},
+            'value',
+            {_key: 'k2'},
+            'children',
+            {_key: 'k3'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 't0'},
+            'rows',
+            {_key: 'r1'},
+            'cells',
+            {_key: 'c11'},
+            'value',
+            {_key: 'k4'},
+            'children',
+            {_key: 'k5'},
+          ],
+          offset: 1,
+        },
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('distributes from a caret in a cell', async () => {
+    const editor = await createEditor()
+    const caret = {
+      anchor: {path: spanPath('c00'), offset: 1},
+      focus: {path: spanPath('c00'), offset: 1},
+    }
+    editor.send({type: 'select', at: caret})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    pasteFragment(editor, columnFragment, caret)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [pastedCell('c00', 'k2', 'k3', 'P'), cell('c01', 'B')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [pastedCell('c10', 'k4', 'k5', 'Q'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('grows rows when the fragment extends past the bottom', async () => {
+    const editor = await createEditor()
+    const caret = {
+      anchor: {path: spanPath('c10'), offset: 1},
+      focus: {path: spanPath('c10'), offset: 1},
+    }
+    editor.send({type: 'select', at: caret})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    pasteFragment(editor, columnFragment, caret)
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      const table = value(snapshot)[0]
+      expect(table?.rows).toHaveLength(3)
+      // The anchor cell receives the fragment's first cell.
+      expect(table?.rows[1]?.cells[0]?.value[0]?.children[0]?.text).toBe('P')
+      // The overflow lands in a grown row: content in the anchor column,
+      // an empty padding cell in the other.
+      expect(
+        table?.rows[2]?.cells.map(
+          (cellNode) => cellNode.value[0]?.children[0]?.text,
+        ),
+      ).toEqual(['Q', ''])
+      // Untouched cells stay untouched.
+      expect(
+        table?.rows[0]?.cells.map(
+          (cellNode) => cellNode.value[0]?.children[0]?.text,
+        ),
+      ).toEqual(['A', 'B'])
+      expect(table?.rows[1]?.cells[1]?.value[0]?.children[0]?.text).toBe('D')
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('grows columns when the fragment extends past the right edge', async () => {
+    const editor = await createEditor()
+    const caret = {
+      anchor: {path: spanPath('c01'), offset: 1},
+      focus: {path: spanPath('c01'), offset: 1},
+    }
+    editor.send({type: 'select', at: caret})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    const rowFragment = [
+      {
+        _type: 'table',
+        _key: 'x-t',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'x-r0',
+            cells: [cell('x-c0', 'P'), cell('x-c1', 'Q')],
+          },
+        ],
+      },
+    ]
+    pasteFragment(editor, rowFragment, caret)
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      const table = value(snapshot)[0]
+      // Every row reaches the grown width; the overflow column carries
+      // content in the anchor row and padding below.
+      expect(
+        table?.rows.map((row) =>
+          row.cells.map((cellNode) => cellNode.value[0]?.children[0]?.text),
+        ),
+      ).toEqual([
+        ['A', 'P', 'Q'],
+        ['C', 'D', ''],
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('cell content is validated against the schema', async () => {
+    const editor = await createEditor()
+    const caret = {
+      anchor: {path: spanPath('c00'), offset: 1},
+      focus: {path: spanPath('c00'), offset: 1},
+    }
+    editor.send({type: 'select', at: caret})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    const rogueFragment = [
+      {
+        _type: 'table',
+        _key: 'x-t',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'x-r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'x-c0',
+                value: [
+                  {_type: 'malicious', _key: 'x-m0', payload: 'boom'},
+                  ...cell('x-c0', 'P').value,
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    pasteFragment(editor, rogueFragment, caret)
+
+    await vi.waitFor(() => {
+      const snapshot = editor.getSnapshot()
+      // The schema-unknown block never reaches the document.
+      expect(JSON.stringify(snapshot.context.value)).not.toContain('malicious')
+      expect(JSON.stringify(snapshot.context.value)).not.toContain('boom')
+    })
+  })
+
+  test('a larger target rectangle only provides the anchor', async () => {
+    const editor = await createEditor()
+    const wholeTable = {
+      anchor: {path: spanPath('c00'), offset: 0},
+      focus: {path: spanPath('c11'), offset: 1},
+    }
+    editor.send({type: 'select', at: wholeTable})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    const singleCellFragment = [
+      {
+        _type: 'table',
+        _key: 'x-t',
+        rows: [{_type: 'row', _key: 'x-r0', cells: [cell('x-c0', 'P')]}],
+      },
+    ]
+    pasteFragment(editor, singleCellFragment, wholeTable)
+
+    await vi.waitFor(() => {
+      // Only the anchor cell receives content; the extra target cells stay
+      // untouched instead of clearing.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [pastedCell('c00', 'k2', 'k3', 'P'), cell('c01', 'B')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ])
+    })
+  })
+})

--- a/packages/plugin-table/src/behaviors/paste.ts
+++ b/packages/plugin-table/src/behaviors/paste.ts
@@ -1,0 +1,527 @@
+import type {
+  EditorSelection,
+  EditorSelectionPoint,
+  EditorSnapshot,
+  Path,
+  PortableTextBlock,
+} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {isSelectionCollapsed} from '@portabletext/editor/selectors'
+import {getPathSubSchema} from '@portabletext/editor/traversal'
+import {getTableSelection} from '../get-table-selection'
+import {resolveCell} from '../resolve-cell'
+import {
+  isTable,
+  type Cell,
+  type ColumnAlignment,
+  type Row,
+  type Table,
+} from './types'
+
+type CellReplacement = {
+  cellPath: Path
+  originalBlockKeys: Array<string>
+  blocks: Array<PortableTextBlock>
+}
+
+type CellAppend = {
+  afterCellPath: Path
+  cell: Cell
+}
+
+type RowAppend = {
+  afterRowPath: Path
+  row: Row
+}
+
+type Distribution = {
+  replacements: Array<CellReplacement>
+  cellAppends: Array<CellAppend>
+  rowAppends: Array<RowAppend>
+  grownAlignment: Array<ColumnAlignment> | undefined
+  tablePath: Path
+  selection: NonNullable<EditorSelection>
+}
+
+/**
+ * Pasting a table fragment into a table distributes it cell-per-cell from
+ * the anchor (the target rectangle's top-left, or the caret's cell), the
+ * spreadsheet convention, instead of dropping the whole fragment into one
+ * cell. A larger target rectangle only provides the anchor; a fragment
+ * extending past the table's edges grows rows and columns, padding
+ * off-fragment positions with empty cells. Non-table fragments fall through
+ * to the editor's paste handling, which replaces the rectangle through the
+ * `delete` decomposition.
+ */
+export const pasteBehaviors = [
+  defineBehavior<Record<string, never>, 'clipboard.paste', Distribution>({
+    on: 'clipboard.paste',
+    guard: ({snapshot, event}) => {
+      const fragment = tableFragment(snapshot, event.originEvent.dataTransfer)
+      if (!fragment) {
+        return false
+      }
+      const anchor = resolveAnchorCell(snapshot)
+      if (!anchor) {
+        return false
+      }
+      return planDistribution(snapshot, fragment, anchor)
+    },
+    actions: [
+      (
+        _,
+        {
+          replacements,
+          cellAppends,
+          rowAppends,
+          grownAlignment,
+          tablePath,
+          selection,
+        },
+      ) => [
+        ...cellAppends.map((append) =>
+          raise({
+            type: 'insert' as const,
+            at: append.afterCellPath,
+            value: append.cell,
+            position: 'after' as const,
+          }),
+        ),
+        ...rowAppends.map((append) =>
+          raise({
+            type: 'insert' as const,
+            at: append.afterRowPath,
+            value: append.row,
+            position: 'after' as const,
+          }),
+        ),
+        ...replacements.flatMap((replacement) => {
+          const lastOriginalKey =
+            replacement.originalBlockKeys[
+              replacement.originalBlockKeys.length - 1
+            ]
+          if (lastOriginalKey === undefined) {
+            return []
+          }
+          return [
+            ...replacement.blocks.map((block, index) =>
+              raise({
+                type: 'insert' as const,
+                at: [
+                  ...replacement.cellPath,
+                  'value',
+                  {
+                    _key:
+                      index === 0
+                        ? lastOriginalKey
+                        : (replacement.blocks[index - 1]?._key as string),
+                  },
+                ],
+                value: block,
+                position: 'after' as const,
+              }),
+            ),
+            ...replacement.originalBlockKeys.map((blockKey) =>
+              raise({
+                type: 'unset' as const,
+                at: [...replacement.cellPath, 'value', {_key: blockKey}],
+              }),
+            ),
+          ]
+        }),
+        ...(grownAlignment
+          ? [
+              raise({
+                type: 'block.set' as const,
+                at: tablePath,
+                props: {alignment: grownAlignment},
+              }),
+            ]
+          : []),
+        raise({type: 'select', at: selection}),
+      ],
+    ],
+  }),
+]
+
+function planDistribution(
+  snapshot: EditorSnapshot,
+  fragment: Table,
+  anchor: {table: Table; tablePath: Path; rowIndex: number; colIndex: number},
+): Distribution | false {
+  const keyGenerator = snapshot.context.keyGenerator
+  const fragmentColCount = Math.max(
+    ...fragment.rows.map((row) => row.cells.length),
+  )
+  const tableColCount = Math.max(
+    ...anchor.table.rows.map((row) => row.cells.length),
+  )
+  const grownColCount = Math.max(
+    tableColCount,
+    anchor.colIndex + fragmentColCount,
+  )
+  const grownRowCount = Math.max(
+    anchor.table.rows.length,
+    anchor.rowIndex + fragment.rows.length,
+  )
+
+  // The deserializing converter is deliberately lenient (`validateFields:
+  // false`), and the distribution applies content through raw `insert`
+  // primitives, so the plugin is the last line of defense: only block types
+  // the cell's sub-schema declares may land in a cell.
+  const firstRow = anchor.table.rows[0]
+  const firstCell = firstRow?.cells[0]
+  if (!firstRow || !firstCell) {
+    return false
+  }
+  const cellSchema = getPathSubSchema(
+    snapshot,
+    cellPathFor(anchor.tablePath, firstRow._key, firstCell._key),
+  )
+  const allowedTypes = new Set([
+    cellSchema.block.name,
+    ...cellSchema.blockObjects.map((blockObject) => blockObject.name),
+  ])
+
+  const contentAt = (rowIndex: number, colIndex: number) => {
+    const fragmentCell =
+      fragment.rows[rowIndex - anchor.rowIndex]?.cells[
+        colIndex - anchor.colIndex
+      ]
+    if (!fragmentCell) {
+      return undefined
+    }
+    const blocks = fragmentCell.value.filter((block) =>
+      allowedTypes.has(block._type),
+    )
+    return blocks.length > 0 ? {...fragmentCell, value: blocks} : undefined
+  }
+
+  const replacements: Array<CellReplacement> = []
+  const cellAppends: Array<CellAppend> = []
+  const rowAppends: Array<RowAppend> = []
+  const contentTargets: Array<{
+    cellPath: Path
+    blocks: Array<PortableTextBlock>
+  }> = []
+
+  const buildCell = (fragmentCell: Cell | undefined): Cell => ({
+    _type: 'cell',
+    _key: keyGenerator(),
+    value: fragmentCell
+      ? rekeyBlocks(keyGenerator, fragmentCell.value)
+      : [emptyBlock(keyGenerator)],
+  })
+
+  let previousRowKey = anchor.table.rows[anchor.table.rows.length - 1]?._key
+  if (previousRowKey === undefined) {
+    return false
+  }
+
+  for (let rowIndex = 0; rowIndex < grownRowCount; rowIndex++) {
+    const existingRow = anchor.table.rows[rowIndex]
+
+    if (!existingRow) {
+      const row: Row = {
+        _type: 'row',
+        _key: keyGenerator(),
+        cells: [],
+      }
+      for (let colIndex = 0; colIndex < grownColCount; colIndex++) {
+        const fragmentCell = contentAt(rowIndex, colIndex)
+        const cellNode = buildCell(fragmentCell)
+        row.cells.push(cellNode)
+        if (fragmentCell) {
+          contentTargets.push({
+            cellPath: cellPathFor(anchor.tablePath, row._key, cellNode._key),
+            blocks: cellNode.value as Array<PortableTextBlock>,
+          })
+        }
+      }
+      rowAppends.push({
+        afterRowPath: [...anchor.tablePath, 'rows', {_key: previousRowKey}],
+        row,
+      })
+      previousRowKey = row._key
+      continue
+    }
+
+    let previousCellKey = existingRow.cells[existingRow.cells.length - 1]?._key
+    for (let colIndex = 0; colIndex < grownColCount; colIndex++) {
+      const fragmentCell = contentAt(rowIndex, colIndex)
+      const existingCell = existingRow.cells[colIndex]
+
+      if (existingCell) {
+        if (fragmentCell) {
+          const blocks = rekeyBlocks(keyGenerator, fragmentCell.value)
+          const cellPath = cellPathFor(
+            anchor.tablePath,
+            existingRow._key,
+            existingCell._key,
+          )
+          replacements.push({
+            cellPath,
+            originalBlockKeys: existingCell.value.map((block) => block._key),
+            blocks,
+          })
+          contentTargets.push({cellPath, blocks})
+        }
+        continue
+      }
+
+      // Column growth: the row is shorter than the grown width. Padding
+      // keeps the grid rectangular where the fragment has no content.
+      if (previousCellKey === undefined) {
+        return false
+      }
+      const cellNode = buildCell(fragmentCell)
+      cellAppends.push({
+        afterCellPath: [
+          ...anchor.tablePath,
+          'rows',
+          {_key: existingRow._key},
+          'cells',
+          {_key: previousCellKey},
+        ],
+        cell: cellNode,
+      })
+      previousCellKey = cellNode._key
+      if (fragmentCell) {
+        contentTargets.push({
+          cellPath: cellPathFor(
+            anchor.tablePath,
+            existingRow._key,
+            cellNode._key,
+          ),
+          blocks: cellNode.value as Array<PortableTextBlock>,
+        })
+      }
+    }
+  }
+
+  const selection = pastedSelection(contentTargets)
+  if (!selection) {
+    return false
+  }
+
+  const grownAlignment =
+    grownColCount > tableColCount && anchor.table.alignment
+      ? [
+          ...anchor.table.alignment,
+          ...Array<ColumnAlignment>(grownColCount - tableColCount).fill(null),
+        ]
+      : undefined
+
+  return {
+    replacements,
+    cellAppends,
+    rowAppends,
+    grownAlignment,
+    tablePath: anchor.tablePath,
+    selection,
+  }
+}
+
+function cellPathFor(tablePath: Path, rowKey: string, cellKey: string): Path {
+  return [...tablePath, 'rows', {_key: rowKey}, 'cells', {_key: cellKey}]
+}
+
+function emptyBlock(keyGenerator: () => string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: keyGenerator(),
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: keyGenerator(), text: '', marks: []}],
+  }
+}
+
+/**
+ * The single table block in the clipboard's Portable Text data, or
+ * `undefined` when the clipboard carries anything else. The data goes
+ * through the same converter the editor's own paste uses, which validates
+ * the fragment against this editor's schema, down into the cells' blocks.
+ * The parser preserves existing keys, so re-keying stays a separate step.
+ */
+function tableFragment(
+  snapshot: EditorSnapshot,
+  dataTransfer: DataTransfer,
+): Table | undefined {
+  const data = dataTransfer.getData('application/x-portable-text')
+  if (!data) {
+    return undefined
+  }
+  const converter = snapshot.context.converters.find(
+    (candidate) => candidate.mimeType === 'application/x-portable-text',
+  )
+  if (!converter) {
+    return undefined
+  }
+  const result = converter.deserialize({
+    snapshot,
+    event: {type: 'deserialize', data},
+  })
+  if (result.type !== 'deserialization.success') {
+    return undefined
+  }
+  const blocks = result.data
+  if (!Array.isArray(blocks) || blocks.length !== 1) {
+    return undefined
+  }
+  const block = blocks[0]
+  if (!isTable(block)) {
+    return undefined
+  }
+  const wellFormed =
+    block.rows.length > 0 &&
+    block.rows.every(
+      (row) =>
+        Array.isArray(row.cells) &&
+        row.cells.length > 0 &&
+        row.cells.every((cellNode) => Array.isArray(cellNode.value)),
+    )
+  return wellFormed ? block : undefined
+}
+
+/**
+ * The cell the distribution starts from: the target rectangle's top-left,
+ * or the caret's cell.
+ */
+function resolveAnchorCell(snapshot: EditorSnapshot):
+  | {
+      table: Table
+      tablePath: Path
+      rowIndex: number
+      colIndex: number
+    }
+  | undefined {
+  const tableSelection = getTableSelection(snapshot)
+  if (tableSelection) {
+    const anchorCell = resolveCell(
+      snapshot,
+      snapshot.context.selection?.anchor.path ?? [],
+    )
+    if (!anchorCell) {
+      return undefined
+    }
+    return {
+      table: anchorCell.table.node,
+      tablePath: anchorCell.table.path,
+      rowIndex: tableSelection.rowRange[0],
+      colIndex: tableSelection.colRange[0],
+    }
+  }
+
+  if (!isSelectionCollapsed(snapshot)) {
+    return undefined
+  }
+  const caretCell = resolveCell(
+    snapshot,
+    snapshot.context.selection?.focus.path ?? [],
+  )
+  if (!caretCell) {
+    return undefined
+  }
+  const rowIndex = caretCell.table.node.rows.findIndex(
+    (row) => row._key === caretCell.row.node._key,
+  )
+  const colIndex = caretCell.row.node.cells.findIndex(
+    (cellNode) => cellNode._key === caretCell.cell.node._key,
+  )
+  if (rowIndex === -1 || colIndex === -1) {
+    return undefined
+  }
+  return {
+    table: caretCell.table.node,
+    tablePath: caretCell.table.path,
+    rowIndex,
+    colIndex,
+  }
+}
+
+/**
+ * Deep-copy blocks with fresh keys, remapping span marks that reference
+ * re-keyed markDefs. Pasting a column next to itself must not duplicate
+ * keys; the deserializing parser preserves keys, so this cannot be
+ * delegated to it.
+ */
+function rekeyBlocks(
+  keyGenerator: () => string,
+  blocks: Array<PortableTextBlock>,
+): Array<PortableTextBlock> {
+  return blocks.map((block) => {
+    const blockKey = keyGenerator()
+    if (!Array.isArray(block.children)) {
+      return {...block, _key: blockKey}
+    }
+    const markDefKeys = new Map<string, string>()
+    const markDefs = (Array.isArray(block.markDefs) ? block.markDefs : []).map(
+      (markDef: {_key: string}) => {
+        const markDefKey = keyGenerator()
+        markDefKeys.set(markDef._key, markDefKey)
+        return {...markDef, _key: markDefKey}
+      },
+    )
+    const children = block.children.map((child) => ({
+      ...child,
+      _key: keyGenerator(),
+      ...(Array.isArray(child.marks)
+        ? {
+            marks: child.marks.map(
+              (mark: string) => markDefKeys.get(mark) ?? mark,
+            ),
+          }
+        : {}),
+    }))
+    return {...block, _key: blockKey, markDefs, children}
+  })
+}
+
+/** An expanded selection spanning the pasted cells leaf-to-leaf. */
+function pastedSelection(
+  targets: Array<{cellPath: Path; blocks: Array<PortableTextBlock>}>,
+): NonNullable<EditorSelection> | undefined {
+  const first = targets.find((target) => target.blocks.length > 0)
+  const last = [...targets].reverse().find((target) => target.blocks.length > 0)
+  if (!first || !last) {
+    return undefined
+  }
+  const anchor = blockEdgePoint(
+    first.cellPath,
+    first.blocks[0] as PortableTextBlock,
+    'start',
+  )
+  const focus = blockEdgePoint(
+    last.cellPath,
+    last.blocks[last.blocks.length - 1] as PortableTextBlock,
+    'end',
+  )
+  if (!anchor || !focus) {
+    return undefined
+  }
+  return {anchor, focus}
+}
+
+function blockEdgePoint(
+  cellPath: Path,
+  block: PortableTextBlock,
+  edge: 'start' | 'end',
+): EditorSelectionPoint | undefined {
+  const blockPath = [...cellPath, 'value', {_key: block._key}]
+  if (!Array.isArray(block.children) || block.children.length === 0) {
+    return {path: blockPath, offset: 0}
+  }
+  const child =
+    edge === 'start'
+      ? block.children[0]
+      : block.children[block.children.length - 1]
+  if (!child) {
+    return undefined
+  }
+  const offset =
+    edge === 'end' && typeof child.text === 'string' ? child.text.length : 0
+  return {
+    path: [...blockPath, 'children', {_key: child._key}],
+    offset,
+  }
+}

--- a/packages/plugin-table/src/plugin.table.tsx
+++ b/packages/plugin-table/src/plugin.table.tsx
@@ -5,6 +5,7 @@ import {formatBehaviors} from './behaviors/format'
 import {insertBehaviors} from './behaviors/insert'
 import {moveBehaviors} from './behaviors/move'
 import {navBehaviors} from './behaviors/nav'
+import {pasteBehaviors} from './behaviors/paste'
 import {serializeBehaviors} from './behaviors/serialize'
 import {unsetBehaviors} from './behaviors/unset'
 
@@ -74,4 +75,5 @@ export const tableBehaviors = [
   ...navBehaviors,
   ...formatBehaviors,
   ...serializeBehaviors,
+  ...pasteBehaviors,
 ]


### PR DESCRIPTION
Copy a column, select another column, paste: the copied cells should land in the target cells, one per cell, the way every spreadsheet and Docs-style editor behaves. Until now the fragment dropped wholesale into the top-left cell, which is not even schema-legal as a nested table, so what actually landed there was an accident of deserialization.

The enabling half shipped in #2903: the clipboard now carries a rectangle-only table as `application/x-portable-text`, so the paste side can detect a tabular fragment losslessly and knows its exact shape. This PR adds the applying half. The interception sits on `clipboard.paste`, deliberately before core's expanded-selection `delete` decomposition, because the target rectangle must survive to define the distribution; plugin-before-abstract ordering provides that. Detection is not name-sniffing alone: the clipboard data goes through the same `application/x-portable-text` converter the editor's own paste uses, validating the fragment against this editor's schema down into the cells' blocks, and the parsed result must be a single canonical table (rows of cells of block arrays, which is also what rejects differently-shaped `table` types from other ecosystems). Everything else falls through untouched, so non-table content over a rectangle keeps the replace-rectangle behavior pinned in #2903.

Two hardening layers cover what the converter cannot: the parser preserves existing keys (a red test caught this assumption), so every pasted block is re-keyed with markDef references remapped, and since the converter is deliberately lenient (`validateFields: false`) while distribution applies content through raw `insert` primitives, cell content is filtered against the cell's own sub-schema, block types the cell does not declare never reach the document, pinned by a rogue-fragment test that smuggles an unknown block type inside a cell.

Distribution semantics, each pinned by its own test: the anchor is the target rectangle's top-left or the caret's cell (copy a column, click a cell, paste works too); a larger target rectangle only provides the anchor, its extra cells stay untouched instead of clearing (the Excel non-divisible rule, tiling deliberately out of scope); a fragment extending past the table's edges grows rows and columns with fully-constructed nodes, off-fragment positions padded with empty cells and the positional `alignment` array extended with `null`s (growth over clipping is the Sheets rule, silent data loss is worse than a bigger table). Growth nodes go through the raw `insert` primitive, which preserves provided keys, the same property the move behaviors rely on.

Every pasted block is re-keyed with markDef references remapped, so pasting a column next to itself cannot duplicate keys. All raises form one undo step, and the pasted rectangle becomes the selection, which the cell-selection visuals then light up, the spreadsheet feel end-to-end.

Stacked on #2903 (consumes the fragment shape it defines); retargets when the stack merges.
