### PR TITLE
feat: address `serialize` events with `at` and `fragment`

### DIFF
--- a/.changeset/serialize-at-and-fragment.md
+++ b/.changeset/serialize-at-and-fragment.md
@@ -1,0 +1,23 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: address `serialize` events with `at` and `fragment`
+
+`serialize` and `serialize.data` gain two optional fields naming the serialization subject: `at` serializes a different range of the document (the same addressing convention as the other synthetic events), and `fragment` serializes different content entirely, with the range defaulting to the fragment's full span. A behavior can re-raise a serialize event with a corrected subject and let the rest of the pipeline, including custom converters, handle it:
+
+```ts
+defineBehavior({
+  on: 'serialize',
+  guard: ({snapshot, event}) => {
+    if (event.fragment) {
+      return false
+    }
+    const table = sliceToRectangle(snapshot)
+    return table ? {fragment: [table]} : false
+  },
+  actions: [({event}, {fragment}) => [raise({...event, fragment})]],
+})
+```
+
+Converters are unchanged: the subject is resolved into the snapshot they receive, so they keep reading `snapshot.context.value` and `snapshot.context.selection` as before.

--- a/packages/editor/src/behaviors/behavior.abstract.serialize.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.serialize.ts
@@ -1,3 +1,8 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import type {EditorSchema} from '../editor/editor-schema'
+import type {EditorSelection} from '../types/editor'
+import {getBlockEndPoint} from '../utils/util.get-block-end-point'
+import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
@@ -10,26 +15,36 @@ export const abstractSerializeBehaviors = [
           type: 'serialize.data',
           mimeType: 'application/x-portable-text',
           originEvent: event.originEvent,
+          at: event.at,
+          fragment: event.fragment,
         }),
         raise({
           type: 'serialize.data',
           mimeType: 'application/json',
           originEvent: event.originEvent,
+          at: event.at,
+          fragment: event.fragment,
         }),
         raise({
           type: 'serialize.data',
           mimeType: 'text/markdown',
           originEvent: event.originEvent,
+          at: event.at,
+          fragment: event.fragment,
         }),
         raise({
           type: 'serialize.data',
           mimeType: 'text/html',
           originEvent: event.originEvent,
+          at: event.at,
+          fragment: event.fragment,
         }),
         raise({
           type: 'serialize.data',
           mimeType: 'text/plain',
           originEvent: event.originEvent,
+          at: event.at,
+          fragment: event.fragment,
         }),
       ],
     ],
@@ -45,18 +60,22 @@ export const abstractSerializeBehaviors = [
         return false
       }
 
-      // Drag origins carry the grabbed selection on the originating event;
-      // the drag pipeline does not update `snapshot.context.selection` on
-      // dragstart, so override the snapshot here so converters see the
-      // grabbed unit through plain `snapshot.context.selection` reads.
+      // `fragment` and `at` name the serialization subject: which content
+      // and which range of it. Resolve them into the snapshot so converters
+      // see the subject through plain `snapshot.context` reads. With a
+      // `fragment` but no `at`, the range defaults to the fragment's full
+      // span.
+      const value = event.fragment ?? snapshot.context.value
+      const selection =
+        event.at ??
+        (event.fragment
+          ? fullSpan(snapshot, event.fragment)
+          : snapshot.context.selection)
       const snapshotForConverter =
-        event.originEvent.type === 'drag.dragstart'
+        event.fragment || event.at
           ? {
               ...snapshot,
-              context: {
-                ...snapshot.context,
-                selection: event.originEvent.position.selection,
-              },
+              context: {...snapshot.context, value, selection},
             }
           : snapshot
 
@@ -109,3 +128,30 @@ export const abstractSerializeBehaviors = [
     ],
   }),
 ]
+
+/**
+ * A selection spanning the whole fragment, from the start of its first
+ * block to the end of its last. The block points descend into containers,
+ * so a table fragment spans its first cell's first leaf to its last cell's
+ * last leaf.
+ */
+function fullSpan(
+  snapshot: {context: {schema: EditorSchema}},
+  fragment: Array<PortableTextBlock>,
+): EditorSelection {
+  const firstBlock = fragment[0]
+  const lastBlock = fragment[fragment.length - 1]
+  if (!firstBlock || !lastBlock) {
+    return null
+  }
+  return {
+    anchor: getBlockStartPoint({
+      context: snapshot.context,
+      block: {node: firstBlock, path: [{_key: firstBlock._key}]},
+    }),
+    focus: getBlockEndPoint({
+      context: snapshot.context,
+      block: {node: lastBlock, path: [{_key: lastBlock._key}]},
+    }),
+  }
+}

--- a/packages/editor/src/behaviors/behavior.abstract.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.ts
@@ -71,6 +71,10 @@ export const abstractBehaviors = [
         raise({
           type: 'serialize',
           originEvent: event,
+          // The drag pipeline does not update `snapshot.context.selection`
+          // on dragstart; the grabbed selection travels as the
+          // serialization range instead.
+          at: event.position.selection,
         }),
       ],
     ],

--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -456,6 +456,16 @@ type AbstractBehaviorEvent =
         'type',
         'clipboard.copy' | 'clipboard.cut' | 'drag.dragstart'
       >
+      /**
+       * Serialize this range instead of the current selection. When a
+       * `fragment` is present, the paths address the fragment and default
+       * to its full span.
+       */
+      at?: NonNullable<EditorSelection>
+      /**
+       * Serialize this content instead of the document.
+       */
+      fragment?: Array<PortableTextBlock>
     }
   | {
       type: StrictExtract<SyntheticBehaviorEventType, 'serialize.data'>
@@ -465,6 +475,16 @@ type AbstractBehaviorEvent =
         'type',
         'clipboard.copy' | 'clipboard.cut' | 'drag.dragstart'
       >
+      /**
+       * Serialize this range instead of the current selection. When a
+       * `fragment` is present, the paths address the fragment and default
+       * to its full span.
+       */
+      at?: NonNullable<EditorSelection>
+      /**
+       * Serialize this content instead of the document.
+       */
+      fragment?: Array<PortableTextBlock>
     }
   | {
       type: StrictExtract<SyntheticBehaviorEventType, 'deserialization.success'>

--- a/packages/editor/tests/event.serialize.test.tsx
+++ b/packages/editor/tests/event.serialize.test.tsx
@@ -1,0 +1,134 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {raise} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {safeParse} from '../src/internal-utils/safe-json'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {createTestEditor} from '../src/test/vitest'
+
+const fragmentBlock = {
+  _type: 'block',
+  _key: 'f0',
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: 'fs0', text: 'FRAG', marks: []}],
+}
+
+/**
+ * Re-raises copies with a `fragment` override whose content exists nowhere
+ * in the document, the way the table plugin re-raises rectangle copies with
+ * a sliced table. No `at` is given: the range defaults to the fragment's
+ * full span.
+ */
+const copyFragmentInstead = defineBehavior({
+  on: 'serialize',
+  guard: ({event}) => event.fragment === undefined,
+  actions: [
+    ({event}) => [
+      raise({
+        ...event,
+        fragment: [fragmentBlock],
+      }),
+    ],
+  ],
+})
+
+/**
+ * Re-raises copies with an `at` override: a different range of the same
+ * document, the way drag serialization carries the grabbed selection.
+ */
+const copyMiddleCharacterInstead = defineBehavior({
+  on: 'serialize',
+  guard: ({event}) => event.at === undefined,
+  actions: [
+    ({event}) => [
+      raise({
+        ...event,
+        at: {
+          anchor: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 1},
+          focus: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 2},
+        },
+      }),
+    ],
+  ],
+})
+
+describe('event.serialize', () => {
+  test('Scenario: an at override serializes that range, not the selection', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'd0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'ds0', text: 'DOC', marks: []}],
+        },
+      ],
+      children: <BehaviorPlugin behaviors={[copyMiddleCharacterInstead]} />,
+    })
+
+    const documentSelection = {
+      anchor: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 0},
+      focus: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 3},
+    }
+    editor.send({type: 'select', at: documentSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(3)
+    })
+
+    const dataTransfer = new DataTransfer()
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer},
+      position: {selection: documentSelection},
+    })
+
+    await vi.waitFor(() => {
+      expect(dataTransfer.getData('text/plain')).toBe('O')
+    })
+  })
+
+  test('Scenario: a fragment override serializes the fragment, not the document', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'd0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'ds0', text: 'DOC', marks: []}],
+        },
+      ],
+      children: <BehaviorPlugin behaviors={[copyFragmentInstead]} />,
+    })
+
+    const documentSelection = {
+      anchor: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 0},
+      focus: {path: [{_key: 'd0'}, 'children', {_key: 'ds0'}], offset: 3},
+    }
+    editor.send({type: 'select', at: documentSelection})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(3)
+    })
+
+    const dataTransfer = new DataTransfer()
+    editor.send({
+      type: 'clipboard.copy',
+      originEvent: {dataTransfer},
+      position: {selection: documentSelection},
+    })
+
+    await vi.waitFor(() => {
+      expect(
+        safeParse(dataTransfer.getData('application/x-portable-text')),
+      ).toEqual([fragmentBlock])
+      expect(dataTransfer.getData('text/plain')).toBe('FRAG')
+    })
+  })
+})


### PR DESCRIPTION
The serialize family had no addressing concept: `serialize` and `serialize.data` always serialize the live selection, so anything that needs to serialize different content has to work around the events rather than through them. Core itself is the first offender: the abstract `serialize.data` behavior pattern-matches `drag.dragstart` origins and doctors the snapshot with the grabbed selection before calling converters, a special case that exists precisely because the event cannot carry its subject. The table plugin's rectangle copy (#2903) generalized that workaround, calling converters directly from its guard with a doctored snapshot, which makes its interception a terminal handler: the rectangle never exists as an observable event, so an app's own serialize behaviors either never see rectangle copies or, if registered first, serialize the wrong cells.

Both events now carry the serialization subject along its two independent axes, each optional and each meaningful alone. `at` serializes a different range of the document, reusing the addressing convention every other synthetic event already has; drag serialization moves onto it, and the origin-type pattern-match in `serialize.data` is deleted, so the diff removes a hack while adding the API. `fragment` serializes different content entirely, standalone blocks whose range defaults to the fragment's full span (the block edge points descend into containers, so a table fragment spans its first cell's first leaf to its last cell's last leaf). An earlier iteration shipped one required pair, `fragment: {value, selection}`; review found that shape to be the table plugin's own mechanics leaking into the API: drag only needs a range, content overrides only need blocks, and nobody needs to hand-compute leaf paths into their own synthetic value. The decomposition fell out of asking what each consumer actually holds.

The abstract `serialize.data` behavior resolves both fields into the snapshot it hands converters (`value = fragment ?? context.value`, `selection = at ?? fullSpan(fragment) ?? context.selection`). Converters change zero, they keep reading `snapshot.context.value` and `snapshot.context.selection` exactly as before. Interceptors become re-addressers instead of terminal handlers, subject-presence is the loop guard:

```ts
defineBehavior({
  on: 'serialize',
  guard: ({snapshot, event}) => {
    if (event.fragment) {
      return false
    }
    const table = sliceToRectangle(snapshot)
    return table ? {fragment: [table]} : false
  },
  actions: [({event}, {fragment}) => [raise({...event, fragment})]],
})
```

On honesty about consumers: the `at` axis has a non-table consumer today, drag itself. The `fragment` axis has exactly one consumer today, the table plugin; its justification is structural rather than a consumer list, without a content override, any plugin whose copyable unit is not expressible as a selection is forced back into terminal handlers, which is the composition failure this PR exists to prevent.

`tests/event.serialize.test.tsx` pins each axis separately: an `at` re-raise puts the addressed range on the clipboard, and a bare `fragment` re-raise (no `at`) serializes content that exists nowhere in the document, full-span by default. The dragstart unification is pinned by the existing drag serialization tests passing unchanged. Full suite: 1695 chromium tests plus the unit project, lint/types/knip/format green.

#2903 stacks on this: its interception collapses to the re-raise above.
