### PR TITLE
fix: push the canonical caret back when the browser parks it on an element

### DIFF
--- a/.changeset/canonicalize-degenerate-carets.md
+++ b/.changeset/canonicalize-degenerate-carets.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: push the canonical caret back when the browser parks it on an element
+
+Clicking the whitespace around a container (a table's gutter, the editable's padding) could leave the blinking caret rendered in that whitespace, a position the document model cannot express, even though the editor's selection pointed at real content. The selection sync now pushes the canonical DOM range back whenever the browser parks a collapsed caret on an element, so the visible caret always sits where the selection actually is.

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -311,6 +311,33 @@ export const Editable = forwardRef(
                   // Suppress browser selection normalization that would
                   // overwrite a block object selection.
                   editor.select(range)
+
+                  if (
+                    domSelection.isCollapsed &&
+                    anchorNode &&
+                    anchorNode.nodeType === Node.ELEMENT_NODE
+                  ) {
+                    // A collapsed caret parked on an element renders in
+                    // whitespace the model cannot express (a table's gutter,
+                    // the editable's padding). When the model already holds
+                    // the position the parked point normalizes to, `select`
+                    // is a no-op and nothing corrects the DOM, so push the
+                    // canonical range back. The pushed range anchors on a
+                    // text node, so this cannot re-enter itself.
+                    try {
+                      const canonicalRange = DOMEditor.toDOMRange(editor, range)
+                      domSelection.setBaseAndExtent(
+                        canonicalRange.startContainer,
+                        canonicalRange.startOffset,
+                        canonicalRange.startContainer,
+                        canonicalRange.startOffset,
+                      )
+                    } catch {
+                      // The canonical range may not be representable in the
+                      // DOM yet (a render is pending); the next sync gets
+                      // another chance.
+                    }
+                  }
                 } else {
                   androidInputManager?.handleUserSelect(range)
                 }

--- a/packages/editor/tests/selection-degenerate-caret.test.tsx
+++ b/packages/editor/tests/selection-degenerate-caret.test.tsx
@@ -1,0 +1,153 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * A click in the whitespace around a container (a table's gutter, the
+ * editable's padding) can make the browser park a collapsed DOM caret on an
+ * element instead of in text. The model normalizes the synced selection to
+ * a leaf, but nothing corrected the DOM caret, so it kept rendering in the
+ * whitespace, a caret the document model does not contain. The sync must
+ * push the canonical position back to the DOM.
+ */
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const containers = [defineContainer({type: 'callout', arrayField: 'content'})]
+
+const initialValue = [
+  {
+    _type: 'callout',
+    _key: 'c0',
+    content: [
+      {
+        _type: 'block',
+        _key: 'cb0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'cs0', text: 'AA', marks: []}],
+      },
+    ],
+  },
+]
+
+describe('degenerate collapsed DOM carets', () => {
+  test('the caret is canonicalized even when the model selection does not change', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={containers} />,
+    })
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    const editable = document.querySelector('[contenteditable="true"]')
+    const container = editable?.querySelector('[data-pt-block="container"]')
+    if (!container) {
+      throw new Error('container not rendered')
+    }
+
+    // Park the model exactly where the element-level point will normalize
+    // to, so the sync below is a no-op on the model side.
+    const leafPoint = {
+      path: [{_key: 'c0'}, 'content', {_key: 'cb0'}, 'children', {_key: 'cs0'}],
+      offset: 0,
+    }
+    editor.send({type: 'focus'})
+    editor.send({type: 'select', at: {anchor: leafPoint, focus: leafPoint}})
+    await vi.waitFor(() => {
+      const selection = window.getSelection()
+      expect(selection?.anchorNode?.nodeType).toBe(Node.TEXT_NODE)
+    })
+
+    // The browser's caret resolution for a click in surrounding whitespace:
+    // a collapsed element-level point on the container. The model already
+    // holds the position it normalizes to, so without canonicalization the
+    // parked caret survives and renders in the whitespace.
+    window.getSelection()?.collapse(container, 0)
+
+    await vi.waitFor(() => {
+      const selection = window.getSelection()
+      expect(selection?.isCollapsed).toBe(true)
+      expect(selection?.anchorNode?.nodeType).toBe(Node.TEXT_NODE)
+      expect(selection?.anchorNode?.textContent).toBe('AA')
+    })
+  })
+
+  test('a caret parked on a container element is pushed into its text', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={containers} />,
+    })
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+    const editable = document.querySelector('[contenteditable="true"]')
+    const container = editable?.querySelector('[data-pt-block="container"]')
+    if (!container) {
+      throw new Error('container not rendered')
+    }
+
+    // Focus and park the caret at a distinct position first, so the synced
+    // selection below provably comes from the element-level point.
+    const leafPoint = {
+      path: [{_key: 'c0'}, 'content', {_key: 'cb0'}, 'children', {_key: 'cs0'}],
+      offset: 2,
+    }
+    editor.send({type: 'focus'})
+    editor.send({type: 'select', at: {anchor: leafPoint, focus: leafPoint}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(2)
+    })
+
+    // The browser's caret resolution for a click in surrounding whitespace:
+    // a collapsed element-level point on the container.
+    const domSelection = window.getSelection()
+    domSelection?.collapse(container, 0)
+
+    await vi.waitFor(() => {
+      // The model normalizes to the container's first leaf.
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 'c0'},
+            'content',
+            {_key: 'cb0'},
+            'children',
+            {_key: 'cs0'},
+          ],
+          offset: 0,
+        },
+        backward: false,
+      })
+      // And the DOM caret follows: it sits in the text node, not on the
+      // element, so it renders inside the container instead of in the
+      // surrounding whitespace.
+      const selection = window.getSelection()
+      expect(selection?.isCollapsed).toBe(true)
+      expect(selection?.anchorNode?.nodeType).toBe(Node.TEXT_NODE)
+      expect(selection?.anchorNode?.textContent).toBe('AA')
+    })
+  })
+})


### PR DESCRIPTION
Clicking the whitespace around a table left the blinking caret floating in the gutter, a position the document model cannot even express. The field trail behind this is long: a June report of carets placeable outside table cells, an event log this week showing a top-gutter click selecting the bottom-right cell, and finally a probe isolating the exact survivor: a collapsed DOM caret parked on an element that nothing ever corrects.

The mechanism is a no-op blind spot in the selection sync. A click in surrounding whitespace makes the browser resolve a collapsed element-level DOM point (each browser with its own heuristics, some resolve to the container's document-order end). The sync normalizes the point and calls `select`, and when the model changes, the existing model-to-DOM writeback corrects the visible caret, that path was already sound. But when the parked point normalizes to the selection the model already holds, `select` is a no-op, no writeback fires, and the element-level caret survives on screen. This is also why the defect felt random: it only manifests when the click's normalization happens to coincide with the current selection.

The fix closes the blind spot at the sync itself: when the DOM selection is collapsed and anchored on an element node, push `toDOMRange` of the synced selection back to the DOM. The pushed range anchors on a text node, so the canonicalization cannot re-enter itself; it runs under the same composition and Android-input guards as the `select` it accompanies, and a `toDOMRange` that cannot yet be represented (pending render) is left for the next sync rather than fought. This is the same philosophy ProseMirror applies with its gapcursor: the editor, not the browser, owns what the caret renders in non-text geometry, PTE's version being "the caret renders where the model selection is, always".

`tests/selection-degenerate-caret.test.tsx` pins both sides: the previously-red no-op case (model already at the normalization target, caret must still move into the text node) and the model-change case, pinning the existing writeback that made the bug intermittent. Blast radius: the push only fires for collapsed element-anchored DOM selections, a shape that is never canonical (every model position maps to a text-node point), and expanded selections and text-anchored carets are untouched, so drag sweeps and ordinary typing never see it. Full suite passes unchanged: 1695 chromium tests plus the unit project, the new test green across all three browsers.
