### PR TITLE
feat(plugin-table): backspace with the whole table selected deletes the table

### DIFF
--- a/packages/plugin-table/src/behaviors/delete.test.tsx
+++ b/packages/plugin-table/src/behaviors/delete.test.tsx
@@ -472,7 +472,35 @@ describe('delete behaviors within tables', () => {
     })
   })
 
-  test('backspace over a multi-cell rectangle clears it', async () => {
+  test('backspace over a partial rectangle clears it', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <TablePlugin />,
+    })
+
+    // Left column only: an explicit delete over a partial rectangle keeps
+    // clearing; only the whole table selected deletes the table.
+    const anchor = pointInSpan('r0c0', 'r0c0b', 'r0c0s', 0)
+    const focus = pointInSpan('r1c0', 'r1c0b', 'r1c0s', 2)
+    editor.send({type: 'select', at: {anchor, focus}})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        tableWithCleared({
+          r0c0: {blockKey: 'k2', spanKey: 'k3'},
+          r1c0: {blockKey: 'k4', spanKey: 'k5'},
+        }),
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(
+        collapsedAtClearedCell('r0c0', 'k2', 'k3'),
+      )
+    })
+  })
+
+  test('backspace with the whole table selected deletes the table', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
       schemaDefinition,
@@ -486,17 +514,21 @@ describe('delete behaviors within tables', () => {
     editor.send({type: 'delete.backward', unit: 'character'})
 
     await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual(
-        tableWithCleared({
-          r0c0: {blockKey: 'k2', spanKey: 'k3'},
-          r0c1: {blockKey: 'k8', spanKey: 'k9'},
-          r1c0: {blockKey: 'k6', spanKey: 'k7'},
-          r1c1: {blockKey: 'k4', spanKey: 'k5'},
-        }),
-      )
-      expect(editor.getSnapshot().context.selection).toEqual(
-        collapsedAtClearedCell('r0c0', 'k2', 'k3'),
-      )
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+        },
+      ])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })
   })
 

--- a/packages/plugin-table/src/behaviors/delete.ts
+++ b/packages/plugin-table/src/behaviors/delete.ts
@@ -16,7 +16,14 @@ import {
 export const deleteBehaviors = [
   defineBehavior<Record<string, never>, 'delete', ResolvedTableSelection>({
     on: 'delete',
-    guard: ({snapshot}) => resolveTableSelection(snapshot) ?? false,
+    guard: ({snapshot, event}) => {
+      if (event.at) {
+        // Addressed deletes target their own range; only selection-scoped
+        // deletes clear the rectangle.
+        return false
+      }
+      return resolveTableSelection(snapshot) ?? false
+    },
     actions: [(_, resolved) => clearCellsAndCollapse(resolved)],
   }),
   defineBehavior<Record<string, never>, 'split', ResolvedTableSelection>({

--- a/packages/plugin-table/src/behaviors/delete.ts
+++ b/packages/plugin-table/src/behaviors/delete.ts
@@ -14,11 +14,39 @@ import {
  * built-in behavior is unchanged.
  */
 export const deleteBehaviors = [
+  defineBehavior<Record<string, never>, 'delete', {tablePath: Path}>({
+    on: 'delete',
+    guard: ({snapshot, event}) => {
+      if (event.direction === undefined) {
+        // Bare `delete`s come from decompositions (typing, paste, cut) that
+        // replace the rectangle's content. Only explicit delete gestures
+        // (Backspace, Delete) remove the table.
+        return false
+      }
+      const resolved = resolveTableSelection(snapshot)
+      if (!resolved) {
+        return false
+      }
+      const [rowStart, rowEnd] = resolved.tableSelection.rowRange
+      const [colStart, colEnd] = resolved.tableSelection.colRange
+      const columnCount = Math.max(
+        ...resolved.table.node.rows.map((row) => row.cells.length),
+      )
+      const wholeTable =
+        rowStart === 0 &&
+        colStart === 0 &&
+        rowEnd === resolved.table.node.rows.length - 1 &&
+        colEnd === columnCount - 1
+      return wholeTable ? {tablePath: resolved.table.path} : false
+    },
+    actions: [(_, {tablePath}) => [raise({type: 'unset', at: tablePath})]],
+  }),
   defineBehavior<Record<string, never>, 'delete', ResolvedTableSelection>({
     on: 'delete',
     guard: ({snapshot, event}) => {
       if (event.at) {
-        // Addressed deletes target their own range; only selection-scoped
+        // Addressed deletes target their own range (the whole-table
+        // removal above decomposes into one); only selection-scoped
         // deletes clear the rectangle.
         return false
       }


### PR DESCRIPTION
Selecting a whole table and hitting Backspace cleared every cell but left the empty skeleton standing, deleting the structure required the trash button. With the entire table selected, removal is the intuitive reading, it matches what every block-based editor does, and this PR makes it so, as a deliberate, narrow exception to the design log's B3 rule (keyboard clears content, structure dies by trash).

The interesting part is keeping every other rectangle contract intact, and the event payloads carry exactly the right discriminator: explicit delete gestures (`delete.backward`/`delete.forward`) re-raise `delete` with a `direction`, while the typing, paste, and cut decompositions raise bare `delete`s. So the whole-table removal guards on `direction` plus a rectangle covering all rows and columns, and raises `unset` at the table path, while typing over a fully selected table keeps replacing content into the top-left cell (that contract was already pinned and stays green untouched), and partial rectangles keep clearing on Backspace, pinned by the resharpened backspace test (now a column selection). One undo restores the table.

The first commit fixes a latent bug the red test flushed out: the rectangle clear guarded only on the snapshot selection, so any `delete` carrying an explicit `at` (core raises them when decomposing block-addressed deletions) got hijacked into clearing the rectangle whenever one was active. Addressed deletes now pass through, the same exemption every other interception in the plugin follows, this was discovered when the whole-table removal's own decomposition got eaten by the clear it was meant to bypass.

Blast radius: the new behavior fires only for direction-carrying deletes over a rectangle spanning the entire table; everything else falls through to the existing clear or to core. Full plugin suite passes: 318 tests across all three browsers.
