### PR TITLE
refactor(plugin-table): reuse editor traversal and point utils

### DIFF
--- a/packages/plugin-table/src/behaviors/nav.ts
+++ b/packages/plugin-table/src/behaviors/nav.ts
@@ -11,8 +11,13 @@ import {
   getEnclosingBlock,
   getFirstChild,
   getLastChild,
+  getSibling,
 } from '@portabletext/editor/traversal'
-import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
+import {
+  getBlockEndPoint,
+  getBlockStartPoint,
+  isEqualPaths,
+} from '@portabletext/editor/utils'
 import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
 import {cellEndPoint, cellStartPoint} from '../cell-points'
 import {resolveCell} from '../resolve-cell'
@@ -58,7 +63,9 @@ export const navBehaviors = [
         return false
       }
       const cells = getChildren(snapshot, position.row.path)
-      const nextRow = adjacentRow(snapshot, position.table, position.row, 1)
+      const nextRow = getSibling(snapshot, position.row.path, {
+        direction: 'next',
+      })
       const target =
         cells[indexOf(cells, position.cell) + 1] ??
         (nextRow && getFirstChild(snapshot, nextRow.path))
@@ -82,12 +89,9 @@ export const navBehaviors = [
       }
       const cells = getChildren(snapshot, position.row.path)
       const columnIndex = indexOf(cells, position.cell)
-      const previousRow = adjacentRow(
-        snapshot,
-        position.table,
-        position.row,
-        -1,
-      )
+      const previousRow = getSibling(snapshot, position.row.path, {
+        direction: 'previous',
+      })
       const target =
         (columnIndex > 0 ? cells[columnIndex - 1] : undefined) ??
         (previousRow && getLastChild(snapshot, previousRow.path))
@@ -113,7 +117,9 @@ export const navBehaviors = [
       if (!focusOnVisualEdge(snapshot, dom, 'last')) {
         return false
       }
-      const rowBelow = adjacentRow(snapshot, position.table, position.row, 1)
+      const rowBelow = getSibling(snapshot, position.row.path, {
+        direction: 'next',
+      })
       const target =
         rowBelow &&
         sameColumnCell(snapshot, position.cell, position.row, rowBelow)
@@ -142,7 +148,9 @@ export const navBehaviors = [
       if (!focusOnVisualEdge(snapshot, dom, 'first')) {
         return false
       }
-      const rowAbove = adjacentRow(snapshot, position.table, position.row, -1)
+      const rowAbove = getSibling(snapshot, position.row.path, {
+        direction: 'previous',
+      })
       const target =
         rowAbove &&
         sameColumnCell(snapshot, position.cell, position.row, rowAbove)
@@ -216,7 +224,7 @@ function cellEntrySelection(
     y: entryLineRect.top + entryLineRect.height / 2,
   })
   const resolved = point && resolveCell(snapshot, point.path)
-  if (!resolved || getKey(resolved.cell.path) !== getKey(cellPath)) {
+  if (!resolved || !isEqualPaths(resolved.cell.path, cellPath)) {
     return fallback
   }
   return {anchor: point, focus: point}
@@ -238,9 +246,7 @@ function focusAtCellEdge(
       ? getFirstChild(snapshot, cellPath)
       : getLastChild(snapshot, cellPath)
   return (
-    !!focusBlock &&
-    !!edgeBlock &&
-    getKey(focusBlock.path) === getKey(edgeBlock.path)
+    !!focusBlock && !!edgeBlock && isEqualPaths(focusBlock.path, edgeBlock.path)
   )
 }
 
@@ -279,26 +285,15 @@ function focusOnVisualEdge(
 }
 
 /** The row `offset` positions above (-1) or below (+1) `row` in `table`. */
-function adjacentRow(
-  snapshot: EditorSnapshot,
-  table: Entry,
-  row: Entry,
-  offset: 1 | -1,
-): Entry | undefined {
-  const rows = getChildren(snapshot, table.path)
-  const index = indexOf(rows, row) + offset
-  return index >= 0 ? rows[index] : undefined
-}
-
-/** The cell in `adjacentRow` sharing `cell`'s column, clamped to the row width. */
+/** The cell in `neighborRow` sharing `cell`'s column, clamped to the row width. */
 function sameColumnCell(
   snapshot: EditorSnapshot,
   cell: Entry,
   row: Entry,
-  adjacentRow: Entry,
+  neighborRow: Entry,
 ): Entry | undefined {
   const columnIndex = indexOf(getChildren(snapshot, row.path), cell)
-  const cells = getChildren(snapshot, adjacentRow.path)
+  const cells = getChildren(snapshot, neighborRow.path)
   return cells[Math.min(columnIndex, cells.length - 1)]
 }
 
@@ -312,17 +307,9 @@ function withinBand(rect: DOMRect, compareRect: DOMRect): boolean {
   return rect.top <= middle && rect.bottom >= middle
 }
 
-/** The index of `entry` among `entries`, matched by keyed path segment. */
+/** The index of `entry` among `entries`. */
 function indexOf(entries: Array<Entry>, entry: Entry): number {
-  return entries.findIndex(
-    (candidate) => getKey(candidate.path) === getKey(entry.path),
+  return entries.findIndex((candidate) =>
+    isEqualPaths(candidate.path, entry.path),
   )
-}
-
-/** The `_key` of a path's last keyed segment. */
-function getKey(path: Path): string | undefined {
-  const segment = path.at(-1)
-  return typeof segment === 'object' && segment !== null && '_key' in segment
-    ? segment._key
-    : undefined
 }

--- a/packages/plugin-table/src/behaviors/paste.ts
+++ b/packages/plugin-table/src/behaviors/paste.ts
@@ -1,6 +1,5 @@
 import type {
   EditorSelection,
-  EditorSelectionPoint,
   EditorSnapshot,
   Path,
   PortableTextBlock,
@@ -8,6 +7,7 @@ import type {
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {isSelectionCollapsed} from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
+import {getBlockEndPoint, getBlockStartPoint} from '@portabletext/editor/utils'
 import {getTableSelection} from '../get-table-selection'
 import {resolveCell} from '../resolve-cell'
 import {
@@ -299,7 +299,7 @@ function planDistribution(
     }
   }
 
-  const selection = pastedSelection(contentTargets)
+  const selection = pastedSelection(snapshot.context, contentTargets)
   if (!selection) {
     return false
   }
@@ -479,6 +479,7 @@ function rekeyBlocks(
 
 /** An expanded selection spanning the pasted cells leaf-to-leaf. */
 function pastedSelection(
+  context: EditorSnapshot['context'],
   targets: Array<{cellPath: Path; blocks: Array<PortableTextBlock>}>,
 ): NonNullable<EditorSelection> | undefined {
   const first = targets.find((target) => target.blocks.length > 0)
@@ -486,42 +487,22 @@ function pastedSelection(
   if (!first || !last) {
     return undefined
   }
-  const anchor = blockEdgePoint(
-    first.cellPath,
-    first.blocks[0] as PortableTextBlock,
-    'start',
-  )
-  const focus = blockEdgePoint(
-    last.cellPath,
-    last.blocks[last.blocks.length - 1] as PortableTextBlock,
-    'end',
-  )
-  if (!anchor || !focus) {
-    return undefined
-  }
-  return {anchor, focus}
-}
-
-function blockEdgePoint(
-  cellPath: Path,
-  block: PortableTextBlock,
-  edge: 'start' | 'end',
-): EditorSelectionPoint | undefined {
-  const blockPath = [...cellPath, 'value', {_key: block._key}]
-  if (!Array.isArray(block.children) || block.children.length === 0) {
-    return {path: blockPath, offset: 0}
-  }
-  const child =
-    edge === 'start'
-      ? block.children[0]
-      : block.children[block.children.length - 1]
-  if (!child) {
-    return undefined
-  }
-  const offset =
-    edge === 'end' && typeof child.text === 'string' ? child.text.length : 0
+  const firstBlock = first.blocks[0] as PortableTextBlock
+  const lastBlock = last.blocks[last.blocks.length - 1] as PortableTextBlock
   return {
-    path: [...blockPath, 'children', {_key: child._key}],
-    offset,
+    anchor: getBlockStartPoint({
+      context,
+      block: {
+        node: firstBlock,
+        path: [...first.cellPath, 'value', {_key: firstBlock._key}],
+      },
+    }),
+    focus: getBlockEndPoint({
+      context,
+      block: {
+        node: lastBlock,
+        path: [...last.cellPath, 'value', {_key: lastBlock._key}],
+      },
+    }),
   }
 }


### PR DESCRIPTION
Pre-release audit of `@portabletext/plugin-table` for reimplementations of APIs the editor already exposes, so the plugin ships as a showcase of building on the public toolbox rather than around it. Every file was walked against the exported surface of `@portabletext/editor/traversal`, `/utils`, and `/selectors`.

Three reimplementations found, all replaced. `paste.ts` derived the pasted selection's edge points by hand (first/last child plus text length); `getBlockStartPoint`/`getBlockEndPoint` do the same container-aware, handling object blocks and childless blocks correctly, so the swap is also a small correctness improvement for image-bearing cells. `nav.ts` walked to adjacent rows via `getChildren` plus index arithmetic where `getSibling` exists, and compared entries by their paths' last keyed segment (`getKey`, the `.at(-1)` dance) where `isEqualPaths` compares whole paths, stricter and already public. Both nav helpers (`adjacentRow`, `getKey`) are deleted outright.

For the record, the audit's clean bill: `resolve-cell` and `cell-points` are pure composition of `getEnclosingBlock`/`getParent`/`getFirstChild`/`getLastChild`/`getBlock` plus the block point utils; `unset.ts` composes `pathContains`, `getLeaf`, `getSibling`; `format.ts` runs entirely on core selectors (`isActiveDecorator`/`isActiveAnnotation`/`isActiveStyle`/`isActiveListItem`, `getSelectedTextBlocks`, `getPathSubSchema`); `serialize.ts` and `paste.ts` route through the editor's own converters. The deliberately bespoke pieces stay, each with its documented reason in place: `rekeyBlocks` (the deserializing parser preserves keys), the paste content filter (raw `insert` primitives bypass core's validating pipeline), `emptyBlock` construction (no public factory), and row/column index math (indexes are the table domain's concept, not a traversal one).

Net behavior unchanged: all 318 tests pass without modification across the three browsers.
