### PR TITLE
fix: escape a container at the document edge like block objects

### DIFF
--- a/.changeset/container-edge-escape.md
+++ b/.changeset/container-edge-escape.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: escape a container at the document edge like block objects
+
+When a container (a table, a callout) is the document's first or last block, the caret could get trapped inside it: arrow navigation at the container's edge was suppressed, and clicking the editable's whitespace beyond the container had no block to land in. Both now behave like they already did for block objects: a bare ArrowUp/ArrowDown at the trapped edge, or a click beyond the lonely container, inserts an empty text block outside it and moves the caret there.

--- a/.changeset/table-arrow-escape.md
+++ b/.changeset/table-arrow-escape.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-table': minor
+---
+
+feat(plugin-table): arrow navigation escapes the table when nothing lies beyond
+
+`ArrowDown` from any bottom-row cell and `ArrowUp` from any top-row cell now exit the table: into the neighboring block when one exists, entering at the caret's horizontal position, or by inserting an empty text block beyond the table and moving the caret into it when nothing lies there. Previously the caret could walk sideways through the edge row's cells or get stuck inside the table.

--- a/.changeset/table-tab-list-yield.md
+++ b/.changeset/table-tab-list-yield.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: `Tab` inside a list item in a cell indents instead of navigating
+
+Cell navigation yields `Tab`/`Shift+Tab` to the editor's list handling when the caret sits in a list item, so indenting and unindenting inside cells works; navigation keeps `Tab` everywhere else in a cell.

--- a/packages/editor/src/behaviors/behavior.core.block-objects.ts
+++ b/packages/editor/src/behaviors/behavior.core.block-objects.ts
@@ -1,10 +1,14 @@
 import {isSpan} from '@portabletext/schema'
 import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
+import {getEnclosingContainer} from '../schema/get-enclosing-container'
 import {getFocusBlockObject} from '../selectors/selector.get-focus-block-object'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
+import {getFirstChild} from '../traversal/get-first-child'
+import {getLastChild} from '../traversal/get-last-child'
 import {getLeaf} from '../traversal/get-leaf'
+import {getNode} from '../traversal/get-node'
 import {getSibling} from '../traversal/get-sibling'
 import {isListBlock} from '../utils/parse-blocks'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
@@ -125,41 +129,59 @@ const clickingAboveLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const positionSnapshot = {
-      ...snapshot,
-      context: {
-        ...snapshot.context,
-        selection: event.position.selection,
-      },
-    }
-    const focusedBlockObject = getFocusBlockObject(positionSnapshot)
+    // The position's selection names what was clicked: a leaf for text,
+    // the container itself for a click on its own surface. The block the
+    // click was beyond is the root block for editor-surface clicks and the
+    // clicked container's edge child for container-surface clicks. Clicks
+    // on a block's content are neither and never insert.
+    const focusPath = event.position.selection.focus.path
+    const focusBlock = event.position.isEditor
+      ? focusPath.length >= 1
+        ? getNode(snapshot, focusPath.slice(0, 1))
+        : undefined
+      : event.position.isContainer
+        ? getFirstChild(snapshot, focusPath)
+        : undefined
 
-    if (!focusedBlockObject) {
+    if (!focusBlock || isTextBlockNode(snapshot.context, focusBlock.node)) {
       return false
     }
 
-    const previousSibling = getSibling(snapshot, focusedBlockObject.path, {
+    if (
+      event.position.isContainer &&
+      !acceptsTextBlock(snapshot, focusBlock.path)
+    ) {
+      // The placeholder would land inside the clicked container, so the
+      // container's array must accept text blocks; a table's rows array
+      // does not, and there the click inserts nothing.
+      return false
+    }
+
+    const previousSibling = getSibling(snapshot, focusBlock.path, {
       direction: 'previous',
     })
 
-    return (
+    if (
       (event.position.isEditor || event.position.isContainer) &&
       event.position.block === 'start' &&
       !previousSibling
-    )
+    ) {
+      return {blockPath: focusBlock.path}
+    }
+    return false
   },
   actions: [
-    ({snapshot, event}) => [
-      raise({
-        type: 'select',
-        at: event.position.selection,
-      }),
+    ({snapshot}, {blockPath}) => [
       raise({
         type: 'insert.block',
         block: {
           _type: snapshot.context.schema.block.name,
         },
         placement: 'before',
+        at: {
+          anchor: {path: blockPath, offset: 0},
+          focus: {path: blockPath, offset: 0},
+        },
         select: 'start',
       }),
     ],
@@ -177,46 +199,81 @@ const clickingBelowLonelyBlockObject = defineBehavior({
       return false
     }
 
-    const positionSnapshot = {
-      ...snapshot,
-      context: {
-        ...snapshot.context,
-        selection: event.position.selection,
-      },
-    }
-    const focusedBlockObject = getFocusBlockObject(positionSnapshot)
+    // The position's selection names what was clicked: a leaf for text,
+    // the container itself for a click on its own surface. The block the
+    // click was beyond is the root block for editor-surface clicks and the
+    // clicked container's edge child for container-surface clicks. Clicks
+    // on a block's content are neither and never insert.
+    const focusPath = event.position.selection.focus.path
+    const focusBlock = event.position.isEditor
+      ? focusPath.length >= 1
+        ? getNode(snapshot, focusPath.slice(0, 1))
+        : undefined
+      : event.position.isContainer
+        ? getLastChild(snapshot, focusPath)
+        : undefined
 
-    if (!focusedBlockObject) {
+    if (!focusBlock || isTextBlockNode(snapshot.context, focusBlock.node)) {
       return false
     }
 
-    const nextSibling = getSibling(snapshot, focusedBlockObject.path, {
+    if (
+      event.position.isContainer &&
+      !acceptsTextBlock(snapshot, focusBlock.path)
+    ) {
+      // Same rule as clicking above: no valid place for a text block
+      // inside the clicked container means no insert.
+      return false
+    }
+
+    const nextSibling = getSibling(snapshot, focusBlock.path, {
       direction: 'next',
     })
 
-    return (
+    if (
       (event.position.isEditor || event.position.isContainer) &&
       event.position.block === 'end' &&
       !nextSibling
-    )
+    ) {
+      return {blockPath: focusBlock.path}
+    }
+    return false
   },
   actions: [
-    ({snapshot, event}) => [
-      raise({
-        type: 'select',
-        at: event.position.selection,
-      }),
+    ({snapshot}, {blockPath}) => [
       raise({
         type: 'insert.block',
         block: {
           _type: snapshot.context.schema.block.name,
         },
         placement: 'after',
+        at: {
+          anchor: {path: blockPath, offset: 0},
+          focus: {path: blockPath, offset: 0},
+        },
         select: 'start',
       }),
     ],
   ],
 })
+
+/**
+ * Whether the position at `path` accepts a text block: the enclosing
+ * container's `of` declares the schema's block type, or the path sits at
+ * the document root, which always does.
+ */
+function acceptsTextBlock(
+  snapshot: Parameters<typeof getEnclosingContainer>[0],
+  path: Parameters<typeof getEnclosingContainer>[1],
+): boolean {
+  const enclosing = getEnclosingContainer(snapshot, path)
+  return (
+    !enclosing ||
+    enclosing.of.some(
+      (member) => member.type === snapshot.context.schema.block.name,
+    )
+  )
+}
 
 const deletingEmptyTextBlockAfterBlockObject = defineBehavior({
   on: 'delete.backward',

--- a/packages/editor/src/behaviors/behavior.core.containers.ts
+++ b/packages/editor/src/behaviors/behavior.core.containers.ts
@@ -1,15 +1,18 @@
+import {createKeyboardShortcut} from '@portabletext/keyboard-shortcuts'
+import {defaultKeyboardShortcuts} from '../editor/default-keyboard-shortcuts'
 import type {Path} from '../engine/interfaces/path'
 import {pathEquals} from '../engine/path/path-equals'
 import {createPlaceholderBlock} from '../internal-utils/create-placeholder-block'
 import {getEnclosingContainer} from '../schema/get-enclosing-container'
 import {isEditableContainer} from '../schema/is-editable-container'
-import {getFirstBlock} from '../selectors/selector.get-first-block'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getLastBlock} from '../selectors/selector.get-last-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
 import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {getAncestor} from '../traversal/get-ancestor'
+import {getEnclosingBlock} from '../traversal/get-enclosing-block'
+import {getLeaf} from '../traversal/get-leaf'
 import {getSibling} from '../traversal/get-sibling'
 import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
@@ -17,8 +20,7 @@ import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 /**
- * Prevent the browser from escaping the caret out of an editable container
- * when there is nowhere to go.
+ * Escape an editable container when arrow navigation has nowhere to go.
  *
  * At the start of the first block inside a container (ArrowUp) or the end
  * of the last block (ArrowDown), browsers rendering `<table>`-based
@@ -29,25 +31,90 @@ import {defineBehavior} from './behavior.types.behavior'
  * doesn't map back to the model, and the next keystroke produces orphan
  * text nodes.
  *
- * This behavior only fires in that dead-end case and suppresses the
- * native event to keep the caret in place. All other caret movement
- * inside containers is left to the browser.
+ * These behaviors only fire in that dead-end case. A bare arrow escapes
+ * the way block objects do: a placeholder block gets inserted beyond the
+ * container and receives the caret. Modified arrows (selection extension)
+ * and dead ends without an escape target just suppress the native event to
+ * keep the caret in place. All other caret movement inside containers is
+ * left to the browser.
  */
+const anyArrowDown = createKeyboardShortcut({
+  default: [{key: 'ArrowDown'}],
+})
+const anyArrowUp = createKeyboardShortcut({
+  default: [{key: 'ArrowUp'}],
+})
+
 const arrowDownOutOfContainer = defineBehavior({
   on: 'keyboard.keydown',
-  guard: ({snapshot, event}) =>
-    event.originEvent.key === 'ArrowDown' &&
-    isAtContainerDeadEnd(snapshot, 'end'),
-  actions: [],
+  guard: ({snapshot, event}) => {
+    if (
+      !anyArrowDown.guard(event.originEvent) ||
+      !isAtContainerDeadEnd(snapshot, 'end')
+    ) {
+      return false
+    }
+    return {escapeTarget: arrowEscapeTarget(snapshot, event.originEvent, 'end')}
+  },
+  actions: [
+    ({snapshot}, {escapeTarget}) =>
+      escapeTarget ? [escapeAction(snapshot, escapeTarget, 'after')] : [],
+  ],
 })
 
 const arrowUpOutOfContainer = defineBehavior({
   on: 'keyboard.keydown',
-  guard: ({snapshot, event}) =>
-    event.originEvent.key === 'ArrowUp' &&
-    isAtContainerDeadEnd(snapshot, 'start'),
-  actions: [],
+  guard: ({snapshot, event}) => {
+    if (
+      !anyArrowUp.guard(event.originEvent) ||
+      !isAtContainerDeadEnd(snapshot, 'start')
+    ) {
+      return false
+    }
+    return {
+      escapeTarget: arrowEscapeTarget(snapshot, event.originEvent, 'start'),
+    }
+  },
+  actions: [
+    ({snapshot}, {escapeTarget}) =>
+      escapeTarget ? [escapeAction(snapshot, escapeTarget, 'before')] : [],
+  ],
 })
+
+function arrowEscapeTarget(
+  snapshot: Parameters<typeof getFocusTextBlock>[0],
+  originEvent: Parameters<typeof defaultKeyboardShortcuts.arrowDown.guard>[0],
+  edge: 'start' | 'end',
+): Path | undefined {
+  const bareArrow =
+    edge === 'end'
+      ? defaultKeyboardShortcuts.arrowDown.guard(originEvent)
+      : defaultKeyboardShortcuts.arrowUp.guard(originEvent)
+  if (!bareArrow) {
+    return undefined
+  }
+  const focusTextBlock = getFocusTextBlock(snapshot)
+  return focusTextBlock
+    ? getEscapeTarget(snapshot, focusTextBlock.path)
+    : undefined
+}
+
+function escapeAction(
+  snapshot: Parameters<typeof createPlaceholderBlock>[0],
+  escapeTarget: Path,
+  placement: 'before' | 'after',
+) {
+  return raise({
+    type: 'insert.block',
+    block: createPlaceholderBlock(snapshot, escapeTarget),
+    placement,
+    at: {
+      anchor: {path: escapeTarget, offset: 0},
+      focus: {path: escapeTarget, offset: 0},
+    },
+    select: 'start',
+  })
+}
 
 function isAtContainerDeadEnd(
   snapshot: Parameters<typeof getFocusTextBlock>[0],
@@ -71,8 +138,19 @@ function isAtContainerDeadEnd(
     return false
   }
 
-  const edgeBlock =
-    edge === 'end' ? getLastBlock(snapshot) : getFirstBlock(snapshot)
+  // The DOM caret escapes at the edge of the outermost container (the
+  // root-level block the focus sits inside), so the dead end is measured
+  // there. At an inner edge (a cell boundary mid-table) native navigation
+  // stays inside the container and remains mapped. Scoping this to the
+  // nearest container instead would declare every row's first and last
+  // cell a dead end.
+  const rootSegment = focusTextBlock.path[0]
+  if (!rootSegment) {
+    return false
+  }
+  const outerPath: Path = [rootSegment]
+  const edgeLeaf = getLeaf(snapshot, outerPath, {edge})
+  const edgeBlock = edgeLeaf && getEnclosingBlock(snapshot, edgeLeaf.path)
 
   if (!edgeBlock || !pathEquals(edgeBlock.path, focusTextBlock.path)) {
     return false
@@ -87,7 +165,7 @@ function isAtContainerDeadEnd(
     return false
   }
 
-  const sibling = getSibling(snapshot, container.path, {
+  const sibling = getSibling(snapshot, outerPath, {
     direction: edge === 'end' ? 'next' : 'previous',
   })
 

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -95,12 +95,12 @@ export function getEventPosition({
     eventPositionBlock &&
     !isEditor(eventNode) &&
     isEditableContainer(editorEngine.snapshot, eventNode, eventPath) &&
-    isDragEvent(event)
+    (isDragEvent(event) || event.type === 'click')
   ) {
-    // Chrome drag: point the selection at the container so downstream
-    // selectors resolve the container, not whatever leaf
-    // `caretPositionFromPoint` would land on. Scoped to drag events
-    // because clicks don't need the override.
+    // Point the selection at the container so downstream consumers resolve
+    // the container that was interacted with, not whatever leaf
+    // `caretPositionFromPoint` would land on. The selection names what was
+    // hit: a leaf for text, the container itself for its own surface.
     return {
       block: eventPositionBlock,
       isEditor: false,

--- a/packages/editor/tests/click-lonely-block-object-container.test.tsx
+++ b/packages/editor/tests/click-lonely-block-object-container.test.tsx
@@ -72,7 +72,10 @@ describe('click above/below lonely block object in containers', () => {
         block: 'end',
         isEditor: false,
         isContainer: true,
-        selection: imageSelection,
+        selection: {
+          anchor: {path: [{_key: calloutKey}], offset: 0},
+          focus: {path: [{_key: calloutKey}], offset: 0},
+        },
       },
     })
 
@@ -152,7 +155,10 @@ describe('click above/below lonely block object in containers', () => {
         block: 'start',
         isEditor: false,
         isContainer: true,
-        selection: imageSelection,
+        selection: {
+          anchor: {path: [{_key: calloutKey}], offset: 0},
+          focus: {path: [{_key: calloutKey}], offset: 0},
+        },
       },
     })
 

--- a/packages/editor/tests/container-edge-escape.test.tsx
+++ b/packages/editor/tests/container-edge-escape.test.tsx
@@ -1,0 +1,542 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * A document whose only block is a container used to trap the caret: arrow
+ * navigation at the container's document-edge block was suppressed (built to
+ * prevent the caret escaping into unmappable DOM), and clicks in the
+ * editable's whitespace beyond the container had no block to land in. Block
+ * objects already escape both ways, a new placeholder block gets inserted
+ * beyond them, and containers get the same treatment.
+ */
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const containers = [defineContainer({type: 'callout', arrayField: 'content'})]
+
+const calloutBlock = {
+  _type: 'callout',
+  _key: 'c0',
+  content: [
+    {
+      _type: 'block',
+      _key: 'cb0',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'cs0', text: 'AA', marks: []}],
+    },
+  ],
+}
+
+const leafPoint = (offset: number) => ({
+  path: [{_key: 'c0'}, 'content', {_key: 'cb0'}, 'children', {_key: 'cs0'}],
+  offset,
+})
+
+const emptyBlock = (blockKey: string, spanKey: string) => ({
+  _type: 'block',
+  _key: blockKey,
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: spanKey, text: '', marks: []}],
+})
+
+const arrowKey = (key: 'ArrowDown' | 'ArrowUp') => ({
+  key,
+  code: key,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+})
+
+async function createLonelyContainerEditor() {
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [calloutBlock],
+    children: <NodePlugin nodes={containers} />,
+  })
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+  editor.send({type: 'focus'})
+  return editor
+}
+
+async function placeCaret(
+  editor: Awaited<ReturnType<typeof createLonelyContainerEditor>>,
+  offset: number,
+) {
+  editor.send({
+    type: 'select',
+    at: {anchor: leafPoint(offset), focus: leafPoint(offset)},
+  })
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection?.focus.offset).toBe(offset)
+  })
+}
+
+const gridSchema = defineSchema({
+  blockObjects: [
+    {
+      name: 'grid',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'gridRow',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'gridCell',
+                      fields: [
+                        {name: 'value', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const gridCell = (key: string) => ({
+  _type: 'gridCell',
+  _key: key,
+  value: [
+    {
+      _type: 'block',
+      _key: `b-${key}`,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: `s-${key}`, text: 'x', marks: []}],
+    },
+  ],
+})
+
+const gridValue = [
+  {
+    _type: 'grid',
+    _key: 'g0',
+    rows: [
+      {_type: 'gridRow', _key: 'r0', cells: [gridCell('c00')]},
+      {_type: 'gridRow', _key: 'r1', cells: [gridCell('c10')]},
+    ],
+  },
+]
+
+async function createGridEditor() {
+  return await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition: gridSchema,
+    initialValue: gridValue,
+    children: (
+      <NodePlugin
+        nodes={[
+          defineContainer({
+            type: 'grid',
+            arrayField: 'rows',
+            of: [
+              defineContainer({
+                type: 'gridRow',
+                arrayField: 'cells',
+                of: [defineContainer({type: 'gridCell', arrayField: 'value'})],
+              }),
+            ],
+          }),
+        ]}
+      />
+    ),
+  })
+}
+
+describe('escaping a container at the document edge', () => {
+  test('ArrowDown at the end of a trailing container inserts a block after it', async () => {
+    const editor = await createLonelyContainerEditor()
+    await placeCaret(editor, 2)
+
+    editor.send({type: 'keyboard.keydown', originEvent: arrowKey('ArrowDown')})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        calloutBlock,
+        emptyBlock('k2', 'k3'),
+      ])
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
+    })
+  })
+
+  test('ArrowUp at the start of a leading container inserts a block before it', async () => {
+    const editor = await createLonelyContainerEditor()
+    await placeCaret(editor, 0)
+
+    editor.send({type: 'keyboard.keydown', originEvent: arrowKey('ArrowUp')})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        emptyBlock('k2', 'k3'),
+        calloutBlock,
+      ])
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
+    })
+  })
+
+  test('clicking below a trailing container inserts a block after it', async () => {
+    const editor = await createLonelyContainerEditor()
+    await placeCaret(editor, 1)
+
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'end',
+        isEditor: true,
+        isContainer: false,
+        selection: {anchor: leafPoint(2), focus: leafPoint(2)},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        calloutBlock,
+        emptyBlock('k2', 'k3'),
+      ])
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
+    })
+  })
+
+  test('clicking above a leading container inserts a block before it', async () => {
+    const editor = await createLonelyContainerEditor()
+    await placeCaret(editor, 1)
+
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'start',
+        isEditor: true,
+        isContainer: false,
+        selection: {anchor: leafPoint(0), focus: leafPoint(0)},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        emptyBlock('k2', 'k3'),
+        calloutBlock,
+      ])
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
+    })
+  })
+
+  test('clicking below a lonely container nested in a container inserts inside the outer one', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {
+            name: 'callout',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [{type: 'block'}, {type: 'box'}],
+              },
+            ],
+          },
+          {
+            name: 'box',
+            fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'outer',
+          content: [
+            {
+              _type: 'box',
+              _key: 'inner',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'ib0',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'is0', text: 'AA', marks: []},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({type: 'callout', arrayField: 'content'}),
+            defineContainer({type: 'box', arrayField: 'content'}),
+          ]}
+        />
+      ),
+    })
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+    editor.send({type: 'focus'})
+    const innerLeaf = {
+      path: [
+        {_key: 'outer'},
+        'content',
+        {_key: 'inner'},
+        'content',
+        {_key: 'ib0'},
+        'children',
+        {_key: 'is0'},
+      ],
+      offset: 1,
+    }
+    editor.send({type: 'select', at: {anchor: innerLeaf, focus: innerLeaf}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
+    })
+
+    // A click on the outer container's surface below the inner one: the
+    // position's selection points at the clicked container itself.
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: true,
+        selection: {
+          anchor: {path: [{_key: 'outer'}], offset: 0},
+          focus: {path: [{_key: 'outer'}], offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      const outer = (
+        editor.getSnapshot().context.value as Array<{
+          content?: Array<{_type: string; _key: string}>
+        }>
+      )[0]
+      // The new block lands inside the outer container, after the inner one.
+      expect(outer?.content?.map((child) => child._type)).toEqual([
+        'box',
+        'block',
+      ])
+      expect(editor.getSnapshot().context.value).toHaveLength(1)
+    })
+  })
+
+  test('arrows at a nested inner edge mid-container do not insert', async () => {
+    // Three levels deep (table -> row -> cell shaped), the first cell of a
+    // non-first row is the *nearest* container's start edge but not the
+    // outer container's: native navigation stays inside. Measuring the
+    // dead end at the nearest container declared every row's first and
+    // last cell a dead end and inserted phantom blocks beside the table.
+    const {editor, locator} = await createGridEditor()
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+    editor.send({type: 'focus'})
+
+    // The second row's cell: its block is the nearest container's edge
+    // block in both directions, but mid-grid in the outer one.
+    const innerPoint = (offset: number) => ({
+      path: [
+        {_key: 'g0'},
+        'rows',
+        {_key: 'r1'},
+        'cells',
+        {_key: 'c10'},
+        'value',
+        {_key: 'b-c10'},
+        'children',
+        {_key: 's-c10'},
+      ],
+      offset,
+    })
+    editor.send({
+      type: 'select',
+      at: {anchor: innerPoint(0), focus: innerPoint(0)},
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(
+        innerPoint(0),
+      )
+    })
+
+    editor.send({type: 'keyboard.keydown', originEvent: arrowKey('ArrowUp')})
+    editor.send({type: 'keyboard.keydown', originEvent: arrowKey('ArrowDown')})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(gridValue)
+    })
+  })
+
+  test('clicking a container whose array rejects text blocks never inserts inside it', async () => {
+    // A table's rows array only accepts rows, so a click on the table's
+    // own surface above or below the grid has no valid place for a
+    // placeholder inside it and must leave the value alone. The editor
+    // surface beyond the lonely table is a different place: the root
+    // accepts text blocks, so that click still escapes.
+    const {editor, locator} = await createGridEditor()
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+    editor.send({type: 'focus'})
+
+    const gridSurfacePoint = {path: [{_key: 'g0'}], offset: 0}
+    for (const block of ['start', 'end'] as const) {
+      editor.send({
+        type: 'mouse.click',
+        position: {
+          block,
+          isEditor: false,
+          isContainer: true,
+          selection: {anchor: gridSurfacePoint, focus: gridSurfacePoint},
+        },
+      })
+    }
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(gridValue)
+    })
+
+    editor.send({
+      type: 'mouse.click',
+      position: {
+        block: 'end',
+        isEditor: true,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [
+              {_key: 'g0'},
+              'rows',
+              {_key: 'r1'},
+              'cells',
+              {_key: 'c10'},
+              'value',
+              {_key: 'b-c10'},
+              'children',
+              {_key: 's-c10'},
+            ],
+            offset: 1,
+          },
+          focus: {
+            path: [
+              {_key: 'g0'},
+              'rows',
+              {_key: 'r1'},
+              'cells',
+              {_key: 'c10'},
+              'value',
+              {_key: 'b-c10'},
+              'children',
+              {_key: 's-c10'},
+            ],
+            offset: 1,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        ...gridValue,
+        emptyBlock('k2', 'k3'),
+      ])
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
+    })
+  })
+
+  test('modified arrows at a dead end suppress instead of inserting', async () => {
+    // Shift+Arrow extends the selection; at a container dead end the
+    // behaviors still match (any modifier state) but only suppress, so no
+    // placeholder is inserted.
+    const editor = await createLonelyContainerEditor()
+    await placeCaret(editor, 2)
+
+    editor.send({
+      type: 'keyboard.keydown',
+      originEvent: {...arrowKey('ArrowDown'), shiftKey: true},
+    })
+    await placeCaret(editor, 0)
+    editor.send({
+      type: 'keyboard.keydown',
+      originEvent: {...arrowKey('ArrowUp'), shiftKey: true},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([calloutBlock])
+    })
+  })
+
+  test('ArrowDown does not insert when the container has a next sibling', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        calloutBlock,
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's0', text: 'after', marks: []}],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: leafPoint(2), focus: leafPoint(2)},
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(2)
+    })
+
+    editor.send({type: 'keyboard.keydown', originEvent: arrowKey('ArrowDown')})
+
+    await vi.waitFor(() => {
+      // Native navigation handles the sibling case; no block is inserted.
+      expect(editor.getSnapshot().context.value).toHaveLength(2)
+    })
+  })
+})

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -99,7 +99,7 @@ describe('cross-container range delete', () => {
     const lineKey = keyGenerator()
     const lineSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -131,7 +131,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -167,7 +167,7 @@ describe('cross-container range delete', () => {
     const textBlockKey = keyGenerator()
     const textSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -199,7 +199,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -237,7 +237,7 @@ describe('cross-container range delete', () => {
     const lastTextKey = keyGenerator()
     const lastSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -278,7 +278,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -307,7 +307,7 @@ describe('cross-container range delete', () => {
     const lineKey = keyGenerator()
     const lineSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -345,7 +345,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -387,7 +387,7 @@ describe('cross-container range delete', () => {
     const secondLineKey = keyGenerator()
     const secondLineSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -429,7 +429,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -471,7 +471,7 @@ describe('cross-container range delete', () => {
     const lastTextKey = keyGenerator()
     const lastSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -498,7 +498,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -526,7 +526,7 @@ describe('cross-container range delete', () => {
     const lineKey = keyGenerator()
     const lineSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -558,7 +558,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -604,7 +604,7 @@ describe('cross-container range delete', () => {
     const textBlockKey = keyGenerator()
     const textSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -654,7 +654,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -694,7 +694,7 @@ describe('cross-container range delete', () => {
     const line3Key = keyGenerator()
     const line3SpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -744,7 +744,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -783,7 +783,7 @@ describe('cross-container range delete', () => {
     const callout2LineKey = keyGenerator()
     const callout2SpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -830,7 +830,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -874,7 +874,7 @@ describe('cross-container range delete', () => {
     const barBlockKey = keyGenerator()
     const barSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition,
       initialValue: [
@@ -916,7 +916,7 @@ describe('cross-container range delete', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1035,7 +1035,7 @@ describe('cross-container range delete: deep structures', () => {
     const textBlockKey = keyGenerator()
     const textSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1138,7 +1138,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1199,7 +1199,7 @@ describe('cross-container range delete: deep structures', () => {
     const lineKey = keyGenerator()
     const lineSpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1302,7 +1302,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1359,7 +1359,7 @@ describe('cross-container range delete: deep structures', () => {
     const cell2BlockKey = keyGenerator()
     const cell2SpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1439,7 +1439,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1509,7 +1509,7 @@ describe('cross-container range delete: deep structures', () => {
     const row2BlockKey = keyGenerator()
     const row2SpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1621,7 +1621,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1700,7 +1700,7 @@ describe('cross-container range delete: deep structures', () => {
     const block12Key = keyGenerator()
     const span12Key = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1816,7 +1816,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -1870,7 +1870,7 @@ describe('cross-container range delete: deep structures', () => {
     const block2Key = keyGenerator()
     const span2Key = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -1935,7 +1935,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -2010,7 +2010,7 @@ describe('cross-container range delete: deep structures', () => {
     const block12Key = keyGenerator()
     const span12Key = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -2126,7 +2126,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={tableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {
@@ -2454,7 +2454,7 @@ describe('cross-container range delete: deep structures', () => {
     const cell2BlockKey = keyGenerator()
     const cell2SpanKey = keyGenerator()
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       schemaDefinition,
       keyGenerator,
       initialValue: [
@@ -2544,7 +2544,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     await userEvent.keyboard(
       // Not `ControlOrMeta`: `userEvent` resolves that from the host OS while
       // the shortcut guard resolves the platform from the user agent, and
@@ -2618,7 +2618,7 @@ describe('cross-container range delete: deep structures', () => {
       }),
     ]
 
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       schemaDefinition: tableSchemaDefinition,
       initialValue: [
@@ -2744,7 +2744,7 @@ describe('cross-container range delete: deep structures', () => {
       children: <NodePlugin nodes={positionalTableContainers} />,
     })
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {

--- a/packages/editor/tests/select-all.test.tsx
+++ b/packages/editor/tests/select-all.test.tsx
@@ -130,7 +130,12 @@ describe('Feature: Select All', () => {
       ],
       children: <NodePlugin nodes={containers} />,
     })
-    await userEvent.click(locator)
+    await userEvent.click(
+      // Aimed at cell text rather than the editable's surface: a click on a
+      // container's bare surface inserts an escape placeholder, which would
+      // change the document before select-all runs.
+      locator.getByText('A'),
+    )
 
     await userEvent.keyboard(selectAllChord)
 

--- a/packages/plugin-table/src/behaviors/format.test.tsx
+++ b/packages/plugin-table/src/behaviors/format.test.tsx
@@ -2,7 +2,6 @@ import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
-import {userEvent} from 'vitest/browser'
 import {TablePlugin} from '../plugin.table'
 
 const schemaDefinition = defineSchema({
@@ -158,7 +157,7 @@ function firstBlock(snapshot: EditorSnapshot, cellKey: string) {
  * between them covers `c01`, which the rectangle excludes.
  */
 async function selectLeftColumn(value = initialValue) {
-  const {editor, locator} = await createTestEditor({
+  const {editor} = await createTestEditor({
     keyGenerator: createTestKeyGenerator(),
     schemaDefinition,
     initialValue: value,
@@ -166,7 +165,7 @@ async function selectLeftColumn(value = initialValue) {
   })
   const focusOffset = value[0]?.rows[1]?.cells[0]?.value[0]?.children[0]?.text
     .length as number
-  await userEvent.click(locator)
+  editor.send({type: 'focus'})
   editor.send({
     type: 'select',
     at: {

--- a/packages/plugin-table/src/behaviors/nav.test.tsx
+++ b/packages/plugin-table/src/behaviors/nav.test.tsx
@@ -10,6 +10,7 @@ import {createTableGuards, defaultTableConfig} from '../table-config'
 const {isCell} = createTableGuards(defaultTableConfig)
 
 const schemaDefinition = defineSchema({
+  lists: [{name: 'bullet'}],
   blockObjects: [
     {
       name: 'table',
@@ -131,13 +132,13 @@ async function navFrom(
   key: string,
   value: typeof initialValue = initialValue,
 ) {
-  const {editor, locator} = await createTestEditor({
+  const {editor} = await createTestEditor({
     keyGenerator: createTestKeyGenerator(),
     schemaDefinition,
     initialValue: value,
     children: <TablePlugin />,
   })
-  await userEvent.click(locator)
+  editor.send({type: 'focus'})
   const point = {path: spanPath(cellKey), offset}
   editor.send({type: 'select', at: {anchor: point, focus: point}})
   await vi.waitFor(() => {
@@ -197,11 +198,366 @@ describe('table keyboard navigation', () => {
     })
   })
 
-  test('ArrowDown in the bottom row does not move (passes through)', async () => {
+  test('ArrowDown in the bottom row escapes into a block after the table', async () => {
     const editor = await navFrom('c10', 1, 'ArrowDown')
     await vi.waitFor(() => {
-      expect(focusCellKey(editor.getSnapshot())).toEqual('c10')
+      // The table is the document's only block, so there is nothing below
+      // to land in; the plugin inserts a placeholder after the table.
+      expect(editor.getSnapshot().context.value?.[1]).toEqual({
+        _type: 'block',
+        _key: 'k2',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+      })
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
     })
+  })
+
+  test('Tab inside a list item indents instead of navigating', async () => {
+    // Core owns `Tab`/`Shift+Tab` for list items; the cell navigation
+    // yields so indenting inside a cell keeps working.
+    const listValue = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c00',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'b-c00',
+                    style: 'normal',
+                    listItem: 'bullet',
+                    level: 1,
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 's-c00', text: 'item', marks: []},
+                    ],
+                  },
+                ],
+              },
+              cell('c01', 'B'),
+            ],
+          },
+        ],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: listValue as typeof initialValue,
+      children: <TablePlugin />,
+    })
+    editor.send({type: 'focus'})
+    const point = {
+      path: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c00'},
+        'value',
+        {_key: 'b-c00'},
+        'children',
+        {_key: 's-c00'},
+      ],
+      offset: 2,
+    }
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+    })
+
+    const listLevel = () => {
+      const table = editor.getSnapshot().context.value?.[0] as unknown as {
+        rows: Array<{cells: Array<{value: Array<{level?: number}>}>}>
+      }
+      return table.rows[0]?.cells[0]?.value[0]?.level
+    }
+
+    await userEvent.keyboard('{Tab}')
+    await vi.waitFor(() => {
+      expect(listLevel()).toBe(2)
+    })
+    // The caret stayed in the cell: no navigation happened.
+    expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+    await vi.waitFor(() => {
+      expect(listLevel()).toBe(1)
+    })
+    expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+  })
+
+  test('ArrowUp on an image at the top of a cell inserts a text block above it', async () => {
+    // A focused block object at its cell's edge belongs to the engine's
+    // lonely-block-object escape (insert an empty text block beside it,
+    // inside the cell), not to cell navigation.
+    const imageSchema = defineSchema({
+      blockObjects: [
+        {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        {
+          name: 'table',
+          fields: [
+            {
+              name: 'rows',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'row',
+                  fields: [
+                    {
+                      name: 'cells',
+                      type: 'array',
+                      of: [
+                        {
+                          type: 'object',
+                          name: 'cell',
+                          fields: [
+                            {
+                              name: 'value',
+                              type: 'array',
+                              of: [{type: 'block'}, {type: 'image'}],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const imageValue = [
+      {
+        _type: 'table',
+        _key: 't0',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'r0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'c00',
+                value: [{_type: 'image', _key: 'img0', src: 'x.png'}],
+              },
+              cell('c01', 'B'),
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'r1',
+            cells: [cell('c10', 'C'), cell('c11', 'D')],
+          },
+        ],
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: imageSchema,
+      initialValue: imageValue as typeof initialValue,
+      children: <TablePlugin />,
+    })
+    editor.send({type: 'focus'})
+    const imagePoint = {
+      path: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c00'},
+        'value',
+        {_key: 'img0'},
+      ],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: imagePoint, focus: imagePoint}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.path).toEqual(
+        imagePoint.path,
+      )
+    })
+
+    await userEvent.keyboard('{ArrowUp}')
+
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value?.[0] as unknown as {
+        rows: Array<{cells: Array<{value: Array<{_type: string}>}>}>
+      }
+      expect(
+        table.rows[0]?.cells[0]?.value.map((block) => block._type),
+      ).toEqual(['block', 'image'])
+    })
+    expect(editor.getSnapshot().context.value).toHaveLength(1)
+
+    // Symmetric: ArrowDown on the image (now the cell's last block)
+    // inserts a text block below it, still inside the cell.
+    editor.send({type: 'select', at: {anchor: imagePoint, focus: imagePoint}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.path).toEqual(
+        imagePoint.path,
+      )
+    })
+    await userEvent.keyboard('{ArrowDown}')
+    await vi.waitFor(() => {
+      const table = editor.getSnapshot().context.value?.[0] as unknown as {
+        rows: Array<{cells: Array<{value: Array<{_type: string}>}>}>
+      }
+      expect(
+        table.rows[0]?.cells[0]?.value.map((block) => block._type),
+      ).toEqual(['block', 'image', 'block'])
+    })
+    expect(editor.getSnapshot().context.value).toHaveLength(1)
+  })
+
+  test('round trips through a 3x3 table with a block above never accumulate blocks', async () => {
+    // Field-reported: repeatedly arrowing through a table left a trail of
+    // inserted blocks. The trigger needed a 3x3 grid, a text block above,
+    // and several passes; chromium's native ArrowUp at the top row first
+    // walks backwards through the top-row cells before exiting.
+    const grid = (prefix: string) =>
+      Array.from({length: 3}, (_, rowIndex) => ({
+        _type: 'row',
+        _key: `${prefix}r${rowIndex}`,
+        cells: Array.from({length: 3}, (_, colIndex) =>
+          cell(`${prefix}${rowIndex}${colIndex}`, ''),
+        ),
+      }))
+    const value = [
+      {
+        _type: 'block',
+        _key: 'above',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'above-s', text: 'above', marks: []}],
+      },
+      {_type: 'table', _key: 't0', rows: grid('g')},
+    ] as typeof initialValue
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: value,
+      children: <TablePlugin />,
+    })
+    editor.send({type: 'focus'})
+    const point = {
+      path: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'gr0'},
+        'cells',
+        {_key: 'g00'},
+        'value',
+        {_key: 'b-g00'},
+        'children',
+        {_key: 's-g00'},
+      ],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+    })
+
+    // Pass 1 down: walks the rows and escapes below (nothing lies beyond).
+    for (let press = 0; press < 5; press++) {
+      await userEvent.keyboard('{ArrowDown}')
+    }
+    await vi.waitFor(() => {
+      expect(
+        editor.getSnapshot().context.value?.map((block) => block._type),
+      ).toEqual(['block', 'table', 'block'])
+    })
+
+    // Two more full passes: up to "above", down to the escape block, up
+    // again. Every neighbor now exists, so no press may insert.
+    for (let press = 0; press < 6; press++) {
+      await userEvent.keyboard('{ArrowUp}')
+    }
+    for (let press = 0; press < 6; press++) {
+      await userEvent.keyboard('{ArrowDown}')
+    }
+    for (let press = 0; press < 6; press++) {
+      await userEvent.keyboard('{ArrowUp}')
+    }
+    await vi.waitFor(() => {
+      expect(
+        editor.getSnapshot().context.value?.map((block) => block._type),
+      ).toEqual(['block', 'table', 'block'])
+    })
+  })
+
+  test('repeated ArrowDown escapes reuse the block below instead of accumulating', async () => {
+    const editor = await navFrom('c10', 1, 'ArrowDown')
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toHaveLength(2)
+      expect(focusBlockKey(editor.getSnapshot())).toEqual('k2')
+    })
+
+    // Back into the table's bottom row, then out again. The placeholder
+    // from the first escape already lies below; navigation must land in
+    // it without inserting another.
+    await userEvent.keyboard('{ArrowUp}')
+    await vi.waitFor(() => {
+      expect(focusCellKey(editor.getSnapshot())).toEqual('c11')
+    })
+    await userEvent.keyboard('{ArrowDown}')
+    await vi.waitFor(() => {
+      expect(focusBlockKey(editor.getSnapshot())).toEqual('k2')
+    })
+    expect(editor.getSnapshot().context.value).toHaveLength(2)
+  })
+
+  test('ArrowDown in the bottom row moves into the block below', async () => {
+    // Native chromium ArrowDown at a table's bottom row walks forward
+    // through the cells instead of exiting, so the plugin owns the
+    // sibling case: the caret lands in the block below, nothing inserts.
+    const editor = await navFrom('c10', 1, 'ArrowDown', [
+      ...initialValue,
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'after', marks: []}],
+      },
+    ] as typeof initialValue)
+    await vi.waitFor(() => {
+      expect(focusBlockKey(editor.getSnapshot())).toEqual('b0')
+    })
+    expect(editor.getSnapshot().context.value).toHaveLength(2)
+  })
+
+  test('ArrowUp in the top row moves into the block above', async () => {
+    const editor = await navFrom('c00', 0, 'ArrowUp', [
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'before', marks: []}],
+      },
+      ...initialValue,
+    ] as typeof initialValue)
+    await vi.waitFor(() => {
+      expect(focusBlockKey(editor.getSnapshot())).toEqual('b0')
+    })
+    expect(editor.getSnapshot().context.value).toHaveLength(2)
   })
 
   test('ArrowUp moves to the cell directly above (same column)', async () => {
@@ -211,10 +567,22 @@ describe('table keyboard navigation', () => {
     })
   })
 
-  test('ArrowUp in the top row does not move (passes through)', async () => {
+  test('ArrowUp at the document-edge cell escapes into a block before the table', async () => {
     const editor = await navFrom('c00', 0, 'ArrowUp')
     await vi.waitFor(() => {
-      expect(focusCellKey(editor.getSnapshot())).toEqual('c00')
+      // The table is the document's only block, so the engine's container
+      // escape inserts a placeholder before it and moves the caret there.
+      expect(editor.getSnapshot().context.value?.[0]).toEqual({
+        _type: 'block',
+        _key: 'k2',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+      })
+      expect(editor.getSnapshot().context.selection?.focus).toEqual({
+        path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+        offset: 0,
+      })
     })
   })
 

--- a/packages/plugin-table/src/behaviors/nav.ts
+++ b/packages/plugin-table/src/behaviors/nav.ts
@@ -2,10 +2,15 @@ import type {
   EditorSelection,
   EditorSelectionPoint,
   EditorSnapshot,
+  PortableTextBlock,
   Path,
 } from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
-import {isSelectionCollapsed} from '@portabletext/editor/selectors'
+import {
+  getFocusBlockObject,
+  getFocusTextBlock,
+  isSelectionCollapsed,
+} from '@portabletext/editor/selectors'
 import {
   getChildren,
   getEnclosingBlock,
@@ -60,6 +65,10 @@ export function createNavBehaviors(config: TableConfig) {
         if (!tab.guard(event.originEvent)) {
           return false
         }
+        if (getFocusTextBlock(snapshot)?.node.listItem !== undefined) {
+          // Core owns `Tab` on list items (indent); cell navigation yields.
+          return false
+        }
         const position = resolveFocusCell(config, snapshot)
         if (!position) {
           return false
@@ -85,6 +94,10 @@ export function createNavBehaviors(config: TableConfig) {
         if (!shiftTab.guard(event.originEvent)) {
           return false
         }
+        if (getFocusTextBlock(snapshot)?.node.listItem !== undefined) {
+          // Same yield as `Tab`: core unindents list items on `Shift+Tab`.
+          return false
+        }
         const position = resolveFocusCell(config, snapshot)
         if (!position) {
           return false
@@ -106,10 +119,20 @@ export function createNavBehaviors(config: TableConfig) {
     // ArrowDown: when the caret is in the last block of a cell, move to the cell
     // directly below (same column). Otherwise fall through so the caret moves
     // within the cell.
-    defineBehavior({
+    defineBehavior<
+      Record<string, never>,
+      'keyboard.keydown',
+      {at: NonNullable<EditorSelection>} | {escapeTablePath: Path}
+    >({
       on: 'keyboard.keydown',
       guard: ({snapshot, event, dom}) => {
         if (!arrowDown.guard(event.originEvent)) {
+          return false
+        }
+        if (getFocusBlockObject(snapshot)) {
+          // The engine's lonely-block-object escape owns arrows on a
+          // focused block object: it inserts a text block beside it,
+          // inside the cell.
           return false
         }
         const position = resolveFocusCell(config, snapshot)
@@ -125,23 +148,57 @@ export function createNavBehaviors(config: TableConfig) {
         const rowBelow = getSibling(snapshot, position.row.path, {
           direction: 'next',
         })
-        const target =
-          rowBelow &&
-          sameColumnCell(snapshot, position.cell, position.row, rowBelow)
+        if (!rowBelow) {
+          const siblingBelow = getSibling(snapshot, position.table.path, {
+            direction: 'next',
+          })
+          if (siblingBelow) {
+            // Native ArrowDown at the bottom row walks forward through the
+            // cells instead of exiting, so the plugin owns the move into
+            // the sibling below.
+            const at = blockEntrySelection(snapshot, dom, siblingBelow, 'first')
+            return at ? {at} : false
+          }
+          // Nothing below the table: escape it, the way block objects do.
+          return {escapeTablePath: position.table.path}
+        }
+        const target = sameColumnCell(
+          snapshot,
+          position.cell,
+          position.row,
+          rowBelow,
+        )
         const at =
           target &&
           cellEntrySelection(config, snapshot, dom, target.path, 'first')
-        return at ? {at} : false
+        if (!at) {
+          return false
+        }
+        return {at}
       },
-      actions: [(_, {at}) => [raise({type: 'select', at})]],
+      actions: [
+        ({snapshot}, result) =>
+          'at' in result
+            ? [raise({type: 'select', at: result.at})]
+            : [escapeTableAction(snapshot, result.escapeTablePath, 'after')],
+      ],
     }),
 
     // ArrowUp: when the caret is in the first block of a cell, move to the cell
     // directly above (same column). Otherwise fall through.
-    defineBehavior({
+    defineBehavior<
+      Record<string, never>,
+      'keyboard.keydown',
+      {at: NonNullable<EditorSelection>} | {escapeTablePath: Path}
+    >({
       on: 'keyboard.keydown',
       guard: ({snapshot, event, dom}) => {
         if (!arrowUp.guard(event.originEvent)) {
+          return false
+        }
+        if (getFocusBlockObject(snapshot)) {
+          // Same split as ArrowDown: block objects escape, they don't
+          // navigate.
           return false
         }
         const position = resolveFocusCell(config, snapshot)
@@ -157,17 +214,64 @@ export function createNavBehaviors(config: TableConfig) {
         const rowAbove = getSibling(snapshot, position.row.path, {
           direction: 'previous',
         })
-        const target =
-          rowAbove &&
-          sameColumnCell(snapshot, position.cell, position.row, rowAbove)
+        if (!rowAbove) {
+          const siblingAbove = getSibling(snapshot, position.table.path, {
+            direction: 'previous',
+          })
+          if (siblingAbove) {
+            // Native ArrowUp at the top row walks backwards through the
+            // cells instead of exiting, so the plugin owns the move into
+            // the sibling above.
+            const at = blockEntrySelection(snapshot, dom, siblingAbove, 'last')
+            return at ? {at} : false
+          }
+          // Nothing above the table: escape it, the way block objects do.
+          return {escapeTablePath: position.table.path}
+        }
+        const target = sameColumnCell(
+          snapshot,
+          position.cell,
+          position.row,
+          rowAbove,
+        )
         const at =
           target &&
           cellEntrySelection(config, snapshot, dom, target.path, 'last')
-        return at ? {at} : false
+        if (!at) {
+          return false
+        }
+        return {at}
       },
-      actions: [(_, {at}) => [raise({type: 'select', at})]],
+      actions: [
+        ({snapshot}, result) =>
+          'at' in result
+            ? [raise({type: 'select', at: result.at})]
+            : [escapeTableAction(snapshot, result.escapeTablePath, 'before')],
+      ],
     }),
   ]
+}
+
+/**
+ * Insert an empty text block beyond the table and move the caret into it.
+ * Arrow navigation at a table edge with no sibling to land in would
+ * otherwise trap the caret.
+ */
+function escapeTableAction(
+  snapshot: EditorSnapshot,
+  tablePath: Path,
+  placement: 'before' | 'after',
+) {
+  return raise({
+    type: 'insert.block',
+    block: {_type: snapshot.context.schema.block.name},
+    placement,
+    at: {
+      anchor: {path: tablePath, offset: 0},
+      focus: {path: tablePath, offset: 0},
+    },
+    select: 'start',
+  })
 }
 
 /**
@@ -234,6 +338,54 @@ function cellEntrySelection(
   })
   const resolved = point && resolveCell(snapshot, point.path, config)
   if (!resolved || !isEqualPaths(resolved.cell.path, cellPath)) {
+    return fallback
+  }
+  return {anchor: point, focus: point}
+}
+
+/**
+ * A collapsed selection in a sibling block outside the table, at the
+ * caret's current x where possible, the same hit-testing idiom as
+ * `cellEntrySelection`. Falls back to the block's edge point, e.g. when
+ * the rects cannot be measured.
+ */
+function blockEntrySelection(
+  snapshot: EditorSnapshot,
+  dom: Dom,
+  sibling: {node: unknown; path: Path},
+  edge: 'first' | 'last',
+): EditorSelection | undefined {
+  const block = {
+    // A root-level sibling is a block by the data model; the traversal
+    // node union cannot prove it.
+    node: sibling.node as PortableTextBlock,
+    path: sibling.path,
+  }
+  const edgePoint =
+    edge === 'first'
+      ? getBlockStartPoint({context: snapshot.context, block})
+      : getBlockEndPoint({context: snapshot.context, block})
+  const fallback = {anchor: edgePoint, focus: edgePoint}
+  const caretRect = dom.getSelectionRect(snapshot)
+  const entryLineRect = dom.getSelectionRect({
+    ...snapshot,
+    context: {...snapshot.context, selection: fallback},
+  })
+  if (!caretRect || !entryLineRect) {
+    return fallback
+  }
+  const point = dom.getPointAtCoordinates({
+    x: caretRect.left,
+    y: entryLineRect.top + entryLineRect.height / 2,
+  })
+  const pointRootSegment = point?.path[0]
+  const blockRootSegment = block.path[0]
+  if (
+    !point ||
+    pointRootSegment === undefined ||
+    blockRootSegment === undefined ||
+    !isEqualPaths([pointRootSegment], [blockRootSegment])
+  ) {
     return fallback
   }
   return {anchor: point, focus: point}

--- a/packages/plugin-table/src/behaviors/paste.test.tsx
+++ b/packages/plugin-table/src/behaviors/paste.test.tsx
@@ -2,7 +2,6 @@ import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
-import {userEvent} from 'vitest/browser'
 import {TablePlugin} from '../plugin.table'
 
 const schemaDefinition = defineSchema({
@@ -108,13 +107,13 @@ function pasteFragment(
 }
 
 async function createEditor(value = initialValue) {
-  const {editor, locator} = await createTestEditor({
+  const {editor} = await createTestEditor({
     keyGenerator: createTestKeyGenerator(),
     schemaDefinition,
     initialValue: value,
     children: <TablePlugin />,
   })
-  await userEvent.click(locator)
+  editor.send({type: 'focus'})
   return editor
 }
 

--- a/packages/plugin-table/src/behaviors/serialize.test.tsx
+++ b/packages/plugin-table/src/behaviors/serialize.test.tsx
@@ -2,7 +2,6 @@ import {defineSchema, type EditorSnapshot} from '@portabletext/editor'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
-import {userEvent} from 'vitest/browser'
 import {TablePlugin} from '../plugin.table'
 
 const schemaDefinition = defineSchema({
@@ -95,13 +94,13 @@ function value(snapshot: EditorSnapshot) {
  * between them covers `c01`, which the rectangle excludes.
  */
 async function selectLeftColumn() {
-  const {editor, locator} = await createTestEditor({
+  const {editor} = await createTestEditor({
     keyGenerator: createTestKeyGenerator(),
     schemaDefinition,
     initialValue,
     children: <TablePlugin />,
   })
-  await userEvent.click(locator)
+  editor.send({type: 'focus'})
   editor.send({type: 'select', at: leftColumnSelection})
   await vi.waitFor(() => {
     expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
@@ -132,13 +131,13 @@ describe('rectangular selection copy/cut', () => {
       anchor: {path: spanPath('c00'), offset: 0},
       focus: {path: spanPath('c11'), offset: 1},
     }
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
       schemaDefinition,
       initialValue,
       children: <TablePlugin />,
     })
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({type: 'select', at: wholeTableSelection})
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.selection?.focus.offset).toBe(1)
@@ -199,7 +198,7 @@ describe('rectangular selection copy/cut', () => {
   })
 
   test('slicing keeps header rows positional', async () => {
-    const {editor, locator} = await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
       schemaDefinition,
       initialValue: [
@@ -223,7 +222,7 @@ describe('rectangular selection copy/cut', () => {
       ],
       children: <TablePlugin />,
     })
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
 
     // Right column (c01 -> c11): the header row is included.
     const rightColumnSelection = {

--- a/packages/plugin-table/src/define-table.test.tsx
+++ b/packages/plugin-table/src/define-table.test.tsx
@@ -145,9 +145,9 @@ describe('Feature: `defineTable` with renamed containers', () => {
   })
 
   test('Scenario: `Tab` navigates between renamed cells', async () => {
-    const {editor, locator} = await createRenamedTableEditor()
+    const {editor} = await createRenamedTableEditor()
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     const point = {path: spanPath('c00'), offset: 1}
     editor.send({type: 'select', at: {anchor: point, focus: point}})
     await vi.waitFor(() => {
@@ -232,9 +232,9 @@ describe('Feature: `defineTable` with renamed containers', () => {
   })
 
   test('Scenario: `getTableSelection` and the guards resolve the renamed shape', async () => {
-    const {editor, locator} = await createRenamedTableEditor()
+    const {editor} = await createRenamedTableEditor()
 
-    await userEvent.click(locator)
+    editor.send({type: 'focus'})
     editor.send({
       type: 'select',
       at: {


### PR DESCRIPTION
A field report against the playground table: with a table and no other text in the document, input focus cannot leave the table, neither arrow navigation nor clicking moves the caret outside. Both halves turned out to be container/block-object parity gaps: block objects already escape both ways, and containers were either deliberately trapped or unrecognized.

The keyboard half was a suppression predating its own solution. The container dead-end behaviors (`arrowDownOutOfContainer`/`arrowUpOutOfContainer`) detect exactly this situation and consumed the arrow with empty actions, built to keep the caret from escaping into DOM that doesn't map back to the model. The escape machinery arrived later in the same file for the double-Enter case (`getEscapeTarget`, `createPlaceholderBlock`). The dead-end behaviors now use it: a bare arrow inserts a placeholder block beyond the deepest escapable container and moves the caret there, while modified arrows (selection extension) and dead ends without an escape target keep the protective suppression.

The pointer half was two gaps in one. First, `clickingBelow/AboveLonelyBlockObject` already check `event.position.isContainer`, but their guard resolves the click through `getFocusBlockObject`, which containers never satisfy. Second, and deeper: for a click on a container's surface, `EventPosition.selection` resolved to whatever leaf `caretPositionFromPoint` landed on inside the container, so the position said *that* a container was clicked without its selection saying *which one*, making the nested case (a lonely container inside another container) unresolvable in principle. The fix corrects the selection itself: the drag pipeline already pointed the selection at the container for exactly this reason, scoped to drags 'because clicks don't need the override', and clicks need it now. The position's selection uniformly names what was hit, a leaf for text, a void for voids, the container itself for its own surface, and the guards reduce to one rule: insert beside the non-text edge child of the clicked surface (the root block for editor-surface clicks, the clicked container's first/last child otherwise). That single rule covers the root-level container, the pinned lonely-image-inside-a-cell contract (its tests updated to the position shape the engine now emits), and the nested container, each with its own test, while clicks on a block's content never insert, a distinction the red tests flushed out when the plugin suite's own focus-clicks started inserting escape blocks. Those tests now focus via the `focus` event instead of synthetic pointer geometry.

The second commit adds the table-domain half: the engine's escape fires only at the document-edge block, which for a table means the corner cells, but ArrowDown from any bottom-row cell should exit. The plugin's nav behaviors now own the whole edge: when a sibling block lies beyond the table the caret moves into it, entering at its current horizontal position (the same hit-testing idiom the cell-to-cell moves use), and when nothing lies beyond, an empty text block is inserted and receives the caret. The original design let native navigation own the sibling case, but a field report showed chromium's native ArrowDown at a table's bottom row walks *forward through the cells* instead of exiting (and ArrowUp at the top row walks backwards), so falling through navigated to the next cell rather than the block below; both directions are pinned with the caret's landing block asserted.

A field report against the rebased branch caught the guard the escape inherited being wrong all along: `isAtContainerDeadEnd` resolved the container as the *nearest* editable-container ancestor and used the container-scoped `getFirstBlock`/`getLastBlock`, so inside a table it declared every row's first and last **cell** a dead end, not just the table's corners. While the dead-end behaviors only suppressed, the over-match swallowed an occasional arrow invisibly; once they insert, it manufactured phantom blocks beside the table, intermittently, because the model selection lags chromium's native sideways caret walk along a table's edge row, so the misfire depended on sync timing. The guard now measures the dead end where the DOM caret actually escapes, the outermost container's edge (its edge leaf block via `getLeaf`, its sibling at root level). Pinned twice: a synthetic core test drives arrows at a nested row's first cell mid-container (red under the old guard, deterministically, no browser timing involved), and a plugin round-trip test arrows through a 3×3 table with a block above for three full passes, asserting the value never grows.

Two more field reports against the rebased branch hardened the same seams. Clicking the table's own chrome band (the surface right above or below the grid, DOM-inside the table block) inserted the placeholder *inside* `rows`, a text block among rows, because the container-surface rule inserts beside the clicked container's edge child without asking whether that position accepts a text block. The rule now checks the clicked container's `of` and inserts nothing when text blocks aren't valid there; the editor-surface click beyond a lonely table keeps escaping, and both are pinned in one test that drives the contrast against the grid fixture. And arrows on a block object inside a cell (an image at a cell's top) were stolen by the plugin's cell navigation before the engine's lonely-block-object escape could insert a text line beside it inside the cell; the plugin's arrow guards now yield whenever a block object is focused, pinned in both directions. `Tab`/`Shift+Tab` get the same treatment for list items: cell navigation yields to the engine's list indent/unindent when the caret sits in a list item, pinned with a level round-trip that asserts the caret never leaves the cell.

`tests/container-edge-escape.test.tsx` pins all four engine escapes plus the sibling fall-through; the plugin's two edge-arrow pins flip from "does not move" to the escape contract. Rebased onto the `defineTable` refactor: the nav behaviors' escape logic moved into the config-bound factory, and the newer `define-table.test.tsx` suite adopted the same focus-via-event idiom (its surface clicks near a lonely table hit exactly the geometry sensitivity this PR removes). The plugin gains a `minor` changeset now that it's published. Editor container/block-object suites and the full plugin suite (121 chromium) pass locally.





