### PR TITLE
feat(playground): dark mode for the table chrome

### DIFF
--- a/apps/playground/src/editor.css
+++ b/apps/playground/src/editor.css
@@ -213,7 +213,7 @@
 /* Horizontal scroll under a wide table: lighter thumb, gap from the table edge. */
 .table-scroll {
   scrollbar-width: thin;
-  scrollbar-color: rgba(28, 31, 36, 0.22) transparent;
+  scrollbar-color: var(--color-table-scrollbar) transparent;
 }
 .table-scroll::-webkit-scrollbar {
   height: 6px;
@@ -223,11 +223,11 @@
   background: transparent;
 }
 .table-scroll::-webkit-scrollbar-thumb {
-  background: rgba(28, 31, 36, 0.22);
+  background: var(--color-table-scrollbar);
   border-radius: 3px;
 }
 .table-scroll::-webkit-scrollbar-thumb:hover {
-  background: rgba(28, 31, 36, 0.35);
+  background: var(--color-table-scrollbar-hover);
 }
 
 .playground-table {

--- a/apps/playground/src/index.css
+++ b/apps/playground/src/index.css
@@ -2,6 +2,65 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Table chrome tokens: the design prototype's light palette with dark
+   counterparts anchored to the editor card (white / gray-800). Consumed as
+   `var(--color-table-*)` from the table's inline styles and stylesheet
+   rules; `@theme` also makes them available as Tailwind utilities. */
+@theme {
+  --color-table-accent: #556bfc;
+  --color-table-bg: #fff;
+  --color-table-fg: #1c1f24;
+  --color-table-border: #e3e4e8;
+  --color-table-header-bg: #f6f6f8;
+  --color-table-selected-bg: rgba(85, 107, 252, 0.06);
+  --color-table-lane-bg: #fafafb;
+  --color-table-lane-bg-hover: #f0f1f3;
+  --color-table-lane-icon: #6e7484;
+  --color-table-lane-icon-hover: #5c5f69;
+  --color-table-handle-rest: #bbbdc9;
+  --color-table-handle-bg: #fff;
+  --color-table-handle-dots: #8a8f99;
+  --color-table-handle-ring: rgba(255, 255, 255, 0.9);
+  --color-table-boundary-dot: #c1c4ca;
+  --color-table-trash-bg: #1c1f24;
+  --color-table-danger: #c0303a;
+  --color-table-menu-bg: #fff;
+  --color-table-menu-border: #e4e6ea;
+  --color-table-menu-hover: #f4f4f6;
+  --color-table-toggle-track: #d3d4d8;
+  --color-table-toggle-track-on: #1c1f24;
+  --color-table-toggle-knob: #fff;
+  --color-table-scrollbar: rgba(28, 31, 36, 0.22);
+  --color-table-scrollbar-hover: rgba(28, 31, 36, 0.35);
+}
+
+.dark {
+  --color-table-bg: #1f2937;
+  --color-table-fg: #e5e7eb;
+  --color-table-border: #374151;
+  --color-table-header-bg: #283345;
+  --color-table-selected-bg: rgba(105, 125, 255, 0.16);
+  --color-table-lane-bg: #242e3d;
+  --color-table-lane-bg-hover: #2b3748;
+  --color-table-lane-icon: #9ca3af;
+  --color-table-lane-icon-hover: #d1d5db;
+  --color-table-handle-rest: #4b5563;
+  --color-table-handle-bg: #374151;
+  --color-table-handle-dots: #aab2bf;
+  --color-table-handle-ring: rgba(0, 0, 0, 0.4);
+  --color-table-boundary-dot: #525c6b;
+  --color-table-trash-bg: #0d1117;
+  --color-table-danger: #e05561;
+  --color-table-menu-bg: #232d3d;
+  --color-table-menu-border: #3a4557;
+  --color-table-menu-hover: #2c384a;
+  --color-table-toggle-track: #4b5563;
+  --color-table-toggle-track-on: #e5e7eb;
+  --color-table-toggle-knob: #1f2937;
+  --color-table-scrollbar: rgba(229, 231, 235, 0.25);
+  --color-table-scrollbar-hover: rgba(229, 231, 235, 0.4);
+}
+
 body {
   @apply text-gray-900 dark:text-gray-100;
   @apply bg-gray-50 dark:bg-gray-900;

--- a/apps/playground/src/plugins/table-cell-style.ts
+++ b/apps/playground/src/plugins/table-cell-style.ts
@@ -1,12 +1,12 @@
 import type {CSSProperties} from 'react'
 
 // Visual tokens from the design prototype (constants.js on pte-tables-phases).
-export const BLUE = '#556bfc'
-export const BORDER = '#e3e4e8'
+export const BLUE = 'var(--color-table-accent)'
+export const BORDER = 'var(--color-table-border)'
 const SELECTION_BORDER = 1.5
-const FG = '#1c1f24'
-const HEADER_BG = '#f6f6f8'
-const SELECTED_BG = 'rgba(85, 107, 252, 0.06)'
+const FG = 'var(--color-table-fg)'
+const HEADER_BG = 'var(--color-table-header-bg)'
+const SELECTED_BG = 'var(--color-table-selected-bg)'
 const CELL_PADDING = '8px 12px'
 const TABLE_RADIUS = 6
 
@@ -138,7 +138,7 @@ export function cellStyle({
     }
   }
 
-  let background = isHeader ? HEADER_BG : '#fff'
+  let background = isHeader ? HEADER_BG : 'var(--color-table-bg)'
   if (showOverlay) {
     background = isHeader
       ? `linear-gradient(${SELECTED_BG}, ${SELECTED_BG}), ${HEADER_BG}`

--- a/apps/playground/src/plugins/table-chrome.tsx
+++ b/apps/playground/src/plugins/table-chrome.tsx
@@ -23,14 +23,14 @@ const HANDLE_REST_COL = {w: 16, h: 3}
 const HANDLE_BTN_ROW = {w: 12, h: 16}
 const HANDLE_BTN_COL = {w: 16, h: 12}
 const HANDLE_BTN_PAD = 3
-const HANDLE_REST_BG = '#bbbdc9'
+const HANDLE_REST_BG = 'var(--color-table-handle-rest)'
 const HANDLE_HIT = 24
-const HANDLE_EXPANDED_SHADOW = `inset 0 0 0 0.5px rgba(255,255,255,0.9), 0 0 0 1px ${BORDER}`
+const HANDLE_EXPANDED_SHADOW = `inset 0 0 0 0.5px var(--color-table-handle-ring), 0 0 0 1px ${BORDER}`
 const HANDLE_EXPANDED_SHADOW_SELECTED =
-  'inset 0 0 0 0.5px rgba(255,255,255,0.9), 0 0 0 1px #fff'
+  'inset 0 0 0 0.5px var(--color-table-handle-ring), 0 0 0 1px var(--color-table-handle-bg)'
 const HANDLE_DOT = 2
 const HANDLE_DOT_GAP = 2
-const HANDLE_GREY = '#c1c4ca'
+const HANDLE_GREY = 'var(--color-table-boundary-dot)'
 const BOUNDARY_DOT = 4
 const BOUNDARY_PLUS = 17
 const GRID_LINE_HALF = 0.5
@@ -39,10 +39,10 @@ const EXTEND_SIZE = 17
 const EXTEND_GAP = 3
 /** The reserved add-row / add-column lane: bar + gap. */
 export const EXTEND_LANE = EXTEND_SIZE + EXTEND_GAP
-const EXTEND_BAR_BG = '#fafafb'
-const EXTEND_BAR_BG_HOVER = '#f0f1f3'
-const EXTEND_ICON = '#6e7484'
-const EXTEND_ICON_HOVER = '#5c5f69'
+const EXTEND_BAR_BG = 'var(--color-table-lane-bg)'
+const EXTEND_BAR_BG_HOVER = 'var(--color-table-lane-bg-hover)'
+const EXTEND_ICON = 'var(--color-table-lane-icon)'
+const EXTEND_ICON_HOVER = 'var(--color-table-lane-icon-hover)'
 const TRASH_SIZE = 26
 const TRASH_GAP = 8
 /** Above the toolbar and field chrome; delete must stay clickable. */
@@ -490,7 +490,7 @@ function Handle({
           padding: showExpanded ? HANDLE_BTN_PAD : 0,
           ...(showExpanded
             ? {
-                background: selected ? BLUE : '#fff',
+                background: selected ? BLUE : 'var(--color-table-handle-bg)',
                 boxShadow: selected
                   ? HANDLE_EXPANDED_SHADOW_SELECTED
                   : HANDLE_EXPANDED_SHADOW,
@@ -498,7 +498,7 @@ function Handle({
             : showRest
               ? {
                   background: HANDLE_REST_BG,
-                  boxShadow: 'inset 0 0 0 0.5px rgba(255,255,255,0.7)',
+                  boxShadow: 'inset 0 0 0 0.5px var(--color-table-handle-ring)',
                 }
               : {background: 'transparent'}),
         }}
@@ -534,7 +534,7 @@ function DragDots({
             width: HANDLE_DOT,
             height: HANDLE_DOT,
             borderRadius: '50%',
-            background: selected ? '#fff' : '#8a8f99',
+            background: selected ? '#fff' : 'var(--color-table-handle-dots)',
           }}
         />
       ))}
@@ -672,7 +672,9 @@ function TrashButton({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: hovered ? '#c0303a' : '#1c1f24',
+        background: hovered
+          ? 'var(--color-table-danger)'
+          : 'var(--color-table-trash-bg)',
         color: '#fff',
         border: 'none',
         borderRadius: 4,
@@ -802,8 +804,12 @@ export function TableMenu({
           border: 'none',
           borderRadius: 3,
           padding: 0,
-          background: open ? '#f0f1f3' : hovered ? '#f6f6f8' : 'transparent',
-          color: '#1c1f24',
+          background: open
+            ? 'var(--color-table-lane-bg-hover)'
+            : hovered
+              ? 'var(--color-table-header-bg)'
+              : 'transparent',
+          color: 'var(--color-table-fg)',
           cursor: 'pointer',
           pointerEvents: visible ? 'auto' : 'none',
           opacity: visible ? 1 : 0,
@@ -823,8 +829,8 @@ export function TableMenu({
                 left: menuPos.left,
                 top: menuPos.top,
                 width: MENU_MIN_WIDTH,
-                background: '#fff',
-                border: '1px solid #e4e6ea',
+                background: 'var(--color-table-menu-bg)',
+                border: '1px solid var(--color-table-menu-border)',
                 borderRadius: 6,
                 padding: 5,
                 zIndex: MENU_Z_INDEX,
@@ -892,12 +898,14 @@ function MenuRow({
         width: '100%',
         padding: '8px 10px',
         border: 'none',
-        background: hovered ? '#f4f4f6' : 'transparent',
+        background: hovered ? 'var(--color-table-menu-hover)' : 'transparent',
         cursor: 'pointer',
         borderRadius: 4,
         textAlign: 'left',
         fontSize: 13,
-        color: destructive ? '#c0303a' : '#1c1f24',
+        color: destructive
+          ? 'var(--color-table-danger)'
+          : 'var(--color-table-fg)',
       }}
     >
       <span
@@ -928,7 +936,9 @@ function ToggleSwitch({checked}: {checked: boolean}): JSX.Element {
         height: 16,
         borderRadius: 8,
         padding: 2,
-        background: checked ? '#1c1f24' : '#d3d4d8',
+        background: checked
+          ? 'var(--color-table-toggle-track-on)'
+          : 'var(--color-table-toggle-track)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: checked ? 'flex-end' : 'flex-start',
@@ -941,7 +951,7 @@ function ToggleSwitch({checked}: {checked: boolean}): JSX.Element {
           width: 12,
           height: 12,
           borderRadius: '50%',
-          background: '#fff',
+          background: 'var(--color-table-toggle-knob)',
           boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
         }}
       />
@@ -1034,7 +1044,9 @@ export function ReorderGhost({
           zIndex: 10000,
           borderRadius: 6,
           border: `1px solid ${BORDER}`,
-          background: isHeader ? '#f6f6f8' : '#fff',
+          background: isHeader
+            ? 'var(--color-table-header-bg)'
+            : 'var(--color-table-bg)',
           boxShadow: GHOST_SHADOW,
           overflow: 'hidden',
           fontWeight: isHeader ? 600 : 400,
@@ -1081,7 +1093,7 @@ export function ReorderGhost({
         zIndex: 10000,
         borderRadius: 6,
         border: `1px solid ${BORDER}`,
-        background: '#fff',
+        background: 'var(--color-table-bg)',
         boxShadow: GHOST_SHADOW,
         overflow: 'hidden',
       }}
@@ -1094,7 +1106,10 @@ export function ReorderGhost({
             padding: '8px 12px',
             borderBottom:
               index < metrics.rows.length - 1 ? `1px solid ${BORDER}` : 'none',
-            background: hasHeader && index === 0 ? '#f6f6f8' : undefined,
+            background:
+              hasHeader && index === 0
+                ? 'var(--color-table-header-bg)'
+                : undefined,
             fontWeight: hasHeader && index === 0 ? 600 : 400,
             overflow: 'hidden',
             whiteSpace: 'nowrap',
@@ -1137,7 +1152,7 @@ export function TableScrollFade({
             ...fadeBase,
             left: 0,
             background:
-              'linear-gradient(to right, #ffffff 0%, rgba(255,255,255,0) 100%)',
+              'linear-gradient(to right, var(--color-table-bg) 0%, transparent 100%)',
           }}
         />
       ) : null}
@@ -1149,7 +1164,7 @@ export function TableScrollFade({
             ...fadeBase,
             right: 0,
             background:
-              'linear-gradient(to left, #ffffff 0%, rgba(255,255,255,0) 100%)',
+              'linear-gradient(to left, var(--color-table-bg) 0%, transparent 100%)',
           }}
         />
       ) : null}


### PR DESCRIPTION
The playground table ignored dark mode entirely: the chrome ports the design prototype's palette as hard-coded light-mode hex values across the cell styles (`table-cell-style.ts`), every piece of interactive chrome (`table-chrome.tsx`: handles, boundary dots, extend lanes, trash, table menu, drag ghost, scroll fades), and the stylesheet (scrollbar). In dark mode that meant white cells and pale grey chrome floating on a gray-800 canvas.

The colors move into Tailwind v4 theme tokens: `--color-table-*` defined in `@theme` (which also exposes them as utilities for any future class-based use), with dark counterparts under a plain `.dark` block, the same class the playground's theme toggle already flips. The inline styles keep their computed geometry and consume the tokens as `var()` references. Custom properties are the one mechanism that covers all three styling surfaces at once: inline styles with runtime-computed positions (which can never become Tailwind classes), portaled chrome (the trash, menu, and drag ghost render into `document.body`, outside any wrapper's scope but still under the `.dark` root, so the cascade reaches them), and stylesheet rules. A full rewrite to `tv()`/className was considered and deliberately deferred: it is a large diff over pixel-pinned chrome for no user-visible gain beyond what tokens deliver, and with tokens in place it becomes a pure refactor if ever wanted.

Light mode is value-identical to before, the same hexes now flow through one indirection. The dark palette anchors to the editor card's `gray-800` canvas (header rows a step lighter, borders `gray-700`-adjacent, the destructive red brightened for contrast on dark panels), and the `#556bfc` accent stays constant across modes, so white-on-accent details (handle dots, the insert `+` glyph) remain literal by design. Verified visually in both modes across the resting table, column selection (outline, tint, accent handle, trash), and the open table menu (panel, hover rows, header-row toggle).
