### PR TITLE
fix: implement editor-owned select-all

### DIFF
--- a/.changeset/editor-owned-select-all.md
+++ b/.changeset/editor-owned-select-all.md
@@ -1,0 +1,14 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: implement editor-owned select-all
+
+Cmd+A/Ctrl+A previously relied on the browser's native select-all, which
+chromium silently collapses whenever a non-editable element sits at either
+content edge of the editor. Any document starting or ending with a block
+object, and any table-shaped container render with selection chrome, made
+select-all a no-op. The editor now handles the shortcut itself and selects
+the full document range, deterministically across browsers and custom
+renders. The behavior is registered alongside the other default keyboard
+shortcuts and can be overridden like any other.

--- a/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.keyboard.ts
@@ -4,9 +4,12 @@ import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-objec
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {isSelectionExpanded} from '../selectors/selector.is-selection-expanded'
+import {getEnclosingBlock} from '../traversal/get-enclosing-block'
+import {getLeaf} from '../traversal/get-leaf'
 import {getSibling} from '../traversal/get-sibling'
 import {getBlock} from '../traversal/is-block'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
+import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
@@ -121,6 +124,51 @@ export const abstractKeyboardBehaviors = [
     guard: ({event}) =>
       defaultKeyboardShortcuts.history.redo.guard(event.originEvent),
     actions: [() => [raise({type: 'history.redo'})]],
+  }),
+
+  /**
+   * Manual handling of select-all. The native gesture cannot be trusted to
+   * build the range: chromium produces an already-collapsed range whenever a
+   * non-editable element sits at either content edge of the editing host,
+   * which any document starting or ending with a void block or a
+   * chrome-bearing container render does. "Everything" is a model-level
+   * statement, so the range is computed from the model instead of
+   * round-tripping through the DOM selection.
+   */
+  defineBehavior({
+    on: 'keyboard.keydown',
+    guard: ({snapshot, event}) => {
+      if (!defaultKeyboardShortcuts.selectAll.guard(event.originEvent)) {
+        return false
+      }
+
+      const startLeaf = getLeaf(snapshot, [], {edge: 'start'})
+      const endLeaf = getLeaf(snapshot, [], {edge: 'end'})
+      const startBlock = startLeaf
+        ? getEnclosingBlock(snapshot, startLeaf.path)
+        : undefined
+      const endBlock = endLeaf
+        ? getEnclosingBlock(snapshot, endLeaf.path)
+        : undefined
+
+      if (!startBlock || !endBlock) {
+        return false
+      }
+
+      return {
+        anchor: getBlockStartPoint({
+          context: snapshot.context,
+          block: startBlock,
+        }),
+        focus: getBlockEndPoint({
+          context: snapshot.context,
+          block: endBlock,
+        }),
+      }
+    },
+    actions: [
+      (_, {anchor, focus}) => [raise({type: 'select', at: {anchor, focus}})],
+    ],
   }),
 
   /**

--- a/packages/editor/src/editor/default-keyboard-shortcuts.ts
+++ b/packages/editor/src/editor/default-keyboard-shortcuts.ts
@@ -121,6 +121,26 @@ export const defaultKeyboardShortcuts = {
     undo,
     redo,
   },
+  selectAll: createKeyboardShortcut({
+    default: [
+      {
+        key: 'A',
+        alt: false,
+        ctrl: true,
+        meta: false,
+        shift: false,
+      },
+    ],
+    apple: [
+      {
+        key: 'A',
+        alt: false,
+        ctrl: false,
+        meta: true,
+        shift: false,
+      },
+    ],
+  }),
   tab: createKeyboardShortcut({
     default: [
       {

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -2,6 +2,7 @@ import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {userEvent} from 'vitest/browser'
+import {IS_MAC} from '../src/internal-utils/is-hotkey'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
@@ -2544,7 +2545,12 @@ describe('cross-container range delete: deep structures', () => {
     })
 
     await userEvent.click(locator)
-    await userEvent.keyboard('{ControlOrMeta>}{A}{/ControlOrMeta}')
+    await userEvent.keyboard(
+      // Not `ControlOrMeta`: `userEvent` resolves that from the host OS while
+      // the shortcut guard resolves the platform from the user agent, and
+      // playwright's webkit reports a Mac user agent on Linux.
+      IS_MAC ? '{Meta>}a{/Meta}' : '{Control>}a{/Control}',
+    )
     await userEvent.keyboard('{Delete}')
 
     expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')

--- a/packages/editor/tests/select-all.test.tsx
+++ b/packages/editor/tests/select-all.test.tsx
@@ -1,0 +1,237 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {userEvent} from '@vitest/browser/context'
+import {describe, expect, test, vi} from 'vitest'
+import {IS_MAC} from '../src/internal-utils/is-hotkey'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {defineContainer} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Select-all is editor-owned. Browsers cannot be trusted to build the range
+ * themselves: chromium's native select-all produces an already-collapsed
+ * range whenever a non-editable element sits at either content edge of the
+ * editing host. Block objects render non-editable, and table renders carry
+ * non-editable chrome, so both a table-only document and any document
+ * starting or ending with a void block had a native select-all no-op.
+ */
+
+// Not `ControlOrMeta`: `userEvent` resolves that from the host OS while the
+// shortcut guard resolves the platform from the user agent, and playwright's
+// webkit reports a Mac user agent on Linux. `IS_MAC` follows the guard's
+// source of truth.
+const selectAllChord = IS_MAC ? '{Meta>}a{/Meta}' : '{Control>}a{/Control}'
+
+const schemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'table',
+      fields: [
+        {
+          name: 'rows',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'row',
+              fields: [
+                {
+                  name: 'cells',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'cell',
+                      fields: [
+                        {name: 'content', type: 'array', of: [{type: 'block'}]},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+/**
+ * Rendered with real `<table>` DOM plus a non-editable chrome sibling, the
+ * shape of any real-world table render with selection chrome. The chrome
+ * sibling is the load-bearing part: it puts a non-editable element at the
+ * document's content edge, which is what collapses chromium's native
+ * select-all.
+ */
+const containers = [
+  defineContainer({
+    type: 'table',
+    arrayField: 'rows',
+    render: ({attributes, children}) => (
+      <div {...attributes}>
+        <table>
+          <tbody>{children}</tbody>
+        </table>
+        <div contentEditable={false}>chrome</div>
+      </div>
+    ),
+  }),
+  defineContainer({
+    type: 'row',
+    arrayField: 'cells',
+    render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
+  }),
+  defineContainer({
+    type: 'cell',
+    arrayField: 'content',
+    render: ({attributes, children}) => <td {...attributes}>{children}</td>,
+  }),
+]
+
+function cell(key: string, text: string) {
+  return {
+    _type: 'cell',
+    _key: key,
+    content: [
+      {
+        _type: 'block',
+        _key: `b-${key}`,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: `s-${key}`, text, marks: []}],
+      },
+    ],
+  }
+}
+
+describe('Feature: Select All', () => {
+  test('Scenario: Selecting the whole document when a table is the only block', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [cell('c00', 'A'), cell('c01', 'B')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+    await userEvent.click(locator)
+
+    await userEvent.keyboard(selectAllChord)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [
+            {_key: 't0'},
+            'rows',
+            {_key: 'r0'},
+            'cells',
+            {_key: 'c00'},
+            'content',
+            {_key: 'b-c00'},
+            'children',
+            {_key: 's-c00'},
+          ],
+          offset: 0,
+        },
+        focus: {
+          path: [
+            {_key: 't0'},
+            'rows',
+            {_key: 'r1'},
+            'cells',
+            {_key: 'c11'},
+            'content',
+            {_key: 'b-c11'},
+            'children',
+            {_key: 's-c11'},
+          ],
+          offset: 1,
+        },
+        backward: false,
+      })
+    })
+  })
+
+  test('Scenario: Selecting the whole document over block objects', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {_type: 'image', _key: 'img1', src: 'a.png'},
+        {_type: 'image', _key: 'img2', src: 'b.png'},
+      ],
+    })
+    await userEvent.click(locator)
+
+    await userEvent.keyboard(selectAllChord)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: [{_key: 'img1'}], offset: 0},
+        focus: {path: [{_key: 'img2'}], offset: 0},
+        backward: false,
+      })
+    })
+  })
+
+  test('Scenario: Selecting the whole document over plain text blocks', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'blockA',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'spanA', text: 'foo', marks: []}],
+        },
+        {
+          _type: 'block',
+          _key: 'blockB',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'spanB', text: 'bar', marks: []}],
+        },
+      ],
+    })
+    await userEvent.click(locator)
+
+    await userEvent.keyboard(selectAllChord)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: 'blockA'}, 'children', {_key: 'spanA'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'blockB'}, 'children', {_key: 'spanB'}],
+          offset: 3,
+        },
+        backward: false,
+      })
+    })
+  })
+})


### PR DESCRIPTION
A field report: with a table as the document's only block, Cmd+A does nothing. The event log shows the `keyboard.keydown` arrive and then silence, no synthetic `select`, no sync, and the caret ends up parked at the table's start.

The diagnosis exonerates the engine. A synchronous capture of `document.execCommand('selectAll')` over the playground's table DOM shows chromium producing an **already-collapsed** range (`div.playground-table-inner@0 -> @0`); the `selectionchange` sync then faithfully applies the collapse and the writeback erases whatever the browser briefly rendered. Bisecting the DOM ingredients isolated the trigger, and it is broader than tables: chromium's select-all collapses whenever a **non-editable element sits at either content edge of the editing host** (fine in the middle, and nesting inside editable wrappers does not help; a `<table>` on its own, `<colgroup>`, and plain wrapper divs are all innocent). Block objects render `contentEditable={false}` and table renders carry non-editable selection chrome, so any document starting or ending with a void block, not just table-only documents, has had a native select-all no-op in chromium all along. The leafless-subtree fix (#2899) is unrelated: probes against its build behave identically, because no range ever exists for it to resolve.

The fix stops trusting the browser with the gesture. "Select everything" is a model-level statement, and round-tripping it through a DOM selection only inherits browser quirks, so the editor now owns the shortcut, the position structured-content editors converge on (ProseMirror binds `Mod-a` to its own `selectAll` command for the same reason). A `selectAll` entry joins `defaultKeyboardShortcuts` (Ctrl+A, Cmd+A on Apple platforms), and an abstract keyboard behavior beside the undo/redo shortcuts raises `select` over the full document range, computed with `getLeaf` edge descent from the root plus `getBlockStartPoint`/`getBlockEndPoint` on the enclosing blocks, following the `behavior.core.insert-break.ts` idiom. The end point matters: a container's block-level point edge-descends to its start during `select` resolution, so the behavior computes leaf-precise points rather than leaning on coercion; the table-only test pins the focus landing at the end of the last cell. Landing as an abstract behavior keeps it consumer-overridable, which leaves the door open for spreadsheet-style escalation (first Cmd+A selects the cell, then the table, then the document) as a plugin behavior later.

The regression test renders containers with real `<table>` DOM plus a non-editable chrome sibling, reproducing the browser's failure mode inside the harness (with a plain-div render, native select-all works and the test could never go red). A second test pins the block-objects-only document (voids at both content edges, the other real-world instance of the trigger), and a third pins plain-text documents. Net behavior for text documents is unchanged in outcome, only the mechanism shifts from DOM luck to a computed range; the existing cross-container suite, which exercises real select-all chords, passes without modification.
