### PR TITLE
fix(perf): seek to the range's boundaries in range-bounded traversal

### DIFF
--- a/.changeset/seek-get-nodes-in-range.md
+++ b/.changeset/seek-get-nodes-in-range.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): seek to the range's boundaries in range-bounded traversal
+
+Toggling a decorator or annotation no longer slows down with the
+selection's position in the document. Range-bounded node traversal
+previously walked from the document's first block to the selection;
+it now jumps directly to the blocks the range touches. Toggling bold
+on one word at the end of an 8,000-block document drops from ~10ms to
+~3ms.

--- a/packages/editor/src/traversal/get-nodes.ts
+++ b/packages/editor/src/traversal/get-nodes.ts
@@ -7,6 +7,7 @@ import type {
   Containers,
   RegisteredContainer,
 } from '../schema/resolve-containers'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren, getNodeChildren} from './get-children'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
@@ -198,7 +199,21 @@ function* getNodesInRange(
   const {from, to, match, reverse = false} = options
 
   const children = getChildren(snapshot, path)
-  const entries = reverse ? [...children].reverse() : children
+
+  // Seek instead of scan: only the children between the boundaries'
+  // branches at this level can intersect [from, to], so resolve those
+  // positions (O(1) through `blockIndexMap`) and iterate the window
+  // between them. The per-entry checks below stay the semantic source
+  // of truth; an unresolvable boundary just leaves its side of the
+  // window open, degrading to the previous full scan.
+  const startIndex =
+    from === undefined ? 0 : (boundaryChildIndex(snapshot, children, from) ?? 0)
+  const endIndex =
+    to === undefined
+      ? children.length - 1
+      : (boundaryChildIndex(snapshot, children, to) ?? children.length - 1)
+  const window = children.slice(startIndex, endIndex + 1)
+  const entries = reverse ? window.reverse() : window
 
   for (const entry of entries) {
     if (canStopTraversal(snapshot, entry.path, from, to, reverse)) {
@@ -217,6 +232,72 @@ function* getNodesInRange(
 
     yield* getNodesInRange(snapshot, entry.path, options)
   }
+}
+
+/**
+ * The index of the child whose subtree `boundary` passes through, at
+ * the level `children` was resolved for. `undefined` when the boundary
+ * does not pass through this level or cannot be resolved, in which
+ * case the caller must not narrow the window on that side.
+ */
+function boundaryChildIndex(
+  snapshot: TraversalSnapshot,
+  children: Array<{node: Node; path: Path}>,
+  boundary: Path,
+): number | undefined {
+  const firstChild = children[0]
+  if (!firstChild) {
+    return undefined
+  }
+  const childPathLength = firstChild.path.length
+  if (boundary.length < childPathLength) {
+    return undefined
+  }
+
+  // The children share every path segment but the last; the boundary
+  // passes through this level only when that shared prefix is an
+  // ancestor of it.
+  const sharedPrefix = firstChild.path.slice(0, -1)
+  if (sharedPrefix.length > 0 && !isAncestorPath(sharedPrefix, boundary)) {
+    return undefined
+  }
+
+  const childSegment = boundary[childPathLength - 1]
+
+  if (isKeyedSegment(childSegment)) {
+    const mappedIndex = snapshot.blockIndexMap.get(
+      serializePath(boundary.slice(0, childPathLength)),
+    )
+    const mappedSegment =
+      mappedIndex !== undefined
+        ? children[mappedIndex]?.path[childPathLength - 1]
+        : undefined
+    if (
+      mappedSegment !== undefined &&
+      isKeyedSegment(mappedSegment) &&
+      mappedSegment._key === childSegment._key
+    ) {
+      return mappedIndex
+    }
+    // The map can miss or disagree with the tree (unmaintained or stale
+    // maps); fall back to a linear scan, mirroring `getNode` and
+    // `getChildren`.
+    const scannedIndex = children.findIndex((child) => {
+      const lastSegment = child.path[child.path.length - 1]
+      return (
+        isKeyedSegment(lastSegment) && lastSegment._key === childSegment._key
+      )
+    })
+    return scannedIndex === -1 ? undefined : scannedIndex
+  }
+
+  if (typeof childSegment === 'number') {
+    return childSegment >= 0 && childSegment < children.length
+      ? childSegment
+      : undefined
+  }
+
+  return undefined
 }
 
 /**

--- a/packages/editor/tests/performance.test.tsx
+++ b/packages/editor/tests/performance.test.tsx
@@ -36,6 +36,60 @@ describe('Performance', () => {
       console.warn(`Inserted 1000 blocks in ${duration.toFixed(2)}ms`)
     })
 
+    test('Toggling a decorator at the end of a 1000-block document', async () => {
+      const {editor, locator} = await createTestEditor({
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      })
+
+      editor.send({
+        type: 'insert.blocks',
+        blocks: Array.from({length: 1000}, (_, i) => ({
+          _type: 'block',
+          _key: `b${i}`,
+          children: [
+            {_type: 'span', _key: `s${i}`, text: `block ${i}`, marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        })),
+        placement: 'auto',
+      })
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value.length).toBe(1000)
+
+        expect(locator.getByText('block 999')).toBeInTheDocument()
+      })
+
+      editor.send({type: 'focus'})
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: 'b999'}, 'children', {_key: 's999'}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: 'b999'}, 'children', {_key: 's999'}],
+            offset: 5,
+          },
+        },
+      })
+
+      const start = performance.now()
+
+      for (let toggleIndex = 0; toggleIndex < 10; toggleIndex++) {
+        editor.send({type: 'decorator.toggle', decorator: 'strong'})
+        await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+      }
+
+      const duration = performance.now() - start
+
+      console.warn(
+        `Toggled a decorator 10 times at the end of a 1000-block document in ${duration.toFixed(2)}ms`,
+      )
+    })
+
     test('Inserting 1000 blocks before an existing block', async () => {
       const {editor, locator} = await createTestEditor()
 


### PR DESCRIPTION
Toggling a decorator or annotation scaled with the selection's position in the document: bolding one word in the last block of an 8,000-block document cost ~10ms, walking blocks the traversal could never yield. This came out of the traversal-utils audit as the last measured hot-path scan.

The cost sits in `getNodesInRange` (`traversal/get-nodes.ts`). The `{from, to}` mode pruned subtree *descent* but iterated every child at each level from the first one, running `comparePathsInTree`, a serializing map lookup, per entry until it passed `to`. Every consumer of a selection-bounded walk paid O(caret position): the decorator ops, annotation ops, `unset-matched-in-range`, and `engine-utils`.

The fix seeks instead of scanning. A new `boundaryChildIndex` resolves the child each boundary path passes through at the current level: a prefix match against the level's shared path prefix (children differ only in their last segment), then a `blockIndexMap` lookup verified against the child's actual key, with the linear-scan fallback mirroring `getNode`/`getChildren`. The loop then iterates only the window between the two boundaries. The design leans on two things: the existing per-entry checks (`canStopTraversal`/`couldContainInRangeNodes`/`isInRange`) are untouched and remain the semantic source of truth, entries outside the window are provably exactly those the old checks skipped or stopped at; and an unresolvable boundary (numeric prefixes, foreign branches, map misses) leaves that side of the window open, degrading to the previous full scan rather than misbehaving, the same fallback discipline as the rest of the traversal layer.

Net behavior unchanged: all 32 range-traversal tests pass unmodified, including deep container boundaries, ancestor bounds (`from` being an ancestor of `to`), reverse iteration, and single-block ranges, and the full suite is green (841 unit, 1698 chromium). Toggling `strong` on one word in the last block (chromium, warmed, medians): 2.2 to 0.7ms at 1k blocks, 10.2 to 3.2ms at 8k (3.2x). The residual scaling in that gesture is the linear sibling ordering inside `comparePaths`, which the decorator/annotation ops call directly; consolidating that onto the map-based compare is the companion ticket and stacks naturally on this. A second commit adds a decorator-toggle-at-document-end baseline to the performance test file.
