### PR TITLE
refactor: consolidate the verify-then-scan sibling-index idiom

### DIFF
--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -509,6 +509,11 @@ function replaceLastSegment(path: Path, segment: Path[number]): Path {
  * (e.g. unkeyed transient nodes, or paths outside registered container
  * fields such as `markDefs`).
  */
+/**
+ * Raw-array sibling of `resolveChildEntryIndex` (`traversal/`): this
+ * and `resolveBlockIndex` run mid-`modifyChildren` against plain node
+ * arrays, where no `{node, path}` entries exist to share the helper.
+ */
 function resolveChildIndex(
   blockIndexMap: ReadonlyMap<string, number>,
   parentSegments: Path,

--- a/packages/editor/src/internal-utils/find-nearest-spans.ts
+++ b/packages/editor/src/internal-utils/find-nearest-spans.ts
@@ -1,11 +1,10 @@
 import type {PortableTextSpan} from '@portabletext/schema'
 import {isSpan} from '@portabletext/schema'
 import type {Path} from '../engine/interfaces/path'
-import {serializePath} from '../paths/serialize-path'
 import {getChildren} from '../traversal/get-children'
 import {getNodes} from '../traversal/get-nodes'
+import {resolveChildEntryIndex} from '../traversal/resolve-child-entry-index'
 import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 
 export type SpanEntry = {
   node: PortableTextSpan
@@ -38,6 +37,13 @@ export function findNearestSpans(
   }
 }
 
+/**
+ * Not built on `getSibling` (`traversal/get-sibling.ts`) deliberately:
+ * its `match` tests the sibling node itself, while this walk needs
+ * "is a span or contains one" and would still have to re-descend the
+ * matched sibling to extract the span entry. Applies to
+ * `findPreviousSpan` too.
+ */
 function findNextSpan(
   snapshot: TraversalSnapshot,
   path: Path,
@@ -54,7 +60,11 @@ function findNextSpan(
   while (currentPath.length > 0) {
     const parentPath = nodeParentPath(currentPath)
     const siblings = getChildren(snapshot, parentPath)
-    const index = childIndex(snapshot, siblings, currentPath)
+    const index = resolveChildEntryIndex(
+      snapshot.blockIndexMap,
+      siblings,
+      currentPath,
+    )
 
     if (index !== -1) {
       for (
@@ -90,7 +100,11 @@ function findPreviousSpan(
   while (currentPath.length > 0) {
     const parentPath = nodeParentPath(currentPath)
     const siblings = getChildren(snapshot, parentPath)
-    const index = childIndex(snapshot, siblings, currentPath)
+    const index = resolveChildEntryIndex(
+      snapshot.blockIndexMap,
+      siblings,
+      currentPath,
+    )
 
     if (index !== -1) {
       for (let siblingIndex = index - 1; siblingIndex >= 0; siblingIndex--) {
@@ -163,56 +177,4 @@ function nodeParentPath(path: Path): Path {
     end--
   }
   return path.slice(0, end)
-}
-
-/**
- * The index of `childPath`'s node within `siblings`. Resolves keyed
- * segments through `blockIndexMap` (O(1), verified against the sibling
- * array) with a linear fallback for misses and paths the map can't key
- * (numeric segments).
- *
- * Not built on `getSibling` (`traversal/get-sibling.ts`) deliberately:
- * its `match` tests the sibling node itself, while this walk needs
- * "is a span or contains one" and would still have to re-descend the
- * matched sibling to extract the span entry.
- */
-function childIndex(
-  snapshot: TraversalSnapshot,
-  siblings: Array<{node: {_key?: string}; path: Path}>,
-  childPath: Path,
-): number {
-  const lastSegment = childPath[childPath.length - 1]
-
-  if (typeof lastSegment === 'number') {
-    return lastSegment < siblings.length ? lastSegment : -1
-  }
-
-  if (!isKeyedSegment(lastSegment)) {
-    return -1
-  }
-
-  let fullyKeyed = true
-  for (
-    let segmentIndex = 0;
-    segmentIndex < childPath.length - 1;
-    segmentIndex++
-  ) {
-    const segment = childPath[segmentIndex]
-    if (typeof segment !== 'string' && !isKeyedSegment(segment)) {
-      fullyKeyed = false
-      break
-    }
-  }
-
-  if (fullyKeyed) {
-    const mapIndex = snapshot.blockIndexMap.get(serializePath(childPath))
-    if (
-      mapIndex !== undefined &&
-      siblings[mapIndex]?.node._key === lastSegment._key
-    ) {
-      return mapIndex
-    }
-  }
-
-  return siblings.findIndex((sibling) => sibling.node._key === lastSegment._key)
 }

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -169,7 +169,9 @@ export function transformBlockIndexMap(
  * the map), so it is an O(1) lookup instead of the linear scan in
  * `resolveChildIndexInValue`. A numeric path segment can't form the map's keyed
  * id, and a map miss falls back to the scan; the oracle/fuzz tests pin
- * equivalence.
+ * equivalence. Raw-value sibling of `resolveChildEntryIndex`
+ * (`traversal/`): the fallback here walks the pre-op value tree, not a
+ * resolved entries array.
  */
 function childIndexFromMap(
   map: ReadonlyMap<string, number>,

--- a/packages/editor/src/traversal/get-nodes.ts
+++ b/packages/editor/src/traversal/get-nodes.ts
@@ -7,8 +7,8 @@ import type {
   Containers,
   RegisteredContainer,
 } from '../schema/resolve-containers'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren, getNodeChildren} from './get-children'
+import {resolveChildEntryIndex} from './resolve-child-entry-index'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
@@ -262,42 +262,12 @@ function boundaryChildIndex(
     return undefined
   }
 
-  const childSegment = boundary[childPathLength - 1]
-
-  if (isKeyedSegment(childSegment)) {
-    const mappedIndex = snapshot.blockIndexMap.get(
-      serializePath(boundary.slice(0, childPathLength)),
-    )
-    const mappedSegment =
-      mappedIndex !== undefined
-        ? children[mappedIndex]?.path[childPathLength - 1]
-        : undefined
-    if (
-      mappedSegment !== undefined &&
-      isKeyedSegment(mappedSegment) &&
-      mappedSegment._key === childSegment._key
-    ) {
-      return mappedIndex
-    }
-    // The map can miss or disagree with the tree (unmaintained or stale
-    // maps); fall back to a linear scan, mirroring `getNode` and
-    // `getChildren`.
-    const scannedIndex = children.findIndex((child) => {
-      const lastSegment = child.path[child.path.length - 1]
-      return (
-        isKeyedSegment(lastSegment) && lastSegment._key === childSegment._key
-      )
-    })
-    return scannedIndex === -1 ? undefined : scannedIndex
-  }
-
-  if (typeof childSegment === 'number') {
-    return childSegment >= 0 && childSegment < children.length
-      ? childSegment
-      : undefined
-  }
-
-  return undefined
+  const resolvedIndex = resolveChildEntryIndex(
+    snapshot.blockIndexMap,
+    children,
+    boundary.slice(0, childPathLength),
+  )
+  return resolvedIndex === -1 ? undefined : resolvedIndex
 }
 
 /**

--- a/packages/editor/src/traversal/get-sibling.ts
+++ b/packages/editor/src/traversal/get-sibling.ts
@@ -1,9 +1,8 @@
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
 import {parentPath} from '../engine/path/parent-path'
-import {serializePath} from '../paths/serialize-path'
-import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildren} from './get-children'
+import {resolveChildEntryIndex} from './resolve-child-entry-index'
 import type {TraversalSnapshot} from './traversal-snapshot'
 
 /**
@@ -50,42 +49,17 @@ export function getSibling(
     return undefined
   }
 
-  const lastSegment = path.at(-1)
-
-  if (!isKeyedSegment(lastSegment) && typeof lastSegment !== 'number') {
-    return undefined
-  }
-
   const parent = parentPath(path)
   const children = getChildren(snapshot, parent)
 
-  let currentIndex: number
+  const currentIndex = resolveChildEntryIndex(
+    snapshot.blockIndexMap,
+    children,
+    path,
+  )
 
-  if (typeof lastSegment === 'number') {
-    if (lastSegment < 0 || lastSegment >= children.length) {
-      return undefined
-    }
-    currentIndex = lastSegment
-  } else {
-    const mappedIndex = snapshot.blockIndexMap.get(serializePath(path))
-
-    if (
-      mappedIndex !== undefined &&
-      children[mappedIndex]?.node._key === lastSegment._key
-    ) {
-      currentIndex = mappedIndex
-    } else {
-      // The map can miss (unkeyed transient nodes, unmaintained maps) or
-      // disagree with the traversed value (snapshots that pair the live map
-      // with a pre-apply value). Fall back to a linear scan in both cases,
-      // mirroring `getNode` and `getChildren`.
-      currentIndex = children.findIndex(
-        (child) => child.node._key === lastSegment._key,
-      )
-      if (currentIndex === -1) {
-        return undefined
-      }
-    }
+  if (currentIndex === -1) {
+    return undefined
   }
 
   if (!match) {

--- a/packages/editor/src/traversal/resolve-child-entry-index.ts
+++ b/packages/editor/src/traversal/resolve-child-entry-index.ts
@@ -1,0 +1,62 @@
+import type {Node} from '../engine/interfaces/node'
+import type {Path} from '../engine/interfaces/path'
+import {serializePath} from '../paths/serialize-path'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+
+/**
+ * The index of the child addressed by `childPath`'s last segment within
+ * `children` (entries as resolved by `getChildren`). Numeric last
+ * segments are literal, bounds-checked indices. Keyed segments resolve
+ * through `blockIndexMap` when the path is fully keyed (the map's id
+ * space), verified against the entry at the mapped position, with a
+ * linear scan fallback for misses, disagreements, and paths the map
+ * cannot key, mirroring `getNode`/`getChildren`. Returns `-1` when the
+ * child is not found.
+ *
+ * The map is taken explicitly rather than assumed current: some callers
+ * deliberately resolve against pre-operation map state. The engine
+ * keeps raw-array siblings of this helper (`resolveChildIndex` in
+ * `apply-operation.ts`, `childIndexFromMap` in
+ * `transform-block-index-map.ts`) for call sites that hold plain node
+ * arrays mid-mutation, where no entries exist.
+ */
+export function resolveChildEntryIndex(
+  blockIndexMap: ReadonlyMap<string, number>,
+  children: ReadonlyArray<{node: Node; path: Path}>,
+  childPath: Path,
+): number {
+  const lastSegment = childPath[childPath.length - 1]
+
+  if (typeof lastSegment === 'number') {
+    return lastSegment >= 0 && lastSegment < children.length ? lastSegment : -1
+  }
+
+  if (!isKeyedSegment(lastSegment)) {
+    return -1
+  }
+
+  let fullyKeyed = true
+  for (
+    let segmentIndex = 0;
+    segmentIndex < childPath.length - 1;
+    segmentIndex++
+  ) {
+    const segment = childPath[segmentIndex]
+    if (typeof segment !== 'string' && !isKeyedSegment(segment)) {
+      fullyKeyed = false
+      break
+    }
+  }
+
+  if (fullyKeyed) {
+    const mappedIndex = blockIndexMap.get(serializePath(childPath))
+    if (
+      mappedIndex !== undefined &&
+      children[mappedIndex]?.node._key === lastSegment._key
+    ) {
+      return mappedIndex
+    }
+  }
+
+  return children.findIndex((child) => child.node._key === lastSegment._key)
+}


### PR DESCRIPTION
Extracted from review discussion on #2914: the "resolve a keyed segment's index among siblings via `blockIndexMap`, verify against the tree, fall back to a linear scan" idiom had accumulated five private copies across `apply-operation.ts`, `transform-block-index-map.ts`, `find-nearest-spans.ts`, `get-sibling.ts`, and `get-nodes.ts`, each written independently as the perf work applied the same pattern, and already drifting (different numeric-segment guards, different fully-keyed checks, different verify targets).

The three entries-based copies now share `resolveChildEntryIndex` (`traversal/resolve-child-entry-index.ts`): numeric last segments resolve as bounds-checked literals, keyed segments go through the map only when the path is fully keyed (the map's id space), the mapped position is verified against the entry's actual key, and everything else falls back to a linear scan, the same discipline as `getNode`/`getChildren`. The map is a parameter rather than an assumption, preserving the pre-operation-state resolution some callers depend on.

The engine-side raw-array variants stay separate on purpose: `resolveChildIndex`/`resolveBlockIndex` run mid-`modifyChildren` against plain node arrays where no `{node, path}` entries exist, and `childIndexFromMap`'s fallback walks the pre-op value tree rather than an entries array. Forcing them into the shared helper would mean accessor parameters or per-call entry allocation, worse than the duplication. Each now carries a pointer to the shared helper naming that reason, so the next reader gets the answer this PR's review question had to dig for.

Net behavior unchanged: the three migrated call sites' suites (26 `getSibling`, 32 `getNodes`, 7 `findNearestSpans`) pass unmodified, plus the full suite (841 unit, 1699 chromium). Two hardenings ride along as the only semantic deltas, both in `getSibling`: paths the map cannot key are no longer serialized into a guaranteed miss, and negative numeric segments are rejected like everywhere else. No changeset: internal refactor, no observable change.
