### PR TITLE
docs: note why `comparePathsInTree` must not be merged with `comparePaths`

### DIFF
--- a/packages/editor/src/traversal/get-nodes.ts
+++ b/packages/editor/src/traversal/get-nodes.ts
@@ -117,10 +117,16 @@ function* getNodesSimple(
 }
 
 /**
- * Compare two keyed paths in document order. Returns -1, 0, or 1.
+ * Compare two keyed paths in DFS pre-order. Returns -1, 0, or 1.
  *
  * Walks both paths in parallel; at the first divergence, consults
  * `blockIndexMap` for the sibling indices and compares them.
+ *
+ * Deliberately not `comparePaths` (`engine/path/compare-paths.ts`):
+ * that compare treats an ancestor/descendant pair as equal (0), while
+ * range traversal needs the ancestor ordered first (-1/1), it is what
+ * excludes `to`'s descendants from a range. The two compares answer
+ * different questions and must not be merged.
  */
 function comparePathsInTree(
   snapshot: TraversalSnapshot,


### PR DESCRIPTION
Investigating whether the linear `comparePaths` should be consolidated onto the map-based `comparePathsInTree` surfaced that they answer different questions: `comparePaths` treats an ancestor/descendant pair as equal (0), while `comparePathsInTree` orders the ancestor first (-1/1) in DFS pre-order, and range traversal depends on that difference, it is what excludes `to`'s descendants from a range. Merging them would silently change range semantics, so the doc comment now names the trap.

Docs-only; the consolidation itself was measured and abandoned (`comparePaths` runs ~6 times per decorator toggle at 0.14-0.27ms total, no gesture pays for the linear scan), full reasoning on the Linear ticket.