### PR TITLE
fix: sync the selection in read-only editors

### DIFF
--- a/.changeset/readonly-selection-sync.md
+++ b/.changeset/readonly-selection-sync.md
@@ -1,0 +1,14 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: sync the selection in read-only editors
+
+Selections made in a read-only editor never reached the editor's model:
+the selection sync bailed unless the editable was the document's active
+element, which a read-only editable never is. Consumers saw a frozen
+selection (stale selection-derived UI stuck on screen after switching to
+read-only) and copying selected content put nothing on the clipboard
+since `serialize` read an outdated selection. The model now tracks the
+selection in read-only editors, so selection-derived rendering and copy
+work; editing remains blocked as before.

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -281,7 +281,14 @@ export const Editable = forwardRef(
               editor.focused = true
             } else {
               editor.focused = false
-              return
+              if (!readOnly) {
+                return
+              }
+              // A read-only editable is never the active element (no
+              // `contenteditable`, no tab stop), yet users legitimately
+              // select its text for copying. Keep syncing the selection so
+              // the model tracks it; the checks below still confine the
+              // sync to selections inside the editor.
             }
 
             if (!domSelection) {

--- a/packages/editor/tests/selection-readonly-sync.test.tsx
+++ b/packages/editor/tests/selection-readonly-sync.test.tsx
@@ -1,0 +1,134 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Selection must keep syncing in read-only editors. The `selectionchange`
+ * handler used to bail unless the editable was the document's active
+ * element, and a read-only editable (`contenteditable="false"`, no tab stop)
+ * can never be the active element, so the model selection froze: stale
+ * selections stuck around and new selections never reached consumers
+ * (selection-derived UI, `serialize` on copy). The editor machine already
+ * whitelists `select` in read-only mode; the DOM side has to deliver it.
+ */
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'blockA',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 'spanA', text: 'first', marks: []}],
+  },
+  {
+    _type: 'block',
+    _key: 'blockB',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 'spanB', text: 'second', marks: []}],
+  },
+]
+
+describe('Feature: Read-Only Selection Sync', () => {
+  test('Scenario: Selecting text in a read-only editor syncs the model selection', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    editor.send({type: 'update readOnly', readOnly: true})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.readOnly).toBe(true)
+    })
+
+    selectDomText('first', 1, 'second', 3)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: 'blockA'}, 'children', {_key: 'spanA'}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: 'blockB'}, 'children', {_key: 'spanB'}],
+          offset: 3,
+        },
+        backward: false,
+      })
+    })
+  })
+
+  test('Scenario: A selection made before turning read-only keeps following the DOM', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue,
+    })
+
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'blockA'}, 'children', {_key: 'spanA'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'blockB'}, 'children', {_key: 'spanB'}],
+          offset: 6,
+        },
+      },
+    })
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(6)
+    })
+
+    editor.send({type: 'update readOnly', readOnly: true})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.readOnly).toBe(true)
+    })
+
+    // The user moves the selection while read-only; the model must not stay
+    // stuck on the pre-read-only range.
+    selectDomText('second', 0, 'second', 2)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {
+          path: [{_key: 'blockB'}, 'children', {_key: 'spanB'}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: 'blockB'}, 'children', {_key: 'spanB'}],
+          offset: 2,
+        },
+        backward: false,
+      })
+    })
+  })
+})
+
+function selectDomText(
+  anchorText: string,
+  anchorOffset: number,
+  focusText: string,
+  focusOffset: number,
+) {
+  const anchorNode = findTextNode(anchorText)
+  const focusNode = findTextNode(focusText)
+  window
+    .getSelection()
+    ?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
+}
+
+function findTextNode(text: string): Text {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  while (walker.nextNode()) {
+    if (walker.currentNode.textContent === text) {
+      return walker.currentNode as Text
+    }
+  }
+  throw new Error(`No text node with text "${text}"`)
+}


### PR DESCRIPTION
A field report from the table work: switch an editor to read-only while a multi-cell (selection-derived) highlight is active and the highlight is stuck forever; make a new selection in the read-only editor and no selection-derived UI appears, and copying puts nothing on the clipboard.

Both symptoms share one root. The `selectionchange` sync bails unless the editable is the document's active element, and a read-only editable (`contenteditable="false"`, no tab stop) can never be the active element, so DOM-to-model selection sync is structurally dead in read-only editors. The model selection freezes at whatever it held when read-only began: stale selection-derived rendering paints forever, new selections never reach `getTableSelection`-style consumers, and `clipboard.copy` serializes the outdated selection onto a prevented default, hence the empty clipboard.

The intent of the surrounding code is clearly the opposite, three separate pieces already accommodate read-only selection: the editor machine whitelists `select`, `clipboard.copy`, and `serialize` in read-only mode, the `selectionchange` handler carries a read-only-specific deselect guard just below the gate, and `hasDOMNode`'s editable check has an explicit clause accepting targets whose closest `contenteditable="false"` ancestor is the editor root, commented as existing precisely for the read-only case. The focus gate above them was the one piece that never yielded.

This is a regression from 2a3e03934 (April 2026), which added a one-line early return so a toolbar click's blur could not clobber the editor's selection with the browser's collapsed one. That purpose is editable-mode-specific; read-only editors, which are never the active element, lost selection sync as collateral.

The fix makes the gate yield in read-only editors only, preserving 2a3e03934's behavior for editable editors exactly. The selectable/in-editor checks below still confine the sync to selections inside the editor, and the existing deselect guard still clears the model when the selection leaves it, so the blast radius is the intended one: read-only editors gain working selection tracking (and therefore selection-derived UI and copy), while editable editors keep the gate exactly as before, all 1701 existing browser tests pass unmodified.

`selection-readonly-sync.test.tsx` pins both reported shapes: a selection made while read-only reaches the model with full literal points, and a selection made before switching to read-only keeps following the DOM instead of freezing. Both scenarios are red without the gate change.
