### PR TITLE
fix: name the actual mismatch in container registration warnings

### DIFF
--- a/.changeset/container-registration-warnings.md
+++ b/.changeset/container-registration-warnings.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: name the actual mismatch in container registration warnings
+
+Registering a container that doesn't match the schema still warns and skips the registration, but the warning now names what is actually wrong. A type that isn't in the schema is reported as an unknown type instead of a missing field, a field that exists but isn't an array is reported as such, and a primitive-only array field produces a single warning instead of two contradictory ones. Code that matches on the exact warning strings will see the new texts.

--- a/packages/editor/src/schema/resolve-container-field.ts
+++ b/packages/editor/src/schema/resolve-container-field.ts
@@ -9,6 +9,21 @@ import type {ChildArrayField} from './container-types'
  */
 const PRIMITIVE_TYPES = new Set(['string', 'number', 'boolean'])
 
+/**
+ * Why a container registration failed to resolve against the schema.
+ * Carried out of {@link resolveContainerFieldResolution} so the caller
+ * can warn (or throw) with a message that names the actual problem.
+ */
+export type ContainerFieldFailure =
+  | 'unknown-type'
+  | 'field-missing'
+  | 'field-not-array'
+  | 'field-primitive-only'
+
+export type ContainerFieldResolution =
+  | {field: ChildArrayField}
+  | {failure: ContainerFieldFailure}
+
 function isChildArrayField(field: FieldDefinition): field is ChildArrayField {
   return field.type === 'array' && 'of' in field && Array.isArray(field.of)
 }
@@ -27,20 +42,19 @@ function synthesizeBlockChildrenField(schema: EditorSchema): ChildArrayField {
 
 function resolveFieldOn(
   fields: ReadonlyArray<FieldDefinition>,
-  type: string,
   fieldName: string,
-): ChildArrayField | undefined {
+): ContainerFieldResolution {
   const field = fields.find((candidate) => candidate.name === fieldName)
-  if (!field || !isChildArrayField(field)) {
-    return undefined
+  if (!field) {
+    return {failure: 'field-missing'}
+  }
+  if (!isChildArrayField(field)) {
+    return {failure: 'field-not-array'}
   }
   if (containsOnlyPrimitiveTypes(field)) {
-    console.warn(
-      `Field '${field.name}' on '${type}' doesn't contain block or container types and will be excluded`,
-    )
-    return undefined
+    return {failure: 'field-primitive-only'}
   }
-  return field
+  return {field}
 }
 
 function findInlineDeclarationIn(
@@ -112,9 +126,8 @@ function findInlineFields(
 
 /**
  * Resolve the {@link ChildArrayField} on a schema for a container
- * registration. Returns `undefined` when the registration is invalid:
- * unknown type, missing field, non-array field, or primitive-only array
- * field.
+ * registration, or report why the registration is invalid: unknown
+ * type, missing field, non-array field, or primitive-only array field.
  *
  * Resolves the type by looking at:
  *   1. The synthesized `block` container (text blocks; field is
@@ -127,23 +140,25 @@ function findInlineFields(
  * Among inline declarations of the same name at multiple depths, prefers
  * the shape with the matching field (rejecting empty-fields placeholders).
  */
-export function resolveContainerField(
+export function resolveContainerFieldResolution(
   schema: EditorSchema,
   type: string,
   fieldName: string,
   parentOf?: ReadonlyArray<OfDefinition>,
-): ChildArrayField | undefined {
+): ContainerFieldResolution {
   if (type === 'block') {
     if (fieldName !== 'children') {
-      return undefined
+      // Text blocks have exactly one child array. Any other field name is
+      // a field mistake, not a type mistake.
+      return {failure: 'field-missing'}
     }
-    return synthesizeBlockChildrenField(schema)
+    return {field: synthesizeBlockChildrenField(schema)}
   }
 
   if (parentOf) {
     const inlineMatch = findInlineDeclarationIn(parentOf, type)
     if (inlineMatch) {
-      return resolveFieldOn(inlineMatch, type, fieldName)
+      return resolveFieldOn(inlineMatch, fieldName)
     }
   }
 
@@ -162,8 +177,32 @@ export function resolveContainerField(
 
   const fields = rootFields ?? inlineFields
   if (!fields) {
-    return undefined
+    if (rootMatch) {
+      // The type exists in the schema but declares no fields, so the
+      // problem to report is the field, not the type.
+      return {failure: 'field-missing'}
+    }
+    return {failure: 'unknown-type'}
   }
 
-  return resolveFieldOn(fields, type, fieldName)
+  return resolveFieldOn(fields, fieldName)
+}
+
+/**
+ * Convenience wrapper over {@link resolveContainerFieldResolution} for
+ * callers that only need the field and not the failure reason.
+ */
+export function resolveContainerField(
+  schema: EditorSchema,
+  type: string,
+  fieldName: string,
+  parentOf?: ReadonlyArray<OfDefinition>,
+): ChildArrayField | undefined {
+  const resolution = resolveContainerFieldResolution(
+    schema,
+    type,
+    fieldName,
+    parentOf,
+  )
+  return 'field' in resolution ? resolution.field : undefined
 }

--- a/packages/editor/src/schema/resolve-containers-batch.ts
+++ b/packages/editor/src/schema/resolve-containers-batch.ts
@@ -11,7 +11,10 @@ import type {
 } from '../renderers/renderer.types'
 import {buildPublicContainers} from './build-public-containers'
 import type {Containers, ResolvedContainers} from './container-types'
-import {resolveContainerField} from './resolve-container-field'
+import {
+  resolveContainerFieldResolution,
+  type ContainerFieldFailure,
+} from './resolve-container-field'
 
 /**
  * Test helper: resolve a list of top-level container registrations into
@@ -73,24 +76,25 @@ export function resolveNestedContainer(
   onFailure: 'warn' | 'throw' = 'warn',
   parentOf?: ReadonlyArray<OfDefinition>,
 ): ContainerConfig | undefined {
-  const field = resolveContainerField(
+  const resolution = resolveContainerFieldResolution(
     schema,
     container.type,
     container.arrayField,
     parentOf,
   )
-  if (!field) {
+  if ('failure' in resolution) {
     const location =
       chain.length > 0
         ? ` (nested inside ${chain.map((type) => `"${type}"`).join(' inside ')})`
         : ''
-    const message = `registerNode: field "${container.arrayField}" not found on type "${container.type}"${location}. Registration skipped.`
+    const message = `registerNode: ${describeContainerFailure(resolution.failure, container)}${location}. Registration skipped.`
     if (onFailure === 'throw') {
       throw new Error(message)
     }
     console.warn(message)
     return undefined
   }
+  const field = resolution.field
   const nextChain = [...chain, container.type]
   const resolvedOf = container.of
     ? container.of.flatMap<
@@ -113,6 +117,22 @@ export function resolveNestedContainer(
       })
     : undefined
   return {container, field, ...(resolvedOf ? {of: resolvedOf} : {})}
+}
+
+function describeContainerFailure(
+  failure: ContainerFieldFailure,
+  container: PublicContainer,
+): string {
+  switch (failure) {
+    case 'unknown-type':
+      return `type "${container.type}" not found in the schema`
+    case 'field-missing':
+      return `field "${container.arrayField}" not found on type "${container.type}"`
+    case 'field-not-array':
+      return `field "${container.arrayField}" on type "${container.type}" is not an array`
+    case 'field-primitive-only':
+      return `field "${container.arrayField}" on type "${container.type}" contains only primitive types and cannot hold block content`
+  }
 }
 
 /**

--- a/packages/editor/src/schema/resolve-containers.test.ts
+++ b/packages/editor/src/schema/resolve-containers.test.ts
@@ -271,6 +271,131 @@ describe(resolveNestedContainer.name, () => {
   })
 })
 
+describe('registration warnings', () => {
+  const warningSchema = compileSchema(
+    defineSchema({
+      blockObjects: [
+        {
+          name: 'table',
+          fields: [
+            {name: 'rows', type: 'array', of: [{type: 'block'}]},
+            {name: 'title', type: 'string'},
+            {name: 'tags', type: 'array', of: [{type: 'string'}]},
+          ],
+        },
+      ],
+    }),
+  )
+
+  test('unknown type names the type, not the field', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const config = resolveNestedContainer(
+        warningSchema,
+        defineContainer({
+          type: 'tabel',
+          arrayField: 'rows',
+          render: containerRender,
+        }),
+      )
+      expect(config).toBeUndefined()
+      expect(warnSpy.mock.calls).toEqual([
+        [
+          'registerNode: type "tabel" not found in the schema. Registration skipped.',
+        ],
+      ])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('missing field names the field on the (existing) type', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const config = resolveNestedContainer(
+        warningSchema,
+        defineContainer({
+          type: 'table',
+          arrayField: 'cols',
+          render: containerRender,
+        }),
+      )
+      expect(config).toBeUndefined()
+      expect(warnSpy.mock.calls).toEqual([
+        [
+          'registerNode: field "cols" not found on type "table". Registration skipped.',
+        ],
+      ])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('non-array field is reported as such', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const config = resolveNestedContainer(
+        warningSchema,
+        defineContainer({
+          type: 'table',
+          arrayField: 'title',
+          render: containerRender,
+        }),
+      )
+      expect(config).toBeUndefined()
+      expect(warnSpy.mock.calls).toEqual([
+        [
+          'registerNode: field "title" on type "table" is not an array. Registration skipped.',
+        ],
+      ])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('primitive-only array warns exactly once', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const config = resolveNestedContainer(
+        warningSchema,
+        defineContainer({
+          type: 'table',
+          arrayField: 'tags',
+          render: containerRender,
+        }),
+      )
+      expect(config).toBeUndefined()
+      // Full-calls assertion: pins both the message and that the failure
+      // does not double-warn (it used to emit a second, wrong "not
+      // found" message).
+      expect(warnSpy.mock.calls).toEqual([
+        [
+          'registerNode: field "tags" on type "table" contains only primitive types and cannot hold block content. Registration skipped.',
+        ],
+      ])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test("'throw' mode throws the same message", () => {
+    expect(() =>
+      resolveNestedContainer(
+        warningSchema,
+        defineContainer({
+          type: 'tabel',
+          arrayField: 'rows',
+          render: containerRender,
+        }),
+        [],
+        'throw',
+      ),
+    ).toThrow(
+      'registerNode: type "tabel" not found in the schema. Registration skipped.',
+    )
+  })
+})
+
 describe(resolveContainerByPath.name, () => {
   const calloutSchema = compileSchema(
     defineSchema({

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -1513,7 +1513,7 @@ describe('container normalization', () => {
     })
 
     expect(warnSpy).toHaveBeenCalledWith(
-      "Field 'tags' on 'card' doesn't contain block or container types and will be excluded",
+      'registerNode: field "tags" on type "card" contains only primitive types and cannot hold block content. Registration skipped.',
     )
 
     warnSpy.mockRestore()


### PR DESCRIPTION
Registering a container that doesn't match the schema warns and skips the registration, which is the right behavior, but the warning could point you at the wrong thing. Typo the *type* name (`defineContainer({type: 'tabel', arrayField: 'rows'})` against a schema that has `table`) and the console said `registerNode: field "rows" not found on type "tabel". Registration skipped.`, blaming the field when the type is the problem. And a primitive-only array field (`tags: array of string`) produced two contradictory warnings: `resolveFieldOn` warned "doesn't contain block or container types and will be excluded", returned `undefined`, and the outer path then warned a second time that the field was "not found", which it wasn't.

The root cause is that `resolveContainerField` collapsed every failure mode (unknown type, missing field, non-array field, primitive-only array) into `undefined`, so `resolveNestedContainer` had exactly one message to emit. The fix moves the distinction to the boundary that already knows it: `resolveContainerFieldResolution` returns a discriminated result, `{field}` or `{failure: 'unknown-type' | 'field-missing' | 'field-not-array' | 'field-primitive-only'}`, and `resolveNestedContainer` maps each failure to a single message that names the actual problem, keeping the existing nested-chain context (`(nested inside "table" inside "row")`). The primitive-only warn moves out of `resolveFieldOn` entirely, so warning is now the resolver's job in exactly one place, which is what kills the double-warn. `resolveContainerField` survives as a three-line wrapper with its old `ChildArrayField | undefined` signature for the internal callers (traversal testbed, union-schema tests) that only need the field.

Two edges are deliberately reported as field mistakes, not type mistakes: a type that exists in the schema but declares no fields (the type is fine, the field can't be on it), and `type: 'block'` with any `arrayField` other than `children` (text blocks have exactly one child array).

Net behavior: registration outcomes are unchanged, still warn-and-skip at runtime and throw in the test helpers (`resolveContainersRich` passes `onFailure: 'throw'`); only the console text changes. The one existing test that asserted the old primitive-only text (`container-normalization.test.tsx`) is updated to the new single message, and `code-block-registration.test.tsx` passes unmodified because a genuine missing field keeps its `field "lines" not found on type "code-block"` substring. New unit tests pin all four messages as full `mock.calls` literals, that primitive-only warns exactly once (previously two), and that `'throw'` mode throws the same message. Gates: `check:types`, `check:lint`, `check:react-compiler`, full `test:unit`, the two affected browser test files on chromium, `build`, root `check:format` and `check:knip`, all green.
