### PR TITLE
refactor: shake the path-walk duplicates

### DIFF
--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -20,6 +20,7 @@ import type {Range} from '../interfaces/range'
 import {commonPath} from '../path/common-path'
 import {isSiblingPath} from '../path/is-sibling-path'
 import {parentPath} from '../path/parent-path'
+import {splitNodePath} from '../path/split-node-path'
 import {transformPoint} from '../point/transform-point'
 import {isBackwardRange} from '../range/is-backward-range'
 import {isRange} from '../range/is-range'
@@ -164,7 +165,7 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
       // Split path into node path (up to last keyed/numeric segment)
       // and property path (trailing string segments)
       const {nodePath: setNodePath, propertyPath: setPropertyPath} =
-        splitNodeAndPropertyPath(path)
+        splitNodePath(path)
 
       if (setNodePath.length === 0) {
         break
@@ -355,7 +356,7 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
 
       // Property removal: split path into node path and property path
       const {nodePath: unsetNodePath, propertyPath: unsetPropertyPath} =
-        splitNodeAndPropertyPath(path)
+        splitNodePath(path)
 
       if (unsetPropertyPath.length === 0 || unsetNodePath.length === 0) {
         break
@@ -549,41 +550,6 @@ function resolveBlockIndex(editor: Editor, segment: KeyedSegment): number {
     return index
   }
   return value.findIndex((block) => block._key === segment._key)
-}
-
-/**
- * Split a path into the node path (up to and including the last
- * keyed/numeric segment) and the property path (trailing string segments).
- */
-function splitNodeAndPropertyPath(path: Path): {
-  nodePath: Path
-  propertyPath: string[]
-} {
-  let lastKeyedOrNumericIndex = -1
-
-  for (let i = path.length - 1; i >= 0; i--) {
-    const segment = path[i]
-    if (isKeyedSegment(segment) || typeof segment === 'number') {
-      lastKeyedOrNumericIndex = i
-      break
-    }
-  }
-
-  if (lastKeyedOrNumericIndex === -1) {
-    return {
-      nodePath: [],
-      propertyPath: path.filter(
-        (segment): segment is string => typeof segment === 'string',
-      ),
-    }
-  }
-
-  const nodePath = path.slice(0, lastKeyedOrNumericIndex + 1)
-  const propertyPath = path
-    .slice(lastKeyedOrNumericIndex + 1)
-    .filter((segment): segment is string => typeof segment === 'string')
-
-  return {nodePath, propertyPath}
 }
 
 /**

--- a/packages/editor/src/engine/path/split-node-path.test.ts
+++ b/packages/editor/src/engine/path/split-node-path.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from 'vitest'
+import {splitNodePath} from './split-node-path'
+
+describe(splitNodePath.name, () => {
+  test('block property path', () => {
+    expect(splitNodePath([{_key: 'b1'}, 'style'])).toEqual({
+      nodePath: [{_key: 'b1'}],
+      propertyPath: ['style'],
+    })
+  })
+
+  test('deep child path with no property trail', () => {
+    expect(splitNodePath([{_key: 'b1'}, 'children', {_key: 's1'}])).toEqual({
+      nodePath: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      propertyPath: [],
+    })
+  })
+
+  test('nested property trail', () => {
+    expect(
+      splitNodePath([{_key: 'b1'}, 'children', {_key: 's1'}, 'text']),
+    ).toEqual({
+      nodePath: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      propertyPath: ['text'],
+    })
+  })
+
+  test('numeric node segment', () => {
+    expect(splitNodePath([3, 'style'])).toEqual({
+      nodePath: [3],
+      propertyPath: ['style'],
+    })
+  })
+
+  test('all-string path has no node', () => {
+    expect(splitNodePath(['style', 'level'])).toEqual({
+      nodePath: [],
+      propertyPath: ['style', 'level'],
+    })
+  })
+
+  test('empty path', () => {
+    expect(splitNodePath([])).toEqual({nodePath: [], propertyPath: []})
+  })
+})

--- a/packages/editor/src/engine/path/split-node-path.ts
+++ b/packages/editor/src/engine/path/split-node-path.ts
@@ -1,0 +1,24 @@
+import type {Path} from '../interfaces/path'
+
+/**
+ * Split a path into the owning node's path (up to and including the
+ * last keyed or numeric segment) and the trailing property segments
+ * after it. Everything after the last keyed or numeric segment is a
+ * string by construction, so stripping the trailing string run is
+ * equivalent to scanning for that segment. Paths without keyed or
+ * numeric segments split into an empty node path and the whole path
+ * as properties.
+ */
+export function splitNodePath(path: Path): {
+  nodePath: Path
+  propertyPath: Array<string>
+} {
+  let nodePathEnd = path.length
+  while (nodePathEnd > 0 && typeof path[nodePathEnd - 1] === 'string') {
+    nodePathEnd--
+  }
+  return {
+    nodePath: path.slice(0, nodePathEnd),
+    propertyPath: path.slice(nodePathEnd) as Array<string>,
+  }
+}

--- a/packages/editor/src/internal-utils/find-nearest-spans.ts
+++ b/packages/editor/src/internal-utils/find-nearest-spans.ts
@@ -1,6 +1,7 @@
 import type {PortableTextSpan} from '@portabletext/schema'
 import {isSpan} from '@portabletext/schema'
 import type {Path} from '../engine/interfaces/path'
+import {splitNodePath} from '../engine/path/split-node-path'
 import {getChildren} from '../traversal/get-children'
 import {getNodes} from '../traversal/get-nodes'
 import {resolveChildEntryIndex} from '../traversal/resolve-child-entry-index'
@@ -172,9 +173,7 @@ function lastSpanIn(
  * `[block]`).
  */
 function nodeParentPath(path: Path): Path {
-  let end = path.length - 1
-  while (end > 0 && typeof path[end - 1] === 'string') {
-    end--
-  }
-  return path.slice(0, end)
+  // Drop the node's own segment, then its field-name trail: the owning
+  // node of what remains is the parent.
+  return splitNodePath(path.slice(0, -1)).nodePath
 }

--- a/packages/editor/src/internal-utils/transform-block-index-map.ts
+++ b/packages/editor/src/internal-utils/transform-block-index-map.ts
@@ -4,12 +4,14 @@ import type {Node} from '../engine/interfaces/node'
 import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Path} from '../engine/interfaces/path'
 import {parentPath as getParentPath} from '../engine/path/parent-path'
+import {splitNodePath} from '../engine/path/split-node-path'
 import {serializePath} from '../paths/serialize-path'
 import type {RegisteredContainer} from '../schema/container-types'
 import {getNodeChildren} from '../traversal/get-children'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {BlockIndexMap} from './block-index-map'
 import {buildIndexMaps, collectDescendantIndexes} from './build-index-maps'
+import {getValue} from './get-value'
 
 /**
  * Context needed by the pure `transformBlockIndexMap` function. Pure
@@ -79,7 +81,7 @@ export function transformBlockIndexMap(
       }
       const lastSegment = op.path[op.path.length - 1]
       if (typeof lastSegment === 'string') {
-        if (hasKeyedEntries(resolveValueAtPath(beforeValue, op.path))) {
+        if (hasKeyedEntries(getValue(beforeValue, op.path))) {
           // The removed property held keyed nodes (a container field), so
           // their entries must be pruned.
           reconcileOwnerSubtree(map, context, beforeValue, afterValue, op.path)
@@ -135,7 +137,7 @@ export function transformBlockIndexMap(
         // replaced by a primitive).
         if (
           (op.value !== null && typeof op.value === 'object') ||
-          hasKeyedEntries(resolveValueAtPath(beforeValue, op.path))
+          hasKeyedEntries(getValue(beforeValue, op.path))
         ) {
           reconcileOwnerSubtree(map, context, beforeValue, afterValue, op.path)
         }
@@ -479,41 +481,12 @@ function reconcileOwnerSubtree(
   afterValue: ReadonlyArray<Node>,
   propertyPath: Path,
 ): void {
-  let ownerPathEnd = propertyPath.length
-  while (
-    ownerPathEnd > 0 &&
-    typeof propertyPath[ownerPathEnd - 1] === 'string'
-  ) {
-    ownerPathEnd--
-  }
-  if (ownerPathEnd === 0) {
+  const ownerPath = splitNodePath(propertyPath).nodePath
+  if (ownerPath.length === 0) {
     return
   }
-  const ownerPath = propertyPath.slice(0, ownerPathEnd)
   pruneSubtreeAtPath(map, beforeValue, ownerPath, /*keepSelf*/ true)
   addSubtree(map, context, afterValue, ownerPath)
-}
-
-/**
- * Resolve the raw value at `path`, following keyed/numeric node
- * segments and a trailing run of property-name segments.
- */
-function resolveValueAtPath(value: ReadonlyArray<Node>, path: Path): unknown {
-  let nodePathEnd = path.length
-  while (nodePathEnd > 0 && typeof path[nodePathEnd - 1] === 'string') {
-    nodePathEnd--
-  }
-  if (nodePathEnd === 0) {
-    return undefined
-  }
-  let current: unknown = resolveNodeAtPath(value, path.slice(0, nodePathEnd))
-  for (let i = nodePathEnd; i < path.length; i++) {
-    if (current === null || typeof current !== 'object') {
-      return undefined
-    }
-    current = (current as Record<string, unknown>)[path[i] as string]
-  }
-  return current
 }
 
 function hasKeyedEntries(value: unknown): boolean {


### PR DESCRIPTION
Two duplication clusters from a codebase sweep, both pure deletions in spirit (13 insertions, 73 deletions net of the new util and its tests).

First, the "owning node path" split existed as four copies in three shapes: `splitNodeAndPropertyPath` in `apply-operation.ts` scanned backward for the last keyed/numeric segment, `nodeParentPath` in `find-nearest-spans.ts` and two inline loops in `transform-block-index-map.ts` stripped trailing string runs. The formulations are equivalent because everything after the last keyed or numeric segment is a string by construction, so all four now go through `splitNodePath` (`engine/path/split-node-path.ts`), which records that argument in its doc comment and carries its own shape tests (property trails, numeric nodes, all-string paths, empty).

Second, `resolveValueAtPath` in the transform re-derived the generic raw-value walk that `getValue` already provides, and is deleted. Its two callers only feed `hasKeyedEntries`; the walks' one observable difference, `null` versus `undefined` at a mid-walk dead end, washes out through `Array.isArray`, and the transform's oracle and fuzz suite pins the equivalence end to end.

Net behavior unchanged: 847 unit and 1701 chromium tests pass unmodified. No changeset, internal refactor. Same motivation as #2915: the perf arc kept applying these idioms, and idioms applied four times are a util that has not been extracted yet.