### PR TITLE
fix(playground): guard the markdown `defaultStyle` callback against style-less sub-schemas

### DIFF
--- a/apps/playground/src/plugins/plugin.markdown.tsx
+++ b/apps/playground/src/plugins/plugin.markdown.tsx
@@ -42,7 +42,7 @@ export const markdownShortcutsPluginProps: MarkdownShortcutsPluginProps = {
       [hrefField.name]: props.href,
     }
   },
-  defaultStyle: ({context}) => context.schema.styles[0].value,
+  defaultStyle: ({context}) => context.schema.styles[0]?.name,
   headingStyle: ({context, props}) =>
     context.schema.styles.find((style) => style.name === `h${props.level}`)
       ?.name,


### PR DESCRIPTION
A field report from the container-edge-escape work, though the bug reproduces on main: backspace anywhere in a code block logs `Evaluating guard for "delete.backward" failed due to: Cannot read properties of undefined (reading 'value')` on every press. No data corruption, backspace still applies, but the console fills up.

The markdown-shortcuts plugin's `clearStyleOnBackspace` guard resolves the focus block's sub-schema via `getPathSubSchema` and hands it to the consumer's `defaultStyle` callback. A code-block line's sub-schema declares no styles, and the playground's callback read `context.schema.styles[0].value` unguarded, so `styles[0]` is `undefined` inside code blocks. The read was doubly wrong: `StyleSchemaType.value` is deprecated in favor of `name`, and the plugin's own sub-schema tests write this exact callback as `styles[0]?.name`.

The fix is the one-line callback correction. With no styles it returns `undefined` and the guard falls through, which is the right outcome for code lines: there is no style to clear. Verified against the dev playground on chromium: backspacing through and across code-block lines logs nothing, and the feature the callback serves stays intact, backspace at the start of an `# heading` still clears it back to `normal` (h1 leaves the DOM).

Playground-only; no package surface.
