### PR TITLE
fix(plugin-markdown-shortcuts): only query `defaultStyle` when backspace can clear a style

### DIFF
--- a/.changeset/markdown-default-style-query.md
+++ b/.changeset/markdown-default-style-query.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-markdown-shortcuts': patch
+---
+
+fix: only query `defaultStyle` when backspace can clear a style
+
+The `defaultStyle` callback (and the sub-schema resolution feeding it) ran on every backspace with a collapsed text-block selection; it now runs only when the caret sits at the start of the block, the one position where a style can clear. Consumers with throwing or expensive callbacks see them called far less often.

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
@@ -107,17 +107,21 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
         focusTextBlock.node.children[0]._key === focusSpan.node._key &&
         snapshot.context.selection?.focus.offset === 0
 
+      if (!atTheBeginningOfBLock) {
+        // A style can only clear at the start of the block; resolving the
+        // sub-schema and calling the consumer's `defaultStyle` callback on
+        // every other backspace is wasted work with a consumer-visible
+        // call frequency.
+        return false
+      }
+
       const subSchema = getPathSubSchema(snapshot, focusTextBlock.path)
       const defaultStyle = config.defaultStyle?.({
         context: {schema: subSchema},
         schema: subSchema,
       })
 
-      if (
-        atTheBeginningOfBLock &&
-        defaultStyle &&
-        focusTextBlock.node.style !== defaultStyle
-      ) {
+      if (defaultStyle && focusTextBlock.node.style !== defaultStyle) {
         return {defaultStyle, focusTextBlock}
       }
 

--- a/packages/plugin-markdown-shortcuts/src/sub-schema.test.tsx
+++ b/packages/plugin-markdown-shortcuts/src/sub-schema.test.tsx
@@ -6,6 +6,83 @@ import {userEvent} from 'vitest/browser'
 import {MarkdownShortcutsPlugin} from './plugin.markdown-shortcuts'
 
 describe('Markdown shortcuts respect the sub-schema at the focus', () => {
+  test('`defaultStyle` is only queried when backspace can clear a style', async () => {
+    const schemaDefinition = defineSchema({
+      styles: [{name: 'normal'}, {name: 'h1'}],
+    })
+    const defaultStyle = vi.fn(
+      ({
+        context,
+      }: {
+        context: {schema: {styles: ReadonlyArray<{name: string}>}}
+      }) => context.schema.styles[0]?.name,
+    )
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'heading', marks: []}],
+          markDefs: [],
+          style: 'h1',
+        },
+      ],
+      children: <MarkdownShortcutsPlugin defaultStyle={defaultStyle} />,
+    })
+    await userEvent.click(locator)
+
+    // Mid-block: the style cannot clear here, so the consumer callback
+    // is never consulted.
+    const midPoint = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 7,
+    }
+    editor.send({type: 'select', at: {anchor: midPoint, focus: midPoint}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(7)
+    })
+    // The semantic event the behavior listens on, dispatched directly:
+    // physical keystrokes after programmatic selection moves are flaky on
+    // webkit, and input plumbing is not what this pin is about.
+    editor.send({type: 'delete.backward', unit: 'character'})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'headin', marks: []}],
+          markDefs: [],
+          style: 'h1',
+        },
+      ])
+    })
+    expect(defaultStyle).not.toHaveBeenCalled()
+
+    // At the block's start it is consulted, and the style clears.
+    const startPoint = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: startPoint, focus: startPoint}})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus.offset).toBe(0)
+    })
+    editor.send({type: 'delete.backward', unit: 'character'})
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'headin', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+    expect(defaultStyle).toHaveBeenCalled()
+  })
+
   test('typing `# ` inside a code-block-line does not consume the keystroke', async () => {
     const schemaDefinition = defineSchema({
       decorators: [{name: 'strong'}, {name: 'em'}],


### PR DESCRIPTION
Extracted from the same incident as #2927: a playground `defaultStyle` callback that read `styles[0].value` unguarded logged a guard error on every backspace inside a code block. #2927 fixes that callback; this fixes the amplifier.

`clearStyleOnBackspace`'s guard resolved the focus block's sub-schema via `getPathSubSchema` and called the consumer's `defaultStyle` callback on every backspace with a collapsed text-block selection, then checked `atTheBeginningOfBLock`, whose result gates the whole outcome anyway. The early return now comes first: the sub-schema resolution and the consumer callback run only when the caret sits at the start of the block, the one position where a style can clear. Net behavior unchanged for well-behaved callbacks; the observable delta is call frequency, which is the point, both for wasted work per keypress and for shrinking the blast radius of throwing or expensive consumer callbacks to block starts.

Pinned with a spy callback: mid-block backspace deletes text without consulting the callback, block-start backspace consults it and clears the style to `normal`, both asserted as full value literals. Red-verified against the old order (one call mid-block). All 48 plugin tests pass on chromium.
