### PR TITLE
feat(plugin-table): export the stylesheet as `stylesText`

### DIFF
--- a/.changeset/styles-text.md
+++ b/.changeset/styles-text.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-table': minor
+---
+
+feat: export the stylesheet as `stylesText` for hosts without a CSS pipeline
+
+`@portabletext/plugin-table/ui` now exports the reference UI's stylesheet as text, generated from `styles.css` so the two cannot diverge. Hosts whose build cannot import a CSS file inject it through whatever styling system they already have, for example a styled-components `createGlobalStyle`. Hosts with a bundler keep importing `@portabletext/plugin-table/ui/styles.css` as before.

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -179,6 +179,19 @@ The stylesheet ships the structural rules plus a set of
 shared ancestor. The defaults are declared at zero specificity, so any
 declaration of yours wins.
 
+If your build has no CSS pipeline and cannot import the stylesheet file,
+`stylesText` is the same content as a string, generated from the
+stylesheet so the two cannot diverge. Inject it through whatever styling
+system you already have, and skip the stylesheet import from the quick
+start:
+
+```tsx
+import {stylesText} from '@portabletext/plugin-table/ui'
+import {createGlobalStyle} from 'styled-components'
+
+const TableStyles = createGlobalStyle`${stylesText}`
+```
+
 Color tokens default to `light-dark()` pairs, so dark mode is a matter of
 declaring the color scheme:
 

--- a/packages/plugin-table/package.config.ts
+++ b/packages/plugin-table/package.config.ts
@@ -1,7 +1,36 @@
+import {readFileSync} from 'node:fs'
 import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
   babel: {reactCompiler: true},
   reactCompilerOptions: {target: '19'},
+  rollup: {
+    plugins: (plugins) => [
+      // Vite-style `?raw` imports (the stylesheet as text). Vitest handles
+      // them natively; the library build needs this shim.
+      {
+        name: 'raw-imports',
+        async resolveId(source, importer) {
+          if (!source.endsWith('?raw')) {
+            return null
+          }
+          const resolved = await this.resolve(
+            source.slice(0, -'?raw'.length),
+            importer,
+            {skipSelf: true},
+          )
+          return resolved ? `\0raw:${resolved.id}` : null
+        },
+        load(id) {
+          if (!id.startsWith('\0raw:')) {
+            return null
+          }
+          const text = readFileSync(id.slice('\0raw:'.length), 'utf8')
+          return `export default ${JSON.stringify(text)}`
+        },
+      },
+      ...plugins,
+    ],
+  },
 })

--- a/packages/plugin-table/src/ui/index.ts
+++ b/packages/plugin-table/src/ui/index.ts
@@ -1,2 +1,3 @@
 export {referenceContainers} from './reference-containers'
+export {stylesText} from './styles-text'
 export {Table, TableCell, TableRow, type TableMenuProps} from './table-render'

--- a/packages/plugin-table/src/ui/styles-text.ts
+++ b/packages/plugin-table/src/ui/styles-text.ts
@@ -1,0 +1,12 @@
+import stylesheet from './styles.css?raw'
+
+/**
+ * The reference UI's stylesheet as text, for hosts whose build has no CSS
+ * pipeline and cannot import `@portabletext/plugin-table/ui/styles.css`.
+ * Inject it through whatever styling system the host already has, for
+ * example a styled-components `createGlobalStyle`. Hosts with a bundler
+ * should import the stylesheet file instead.
+ *
+ * @public
+ */
+export const stylesText: string = stylesheet

--- a/packages/plugin-table/src/vite-env.d.ts
+++ b/packages/plugin-table/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?raw' {
+  const cssText: string
+  export default cssText
+}


### PR DESCRIPTION
The driver is the Studio integration of `@portabletext/plugin-table`: the `sanity` package is a styled-components library build with no CSS pipeline, so it cannot `import '@portabletext/plugin-table/ui/styles.css'`, and the integration spike carried a hand-inlined copy of the stylesheet instead. That copy is drift waiting to happen, and dangerously so, because the stylesheet is not just theming: it carries structural rules the chrome depends on (selection hiding, focus rings, the portal font, button resets), all version-locked to the chrome's markup. A host running a stale copy against newer chrome breaks subtly with nothing in the console.

The shape follows the ecosystem's established answer for this exact problem. Styled-chrome libraries ship a CSS file the app imports (BlockNote, ProseMirror, Leaflet), and for hosts that cannot take the file, the precedents are auto-injection with an opt-out (`react-tooltip`, `sonner`) or the file plus the same content as importable JS (`react-toastify`'s `injectStyle`). This PR is the third pattern: `@portabletext/plugin-table/ui` now exports `stylesText`, and Studio interpolates it into a styled-components `createGlobalStyle`, version-locked to whatever plugin version it ships. Auto-injection was considered and rejected: it would bypass every consumer's CSS toolchain to solve one host's build constraint.

The implementation is deliberately mechanism-free: `styles-css-text.ts` does a Vite-style `?raw` import of `styles.css` itself, which vitest resolves natively and the library build resolves through a ten-line rollup shim in `package.config.ts`. The export is byte-identical to the file by construction, so there is no codegen step, no generated module, and no drift test to maintain. The stylesheet file stays the canonical path and the README says so: for hosts with a bundler it participates in the consumer's CSS toolchain (PostCSS transforms such as a `light-dark()` polyfill, content hashing, cascade placement, forkability), which text cannot.

Full plugin suite (120 on chromium) passes; the strict build inlines the stylesheet into `dist/ui/index.js` and declares `stylesText: string` in the d.ts; `check:types`, lint, react-compiler, knip, and format are green.


