### PR TITLE
fix(plugin-table): hide the portaled chrome when its anchor scrolls out of view

### DIFF
--- a/.changeset/chrome-scroll-clipping.md
+++ b/.changeset/chrome-scroll-clipping.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: hide the portaled chrome when its anchor scrolls out of view
+
+The trash chip and the table menu tracked the table on scroll but never clipped against it, so scrolling the table out of the editor's scrollport left them floating over unrelated UI. The chrome now anchors through `@floating-ui/dom`: the trash chip hides when its handle is clipped, the built-in menu closes when its trigger scrolls out, and a menu rendered through `renderMenu` closes the same way (its anchor unmounts it).

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -58,6 +58,7 @@
     "prepublishOnly": "turbo run build"
   },
   "dependencies": {
+    "@floating-ui/dom": "catalog:",
     "@portabletext/keyboard-shortcuts": "workspace:^"
   },
   "devDependencies": {

--- a/packages/plugin-table/src/ui/table-chrome.tsx
+++ b/packages/plugin-table/src/ui/table-chrome.tsx
@@ -1,6 +1,7 @@
+import {autoUpdate, computePosition, hide, offset} from '@floating-ui/dom'
 import {
-  type ReactNode,
   useCallback,
+  type ReactNode,
   useLayoutEffect,
   useRef,
   useState,
@@ -171,6 +172,7 @@ export function TableChrome({
           // biome-ignore lint/suspicious/noArrayIndexKey: positional by design; the index is the identity
           key={`col-${index}`}
           kind="column"
+          index={index}
           x={GUTTER_LEFT + col.centerX}
           y={GUTTER_TOP}
           active={active}
@@ -185,6 +187,7 @@ export function TableChrome({
           // biome-ignore lint/suspicious/noArrayIndexKey: positional by design; the index is the identity
           key={`row-${index}`}
           kind="row"
+          index={index}
           x={GUTTER_LEFT}
           y={GUTTER_TOP + row.centerY}
           active={active}
@@ -434,6 +437,7 @@ function InsertGuideline({
 
 function Handle({
   kind,
+  index,
   x,
   y,
   active,
@@ -443,6 +447,7 @@ function Handle({
   onPointerDown,
 }: {
   kind: 'row' | 'column'
+  index: number
   x: number
   y: number
   active: boolean
@@ -463,6 +468,8 @@ function Handle({
     <button
       type="button"
       aria-label={isColumn ? 'Column handle' : 'Row handle'}
+      data-pt-plugin-table-handle={kind}
+      data-pt-plugin-table-handle-index={index}
       tabIndex={lit ? 0 : -1}
       onMouseEnter={() => setHot(true)}
       onMouseLeave={() => setHot(false)}
@@ -557,11 +564,6 @@ function DragDots({
   )
 }
 
-type TrashLayout = {
-  row: {left: number; top: number} | null
-  col: {left: number; top: number} | null
-}
-
 /**
  * Row/column delete buttons in a top-level portal so they are never clipped
  * by the editable's scrollport. Fixed-positioned from the live table rect,
@@ -596,68 +598,34 @@ export function TableTrashLayer({
   /** Replaces the built-in trash icon (host design systems pass their own). */
   trashIcon?: ReactNode
 }): JSX.Element | null {
-  const [layout, setLayout] = useState<TrashLayout | null>(null)
-
-  const measure = useCallback(() => {
-    const table = tableRef.current
-    if (!table || !metrics) {
-      setLayout(null)
-      return
-    }
-    const rect = table.getBoundingClientRect()
-    const next: TrashLayout = {row: null, col: null}
-    if (selectedRow !== null && canDeleteRow && metrics.rows[selectedRow]) {
-      const row = metrics.rows[selectedRow]
-      const handleLeft = rect.left - HANDLE_BTN_ROW.w / 2
-      next.row = {
-        left: handleLeft - TRASH_GAP - TRASH_SIZE,
-        top: rect.top + row.centerY,
-      }
-    }
-    if (selectedCol !== null && canDeleteCol && metrics.cols[selectedCol]) {
-      const col = metrics.cols[selectedCol]
-      next.col = {
-        left: rect.left + col.centerX,
-        top: rect.top - HANDLE_BTN_COL.h / 2 - TRASH_GAP - TRASH_SIZE,
-      }
-    }
-    setLayout(next)
-  }, [tableRef, metrics, selectedRow, selectedCol, canDeleteRow, canDeleteCol])
-
-  useLayoutEffect(() => {
-    measure()
-    window.addEventListener('resize', measure)
-    window.addEventListener('scroll', measure, true)
-    return () => {
-      window.removeEventListener('resize', measure)
-      window.removeEventListener('scroll', measure, true)
-    }
-  }, [measure])
-
-  if (!layout || (!layout.row && !layout.col)) {
+  const rowIndex = selectedRow !== null && canDeleteRow ? selectedRow : null
+  const colIndex = selectedCol !== null && canDeleteCol ? selectedCol : null
+  if (!metrics || (rowIndex === null && colIndex === null)) {
     return null
   }
 
   return createPortal(
     <div className="pt-plugin-table-portal">
-      {layout.row && selectedRow !== null ? (
+      {rowIndex !== null ? (
         <TrashButton
           icon={trashIcon}
           label="Delete row"
-          left={layout.row.left}
-          top={layout.row.top}
-          transform="translate(0, -50%)"
-          onClick={() => onDeleteRow(selectedRow)}
+          placement="left"
+          handleKind="row"
+          handleIndex={rowIndex}
+          tableRef={tableRef}
+          onClick={() => onDeleteRow(rowIndex)}
         />
       ) : null}
-      {layout.col && selectedCol !== null ? (
+      {colIndex !== null ? (
         <TrashButton
           icon={trashIcon}
           label="Delete column"
-          left={layout.col.left}
-          top={layout.col.top}
-          transform="translate(-50%, 0)"
-          onClick={() => onDeleteCol(selectedCol)}
+          placement="top"
+          handleKind="column"
+          handleIndex={colIndex}
+          tableRef={tableRef}
+          onClick={() => onDeleteCol(colIndex)}
         />
       ) : null}
     </div>,
@@ -668,21 +636,62 @@ export function TableTrashLayer({
 function TrashButton({
   icon,
   label,
-  left,
-  top,
-  transform,
+  placement,
+  handleKind,
+  handleIndex,
+  tableRef,
   onClick,
 }: {
   icon?: ReactNode
   label: string
-  left: number
-  top: number
-  transform: string
+  placement: 'left' | 'top'
+  handleKind: 'row' | 'column'
+  handleIndex: number
+  tableRef: RefObject<HTMLTableElement | null>
   onClick: () => void
 }): JSX.Element {
   const [hovered, setHovered] = useState(false)
+  const floatingRef = useRef<HTMLButtonElement>(null)
+  const [position, setPosition] = useState<{
+    left: number
+    top: number
+    hidden: boolean
+  } | null>(null)
+
+  // The chip anchors to the selected row/column's handle element, the same
+  // pattern the toolbar hooks use (a real element handed to the anchoring
+  // machinery). `autoUpdate` observes real references for layout shifts, so
+  // structural edits that move the handle move the chip, and the `hide`
+  // middleware retires it when the handle is clipped out of the scrollport.
+  useLayoutEffect(() => {
+    const floating = floatingRef.current
+    const reference = tableRef.current?.parentElement?.querySelector(
+      `[data-pt-plugin-table-handle="${handleKind}"][data-pt-plugin-table-handle-index="${handleIndex}"]`,
+    )
+    if (!floating || !reference) {
+      return undefined
+    }
+    const update = () => {
+      computePosition(reference, floating, {
+        strategy: 'fixed',
+        placement,
+        middleware: [offset(TRASH_GAP), hide()],
+      }).then(({x, y, middlewareData}) => {
+        setPosition({
+          left: x,
+          top: y,
+          hidden: middlewareData.hide?.referenceHidden ?? false,
+        })
+      })
+    }
+    return autoUpdate(reference, floating, update)
+  }, [placement, handleKind, handleIndex, tableRef])
+
+  const hidden = !position || position.hidden
+
   return (
     <button
+      ref={floatingRef}
       type="button"
       aria-label={label}
       onMouseEnter={() => setHovered(true)}
@@ -694,9 +703,10 @@ function TrashButton({
       style={{
         fontSize: 15,
         position: 'fixed',
-        left,
-        top,
-        transform,
+        left: position?.left ?? 0,
+        top: position?.top ?? 0,
+        visibility: hidden ? 'hidden' : 'visible',
+        pointerEvents: hidden ? 'none' : 'auto',
         width: TRASH_SIZE,
         height: TRASH_SIZE,
         display: 'flex',
@@ -739,9 +749,29 @@ export function TableMenuAnchor({
   visible: boolean
   children: ReactNode
 }): JSX.Element {
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const [clipped, setClipped] = useState(false)
+
+  // The anchor itself scrolls with the table and clips visually, but the
+  // consumer's widget may float a portaled popover from inside it. When the
+  // anchor leaves the scrollport, unmount the widget so that popover closes
+  // instead of floating over unrelated UI.
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current
+    if (!anchor) {
+      return undefined
+    }
+    const observer = new IntersectionObserver(([entry]) => {
+      setClipped(!(entry?.isIntersecting ?? true))
+    })
+    observer.observe(anchor)
+    return () => observer.disconnect()
+  }, [])
+
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: preventing default on pointerdown keeps the editor focused; interaction lives on the consumer's widget
     <div
+      ref={anchorRef}
       contentEditable={false}
       onPointerDown={(event) => {
         // Keep DOM focus in the editable; a focus steal here would blur the
@@ -753,13 +783,13 @@ export function TableMenuAnchor({
         right,
         top: WRAPPER_PAD_TOP + GUTTER_TOP - MENU_ABOVE_GAP,
         transform: 'translateY(-100%)',
-        pointerEvents: visible ? 'auto' : 'none',
-        opacity: visible ? 1 : 0,
+        pointerEvents: visible && !clipped ? 'auto' : 'none',
+        opacity: visible && !clipped ? 1 : 0,
         transition: 'opacity 100ms ease',
         zIndex: 6,
       }}
     >
-      {children}
+      {clipped ? null : children}
     </div>
   )
 }
@@ -797,26 +827,38 @@ export function TableMenu({
     null,
   )
 
-  const syncMenuPos = useCallback(() => {
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (!rect) {
-      return
-    }
-    setMenuPos({left: rect.right - MENU_MIN_WIDTH, top: rect.bottom + 6})
+  const closeMenu = useCallback(() => {
+    setOpen(false)
+    setMenuPos(null)
   }, [])
 
+  // The dropdown anchors to its trigger through `autoUpdate`; the `hide`
+  // middleware closes it when the trigger scrolls out of the scrollport,
+  // where a floating dropdown would read as detached chrome.
   useLayoutEffect(() => {
     if (!open) {
-      return
+      return undefined
     }
-    syncMenuPos()
-    window.addEventListener('resize', syncMenuPos)
-    window.addEventListener('scroll', syncMenuPos, true)
-    return () => {
-      window.removeEventListener('resize', syncMenuPos)
-      window.removeEventListener('scroll', syncMenuPos, true)
+    const trigger = triggerRef.current
+    const menu = menuRef.current
+    if (!trigger || !menu) {
+      return undefined
     }
-  }, [open, syncMenuPos])
+    const update = () => {
+      computePosition(trigger, menu, {
+        strategy: 'fixed',
+        placement: 'bottom-end',
+        middleware: [offset(6), hide()],
+      }).then(({x, y, middlewareData}) => {
+        if (middlewareData.hide?.referenceHidden) {
+          closeMenu()
+          return
+        }
+        setMenuPos({left: x, top: y})
+      })
+    }
+    return autoUpdate(trigger, menu, update)
+  }, [open, closeMenu])
 
   useLayoutEffect(() => {
     if (!open) {
@@ -831,11 +873,11 @@ export function TableMenu({
       ) {
         return
       }
-      setOpen(false)
+      closeMenu()
     }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        setOpen(false)
+        closeMenu()
       }
     }
     document.addEventListener('pointerdown', onPointerDown)
@@ -844,7 +886,7 @@ export function TableMenu({
       document.removeEventListener('pointerdown', onPointerDown)
       document.removeEventListener('keydown', onKeyDown)
     }
-  }, [open])
+  }, [open, closeMenu])
 
   const visible = active || open
 
@@ -863,7 +905,11 @@ export function TableMenu({
         onPointerDown={(event) => {
           event.preventDefault()
           event.stopPropagation()
-          setOpen((wasOpen) => !wasOpen)
+          if (open) {
+            closeMenu()
+          } else {
+            setOpen(true)
+          }
         }}
         style={{
           position: 'absolute',
@@ -892,7 +938,7 @@ export function TableMenu({
       >
         <EllipsisIcon size={20} />
       </button>
-      {open && menuPos
+      {open
         ? createPortal(
             <div
               ref={menuRef}
@@ -900,8 +946,9 @@ export function TableMenu({
               className="pt-plugin-table-portal"
               style={{
                 position: 'fixed',
-                left: menuPos.left,
-                top: menuPos.top,
+                left: menuPos?.left ?? 0,
+                top: menuPos?.top ?? 0,
+                visibility: menuPos ? 'visible' : 'hidden',
                 width: MENU_MIN_WIDTH,
                 background: 'var(--pt-plugin-table-menu-bg)',
                 border: '1px solid var(--pt-plugin-table-menu-border)',
@@ -920,7 +967,7 @@ export function TableMenu({
                 label="Select table"
                 icon={<TableIcon size={16} />}
                 onClick={() => {
-                  setOpen(false)
+                  closeMenu()
                   handlers.onSelectTable()
                 }}
               />
@@ -929,7 +976,7 @@ export function TableMenu({
                 icon={<Trash2Icon size={16} />}
                 destructive
                 onClick={() => {
-                  setOpen(false)
+                  closeMenu()
                   handlers.onDeleteTable()
                 }}
               />

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -1,8 +1,9 @@
 import {defineContainer, defineSchema} from '@portabletext/editor'
-import {NodePlugin} from '@portabletext/editor/plugins'
+import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
+import {tableBehaviors} from '../plugin.table'
 import {TableCell, Table, TableRow} from './table-render'
 
 const schemaDefinition = defineSchema({
@@ -86,6 +87,217 @@ const initialValue = [
     ],
   },
 ]
+
+describe('Feature: Scroll Clipping of Portaled Chrome', () => {
+  const paragraph = (index: number) => ({
+    _type: 'block',
+    _key: `p${index}`,
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {
+        _type: 'span',
+        _key: `ps${index}`,
+        text: `paragraph ${index}`,
+        marks: [],
+      },
+    ],
+  })
+
+  test('Scenario: the trash chip hides when the table scrolls out of view', async () => {
+    // Enough content below the table that the window can scroll it out.
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        ...initialValue,
+        ...Array.from({length: 60}, (_, index) => paragraph(index)),
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+    editor.send({type: 'focus'})
+
+    // A whole-row rectangle summons the row trash chip.
+    const point = (
+      cellKey: string,
+      blockKey: string,
+      spanKey: string,
+      offset: number,
+    ) => ({
+      path: [
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: cellKey},
+        'value',
+        {_key: blockKey},
+        'children',
+        {_key: spanKey},
+      ],
+      offset,
+    })
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: point('c00', 'b-c00', 's-c00', 0),
+        focus: point('c01', 'b-c01', 's-c01', 1),
+      },
+    })
+    await vi.waitFor(() => {
+      expect(
+        document.querySelectorAll('button[aria-label="Delete row"]').length,
+      ).toBe(1)
+    })
+
+    // Scroll the table far above the viewport: the chip must not float.
+    // It stays mounted (the anchoring keeps watching for its return) but
+    // invisible and inert.
+    window.scrollTo(0, 4000)
+    await vi.waitFor(() => {
+      const chip = document.querySelector('button[aria-label="Delete row"]')
+      expect(chip).not.toBeNull()
+      expect(getComputedStyle(chip as HTMLElement).visibility).toBe('hidden')
+    })
+
+    // Scrolling back restores it: the selection never changed.
+    window.scrollTo(0, 0)
+    await vi.waitFor(() => {
+      const chip = document.querySelector('button[aria-label="Delete row"]')
+      expect(chip).not.toBeNull()
+      expect(getComputedStyle(chip as HTMLElement).visibility).toBe('visible')
+    })
+  })
+
+  test('Scenario: the trash chip follows its column when a structural edit shifts the bands', async () => {
+    // The real stylesheet fixes the table's width (`width: 100%`,
+    // `table-layout: fixed`), so adding a column compresses the bands
+    // inside an unchanged table box: nothing scrolls or resizes, only the
+    // measured geometry moves.
+    const style = document.createElement('style')
+    style.textContent =
+      'table.pt-plugin-table {width: 400px; table-layout: fixed}'
+    document.head.appendChild(style)
+    try {
+      const {editor} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        schemaDefinition,
+        initialValue,
+        children: (
+          <>
+            <NodePlugin nodes={[tableContainer]} />
+            <BehaviorPlugin behaviors={tableBehaviors} />
+          </>
+        ),
+      })
+      editor.send({type: 'focus'})
+
+      // A whole-column rectangle on the first column summons its chip.
+      const point = (cellKey: string, offset: number) => ({
+        path: [
+          {_key: 't0'},
+          'rows',
+          {_key: cellKey === 'c00' ? 'r0' : 'r1'},
+          'cells',
+          {_key: cellKey},
+          'value',
+          {_key: `b-${cellKey}`},
+          'children',
+          {_key: `s-${cellKey}`},
+        ],
+        offset,
+      })
+      editor.send({
+        type: 'select',
+        at: {anchor: point('c00', 0), focus: point('c10', 1)},
+      })
+      const chipCenter = () => {
+        const chip = document.querySelector(
+          'button[aria-label="Delete column"]',
+        )
+        if (!chip) {
+          return null
+        }
+        const rect = chip.getBoundingClientRect()
+        return rect.left + rect.width / 2
+      }
+      const columnCenter = () => {
+        const cell = document.querySelector('table.pt-plugin-table td')
+        if (!cell) {
+          return null
+        }
+        const rect = cell.getBoundingClientRect()
+        return rect.left + rect.width / 2
+      }
+      await vi.waitFor(() => {
+        expect(chipCenter()).not.toBeNull()
+        expect(
+          Math.abs((chipCenter() ?? 0) - (columnCenter() ?? 0)),
+        ).toBeLessThan(2)
+      })
+
+      // Inserting a column after the selection keeps the selected index
+      // but compresses every band; the chip must follow its column.
+      editor.send({
+        type: 'custom.insert.column',
+        at: [
+          {_key: 't0'},
+          'rows',
+          {_key: 'r0'},
+          'cells',
+          {_key: 'c00'},
+          'value',
+          {_key: 'b-c00'},
+        ],
+        position: 'after',
+      })
+      await vi.waitFor(() => {
+        expect(
+          document.querySelectorAll('table.pt-plugin-table td').length,
+        ).toBe(6)
+        expect(
+          Math.abs((chipCenter() ?? 0) - (columnCenter() ?? 0)),
+        ).toBeLessThan(2)
+      })
+    } finally {
+      style.remove()
+    }
+  })
+
+  test('Scenario: the open table menu closes when its trigger scrolls out of view', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        ...initialValue,
+        ...Array.from({length: 60}, (_, index) => paragraph(index)),
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+    editor.send({type: 'focus'})
+    window.scrollTo(0, 0)
+
+    // Reveal the trigger by hovering the table, then open the menu.
+    const {userEvent} = await import('vitest/browser')
+    await userEvent.hover(
+      locator.element().querySelector('table.pt-plugin-table')!,
+    )
+    const trigger = document.querySelector(
+      'button[aria-label="Table options"]',
+    ) as HTMLButtonElement
+    trigger.dispatchEvent(
+      new PointerEvent('pointerdown', {bubbles: true, cancelable: true}),
+    )
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[role="menu"]').length).toBe(1)
+    })
+
+    window.scrollTo(0, 4000)
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[role="menu"]').length).toBe(0)
+    })
+  })
+})
 
 describe('Feature: Read-Only Table Chrome', () => {
   test('Scenario: A read-only editor renders the table without mutation affordances', async () => {

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -447,6 +447,11 @@ export function Table({
             <table
               ref={tableRef}
               className="pt-plugin-table"
+              // State attributes on plugin-rendered elements stay short
+              // (the Radix `data-state` convention); consumers select them
+              // anchored to the `pt-plugin-table` scope. Only identity
+              // attributes that get queried unanchored carry the full
+              // `data-pt-plugin-table-*` prefix.
               data-cell-range={hasCellRange ? '' : undefined}
             >
               {/* Leafless subtrees derail the engine's DOM-point

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@floating-ui/dom':
+      specifier: ^1.7.6
+      version: 1.7.6
     '@sanity/diff-match-patch':
       specifier: ^3.2.0
       version: 3.2.0
@@ -1259,6 +1262,9 @@ importers:
 
   packages/plugin-table:
     dependencies:
+      '@floating-ui/dom':
+        specifier: 'catalog:'
+        version: 1.7.6
       '@portabletext/keyboard-shortcuts':
         specifier: workspace:^
         version: link:../keyboard-shortcuts
@@ -2555,8 +2561,14 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.4':
     resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
   '@floating-ui/react-dom@2.1.6':
     resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
@@ -2566,6 +2578,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
@@ -10250,10 +10265,19 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.4':
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
 
   '@floating-ui/react-dom@2.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -10262,6 +10286,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - examples/*
 
 catalog:
+  "@floating-ui/dom": ^1.7.6
   "@sanity/diff-match-patch": ^3.2.0
   "@sanity/schema": ^6.1.0
   "@sanity/types": ^6.1.0


### PR DESCRIPTION
Testing the Studio integration surfaced this: open the table menu or select a row so the trash chip shows, scroll the table out of view inside the document pane, and the floating chrome stays on screen above unrelated UI. The layers already remeasured on capture-phase scroll, so they tracked the table faithfully, straight out of the scrollport: tracking without clipping.

The first fix hand-rolled the clipping (an overflow-walking `visibleClipRect` plus per-floater point checks), which was a partial reimplementation of what `@floating-ui/dom` already does correctly, and an incorrect one: it assumed a single window (wrong for iframe-mounted editors, which we explicitly support) and missed transform containing blocks and `contain: paint`. So the chrome now positions through the standard machinery instead, and anchors to real elements, the same pattern the toolbar hooks use (`use-annotation-popover` hands consumers an `elementRef`). The trash chip's reference is the selected row/column's handle element (handles now carry `data-pt-table-handle` attributes), which makes tracking automatic: a structural edit that shifts the bands moves the handle, `autoUpdate`'s layout-shift observer sees the real reference move, and the chip follows with no invalidation plumbing. An intermediate revision anchored to virtual references (computed handle-band rects) and needed hand-fed dependencies for every data change that moved the anchor; real elements deleted all of it. The built-in dropdown anchors to its trigger with `placement: 'bottom-end'` and `offset(6)`, reproducing the previous geometry exactly, and the `hide` middleware's `referenceHidden` drives all clipping decisions. The dependency is 3kB, dependency-free, and the same engine Sanity UI and Radix sit on.

One behavioral asymmetry is deliberate. The trash chip hides and restores across a scroll cycle: it carries no interaction state, and its presence derives from the selection, which survives the scroll. Menus close instead of hiding: a host menu rendered through the `renderMenu` slot can only be dismissed by unmounting its button, since the plugin cannot hide a widget the host owns (the `TableMenuAnchor` unmounts its children when an `IntersectionObserver` reports the anchor clipped), and the built-in menu matches that so both menu paths behave identically.

Pinned in `table-render.test.tsx`: the row chip turns invisible and inert when the table scrolls out of the viewport and returns when it scrolls back with the selection intact; the open built-in menu closes when its trigger leaves the scrollport (both red against the pre-fix chrome); and the column chip follows its band when `custom.insert.column` compresses the columns inside a fixed-width table box (red against the virtual-reference revision, where nothing observable moved). Full plugin suite passes (123 on chromium), and chip/dropdown positioning was eyeballed against the previous geometry in the playground.

