### PR TITLE
fix: scroll the selection to the nearest edge instead of centering

### DIFF
--- a/.changeset/scroll-selection-nearest.md
+++ b/.changeset/scroll-selection-nearest.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: scroll the selection to the nearest edge instead of centering
+
+Selecting out-of-view content now scrolls the minimal distance to bring the focus to the nearest viewport edge, matching native caret behavior. Previously any selection whose focus was even slightly out of view, including programmatic selects like a table handle click whose rectangle ends in an off-screen column, re-centered the whole editor on the focus point.

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -1937,6 +1937,13 @@ const defaultScrollSelectionIntoView = (
       domFocusPoint.getBoundingClientRect.bind(domFocusPoint)
     scrollIntoView(leafEl, {
       scrollMode: 'if-needed',
+      // Native-caret semantics: the minimal delta to the nearest edge. The
+      // library's default `block: 'center'` re-centered the viewport on
+      // every sync whose focus was even slightly clipped, yanking the
+      // editor around on programmatic selects (a table handle click whose
+      // rectangle ends in an off-screen column, for example).
+      block: 'nearest',
+      inline: 'nearest',
     })
 
     // @ts-expect-error an unorthodox delete D:

--- a/packages/editor/tests/selection-scroll-into-view.test.tsx
+++ b/packages/editor/tests/selection-scroll-into-view.test.tsx
@@ -1,0 +1,81 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Selecting out-of-view content scrolls it into view with native-caret
+ * semantics: the minimal delta to the nearest edge. The previous default
+ * (inherited from `scroll-into-view-if-needed`'s `block: 'center'`) centered
+ * the viewport on the focus, which made any programmatic `select` whose
+ * focus was even slightly clipped, a row-handle click selecting into a
+ * wide table's off-screen column, for example, yank the whole editor to
+ * the middle of the screen.
+ */
+
+const schemaDefinition = defineSchema({})
+
+const paragraph = (index: number) => ({
+  _type: 'block',
+  _key: `p${index}`,
+  style: 'normal',
+  markDefs: [],
+  children: [
+    {_type: 'span', _key: `s${index}`, text: `paragraph ${index}`, marks: []},
+  ],
+})
+
+describe('Feature: Scrolling the Selection Into View', () => {
+  test('Scenario: an off-screen selection lands at the nearest edge, not the center', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: Array.from({length: 120}, (_, index) => paragraph(index)),
+    })
+    editor.send({type: 'focus'})
+    window.scrollTo(0, 0)
+
+    // A caret far below the fold.
+    const point = {
+      path: [{_key: 'p100'}, 'children', {_key: 's100'}],
+      offset: 0,
+    }
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+
+    await vi.waitFor(() => {
+      const block = document.querySelector('[data-block-key="p100"]')
+      if (!block) {
+        throw new Error('block not rendered')
+      }
+      const rect = block.getBoundingClientRect()
+      // The minimal scroll delta parks the block's bottom at the viewport's
+      // bottom edge (within sub-pixel rounding). A centering scroll would
+      // leave it around the viewport's middle.
+      const distanceFromBottom = window.innerHeight - rect.bottom
+      expect(rect.top).toBeGreaterThanOrEqual(0)
+      expect(distanceFromBottom).toBeGreaterThanOrEqual(-2)
+      expect(distanceFromBottom).toBeLessThan(window.innerHeight * 0.2)
+    })
+  })
+
+  test('Scenario: a selection already in view does not scroll', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: Array.from({length: 120}, (_, index) => paragraph(index)),
+    })
+    editor.send({type: 'focus'})
+    window.scrollTo(0, 0)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // The first paragraph is visible at scroll 0; selecting it must not
+    // move the viewport at all.
+    const point = {path: [{_key: 'p1'}, 'children', {_key: 's1'}], offset: 0}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+    })
+    expect(window.scrollY).toBe(0)
+  })
+})


### PR DESCRIPTION
Clicking a table row/column handle could yank the whole editor so the table sat centered in the viewport. The handle click is just the trigger: every model-to-DOM selection sync scrolls the focus point into view through `scroll-into-view-if-needed`, passing only `scrollMode: 'if-needed'` and inheriting the library's `block: 'center'` default. The whole `defaultScrollSelectionIntoView` is lifted from slate-react, which carries the same default, so the centering was never a considered choice here. If-needed correctly skips fully visible selections, but any focus even slightly clipped, a handle click whose rectangle ends in a wide table's horizontally off-screen column, for example, re-centered the entire editor on the focus point.

The fix passes `block: 'nearest', inline: 'nearest'`: native-caret semantics, the minimal delta to the nearest edge. Typing at the document's edge still scrolls into view; nothing recenters. This is observable for every consumer, a caret arriving from off-screen now lands at the viewport edge instead of the middle, which is what native `contenteditable` carets and other editors do.

Pinned in `tests/selection-scroll-into-view.test.tsx`: an off-screen select lands the block at the bottom edge (red under the centering default, which parked it at ~62% of the viewport), and an in-view select does not move the viewport at all. The full editor suite (1703 on chromium) and the plugin-table suite (120) pass unmodified, so nothing relied on centering.
