### PR TITLE
fix(plugin-table): mark header cells with `data-pt-plugin-table-header`

### DIFF
--- a/.changeset/header-cell-state-attribute.md
+++ b/.changeset/header-cell-state-attribute.md
@@ -1,0 +1,18 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: mark header cells with `data-pt-plugin-table-header` for host CSS
+
+Header cells set their weight through an inline style, which only reaches
+text that inherits. Hosts whose text components declare their own weight
+can now restore it with a rule against the new attribute (see the README's
+Theming section). The weight itself becomes a theming token,
+`--pt-plugin-table-header-weight` (default `600`), consumed by the cell and
+the drag ghost alike.
+
+All plugin-rendered state attributes now carry the full
+`data-pt-plugin-table-` prefix: the previously undocumented `data-selected`
+(selected rows) and `data-cell-range` (the table while a rectangle is
+active) become `data-pt-plugin-table-selected` and
+`data-pt-plugin-table-cell-range`.

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -205,6 +205,7 @@ resolved values per token instead.
 | `--pt-plugin-table-font-family`            | Text in the portaled layers, which cannot inherit the host font.             |
 | `--pt-plugin-table-bg` / `-fg` / `-border` | The table's base surface, text, and grid.                                    |
 | `--pt-plugin-table-header-bg`              | Header row background.                                                       |
+| `--pt-plugin-table-header-weight`          | Header row font weight.                                                      |
 | `--pt-plugin-table-selected-bg`            | The rectangle overlay's tint.                                                |
 | `--pt-plugin-table-lane-*`                 | The extend lanes (background, hover, icon states).                           |
 | `--pt-plugin-table-handle-*`               | Row/column handles (rest bar, expanded background, dots, ring).              |
@@ -218,6 +219,19 @@ resolved values per token instead.
 The chrome's geometry (gutter sizes, handle and lane dimensions, hit
 areas) is deliberately not themable. Those values feed the hit-testing
 and positioning math.
+
+Beyond the tokens, the plugin marks DOM state with
+`data-pt-plugin-table-*` attributes for host CSS to target. The one you
+are most likely to need is `data-pt-plugin-table-header` on header row
+cells: the cell sets the header weight inline, but that only reaches
+text that inherits, so if your text components declare their own weight,
+restore it with a rule like:
+
+```css
+td[data-pt-plugin-table-header] .your-text-component {
+  font-weight: var(--pt-plugin-table-header-weight, 600);
+}
+```
 
 ## Bringing your own containers
 

--- a/packages/plugin-table/src/ui/styles.css
+++ b/packages/plugin-table/src/ui/styles.css
@@ -36,6 +36,7 @@
   --pt-plugin-table-fg: light-dark(#1c1f24, #e5e7eb);
   --pt-plugin-table-border: light-dark(#e3e4e8, #374151);
   --pt-plugin-table-header-bg: light-dark(#f6f6f8, #283345);
+  --pt-plugin-table-header-weight: 600;
   --pt-plugin-table-selected-bg: light-dark(
     rgba(85, 107, 252, 0.06),
     rgba(105, 125, 255, 0.16)
@@ -137,9 +138,9 @@
    structural and must beat host apps' own `::selection` styling (Studio
    scopes one under its text blocks at equal specificity, and whoever injects
    last would win the tie), hence the `!important`. */
-table.pt-plugin-table[data-cell-range] ::selection {
+table.pt-plugin-table[data-pt-plugin-table-cell-range] ::selection {
   background-color: transparent !important;
 }
-table.pt-plugin-table[data-cell-range] ::-moz-selection {
+table.pt-plugin-table[data-pt-plugin-table-cell-range] ::-moz-selection {
   background-color: transparent !important;
 }

--- a/packages/plugin-table/src/ui/table-cell-style.ts
+++ b/packages/plugin-table/src/ui/table-cell-style.ts
@@ -6,6 +6,7 @@ export const BORDER = 'var(--pt-plugin-table-border)'
 const SELECTION_BORDER = 1.5
 const FG = 'var(--pt-plugin-table-fg)'
 const HEADER_BG = 'var(--pt-plugin-table-header-bg)'
+export const HEADER_WEIGHT = 'var(--pt-plugin-table-header-weight, 600)'
 const SELECTED_BG = 'var(--pt-plugin-table-selected-bg)'
 const CELL_PADDING = 'var(--pt-plugin-table-cell-padding)'
 const TABLE_RADIUS = 'var(--pt-plugin-table-radius)'
@@ -155,7 +156,7 @@ export function cellStyle({
     padding: CELL_PADDING,
     verticalAlign: 'top',
     background,
-    fontWeight: isHeader ? 600 : 400,
+    fontWeight: isHeader ? HEADER_WEIGHT : 400,
     color: FG,
     wordBreak: 'break-word',
     ...(showOverlay ? {position: 'relative', zIndex: 1} : {}),

--- a/packages/plugin-table/src/ui/table-chrome.tsx
+++ b/packages/plugin-table/src/ui/table-chrome.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react'
 import {createPortal} from 'react-dom'
 import {EllipsisIcon, PanelTopIcon, TableIcon, Trash2Icon} from './icons'
-import {BLUE, BORDER} from './table-cell-style'
+import {BLUE, BORDER, HEADER_WEIGHT} from './table-cell-style'
 import type {DragState} from './table-drag'
 import {snapPxCenter, type TableMetrics} from './table-metrics'
 
@@ -1172,7 +1172,7 @@ export function ReorderGhost({
             : 'var(--pt-plugin-table-bg)',
           boxShadow: GHOST_SHADOW,
           overflow: 'hidden',
-          fontWeight: isHeader ? 600 : 400,
+          fontWeight: isHeader ? HEADER_WEIGHT : 400,
         }}
       >
         {metrics.cols.map((col, index) => (
@@ -1235,7 +1235,7 @@ export function ReorderGhost({
               hasHeader && index === 0
                 ? 'var(--pt-plugin-table-header-bg)'
                 : undefined,
-            fontWeight: hasHeader && index === 0 ? 600 : 400,
+            fontWeight: hasHeader && index === 0 ? HEADER_WEIGHT : 400,
             overflow: 'hidden',
             whiteSpace: 'nowrap',
             textOverflow: 'ellipsis',

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -299,6 +299,66 @@ describe('Feature: Scroll Clipping of Portaled Chrome', () => {
   })
 })
 
+describe('Feature: Header Cell State Attribute', () => {
+  test('Scenario: header row cells carry `data-pt-plugin-table-header`', async () => {
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [cell('c00', 'A'), cell('c01', 'B')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    await vi.waitFor(() => {
+      const cells = Array.from(
+        document.querySelectorAll('table.pt-plugin-table td'),
+      )
+      expect(
+        cells.map((cellElement) =>
+          cellElement.hasAttribute('data-pt-plugin-table-header'),
+        ),
+      ).toEqual([true, true, false, false])
+    })
+  })
+
+  test('Scenario: a table without header rows marks no cells', async () => {
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    await vi.waitFor(() => {
+      const cells = Array.from(
+        document.querySelectorAll('table.pt-plugin-table td'),
+      )
+      expect(
+        cells.map((cellElement) =>
+          cellElement.hasAttribute('data-pt-plugin-table-header'),
+        ),
+      ).toEqual([false, false, false, false])
+    })
+  })
+})
+
 describe('Feature: Read-Only Table Chrome', () => {
   test('Scenario: A read-only editor renders the table without mutation affordances', async () => {
     const {editor} = await createTestEditor({

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -447,12 +447,11 @@ export function Table({
             <table
               ref={tableRef}
               className="pt-plugin-table"
-              // State attributes on plugin-rendered elements stay short
-              // (the Radix `data-state` convention); consumers select them
-              // anchored to the `pt-plugin-table` scope. Only identity
-              // attributes that get queried unanchored carry the full
-              // `data-pt-plugin-table-*` prefix.
-              data-cell-range={hasCellRange ? '' : undefined}
+              // Every attribute the plugin puts in the DOM carries the
+              // full `data-pt-plugin-table-` prefix: they are host-CSS
+              // API surface, and namespacing keeps them from colliding
+              // with design systems that style bare state attributes.
+              data-pt-plugin-table-cell-range={hasCellRange ? '' : undefined}
             >
               {/* Leafless subtrees derail the engine's DOM-point
                 normalization; mark them non-editable so it skips them. */}
@@ -548,7 +547,10 @@ export function TableRow({
   selected,
 }: ContainerRenderProps): JSX.Element {
   return (
-    <tr {...attributes} data-selected={selected ? '' : undefined}>
+    <tr
+      {...attributes}
+      data-pt-plugin-table-selected={selected ? '' : undefined}
+    >
       {children}
     </tr>
   )
@@ -630,7 +632,15 @@ export function TableCell({
     [descriptor],
   )
   return (
-    <td {...attributes} style={dimmed ? {...style, opacity: 0.35} : style}>
+    <td
+      {...attributes}
+      // Header-ness must be queryable from host CSS: the inline
+      // `fontWeight` below only reaches text that inherits, and hosts
+      // whose text components declare their own weight (Sanity UI's
+      // `Text`) need a hook to restore it.
+      data-pt-plugin-table-header={descriptor?.isHeader ? '' : undefined}
+      style={dimmed ? {...style, opacity: 0.35} : style}
+    >
       {children}
     </td>
   )


### PR DESCRIPTION
In Sanity Studio, header row cells render at body weight. The reference cell communicates header-ness through an inline `font-weight: 600`, which only reaches text that *inherits*: Studio's text blocks render through Sanity UI's `Text`, which declares its own explicit weight, severing the inheritance chain. And the DOM offered no hook to fix it from the host side, the plugin exposed header state nowhere; the only `data-` attributes were the handle identity attrs, `data-selected`, and `data-cell-range`.

Header cells now carry `data-pt-plugin-table-header`, so a host can restore the weight on its own text components. And the weight itself becomes a theming token, `--pt-plugin-table-header-weight` (default `600`, declared in the stylesheet next to `-header-bg`), consumed by the cell's inline style and both drag-ghost sites through a shared `HEADER_WEIGHT` constant. That gives the host restore rule and the plugin's own rendering one source of truth: a consumer who overrides the token to `700` moves every surface at once, including the rule a non-inheriting host writes (`td[data-pt-plugin-table-header] [data-ui='Text'] {font-weight: var(--pt-plugin-table-header-weight, 600)}` in the Studio integration). Two scenarios in `table-render.test.tsx` pin the attribute: present on exactly the first row's cells when `headerRows: 1`, absent everywhere without header rows.

While adding the first attribute that exists *for* host CSS, the attribute naming rule changed from two-tier to uniform: every plugin-rendered state attribute now carries the full `data-pt-plugin-table-` prefix. The previous rule kept state attributes short (`data-selected`, `data-cell-range`, the Radix `data-state` convention) on the theory that only the plugin's own scoped stylesheet consumed them, but `data-pt-plugin-table-header` is host-facing API, and a namespaced attribute cannot collide with design systems that style bare state attributes globally. Both renamed attributes shipped undocumented in 1.1.0 two days ago, and nothing in the repo or the Studio integration targets the old names; the changeset names the rename for anyone who found them anyway. The README's Theming section now documents the attribute surface and the header-weight recipe.

One pre-existing failure worth noting: `nav.test.tsx > repeated ArrowDown escapes reuse the block below` fails on firefox on a clean checkout of main (three deterministic reproductions with this diff stashed), so it is not this change. Everything else passes across chromium, firefox, and webkit.

