### PR TITLE
fix(plugin-table): activate chrome buttons with `Space` and `Enter`

### DIFF
--- a/.changeset/chrome-keyboard-activation.md
+++ b/.changeset/chrome-keyboard-activation.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: chrome buttons activate with `Space` and `Enter`
+
+The extend lanes, boundary insert dots, row and column handles, the trash
+chip, and the built-in menu trigger could be focused with the keyboard but
+not activated: they acted on pointer presses only. They now activate on
+`click`, which serves pointer and keyboard alike; a handle activation
+selects its row or column, same as a press without a drag. For pointers
+this moves the action from press to release, matching platform buttons and
+allowing drag-off to cancel.

--- a/packages/plugin-table/src/ui/table-chrome.tsx
+++ b/packages/plugin-table/src/ui/table-chrome.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type JSX,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from 'react'
@@ -90,6 +91,7 @@ export function TableChrome({
   selectedRow,
   selectedCol,
   onHandlePointerDown,
+  onHandleKeyboardSelect,
   drag,
   onInsertRow,
   onInsertCol,
@@ -104,6 +106,7 @@ export function TableChrome({
     index: number,
     event: ReactPointerEvent<HTMLButtonElement>,
   ) => void
+  onHandleKeyboardSelect: (kind: 'row' | 'column', index: number) => void
   drag: DragState | null
   onInsertRow: (boundary: number) => void
   onInsertCol: (boundary: number) => void
@@ -180,6 +183,7 @@ export function TableChrome({
           selected={selectedCol === index}
           dragging={dragging && drag?.kind === 'column'}
           onPointerDown={(event) => onHandlePointerDown('column', index, event)}
+          onKeyboardSelect={() => onHandleKeyboardSelect('column', index)}
         />
       ))}
       {metrics.rows.map((row, index) => (
@@ -195,6 +199,7 @@ export function TableChrome({
           selected={selectedRow === index}
           dragging={dragging && drag?.kind === 'row'}
           onPointerDown={(event) => onHandlePointerDown('row', index, event)}
+          onKeyboardSelect={() => onHandleKeyboardSelect('row', index)}
         />
       ))}
       {drag?.active ? (
@@ -260,10 +265,12 @@ function ExtendBar({
       type="button"
       aria-label={label}
       tabIndex={visible ? 0 : -1}
+      // Act on click but keep DOM focus in the editable; a focus steal
+      // here would blur the editor and hide the chrome mid-interaction.
       onPointerDown={(event) => {
         event.preventDefault()
-        onClick()
       }}
+      onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
@@ -330,8 +337,8 @@ function BoundaryControl({
       onPointerDown={(event) => {
         event.preventDefault()
         event.stopPropagation()
-        onInsert()
       }}
+      onClick={onInsert}
       style={{
         position: 'absolute',
         left: x - hit / 2,
@@ -445,6 +452,7 @@ function Handle({
   selected,
   dragging,
   onPointerDown,
+  onKeyboardSelect,
 }: {
   kind: 'row' | 'column'
   index: number
@@ -455,6 +463,7 @@ function Handle({
   selected: boolean
   dragging: boolean
   onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
+  onKeyboardSelect: () => void
 }): JSX.Element {
   const [hot, setHot] = useState(false)
   const isColumn = kind === 'column'
@@ -474,6 +483,7 @@ function Handle({
       onMouseEnter={() => setHot(true)}
       onMouseLeave={() => setHot(false)}
       onPointerDown={onPointerDown}
+      onClick={keyboardActivation(onKeyboardSelect)}
       style={{
         position: 'absolute',
         left: x,
@@ -698,8 +708,8 @@ function TrashButton({
       onMouseLeave={() => setHovered(false)}
       onPointerDown={(event) => {
         event.preventDefault()
-        onClick()
       }}
+      onClick={onClick}
       style={{
         fontSize: 15,
         position: 'fixed',
@@ -905,6 +915,8 @@ export function TableMenu({
         onPointerDown={(event) => {
           event.preventDefault()
           event.stopPropagation()
+        }}
+        onClick={() => {
           if (open) {
             closeMenu()
           } else {
@@ -1124,6 +1136,22 @@ function ReorderInsertLine({
       }}
     />
   )
+}
+
+/**
+ * The handle must act on `pointerdown` (the press starts the drag
+ * session), so its keyboard path cannot share the chrome's act-on-click
+ * pattern: a pointer press already resolves press-without-drag to a
+ * select on `pointerup`, and an unguarded `click` would double-fire.
+ * `Space`/`Enter` synthesize a `click` with `detail === 0`;
+ * pointer-initiated clicks carry a positive count.
+ */
+function keyboardActivation(action: () => void) {
+  return (event: ReactMouseEvent<HTMLButtonElement>) => {
+    if (event.detail === 0) {
+      action()
+    }
+  }
 }
 
 const GHOST_SHADOW =

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -3,6 +3,7 @@ import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
 import {tableBehaviors} from '../plugin.table'
 import {TableCell, Table, TableRow} from './table-render'
 
@@ -278,16 +279,13 @@ describe('Feature: Scroll Clipping of Portaled Chrome', () => {
     window.scrollTo(0, 0)
 
     // Reveal the trigger by hovering the table, then open the menu.
-    const {userEvent} = await import('vitest/browser')
     await userEvent.hover(
       locator.element().querySelector('table.pt-plugin-table')!,
     )
     const trigger = document.querySelector(
       'button[aria-label="Table options"]',
     ) as HTMLButtonElement
-    trigger.dispatchEvent(
-      new PointerEvent('pointerdown', {bubbles: true, cancelable: true}),
-    )
+    await userEvent.click(trigger)
     await vi.waitFor(() => {
       expect(document.querySelectorAll('[role="menu"]').length).toBe(1)
     })
@@ -295,6 +293,117 @@ describe('Feature: Scroll Clipping of Portaled Chrome', () => {
     window.scrollTo(0, 4000)
     await vi.waitFor(() => {
       expect(document.querySelectorAll('[role="menu"]').length).toBe(0)
+    })
+  })
+})
+
+describe('Feature: Keyboard Activation of Chrome', () => {
+  test('Scenario: `Space` on the extend lane appends a row', async () => {
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: (
+        <>
+          <NodePlugin nodes={[tableContainer]} />
+          <BehaviorPlugin behaviors={tableBehaviors} />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('table.pt-plugin-table td').length).toBe(
+        4,
+      )
+    })
+
+    const lane = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Add row at end"]',
+    )
+    expect(lane).not.toBeNull()
+    lane?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('table.pt-plugin-table td').length).toBe(
+        6,
+      )
+    })
+  })
+
+  test('Scenario: `Space` on a row handle selects the row and `Space` on the trash deletes it', async () => {
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: (
+        <>
+          <NodePlugin nodes={[tableContainer]} />
+          <BehaviorPlugin behaviors={tableBehaviors} />
+        </>
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('table.pt-plugin-table td').length).toBe(
+        4,
+      )
+    })
+
+    const handle = document.querySelector<HTMLButtonElement>(
+      '[data-pt-plugin-table-handle="row"][data-pt-plugin-table-handle-index="1"]',
+    )
+    expect(handle).not.toBeNull()
+    handle?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      const rows = Array.from(
+        document.querySelectorAll('table.pt-plugin-table tr'),
+      )
+      expect(
+        rows.map((row) => row.hasAttribute('data-pt-plugin-table-selected')),
+      ).toEqual([false, true])
+    })
+
+    const trash = await vi.waitFor(() => {
+      const trashButton = document.querySelector<HTMLButtonElement>(
+        'button[aria-label="Delete row"]',
+      )
+      expect(trashButton).not.toBeNull()
+      return trashButton
+    })
+    trash?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('table.pt-plugin-table td').length).toBe(
+        2,
+      )
+    })
+  })
+
+  test('Scenario: `Space` on the trigger opens the table menu', async () => {
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={[tableContainer]} />,
+    })
+
+    const trigger = await vi.waitFor(() => {
+      const triggerButton = document.querySelector<HTMLButtonElement>(
+        'button[aria-label="Table options"]',
+      )
+      expect(triggerButton).not.toBeNull()
+      return triggerButton
+    })
+    trigger?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      expect(trigger?.getAttribute('aria-expanded')).toBe('true')
+      expect(document.querySelectorAll('[role="menuitem"]').length).toBe(3)
     })
   })
 })

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -475,6 +475,13 @@ export function Table({
                 selectedRow={selectedRow}
                 selectedCol={selectedCol}
                 onHandlePointerDown={onHandlePointerDown}
+                onHandleKeyboardSelect={(kind, index) => {
+                  if (kind === 'row') {
+                    selectRow(index)
+                  } else {
+                    selectCol(index)
+                  }
+                }}
                 drag={drag}
                 onInsertRow={insertRow}
                 onInsertCol={insertCol}


### PR DESCRIPTION
Tabbing to any of the table chrome's buttons (the extend lanes, boundary insert dots, row/column handles, trash chip, and the built-in menu trigger) and pressing `Space` or `Enter` did nothing. The buttons are real `<button>` elements, so they take focus, but their actions ran on `pointerdown`, which keyboard input never produces: `Space`/`Enter` synthesize a `click`, and none of these buttons handled it. Focusable but not operable, which quietly undercut the README's "everything is reachable with the keyboard" claim.

The fix moves activation to `click`, the platform's unified activation event, so pointer and keyboard share one path and keyboard support needs no special casing. `pointerdown` keeps only its `preventDefault`: the press still cannot steal DOM focus from the editable, whose blur would hide the chrome mid-interaction. This is the exact combination the built-in menu items already used (act on `click`, preventDefault the `pointerdown`), so its cross-browser focus-preservation behavior was already proven in this codebase. The toolbar package solves the same problem the other way (activate on `click`, then restore focus with `editor.send({type: 'focus'})`), which works there because the toolbar's visibility does not depend on editor state; the chrome's does, so prevention beats restoration here.

One semantic delta for pointers: the four buttons now act on release instead of press, matching platform buttons and allowing drag-off-to-cancel. The handle is the deliberate exception: its press must start the drag state machine before any click exists, and a pointer press already resolves press-without-drag to a select on `pointerup`. Its keyboard path therefore guards on `event.detail === 0` (keyboard-synthesized clicks carry no detail count; pointer clicks have already been handled) and performs the same select through a new `onHandleKeyboardSelect` prop threaded from the render, where `selectRow`/`selectCol` live.

Three scenarios in `table-render.test.tsx` pin the flows end to end via `element.focus()` plus a real `Space` press: the extend lane appends a row (cell count 4 to 6), a row handle selects its row (asserted through `data-pt-plugin-table-selected` on the `tr`) and the trash chip then deletes it (4 to 2), and the trigger opens the built-in menu (`aria-expanded` plus three `menuitem`s). The mutating scenarios register `tableBehaviors` alongside the containers, same as the pointer-path behavior tests. The scroll-clipping scenario previously opened the menu by hand-dispatching a `pointerdown`, coupling it to the old wiring; it now performs a real click.

Same pre-existing firefox failure as noted on #2941: `nav.test.tsx > repeated ArrowDown escapes reuse the block below` fails on clean main, unrelated. Everything else passes across chromium, firefox, and webkit, including the full plugin suite.