### PR TITLE
fix(plugin-table): re-measure chrome geometry when rows or columns move

### DIFF
--- a/.changeset/remeasure-on-row-reorder.md
+++ b/.changeset/remeasure-on-row-reorder.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: re-measure chrome geometry when rows or columns are reordered
+
+Moving a row (or column) of a different size than its neighbors left the
+gutter dots, handles, and lanes at their old positions: the reorder swaps
+offsets without resizing any element, so nothing triggered a re-measure.
+The chrome now re-measures whenever the table's row or cell order changes.

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -408,6 +408,109 @@ describe('Feature: Keyboard Activation of Chrome', () => {
   })
 })
 
+describe('Feature: Chrome Geometry After Reorder', () => {
+  test('Scenario: moving rows of unequal heights re-measures the chrome', async () => {
+    const tallCell = (key: string) => ({
+      _type: 'cell',
+      _key: key,
+      value: [
+        {
+          _type: 'block',
+          _key: `b1-${key}`,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: `s1-${key}`, text: 'one', marks: []},
+          ],
+        },
+        {
+          _type: 'block',
+          _key: `b2-${key}`,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: `s2-${key}`, text: 'two', marks: []},
+          ],
+        },
+        {
+          _type: 'block',
+          _key: `b3-${key}`,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: `s3-${key}`, text: 'three', marks: []},
+          ],
+        },
+      ],
+    })
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't0',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r0',
+              cells: [tallCell('c00'), tallCell('c01')],
+            },
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [cell('c10', 'C'), cell('c11', 'D')],
+            },
+          ],
+        },
+      ],
+      children: (
+        <>
+          <NodePlugin nodes={[tableContainer]} />
+          <BehaviorPlugin behaviors={tableBehaviors} />
+        </>
+      ),
+    })
+
+    const handlesTrackRows = () => {
+      const rowElements = Array.from(
+        document.querySelectorAll('table.pt-plugin-table tbody tr'),
+      )
+      for (const [index, rowElement] of rowElements.entries()) {
+        const handle = document.querySelector(
+          `[data-pt-plugin-table-handle="row"][data-pt-plugin-table-handle-index="${index}"]`,
+        )
+        expect(handle).not.toBeNull()
+        const handleRect = handle!.getBoundingClientRect()
+        const rowRect = rowElement.getBoundingClientRect()
+        const handleCenter = handleRect.top + handleRect.height / 2
+        const rowCenter = rowRect.top + rowRect.height / 2
+        // Sub-pixel rounding tolerance.
+        expect(Math.abs(handleCenter - rowCenter)).toBeLessThanOrEqual(2)
+      }
+    }
+
+    await vi.waitFor(handlesTrackRows)
+
+    editor.send({
+      type: 'custom.move.row',
+      at: [{_key: 't0'}, 'rows', {_key: 'r0'}],
+      to: [{_key: 't0'}, 'rows', {_key: 'r1'}],
+    })
+
+    // The tall row is now second; the handles must sit on the new centers.
+    await vi.waitFor(() => {
+      const firstRow = document.querySelector('table.pt-plugin-table tbody tr')
+      expect(
+        firstRow?.querySelector('[data-pt-plugin-table-cell] p, td')
+          ?.textContent ?? firstRow?.textContent,
+      ).toContain('C')
+    })
+    await vi.waitFor(handlesTrackRows)
+  })
+})
+
 describe('Feature: Header Cell State Attribute', () => {
   test('Scenario: header row cells carry `data-pt-plugin-table-header`', async () => {
     await createTestEditor({

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -130,13 +130,25 @@ export function Table({
   const columnCount = rows[0] ? configRowCells(config, rows[0]).length : 0
   const tableRef = useRef<HTMLTableElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const metrics = useTableMetrics(tableRef, `${rowCount}x${columnCount}`)
+  // The revision must capture identity *order*, not just counts: reordering
+  // rows (or columns) of unequal sizes swaps offsets without resizing any
+  // element, so no ResizeObserver fires, and only a revision change
+  // re-measures the boundaries the chrome sits on.
+  const structureRevision = rows
+    .map(
+      (row) =>
+        `${row._key}:${configRowCells(config, row)
+          .map((rowCell) => rowCell._key)
+          .join(',')}`,
+    )
+    .join('|')
+  const metrics = useTableMetrics(tableRef, structureRevision)
   const scrollWide = useTableHorizontalLayout(
     scrollRef,
     columnCount,
-    `${rowCount}x${columnCount}`,
+    structureRevision,
   )
-  const fade = useScrollFade(scrollRef, `${rowCount}x${columnCount}`)
+  const fade = useScrollFade(scrollRef, structureRevision)
   const [active, setActive] = useState(false)
   const [hoverCell, setHoverCell] = useState<HoverCell>(null)
   const [menuOpen, setMenuOpen] = useState(false)


### PR DESCRIPTION
Moving a row in a table whose rows have different heights left the gutter dots (and the handles and lanes, all fed by the same metrics) at their pre-move positions.

The measurement pipeline (`useTableMetrics`, plus the horizontal-layout and scroll-fade hooks) re-runs on two triggers: a `ResizeObserver` on the table element, and a revision string of `${rowCount}x${columnCount}`. A reorder fires neither. React moves the same row elements to new offsets: no element resizes, the table box keeps its total size, and the counts are unchanged, so the chrome keeps stale boundaries. Columns have the same latent bug: moving unequal-width columns swaps offsets without resizing anything.

The revision now encodes identity order, each row's key with its cells' keys, so any structural rearrangement (move, and also insert/delete, which previously relied on counts) re-measures. The cost profile is unchanged where it matters: typing inside cells leaves the key order untouched, so keystrokes trigger nothing new, and content-driven height growth stays the `ResizeObserver`'s job as before.

The pin (`table-render.test.tsx`) builds a two-row table with a three-block-tall first row, asserts every row handle's center tracks its `tr`'s center (±2px sub-pixel tolerance), moves the tall row below the short one via `custom.move.row`, and asserts the handles track the new centers. Red-verified: without the fix the handle sits 18px off its row center after the move.

Same pre-existing firefox failure as on #2941/#2942 (`nav.test.tsx`, tracked separately), unrelated; everything else passes across all three browsers.

