### PR TITLE
fix(plugin-table): resolve the `./ui/styles.css` export to a no-op in Node

### DIFF
--- a/.changeset/css-export-node-stub.md
+++ b/.changeset/css-export-node-stub.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: resolve the `./ui/styles.css` export to a no-op module in Node
+
+Importing the stylesheet from code that also runs outside a browser
+bundler (server-side rendering, Node scripts importing a consuming
+package) crashed Node's ESM loader, which cannot import CSS. The export
+now carries resolution conditions: bundlers resolve `browser`/`style` to
+the real stylesheet, Node and unknown resolvers get an empty JS module.

--- a/packages/plugin-table/eslint.config.js
+++ b/packages/plugin-table/eslint.config.js
@@ -3,7 +3,7 @@ import {globalIgnores} from 'eslint/config'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config([
-  globalIgnores(['dist', '*.test.tsx']),
+  globalIgnores(['dist', '*.test.tsx', 'src/ui/styles.css.node-stub.js']),
   reactHooks.configs.flat.recommended,
   {
     files: ['src/**/*.{cjs,mjs,js,jsx,ts,tsx}'],

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -35,14 +35,24 @@
       "source": "./src/ui/index.ts",
       "default": "./dist/ui/index.js"
     },
-    "./ui/styles.css": "./src/ui/styles.css",
+    "./ui/styles.css": {
+      "browser": "./src/ui/styles.css",
+      "style": "./src/ui/styles.css",
+      "node": "./src/ui/styles.css.node-stub.js",
+      "default": "./src/ui/styles.css.node-stub.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",
       "./ui": "./dist/ui/index.js",
-      "./ui/styles.css": "./src/ui/styles.css",
+      "./ui/styles.css": {
+        "browser": "./src/ui/styles.css",
+        "style": "./src/ui/styles.css",
+        "node": "./src/ui/styles.css.node-stub.js",
+        "default": "./src/ui/styles.css.node-stub.js"
+      },
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-table/src/ui/styles.css.node-stub.js
+++ b/packages/plugin-table/src/ui/styles.css.node-stub.js
@@ -1,0 +1,4 @@
+// No-op shim for `styles.css` in runtimes that cannot import `.css` files
+// directly (Node resolves the `./ui/styles.css` export here). Bundlers
+// resolve the `browser`/`style` conditions and get the real stylesheet.
+export default ''


### PR DESCRIPTION
Surfaced by the `sanity` integration: its bundle-stats job measures Node cold-start import time of the built package, and the measurement crashed with `ERR_UNKNOWN_FILE_EXTENSION` the moment `TablePlugin.tsx` imported `@portabletext/plugin-table/ui/styles.css`. The `sanity` build preserves third-party CSS imports verbatim in its dist ESM (its own CSS goes through vanilla-extract into `bundle.css`), so the import reaches bare Node, which cannot load CSS. The same crash awaits any consumer whose module graph gets imported outside a browser bundler: SSR frameworks, Node scripts importing a consuming package.

The fix is resolution conditions on the export, following the exact shape `sanity` ships for its own `./bundle.css` (`browser`/`style` to the real file, `node`/`default` to a JS no-op): bundlers get the stylesheet, Node gets an empty module instead of a crash. `default` maps to the stub deliberately, an unknown resolver degrades to missing styles rather than a hard error, and every CSS-aware resolver matches `browser` or `style` first.

Verified both directions: `import("@portabletext/plugin-table/ui/styles.css")` in bare Node resolves to the stub and completes, and vite's browser resolver (`pluginContainer.resolveId` from the playground root) resolves to `src/ui/styles.css`. The playground continues to consume the real stylesheet through the same specifier.