### PR TITLE
fix(plugin-table): ship the `styles.css` Node stub in the published package

### DIFF
--- a/.changeset/ship-css-node-stub.md
+++ b/.changeset/ship-css-node-stub.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/plugin-table': patch
+---
+
+fix: ship the `styles.css` Node stub in the published package
+
+1.1.3 pointed the `node`/`default` conditions of the `./ui/styles.css`
+export at a file excluded from the tarball, so resolving the stylesheet
+outside a browser bundler failed with a module-not-found error instead of
+the intended no-op.

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -20,7 +20,8 @@
   },
   "files": [
     "dist",
-    "src/ui/styles.css"
+    "src/ui/styles.css",
+    "src/ui/styles.css.node-stub.js"
   ],
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Follow-up to #2945, which pointed the `node`/`default` conditions of the `./ui/styles.css` export at `src/ui/styles.css.node-stub.js` but never added that file to the package's `files` allowlist (`["dist", "src/ui/styles.css"]` is exact, not a directory include). The published 1.1.3 tarball therefore carries export conditions targeting a nonexistent file, and every Node-side resolution of the stylesheet fails with `ERR_MODULE_NOT_FOUND`. That is a regression beyond the bug #2945 fixed: bundler resolution (`browser`/`style`) still works, but consumer test suites and Node imports break outright.

The fix is the one-line `files` addition. Verified against the packed tarball this time, `npm pack --dry-run` lists the 238B stub, which is the verification #2945 skipped by only exercising resolution inside the workspace, where every file exists by definition.
