### PR TITLE
feat(plugin-table): add `labels` to the reference `Table`

### DIFF
--- a/.changeset/chrome-label-overrides.md
+++ b/.changeset/chrome-label-overrides.md
@@ -1,0 +1,14 @@
+---
+'@portabletext/plugin-table': minor
+---
+
+feat: add `labels` to the reference `Table` for chrome string overrides
+
+The chrome's rendered strings (aria-labels and tooltips) were hardcoded
+English. `Table` now takes an optional `labels` record, merged over the
+defaults, with keys `add-column`, `add-row`, `column-handle`,
+`delete-column`, `delete-row`, `insert-here`, `menu-delete-table`,
+`menu-header-row`, `menu-select-table`, `row-handle`, and
+`table-options`. The `TableLabels` type is exported from
+`@portabletext/plugin-table/ui`. The `menu-*` keys only render when the
+built-in menu does; a `renderMenu` widget carries its own strings.

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -364,6 +364,34 @@ built-in scale:
 render: (props) => <Table {...props} icons={{trash: <MyTrashIcon />}} />
 ```
 
+`labels` overrides the strings the chrome renders (aria-labels and
+tooltips for the handles, lanes, insert dots, trash chips, and the menu
+trigger, plus the built-in menu's items), merged over the English
+defaults. Hosts with their own i18n resolve translations and pass the
+final strings. The `menu-*` keys only render when the built-in menu does;
+a `renderMenu` widget carries its own strings:
+
+```tsx
+render: (props) => (
+  <Table
+    {...props}
+    labels={{
+      'insert-here': t('table.insert-here'),
+      'row-handle': t('table.row-handle'),
+      'column-handle': t('table.column-handle'),
+      'add-row': t('table.add-row'),
+      'add-column': t('table.add-column'),
+      'delete-row': t('table.delete-row'),
+      'delete-column': t('table.delete-column'),
+      'table-options': t('table.table-options'),
+      'menu-header-row': t('table.menu-header-row'),
+      'menu-select-table': t('table.menu-select-table'),
+      'menu-delete-table': t('table.menu-delete-table'),
+    }}
+  />
+)
+```
+
 ## Driving it from your own UI
 
 Structural edits are custom behavior events dispatched with

--- a/packages/plugin-table/src/ui/index.ts
+++ b/packages/plugin-table/src/ui/index.ts
@@ -1,2 +1,3 @@
 export {referenceContainers} from './reference-containers'
 export {Table, TableCell, TableRow, type TableMenuProps} from './table-render'
+export type {TableLabels} from './table-chrome'

--- a/packages/plugin-table/src/ui/table-chrome.tsx
+++ b/packages/plugin-table/src/ui/table-chrome.tsx
@@ -84,6 +84,42 @@ function rowBorderY(metrics: TableMetrics, index: number): number {
 
 export type HoverCell = {row: number; col: number} | null
 
+/**
+ * The strings the chrome renders: aria-labels and tooltips for the
+ * handles, lanes, dots, trash chips, and the menu trigger, plus the
+ * built-in menu's item labels. The `menu-*` keys only render when the
+ * built-in menu does; a `renderMenu` widget carries its own strings.
+ *
+ * @public
+ */
+export type TableLabels = {
+  'add-column': string
+  'add-row': string
+  'column-handle': string
+  'delete-column': string
+  'delete-row': string
+  'insert-here': string
+  'menu-delete-table': string
+  'menu-header-row': string
+  'menu-select-table': string
+  'row-handle': string
+  'table-options': string
+}
+
+export const defaultLabels: TableLabels = {
+  'add-column': 'Add column at end',
+  'add-row': 'Add row at end',
+  'column-handle': 'Column handle',
+  'delete-column': 'Delete column',
+  'delete-row': 'Delete row',
+  'insert-here': 'Insert here',
+  'menu-delete-table': 'Delete table',
+  'menu-header-row': 'Header row',
+  'menu-select-table': 'Select table',
+  'row-handle': 'Row handle',
+  'table-options': 'Table options',
+}
+
 export function TableChrome({
   metrics,
   active,
@@ -95,6 +131,7 @@ export function TableChrome({
   drag,
   onInsertRow,
   onInsertCol,
+  labels,
 }: {
   metrics: TableMetrics | null
   active: boolean
@@ -110,6 +147,10 @@ export function TableChrome({
   drag: DragState | null
   onInsertRow: (boundary: number) => void
   onInsertCol: (boundary: number) => void
+  labels: Pick<
+    TableLabels,
+    'add-column' | 'add-row' | 'column-handle' | 'insert-here' | 'row-handle'
+  >
 }): JSX.Element | null {
   const [boundary, setBoundary] = useState<BoundaryHover>(null)
   if (!metrics) {
@@ -149,7 +190,7 @@ export function TableChrome({
         }}
       />
       <ExtendBar
-        label="Add row at end"
+        label={labels['add-row']}
         visible={active && !dragging && hoverCell?.row === lastRow}
         style={{
           left: GUTTER_LEFT,
@@ -160,7 +201,7 @@ export function TableChrome({
         onClick={() => onInsertRow(metrics.rows.length)}
       />
       <ExtendBar
-        label="Add column at end"
+        label={labels['add-column']}
         visible={active && !dragging && hoverCell?.col === lastCol}
         style={{
           left: GUTTER_LEFT + metrics.width + EXTEND_GAP,
@@ -183,6 +224,7 @@ export function TableChrome({
           selected={selectedCol === index}
           dragging={dragging && drag?.kind === 'column'}
           onPointerDown={(event) => onHandlePointerDown('column', index, event)}
+          label={labels['column-handle']}
           onKeyboardSelect={() => onHandleKeyboardSelect('column', index)}
         />
       ))}
@@ -199,6 +241,7 @@ export function TableChrome({
           selected={selectedRow === index}
           dragging={dragging && drag?.kind === 'row'}
           onPointerDown={(event) => onHandlePointerDown('row', index, event)}
+          label={labels['row-handle']}
           onKeyboardSelect={() => onHandleKeyboardSelect('row', index)}
         />
       ))}
@@ -223,6 +266,7 @@ export function TableChrome({
             onEnter={() => setBoundary({kind: 'column', index})}
             onLeave={() => setBoundary(null)}
             onInsert={() => onInsertCol(index)}
+            label={labels['insert-here']}
           />
         )
       })}
@@ -238,6 +282,7 @@ export function TableChrome({
             onEnter={() => setBoundary({kind: 'row', index})}
             onLeave={() => setBoundary(null)}
             onInsert={() => onInsertRow(index)}
+            label={labels['insert-here']}
           />
         )
       })}
@@ -317,6 +362,7 @@ function BoundaryControl({
   onEnter,
   onLeave,
   onInsert,
+  label,
 }: {
   x: number
   y: number
@@ -325,12 +371,13 @@ function BoundaryControl({
   onEnter: () => void
   onLeave: () => void
   onInsert: () => void
+  label: TableLabels['insert-here']
 }): JSX.Element {
   const hit = 20
   return (
     <button
       type="button"
-      aria-label="Insert here"
+      aria-label={label}
       tabIndex={visible ? 0 : -1}
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
@@ -453,6 +500,7 @@ function Handle({
   dragging,
   onPointerDown,
   onKeyboardSelect,
+  label,
 }: {
   kind: 'row' | 'column'
   index: number
@@ -464,6 +512,7 @@ function Handle({
   dragging: boolean
   onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
   onKeyboardSelect: () => void
+  label: TableLabels['row-handle'] | TableLabels['column-handle']
 }): JSX.Element {
   const [hot, setHot] = useState(false)
   const isColumn = kind === 'column'
@@ -476,7 +525,7 @@ function Handle({
   return (
     <button
       type="button"
-      aria-label={isColumn ? 'Column handle' : 'Row handle'}
+      aria-label={label}
       data-pt-plugin-table-handle={kind}
       data-pt-plugin-table-handle-index={index}
       tabIndex={lit ? 0 : -1}
@@ -590,6 +639,7 @@ export function TableTrashLayer({
   onDeleteCol,
   portalElement,
   trashIcon,
+  labels,
 }: {
   tableRef: RefObject<HTMLTableElement | null>
   metrics: TableMetrics | null
@@ -607,6 +657,7 @@ export function TableTrashLayer({
   portalElement?: HTMLElement | null
   /** Replaces the built-in trash icon (host design systems pass their own). */
   trashIcon?: ReactNode
+  labels: Pick<TableLabels, 'delete-row' | 'delete-column'>
 }): JSX.Element | null {
   const rowIndex = selectedRow !== null && canDeleteRow ? selectedRow : null
   const colIndex = selectedCol !== null && canDeleteCol ? selectedCol : null
@@ -619,7 +670,7 @@ export function TableTrashLayer({
       {rowIndex !== null ? (
         <TrashButton
           icon={trashIcon}
-          label="Delete row"
+          label={labels['delete-row']}
           placement="left"
           handleKind="row"
           handleIndex={rowIndex}
@@ -630,7 +681,7 @@ export function TableTrashLayer({
       {colIndex !== null ? (
         <TrashButton
           icon={trashIcon}
-          label="Delete column"
+          label={labels['delete-column']}
           placement="top"
           handleKind="column"
           handleIndex={colIndex}
@@ -821,6 +872,7 @@ export function TableMenu({
   active,
   handlers,
   portalElement,
+  labels,
 }: {
   /** Distance from the wrapper's right edge; pins the trigger to the scrollport when the table overflows. */
   right: number
@@ -828,6 +880,13 @@ export function TableMenu({
   handlers: TableMenuHandlers
   /** See {@link TableTrashLayer}'s `portalElement`. */
   portalElement?: HTMLElement | null
+  labels: Pick<
+    TableLabels,
+    | 'menu-delete-table'
+    | 'menu-header-row'
+    | 'menu-select-table'
+    | 'table-options'
+  >
 }): JSX.Element {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -906,7 +965,7 @@ export function TableMenu({
         ref={triggerRef}
         type="button"
         contentEditable={false}
-        aria-label="Table options"
+        aria-label={labels['table-options']}
         aria-haspopup="menu"
         aria-expanded={open}
         tabIndex={visible ? 0 : -1}
@@ -970,13 +1029,13 @@ export function TableMenu({
               }}
             >
               <MenuRow
-                label="Header row"
+                label={labels['menu-header-row']}
                 icon={<PanelTopIcon size={16} />}
                 trailing={<ToggleSwitch checked={handlers.hasHeader} />}
                 onClick={handlers.onToggleHeader}
               />
               <MenuRow
-                label="Select table"
+                label={labels['menu-select-table']}
                 icon={<TableIcon size={16} />}
                 onClick={() => {
                   closeMenu()
@@ -984,7 +1043,7 @@ export function TableMenu({
                 }}
               />
               <MenuRow
-                label="Delete table"
+                label={labels['menu-delete-table']}
                 icon={<Trash2Icon size={16} />}
                 destructive
                 onClick={() => {

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -297,6 +297,87 @@ describe('Feature: Scroll Clipping of Portaled Chrome', () => {
   })
 })
 
+describe('Feature: Chrome Label Overrides', () => {
+  test('Scenario: `labels` overrides merge over the English defaults', async () => {
+    const labeledContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      render: (props) => (
+        <Table
+          {...props}
+          labels={{
+            'table-options': 'Tabellenoptionen',
+            'insert-here': 'Hier einf\u00fcgen',
+            'row-handle': 'Zeilengriff',
+            'menu-delete-table': 'Tabelle l\u00f6schen',
+          }}
+        />
+      ),
+      of: [
+        defineContainer({
+          type: 'row',
+          arrayField: 'cells',
+          render: (props) => <TableRow {...props} />,
+          of: [
+            defineContainer({
+              type: 'cell',
+              arrayField: 'value',
+              render: (props) => <TableCell {...props} />,
+            }),
+          ],
+        }),
+      ],
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: <NodePlugin nodes={[labeledContainer]} />,
+    })
+
+    await vi.waitFor(() => {
+      // Overridden strings reach the DOM.
+      expect(
+        document.querySelectorAll('button[aria-label="Tabellenoptionen"]')
+          .length,
+      ).toBe(1)
+      expect(
+        document.querySelectorAll('button[aria-label="Hier einf\u00fcgen"]')
+          .length,
+      ).toBeGreaterThan(0)
+      expect(
+        document.querySelectorAll('button[aria-label="Zeilengriff"]').length,
+      ).toBe(2)
+      // Keys that were not overridden keep their defaults.
+      expect(
+        document.querySelectorAll('button[aria-label="Add row at end"]').length,
+      ).toBe(1)
+      expect(
+        document.querySelectorAll('button[aria-label="Column handle"]').length,
+      ).toBe(2)
+    })
+
+    // The built-in menu's items render the `menu-*` keys once opened.
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Tabellenoptionen"]',
+    )
+    trigger?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      const items = Array.from(
+        document.querySelectorAll('[role="menuitem"]'),
+      ).map((item) => item.textContent)
+      expect(items).toEqual([
+        'Header row',
+        'Select table',
+        'Tabelle l\u00f6schen',
+      ])
+    })
+  })
+})
+
 describe('Feature: Keyboard Activation of Chrome', () => {
   test('Scenario: `Space` on the extend lane appends a row', async () => {
     await createTestEditor({

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -55,6 +55,8 @@ import {
   TableTrashLayer,
   type HoverCell,
   type TableMenuHandlers,
+  defaultLabels,
+  type TableLabels,
 } from './table-chrome'
 import {useTableDragReorder} from './table-drag'
 import {useTableMetrics} from './table-metrics'
@@ -100,6 +102,7 @@ export function Table({
   portalElement,
   renderMenu,
   icons,
+  labels,
 }: ContainerRenderProps & {
   /**
    * Where the menu and trash layer portal (default `document.body`). Hosts
@@ -120,7 +123,14 @@ export function Table({
    * `renderMenu`).
    */
   icons?: {trash?: ReactNode}
+  /**
+   * Overrides for the chrome's rendered strings, merged over the English
+   * defaults. Hosts with their own i18n resolve translations and pass the
+   * final strings.
+   */
+  labels?: Partial<TableLabels>
 }): JSX.Element {
+  const resolvedLabels = {...defaultLabels, ...labels}
   const editor = useEditor()
   const config = resolveTableConfig(node._type)
   const {isTable} = createTableGuards(config)
@@ -481,6 +491,7 @@ export function Table({
             </table>
             {readOnly ? null : (
               <TableChrome
+                labels={resolvedLabels}
                 metrics={metrics}
                 active={active}
                 hoverCell={hoverCell}
@@ -524,6 +535,7 @@ export function Table({
           </TableMenuAnchor>
         ) : (
           <TableMenu
+            labels={resolvedLabels}
             right={scrollWide ? 0 : 20}
             active={active}
             portalElement={portalElement}
@@ -538,6 +550,7 @@ export function Table({
         <TableScrollFade left={fade.left} right={fade.right} />
         {readOnly ? null : (
           <TableTrashLayer
+            labels={resolvedLabels}
             tableRef={tableRef}
             metrics={metrics}
             portalElement={portalElement}


### PR DESCRIPTION
The chrome renders eleven strings (the row/column handle aria-labels, the boundary dots' "Insert here", the extend lanes, the trash chips, the menu trigger's "Table options", and the built-in menu's three items), all hardcoded English with no override surface, so a host with its own i18n system cannot localize the table UI.

`Table` now takes an optional `labels` record, merged over the English defaults:

```tsx
render: (props) => (
  <Table
    {...props}
    labels={{
      "insert-here": t("table.insert-here"),
      "row-handle": t("table.row-handle"),
      // ...one key per rendered string
    }}
  />
)
```

The shape follows `@sanity/insert-menu`'s `labels` prop: a flat record of namespaced keys to final display strings, no i18n machinery in the component, the type doubling as the documentation of the label surface. One deliberate divergence: theirs is required, ours is optional with English defaults, because the component already ships and a required prop would break every consumer. The `TableLabels` type is exported from `@portabletext/plugin-table/ui`.

The record covers all eleven rendered strings, including the built-in menu's items as `menu-*` keys. Those keys only render when the built-in menu does: a `renderMenu` widget carries its own strings, so the keys are dead (not conflicting) under it, and a host that keeps the built-in menu can localize it without rebuilding the widget. Internally each chrome component types its `labels` as a `Pick` of exactly the keys it renders, so every widget's label surface is readable from its props and a removed key errors at the component that renders it.

The pin (`table-render.test.tsx`) renders a table whose `labels` override four keys and asserts the overridden strings reach the DOM (menu trigger, boundary dots, both row handles, and, after opening the menu, the delete item) while untouched keys keep their defaults (extend lane, column handles, the other two menu items). All existing scenarios select by the default labels and pass unchanged, which also pins that omitting the prop changes nothing.
