### PR TITLE
feat(plugin-table): add `tokens` to the reference `Table`

### DIFF
--- a/.changeset/table-tokens-prop.md
+++ b/.changeset/table-tokens-prop.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/plugin-table': minor
+---
+
+feat: add `tokens` to the reference `Table` for per-instance theming
+
+Themes that only exist as runtime objects could not reach the plugin's
+custom properties without writing them to a shared DOM scope themselves,
+which breaks down when multiple tables need different values and when the
+chrome portals outside the host's wrapper. `Table` now takes an optional
+`tokens` record keyed by the documented `--pt-plugin-table-*` names and
+applies the values inline to its own roots, including the portal layers.
+The `TableTokens` type is exported from `@portabletext/plugin-table/ui`.

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -220,6 +220,25 @@ The chrome's geometry (gutter sizes, handle and lane dimensions, hit
 areas) is deliberately not themable. Those values feed the hit-testing
 and positioning math.
 
+When the theme only exists as a runtime object (a design system resolving
+colors in JavaScript), pass the same token names per instance through the
+`tokens` prop instead of a stylesheet. The plugin applies them inline to
+its own roots, including the portal layers, so they reach the chrome no
+matter where it renders:
+
+```tsx
+render: (props) => (
+  <Table
+    {...props}
+    tokens={{
+      '--pt-plugin-table-accent': theme.focusRing,
+      '--pt-plugin-table-bg': theme.bg,
+      // ...any subset; the stylesheet defaults cover the rest
+    }}
+  />
+)
+```
+
 Beyond the tokens, the plugin marks DOM state with
 `data-pt-plugin-table-*` attributes for host CSS to target. The one you
 are most likely to need is `data-pt-plugin-table-header` on header row

--- a/packages/plugin-table/src/ui/index.ts
+++ b/packages/plugin-table/src/ui/index.ts
@@ -1,3 +1,9 @@
 export {referenceContainers} from './reference-containers'
-export {Table, TableCell, TableRow, type TableMenuProps} from './table-render'
+export {
+  Table,
+  TableCell,
+  TableRow,
+  type TableMenuProps,
+  type TableTokens,
+} from './table-render'
 export type {TableLabels} from './table-chrome'

--- a/packages/plugin-table/src/ui/table-chrome.tsx
+++ b/packages/plugin-table/src/ui/table-chrome.tsx
@@ -1,5 +1,6 @@
 import {autoUpdate, computePosition, hide, offset} from '@floating-ui/dom'
 import {
+  type CSSProperties,
   useCallback,
   type ReactNode,
   useLayoutEffect,
@@ -640,6 +641,7 @@ export function TableTrashLayer({
   portalElement,
   trashIcon,
   labels,
+  tokenStyle,
 }: {
   tableRef: RefObject<HTMLTableElement | null>
   metrics: TableMetrics | null
@@ -658,6 +660,9 @@ export function TableTrashLayer({
   /** Replaces the built-in trash icon (host design systems pass their own). */
   trashIcon?: ReactNode
   labels: Pick<TableLabels, 'delete-row' | 'delete-column'>
+  /** The table's theming custom properties; portal layers escape the
+   * in-tree scope, so each carries its own copy. */
+  tokenStyle?: CSSProperties
 }): JSX.Element | null {
   const rowIndex = selectedRow !== null && canDeleteRow ? selectedRow : null
   const colIndex = selectedCol !== null && canDeleteCol ? selectedCol : null
@@ -666,7 +671,7 @@ export function TableTrashLayer({
   }
 
   return createPortal(
-    <div className="pt-plugin-table-portal">
+    <div className="pt-plugin-table-portal" style={tokenStyle}>
       {rowIndex !== null ? (
         <TrashButton
           icon={trashIcon}
@@ -873,6 +878,7 @@ export function TableMenu({
   handlers,
   portalElement,
   labels,
+  tokenStyle,
 }: {
   /** Distance from the wrapper's right edge; pins the trigger to the scrollport when the table overflows. */
   right: number
@@ -887,6 +893,8 @@ export function TableMenu({
     | 'menu-select-table'
     | 'table-options'
   >
+  /** See {@link TableTrashLayer}'s `tokenStyle`. */
+  tokenStyle?: CSSProperties
 }): JSX.Element {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -1016,6 +1024,7 @@ export function TableMenu({
               role="menu"
               className="pt-plugin-table-portal"
               style={{
+                ...tokenStyle,
                 position: 'fixed',
                 left: menuPos?.left ?? 0,
                 top: menuPos?.top ?? 0,

--- a/packages/plugin-table/src/ui/table-render.test.tsx
+++ b/packages/plugin-table/src/ui/table-render.test.tsx
@@ -297,6 +297,74 @@ describe('Feature: Scroll Clipping of Portaled Chrome', () => {
   })
 })
 
+describe('Feature: Per-Instance Theming Tokens', () => {
+  test('Scenario: `tokens` reach the chrome root and the portal layers', async () => {
+    const tokenedContainer = defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      render: (props) => (
+        <Table
+          {...props}
+          tokens={{
+            '--pt-plugin-table-bg': 'rgb(1, 2, 3)',
+            '--pt-plugin-table-trash-bg': 'rgb(4, 5, 6)',
+          }}
+        />
+      ),
+      of: [
+        defineContainer({
+          type: 'row',
+          arrayField: 'cells',
+          render: (props) => <TableRow {...props} />,
+          of: [
+            defineContainer({
+              type: 'cell',
+              arrayField: 'value',
+              render: (props) => <TableCell {...props} />,
+            }),
+          ],
+        }),
+      ],
+    })
+
+    await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+      children: (
+        <>
+          <NodePlugin nodes={[tokenedContainer]} />
+          <BehaviorPlugin behaviors={tableBehaviors} />
+        </>
+      ),
+    })
+
+    // The in-tree chrome root carries the values; the cells (which paint
+    // `--pt-plugin-table-bg`) resolve them by inheritance.
+    await vi.waitFor(() => {
+      const cell = document.querySelector('table.pt-plugin-table td')
+      expect(cell).not.toBeNull()
+      expect(getComputedStyle(cell!).backgroundColor).toBe('rgb(1, 2, 3)')
+    })
+
+    // Selecting a row summons the trash chip, which portals outside the
+    // editor subtree and must carry its own copy of the values.
+    const handle = document.querySelector<HTMLButtonElement>(
+      '[data-pt-plugin-table-handle="row"][data-pt-plugin-table-handle-index="0"]',
+    )
+    handle?.focus()
+    await userEvent.keyboard(' ')
+
+    await vi.waitFor(() => {
+      const trash = document.querySelector<HTMLButtonElement>(
+        'button[aria-label="Delete row"]',
+      )
+      expect(trash).not.toBeNull()
+      expect(getComputedStyle(trash!).backgroundColor).toBe('rgb(4, 5, 6)')
+    })
+  })
+})
+
 describe('Feature: Chrome Label Overrides', () => {
   test('Scenario: `labels` overrides merge over the English defaults', async () => {
     const labeledContainer = defineContainer({

--- a/packages/plugin-table/src/ui/table-render.tsx
+++ b/packages/plugin-table/src/ui/table-render.tsx
@@ -16,6 +16,7 @@ import {
 import {getBlockStartPoint, isEqualPaths} from '@portabletext/editor/utils'
 import {
   createContext,
+  type CSSProperties,
   type ReactNode,
   useCallback,
   useContext,
@@ -76,6 +77,51 @@ const TableDragContext = createContext<{
 } | null>(null)
 
 /**
+ * Per-instance values for the theming custom properties, applied inline to
+ * the plugin's own roots: the in-tree chrome wrapper and the portal
+ * layers. The keys are the same `--pt-plugin-table-*` names the stylesheet
+ * declares defaults for; inline values win over those defaults. Hosts
+ * whose theme is a runtime object (not static CSS) resolve values and pass
+ * them here.
+ *
+ * @public
+ */
+export type TableTokens = {
+  [key in
+    | '--pt-plugin-table-accent'
+    | '--pt-plugin-table-accent-fg'
+    | '--pt-plugin-table-bg'
+    | '--pt-plugin-table-border'
+    | '--pt-plugin-table-boundary-dot'
+    | '--pt-plugin-table-cell-padding'
+    | '--pt-plugin-table-danger'
+    | '--pt-plugin-table-fg'
+    | '--pt-plugin-table-font-family'
+    | '--pt-plugin-table-handle-bg'
+    | '--pt-plugin-table-handle-dots'
+    | '--pt-plugin-table-handle-rest'
+    | '--pt-plugin-table-handle-ring'
+    | '--pt-plugin-table-header-bg'
+    | '--pt-plugin-table-header-weight'
+    | '--pt-plugin-table-lane-bg'
+    | '--pt-plugin-table-lane-bg-hover'
+    | '--pt-plugin-table-lane-icon'
+    | '--pt-plugin-table-lane-icon-hover'
+    | '--pt-plugin-table-menu-bg'
+    | '--pt-plugin-table-menu-border'
+    | '--pt-plugin-table-menu-hover'
+    | '--pt-plugin-table-radius'
+    | '--pt-plugin-table-scrollbar'
+    | '--pt-plugin-table-scrollbar-hover'
+    | '--pt-plugin-table-selected-bg'
+    | '--pt-plugin-table-toggle-knob'
+    | '--pt-plugin-table-toggle-track'
+    | '--pt-plugin-table-toggle-track-on'
+    | '--pt-plugin-table-trash-bg'
+    | '--pt-plugin-table-trash-fg']?: string
+}
+
+/**
  * The reference render for the table container: chrome (handles, lanes,
  * menu, trash, drag ghost), scroll handling, and selection visuals around the
  * editable `<table>`. Wire it into the container definition:
@@ -103,6 +149,7 @@ export function Table({
   renderMenu,
   icons,
   labels,
+  tokens,
 }: ContainerRenderProps & {
   /**
    * Where the menu and trash layer portal (default `document.body`). Hosts
@@ -129,8 +176,15 @@ export function Table({
    * final strings.
    */
   labels?: Partial<TableLabels>
+  /**
+   * Theming values applied to the plugin's roots, including the portal
+   * layers. See {@link TableTokens}.
+   */
+  tokens?: TableTokens
 }): JSX.Element {
   const resolvedLabels = {...defaultLabels, ...labels}
+  // React style objects pass custom properties through as-is.
+  const tokenStyle = tokens as CSSProperties | undefined
   const editor = useEditor()
   const config = resolveTableConfig(node._type)
   const {isTable} = createTableGuards(config)
@@ -440,6 +494,7 @@ export function Table({
       {/* biome-ignore lint/a11y/noStaticElementInteractions: mouse events only reveal the hover chrome; all interaction lives on the chrome's buttons */}
       <div
         className="pt-plugin-table-chrome"
+        style={tokenStyle}
         onMouseEnter={() => setActive(true)}
         onMouseLeave={() => {
           setActive(false)
@@ -536,6 +591,7 @@ export function Table({
         ) : (
           <TableMenu
             labels={resolvedLabels}
+            tokenStyle={tokenStyle}
             right={scrollWide ? 0 : 20}
             active={active}
             portalElement={portalElement}
@@ -551,6 +607,7 @@ export function Table({
         {readOnly ? null : (
           <TableTrashLayer
             labels={resolvedLabels}
+            tokenStyle={tokenStyle}
             tableRef={tableRef}
             metrics={metrics}
             portalElement={portalElement}


### PR DESCRIPTION
The plugin themes through `--pt-plugin-table-*` custom properties, which works cleanly when the host's theme is CSS: declare overrides in a stylesheet and the zero-specificity defaults yield. But when the theme exists only as a runtime object (a design system resolving colors, fonts, and radii in JavaScript), the host has to write the properties into the DOM itself, and every scope it owns fails one way or another: a wrapper around the editor cannot reach the chrome that portals out of the editor's subtree (the trash chips, the built-in menu's dropdown), and a shared global scope like `documentElement` makes concurrent tables fight over one set of values, with the last unmount's cleanup stripping properties a surviving table still needs.

`Table` now accepts the values through its own API:

```tsx
render: (props) => (
  <Table
    {...props}
    tokens={{
      "--pt-plugin-table-accent": theme.focusRing,
      "--pt-plugin-table-bg": theme.bg,
      // ...any subset; the stylesheet defaults cover the rest
    }}
  />
)
```

The record's keys are the documented token names, so the README's Theming table remains the single contract and the prop is a second delivery route for the same vocabulary, not a second vocabulary. The plugin applies the values inline to the roots it owns: the in-tree chrome wrapper (covering the table, handles, lanes, dots, and drag ghost by inheritance) and each portal layer (the trash layer and the built-in menu's dropdown carry their own copy, since portals escape the in-tree scope). Inline properties win over the stylesheet defaults exactly where a value is passed and nowhere else, and each table instance carries its own set, so two tables with different tokens theme independently by construction.

This is the same host-facing shape widgets with their own theming systems conventionally expose: live theme values in through the widget's API, applied by the widget to surfaces only it knows about. The application mechanism is inherited custom properties rather than generated stylesheets because the plugin's styling is one static stylesheet already parameterized by these properties, so no rule generation is needed, only values.

The pin sets `--pt-plugin-table-bg` and `--pt-plugin-table-trash-bg` through the prop and asserts computed colors in both worlds: a cell resolving the value by inheritance through the in-tree root, and the trash chip resolving it from its portaled layer's own copy (summoned by selecting a row via keyboard, so the scenario also exercises the portal path end to end).