### PR TITLE
fix: preserve marks the schema cannot resolve

### DIFF
--- a/.changeset/preserve-schema-less-marks.md
+++ b/.changeset/preserve-schema-less-marks.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: preserve marks the schema cannot resolve
+
+The editor no longer removes marks it doesn't recognize: they render
+as plain text and survive the round-trip. Previously, removing a
+decorator from the schema deleted that formatting from existing
+documents and could merge spans and corrupt their text.

--- a/.changeset/warn-on-unresolvable-marks.md
+++ b/.changeset/warn-on-unresolvable-marks.md
@@ -1,0 +1,8 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: warn when a mark or annotation cannot be resolved
+
+The warning names the value, states that it is kept but does not
+render, and says what to add to the schema to render it.

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -79,6 +79,9 @@ export function RenderSpan(props: RenderSpanProps) {
         return [markDef]
       }
 
+      console.warn(
+        `Mark ${mark} is neither a decorator in the schema nor a markDef key in the block. The mark is kept in the value but does not render. If it is a decorator, add it to the schema.`,
+      )
       return []
     },
   )
@@ -117,6 +120,11 @@ export function RenderSpan(props: RenderSpanProps) {
     const annotationSchemaType = subSchema.annotations.find(
       (t) => t.name === annotationMarkDef._type,
     )
+    if (!annotationSchemaType) {
+      console.warn(
+        `The schema has no annotation type ${annotationMarkDef._type}. The annotation is kept in the value but does not render. Add ${annotationMarkDef._type} to the schema to render it.`,
+      )
+    }
     if (annotationSchemaType) {
       if (block && props.renderAnnotation) {
         children = (

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -322,91 +322,22 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     if (!blockEntry) {
       return
     }
-    const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
-      (decorator) => decorator.name,
+    // Only treat a mark as an annotation if it points to one of the
+    // block's `markDefs`. A mark that doesn't resolve might be a decorator
+    // from another schema (one that was removed here, or one a collaborator
+    // has that we don't), so it is left alone.
+    const annotations = node.marks?.filter((mark) =>
+      blockEntry.node.markDefs?.some((markDef) => markDef._key === mark),
     )
-    const annotations = node.marks?.filter((mark) => !decorators.includes(mark))
 
     if (node.text === '' && annotations && annotations.length > 0) {
       debug.normalization('removing annotations from empty span node')
       setNodeProperties(
         editor,
-        {marks: node.marks?.filter((mark) => decorators.includes(mark))},
+        {marks: node.marks?.filter((mark) => !annotations.includes(mark))},
         path,
       )
       return
-    }
-  }
-
-  /**
-   * Remove orphaned annotations from child spans of block nodes
-   */
-  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
-    const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
-      (decorator) => decorator.name,
-    )
-
-    for (const {node: child, path: childPath} of getChildren(
-      editor.snapshot,
-      path,
-    )) {
-      if (isSpan({schema: editor.snapshot.context.schema}, child)) {
-        const marks = child.marks ?? []
-        const orphanedAnnotations = marks.filter((mark) => {
-          return (
-            !decorators.includes(mark) &&
-            !node.markDefs?.find((def) => def._key === mark)
-          )
-        })
-
-        if (orphanedAnnotations.length > 0) {
-          debug.normalization('removing orphaned annotations from span node')
-          setNodeProperties(
-            editor,
-            {
-              marks: marks.filter(
-                (mark) => !orphanedAnnotations.includes(mark),
-              ),
-            },
-            childPath,
-          )
-          return
-        }
-      }
-    }
-  }
-
-  /**
-   * Remove orphaned annotations from span nodes
-   */
-  if (isSpan({schema: editor.snapshot.context.schema}, node)) {
-    const blockPath = parentPath(path)
-    const blockEntry2 = getTextBlock(editor.snapshot, blockPath)
-
-    if (blockEntry2) {
-      const block = blockEntry2.node
-      const decorators = getPathSubSchema(editor.snapshot, path).decorators.map(
-        (decorator) => decorator.name,
-      )
-      const marks = node.marks ?? []
-      const orphanedAnnotations = marks.filter((mark) => {
-        return (
-          !decorators.includes(mark) &&
-          !block.markDefs?.find((def) => def._key === mark)
-        )
-      })
-
-      if (orphanedAnnotations.length > 0) {
-        debug.normalization('removing orphaned annotations from span node')
-        setNodeProperties(
-          editor,
-          {
-            marks: marks.filter((mark) => !orphanedAnnotations.includes(mark)),
-          },
-          path,
-        )
-        return
-      }
     }
   }
 

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -3,7 +3,6 @@ import {
   isSpan,
   isTextBlock,
   type PortableTextBlock,
-  type PortableTextSpan,
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
@@ -259,53 +258,6 @@ export function validateValue(
                 values: {
                   key: blk._key,
                   unusedMarkDefs: unusedMarkDefs.map((m) => m.toString()),
-                },
-              },
-            }
-            return true
-          }
-        }
-
-        // Test that every annotation mark used has a definition
-        const annotationMarks = allUsedMarks.filter(
-          (mark) => !types.decorators.map((dec) => dec.name).includes(mark),
-        )
-        const orphanedMarks = annotationMarks.filter(
-          (mark) =>
-            textBlock.markDefs === undefined ||
-            !textBlock.markDefs.find((def) => def._key === mark),
-        )
-        if (orphanedMarks.length > 0) {
-          const spanChildren = textBlock.children.filter(
-            (cld) =>
-              cld._type === types.span.name &&
-              Array.isArray(cld.marks) &&
-              cld.marks.some((mark) => orphanedMarks.includes(mark)),
-          ) as PortableTextSpan[]
-          if (spanChildren) {
-            const orphaned = orphanedMarks.join(', ')
-            resolution = {
-              autoResolve: true,
-              patches: spanChildren.map((child) => {
-                return set(
-                  (child.marks || []).filter(
-                    (cMrk) => !orphanedMarks.includes(cMrk),
-                  ),
-                  [{_key: blk._key}, 'children', {_key: child._key}, 'marks'],
-                )
-              }),
-              description: `Block with _key '${blk._key}' contains marks (${orphaned}) not supported by the current content model.`,
-              action: 'Remove invalid marks',
-              item: blk,
-
-              i18n: {
-                description:
-                  'inputs.portable-text.invalid-value.orphaned-marks.description',
-                action:
-                  'inputs.portable-text.invalid-value.orphaned-marks.action',
-                values: {
-                  key: blk._key,
-                  orphanedMarks: orphanedMarks.map((m) => m.toString()),
                 },
               },
             }

--- a/packages/editor/tests/collaborative-editing.test.tsx
+++ b/packages/editor/tests/collaborative-editing.test.tsx
@@ -1508,8 +1508,8 @@ describe('Collaborative editing', () => {
     })
   })
 
-  describe('Unknown decorator normalization', () => {
-    test('Scenario: Setting a block with unknown decorators emits a patch to strip them', async () => {
+  describe('Unknown decorator preservation', () => {
+    test('Scenario: Setting a block with unknown decorators preserves them', async () => {
       const keyGenerator = createTestKeyGenerator()
       const blockKey = keyGenerator()
       const spanKey = keyGenerator()
@@ -1593,8 +1593,10 @@ describe('Collaborative editing', () => {
         ],
       })
 
-      // The editor should normalize the block, strip the unknown
-      // 'underline' decorator, and emit a patch back
+      // 'underline' may be a decorator in the other client's schema. The
+      // editor keeps it and sends nothing back. It used to strip it and
+      // patch the deletion into the document, so two clients on different
+      // schema versions would delete each other's formatting.
       await vi.waitFor(() => {
         expect(editor.getSnapshot().context.value).toEqual([
           {
@@ -1605,7 +1607,7 @@ describe('Collaborative editing', () => {
                 _type: 'span',
                 _key: spanKey,
                 text: 'foo',
-                marks: ['strong'],
+                marks: ['strong', 'underline'],
               },
             ],
             markDefs: [],
@@ -1614,15 +1616,7 @@ describe('Collaborative editing', () => {
         ])
       })
 
-      await vi.waitFor(() => {
-        expect(emittedPatches).toEqual([
-          {
-            type: 'set',
-            path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
-            value: ['strong'],
-          },
-        ])
-      })
+      expect(emittedPatches).toEqual([])
     })
   })
 })

--- a/packages/editor/tests/event.block.unset.test.tsx
+++ b/packages/editor/tests/event.block.unset.test.tsx
@@ -273,7 +273,7 @@ describe('event.block.unset', () => {
     })
   })
 
-  test('Scenario: `unset`ing text block `markDefs` removes the annotation', async () => {
+  test('Scenario: `unset`ing text block `markDefs` leaves the marks in place', async () => {
     const patches: Array<Patch> = []
     const keyGenerator = createTestKeyGenerator()
     const textBlockKey = keyGenerator()
@@ -323,11 +323,20 @@ describe('event.block.unset', () => {
     })
 
     await vi.waitFor(() => {
+      // The mark stays: it now points at nothing and renders plain, the
+      // same treatment as any other mark the editor cannot resolve.
       expect(editor.getSnapshot().context.value).toEqual([
         {
           _key: textBlockKey,
           _type: 'block',
-          children: [{_key: spanKey, _type: 'span', text: 'foo ', marks: []}],
+          children: [
+            {
+              _key: spanKey,
+              _type: 'span',
+              text: 'foo ',
+              marks: [annotationKey],
+            },
+          ],
           style: 'normal',
           markDefs: [],
         },
@@ -336,7 +345,6 @@ describe('event.block.unset', () => {
       expect(patches).toEqual([
         unset([{_key: textBlockKey}, 'markDefs']),
         set([], [{_key: textBlockKey}, 'markDefs']),
-        set([], [{_key: textBlockKey}, 'children', {_key: spanKey}, 'marks']),
       ])
     })
   })

--- a/packages/editor/tests/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/tests/pteWarningsSelfSolving.test.tsx
@@ -202,7 +202,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
     })
   })
 
-  it('removes orphaned marks', async () => {
+  it('preserves marks it cannot resolve', async () => {
     const editorRef: RefObject<PortableTextEditor | null> = createRef()
     const initialValue = [
       {
@@ -252,7 +252,10 @@ describe('when PTE would display warnings, instead it self solves', () => {
                 _key: 'def',
                 _type: 'span',
                 text: 'Hello',
-                marks: [],
+                // 'ghi' could be a leftover annotation key or a decorator
+                // from another schema. The editor can't tell which, so it
+                // leaves the value alone.
+                marks: ['ghi'],
               },
             ],
             markDefs: [],

--- a/packages/editor/tests/schema-less-marks.test.tsx
+++ b/packages/editor/tests/schema-less-marks.test.tsx
@@ -33,6 +33,9 @@ const initialValue = [
 
 describe('Feature: Schema-Less Decorator Marks', () => {
   test('Scenario: marks unknown to the schema survive the round-trip', async () => {
+    const consoleWarn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
       schemaDefinition,
@@ -45,6 +48,14 @@ describe('Feature: Schema-Less Decorator Marks', () => {
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })
+
+    // The mark renders without effect, and the editor says so.
+    await vi.waitFor(() => {
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Mark strong is neither a decorator in the schema nor a markDef key in the block. The mark is kept in the value but does not render. If it is a decorator, add it to the schema.',
+      )
+    })
+    consoleWarn.mockRestore()
   })
 
   test('Scenario: editing one block leaves blocks with unknown marks untouched', async () => {

--- a/packages/editor/tests/schema-less-marks.test.tsx
+++ b/packages/editor/tests/schema-less-marks.test.tsx
@@ -1,0 +1,120 @@
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+
+// A schema without `strong`. The value below still uses it, the situation
+// after removing a decorator from a schema with existing documents.
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'em'}],
+  annotations: [{name: 'link', fields: [{name: 'url', type: 'string'}]}],
+})
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'b0',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {_type: 'span', _key: 's0', text: 'heading with ', marks: []},
+      {_type: 'span', _key: 's1', text: 'bold', marks: ['strong']},
+      {_type: 'span', _key: 's2', text: ' text', marks: []},
+    ],
+  },
+  {
+    _type: 'block',
+    _key: 'b1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's3', text: 'plain paragraph', marks: []}],
+  },
+]
+
+describe('Feature: Schema-Less Decorator Marks', () => {
+  test('Scenario: marks unknown to the schema survive the round-trip', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+    })
+
+    // The editor must not change the value: the `strong` mark stays, the
+    // three spans stay separate. Unknown `style` and `listItem` values
+    // already pass through untouched; marks work the same way.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: editing one block leaves blocks with unknown marks untouched', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+
+    const patches: Array<{path?: unknown; value?: unknown}> = []
+    editor.on('mutation', (event) => {
+      patches.push(
+        ...(event.patches as Array<{path?: unknown; value?: unknown}>),
+      )
+    })
+
+    // Type at the end of the second block, away from the block with the
+    // unknown mark.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: 'b1'}, 'children', {_key: 's3'}],
+          offset: 'plain paragraph'.length,
+        },
+        focus: {
+          path: [{_key: 'b1'}, 'children', {_key: 's3'}],
+          offset: 'plain paragraph'.length,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(
+        editor
+          .getSnapshot()
+          .context.value?.find((block) => block._key === 'b1'),
+      ).toEqual({
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's3', text: 'plain paragraph!', marks: []},
+        ],
+      })
+    })
+
+    // The block with the unknown mark is unchanged and no patch touched
+    // it. Writing "fixes" back to blocks the user didn't edit is what
+    // corrupted documents (merged spans, dropped marks, duplicated text).
+    expect(
+      editor.getSnapshot().context.value?.find((block) => block._key === 'b0'),
+    ).toEqual(initialValue[0])
+    const patchesTouchingUntouchedBlock = patches.filter(
+      (patch) =>
+        Array.isArray(patch.path) &&
+        patch.path.some(
+          (segment) =>
+            typeof segment === 'object' &&
+            segment !== null &&
+            '_key' in segment &&
+            segment._key === 'b0',
+        ),
+    )
+    expect(patchesTouchingUntouchedBlock).toEqual([])
+  })
+})


### PR DESCRIPTION
Remove a decorator from your schema, open a document that still uses it, and the document gets destroyed: the formatting is deleted from the stored document, spans get merged, and text can get corrupted (seen live: "heading with bold text" became "heading with bold textbold text"). Silently: `validateValue` flags the marks with `autoResolve: true` (no invalid-value screen, no warning on initial load) and, with two `normalize-node` sweeps, patches the "fix" back into the document.

But a mark the schema can't resolve isn't provably garbage: it can be a decorator from a schema the editor doesn't have, removed yesterday or held by a collaborator on a newer deploy. So the removal sites are deleted and the empty-span rule is narrowed to marks that resolve to an actual `markDef`. Unrecognized marks survive load, render as plain text, and round-trip unchanged, the treatment `style` and `listItem` already get: checked at the insertion boundary (unchanged), left alone at rest. No cleanup logic has ever existed for garbage styles or list items, and years of production haven't turned that into a problem, so the retention policy is proven, marks were the odd one out. Provable cleanup stays: unused `markDefs` are still removed, `annotation.remove` still cleans up its mark, and paste and insert still parse strictly.

Three pins are inverted on purpose: `pteWarningsSelfSolving` now preserves instead of removes, `collaborative-editing` no longer expects a client to strip a peer's unknown decorator and patch the deletion back (that mutual stripping is how two clients on different schema versions destroyed each other's formatting), and `unset`ing a block's `markDefs` leaves the marks in place (no real caller unsets `markDefs`). New tests pin the round-trip and that editing one block emits no patches for another.

A second commit adds a `console.warn` where `RenderSpan` silently skips unresolvable marks and unknown annotation types; the block-level guards for unknown `style` and `listItem` values already log when they skip.


