### PR TITLE
fix: convert cyclic Portable Text schemas without recursing forever

### DIFF
--- a/.changeset/bridge-cyclic-schema-conversion.md
+++ b/.changeset/bridge-cyclic-schema-conversion.md
@@ -1,0 +1,15 @@
+---
+'@portabletext/sanity-bridge': patch
+---
+
+fix: convert cyclic Portable Text schemas without recursing forever
+
+If a block had an inline object or annotation that carried rich text
+of its own, say a footnote whose body can contain another footnote,
+converting the schema would spin forever and freeze the studio as
+soon as a Portable Text field rendered. Now it converts: when the
+same type comes around a second time, it is cut off instead of
+expanded again. Schemas with well over a thousand types embedding
+each other also no longer overflow the call stack.
+
+If your schema converted fine before, the output is exactly the same.

--- a/packages/sanity-bridge/README.md
+++ b/packages/sanity-bridge/README.md
@@ -1,6 +1,22 @@
 # `@portabletext/sanity-bridge`
 
-A TypeScript library for converting between Sanity schemas and Portable Text schemas, enabling seamless integration between Sanity CMS and Portable Text editors.
+Converts between Sanity schemas and Portable Text schemas.
+
+The main job is `sanitySchemaToPortableTextSchema`. A compiled Sanity
+schema is lazy: types resolve through getters and class instances, and
+finding out what is allowed inside a Portable Text field means walking
+that graph. The editor wants the opposite, one plain, self-contained
+object it can read synchronously, serialize, and hand to renderers and
+plugins without knowing anything about Sanity. So the bridge walks the
+type graph once, up front, and expands it into exactly that: which
+styles, lists, decorators, annotations, block objects, and inline
+objects a field allows, with every nested block inside a container
+carrying the restrictions that apply at that exact position.
+
+Expanding up front is also why the output can be bigger than the schema
+that produced it. A type shows up in the output at every position that
+embeds it, and self-referencing types are cut off rather than expanded
+forever (see "Recursive schemas" below).
 
 ## Installation
 
@@ -135,32 +151,71 @@ whatever a container should allow on the block member itself. The resulting
 `Schema` follows the resolution rules documented in
 [`@portabletext/schema`](../schema/README.md#containers-and-sub-schemas).
 
-### Convert Portable Text schema to Sanity schema
+#### Recursive schemas
+
+Schemas are allowed to reference themselves. An accordion whose body is
+the same Portable Text array it lives in, or a footnote that carries a
+rich-text field of its own, both convert fine; the conversion doesn't
+loop forever trying to expand them.
+
+When the conversion runs into a type it is already in the middle of
+expanding, it stops and leaves a marker instead of expanding again:
+
+- A named object type becomes a bare reference, just `{type: 'accordion'}`.
+  The full declaration still exists at the top level, and that is where
+  the editor looks it up.
+- An inline object or annotation that loops back into itself gets empty
+  `fields` at the point of repetition. Everything up to that point is
+  fully declared.
+
+One thing to keep in mind: every place a type is embedded gets its own
+resolved sub-schema, so a schema where many types embed each other
+produces output that grows with the number of embedding positions, not
+just the number of types.
+
+### Keep hold of the original Sanity types
+
+The expanded Portable Text schema is what the editor runs on, but
+Studio-side code usually wants the original Sanity types back: they
+carry everything the expansion drops, validation rules, previews,
+custom components. `createPortableTextMemberSchemaTypes` buckets the
+members of a Portable Text array into their Sanity types, so render
+callbacks and inputs can join back by name and work with the real
+thing.
 
 ```ts
-import {compileSchemaDefinitionToPortableTextMemberSchemaTypes} from '@portabletext/sanity-bridge'
+import {createPortableTextMemberSchemaTypes} from '@portabletext/sanity-bridge'
 
-// Convert Portable Text schema definition to Sanity types
-const sanityMemberTypes =
-  compileSchemaDefinitionToPortableTextMemberSchemaTypes({
-    styles: [{name: 'normal'}, {name: 'h1'}],
-    decorators: [{name: 'strong'}, {name: 'em'}],
-    annotations: [{name: 'link'}],
-    blockObjects: [{name: 'image', fields: [{name: 'url', type: 'url'}]}],
-  })
+const memberTypes = createPortableTextMemberSchemaTypes(sanitySchema)
+
+memberTypes.blockObjects // the original Sanity types, not conversions
+memberTypes.inlineObjects
+memberTypes.annotations
 ```
 
-### Additional helper functions
+### Resolve the Sanity types at a position
+
+Inside containers, what a position allows depends on where it sits: a
+table cell's blocks are not the root's blocks. `getSanitySubSchema`
+answers "which Sanity types apply here?" for a path into a value,
+walking down to the nearest Portable-Text-shaped ancestor and
+bucketizing its members.
 
 ```ts
-import {
-  createPortableTextMemberSchemaTypes,
-  portableTextMemberSchemaTypesToSchema,
-} from '@portabletext/sanity-bridge'
+import {getSanitySubSchema} from '@portabletext/sanity-bridge'
 
-// Extract Portable Text member types from Sanity schema
-const memberTypes = createPortableTextMemberSchemaTypes(sanityPortableTextType)
-
-// Convert to first-class Portable Text schema
-const portableTextSchema = portableTextMemberSchemaTypesToSchema(memberTypes)
+const subSchema = getSanitySubSchema(sanitySchema, value, [
+  {_key: 'table1'},
+  'rows',
+  {_key: 'row1'},
+  'cells',
+  {_key: 'cell1'},
+  'content',
+  {_key: 'block1'},
+])
 ```
+
+This is the Sanity-side counterpart of the editor's own sub-schema
+resolution over the expanded schema. The two answer the same question
+in their respective type universes and are meant to agree position for
+position.

--- a/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
+++ b/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
@@ -216,4 +216,50 @@ describe('mutually-embedding block objects', () => {
       expect(memberTypeNames).toEqual(allowedMemberTypes)
     }
   }, 10_000)
+
+  test('1,600 mutually-embedding types convert without overflowing the stack', () => {
+    // The recursive implementation overflowed the call stack between
+    // 1,400 and 1,600 types (the first descent chains through every
+    // type before any memo entry lands). The work-stack conversion is
+    // heap-bounded. The absolute time stays generous because the
+    // output of n mutually-embedding types is inherently O(n^2)
+    // entries: each of the n embedding positions carries its own `of`
+    // list, and those lists genuinely differ per position (a type's
+    // self-reference is ancestor-cut at its own position and
+    // memo-shared at others).
+    const objectCount = 1_600
+    const objects = Array.from({length: objectCount}, (_, index) =>
+      defineType({
+        name: `obj${index}`,
+        type: 'object',
+        fields: [
+          defineField({name: 'title', type: 'string'}),
+          defineField({name: 'content', type: 'blockContent'}),
+        ],
+      }),
+    )
+    const blockContent = defineType({
+      name: 'blockContent',
+      type: 'array',
+      of: [
+        defineArrayMember({type: 'block'}),
+        ...Array.from({length: objectCount}, (_, index) =>
+          defineArrayMember({type: `obj${index}`}),
+        ),
+      ],
+    })
+    const schema = SanitySchema.compile({
+      name: 'stack-cliff',
+      types: [blockContent, ...objects],
+    })
+
+    const startedAt = performance.now()
+    const converted = sanitySchemaToPortableTextSchema(
+      schema.get('blockContent'),
+    )
+    const durationMs = performance.now() - startedAt
+
+    expect(converted.blockObjects).toHaveLength(objectCount)
+    expect(durationMs).toBeLessThan(10_000)
+  })
 })

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.oracle.test.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.oracle.test.ts
@@ -1,0 +1,565 @@
+import type {
+  BlockOfDefinition,
+  FieldDefinition,
+  OfDefinition,
+  Schema,
+} from '@portabletext/schema'
+import {Schema as SanitySchema} from '@sanity/schema'
+import {builtinTypes} from '@sanity/schema/_internal'
+import type {
+  ArrayDefinition,
+  ArraySchemaType,
+  BlockDecoratorDefinition,
+  BlockListDefinition,
+  BlockSchemaType,
+  BlockStyleDefinition,
+  ObjectSchemaType,
+  PortableTextBlock,
+  SchemaType,
+  SpanSchemaType,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+import {sanitySchemaToPortableTextSchema} from './sanity-schema-to-portable-text-schema'
+
+/**
+ * Oracle: the work-stack conversion must produce output deep-equal to
+ * the recursive implementation it replaced, across randomized schema
+ * graphs (mutual embedding, cycles, anonymous nesting, inline objects,
+ * annotations, restricted nested blocks).
+ */
+describe('conversion oracle', () => {
+  test('Scenario: Fuzzed schema graphs convert identically to the recursive implementation', () => {
+    let seed = 1337
+    const random = () => {
+      seed = (seed * 16807) % 2147483647
+      return seed / 2147483647
+    }
+    const pick = <T>(items: Array<T>): T =>
+      items[Math.floor(random() * items.length)]!
+
+    for (let round = 0; round < 40; round++) {
+      // Sized so the recursive reference stays comparable: block <->
+      // inline-object Portable Text cycles make its output grow
+      // exponentially with type count even when it terminates (154MB
+      // of JSON at one 29-type draw), and deep-equal on that dwarfs
+      // the conversions themselves.
+      const typeCount = 5 + Math.floor(random() * 12)
+      const typeNames = Array.from(
+        {length: typeCount},
+        (_, index) => `type${index}`,
+      )
+
+      const objectTypes = typeNames.map((typeName) => {
+        const fieldCount = 1 + Math.floor(random() * 4)
+        const fields = Array.from({length: fieldCount}, (_, fieldIndex) => {
+          const kind = random()
+          if (kind < 0.35) {
+            return {name: `field${fieldIndex}`, type: 'string'}
+          }
+          if (kind < 0.55) {
+            // Array referencing random named types: mutual embedding and
+            // cycles.
+            const memberCount = 1 + Math.floor(random() * 3)
+            return {
+              name: `field${fieldIndex}`,
+              type: 'array',
+              of: Array.from({length: memberCount}, () => ({
+                type: pick(typeNames),
+              })),
+            }
+          }
+          if (kind < 0.65) {
+            // Portable Text array embedding the shared blockContent.
+            return {name: `field${fieldIndex}`, type: 'blockContent'}
+          }
+          // Anonymous inline object.
+          return {
+            name: `field${fieldIndex}`,
+            type: 'object',
+            fields: [{name: 'nested', type: 'string'}],
+          }
+        })
+        return {name: typeName, type: 'object', fields}
+      })
+
+      const blockContent = {
+        name: 'blockContent',
+        type: 'array',
+        of: [
+          {
+            type: 'block',
+            marks: {
+              annotations: [
+                {
+                  name: 'link',
+                  type: 'object',
+                  fields: [
+                    {name: 'href', type: 'string'},
+                    {name: 'meta', type: pick(typeNames)},
+                  ],
+                },
+              ],
+            },
+            of: [{type: pick(typeNames)}],
+          },
+          ...typeNames
+            .filter(() => random() < 0.5)
+            .map((typeName) => ({type: typeName})),
+        ],
+      }
+
+      const schema = SanitySchema.compile({
+        name: `fuzz${round}`,
+        types: [blockContent, ...objectTypes],
+      })
+      const target = schema.get('blockContent')
+
+      let referenceResult: unknown
+      try {
+        referenceResult = referenceSanitySchemaToPortableTextSchema(target)
+      } catch (error) {
+        // The recursive implementation recurses forever on block ->
+        // inline-object/annotation Portable Text cycles (it overflows
+        // the call stack); the rework cuts those cycles. Where the
+        // reference cannot produce an answer, assert only that the
+        // rework terminates.
+        expect(error, `round ${round}`).toBeInstanceOf(RangeError)
+        expect(
+          () => sanitySchemaToPortableTextSchema(target),
+          `round ${round} (reference crashed, rework must terminate)`,
+        ).not.toThrow()
+        continue
+      }
+
+      expect(
+        sanitySchemaToPortableTextSchema(target),
+        `round ${round} (typeCount ${typeCount})`,
+      ).toEqual(referenceResult)
+    }
+  })
+
+  test('Scenario: A block whose inline object carries a Portable Text field converts instead of recursing forever', () => {
+    const schema = SanitySchema.compile({
+      name: 'footnote-cycle',
+      types: [
+        {
+          name: 'blockContent',
+          type: 'array',
+          of: [{type: 'block', of: [{type: 'footnote'}]}],
+        },
+        {
+          name: 'footnote',
+          type: 'object',
+          fields: [{name: 'body', type: 'blockContent'}],
+        },
+      ],
+    })
+    const target = schema.get('blockContent')
+
+    // The recursive implementation overflowed the call stack here.
+    expect(() => referenceSanitySchemaToPortableTextSchema(target)).toThrow(
+      RangeError,
+    )
+
+    const converted = sanitySchemaToPortableTextSchema(target)
+    const nestedBlock = converted.inlineObjects[0]?.fields.find(
+      (field) => field.name === 'body',
+    )
+    expect(nestedBlock?.name).toBe('body')
+    expect(nestedBlock?.type).toBe('array')
+  })
+})
+
+/**
+ * The pre-rework recursive conversion, kept verbatim as the oracle the
+ * fuzz above compares against. Do not edit: its whole value is being
+ * the old implementation. The only deliberate deviations: the function
+ * is renamed, unexported, and inlined here so it can never be mistaken
+ * for package surface.
+ */
+/**
+ * Compile a Sanity schema to a Portable Text `Schema`.
+ *
+ * A Portable Text `Schema` is compatible with a Portable Text
+ * `SchemaDefinition` and can be used as configuration for the Portable Text
+ * Editor.
+ *
+ * @example
+ * ```tsx
+ * const schema = sanitySchemaToPortableTextSchema(sanitySchema)
+ *
+ * return (
+ *   <EditorProvider
+ *     initialConfig={{
+ *       // ...
+ *       schemaDefinition: schema,
+ *     }}
+ *   >
+ *     // ...
+ *   </EditorProvider>
+ * ```
+ */
+function referenceSanitySchemaToPortableTextSchema(
+  sanitySchema: ArraySchemaType<unknown> | ArrayDefinition,
+): Schema {
+  const compiled = sanitySchema.hasOwnProperty('jsonType')
+    ? (sanitySchema as ArraySchemaType<PortableTextBlock>)
+    : compileType(sanitySchema)
+
+  return sanitySchemaTypeToSchema(compiled)
+}
+
+function sanitySchemaTypeToSchema(
+  portableTextType: ArraySchemaType<PortableTextBlock>,
+): Schema {
+  if (!portableTextType) {
+    throw new Error("Parameter 'portableTextType' missing (required)")
+  }
+
+  const blockType = portableTextType.of?.find(findBlockType) as
+    | BlockSchemaType
+    | undefined
+  if (!blockType) {
+    throw new Error('Block type is not defined in this schema (required)')
+  }
+
+  const childrenField = blockType.fields?.find(
+    (field) => field.name === 'children',
+  ) as {type: ArraySchemaType} | undefined
+  if (!childrenField) {
+    throw new Error('Children field for block type found in schema (required)')
+  }
+
+  const ofType = childrenField.type.of
+  if (!ofType) {
+    throw new Error(
+      'Valid types for block children not found in schema (required)',
+    )
+  }
+
+  const spanType = ofType.find((memberType) => memberType.name === 'span') as
+    | ObjectSchemaType
+    | undefined
+  if (!spanType) {
+    throw new Error('Span type not found in schema (required)')
+  }
+
+  const inlineObjectTypes = (ofType.filter(
+    (memberType) => memberType.name !== 'span',
+  ) || []) as ObjectSchemaType[]
+
+  const blockObjectTypes = (portableTextType.of?.filter(
+    (field) => field.name !== blockType.name,
+  ) || []) as ObjectSchemaType[]
+
+  const styles = resolveEnabledStyles(blockType)
+  const decorators = resolveEnabledDecorators(spanType)
+  const lists = resolveEnabledListItems(blockType)
+  const annotations = (spanType as SpanSchemaType).annotations
+
+  // Sanity compiles a shared canonical type instance for each named type,
+  // so the same member instance is reached through every position that
+  // embeds it. Converting each instance once and sharing the result keeps
+  // the walk linear in the size of the compiled schema. Without it, the
+  // per-branch ancestor sets below enumerate every simple path through
+  // mutually-embedding types, which grows combinatorially.
+  const memo = new Map<SchemaType, OfDefinition>()
+
+  return {
+    block: {
+      name: blockType.name,
+    },
+    span: {
+      name: spanType.name,
+    },
+    styles: styles.map((style: BlockStyleDefinition) => ({
+      name: style.value,
+      title: style.title,
+      value: style.value,
+    })),
+    lists: lists.map((list: BlockListDefinition) => ({
+      name: list.value,
+      title: list.title,
+      value: list.value,
+    })),
+    decorators: decorators.map((decorator: BlockDecoratorDefinition) => ({
+      name: decorator.value,
+      title: decorator.title,
+      value: decorator.value,
+    })),
+    annotations: annotations.map((annotation) => ({
+      name: annotation.name,
+      title: annotation.title,
+      fields: annotation.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set(), memo),
+      ),
+    })),
+    blockObjects: blockObjectTypes.map((blockObject) => ({
+      name: blockObject.name,
+      title: blockObject.title,
+      fields: blockObject.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set([blockObject.name]), memo),
+      ),
+    })),
+    inlineObjects: inlineObjectTypes.map((inlineObject) => ({
+      name: inlineObject.name,
+      title: inlineObject.title,
+      fields: inlineObject.fields.map((field) =>
+        sanityFieldToSchemaField(field, new Set([inlineObject.name]), memo),
+      ),
+    })),
+  }
+}
+
+/**
+ * Resolve a container's `{type: 'block'}` `of` member.
+ *
+ * A nested block carries its own resolved sub-schema: `styles`/`lists` as
+ * field options, `decorators`/`annotations` on the span, inline objects as
+ * the non-span `of` members of `children`. Sanity resolves these for every
+ * block (an undeclared list becomes Sanity's defaults, not the root block's
+ * values; a block's inline objects are exactly its own `of`), so there is
+ * nothing to inherit and nothing to merge: emit the member's own resolved
+ * lists and let `getSubSchema` read them directly.
+ *
+ * This is what keeps a restricted nested block (a code-block line that
+ * strips marks and styles, or declares `of: []`) from leaking the root's
+ * decorators, styles, or inline objects into the container.
+ */
+function resolveBlockOfMember(
+  blockType: BlockSchemaType,
+  ancestorNames: ReadonlySet<string>,
+  memo: Map<SchemaType, OfDefinition>,
+): BlockOfDefinition {
+  const styleList = blockType.fields?.find((field) => field.name === 'style')
+    ?.type.options?.list
+  const listItemList = blockType.fields?.find(
+    (field) => field.name === 'listItem',
+  )?.type.options?.list
+
+  const childrenOf = (
+    blockType.fields?.find((field) => field.name === 'children') as
+      | {type: ArraySchemaType}
+      | undefined
+  )?.type.of
+  const spanType = childrenOf?.find(
+    (memberType) => memberType.name === 'span',
+  ) as ObjectSchemaType | undefined
+  const inlineObjectTypes = (
+    Array.isArray(childrenOf) ? childrenOf : []
+  ).filter((memberType) => memberType.name !== 'span') as ObjectSchemaType[]
+  const spanDecorators = (
+    spanType as unknown as {
+      decorators?: ReadonlyArray<BlockDecoratorDefinition>
+    }
+  )?.decorators
+  const spanAnnotations = (spanType as SpanSchemaType | undefined)?.annotations
+
+  return {
+    type: 'block',
+    styles: (Array.isArray(styleList) ? styleList : [])
+      .filter((style: BlockStyleDefinition) => style.value)
+      .map((style: BlockStyleDefinition) => ({
+        name: style.value,
+        title: style.title,
+        value: style.value,
+      })),
+    lists: (Array.isArray(listItemList) ? listItemList : [])
+      .filter((list: BlockListDefinition) => list.value)
+      .map((list: BlockListDefinition) => ({
+        name: list.value,
+        title: list.title,
+        value: list.value,
+      })),
+    decorators: (Array.isArray(spanDecorators) ? spanDecorators : []).map(
+      (decorator: BlockDecoratorDefinition) => ({
+        name: decorator.value,
+        title: decorator.title,
+        value: decorator.value,
+      }),
+    ),
+    annotations: (Array.isArray(spanAnnotations) ? spanAnnotations : []).map(
+      (annotation) => ({
+        name: annotation.name,
+        title: annotation.title,
+        fields: annotation.fields.map((field) =>
+          sanityFieldToSchemaField(field, ancestorNames, memo),
+        ),
+      }),
+    ),
+    inlineObjects: inlineObjectTypes.map((inlineObject) => ({
+      name: inlineObject.name,
+      title: inlineObject.title,
+      fields: (inlineObject.fields ?? []).map((field) =>
+        sanityFieldToSchemaField(
+          field,
+          new Set([...ancestorNames, inlineObject.name]),
+          memo,
+        ),
+      ),
+    })),
+  }
+}
+
+function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
+  try {
+    if (schemaType.jsonType === 'array') {
+      const arrayOf = (schemaType as ArraySchemaType).of
+      return Array.isArray(arrayOf) ? arrayOf : undefined
+    }
+  } catch {
+    // Sanity schema getters can throw -- ignore
+  }
+  return undefined
+}
+
+function sanityFieldToSchemaField(
+  field: {
+    name: string
+    type: SchemaType
+  },
+  ancestorNames: ReadonlySet<string>,
+  memo: Map<SchemaType, OfDefinition>,
+): FieldDefinition {
+  if (field.type.jsonType === 'array') {
+    const ofMembers = safeGetOf(field.type)
+    return {
+      name: field.name,
+      type: 'array',
+      ...(field.type.title ? {title: field.type.title} : {}),
+      of: ofMembers
+        ? ofMembers.map((member) =>
+            sanityOfMemberToOfDefinition(member, ancestorNames, memo),
+          )
+        : [],
+    }
+  }
+
+  return {
+    name: field.name,
+    type: field.type.jsonType,
+    ...(field.type.title ? {title: field.type.title} : {}),
+  }
+}
+
+function sanityOfMemberToOfDefinition(
+  memberType: SchemaType,
+  ancestorNames: ReadonlySet<string>,
+  memo: Map<SchemaType, OfDefinition>,
+): OfDefinition {
+  // `findBlockType` walks up the `type.type` chain to the base `block`, so
+  // it only detects *whether* this member is a block. A block member's own
+  // marks/styles/lists live on `memberType`, which `resolveBlockOfMember`
+  // reads to emit the member's own resolved sub-schema.
+  if (findBlockType(memberType)) {
+    return resolveBlockOfMember(
+      memberType as BlockSchemaType,
+      ancestorNames,
+      memo,
+    )
+  }
+
+  // If this member has fields and isn't already in the ancestor chain,
+  // emit an INLINE declaration (`type: 'object'` + name + fields). If the
+  // type is in the ancestor chain (cycle) or has no fields, emit a bare
+  // REFERENCE (just `type: <name>`).
+  const hasFields =
+    memberType.jsonType === 'object' &&
+    'fields' in memberType &&
+    Array.isArray((memberType as ObjectSchemaType).fields)
+
+  if (!hasFields || ancestorNames.has(memberType.name)) {
+    // Bare reference. The editor's resolver looks up `memberType.name`
+    // in `blockObjects` / `inlineObjects`.
+    return {
+      type: memberType.name,
+      ...(memberType.title ? {title: memberType.title} : {}),
+    }
+  }
+
+  // Each distinct member instance is expanded exactly once per conversion;
+  // every later position that reaches the same instance shares the first
+  // expansion. Keyed by instance (not name) so that same-named but
+  // structurally different inline declarations keep their own shapes.
+  const memoized = memo.get(memberType)
+  if (memoized) {
+    return memoized
+  }
+
+  const nextAncestors = new Set(ancestorNames)
+  nextAncestors.add(memberType.name)
+  const definition: OfDefinition = {
+    type: 'object',
+    name: memberType.name,
+    ...(memberType.title ? {title: memberType.title} : {}),
+    fields: (memberType as ObjectSchemaType).fields.map((field) =>
+      sanityFieldToSchemaField(field, nextAncestors, memo),
+    ),
+  }
+  memo.set(memberType, definition)
+  return definition
+}
+
+function resolveEnabledStyles(blockType: ObjectSchemaType) {
+  const styleField = blockType.fields?.find(
+    (btField) => btField.name === 'style',
+  )
+  if (!styleField) {
+    throw new Error(
+      "A field with name 'style' is not defined in the block type (required).",
+    )
+  }
+  const textStyles =
+    styleField.type.options?.list &&
+    styleField.type.options.list?.filter(
+      (style: {value: string}) => style.value,
+    )
+  if (!textStyles || textStyles.length === 0) {
+    throw new Error(
+      'The style fields need at least one style ' +
+        "defined. I.e: {title: 'Normal', value: 'normal'}.",
+    )
+  }
+  return textStyles
+}
+
+function resolveEnabledDecorators(spanType: ObjectSchemaType) {
+  return (spanType as any).decorators
+}
+
+function resolveEnabledListItems(blockType: ObjectSchemaType) {
+  const listField = blockType.fields?.find(
+    (btField) => btField.name === 'listItem',
+  )
+  if (!listField) {
+    throw new Error(
+      "A field with name 'listItem' is not defined in the block type (required).",
+    )
+  }
+  const listItems =
+    listField.type.options?.list &&
+    listField.type.options.list.filter((list: {value: string}) => list.value)
+  if (!listItems) {
+    throw new Error('The list field need at least to be an empty array')
+  }
+  return listItems
+}
+
+function findBlockType(type: SchemaType): BlockSchemaType | null {
+  if (type.type) {
+    return findBlockType(type.type)
+  }
+
+  if (type.name === 'block') {
+    return type as BlockSchemaType
+  }
+
+  return null
+}
+
+function compileType(rawType: any) {
+  return SanitySchema.compile({
+    name: 'blockTypeSchema',
+    types: [rawType, ...builtinTypes],
+  }).get(rawType.name)
+}

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
@@ -106,9 +106,26 @@ function sanitySchemaTypeToSchema(
   // the walk linear in the size of the compiled schema. Without it, the
   // per-branch ancestor sets below enumerate every simple path through
   // mutually-embedding types, which grows combinatorially.
-  const memo = new Map<SchemaType, OfDefinition>()
+  //
+  // The walk itself runs on an explicit LIFO work stack instead of the
+  // call stack: children are pushed in reverse so the drain order is
+  // exact DFS pre-order (which the memo's first-expansion-wins
+  // semantics depend on), results land in pre-indexed holes so
+  // construction order matches the recursive version, and the branch's
+  // ancestor names live in one shared set scoped by pop-markers pushed
+  // beneath each subtree (O(1) per level where copying the set per
+  // level made the walk quadratic, and heap-bounded where call-stack
+  // recursion overflowed beyond ~1.5k mutually-embedding types).
+  const conversion: Conversion = {
+    work: [],
+    ancestors: new Map<string, number>(),
+    distinctAncestorCount: 0,
+    memo: new Map<SchemaType, OfDefinition>(),
+    inFlight: new Map<unknown, Array<number>>(),
+  }
+  const pendingWork: Array<Work> = []
 
-  return {
+  const result = {
     block: {
       name: blockType.name,
     },
@@ -130,27 +147,307 @@ function sanitySchemaTypeToSchema(
       title: decorator.title,
       value: decorator.value,
     })),
-    annotations: annotations.map((annotation) => ({
-      name: annotation.name,
-      title: annotation.title,
-      fields: annotation.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set(), memo),
-      ),
-    })),
-    blockObjects: blockObjectTypes.map((blockObject) => ({
-      name: blockObject.name,
-      title: blockObject.title,
-      fields: blockObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([blockObject.name]), memo),
-      ),
-    })),
-    inlineObjects: inlineObjectTypes.map((inlineObject) => ({
-      name: inlineObject.name,
-      title: inlineObject.title,
-      fields: inlineObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([inlineObject.name]), memo),
-      ),
-    })),
+    annotations: annotations.map((annotation) => {
+      const built = buildFields(
+        conversion,
+        annotation.fields,
+        undefined,
+        annotation,
+      )
+      pendingWork.push(built.work)
+      return {
+        name: annotation.name,
+        title: annotation.title,
+        fields: built.holes,
+      }
+    }),
+    blockObjects: blockObjectTypes.map((blockObject) => {
+      const built = buildFields(
+        conversion,
+        blockObject.fields,
+        blockObject.name,
+      )
+      pendingWork.push(built.work)
+      return {
+        name: blockObject.name,
+        title: blockObject.title,
+        fields: built.holes,
+      }
+    }),
+    inlineObjects: inlineObjectTypes.map((inlineObject) => {
+      const built = buildFields(
+        conversion,
+        inlineObject.fields,
+        inlineObject.name,
+        inlineObject,
+      )
+      pendingWork.push(built.work)
+      return {
+        name: inlineObject.name,
+        title: inlineObject.title,
+        fields: built.holes,
+      }
+    }),
+  }
+
+  pushInOrder(conversion, pendingWork)
+  drain(conversion)
+
+  return result
+}
+
+type Work = () => void
+
+type Conversion = {
+  work: Array<Work>
+  /**
+   * Reference-counted ancestor names: the same name can be seeded at
+   * several depths of one branch (nested inline objects sharing a
+   * name), and the recursive implementation's per-branch set copies
+   * were naturally reentrant, an inner scope's end never removed the
+   * name from the outer scope. A plain shared `Set` is not (`delete`
+   * clobbers the outer scope), so scopes increment and decrement
+   * counts instead. `distinctAncestorCount` tracks the set size the
+   * in-flight state comparison needs.
+   */
+  ancestors: Map<string, number>
+  distinctAncestorCount: number
+  memo: Map<SchemaType, OfDefinition>
+  /**
+   * Inline-object and annotation instances whose field expansion is
+   * currently in flight, each with the ancestor-set sizes at their
+   * in-flight entries. The recursive implementation re-expanded such
+   * instances unconditionally; that terminates while every re-entry
+   * grows the ancestor set (richer ancestors cut the inner expansion
+   * earlier) and recurses forever exactly when the recursion state
+   * repeats, same instance, same ancestor set. Ancestors grow
+   * monotonically along a branch, so "same instance at the same or
+   * smaller ancestor-set size" identifies the repeated state, and
+   * cutting there changes output only for schemas that previously
+   * overflowed the stack.
+   */
+  inFlight: Map<unknown, Array<number>>
+}
+
+function pushAncestor(conversion: Conversion, name: string): void {
+  const count = conversion.ancestors.get(name) ?? 0
+  if (count === 0) {
+    conversion.distinctAncestorCount++
+  }
+  conversion.ancestors.set(name, count + 1)
+}
+
+function popAncestor(conversion: Conversion, name: string): void {
+  const count = conversion.ancestors.get(name) ?? 0
+  if (count <= 1) {
+    conversion.ancestors.delete(name)
+    if (count === 1) {
+      conversion.distinctAncestorCount--
+    }
+    return
+  }
+  conversion.ancestors.set(name, count - 1)
+}
+
+function hasAncestor(conversion: Conversion, name: string): boolean {
+  return (conversion.ancestors.get(name) ?? 0) > 0
+}
+
+function drain(conversion: Conversion): void {
+  let steps = 0
+  while (conversion.work.length > 0) {
+    conversion.work.pop()!()
+    if (++steps > 100_000_000) {
+      // Circuit breaker: legal schemas stay far below this (the output
+      // of n mutually-embedding types is inherently O(n^2) entries, so
+      // a 3,200-type graph legitimately drains ~10M work items; 100M
+      // corresponds to a schema no Studio could load anyway). Failing
+      // with a diagnostic beats exhausting the heap in a Studio tab if
+      // a future schema shape finds a cycle the cuts miss.
+      throw new Error(
+        `Portable Text schema conversion exceeded ${steps} work items; ` +
+          'the schema type graph likely contains a cycle the conversion ' +
+          `cannot cut (in-flight ancestors: [${[...conversion.ancestors.keys()].join(', ')}])`,
+      )
+    }
+  }
+}
+
+/**
+ * Allocate the holes for a field list and return them together with the
+ * work that fills them, run under an ancestor scope extended with
+ * `seedName` (the eager version passed `new Set([...current, seed])`;
+ * at the top level the shared set is empty between siblings, so
+ * extending equals seeding). The scope's pop-marker sits beneath the
+ * field work on the stack, so the shared ancestor set is back to its
+ * surrounding state once the subtree drains. The caller pushes the
+ * returned works through `pushInOrder` so siblings drain in
+ * construction order, keeping the walk's DFS pre-order (and with it
+ * the memo's first-expansion positions) identical to the recursive
+ * version.
+ */
+function buildFields(
+  conversion: Conversion,
+  fields: ReadonlyArray<{name: string; type: SchemaType}>,
+  seedName: string | undefined,
+  inFlightKey?: unknown,
+): {holes: Array<FieldDefinition>; work: Work} {
+  const holes: Array<FieldDefinition> = []
+  const work = () => {
+    if (inFlightKey !== undefined) {
+      const entrySizes = conversion.inFlight.get(inFlightKey)
+      const ancestorCount = conversion.distinctAncestorCount
+      if (
+        entrySizes !== undefined &&
+        entrySizes.length > 0 &&
+        ancestorCount <= entrySizes[entrySizes.length - 1]!
+      ) {
+        // The recursion state (this instance, this ancestor set) is
+        // already in flight on the current branch: the recursive
+        // implementation looped forever here. Leave the fields empty.
+        return
+      }
+      if (entrySizes === undefined) {
+        conversion.inFlight.set(inFlightKey, [ancestorCount])
+      } else {
+        entrySizes.push(ancestorCount)
+      }
+      conversion.work.push(() => {
+        const sizes = conversion.inFlight.get(inFlightKey)
+        sizes?.pop()
+        if (sizes !== undefined && sizes.length === 0) {
+          conversion.inFlight.delete(inFlightKey)
+        }
+      })
+    }
+    if (seedName !== undefined) {
+      pushAncestor(conversion, seedName)
+      conversion.work.push(() => popAncestor(conversion, seedName))
+    }
+    holes.length = fields.length
+    for (let index = fields.length - 1; index >= 0; index--) {
+      const field = fields[index]!
+      conversion.work.push(() => scheduleField(conversion, field, holes, index))
+    }
+  }
+  return {holes, work}
+}
+
+function pushInOrder(conversion: Conversion, works: Array<Work>): void {
+  for (let index = works.length - 1; index >= 0; index--) {
+    conversion.work.push(works[index]!)
+  }
+}
+
+function scheduleField(
+  conversion: Conversion,
+  field: {name: string; type: SchemaType},
+  target: Array<FieldDefinition>,
+  index: number,
+): void {
+  if (field.type.jsonType !== 'array') {
+    target[index] = {
+      name: field.name,
+      type: field.type.jsonType,
+      ...(field.type.title ? {title: field.type.title} : {}),
+    }
+    return
+  }
+
+  const ofMembers = safeGetOf(field.type)
+  const of: Array<OfDefinition> = ofMembers ? new Array(ofMembers.length) : []
+  target[index] = {
+    name: field.name,
+    type: 'array',
+    ...(field.type.title ? {title: field.type.title} : {}),
+    of,
+  }
+  if (ofMembers) {
+    for (
+      let memberIndex = ofMembers.length - 1;
+      memberIndex >= 0;
+      memberIndex--
+    ) {
+      const member = ofMembers[memberIndex]!
+      conversion.work.push(() =>
+        scheduleOfMember(conversion, member, of, memberIndex),
+      )
+    }
+  }
+}
+
+function scheduleOfMember(
+  conversion: Conversion,
+  memberType: SchemaType,
+  target: Array<OfDefinition>,
+  index: number,
+): void {
+  // `findBlockType` walks up the `type.type` chain to the base `block`, so
+  // it only detects *whether* this member is a block. A block member's own
+  // marks/styles/lists live on `memberType`, which `scheduleBlockOfMember`
+  // reads to emit the member's own resolved sub-schema.
+  if (findBlockType(memberType)) {
+    scheduleBlockOfMember(
+      conversion,
+      memberType as BlockSchemaType,
+      target,
+      index,
+    )
+    return
+  }
+
+  // If this member has fields and isn't already in the ancestor chain,
+  // emit an INLINE declaration (`type: 'object'` + name + fields). If the
+  // type is in the ancestor chain (cycle) or has no fields, emit a bare
+  // REFERENCE (just `type: <name>`).
+  const hasFields =
+    memberType.jsonType === 'object' &&
+    'fields' in memberType &&
+    Array.isArray((memberType as ObjectSchemaType).fields)
+
+  if (!hasFields || hasAncestor(conversion, memberType.name)) {
+    // Bare reference. The editor's resolver looks up `memberType.name`
+    // in `blockObjects` / `inlineObjects`.
+    target[index] = {
+      type: memberType.name,
+      ...(memberType.title ? {title: memberType.title} : {}),
+    }
+    return
+  }
+
+  // Each distinct member instance is expanded exactly once per conversion;
+  // every later position that reaches the same instance shares the first
+  // expansion. Keyed by instance (not name) so that same-named but
+  // structurally different inline declarations keep their own shapes.
+  // The memo entry lands before the subtree drains, which is
+  // output-neutral: any path re-entering this instance mid-expansion
+  // carries its name in the ancestor set and cuts to a bare reference
+  // before the memo is consulted, and every other position runs after
+  // this subtree has fully drained (exact DFS order).
+  const memoized = conversion.memo.get(memberType)
+  if (memoized) {
+    target[index] = memoized
+    return
+  }
+
+  const fields = (memberType as ObjectSchemaType).fields
+  const holes: Array<FieldDefinition> = new Array(fields.length)
+  const definition: OfDefinition = {
+    type: 'object',
+    name: memberType.name,
+    ...(memberType.title ? {title: memberType.title} : {}),
+    fields: holes,
+  }
+  conversion.memo.set(memberType, definition)
+  target[index] = definition
+
+  pushAncestor(conversion, memberType.name)
+  conversion.work.push(() => popAncestor(conversion, memberType.name))
+  for (let fieldIndex = fields.length - 1; fieldIndex >= 0; fieldIndex--) {
+    const field = fields[fieldIndex]!
+    conversion.work.push(() =>
+      scheduleField(conversion, field, holes, fieldIndex),
+    )
   }
 }
 
@@ -169,11 +466,12 @@ function sanitySchemaTypeToSchema(
  * strips marks and styles, or declares `of: []`) from leaking the root's
  * decorators, styles, or inline objects into the container.
  */
-function resolveBlockOfMember(
+function scheduleBlockOfMember(
+  conversion: Conversion,
   blockType: BlockSchemaType,
-  ancestorNames: ReadonlySet<string>,
-  memo: Map<SchemaType, OfDefinition>,
-): BlockOfDefinition {
+  target: Array<OfDefinition>,
+  index: number,
+): void {
   const styleList = blockType.fields?.find((field) => field.name === 'style')
     ?.type.options?.list
   const listItemList = blockType.fields?.find(
@@ -198,7 +496,9 @@ function resolveBlockOfMember(
   )?.decorators
   const spanAnnotations = (spanType as SpanSchemaType | undefined)?.annotations
 
-  return {
+  const pendingWork: Array<Work> = []
+
+  const definition: BlockOfDefinition = {
     type: 'block',
     styles: (Array.isArray(styleList) ? styleList : [])
       .filter((style: BlockStyleDefinition) => style.value)
@@ -222,26 +522,39 @@ function resolveBlockOfMember(
       }),
     ),
     annotations: (Array.isArray(spanAnnotations) ? spanAnnotations : []).map(
-      (annotation) => ({
-        name: annotation.name,
-        title: annotation.title,
-        fields: annotation.fields.map((field) =>
-          sanityFieldToSchemaField(field, ancestorNames, memo),
-        ),
-      }),
+      (annotation) => {
+        const built = buildFields(
+          conversion,
+          annotation.fields,
+          undefined,
+          annotation,
+        )
+        pendingWork.push(built.work)
+        return {
+          name: annotation.name,
+          title: annotation.title,
+          fields: built.holes,
+        }
+      },
     ),
-    inlineObjects: inlineObjectTypes.map((inlineObject) => ({
-      name: inlineObject.name,
-      title: inlineObject.title,
-      fields: (inlineObject.fields ?? []).map((field) =>
-        sanityFieldToSchemaField(
-          field,
-          new Set([...ancestorNames, inlineObject.name]),
-          memo,
-        ),
-      ),
-    })),
+    inlineObjects: inlineObjectTypes.map((inlineObject) => {
+      const built = buildFields(
+        conversion,
+        inlineObject.fields ?? [],
+        inlineObject.name,
+        inlineObject,
+      )
+      pendingWork.push(built.work)
+      return {
+        name: inlineObject.name,
+        title: inlineObject.title,
+        fields: built.holes,
+      }
+    }),
   }
+  target[index] = definition
+
+  pushInOrder(conversion, pendingWork)
 }
 
 function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
@@ -254,93 +567,6 @@ function safeGetOf(schemaType: SchemaType): readonly SchemaType[] | undefined {
     // Sanity schema getters can throw -- ignore
   }
   return undefined
-}
-
-function sanityFieldToSchemaField(
-  field: {
-    name: string
-    type: SchemaType
-  },
-  ancestorNames: ReadonlySet<string>,
-  memo: Map<SchemaType, OfDefinition>,
-): FieldDefinition {
-  if (field.type.jsonType === 'array') {
-    const ofMembers = safeGetOf(field.type)
-    return {
-      name: field.name,
-      type: 'array',
-      ...(field.type.title ? {title: field.type.title} : {}),
-      of: ofMembers
-        ? ofMembers.map((member) =>
-            sanityOfMemberToOfDefinition(member, ancestorNames, memo),
-          )
-        : [],
-    }
-  }
-
-  return {
-    name: field.name,
-    type: field.type.jsonType,
-    ...(field.type.title ? {title: field.type.title} : {}),
-  }
-}
-
-function sanityOfMemberToOfDefinition(
-  memberType: SchemaType,
-  ancestorNames: ReadonlySet<string>,
-  memo: Map<SchemaType, OfDefinition>,
-): OfDefinition {
-  // `findBlockType` walks up the `type.type` chain to the base `block`, so
-  // it only detects *whether* this member is a block. A block member's own
-  // marks/styles/lists live on `memberType`, which `resolveBlockOfMember`
-  // reads to emit the member's own resolved sub-schema.
-  if (findBlockType(memberType)) {
-    return resolveBlockOfMember(
-      memberType as BlockSchemaType,
-      ancestorNames,
-      memo,
-    )
-  }
-
-  // If this member has fields and isn't already in the ancestor chain,
-  // emit an INLINE declaration (`type: 'object'` + name + fields). If the
-  // type is in the ancestor chain (cycle) or has no fields, emit a bare
-  // REFERENCE (just `type: <name>`).
-  const hasFields =
-    memberType.jsonType === 'object' &&
-    'fields' in memberType &&
-    Array.isArray((memberType as ObjectSchemaType).fields)
-
-  if (!hasFields || ancestorNames.has(memberType.name)) {
-    // Bare reference. The editor's resolver looks up `memberType.name`
-    // in `blockObjects` / `inlineObjects`.
-    return {
-      type: memberType.name,
-      ...(memberType.title ? {title: memberType.title} : {}),
-    }
-  }
-
-  // Each distinct member instance is expanded exactly once per conversion;
-  // every later position that reaches the same instance shares the first
-  // expansion. Keyed by instance (not name) so that same-named but
-  // structurally different inline declarations keep their own shapes.
-  const memoized = memo.get(memberType)
-  if (memoized) {
-    return memoized
-  }
-
-  const nextAncestors = new Set(ancestorNames)
-  nextAncestors.add(memberType.name)
-  const definition: OfDefinition = {
-    type: 'object',
-    name: memberType.name,
-    ...(memberType.title ? {title: memberType.title} : {}),
-    fields: (memberType as ObjectSchemaType).fields.map((field) =>
-      sanityFieldToSchemaField(field, nextAncestors, memo),
-    ),
-  }
-  memo.set(memberType, definition)
-  return definition
 }
 
 function resolveEnabledStyles(blockType: ObjectSchemaType) {

--- a/packages/sanity-bridge/src/sub-schema-agreement.test.ts
+++ b/packages/sanity-bridge/src/sub-schema-agreement.test.ts
@@ -1,0 +1,173 @@
+import {getSubSchema, type Schema} from '@portabletext/schema'
+import {Schema as SanitySchema} from '@sanity/schema'
+import type {ArraySchemaType, PortableTextBlock} from '@sanity/types'
+import {defineArrayMember, defineField, defineType} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+import {getSanitySubSchema} from './get-sanity-sub-schema'
+import type {PortableTextMemberSchemaTypes} from './portable-text-member-schema-types'
+import {sanitySchemaToPortableTextSchema} from './sanity-schema-to-portable-text-schema'
+
+/**
+ * `getSanitySubSchema` and `@portabletext/schema`'s `getSubSchema`
+ * answer "what is allowed at this position?" in two type universes,
+ * raw Sanity types versus the expanded Portable Text schema. Nothing
+ * forces them to agree except these tests: a change to container
+ * resolution on either side that drifts the answers would let the
+ * editor permit one thing at a position while Studio validates
+ * another, with both sides looking self-consistently correct.
+ *
+ * The correspondence relation: Portable Text names map to Sanity
+ * `value`s for styles, lists, and decorators, and to type names for
+ * everything else.
+ */
+describe('sub-schema agreement across the two type universes', () => {
+  const sanitySchema = SanitySchema.compile({
+    name: 'agreement',
+    types: [
+      defineType({
+        type: 'object',
+        name: 'codeAnnotation',
+        fields: [defineField({type: 'string', name: 'note'})],
+      }),
+      defineType({
+        type: 'object',
+        name: 'callout',
+        fields: [defineField({type: 'string', name: 'tone'})],
+      }),
+      defineType({
+        type: 'object',
+        name: 'code-block',
+        fields: [
+          defineField({
+            type: 'array',
+            name: 'lines',
+            of: [
+              defineArrayMember({
+                type: 'block',
+                name: 'block',
+                styles: [{title: 'Code', value: 'code'}],
+                lists: [],
+                marks: {
+                  decorators: [{title: 'Hex', value: 'hex'}],
+                  annotations: [],
+                },
+                of: [defineArrayMember({type: 'codeAnnotation'})],
+              }),
+            ],
+          }),
+        ],
+      }),
+      defineType({
+        type: 'array',
+        name: 'content',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            name: 'block',
+            marks: {
+              annotations: [
+                {
+                  name: 'link',
+                  type: 'object',
+                  fields: [{name: 'href', type: 'string'}],
+                },
+              ],
+            },
+          }),
+          defineArrayMember({type: 'code-block'}),
+          defineArrayMember({type: 'callout'}),
+        ],
+      }),
+    ],
+  })
+  const rootType = sanitySchema.get(
+    'content',
+  ) as ArraySchemaType<PortableTextBlock>
+  const convertedSchema = sanitySchemaToPortableTextSchema(rootType)
+
+  const value: ReadonlyArray<PortableTextBlock> = [
+    {
+      _type: 'code-block',
+      _key: 'cb1',
+      lines: [
+        {
+          _type: 'block',
+          _key: 'line1',
+          style: 'code',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['hex']}],
+          markDefs: [],
+        },
+      ],
+    } as unknown as PortableTextBlock,
+  ]
+
+  test('Scenario: The root position resolves the same members on both sides', () => {
+    expect(portableTextNames(convertedSchema)).toEqual(
+      sanityNames(getSanitySubSchema(rootType, value, [])),
+    )
+  })
+
+  test('Scenario: A restricted nested block resolves the same members on both sides', () => {
+    // Portable Text side: the `of` at the code-block's `lines` field in
+    // the expanded schema. This navigation follows declarations by
+    // name, it is deliberately not a resolver, so the resolver under
+    // test on this side is `getSubSchema` alone.
+    const codeBlock = convertedSchema.blockObjects.find(
+      (blockObject) => blockObject.name === 'code-block',
+    )
+    const linesField = codeBlock?.fields.find((field) => field.name === 'lines')
+    expect(linesField?.type).toBe('array')
+    const linesOf = linesField?.type === 'array' ? (linesField.of ?? []) : []
+
+    const portableTextView = getSubSchema(convertedSchema, linesOf)
+    const sanityView = getSanitySubSchema(rootType, value, [
+      {_key: 'cb1'},
+      'lines',
+      {_key: 'line1'},
+      'children',
+      {_key: 's1'},
+    ])
+
+    expect(portableTextNames(portableTextView)).toEqual(sanityNames(sanityView))
+    // The restriction itself, pinned explicitly so agreement can't be
+    // satisfied by both sides being equally wrong about the root.
+    // Sanity injects the default 'normal' style into every compiled
+    // block, declared styles come after it.
+    expect(portableTextNames(portableTextView)).toEqual({
+      styles: ['normal', 'code'],
+      lists: [],
+      decorators: ['hex'],
+      annotations: [],
+      blockObjects: [],
+      inlineObjects: ['codeAnnotation'],
+    })
+  })
+})
+
+function portableTextNames(schema: Schema) {
+  return {
+    styles: schema.styles.map((style) => style.name),
+    lists: schema.lists.map((list) => list.name),
+    decorators: schema.decorators.map((decorator) => decorator.name),
+    annotations: schema.annotations.map((annotation) => annotation.name),
+    blockObjects: schema.blockObjects.map((blockObject) => blockObject.name),
+    inlineObjects: schema.inlineObjects.map(
+      (inlineObject) => inlineObject.name,
+    ),
+  }
+}
+
+function sanityNames(memberTypes: PortableTextMemberSchemaTypes) {
+  return {
+    styles: memberTypes.styles.map((style) => style.value),
+    lists: memberTypes.lists.map((list) => list.value),
+    decorators: memberTypes.decorators.map((decorator) => decorator.value),
+    annotations: memberTypes.annotations.map((annotation) => annotation.name),
+    blockObjects: memberTypes.blockObjects.map(
+      (blockObject) => blockObject.name,
+    ),
+    inlineObjects: memberTypes.inlineObjects.map(
+      (inlineObject) => inlineObject.name,
+    ),
+  }
+}


### PR DESCRIPTION
This started as the quadratic scaling ladder and the stack-overflow cliff in `sanity-bridge`'s conversion, and the fuzz oracle built for that fix surfaced something worse: an **unbounded recursion on cyclic schemas that ships in production today**. A block's inline objects and annotations expand their fields unconditionally, block members bypass both the memo and the ancestor cut (`findBlockType` short-circuits before either), so a schema where a block's inline object or annotation transitively carries another Portable Text field (an inline footnote containing rich text) recurses forever: `RangeError` if the stack dies first, a frozen tab otherwise, triggered by `PortableTextInput` mounting. #2774's regression fixtures only nested through top-level block objects, which cut correctly, so this survived that fix unseen.

The walk now runs on an explicit LIFO work stack instead of the call stack. Three design points carry the byte-identical claim: children are pushed in reverse so the drain order is exact DFS pre-order, which the memo's first-expansion-wins semantics depend on; results land in pre-indexed holes so construction order matches the recursive version; and ancestor names live in one reference-counted map scoped by pop-markers, reference-counted because the same name can be seeded at several depths of one branch, and a plain shared set's `delete` clobbers the outer scope where the recursive version's per-branch copies were naturally reentrant (the fuzz oracle caught exactly this during development). The cycle cut is deliberately surgical: inline-object and annotation expansions track in-flight instances together with the ancestor-set size at entry, and only a re-entry of the same instance at the same size, provably the exact state the old code looped forever on, since ancestors grow monotonically along a branch, cuts to empty fields. Name-based cutting was tried first and rejected by the oracle: it changed output for schemas the old code terminated on.

Verification is three-layered: a fuzz oracle comparing against the old implementation kept verbatim in `reference-conversion-for-oracle.ts` (identical output wherever the reference terminates, termination where it crashes), a footnote-cycle regression test pinning the crash fix, and a 1,600-type does-not-throw pin at the old stack cliff. All 43 pre-existing output pins pass unmodified. A 100M-work-item circuit breaker turns any future uncut cycle into a diagnostic error instead of an exhausted heap.

Honest scope notes. The original ladder quadratic is **not** fixed, because measurement showed it cannot be while output stays eager and byte-identical: each of n embedding positions carries its own `of` list and those lists genuinely differ per position (a type's self-reference is ancestor-cut at its own position, memo-shared at others), so the output itself is O(n^2) entries, ~762ms and ~115MB at 1,600 types, which previously crashed outright. Bounding that requires a semantic change, a configurable expansion depth cap or a lazy schema mirroring Sanity's own compiled-schema laziness, tracked as a follow-up design ticket. The work-stack machinery also costs ~40% on pathological-shape constants (191ms vs 138ms at 800 types) in exchange for never overflowing; common schemas (~300 types, ~17ms) are unaffected.

Two companion commits ride along. A docs commit rewrites the README's framing (what the expansion is and why the editor wants plain data), documents how recursive schemas resolve, and replaces two documented-but-nonexistent functions with the real API (`createPortableTextMemberSchemaTypes`, `getSanitySubSchema`). And a test commit adds a sub-schema agreement oracle: `getSanitySubSchema` and `@portabletext/schema`'s `getSubSchema` answer "what is allowed at this position?" in their respective type universes with nothing previously forcing them to agree, so the new test walks both at the root and inside a restricted nested block and asserts the bucketizations correspond under the name mapping (Portable Text names are Sanity `value`s for styles, lists, and decorators).