### PR TITLE
fix: expand marks the schema cannot resolve when typing at span edges

### DIFF
--- a/.changeset/unknown-mark-typing-semantics.md
+++ b/.changeset/unknown-mark-typing-semantics.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: expand marks the schema cannot resolve when typing at span edges
+
+Typing at the edge of a span whose mark the schema cannot resolve now
+extends the span, the way decorators behave. Previously such marks
+were treated as annotations and escaped, so the typed text started a
+new unmarked span next to the marked one.

--- a/packages/editor/src/behaviors/behavior.core.insert.ts
+++ b/packages/editor/src/behaviors/behavior.core.insert.ts
@@ -19,13 +19,14 @@ export const coreInsertBehaviors = [
       const markState = getMarkState(snapshot)
       const activeDecorators = getActiveDecorators(snapshot)
       const activeAnnotations = getActiveAnnotationsMarks(snapshot)
+      const focusSubSchema = getPathSubSchema(snapshot, focusSpan.path)
+      const decoratorNames = focusSubSchema.decorators.map(
+        (decorator) => decorator.name,
+      )
 
       if (markState && markState.state === 'unchanged') {
-        const focusSubSchema = getPathSubSchema(snapshot, focusSpan.path)
         const markStateDecorators = (markState.marks ?? []).filter((mark) =>
-          focusSubSchema.decorators
-            .map((decorator) => decorator.name)
-            .includes(mark),
+          decoratorNames.includes(mark),
         )
 
         if (
@@ -36,16 +37,29 @@ export const coreInsertBehaviors = [
         }
       }
 
-      return {activeDecorators, activeAnnotations}
+      // Marks that are neither declared decorators nor annotations are marks
+      // the schema cannot resolve. They get decorator semantics, so they
+      // carry over onto the inserted text. Declared decorators are excluded
+      // by name, not by active state: a toggled-off decorator must not ride
+      // along.
+      const unknownMarks = (markState?.marks ?? []).filter(
+        (mark) =>
+          !decoratorNames.includes(mark) && !activeAnnotations.includes(mark),
+      )
+
+      return {activeDecorators, activeAnnotations, unknownMarks}
     },
     actions: [
-      ({snapshot, event}, {activeDecorators, activeAnnotations}) => [
+      (
+        {snapshot, event},
+        {activeDecorators, activeAnnotations, unknownMarks},
+      ) => [
         raise({
           type: 'insert.child',
           child: {
             _type: snapshot.context.schema.span.name,
             text: event.text,
-            marks: [...activeDecorators, ...activeAnnotations],
+            marks: [...activeDecorators, ...activeAnnotations, ...unknownMarks],
           },
         }),
       ],

--- a/packages/editor/src/selectors/selector.get-active-annotation-marks.ts
+++ b/packages/editor/src/selectors/selector.get-active-annotation-marks.ts
@@ -1,12 +1,16 @@
 import type {EditorSnapshot} from '../editor/editor-snapshot'
+import {getFocusTextBlock} from './selector.get-focus-text-block'
 import {getMarkState} from './selector.get-mark-state'
 
 export function getActiveAnnotationsMarks(snapshot: EditorSnapshot) {
-  const schema = snapshot.context.schema
   const markState = getMarkState(snapshot)
-
-  return (markState?.marks ?? []).filter(
-    (mark) =>
-      !schema.decorators.map((decorator) => decorator.name).includes(mark),
+  // A mark is an annotation only when it resolves to one of the block's
+  // `markDefs`. "Not a decorator" is not enough: a mark the schema cannot
+  // resolve might be a decorator from another schema.
+  const focusBlock = getFocusTextBlock(snapshot)
+  const markDefKeys = (focusBlock?.node.markDefs ?? []).map(
+    (markDef) => markDef._key,
   )
+
+  return (markState?.marks ?? []).filter((mark) => markDefKeys.includes(mark))
 }

--- a/packages/editor/src/selectors/selector.get-mark-state.test.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.test.ts
@@ -152,6 +152,13 @@ describe(getMarkState.name, () => {
           {
             _type: 'block',
             _key: blockKey,
+            markDefs: [
+              {
+                _type: 'link',
+                _key: linkKey,
+                href: 'https://portabletext.org',
+              },
+            ],
             children: [
               {
                 _type: 'span',
@@ -214,6 +221,13 @@ describe(getMarkState.name, () => {
           {
             _type: 'block',
             _key: blockKey,
+            markDefs: [
+              {
+                _type: 'link',
+                _key: linkKey,
+                href: 'https://portabletext.org',
+              },
+            ],
             children: [
               {
                 _type: 'span',

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -152,13 +152,19 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
     }
   }
 
-  const focusSubSchema = getPathSubSchema(snapshot, focusSpan.path)
-  const decorators = focusSubSchema.decorators.map(
-    (decorator) => decorator.name,
+  // A mark is an annotation only when it resolves to one of the block's
+  // `markDefs`. Marks the schema cannot resolve might be decorators from
+  // another schema, so they get decorator semantics (they expand when
+  // typing at the edges of the span) instead of the annotation escape.
+  const focusBlock = getParent(snapshot, focusSpan.path, {
+    match: (node) => isTextBlock({schema: snapshot.context.schema}, node),
+  })
+  const markDefKeys = (focusBlock?.node.markDefs ?? []).map(
+    (markDef) => markDef._key,
   )
   const marks = focusSpan.node.marks ?? []
-  const marksWithoutAnnotations = marks.filter((mark) =>
-    decorators.includes(mark),
+  const marksWithoutAnnotations = marks.filter(
+    (mark) => !markDefKeys.includes(mark),
   )
 
   const spanHasAnnotations = marks.length > marksWithoutAnnotations.length
@@ -184,20 +190,20 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
     },
   })
   const nextSpanAnnotations =
-    nextSpan?.node?.marks?.filter((mark) => !decorators.includes(mark)) ?? []
-  const spanAnnotations = marks.filter((mark) => !decorators.includes(mark))
+    nextSpan?.node?.marks?.filter((mark) => markDefKeys.includes(mark)) ?? []
+  const spanAnnotations = marks.filter((mark) => markDefKeys.includes(mark))
 
   const previousSpanHasAnnotations = previousSpan
-    ? previousSpan.node.marks?.some((mark) => !decorators.includes(mark))
+    ? previousSpan.node.marks?.some((mark) => markDefKeys.includes(mark))
     : false
   const previousSpanHasSameAnnotations = previousSpan
     ? previousSpan.node.marks
-        ?.filter((mark) => !decorators.includes(mark))
+        ?.filter((mark) => markDefKeys.includes(mark))
         .every((mark) => marks.includes(mark))
     : false
   const previousSpanHasSameAnnotation = previousSpan
     ? previousSpan.node.marks?.some(
-        (mark) => !decorators.includes(mark) && marks.includes(mark),
+        (mark) => markDefKeys.includes(mark) && marks.includes(mark),
       )
     : false
 
@@ -278,8 +284,8 @@ export const getMarkState: EditorSelector<MarkState | undefined> = (
       return {
         state: 'changed',
         previousMarks: marks,
-        marks: (previousSpan?.node.marks ?? []).filter((mark) =>
-          decorators.includes(mark),
+        marks: (previousSpan?.node.marks ?? []).filter(
+          (mark) => !markDefKeys.includes(mark),
         ),
       }
     }

--- a/packages/editor/tests/schema-less-marks.test.tsx
+++ b/packages/editor/tests/schema-less-marks.test.tsx
@@ -129,3 +129,94 @@ describe('Feature: Schema-Less Decorator Marks', () => {
     expect(patchesTouchingUntouchedBlock).toEqual([])
   })
 })
+
+describe('Feature: Typing Around Schema-Less Marks', () => {
+  function typingEditor(children: Array<Record<string, unknown>>) {
+    return createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [],
+          children,
+        },
+      ],
+    })
+  }
+
+  function typeAt(
+    editor: Awaited<ReturnType<typeof createTestEditor>>['editor'],
+    spanKey: string,
+    offset: number,
+  ) {
+    const point = {path: [{_key: 'b0'}, 'children', {_key: spanKey}], offset}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'insert.text', text: 'X'})
+  }
+
+  // The baseline: a decorator the schema knows expands when typing at the
+  // trailing edge of its span.
+  test('Scenario: typing after a known decorator expands it', async () => {
+    const {editor} = await typingEditor([
+      {_type: 'span', _key: 's1', text: 'foo', marks: ['em']},
+      {_type: 'span', _key: 's2', text: ' bar', marks: []},
+    ])
+    typeAt(editor, 's1', 'foo'.length)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value?.at(0)?.children).toEqual([
+        {_type: 'span', _key: 's1', text: 'fooX', marks: ['em']},
+        {_type: 'span', _key: 's2', text: ' bar', marks: []},
+      ])
+    })
+  })
+
+  test('Scenario: typing inside an unknown mark keeps the span whole', async () => {
+    const {editor} = await typingEditor([
+      {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+    ])
+    typeAt(editor, 's1', 1)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value?.at(0)?.children).toEqual([
+        {_type: 'span', _key: 's1', text: 'fXoo', marks: ['strong']},
+      ])
+    })
+  })
+
+  // The contrast: typing after an annotation escapes it. Unknown marks must
+  // not inherit this, only marks that resolve to a markDef are annotations.
+  test('Scenario: typing after an annotation escapes it', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          style: 'normal',
+          markDefs: [{_type: 'link', _key: 'l0', url: 'https://example.com'}],
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['l0']},
+            {_type: 'span', _key: 's2', text: ' bar', marks: []},
+          ],
+        },
+      ],
+    })
+    const point = {path: [{_key: 'b0'}, 'children', {_key: 's1'}], offset: 3}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+    editor.send({type: 'insert.text', text: 'X'})
+
+    await vi.waitFor(() => {
+      // The typed text lands outside the annotation; merging it with the
+      // following plain span re-keys that span.
+      expect(editor.getSnapshot().context.value?.at(0)?.children).toEqual([
+        {_type: 'span', _key: 's1', text: 'foo', marks: ['l0']},
+        {_type: 'span', _key: 'k2', text: 'X bar', marks: []},
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/schema-less-marks.test.tsx
+++ b/packages/editor/tests/schema-less-marks.test.tsx
@@ -174,6 +174,23 @@ describe('Feature: Typing Around Schema-Less Marks', () => {
     })
   })
 
+  // The desired contract: a mark the schema cannot resolve might be a
+  // decorator from another schema, so typing treats it like one.
+  test('Scenario: typing after an unknown mark expands it like a decorator', async () => {
+    const {editor} = await typingEditor([
+      {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+      {_type: 'span', _key: 's2', text: ' bar', marks: []},
+    ])
+    typeAt(editor, 's1', 'foo'.length)
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value?.at(0)?.children).toEqual([
+        {_type: 'span', _key: 's1', text: 'fooX', marks: ['strong']},
+        {_type: 'span', _key: 's2', text: ' bar', marks: []},
+      ])
+    })
+  })
+
   test('Scenario: typing inside an unknown mark keeps the span whole', async () => {
     const {editor} = await typingEditor([
       {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},


### PR DESCRIPTION
Typing at the trailing edge of a span whose mark the schema cannot resolve started a new unmarked span, the text escaped the mark the way it escapes an annotation. For a decorator that was merely removed from the schema (or one a collaborator has and you don't), that's the wrong instinct: since 7.10.4 such marks are preserved as possible decorators, so editing should give them decorator semantics too, and decorators expand.

The cause is the same closed-world inference #2954 removed from normalization, still alive in the typing path: the caret branch of `getMarkState` and `getActiveAnnotationsMarks` classified every mark that isn't a schema decorator as an annotation. A mark is now an annotation only when it resolves to one of the block's `markDefs`, the line the expanded-selection branch of the same selector, the render classification, and normalization already draw. The `insert.text` behavior carries unresolvable marks onto inserted text, excluding declared decorators by name rather than active state so a toggled-off decorator doesn't ride along (the existing `Toggling bold inside italic as you write` scenario pins exactly that, and caught exactly that during development).

Four new scenarios in `tests/schema-less-marks.test.tsx`: the decorator-expansion and annotation-escape baselines, typing inside an unresolvable mark, and the trailing-edge expansion (red before the fix). Two `getMarkState` unit fixtures gained the `markDefs` they always meant to have: the old classifier never read markDefs, so their annotation marks referenced none, which the new classifier correctly treats as unresolvable. Full suites: 1718 browser, 852 unit.

