### PR TITLE
fix: stop logging unresolvable marks and annotations

### DIFF
--- a/.changeset/silence-render-warnings.md
+++ b/.changeset/silence-render-warnings.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stop logging unresolvable marks and annotations
+
+The two render warnings introduced in 7.10.4 are removed. Reporting
+belongs to the host: the editor renders such values without effect and
+stays silent.

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -79,9 +79,6 @@ export function RenderSpan(props: RenderSpanProps) {
         return [markDef]
       }
 
-      console.warn(
-        `Mark ${mark} is neither a decorator in the schema nor a markDef key in the block. The mark is kept in the value but does not render. If it is a decorator, add it to the schema.`,
-      )
       return []
     },
   )
@@ -120,11 +117,6 @@ export function RenderSpan(props: RenderSpanProps) {
     const annotationSchemaType = subSchema.annotations.find(
       (t) => t.name === annotationMarkDef._type,
     )
-    if (!annotationSchemaType) {
-      console.warn(
-        `The schema has no annotation type ${annotationMarkDef._type}. The annotation is kept in the value but does not render. Add ${annotationMarkDef._type} to the schema to render it.`,
-      )
-    }
     if (annotationSchemaType) {
       if (block && props.renderAnnotation) {
         children = (

--- a/packages/editor/tests/schema-less-marks.test.tsx
+++ b/packages/editor/tests/schema-less-marks.test.tsx
@@ -49,12 +49,9 @@ describe('Feature: Schema-Less Decorator Marks', () => {
       expect(editor.getSnapshot().context.value).toEqual(initialValue)
     })
 
-    // The mark renders without effect, and the editor says so.
-    await vi.waitFor(() => {
-      expect(consoleWarn).toHaveBeenCalledWith(
-        'Mark strong is neither a decorator in the schema nor a markDef key in the block. The mark is kept in the value but does not render. If it is a decorator, add it to the schema.',
-      )
-    })
+    // The mark renders without effect, silently: reporting is the host's
+    // job, so the console stays clean.
+    expect(consoleWarn).not.toHaveBeenCalled()
     consoleWarn.mockRestore()
   })
 


### PR DESCRIPTION
The two render warnings shipped in 7.10.4 (`Mark X is neither a decorator...`, `The schema has no annotation type...`) assumed the engine was the only reporter. Inside Sanity Studio they now talk over the host's own reporting, which is deduped, path-annotated, and consistent in shape, while the engine's copies repeat per render pass with no dedup and no location. A library logging to the console makes a UX decision that belongs to the host.

The warnings are removed outright, no debug channel either: a host that wants to report unresolvable marks classifies spans itself, the same way it renders them (the span's `marks`, the block's `markDefs`, and the schema are all in consumer hands). The round-trip pin in `tests/schema-less-marks.test.tsx` now asserts the silence.
