### PR TITLE
chore: allow manually dispatching the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # Rerunning a failed release replays the reusable workflow at the commit
+  # it was first resolved to, so fixes to the shared workflow never reach a
+  # rerun. A manual dispatch starts a fresh run that resolves `@main` anew.
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Today's stuck release train demonstrated the gap: the publish failure was fixed in portabletext/.github#22, but reruns of the failed run replay the reusable workflow at the SHA it resolved to at run creation, so the fix could never reach them, and the only way to start a fresh run was an empty commit to main.

`workflow_dispatch` adds the missing lever. Merging this PR is itself the push to main that starts a fresh release run and publishes the stuck versions.
