### PR TITLE
fix: anchor replaced children on the incoming previous sibling during value sync

### DIFF
--- a/.changeset/value-sync-replace-anchor.md
+++ b/.changeset/value-sync-replace-anchor.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: anchor replaced children on the incoming previous sibling during value sync
+
+Updating the value of an editor whose document contains two or more
+adjacent spans with identical marks (valid Portable Text, common after
+CMS migrations) could crash the internal sync with `Cannot apply an
+"insert" operation ... because the sibling was not found.` The editor
+kept rendering and accepting keystrokes, but edits no longer reached the
+consumer's patch stream until reload. Value updates on such documents
+now sync correctly.

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -1101,9 +1101,16 @@ function updateBlock({
                 {_key: oldChild._key},
               ],
             })
+            // Anchor on the incoming block's previous child, not the
+            // pre-loop engine snapshot: earlier iterations may have unset
+            // the snapshot's sibling (e.g. when the engine merged adjacent
+            // same-mark spans on load and the incoming value still holds
+            // the split shape), while the incoming previous child is
+            // guaranteed present, the previous iteration just updated,
+            // replaced, or inserted it.
             const prevSibling =
               currentBlockChildIndex > 0
-                ? oldEngineBlock.children[currentBlockChildIndex - 1]
+                ? engineBlock.children[currentBlockChildIndex - 1]
                 : undefined
             if (prevSibling) {
               editorEngine.apply({

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1798,3 +1798,117 @@ describe('event.update value', () => {
     })
   })
 })
+
+describe('event.update value: adjacent same-mark spans', () => {
+  // Regression: the engine merges adjacent same-mark spans on load, so its
+  // state diverges from the stored value. A subsequent `update value` with
+  // the stored (split) shape walked the children against a pre-loop engine
+  // snapshot: each replaced child was unset, and the next iteration then
+  // anchored its insert on that just-unset sibling, throwing
+  // `Cannot apply an "insert" operation ... because the sibling was not
+  // found.` and killing the sync actor.
+  const splitValue = [
+    {
+      _key: 'b0',
+      _type: 'block',
+      children: [
+        {_key: 's1', _type: 'span', text: 'C1', marks: ['strong']},
+        {_key: 's2', _type: 'span', text: 'C2', marks: ['strong']},
+        {_key: 's3', _type: 'span', text: 'C3', marks: ['strong']},
+        {_key: 's4', _type: 'span', text: 'D', marks: []},
+        {_key: 's5', _type: 'span', text: 'E', marks: ['em']},
+      ],
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+
+  test('Scenario: updating with the stored split shape after the engine merged on load', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+      }),
+      initialValue: splitValue,
+    })
+
+    // The engine normalizes on load: the three adjacent `strong` spans
+    // merge into one.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's1', _type: 'span', text: 'C1C2C3', marks: ['strong']},
+            {_key: 's4', _type: 'span', text: 'D', marks: []},
+            {_key: 's5', _type: 'span', text: 'E', marks: ['em']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The consumer sends an update: a new block appended, while the
+    // adjacent-span block is still in its stored (split) shape. The
+    // changed value forces a sync, and the untouched block diffs against
+    // the engine's merged shape.
+    const appendedBlock = {
+      _key: 'b1',
+      _type: 'block',
+      children: [{_key: 's6', _type: 'span', text: 'new', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+    editor.send({
+      type: 'update value',
+      value: [...splitValue, appendedBlock],
+    })
+
+    // The sync applies the split shape and the engine re-normalizes it to
+    // the merged shape; the sync actor survives.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's1', _type: 'span', text: 'C1C2C3', marks: ['strong']},
+            {_key: 's4', _type: 'span', text: 'D', marks: []},
+            {_key: 's5', _type: 'span', text: 'E', marks: ['em']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        appendedBlock,
+      ])
+    })
+
+    // The sync actor is still alive: a later update still lands.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: 'changed', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's1', _type: 'span', text: 'changed', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
A consumer reported editors silently losing edits on any document containing two or more consecutive spans with identical marks, valid Portable Text, and in their case the shape of ~430 of 640 documents after a CMS migration. The editor keeps rendering and accepting keystrokes, but the internal sync actor is dead: `Cannot apply an "insert" operation at path [[object Object],children,[object Object]] because the sibling was not found.`, and no further edits reach the consumer until reload. Present in 7.8.0 and unchanged on `main`. (The consumer's report was exceptional; this diagnosis confirms it.)

Three things line up. The engine merges adjacent same-mark spans when a document loads (`normalize-node.ts`), so the engine's state diverges from the stored value. When a later `update value` carries the stored (still split) shape, `updateBlock`'s children diff-walk pairs incoming children against the engine block by index; for each mismatched pair it unsets the engine child by key and inserts the incoming child after a keyed sibling read from `oldEngineBlock.children[i - 1]`, a snapshot captured before the walk started. Each iteration's unset invalidates the sibling the next iteration anchors on, so with two or more consecutive replacements the second insert targets a key unset one iteration earlier and `apply-operation` throws. The throw escapes `syncBlock` (the `try`/`catch` only wraps the final `onChange`) and kills the sync actor.

The fix anchors the insert on the incoming block's previous child (`engineBlock.children[i - 1]`) instead. That child is present by construction: the previous iteration just updated, replaced, or inserted it. It is also exactly what the adjacent inserting-new-child branch already does with `prevChild`, so the two branches now anchor identically. Keyed addressing is kept (the consumer's own stopgap switched that one insert to a numeric segment, which works but silently changes the addressing mode of a single branch); only the stale snapshot read goes.

The regression test uses the reported shape: three adjacent same-mark spans that the engine merges on load, then an `update value` carrying the stored split shape plus an appended block. The appended block is load-bearing: the incoming value must differ from the previous one for the sync to run at all, which is why the crash bites documents the user never touched, any edit elsewhere forces the full-value sync that walks the diverged block. Before the fix the test dies with the exact reported error; after it, the sync applies the split shape, the engine re-normalizes to the merged shape, and a subsequent update still lands (the actor survived). Full unit (852) and browser (1715) suites pass unchanged.

One thing this PR deliberately does not fix: the underlying engine/document divergence. The on-load merge patches are parked in `pendingEvents` on a pristine editor and blanket-dropped by `discard all pending events` when a sync starts, so the engine and the stored document permanently disagree about the merged block, which also explains the consumer's remaining symptom (discarding a draft in the same session can resurrect it with invisible changes). That discard semantics question, revert pending changes vs flush them, is a real design decision and is tracked separately as a follow-up; this PR removes the crash and the data loss.
