### PR TITLE
fix: apply value-sync auto-resolutions to the block the engine receives

### DIFF
--- a/.changeset/apply-autoresolve-to-engine-block.md
+++ b/.changeset/apply-autoresolve-to-engine-block.md
@@ -1,0 +1,15 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: apply value-sync auto-resolutions to the block the engine receives
+
+When an `update value` carried a block the editor could repair
+automatically (a child missing its `_key`, an empty `children` array,
+unused `markDefs`), the repair was emitted as patches while the raw,
+un-repaired block proceeded into the editor. The editor then held an
+invalid shape that diverged from the document: the emitted patch minted
+one key, internal normalization minted another. The repair is now
+applied to the block before it enters the editor, so the emitted patch
+and the editor state agree, and the editor never holds the un-repaired
+shape.

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -1,4 +1,4 @@
-import type {Patch} from '@portabletext/patches'
+import {applyAll, type Patch} from '@portabletext/patches'
 import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {ActorRefFrom} from 'xstate'
 import {
@@ -703,7 +703,8 @@ function syncBlock({
     )
 
     if (validation.valid || validation.resolution?.autoResolve) {
-      const engineBlock = toEngineBlock(block, {
+      const repairedBlock = applyAutoResolution(validation, [block], block)
+      const engineBlock = toEngineBlock(repairedBlock, {
         schemaTypes: context.schema,
       })
 
@@ -785,8 +786,14 @@ function syncBlock({
   }
 
   if (validation.valid || validation.resolution?.autoResolve) {
+    const repairedBlock = applyAutoResolution(
+      validation,
+      validationValue,
+      block,
+    )
+
     if (oldBlock._key === block._key && oldBlock._type === block._type) {
-      debug.syncValue('Updating block', oldBlock, block)
+      debug.syncValue('Updating block', oldBlock, repairedBlock)
 
       withoutNormalizing(editorEngine, () => {
         withRemoteChanges(editorEngine, () => {
@@ -795,14 +802,14 @@ function syncBlock({
               context,
               editorEngine,
               oldEngineBlock,
-              block,
+              block: repairedBlock,
               index,
             })
           })
         })
       })
     } else {
-      debug.syncValue('Replacing block', oldBlock, block)
+      debug.syncValue('Replacing block', oldBlock, repairedBlock)
 
       withoutNormalizing(editorEngine, () => {
         withRemoteChanges(editorEngine, () => {
@@ -810,7 +817,7 @@ function syncBlock({
             replaceBlock({
               context,
               editorEngine,
-              block,
+              block: repairedBlock,
               index,
             })
           })
@@ -834,6 +841,26 @@ function syncBlock({
       blockValid: false,
     }
   }
+}
+
+/**
+ * `validateValue` auto-resolutions must reach the engine as state, not
+ * only the document as patches. Applying them only outbound forks the
+ * repair: the document receives the resolution (e.g. a minted child
+ * `_key`) while the engine holds the un-repaired shape its addressing
+ * model cannot represent, and normalization then mints a different key
+ * for the same node. The resolution patches were built from
+ * `validationValue` itself, so they always apply; the fallback only
+ * covers the impossible empty result.
+ */
+function applyAutoResolution(
+  validation: ReturnType<typeof validateValue>,
+  validationValue: Array<PortableTextBlock>,
+  block: PortableTextBlock,
+): PortableTextBlock {
+  return !validation.valid && validation.resolution?.autoResolve
+    ? (applyAll(validationValue, validation.resolution.patches).at(0) ?? block)
+    : block
 }
 
 function replaceBlock({

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -398,7 +398,7 @@ describe('container normalization', () => {
           children: [
             {
               _type: 'span',
-              _key: 'k4',
+              _key: 'k3',
               text: '',
               marks: [],
             },

--- a/packages/editor/tests/event.operation.test.tsx
+++ b/packages/editor/tests/event.operation.test.tsx
@@ -105,17 +105,13 @@ describe('event.operation', () => {
     expect(patches).toEqual([])
   })
 
-  test('Scenario: Normalization fix operations are delivered adjacent to their trigger', async () => {
+  test('Scenario: Auto-resolved blocks arrive repaired in their own insert operation', async () => {
     const {editor} = await createTestEditor()
     const operations = collectOperations(editor)
 
-    // A text block with no children triggers a normalization fix that
-    // inserts a placeholder span. Value sync applies in a batch, so the fix
-    // runs at the batch close and is delivered after its trigger
-    // (application order). The opposite, nested order for unbatched applies
-    // is pinned at the unit level in `operation-channel.test.ts`; the
-    // public contract is only adjacency, which is why the docs steer
-    // consumers toward snapshot-seeded recompute.
+    // A text block with no children is auto-resolved by `validateValue` at
+    // sync ingress: the placeholder span is part of the inserted node
+    // itself, not a separate normalization fix operation.
     editor.send({type: 'update value', value: [emptyBlock('b1')]})
 
     await vi.waitFor(() => {
@@ -128,16 +124,61 @@ describe('event.operation', () => {
           type: 'insert',
           path: [0],
           position: 'before',
-          node: emptyBlock('b1'),
+          node: {
+            ...emptyBlock('b1'),
+            children: [{_type: 'span', _key: 'k2', text: '', marks: []}],
+          },
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Normalization fix operations are delivered adjacent to their trigger', async () => {
+    const {editor} = await createTestEditor()
+    const operations = collectOperations(editor)
+
+    // Duplicate child keys pass value validation (no dup-key check at
+    // ingress) and are repaired by engine normalization, which renames the
+    // second occurrence. Value sync applies in a batch, so the fix runs at
+    // the batch close and is delivered after its trigger (application
+    // order). The opposite, nested order for unbatched applies is pinned
+    // at the unit level in `operation-channel.test.ts`; the public
+    // contract is only adjacency, which is why the docs steer consumers
+    // toward snapshot-seeded recompute.
+    // The differing marks keep the two spans from also triggering the
+    // adjacent same-mark merge, so the rename is the only fix.
+    const dupBlock: PortableTextBlock = {
+      _type: 'block',
+      _key: 'b1',
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {_type: 'span', _key: 'dup', text: 'one', marks: []},
+        {_type: 'span', _key: 'dup', text: 'two', marks: ['strong']},
+      ],
+    }
+    editor.send({type: 'update value', value: [dupBlock]})
+
+    await vi.waitFor(() => {
+      expect(operations).toEqual([
+        {
+          type: 'unset',
+          path: [{_key: 'k0'}],
         },
         {
           type: 'insert',
-          path: [{_key: 'b1'}, 'children', 0],
+          path: [0],
           position: 'before',
-          node: {_type: 'span', _key: 'k3', text: '', marks: []},
+          node: dupBlock,
+        },
+        {
+          type: 'set',
+          path: [{_key: 'b1'}, 'children', 1, '_key'],
+          value: 'k2',
           inverse: {
-            type: 'unset',
-            path: [{_key: 'b1'}, 'children', {_key: 'k3'}],
+            type: 'set',
+            path: [{_key: 'b1'}, 'children', 1, '_key'],
+            value: 'dup',
           },
         },
       ])

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1,6 +1,12 @@
 import {createTestKeyGenerator} from '@portabletext/test'
+import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
-import {defineSchema, type EditorEmittedEvent} from '../src'
+import {
+  defineSchema,
+  type EditorEmittedEvent,
+  type MutationEvent,
+  type Patch,
+} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {toTextspec} from '../test-utils/to-textspec'
@@ -1908,6 +1914,277 @@ describe('event.update value: adjacent same-mark spans', () => {
           markDefs: [],
           style: 'normal',
         },
+      ])
+    })
+  })
+})
+
+describe('event.update value: auto-resolved invalid blocks', () => {
+  // Regression: `validateValue` auto-resolutions (e.g. minting a missing
+  // child `_key`) were emitted as outbound patches while the *raw* block
+  // proceeded into the engine. The engine ended up holding the un-repaired
+  // shape (a keyless child), diverging from the document that received the
+  // minted key, and the next sync against that invalid engine state killed
+  // the sync silently.
+  const keylessChildBlock = {
+    _key: 'b0',
+    _type: 'block',
+    children: [{_type: 'span', text: 'hello changed', marks: []}],
+    markDefs: [],
+    style: 'normal',
+  }
+
+  test('Scenario: a mid-session update with a keyless child is repaired once and the sync survives', async () => {
+    const patches: Array<Patch> = []
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // A changed block arrives whose span lost its `_key`.
+    editor.send({type: 'update value', value: [keylessChildBlock]})
+
+    // The auto-resolution is emitted as a patch AND applied to the block
+    // the engine receives: one key, minted once, on both sides.
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [{_key: 'b0'}, 'children', 0],
+          value: {
+            _type: 'span',
+            _key: 'k2',
+            text: 'hello changed',
+            marks: [],
+          },
+        },
+      ])
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 'k2', _type: 'span', text: 'hello changed', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The sync is still alive: a later update still lands.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's9', _type: 'span', text: 'recovered', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          {
+            _key: 'b0',
+            _type: 'block',
+            children: [
+              {_key: 's9', _type: 'span', text: 'recovered', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
+      },
+      // The sync machine parks in `busy` while its own emitted mutation
+      // flushes and re-checks on a 1s timer, so the recovery value can
+      // take a beat over a second to land.
+      {timeout: 5000},
+    )
+  })
+
+  test('Scenario: a mid-session update with an unused markDef is repaired on both sides', async () => {
+    const patches: Array<Patch> = []
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // A changed block arrives carrying a markDef no span references.
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello changed', marks: []},
+          ],
+          markDefs: [{_key: 'm1', _type: 'link', href: 'https://example.com'}],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const unsetPatch = {
+      type: 'unset',
+      path: [{_key: 'b0'}, 'markDefs', {_key: 'm1'}],
+    }
+
+    // The auto-resolution is emitted as a patch AND applied to the block
+    // the engine receives: the def is gone on both sides.
+    await vi.waitFor(() => {
+      expect(patches).toEqual([unsetPatch])
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello changed', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // Causal sentinel: one local edit, then assert the full emission
+    // history. Before the fix the engine received the block with the def
+    // still present, its own normalizer pruned it and parked a whole-array
+    // `set` on the pristine editor, and that parked patch flushed here,
+    // ahead of the sentinel's.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 13},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 13},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        unsetPatch,
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
+          value: stringifyPatches(
+            makePatches(makeDiff('hello changed', 'hello changed!')),
+          ),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: a startup value with a keyless child is repaired in the engine without emitting patches', async () => {
+    const patches: Array<Patch> = []
+    const mutations: Array<MutationEvent> = []
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+            if (event.type === 'mutation') {
+              mutations.push(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 'k2', _type: 'span', text: 'hello', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // No mutation leaves a pristine editor on open. "Nothing was emitted"
+    // can't be awaited directly, so prove it with a causal sentinel: make
+    // one local edit and assert its patches are the only ones ever
+    // collected. Event ordering guarantees a would-be repair emission had
+    // flushed before the sentinel's.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'k2'}], offset: 5},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'k2'}], offset: 5},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    const sentinelPatch = {
+      type: 'diffMatchPatch',
+      path: [{_key: 'b0'}, 'children', {_key: 'k2'}, 'text'],
+      value: stringifyPatches(makePatches(makeDiff('hello', 'hello!'))),
+      origin: 'local',
+    }
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([sentinelPatch])
+      expect(mutations.map((mutation) => mutation.patches)).toEqual([
+        [sentinelPatch],
       ])
     })
   })

--- a/packages/editor/tests/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/tests/pteWarningsSelfSolving.test.tsx
@@ -54,7 +54,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
             _type: 'block',
             children: [
               {
-                _key: 'k3',
+                _key: 'k2',
                 _type: 'span',
                 text: 'Hello with a new key',
                 marks: [],
@@ -174,7 +174,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
             _type: 'block',
             children: [
               {
-                _key: 'k3',
+                _key: 'k2',
                 _type: 'span',
                 text: '',
                 marks: [],
@@ -188,7 +188,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
             _type: 'block',
             children: [
               {
-                _key: 'k5',
+                _key: 'k3',
                 _type: 'span',
                 text: '',
                 marks: [],


### PR DESCRIPTION
Probing the value sync's repair paths (follow-up territory from #2965) surfaced this: send an editor a mid-session `update value` whose changed block has a child missing its `_key`, and the editor ends up holding that keyless child, a shape its own addressing model can't represent (React immediately warns about duplicate keys rendering it), while the document receives a repair patch the editor never applied to itself.

The mechanism: `validateValue` runs at sync ingress and can auto-resolve certain defects (child missing `_key`, empty `children`, unused `markDefs`). But the resolution existed only as patches. The changed-block path emitted them outbound (gated to mid-session, non-readOnly, with a `console.warn`) while passing the **raw** block into `updateBlock`/`replaceBlock`; the insert path computed them and dropped them entirely. So the repair forked: the document got the resolution's minted key, the engine got the un-repaired block, and engine normalization later minted a *different* key for the same node. The old test pins are the fossil record of this double mint, `pteWarningsSelfSolving` expected `k3`, the key normalization minted *after* `validateValue`'s `k2` was discarded.

The fix applies the resolution to the block before it enters the engine, at both call sites, via `applyAll` from `@portabletext/patches` (the same constructors `validateValue` builds its resolutions with). The emitted patches are byte-identical to before and now agree with engine state: one key, minted once, on both sides. Emission semantics are deliberately untouched, the insert path still emits nothing, the changed path still emits only mid-session for non-readOnly editors; changing *when* repairs are emitted is the pending-events design work, tracked separately.

Three regression scenarios in `event.update-value.test.tsx` pin the contract: a mid-session keyless-child update repairs once (emitted patch key === engine key, exact values) and the sync survives to apply a subsequent update; a mid-session update with an unused `markDef` repairs on both sides, where the pre-fix red exposed a second defect of the fork: the repair was *doubly* emitted, the ingress keyed `unset` plus the engine normalizer's whole-array `set` for the same def, two conflicting patch shapes for one repair; and a startup value with a keyless child is repaired in the engine while emitting nothing (no mutation leaves a pristine editor on open). Negative assertions use a causal sentinel (one local edit, then a full-literal assert of the entire emission history) instead of sleeps, so a would-be emission is caught by ordering, not timing. The survival assertion needs a beat over a second: the sync machine parks in `busy` while its own emitted mutation flushes and re-polls on a 1s timer, which is also worth naming because an earlier probe mistook that delay for a permanent wedge; there is no wedge, the machine recovers by design.

Semantic deltas, all deliberate and pinned: repaired blocks now carry the first mint's key (`pteWarningsSelfSolving`, `container-normalization` pins shift from the second mint to the first), and an empty-children block arrives with its placeholder span inside the block's own `insert` operation instead of as a separate normalization fix op (`event.operation`). The normalization-adjacency contract that scenario used to exercise is re-pinned on duplicate child keys, which have no ingress check and are still repaired by normalization, so the contract keeps a living fixture. Full unit (852) and browser (1718) suites pass.

