### PR TITLE
test: pin list-container conversion via input rules

### DIFF
--- a/packages/plugin-input-rule/README.md
+++ b/packages/plugin-input-rule/README.md
@@ -71,6 +71,50 @@ export function MyMarkdownPlugin() {
 
 > **Tip:** The [`@portabletext/plugin-markdown-shortcuts`](../plugin-markdown-shortcuts/) package is already built using Input Rules and provides common markdown shortcuts out of the box.
 
+## How rules execute
+
+A rule looks like a Behavior, but three contracts matter as soon as its actions read state:
+
+1. **The pattern matches the text up to the caret, plus the insertion.** `textBefore` is the focus block's text from its start to the caret, and the pattern runs against `textBefore + textInserted`. `^` anchors to the start of the block's text; `$` anchors to the end of the insertion, not the end of the block, and text after the caret is invisible to the pattern. A match that sits entirely in already-typed text is ignored; only matches involving the insertion fire.
+
+2. **Action callbacks see the document as it was before the insertion.** The `guard` and every entry in `actions` receive the same pre-insertion snapshot, and a later entry does not observe an earlier entry's effects. The events they raise apply to the document with the insertion in place, but anything computed inside a callback, a block value, a selection, reflects the state before it landed. Embedding a block read this way into an `insert.block` resurrects the very text your `delete` removes.
+
+3. **Target the match with `match.targetOffsets`.** They address the text your raised events apply to, the document with the insertion in place, so they are the right target for `select` and `delete`. `match.selection` stops at the caret and falls one character short of a match that includes the insertion.
+
+When an action needs the document as it looks after earlier raised events have applied, raise a custom event and let a companion Behavior do the reading; a Behavior handling a raised event sees the document with all previously raised events applied:
+
+```tsx
+const bulletListRule = defineInputRule({
+  on: /^[-*] $/,
+  actions: [
+    ({event}) => {
+      const match = event.matches.at(0)
+
+      if (!match) {
+        return []
+      }
+
+      return [
+        raise({type: 'delete', at: match.targetOffsets}),
+        raise({type: 'custom.convert to list'}),
+      ]
+    },
+  ],
+})
+
+const convertToList = defineBehavior({
+  on: 'custom.convert to list',
+  guard: ({snapshot}) => {
+    // Runs after the raised `delete` has applied, so the focus block
+    // reads back without the matched marker and can be moved or embedded
+    // safely.
+    const focusBlock = getFocusTextBlock(snapshot)
+    return focusBlock ? {focusBlock} : false
+  },
+  // ...
+})
+```
+
 ## Working with capture groups
 
 When a rule needs the location of a _part_ of its match, capture that part in a **named group** and read it back by name from `match.groups`:

--- a/packages/plugin-input-rule/package.json
+++ b/packages/plugin-input-rule/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:*",
+    "@portabletext/test": "workspace:^",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",

--- a/packages/plugin-input-rule/src/input-rule.ts
+++ b/packages/plugin-input-rule/src/input-rule.ts
@@ -30,11 +30,12 @@ export type InputRuleEvent = {
    */
   matches: Array<InputRuleMatch>
   /**
-   * The text before the insertion
+   * The focus block's text from its start to the caret, as it was before
+   * the insertion
    */
   textBefore: string
   /**
-   * The text is destined to be inserted
+   * The text carried by the triggering `insert.text` event
    */
   textInserted: string
   /**

--- a/packages/plugin-input-rule/src/rule.list-conversion.test.tsx
+++ b/packages/plugin-input-rule/src/rule.list-conversion.test.tsx
@@ -1,0 +1,399 @@
+import {defineContainer} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {getFocusTextBlock} from '@portabletext/editor/selectors'
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {expect, test, vi} from 'vitest'
+import {defineInputRule} from './input-rule'
+import {InputRulePlugin} from './plugin.input-rule'
+
+// Mirrors the structured-lists container example: typing a markdown list
+// marker at the start of a block deletes the marker and lifts the block,
+// trailing content included, into the first item of a new `list`
+// container.
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  blockObjects: [
+    {
+      name: 'list',
+      fields: [
+        {name: 'kind', type: 'string'},
+        {
+          name: 'items',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'list-item',
+              fields: [
+                {
+                  name: 'content',
+                  type: 'array',
+                  of: [{type: 'block'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const containers = [
+  defineContainer({
+    type: 'list',
+    arrayField: 'items',
+    render: ({attributes, children}) => <ul {...attributes}>{children}</ul>,
+    of: [
+      defineContainer({
+        type: 'list-item',
+        arrayField: 'content',
+        render: ({attributes, children}) => <li {...attributes}>{children}</li>,
+      }),
+    ],
+  }),
+]
+
+function listInputRule(kind: 'bullet' | 'number', on: RegExp) {
+  return defineInputRule({
+    on,
+    actions: [
+      // Rule actions are evaluated eagerly against the pre-insertion
+      // snapshot, so they only raise events with statically known
+      // payloads. The machinery forwards the original `insert.text`
+      // before executing them, so the match's `targetOffsets` (block
+      // offsets in the post-insertion text) address exactly what the
+      // document contains; `match.selection` is estimated against the
+      // pre-insertion document and falls one character short.
+      ({event}) => {
+        const match = event.matches.at(0)
+        if (!match) {
+          return []
+        }
+        return [
+          raise({type: 'delete', at: match.targetOffsets}),
+          raise({type: 'custom.convert to list', kind}),
+        ]
+      },
+    ],
+  })
+}
+
+// Raised events perform against live state, so this behavior sees the
+// block after the marker delete has applied.
+const convertToList = defineBehavior<
+  {kind: 'bullet' | 'number'},
+  'custom.convert to list',
+  {focusBlock: NonNullable<ReturnType<typeof getFocusTextBlock>>}
+>({
+  on: 'custom.convert to list',
+  guard: ({snapshot}) => {
+    const focusBlock = getFocusTextBlock(snapshot)
+    return focusBlock ? {focusBlock} : false
+  },
+  actions: [
+    ({event}, {focusBlock}) => [
+      raise({type: 'delete.block', at: focusBlock.path}),
+      raise({
+        type: 'insert.block',
+        block: {
+          _type: 'list',
+          kind: event.kind,
+          items: [{_type: 'list-item', content: [focusBlock.node]}],
+        },
+        placement: 'auto',
+        select: 'start',
+      }),
+    ],
+  ],
+})
+
+const rules = [
+  listInputRule('bullet', /^[-*] $/),
+  listInputRule('number', /^\d+\. $/),
+]
+
+test('Scenario: typing a bullet marker in an empty block converts it to a list', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+    },
+  })
+  // Typed as separate events, the way real typing arrives: the marker
+  // must already be in the document when the trigger character fires the
+  // rule.
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'insert.text', text: ' '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k3',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'k2',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b0',
+                _type: 'block',
+                children: [{_key: 's0', _type: 'span', marks: [], text: ''}],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+test('Scenario: typing a bullet marker before existing text lifts the text into the list', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: 'hello', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+    },
+  })
+  // Typed as separate events, the way real typing arrives: the marker
+  // must already be in the document when the trigger character fires the
+  // rule.
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'insert.text', text: ' '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k3',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'k2',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b0',
+                _type: 'block',
+                children: [
+                  {_key: 's0', _type: 'span', marks: [], text: 'hello'},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+  expect(editor.getSnapshot().context.selection).toEqual({
+    anchor: {
+      path: [
+        {_key: 'k3'},
+        'items',
+        {_key: 'k2'},
+        'content',
+        {_key: 'b0'},
+        'children',
+        {_key: 's0'},
+      ],
+      offset: 0,
+    },
+    backward: false,
+    focus: {
+      path: [
+        {_key: 'k3'},
+        'items',
+        {_key: 'k2'},
+        'content',
+        {_key: 'b0'},
+        'children',
+        {_key: 's0'},
+      ],
+      offset: 0,
+    },
+  })
+})
+
+test('Scenario: a bullet marker arriving in a single event converts the block', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: 'hello', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+    },
+  })
+  // The whole marker in one event, the way a paste or IME commit
+  // delivers it. This is also the shape that hides the eager-evaluation
+  // staleness bug (the pre-insertion block is coincidentally clean), so
+  // it is pinned to keep working alongside the character-by-character
+  // scenarios rather than instead of them.
+  editor.send({type: 'insert.text', text: '- '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k3',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'k2',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b0',
+                _type: 'block',
+                children: [
+                  {_key: 's0', _type: 'span', marks: [], text: 'hello'},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+test('Scenario: a bold marker with bold toggled off before the trigger space still converts', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+    },
+  })
+  // The marker ends up straddling two spans (a bold `-` and a plain
+  // ` `), so the delete at `targetOffsets` must span the boundary.
+  editor.send({type: 'decorator.toggle', decorator: 'strong'})
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'decorator.toggle', decorator: 'strong'})
+  editor.send({type: 'insert.text', text: ' '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k4',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'k3',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b0',
+                _type: 'block',
+                children: [
+                  // The range delete merges back into the first span of
+                  // the deleted range, so the emptied span keeps the bold
+                  // mark.
+                  {_key: 's0', _type: 'span', marks: ['strong'], text: ''},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -936,6 +936,9 @@ importers:
       '@portabletext/schema':
         specifier: workspace:*
         version: link:../schema
+      '@portabletext/test':
+        specifier: workspace:^
+        version: link:../test
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 10.8.2(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@6.0.3)


### PR DESCRIPTION
Converting a block into a `list` container from an input rule (typing `- ` in front of existing text, the way markdown editors convert) has a failure mode that survives a green test if the test types unrealistically: the item comes back with the marker still in it.

The mechanism: `defineInputRule` action callbacks are evaluated eagerly inside the behavior's guard, against the pre-insertion snapshot, and their returned actions execute later, after the original `insert.text` is forwarded. Any document state captured in an action's payload is therefore stale by one insertion. A conversion that reads the focus block in the action and embeds it into `insert.block` resurrects the marker, because the block was read before the marker delete applied. The failure only reproduces when the marker arrives as separate `insert.text` events, real typing, since a single-event `- ` leaves the pre-insertion block clean and the stale embed is coincidentally correct.

The suite pins the pattern that works: rule actions raise only statically known events, `delete` at `match.targetOffsets` plus a custom event, and a companion `defineBehavior` performs the lift when the raised event executes, reading the by-then markerless block from live state. It also pins the coordinate contract the pattern relies on: `targetOffsets` are block offsets in the post-insertion text, which is what the document contains by execution time, while `match.selection` is estimated against the pre-insertion document and falls one character short of the landed marker.

The two conversion scenarios type the marker character by character, the honesty requirement this bug demands, and the suite documents it inline. Two more scenarios pin the boundaries: the whole marker arriving in a single event (the paste/IME shape, which is also the shape that hides the staleness bug, so it is pinned to keep working alongside the typed scenarios rather than instead of them), and a bold `-` with bold toggled off before the trigger space, where the marker straddles two spans and the delete at `targetOffsets` must span the boundary. The latter pins one engine wrinkle as observed behavior: the range delete merges back into the first span of the deleted range, so the emptied span keeps the bold mark.


A companion `docs:` commit adds a "How rules execute" section to the README stating the four contracts the suite pins: the matched-text window (`textBefore + textInserted`, so `$` anchors to the insertion), forward-then-actions ordering, eager evaluation of action callbacks against the pre-insertion snapshot with the `actions` array flattened into one set, and the `targetOffsets`/`selection` coordinate split, plus the custom-event pattern for reading live state. The README's examples were already correct on every one of these points; they just never said which of their properties were load-bearing, so getting a new rule right required imitating them blind.
