### PR TITLE
fix(schema): resolve bare `of` references against the schema's block objects in `getSubSchema`

### DIFF
--- a/.changeset/get-sub-schema-resolve-references.md
+++ b/.changeset/get-sub-schema-resolve-references.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/schema': patch
+---
+
+fix: resolve bare `of` references against the schema's block objects in `getSubSchema`
+
+A container field's `of` can reference a type declared on the schema by bare name (`{type: 'list'}`), the shape recursive schemas require. `getSubSchema` previously resolved such a reference to a block object with no fields, so inserting or dropping one of these blocks inside a container stripped it to its `_type` and `_key`: a `list` nested inside a `list-item` lost its `kind` and `items`, an `image` dropped into a table cell lost its `src`. Referenced types now resolve to their declaration and keep their fields.

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -922,6 +922,7 @@ describe('event.drag.drop', () => {
                     {
                       _key: imageKey,
                       _type: 'image',
+                      src: 'https://example.com/image.jpg',
                     },
                   ],
                 },

--- a/packages/plugin-input-rule/src/rule.list-conversion.test.tsx
+++ b/packages/plugin-input-rule/src/rule.list-conversion.test.tsx
@@ -1,7 +1,11 @@
 import {defineContainer} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
-import {getFocusTextBlock} from '@portabletext/editor/selectors'
+import {
+  getFocusTextBlock,
+  getNextBlock,
+  getPreviousBlock,
+} from '@portabletext/editor/selectors'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
@@ -31,7 +35,7 @@ const schemaDefinition = defineSchema({
                 {
                   name: 'content',
                   type: 'array',
-                  of: [{type: 'block'}],
+                  of: [{type: 'block'}, {type: 'list'}],
                 },
               ],
             },
@@ -87,15 +91,33 @@ function listInputRule(kind: 'bullet' | 'number', on: RegExp) {
 const convertToList = defineBehavior<
   {kind: 'bullet' | 'number'},
   'custom.convert to list',
-  {focusBlock: NonNullable<ReturnType<typeof getFocusTextBlock>>}
+  {
+    focusBlock: NonNullable<ReturnType<typeof getFocusTextBlock>>
+    placement: 'before' | 'after' | 'auto'
+    at: ReturnType<typeof getPreviousBlock>
+  }
 >({
   on: 'custom.convert to list',
   guard: ({snapshot}) => {
     const focusBlock = getFocusTextBlock(snapshot)
-    return focusBlock ? {focusBlock} : false
+    if (!focusBlock) {
+      return false
+    }
+    // After the `delete.block` below, the selection no longer describes
+    // the deleted block's position, so `placement: 'auto'` cannot be
+    // trusted to keep the list where the block was. Anchor the insert to
+    // a live sibling instead; `auto` remains only for a block that is
+    // alone in its array.
+    const previousBlock = getPreviousBlock(snapshot)
+    const nextBlock = getNextBlock(snapshot)
+    return {
+      focusBlock,
+      placement: previousBlock ? 'after' : nextBlock ? 'before' : 'auto',
+      at: previousBlock ?? nextBlock,
+    }
   },
   actions: [
-    ({event}, {focusBlock}) => [
+    ({event}, {focusBlock, placement, at}) => [
       raise({type: 'delete.block', at: focusBlock.path}),
       raise({
         type: 'insert.block',
@@ -104,7 +126,13 @@ const convertToList = defineBehavior<
           kind: event.kind,
           items: [{_type: 'list-item', content: [focusBlock.node]}],
         },
-        placement: 'auto',
+        placement,
+        at: at
+          ? {
+              anchor: {path: at.path, offset: 0},
+              focus: {path: at.path, offset: 0},
+            }
+          : undefined,
         select: 'start',
       }),
     ],
@@ -387,6 +415,204 @@ test('Scenario: a bold marker with bold toggled off before the trigger space sti
                   // mark.
                   {_key: 's0', _type: 'span', marks: ['strong'], text: ''},
                 ],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+test('Scenario: converting a block below prior content in a list item nests the list below it', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'list',
+        _key: 'l0',
+        kind: 'bullet',
+        items: [
+          {
+            _type: 'list-item',
+            _key: 'i0',
+            content: [
+              {
+                _type: 'block',
+                _key: 'b0',
+                children: [
+                  {_type: 'span', _key: 's0', text: 'first', marks: []},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _type: 'block',
+                _key: 'b1',
+                children: [{_type: 'span', _key: 's1', text: '', marks: []}],
+                markDefs: [],
+                style: 'normal',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {
+        path: [
+          {_key: 'l0'},
+          'items',
+          {_key: 'i0'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 0,
+      },
+      focus: {
+        path: [
+          {_key: 'l0'},
+          'items',
+          {_key: 'i0'},
+          'content',
+          {_key: 'b1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 0,
+      },
+    },
+  })
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'insert.text', text: ' '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'l0',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'i0',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b0',
+                _type: 'block',
+                children: [
+                  {_key: 's0', _type: 'span', marks: [], text: 'first'},
+                ],
+                markDefs: [],
+                style: 'normal',
+              },
+              {
+                _key: 'k3',
+                _type: 'list',
+                kind: 'bullet',
+                items: [
+                  {
+                    _key: 'k2',
+                    _type: 'list-item',
+                    content: [
+                      {
+                        _key: 'b1',
+                        _type: 'block',
+                        children: [
+                          {_key: 's1', _type: 'span', marks: [], text: ''},
+                        ],
+                        markDefs: [],
+                        style: 'normal',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+test('Scenario: converting a block below prior content at the root keeps the list below it', async () => {
+  const {editor} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: 'first', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={containers} />
+        <InputRulePlugin rules={rules} />
+        <BehaviorPlugin behaviors={[convertToList]} />
+      </>
+    ),
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+      focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+    },
+  })
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'insert.text', text: ' '})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'b0',
+        _type: 'block',
+        children: [{_key: 's0', _type: 'span', marks: [], text: 'first'}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _key: 'k3',
+        _type: 'list',
+        kind: 'bullet',
+        items: [
+          {
+            _key: 'k2',
+            _type: 'list-item',
+            content: [
+              {
+                _key: 'b1',
+                _type: 'block',
+                children: [{_key: 's1', _type: 'span', marks: [], text: ''}],
                 markDefs: [],
                 style: 'normal',
               },

--- a/packages/schema/src/get-sub-schema.test.ts
+++ b/packages/schema/src/get-sub-schema.test.ts
@@ -74,4 +74,118 @@ describe(getSubSchema.name, () => {
     const withoutName = getSubSchema(schema, [{type: 'block'}])
     expect(withoutName.block.name).toBe('myBlock')
   })
+
+  test('a bare reference resolves to the block object declared on the schema', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'list',
+            fields: [
+              {name: 'kind', type: 'string'},
+              {
+                name: 'items',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'list-item',
+                    fields: [
+                      {
+                        name: 'content',
+                        type: 'array',
+                        of: [{type: 'block'}, {type: 'list'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const result = getSubSchema(schema, [{type: 'block'}, {type: 'list'}])
+
+    const list = result.blockObjects.find(
+      (blockObject) => blockObject.name === 'list',
+    )
+    expect(list).toBe(
+      schema.blockObjects.find((blockObject) => blockObject.name === 'list'),
+    )
+    expect(list?.fields.map((field) => field.name)).toEqual(['kind', 'items'])
+  })
+
+  test('inline fields win over a same-named schema declaration', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {name: 'note', fields: [{name: 'body', type: 'string'}]},
+        ],
+      }),
+    )
+
+    const result = getSubSchema(schema, [
+      {type: 'object', name: 'note', fields: []},
+    ])
+
+    expect(
+      result.blockObjects.find((blockObject) => blockObject.name === 'note')
+        ?.fields,
+    ).toEqual([])
+  })
+
+  test("a fieldless inline block object declaration does not take a same-named root type's fields", () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {name: 'note', fields: [{name: 'body', type: 'string'}]},
+        ],
+      }),
+    )
+
+    const result = getSubSchema(schema, [{type: 'object', name: 'note'}])
+
+    expect(
+      result.blockObjects.find((blockObject) => blockObject.name === 'note')
+        ?.fields,
+    ).toEqual([])
+  })
+
+  test('a reference to a type declared only inline resolves to no fields', () => {
+    // Pins the boundary of reference resolution: only root-declared block
+    // objects resolve. `callout` is declared inline inside `wrapper` and
+    // referenced bare in the queried `of`; the sub-schema keeps it
+    // fieldless rather than walking the `of` tree for the declaration.
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'wrapper',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'callout',
+                    fields: [{name: 'tone', type: 'string'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const result = getSubSchema(schema, [{type: 'callout'}])
+
+    expect(
+      result.blockObjects.find((blockObject) => blockObject.name === 'callout')
+        ?.fields,
+    ).toEqual([])
+  })
 })

--- a/packages/schema/src/get-sub-schema.ts
+++ b/packages/schema/src/get-sub-schema.ts
@@ -87,8 +87,26 @@ export function getSubSchema(
         title?: string
         fields?: ReadonlyArray<unknown>
       }
+      const name = objectMember.name ?? objectMember.type
+      if (objectMember.fields === undefined && objectMember.type !== 'object') {
+        // A bare `{type: <name>}` entry is a `ReferenceOfDefinition`: a
+        // reference to a type declared elsewhere, and the only
+        // representation a recursive type can have, since its fields
+        // cannot be materialized inline without unrolling the cycle.
+        // Only root-declared block objects are resolved here; a reference
+        // to a type declared inline in another `of` tree stays
+        // unresolved with no fields. The `type !== 'object'` check keeps
+        // fieldless inline declarations (`{type: 'object', name}`) from
+        // taking a same-named root type's fields.
+        const declared = schema.blockObjects.find(
+          (blockObject) => blockObject.name === name,
+        )
+        if (declared) {
+          return declared
+        }
+      }
       return {
-        name: objectMember.name ?? objectMember.type,
+        name,
         title: objectMember.title,
         fields: (objectMember.fields ?? []) as BlockObjectSchemaType['fields'],
       }


### PR DESCRIPTION
In a list container with a list item holding a text block, adding a second block below it and typing `- ` should nest a new list below the existing text. Instead the list landed above it, and on current main the converted block vanished entirely: the list arrived with no `kind` and no `items`, and container normalization minted a placeholder item into the emptied array.

Two independent bugs compose into that behavior. The vanish is an engine bug: `compileSchema` keeps a `ReferenceOfDefinition` (`{type: 'list'}` in a container's `of`) as a bare entry, the only representation a recursive type can have, since its fields cannot be materialized inline without unrolling the cycle. `getSubSchema` built sub-schema block objects from inline properties alone, so a bare reference resolved to `{name, fields: []}`, and `parseBlock` at that scope stripped every field from an inserted block. This is not list-specific: the existing `event.drag.drop` suite pinned an `image` losing its `src` when dropped into a table cell, the same strip observed from the other end. Bare references now resolve to the block object declared on the schema root, the declare-once-reference-everywhere path `ReferenceOfDefinition` documents. The resolution is deliberately narrower than `resolveContainerFieldResolution`'s, which also accepts types declared inline anywhere in the `of` tree: a bare reference to an inline-declared type still resolves to no fields, pinned by a boundary test, and can pick up the tree walk later if a real schema needs it. Inline `fields` still win over a same-named root declaration, and a fieldless inline declaration (`{type: 'object', name}`) does not take a same-named root type's fields, both pinned by unit tests. The drag-drop expectation is corrected from the stripped image to the preserved one, the only behavioral delta in the existing suites (1714 other browser tests pass unchanged).

The misordering is a consumer-pattern bug in the list-conversion example the `plugin-input-rule` suite pins: `insert.block` with `placement: 'auto'` resolves against wherever the selection sits after the preceding `delete.block`, which is not where the deleted block was. The conversion behavior now anchors the insert to a live sibling read at guard time, `after` the previous block, `before` the next, with `auto` only for a block alone in its array. Two scenarios pin the resulting order at the root and inside a list item's content; the nested one also exercises `insert.block` of a recursive type at depth, which no test covered before.
