### PR TITLE
chore: gate typescript majors behind dashboard approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,12 @@
       "schedule": ["every weekday"]
     },
     {
+      "description": "TypeScript majors are a toolchain migration (typecheck, declaration emit, every TS-peer'd build tool), not a dep bump; gate them behind dashboard approval while minors/patches stay fast-tracked",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
       "description": "Group Tailwind packages",
       "matchPackageNames": ["/tailwind/"],
       "groupName": "tailwind"


### PR DESCRIPTION
Renovate opened #2972 (typescript 6.0.3 → 7.0.2) unattended and every CI job failed at install in under 25 seconds: the `renovate/artifacts` failure shows it couldn't even regenerate the lockfile, the toolchain's peer ranges (`typescript-eslint`, the build tooling) don't admit 7.x, so the catalog and `pnpm-lock.yaml` diverged and `--frozen-lockfile` died in every job.

The PR existed at all because the important-packages rule fast-tracks `typescript` past the dependency dashboard, which is right for minors/patches (keep TS current) but wrong for majors: 6 → 7 is the jump to the native Go compiler, a deliberate toolchain migration touching `check:types`, declaration emit, and every TS-peer'd build tool. The catalog even pins TS exactly (`6.0.3`), signaling it's deliberately managed.

This adds one packageRule after the fast-track rule (later rules override earlier ones for what they match): `typescript` + `matchUpdateTypes: ["major"]` → back behind dashboard approval. Minors and patches keep the fast track. Same shape as the vitest changeset fix (#2964): a package rule that was missing a majors carve-out.

#2972 is closed in favor of a deliberate TS7 migration whenever it's chosen.
