### PR TITLE
fix: apply remote patches addressing marks and markDefs elements as data patches

### DIFF
--- a/.changeset/sidecar-array-remote-patches.md
+++ b/.changeset/sidecar-array-remote-patches.md
@@ -1,0 +1,24 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: apply remote patches addressing `marks` and `markDefs` elements as data patches
+
+Remote patches produced by diffing tools (e.g. `@sanity/diff-patch` in
+`@portabletext/plugin-sdk-value`) can address elements of sidecar
+arrays: `span.marks[0]`, `span.marks[-1]`, `block.markDefs[_key==...]`.
+These paths end in a keyed or numeric segment just like structural node
+paths, so the engine routed them through structural child
+insertion/removal. Removals threw `Cannot apply an "unset" (node
+removal) operation ... because the node was not found.` and killed the
+consumer's sync, while inserts silently wrote a bogus `children` array
+onto the span, corrupting the document once the value was pushed back
+to the datastore. In practice this broke concurrent editing whenever a
+collaborator toggled a decorator or annotation.
+
+The engine now detects that such a path does not target the owning
+node's structural child array and applies the operation as a plain data
+patch on the root block, matching what the datastore computed.
+`diffMatchPatch` patches on strings outside span text (e.g. a swapped
+decorator inside `marks`) are applied the same way instead of being
+ignored.

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -2,11 +2,14 @@ import {
   applyAll,
   set as setPatchHelper,
   unset as unsetPatchHelper,
+  type JSONValue,
+  type Patch,
 } from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import {findNearestSpans} from '../../internal-utils/find-nearest-spans'
 import {getValue} from '../../internal-utils/get-value'
 import {safeStringify} from '../../internal-utils/safe-json'
+import {getChildFieldName} from '../../paths/get-child-field-name'
 import {serializePath} from '../../paths/serialize-path'
 import {getNode} from '../../traversal/get-node'
 import type {EditorSelection} from '../../types/editor'
@@ -40,6 +43,26 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
     case 'insert': {
       const {path} = op
       let {node} = op
+
+      if (!targetsStructuralChildren(editor, path)) {
+        // The path addresses an element of a sidecar array (e.g.
+        // `span.marks` or `block.markDefs`) rather than a structural
+        // child. Apply the insert as a plain data patch on the root
+        // block so the result matches what the datastore computed.
+        // These operations only arrive from remote patches, so no
+        // inverse is needed.
+        applyOnRootBlock(editor, path, {
+          type: 'insert',
+          path: path.slice(1),
+          position: op.position,
+          // Sidecar array members aren't necessarily objects (e.g. `marks`
+          // holds strings), so the node is plain JSON data here.
+          items: [node as unknown as JSONValue],
+        })
+
+        transformSelection = true
+        break
+      }
 
       modifyChildren(editor, parentPath(path), (children) => {
         // Ensure unique keys on inserted nodes (skip during remote/undo/redo)
@@ -172,6 +195,16 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
       }
 
       if (setPropertyPath.length === 0) {
+        if (!targetsStructuralChildren(editor, setNodePath)) {
+          // The path addresses an element of a sidecar array (e.g.
+          // `span.marks[0]`). Apply the set as a plain data patch on the
+          // root block; `modifyDescendant` can't reach these elements.
+          applyOnRootBlock(editor, path, setPatchHelper(value, path.slice(1)))
+
+          transformSelection = true
+          break
+        }
+
         // Full node replacement: replace the node at setNodePath with value
         if (
           value !== null &&
@@ -253,6 +286,33 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
       // array member. Check this BEFORE splitting into node/property paths
       // since node removal doesn't need that split.
       const lastSegment = path[path.length - 1]
+      if (
+        (isKeyedSegment(lastSegment) || typeof lastSegment === 'number') &&
+        !targetsStructuralChildren(editor, path)
+      ) {
+        // The path addresses an element of a sidecar array (e.g.
+        // `span.marks[0]` or `block.markDefs[_key==...]`) rather than a
+        // structural child. Removing it never affects the selection, so
+        // apply it as a plain data patch on the root block.
+        if (!op.inverse && !editor.isProcessingRemoteChanges) {
+          const arrayValue = getValue(
+            editor.snapshot.context.value,
+            path.slice(0, -1),
+          )
+          if (Array.isArray(arrayValue)) {
+            op.inverse = {
+              type: 'set',
+              path: path.slice(0, -1),
+              value: arrayValue,
+            }
+          }
+        }
+
+        applyOnRootBlock(editor, path, unsetPatchHelper(path.slice(1)))
+
+        transformSelection = true
+        break
+      }
       if (isKeyedSegment(lastSegment) || typeof lastSegment === 'number') {
         // Transform the selection BEFORE removing the node from the tree.
         // `findNearestSpans` anchors on the removed node's position, so the
@@ -490,6 +550,70 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
       }
     }
   }
+}
+
+/**
+ * Whether the last (keyed or numeric) segment of `path` addresses a member
+ * of its owning node's structural child array.
+ *
+ * Remote patches can address elements of sidecar arrays — `span.marks`
+ * (array of strings) and `block.markDefs` — whose paths also end in a keyed
+ * or numeric segment. Those must not be routed through structural child
+ * insertion/removal: the owning node's child field is a different array (or
+ * doesn't exist at all), so the operation would corrupt the tree or throw.
+ */
+function targetsStructuralChildren(editor: Editor, path: Path): boolean {
+  if (path.length < 2) {
+    return true
+  }
+
+  const fieldSegment = path[path.length - 2]
+  if (typeof fieldSegment !== 'string') {
+    // Compact paths ([{_key}, {_key}] or numeric) always descend
+    // structurally.
+    return true
+  }
+
+  const structuralFieldName = getChildFieldName(
+    {
+      schema: editor.snapshot.context.schema,
+      containers: editor.snapshot.context.containers,
+      value: editor.snapshot.context.value,
+    },
+    path.slice(0, -2),
+  )
+
+  return structuralFieldName === fieldSegment
+}
+
+/**
+ * Apply a patch on the root block of `path` as plain data (no structural
+ * traversal), mirroring how the datastore applies it. Used for operations
+ * addressing sidecar arrays that `modifyChildren`/`modifyDescendant` can't
+ * reach. The patch's own `path` must be relative to the block (the leading
+ * block segment stripped).
+ */
+function applyOnRootBlock(editor: Editor, path: Path, patch: Patch): void {
+  const blockSegment = findBlockSegment(path)
+  if (!blockSegment) {
+    return
+  }
+
+  const blockIndex = resolveBlockIndex(editor, blockSegment)
+  if (blockIndex === -1) {
+    return
+  }
+
+  const block = editor.snapshot.context.value[blockIndex]
+  if (!block) {
+    return
+  }
+
+  const updatedBlock = applyAll(block, [patch])
+
+  const newValue = editor.snapshot.context.value.slice()
+  newValue[blockIndex] = updatedBlock
+  editor.snapshot.context.value = newValue
 }
 
 /**

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -70,7 +70,27 @@ function diffMatchPatch(
 ): boolean {
   const lastSegment = patch.path.at(-1)
   if (lastSegment !== 'text') {
-    return false
+    // Diffing tools also emit `diffMatchPatch` for strings outside span
+    // text, e.g. `span.marks[0]` when a decorator is swapped. Resolve the
+    // current string, apply the diff, and set the result.
+    const currentValue = getValue(editor.snapshot.context.value, patch.path)
+    if (typeof currentValue !== 'string') {
+      return false
+    }
+
+    const [newValue] = diffMatchPatchApplyPatches(
+      parsePatch(patch.value),
+      currentValue,
+      {allowExceedingIndices: true},
+    )
+
+    editor.apply({
+      type: 'set',
+      path: patch.path,
+      value: newValue,
+    })
+
+    return true
   }
 
   const spanPath = patch.path.slice(0, -1)

--- a/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
+++ b/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
@@ -1,0 +1,286 @@
+import {defineSchema} from '@portabletext/schema'
+import {describe, expect, test, vi} from 'vitest'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Remote patches produced by diffing tools (e.g. `@sanity/diff-patch` in
+ * `@portabletext/plugin-sdk-value`, or Studio's remote patch stream) can
+ * address elements of sidecar arrays: `span.marks` (array of strings) and
+ * `block.markDefs`. These paths end in a keyed or numeric segment just like
+ * structural node paths, but the target array is not the owning node's
+ * structural `children`. The engine must route them to plain data patching
+ * instead of structural child insertion/removal.
+ *
+ * The patch shapes below are exactly what `diffValue` emits when a
+ * collaborator toggles a decorator or annotation.
+ */
+describe('event.patches sidecar arrays', () => {
+  const schemaDefinition = defineSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  })
+
+  test('Scenario: remote `insert` into `marks` (decorator toggled on)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', -1],
+          items: ['strong'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote `unset` of a `marks` element (decorator toggled off)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', 0],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote annotation toggled on (`marks` insert + `markDefs` insert)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', -1],
+          items: ['m1'],
+        },
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'before',
+          path: [{_key: 'b1'}, 'markDefs', 0],
+          items: [{_key: 'm1', _type: 'link', href: 'https://www.sanity.io'}],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['m1']}],
+          markDefs: [
+            {_key: 'm1', _type: 'link', href: 'https://www.sanity.io'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote annotation toggled off (`marks` unset + `markDefs` unset)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['m1']}],
+          markDefs: [
+            {_key: 'm1', _type: 'link', href: 'https://www.sanity.io'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', 0],
+        },
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'markDefs', {_key: 'm1'}],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote `set` of a `marks` element (decorator swapped)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', 0],
+          value: 'em',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['em']}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote `diffMatchPatch` on a `marks` element (decorator swapped)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'diffMatchPatch',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'marks', 0],
+          value: '@@ -1,6 +1,2 @@\n-strong\n+em\n',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: ['em']}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -47,6 +47,7 @@ type MockStore = ReturnType<typeof createMockValueStore>
 async function createSyncedEditor(options: {
   initialValue?: PortableTextBlock[]
   store: MockStore
+  schemaDefinition?: ReturnType<typeof defineSchema>
 }) {
   const editorRef = createRef<Editor>()
   const keyGenerator = createTestKeyGenerator()
@@ -55,7 +56,7 @@ async function createSyncedEditor(options: {
     <EditorProvider
       initialConfig={{
         keyGenerator,
-        schemaDefinition: defineSchema({}),
+        schemaDefinition: options.schemaDefinition ?? defineSchema({}),
         initialValue: options.initialValue,
       }}
     >
@@ -161,6 +162,105 @@ describe('ValueSyncPlugin', () => {
 
       await vi.waitFor(() => {
         expect(getEditorText(editor)).toEqual('B: Hello from remote')
+      })
+    })
+
+    test('remote decorator toggle syncs `marks` inserts and unsets', async () => {
+      const makeValue = (marks: string[]): PortableTextBlock[] => [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'Hello', marks}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ]
+
+      const store = createMockValueStore(makeValue([]))
+      const {editor, unmount} = await createSyncedEditor({
+        store,
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      })
+      cleanup = unmount
+
+      await vi.waitFor(() => {
+        expect(getEditorText(editor)).toEqual('B: Hello')
+      })
+
+      // A collaborator toggles bold on. `applySync` diffs this into an
+      // `insert` after `marks[-1]`.
+      store.setRemoteValue(makeValue(['strong']))
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual(
+          makeValue(['strong']),
+        )
+      })
+
+      // The collaborator toggles bold back off. `applySync` diffs this
+      // into an `unset` of `marks[0]`.
+      store.setRemoteValue(makeValue([]))
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual(makeValue([]))
+      })
+    })
+
+    test('remote annotation toggle syncs span splits, `marks` and `markDefs`', async () => {
+      const plainValue: PortableTextBlock[] = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'hello world', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ]
+      const annotatedValue: PortableTextBlock[] = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [
+            {_type: 'span', _key: 's1', text: 'hello ', marks: []},
+            {_type: 'span', _key: 's2', text: 'wor', marks: ['m1']},
+            {_type: 'span', _key: 's3', text: 'ld', marks: []},
+          ],
+          markDefs: [{_key: 'm1', _type: 'link', href: 'https://sanity.io'}],
+          style: 'normal',
+        },
+      ]
+
+      const store = createMockValueStore(plainValue)
+      const {editor, unmount} = await createSyncedEditor({
+        store,
+        schemaDefinition: defineSchema({
+          annotations: [
+            {name: 'link', fields: [{name: 'href', type: 'string'}]},
+          ],
+        }),
+      })
+      cleanup = unmount
+
+      await vi.waitFor(() => {
+        expect(getEditorText(editor)).toEqual('B: hello world')
+      })
+
+      // A collaborator applies a link to "wor": the span splits in three,
+      // the middle one referencing a new markDef.
+      store.setRemoteValue(annotatedValue)
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual(annotatedValue)
+      })
+
+      // The collaborator removes the link again: spans merge back and the
+      // markDef is removed.
+      store.setRemoteValue(plainValue)
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual(plainValue)
       })
     })
   })


### PR DESCRIPTION
## Description

Remote patches produced by diffing tools (e.g. `@sanity/diff-patch` in `@portabletext/plugin-sdk-value`) can address elements of sidecar arrays: `span.marks[0]`, `span.marks[-1]`, `block.markDefs[_key=="..."]`. These paths end in a keyed or numeric segment just like structural node paths, so `applyOperation` routed them through structural child insertion/removal against the owning node's `children`.

The consequences in a two-editor session, whenever a collaborator toggles a decorator or annotation:

- `unset marks[0]` / `unset markDefs[_key=="..."]` threw `Cannot apply an "unset" (node removal) operation ... because the node was not found.`, killing the consumer's sync actor. The editor kept accepting keystrokes but stopped receiving remote changes until reload.
- `insert after marks[-1]` silently wrote a bogus `children: ['strong']` array onto the span. The corrupted span was then pushed back to the datastore and persisted.
- `set marks[0]` and `diffMatchPatch` on `marks[0]` were silently ignored, so the editors drifted apart.

The fix teaches the engine to detect that such a path does not target the owning node's structural child array (`targetsStructuralChildren`) and to apply the operation as a plain data patch on the root block (`applyOnRootBlock`, via `applyAll` from `@portabletext/patches`), matching what the datastore computed. This is the same fallback pattern the `set` and property-`unset` handlers already use for markDefs property paths. An alternative of rewriting these patches in `plugin-sdk-value` was rejected: it would only cover SDK apps and leave the engine bug reachable from every other remote patch source.

## What to review

- `packages/editor/src/engine/core/apply-operation.ts`: the routing check and the data-patch fallback, including the `set`-based inverse computed for local sidecar unsets (remote patches skip inverses).
- `packages/editor/src/internal-utils/applyPatch.ts`: the `diffMatchPatch` fallback for non-`text` string targets.
- Whether `getChildFieldName` is the right structural-field oracle for the check.

## Testing

- `packages/editor/tests/event.patches.sidecar-arrays.test.tsx`: 6 regression tests using the exact patch shapes `diffValue` emits for decorator/annotation toggles. All 6 fail on `main` (three throw, three silently corrupt or no-op).
- `packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx`: 2 end-to-end tests driving `ValueSyncPlugin` through remote decorator and annotation toggles, covering the span split/merge + `markDefs` flow.
- Full existing suites pass: editor chromium browser tests (1721), editor unit tests (852), plugin-sdk-value suites, typecheck, lint.
