### PR TITLE
fix: crash-proof concurrent value sync on top of #2974

### DIFF
--- a/.changeset/concurrent-crashproof.md
+++ b/.changeset/concurrent-crashproof.md
@@ -1,0 +1,28 @@
+---
+'@portabletext/editor': patch
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: crash-proof concurrent value sync against divergent live trees
+
+Builds on the engine routing fix in #2974 (which stops remote sidecar-array
+patches — `span.marks[n]`, `block.markDefs[_key==...]` — from being routed
+through structural child insertion/removal, the root cause of the sync-killing
+`unset` throw and the bogus-`children` document corruption). This changeset adds
+the residual client-side resilience so a divergent live tree degrades safely
+instead of crashing:
+
+- `@portabletext/editor`: keyed `updateBlock` unsets are guarded against the
+  live engine tree, and the `updateValue` try/catch is widened so a stale-key
+  removal degrades to a safe re-sync instead of surfacing an unhandled rejection
+  that freezes the sync actor. Some of the per-`updateBlock` unset guards now
+  overlap with the engine fix in #2974 and are kept as defense-in-depth.
+- `@portabletext/plugin-sdk-value`: `arrayifyPath` returns `null` instead of
+  throwing on diff-patch paths it cannot convert (e.g. array slices produced
+  when clearing multiple `marks`); `convertPatches` drops the unconvertible ops
+  and flags the batch incomplete, and `applySync` then falls back to an
+  authoritative full value update / resync.
+
+Together this stops the crash and the document corruption. It does NOT fix the
+underlying SDK concurrency clobber (two editors racing on the same block can
+still overwrite each other's changes); that remains to be addressed separately.

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -443,21 +443,65 @@ async function updateValue({
 
   const hadSelection = !!editorEngine.snapshot.context.selection
 
-  if (!value || value.length === 0) {
-    clearEditor({
-      editorEngine,
-      doneSyncing,
-    })
+  try {
+    if (!value || value.length === 0) {
+      clearEditor({
+        editorEngine,
+        doneSyncing,
+      })
 
-    isChanged = true
-  }
+      isChanged = true
+    }
 
-  // Remove, replace or add nodes according to what is changed.
-  if (value && value.length > 0) {
-    if (streamBlocks) {
-      await new Promise<void>((resolve) => {
+    // Remove, replace or add nodes according to what is changed.
+    if (value && value.length > 0) {
+      if (streamBlocks) {
+        await new Promise<void>((resolve, reject) => {
+          if (doneSyncing) {
+            resolve()
+            return
+          }
+
+          isChanged = removeExtraBlocks({
+            editorEngine,
+            value,
+          })
+
+          const processBlocks = async () => {
+            try {
+              for await (const [
+                currentBlock,
+                currentBlockIndex,
+              ] of getStreamedBlocks({
+                value,
+              })) {
+                const {blockChanged, blockValid} = syncBlock({
+                  context,
+                  sendBack,
+                  block: currentBlock,
+                  index: currentBlockIndex,
+                  editorEngine,
+                  value,
+                })
+
+                isChanged = blockChanged || isChanged
+                isValid = isValid && blockValid
+
+                if (!isValid) {
+                  break
+                }
+              }
+
+              resolve()
+            } catch (error) {
+              reject(error)
+            }
+          }
+
+          processBlocks()
+        })
+      } else {
         if (doneSyncing) {
-          resolve()
           return
         }
 
@@ -466,67 +510,50 @@ async function updateValue({
           value,
         })
 
-        const processBlocks = async () => {
-          for await (const [
-            currentBlock,
-            currentBlockIndex,
-          ] of getStreamedBlocks({
+        let index = 0
+
+        for (const block of value) {
+          const {blockChanged, blockValid} = syncBlock({
+            context,
+            sendBack,
+            block,
+            index,
+            editorEngine,
             value,
-          })) {
-            const {blockChanged, blockValid} = syncBlock({
-              context,
-              sendBack,
-              block: currentBlock,
-              index: currentBlockIndex,
-              editorEngine,
-              value,
-            })
+          })
 
-            isChanged = blockChanged || isChanged
-            isValid = isValid && blockValid
+          isChanged = blockChanged || isChanged
+          isValid = isValid && blockValid
 
-            if (!isValid) {
-              break
-            }
+          if (!blockValid) {
+            break
           }
 
-          resolve()
+          index++
         }
-
-        processBlocks()
-      })
-    } else {
-      if (doneSyncing) {
-        return
-      }
-
-      isChanged = removeExtraBlocks({
-        editorEngine,
-        value,
-      })
-
-      let index = 0
-
-      for (const block of value) {
-        const {blockChanged, blockValid} = syncBlock({
-          context,
-          sendBack,
-          block,
-          index,
-          editorEngine,
-          value,
-        })
-
-        isChanged = blockChanged || isChanged
-        isValid = isValid && blockValid
-
-        if (!blockValid) {
-          break
-        }
-
-        index++
       }
     }
+  } catch (err) {
+    // syncBlock/updateBlock apply keyed operations against a pre-loop snapshot
+    // of the engine tree. If the live tree has diverged (e.g. a concurrent
+    // collaborator re-keyed spans while toggling a mark), a keyed operation can
+    // target a node that is no longer present and throw. Degrade gracefully to
+    // the invalid-value / resync path instead of letting the error escape and
+    // kill the sync actor — which would keep the editor accepting keystrokes
+    // while silently dropping every further remote/value update until reload.
+    console.error(err)
+
+    sendBack({
+      type: 'invalid value',
+      resolution: null,
+      value,
+    })
+
+    doneSyncing = true
+
+    sendBack({type: 'done syncing', value})
+
+    return
   }
 
   if (!isValid) {
@@ -994,6 +1021,24 @@ function updateBlock({
           if (!childNode) {
             return
           }
+          // Guard against a stale keyed unset. `oldEngineBlock` is a pre-loop
+          // snapshot; the live tree can diverge from it (e.g. a concurrent
+          // collaborator re-keyed spans), and unsetting a `_key` that is no
+          // longer present throws in `apply-operation` and would kill the
+          // sync actor. Mirrors the sibling-insert guard from #2965.
+          if (
+            !liveBlockHasChildKey(
+              editorEngine,
+              oldEngineBlock._key,
+              childNode._key,
+            )
+          ) {
+            debug.syncValue(
+              'Skipping superfluous-child unset; _key not present in live children',
+              childNode._key,
+            )
+            return
+          }
           editorEngine.apply({
             type: 'unset',
             path: [
@@ -1093,14 +1138,31 @@ function updateBlock({
             if (!oldChild) {
               return
             }
-            editorEngine.apply({
-              type: 'unset',
-              path: [
-                {_key: oldEngineBlock._key},
-                'children',
-                {_key: oldChild._key},
-              ],
-            })
+            // Guard against a stale keyed unset (see note in the superfluous
+            // child removal above). If the live tree no longer holds this
+            // `_key`, skip the removal but still insert the replacement child
+            // below so the block converges to the incoming value.
+            if (
+              liveBlockHasChildKey(
+                editorEngine,
+                oldEngineBlock._key,
+                oldChild._key,
+              )
+            ) {
+              editorEngine.apply({
+                type: 'unset',
+                path: [
+                  {_key: oldEngineBlock._key},
+                  'children',
+                  {_key: oldChild._key},
+                ],
+              })
+            } else {
+              debug.syncValue(
+                'Skipping replace-child unset; _key not present in live children',
+                oldChild._key,
+              )
+            }
             // Anchor on the incoming block's previous child, not the
             // pre-loop engine snapshot: earlier iterations may have unset
             // the snapshot's sibling (e.g. when the engine merged adjacent
@@ -1167,4 +1229,35 @@ function updateBlock({
       },
     )
   }
+}
+
+/**
+ * Check whether a child `_key` is present in the *current* (live) engine block
+ * children.
+ *
+ * `updateBlock` reads its keyed removal targets from a pre-loop `oldEngineBlock`
+ * snapshot. The live tree can diverge from that snapshot mid-sync (for example
+ * when a concurrent collaborator re-keys spans while toggling a mark), so a
+ * keyed `unset` may target a `_key` that no longer exists. Applying such an
+ * unset throws in `apply-operation`, which — because the block loop runs
+ * outside the sync's try/catch — used to escape and kill the sync actor.
+ * Callers use this to skip stale unsets instead.
+ */
+function liveBlockHasChildKey(
+  editorEngine: PortableTextEditorEngine,
+  blockKey: string,
+  childKey: string,
+): boolean {
+  const liveBlock = editorEngine.snapshot.context.value.find(
+    (node) => node._key === blockKey,
+  )
+
+  if (
+    !liveBlock ||
+    !isTextBlock({schema: editorEngine.snapshot.context.schema}, liveBlock)
+  ) {
+    return false
+  }
+
+  return liveBlock.children.some((child) => child._key === childKey)
 }

--- a/packages/editor/tests/value-sync-crashproof.test.tsx
+++ b/packages/editor/tests/value-sync-crashproof.test.tsx
@@ -1,0 +1,266 @@
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
+import {describe, expect, test, vi} from 'vitest'
+import {InternalEditorEngineRefPlugin} from '../src/plugins/plugin.internal.editor-engine-ref'
+import {createTestEditor} from '../src/test/vitest'
+import type {PortableTextEditorEngine} from '../src/types/editor-engine'
+import {getTextSelection} from '../test-utils/text-selection'
+
+const CUSTOMER_ERROR = 'node was not found'
+
+/**
+ * Capture anything that would surface a thrown error to the customer:
+ * - `console.error` (what a swallowed/handled error is logged through), and
+ * - genuinely *uncaught* errors: `window.onerror` and unhandled rejections.
+ *
+ * Browser `console.log` is not forwarded to the test runner, so findings are
+ * encoded as assertions over these captured buffers.
+ */
+function captureErrors() {
+  const consoleErrors: Array<string> = []
+  const uncaught: Array<string> = []
+  const originalError = console.error
+
+  console.error = (...args: Array<unknown>) => {
+    consoleErrors.push(
+      args
+        .map((arg) => (arg instanceof Error ? arg.message : String(arg)))
+        .join(' '),
+    )
+  }
+  const onError = (event: ErrorEvent) => {
+    uncaught.push(`window.onerror: ${event.message}`)
+  }
+  const onRejection = (event: PromiseRejectionEvent) => {
+    uncaught.push(`unhandledrejection: ${String(event.reason)}`)
+  }
+  window.addEventListener('error', onError)
+  window.addEventListener('unhandledrejection', onRejection)
+
+  return {
+    consoleErrors,
+    uncaught,
+    uncaughtCustomerErrors: () =>
+      uncaught.filter((message) => message.includes(CUSTOMER_ERROR)),
+    restore: () => {
+      console.error = originalError
+      window.removeEventListener('error', onError)
+      window.removeEventListener('unhandledrejection', onRejection)
+    },
+  }
+}
+
+const schema = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+})
+
+function block(children: Array<Record<string, unknown>>): PortableTextBlock {
+  return {
+    _key: 'b0',
+    _type: 'block',
+    children,
+    markDefs: [],
+    style: 'normal',
+  } as unknown as PortableTextBlock
+}
+
+const span = (key: string, text: string, marks: Array<string> = []) => ({
+  _key: key,
+  _type: 'span',
+  text,
+  marks,
+})
+
+type TextChild = {_key: string; _type: string; text: string}
+
+function childrenOf(block: PortableTextBlock | undefined): Array<TextChild> {
+  return ((block as unknown as {children?: Array<TextChild>})?.children ??
+    []) as Array<TextChild>
+}
+
+function firstChildText(value: Array<PortableTextBlock>): string | undefined {
+  return childrenOf(value[0])[0]?.text
+}
+
+describe('value sync is crash-proof against re-keyed / diverged children', () => {
+  test('Scenario: a keyed unset whose target diverged from the live tree does not kill the sync actor', async () => {
+    const cap = captureErrors()
+    const editorEngineRef = React.createRef<PortableTextEditorEngine>()
+
+    // Editor B loads a block whose spans carry distinct marks so the engine
+    // does NOT merge them on load. `s1` is kept; `s2`/`s3`/`s4` are the spans a
+    // concurrent collaborator re-keys while toggling a mark.
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator('b-'),
+      schemaDefinition: schema,
+      initialValue: [
+        block([
+          span('s1', 'A'),
+          span('s2', 'B', ['strong']),
+          span('s3', 'C'),
+          span('s4', 'D', ['em']),
+        ]),
+      ],
+      children: <InternalEditorEngineRefPlugin ref={editorEngineRef} />,
+    })
+
+    await vi.waitFor(() => {
+      expect(editorEngineRef.current).toBeTruthy()
+    })
+    const editorEngine = editorEngineRef.current!
+
+    // Simulate the divergence the customer hit: while `updateBlock` walks its
+    // pre-loop `oldEngineBlock` snapshot and emits keyed unsets, a concurrent
+    // change removes a sibling from the LIVE tree. We reproduce this
+    // deterministically by intercepting the engine's `apply`: on the first
+    // keyed children `unset`, we also remove a later-targeted sibling (`s4`).
+    // The sync's own subsequent unset of `s4` then targets a `_key` that is no
+    // longer present.
+    //
+    // Before the fix, `apply-operation` throws
+    // `Cannot apply an "unset" ... because the node was not found.` from
+    // OUTSIDE the sync's only try/catch, so it escapes and kills the actor.
+    const originalApply = editorEngine.apply.bind(editorEngine)
+    let injectedDivergence = false
+    ;(editorEngine as {apply: PortableTextEditorEngine['apply']}).apply = (
+      operation,
+    ) => {
+      const isKeyedChildUnset =
+        operation.type === 'unset' &&
+        operation.path.length === 3 &&
+        operation.path[1] === 'children' &&
+        typeof operation.path[2] === 'object'
+
+      if (isKeyedChildUnset && !injectedDivergence) {
+        const targetKey = (operation.path[2] as {_key: string})._key
+        if (targetKey !== 's4') {
+          injectedDivergence = true
+          originalApply(operation)
+          const liveBlock = editorEngine.snapshot.context.value.find(
+            (node) => node._key === 'b0',
+          ) as PortableTextBlock | undefined
+          const stillHasS4 = childrenOf(liveBlock).some(
+            (child) => child._key === 's4',
+          )
+          if (stillHasS4) {
+            originalApply({
+              type: 'unset',
+              path: [{_key: 'b0'}, 'children', {_key: 's4'}],
+            })
+          }
+          return
+        }
+      }
+
+      return originalApply(operation)
+    }
+
+    // Collaborator toggled marks -> spans re-keyed (s2->r2, s3->r3, s4->r4),
+    // content preserved. Delivered to B as a plain value update (the classic
+    // prop-driven value-sync path).
+    editor.send({
+      type: 'update value',
+      value: [
+        block([
+          span('s1', 'A'),
+          span('r2', 'B', ['strong']),
+          span('r3', 'C'),
+          span('r4', 'D', ['em']),
+        ]),
+      ],
+    })
+
+    // The actor must survive: a FOLLOW-UP update still applies.
+    editor.send({
+      type: 'update value',
+      value: [block([span('final', 'FINAL')])],
+    })
+
+    let survived = false
+    try {
+      await vi.waitFor(
+        () => {
+          expect(firstChildText(editor.getSnapshot().context.value)).toBe(
+            'FINAL',
+          )
+        },
+        {timeout: 3000},
+      )
+      survived = true
+    } catch {
+      survived = false
+    }
+
+    cap.restore()
+
+    // (a) The customer error must not escape uncaught.
+    expect(cap.uncaughtCustomerErrors()).toEqual([])
+    // The fix skips the stale unset entirely, so it is not even logged.
+    expect(
+      cap.consoleErrors.filter((message) => message.includes(CUSTOMER_ERROR)),
+    ).toEqual([])
+    // (b) The sync actor survived the divergence and applied the follow-up.
+    expect(survived).toBe(true)
+    expect(editor.getSnapshot().context.value).toEqual([
+      block([span('final', 'FINAL', [])]),
+    ])
+  })
+
+  test('Scenario: a real concurrent decorator toggle re-keys spans and B converges + keeps syncing', async () => {
+    const cap = captureErrors()
+
+    // Editor A produces the re-keyed value by toggling a decorator on a
+    // sub-range of a single span (this splits + re-keys the spans).
+    const {editor: editorA} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator('a-'),
+      schemaDefinition: schema,
+      initialValue: [block([span('a-s1', 'foo bar baz')])],
+    })
+
+    editorA.send({
+      type: 'decorator.toggle',
+      decorator: 'strong',
+      at: getTextSelection(editorA.getSnapshot().context, 'bar'),
+    })
+
+    let rekeyedValue: Array<PortableTextBlock> = []
+    await vi.waitFor(() => {
+      rekeyedValue = editorA.getSnapshot().context
+        .value as Array<PortableTextBlock>
+      expect(childrenOf(rekeyedValue[0]).length).toBe(3)
+    })
+
+    // Editor B starts from the same original value and only receives A's
+    // re-keyed value through `update value`.
+    const {editor: editorB} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator('b-'),
+      schemaDefinition: schema,
+      initialValue: [block([span('a-s1', 'foo bar baz')])],
+    })
+
+    editorB.send({type: 'update value', value: rekeyedValue})
+
+    await vi.waitFor(() => {
+      expect(editorB.getSnapshot().context.value).toEqual(rekeyedValue)
+    })
+
+    // Follow-up update still applies (actor alive).
+    editorB.send({
+      type: 'update value',
+      value: [block([span('a-s1', 'changed')])],
+    })
+    await vi.waitFor(() => {
+      expect(firstChildText(editorB.getSnapshot().context.value)).toBe(
+        'changed',
+      )
+    })
+
+    cap.restore()
+    expect(cap.uncaughtCustomerErrors()).toEqual([])
+    expect(
+      cap.consoleErrors.filter((message) => message.includes(CUSTOMER_ERROR)),
+    ).toEqual([])
+  })
+})

--- a/packages/plugin-sdk-value/src/plugin.recovery.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.recovery.browser.test.tsx
@@ -1,0 +1,119 @@
+import type {Editor} from '@portabletext/editor'
+import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
+import {EditorRefPlugin} from '@portabletext/editor/plugins'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {createRef} from 'react'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {page} from 'vitest/browser'
+import {ValueSyncPlugin} from './plugin.sdk-value'
+
+function createMockValueStore(initialValue: PortableTextBlock[] = []) {
+  let value = initialValue
+  let subscriber: (() => void) | null = null
+
+  const pushValue = vi.fn((newValue: PortableTextBlock[]) => {
+    value = newValue
+    subscriber?.()
+  })
+
+  return {
+    getRemoteValue: () => value,
+    pushValue,
+    onRemoteValueChange: (callback: () => void) => {
+      subscriber = callback
+      return () => {
+        subscriber = null
+      }
+    },
+    // Simulate a remote change (updates value and notifies subscriber)
+    setRemoteValue: (newValue: PortableTextBlock[]) => {
+      value = newValue
+      subscriber?.()
+    },
+  }
+}
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+})
+
+function makeSpanBlock(marks: Array<string>): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: 'b1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 's1', text: 'hello', marks}],
+  }
+}
+
+function getSpanMarks(editor: Editor): Array<string> | undefined {
+  const [block] = editor.getSnapshot().context.value ?? []
+  if (!block || !('children' in block)) {
+    return undefined
+  }
+  const [child] = block.children as Array<{marks?: Array<string>}>
+  return child?.marks
+}
+
+describe('ValueSyncPlugin diff recovery', () => {
+  let cleanup: (() => void) | undefined
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+  })
+
+  test('recovers with a full value update when a diff patch is unconvertible', async () => {
+    // A span carrying several decorator marks. Clearing more than one of them
+    // at once makes `diffValue` emit an array slice (`...marks[1:]`) which
+    // `arrayifyPath` can't convert — the exact case that used to throw inside
+    // the synchronous `applySync` and break syncing.
+    const initialValue = [makeSpanBlock(['strong', 'em', 'underline'])]
+    const store = createMockValueStore(initialValue)
+
+    const editorRef = createRef<Editor>()
+    const result = await render(
+      <EditorProvider
+        initialConfig={{
+          keyGenerator: createTestKeyGenerator(),
+          schemaDefinition,
+          initialValue,
+        }}
+      >
+        <EditorRefPlugin ref={editorRef} />
+        <PortableTextEditable />
+        <ValueSyncPlugin
+          getRemoteValue={store.getRemoteValue}
+          pushValue={store.pushValue}
+          onRemoteValueChange={store.onRemoteValueChange}
+        />
+      </EditorProvider>,
+    )
+    cleanup = result.unmount
+
+    const locator = page.getByRole('textbox')
+    await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+    const editor = editorRef.current!
+
+    await vi.waitFor(() => {
+      expect([...(getSpanMarks(editor) ?? [])].sort()).toEqual([
+        'em',
+        'strong',
+        'underline',
+      ])
+    })
+
+    // The remote clears all but the first mark. The diff contains an
+    // unconvertible slice unset, so instead of throwing the plugin must fall
+    // back to a full `update value` and converge on the remote value.
+    const remoteValue = [makeSpanBlock(['strong'])]
+    expect(() => store.setRemoteValue(remoteValue)).not.toThrow()
+
+    await vi.waitFor(() => {
+      expect(getSpanMarks(editor)).toEqual(['strong'])
+    })
+  })
+})

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
@@ -25,8 +25,17 @@ describe(arrayifyPath.name, () => {
     ])
   })
 
-  test('throws on empty path', () => {
-    expect(() => arrayifyPath('')).toThrow()
+  test('returns null instead of throwing on an empty path', () => {
+    expect(() => arrayifyPath('')).not.toThrow()
+    expect(arrayifyPath('')).toBeNull()
+  })
+
+  test('returns null instead of throwing on an array slice path', () => {
+    // `diffValue` emits a slice like this when several non-keyed items (e.g.
+    // span `marks`) are removed at once. It used to throw and crash `applySync`.
+    const slicePath = '[_key=="b1"].children[_key=="s1"].marks[1:]'
+    expect(() => arrayifyPath(slicePath)).not.toThrow()
+    expect(arrayifyPath(slicePath)).toBeNull()
   })
 })
 
@@ -36,24 +45,30 @@ describe(convertPatches.name, () => {
       convertPatches([
         {set: {'[_key=="k0"].children[_key=="k1"].text': 'Hello'}},
       ]),
-    ).toEqual([
-      {
-        type: 'set',
-        origin: 'remote',
-        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
-        value: 'Hello',
-      },
-    ])
+    ).toEqual({
+      patches: [
+        {
+          type: 'set',
+          origin: 'remote',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: 'Hello',
+        },
+      ],
+      incomplete: false,
+    })
   })
 
   test('unset patches', () => {
-    expect(convertPatches([{unset: ['[_key=="k0"]']}])).toEqual([
-      {
-        type: 'unset',
-        origin: 'remote',
-        path: [{_key: 'k0'}],
-      },
-    ])
+    expect(convertPatches([{unset: ['[_key=="k0"]']}])).toEqual({
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [{_key: 'k0'}],
+        },
+      ],
+      incomplete: false,
+    })
   })
 
   test('insert patches', () => {
@@ -66,15 +81,18 @@ describe(convertPatches.name, () => {
           },
         },
       ]),
-    ).toEqual([
-      {
-        type: 'insert',
-        origin: 'remote',
-        position: 'after',
-        path: [{_key: 'k0'}],
-        items: [{_type: 'block', _key: 'k1', children: []}],
-      },
-    ])
+    ).toEqual({
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'k0'}],
+          items: [{_type: 'block', _key: 'k1', children: []}],
+        },
+      ],
+      incomplete: false,
+    })
   })
 
   test('diffMatchPatch patches', () => {
@@ -87,12 +105,36 @@ describe(convertPatches.name, () => {
           },
         },
       ]),
-    ).toEqual([
+    ).toEqual({
+      patches: [
+        {
+          type: 'diffMatchPatch',
+          origin: 'remote',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: '@@ -1,3 +1,6 @@\n foo\n+bar\n',
+        },
+      ],
+      incomplete: false,
+    })
+  })
+
+  test('drops unconvertible patches and flags the batch as incomplete', () => {
+    const result = convertPatches([
       {
-        type: 'diffMatchPatch',
+        unset: [
+          '[_key=="b1"].markDefs[_key=="l1"]',
+          // Array slice that `arrayifyPath` can't convert.
+          '[_key=="b1"].children[_key=="s1"].marks[1:]',
+        ],
+      },
+    ])
+
+    expect(result.incomplete).toBe(true)
+    expect(result.patches).toEqual([
+      {
+        type: 'unset',
         origin: 'remote',
-        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
-        value: '@@ -1,3 +1,6 @@\n foo\n+bar\n',
+        path: [{_key: 'b1'}, 'markDefs', {_key: 'l1'}],
       },
     ])
   })

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -7,7 +7,6 @@ import {
 import type {
   JSONValue,
   Path,
-  PathSegment,
   InsertPatch as PteInsertPatch,
 } from '@portabletext/patches'
 import {diffValue, type SanityPatchOperations} from '@sanity/diff-patch'
@@ -28,9 +27,6 @@ import {useActorRef} from '@xstate/react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
 
 type InsertPatch = Required<Pick<SanityPatchOperations, 'insert'>>
-
-const ARRAYIFY_ERROR_MESSAGE =
-  'Unexpected path format from diffValue output. Please report this issue.'
 
 function* getSegments(
   node: PathNode,
@@ -59,52 +55,89 @@ function isKeyPath(node: ExprNode): node is PathNode {
   return node.segment.name === '_key'
 }
 
-export function arrayifyPath(pathExpr: string): Path {
-  const node = parsePath(pathExpr)
+/**
+ * Converts a `diffValue` path expression (e.g. `[_key=="a"].children[0]`) into
+ * a keyed Portable Text Editor path.
+ *
+ * Returns `null` – rather than throwing – for any expression that can't be
+ * represented as a keyed PTE path. `diffValue` can emit such expressions in
+ * practice: removing several non-keyed array items at once (e.g. clearing
+ * multiple span `marks`) produces an array slice like `...marks[1:]`. Throwing
+ * here would escape the synchronous `applySync` and break syncing entirely, so
+ * we signal failure via `null` and let the caller skip the offending patch and
+ * recover.
+ */
+export function arrayifyPath(pathExpr: string): Path | null {
+  let node: ExprNode | undefined
+  try {
+    node = parsePath(pathExpr)
+  } catch {
+    // `parsePath` throws on malformed input such as an empty expression.
+    return null
+  }
   if (!node) {
-    return []
+    return null
   }
   if (node.type !== 'Path') {
-    throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    return null
   }
 
-  return Array.from(getSegments(node)).map((segment): PathSegment => {
+  const path: Path = []
+  for (const segment of getSegments(node)) {
     if (segment.type === 'Identifier') {
-      return segment.name
+      path.push(segment.name)
+      continue
     }
     if (segment.type !== 'Subscript') {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      return null
     }
     if (segment.elements.length !== 1) {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      return null
     }
 
     const [element] = segment.elements
     if (element.type === 'Number') {
-      return element.value
+      path.push(element.value)
+      continue
     }
-
     if (element.type !== 'Comparison') {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      // e.g. an array slice (`Slice`) that `diffValue` emits when removing
+      // multiple non-keyed items at once.
+      return null
     }
     if (element.operator !== '==') {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      return null
     }
     const keyPathNode = [element.left, element.right].find(isKeyPath)
     if (!keyPathNode) {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      return null
     }
     const other = element.left === keyPathNode ? element.right : element.left
     if (other.type !== 'String') {
-      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+      return null
     }
-    return {_key: other.value}
-  })
+    path.push({_key: other.value})
+  }
+
+  return path
 }
 
-export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
-  return patches.flatMap((p) => {
-    return Object.entries(p).flatMap(([type, values]): PtePatch[] => {
+/**
+ * Converts a batch of `diffValue` patch operations into PTE patches.
+ *
+ * `incomplete` is `true` when one or more operations had to be dropped because
+ * their path couldn't be converted (see `arrayifyPath`). The caller uses this
+ * to fall back to an authoritative full value update instead of persisting a
+ * partial diff.
+ */
+export function convertPatches(patches: SanityPatchOperations[]): {
+  patches: PtePatch[]
+  incomplete: boolean
+} {
+  let incomplete = false
+
+  const converted = patches.flatMap((operation) => {
+    return Object.entries(operation).flatMap(([type, values]): PtePatch[] => {
       const origin = 'remote'
 
       switch (type) {
@@ -113,16 +146,27 @@ export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
         case 'diffMatchPatch':
         case 'inc':
         case 'dec': {
-          return Object.entries(values).map(
-            ([pathExpr, value]) =>
-              ({type, value, origin, path: arrayifyPath(pathExpr)}) as PtePatch,
-          )
+          return Object.entries(values).flatMap(([pathExpr, value]) => {
+            const path = arrayifyPath(pathExpr)
+            if (!path) {
+              incomplete = true
+              return []
+            }
+            return [{type, value, origin, path} as PtePatch]
+          })
         }
         case 'unset': {
           if (!Array.isArray(values)) {
             return []
           }
-          return values.map(arrayifyPath).map((path) => ({type, origin, path}))
+          return values.flatMap((pathExpr) => {
+            const path = arrayifyPath(pathExpr)
+            if (!path) {
+              incomplete = true
+              return []
+            }
+            return [{type, origin, path} as PtePatch]
+          })
         }
         case 'insert': {
           const {items, ...rest} = values as InsertPatch['insert']
@@ -133,11 +177,16 @@ export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
             return []
           }
           const pathExpr = (rest as {[K in InsertPosition]: string})[position]
+          const path = arrayifyPath(pathExpr)
+          if (!path) {
+            incomplete = true
+            return []
+          }
           const insertPatch: PteInsertPatch = {
             type,
             origin,
             position,
-            path: arrayifyPath(pathExpr),
+            path,
             items: items as JSONValue[],
           }
 
@@ -150,6 +199,8 @@ export function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
       }
     })
   })
+
+  return {patches: converted, incomplete}
 }
 
 function applySync({
@@ -166,11 +217,31 @@ function applySync({
   }
 
   const snapshot = editor.getSnapshot().context.value
-  const patches = convertPatches(diffValue(snapshot, remoteValue))
+  const {patches, incomplete} = convertPatches(diffValue(snapshot, remoteValue))
+
+  // Recover with an authoritative full value update when the diff can't be
+  // applied faithfully. Either a patch was dropped – replaying the rest would
+  // leave the editor in a partial/garbled state – or the editor moved on from
+  // `snapshot` while we were diffing, so the patches were computed against a
+  // value the editor no longer holds and can't be reconciled safely.
+  if (incomplete || editor.getSnapshot().context.value !== snapshot) {
+    updateValueFromRemote({editor, getRemoteValue})
+    return
+  }
 
   if (patches.length) {
     editor.send({type: 'patches', patches, snapshot})
   }
+}
+
+function updateValueFromRemote({
+  editor,
+  getRemoteValue,
+}: {
+  editor: Editor
+  getRemoteValue: () => PortableTextBlock[] | null | undefined
+}) {
+  editor.send({type: 'update value', value: getRemoteValue() ?? []})
 }
 
 const listenToEditor = fromCallback<AnyEventObject, {editor: Editor}>(
@@ -218,9 +289,9 @@ const valueSyncMachine = setup({
   },
   actions: {
     'send initial value': ({context}) => {
-      context.editor.send({
-        type: 'update value',
-        value: context.getRemoteValue() ?? [],
+      updateValueFromRemote({
+        editor: context.editor,
+        getRemoteValue: context.getRemoteValue,
       })
     },
     'push to remote': () => {


### PR DESCRIPTION
## Summary

This is the combined **crx snapshot publish platform** hotfix: Ryan Bonial's engine
routing fix (#2974) with our residual client-side crash-proofing stacked on top.

The PR is opened with **base = `fix-sidecar-array-remote-patches`** (the branch
behind #2974), so the diff shown here is **only our residual** — two `fix` commits
plus a changeset.

## ✅ Released under the `crx` dist-tag

The combined fix (this PR **+ #2974**) is published to npm under the **`crx`**
dist-tag. This does **not** touch `latest` — it's a snapshot hotfix for affected
users to pin to today:

| package | version | npm |
|---|---|---|
| `@portabletext/editor` | `7.10.8-crx.0` | https://www.npmjs.com/package/@portabletext/editor/v/7.10.8-crx.0 |
| `@portabletext/plugin-sdk-value` | `7.0.35-crx.0` | https://www.npmjs.com/package/@portabletext/plugin-sdk-value/v/7.0.35-crx.0 |

Install:

```sh
npm i @portabletext/editor@crx @portabletext/plugin-sdk-value@crx
```

Verified end-to-end against real Content Lake with the **published** packages: two
tabs editing the same field concurrently (typing + toggling bold/link) → **no crash,
no document corruption, tabs converge**. (See the SAFETY matrix in the repro repo:
crash-and-corrupt → recoverable silent-loss.)

## Root cause — credit to #2974

[#2974](https://github.com/portabletext/editor/pull/2974) (Ryan Bonial,
`fix-sidecar-array-remote-patches`) is the actual root-cause fix. Remote patches
produced by diffing tools address elements of sidecar arrays
(`span.marks[0]`, `span.marks[-1]`, `block.markDefs[_key==...]`). The engine
previously routed those through structural child insertion/removal, which:

- threw `Cannot apply an "unset" (node removal) operation ... because the node
  was not found`, killing the consumer's sync; and
- silently wrote a bogus `children` array onto spans on insert, corrupting the
  document once pushed back to the datastore.

#2974 makes the engine detect these non-structural paths and apply them as plain
data patches on the root block. That is the fix; everything below is defense in
depth layered on top of it.

## Our residual (this PR's diff)

- **`@portabletext/editor`** (`sync-machine.ts`): keyed `updateBlock` unsets are
  guarded against the live engine tree, and the `updateValue` try/catch is widened
  so a stale-key removal degrades to a safe re-sync instead of surfacing an
  unhandled rejection that freezes the sync actor. Some of the per-`updateBlock`
  unset guards now overlap with #2974 and are intentionally kept as belt-and-braces.
- **`@portabletext/plugin-sdk-value`** (`plugin.sdk-value.tsx`): `arrayifyPath`
  returns `null` instead of throwing on diff-patch paths it cannot convert (e.g.
  array slices produced when clearing multiple `marks`); `convertPatches` drops the
  unconvertible ops and flags the batch incomplete; `applySync` then falls back to
  an authoritative full value update / resync.

## Scope / what this does NOT fix

- It **stops the crash and the document corruption** under concurrent editing.
- It does **NOT** fix the underlying **SDK concurrency clobber** — two editors
  racing on the same block can still overwrite each other's changes. That remains
  to be addressed separately.

## Status

- Draft. Do not merge / do not publish to `latest`.
- **Shipped as a snapshot under the `crx` dist-tag** (see above) — the interim
  hotfix affected users can pin to now.
- **Supersedes** the private `sanity-labs/editor-crx-fix#1`.
- Tests green locally: editor browser (chromium) 1723 passed / 1 skipped; plugin
  unit 10 passed; plugin browser (chromium) 12 passed. `pnpm build` all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
