### PR TITLE
test: pin sidecar-array patch routing for containers and custom arrays

### DIFF
--- a/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
+++ b/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
@@ -1,5 +1,7 @@
 import {defineSchema} from '@portabletext/schema'
 import {describe, expect, test, vi} from 'vitest'
+import {defineContainer} from '../src'
+import {NodePlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
 
 /**
@@ -280,6 +282,660 @@ describe('event.patches sidecar arrays', () => {
           markDefs: [],
           style: 'normal',
         },
+      ])
+    })
+  })
+})
+
+describe('event.patches sidecar arrays in containers and custom arrays', () => {
+  const schemaDefinition = defineSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    blockObjects: [
+      {
+        name: 'callout',
+        fields: [
+          {name: 'content', type: 'array', of: [{type: 'block'}]},
+          {name: 'tags', type: 'array', of: [{type: 'string'}]},
+        ],
+      },
+      {
+        name: 'table',
+        fields: [
+          {
+            name: 'rows',
+            type: 'array',
+            of: [
+              {
+                type: 'object',
+                name: 'row',
+                fields: [
+                  {
+                    name: 'cells',
+                    type: 'array',
+                    of: [
+                      {
+                        type: 'object',
+                        name: 'cell',
+                        fields: [
+                          {
+                            name: 'content',
+                            type: 'array',
+                            of: [{type: 'block'}],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'image',
+        fields: [{name: 'tags', type: 'array', of: [{type: 'string'}]}],
+      },
+    ],
+  })
+
+  const containers = [
+    defineContainer({type: 'callout', arrayField: 'content'}),
+    defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      of: [
+        defineContainer({
+          type: 'row',
+          arrayField: 'cells',
+          of: [defineContainer({type: 'cell', arrayField: 'content'})],
+        }),
+      ],
+    }),
+  ]
+
+  test('Scenario: remote `insert` into `marks` on a container-nested span', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: [],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            -1,
+          ],
+          items: ['strong'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [
+                {_type: 'span', _key: 's1', text: 'foo', marks: ['strong']},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: [],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote annotation toggled on inside a container (`marks` + `markDefs` insert)', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: [],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'c1'}, 'content', {_key: 'b1'}, 'markDefs', -1],
+          items: [{_type: 'link', _key: 'm1', href: 'https://example.com'}],
+        },
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            -1,
+          ],
+          items: ['m1'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [
+                {_type: 'span', _key: 's1', text: 'foo', marks: ['m1']},
+              ],
+              markDefs: [
+                {_type: 'link', _key: 'm1', href: 'https://example.com'},
+              ],
+              style: 'normal',
+            },
+          ],
+          tags: [],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote `unset` of a `marks` element two containers deep', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'table',
+          _key: 't1',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cl1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: 's1',
+                          text: 'foo',
+                          marks: ['strong'],
+                        },
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [
+            {_key: 't1'},
+            'rows',
+            {_key: 'r1'},
+            'cells',
+            {_key: 'cl1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            0,
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'table',
+          _key: 't1',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'cl1',
+                  content: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      children: [
+                        {_type: 'span', _key: 's1', text: 'foo', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: remote `insert` into a void block object custom array', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [{_type: 'image', _key: 'i1', tags: ['photo']}],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'i1'}, 'tags', -1],
+          items: ['landscape'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {_type: 'image', _key: 'i1', tags: ['photo', 'landscape']},
+      ])
+    })
+  })
+
+  test('Scenario: remote `unset` of an element in a container-owned data array', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: ['news', 'sports'],
+        },
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    // `tags` sits beside the container's structural child field (`content`);
+    // the element removal must hit `tags`, not the container's children.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [{_key: 'c1'}, 'tags', 0],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'callout',
+          _key: 'c1',
+          content: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          tags: ['sports'],
+        },
+      ])
+    })
+  })
+})
+
+describe('event.patches sidecar arrays: multi-element and keyed tails', () => {
+  // Multi-element fixtures: empty and single-element arrays cannot
+  // distinguish "landed at the anchor" from "landed at the end", nor keyed
+  // resolution from "accidentally index 0".
+  const schemaDefinition = defineSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    blockObjects: [
+      {
+        name: 'callout',
+        fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+      },
+    ],
+  })
+  const containers = [defineContainer({type: 'callout', arrayField: 'content'})]
+
+  function calloutWith(children: unknown, markDefs: unknown) {
+    return {
+      _type: 'callout',
+      _key: 'c1',
+      content: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children,
+          markDefs,
+          style: 'normal',
+        },
+      ],
+    }
+  }
+
+  test('Scenario: remote `insert` after a middle `marks` element lands between its neighbors', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        calloutWith(
+          [{_type: 'span', _key: 's1', text: 'foo', marks: ['strong', 'em']}],
+          [],
+        ),
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            0,
+          ],
+          items: ['underline'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        calloutWith(
+          [
+            {
+              _type: 'span',
+              _key: 's1',
+              text: 'foo',
+              marks: ['strong', 'underline', 'em'],
+            },
+          ],
+          [],
+        ),
+      ])
+    })
+  })
+
+  test('Scenario: remote `unset` of a middle `marks` element removes only that element', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        calloutWith(
+          [
+            {
+              _type: 'span',
+              _key: 's1',
+              text: 'foo',
+              marks: ['strong', 'underline', 'em'],
+            },
+          ],
+          [],
+        ),
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            1,
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        calloutWith(
+          [{_type: 'span', _key: 's1', text: 'foo', marks: ['strong', 'em']}],
+          [],
+        ),
+      ])
+    })
+  })
+
+  test('Scenario: remote `insert` anchored on a keyed `markDefs` element lands between its neighbors', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        calloutWith(
+          [{_type: 'span', _key: 's1', text: 'foo', marks: ['m1', 'm2']}],
+          [
+            {_type: 'link', _key: 'm1', href: 'https://one.example'},
+            {_type: 'link', _key: 'm2', href: 'https://two.example'},
+          ],
+        ),
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    // The mark insert rides along so the new markDef is referenced; an
+    // unreferenced markDef is orphaned data the editor strips (both the
+    // unused-markDefs normalization rule and `validateValue`'s
+    // auto-resolution remove it).
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'markDefs',
+            {_key: 'm1'},
+          ],
+          items: [{_type: 'link', _key: 'm3', href: 'https://three.example'}],
+        },
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            -1,
+          ],
+          items: ['m3'],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        calloutWith(
+          [
+            {
+              _type: 'span',
+              _key: 's1',
+              text: 'foo',
+              marks: ['m1', 'm2', 'm3'],
+            },
+          ],
+          [
+            {_type: 'link', _key: 'm1', href: 'https://one.example'},
+            {_type: 'link', _key: 'm3', href: 'https://three.example'},
+            {_type: 'link', _key: 'm2', href: 'https://two.example'},
+          ],
+        ),
+      ])
+    })
+  })
+
+  test('Scenario: remote keyed `unset` removes the addressed `markDefs` element, not index 0', async () => {
+    const {editor} = await createTestEditor({
+      schemaDefinition,
+      initialValue: [
+        calloutWith(
+          [{_type: 'span', _key: 's1', text: 'foo', marks: ['m1', 'm2']}],
+          [
+            {_type: 'link', _key: 'm1', href: 'https://one.example'},
+            {_type: 'link', _key: 'm2', href: 'https://two.example'},
+          ],
+        ),
+      ],
+      children: <NodePlugin nodes={containers} />,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+            'marks',
+            1,
+          ],
+        },
+        {
+          type: 'unset',
+          origin: 'remote',
+          path: [
+            {_key: 'c1'},
+            'content',
+            {_key: 'b1'},
+            'markDefs',
+            {_key: 'm2'},
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([
+        calloutWith(
+          [{_type: 'span', _key: 's1', text: 'foo', marks: ['m1']}],
+          [{_type: 'link', _key: 'm1', href: 'https://one.example'}],
+        ),
       ])
     })
   })


### PR DESCRIPTION
Test-only follow-up to #2974. Its suite pins `marks`/`markDefs` routing on root-level text blocks; during review the container-nested case was verified by a throwaway probe, and the "does this hold for arrays that aren't `marks`?" question wasn't pinned at all. This promotes both into the repo.

Five new scenarios in `event.patches.sidecar-arrays.test.tsx`, all passing against the shipped implementation unchanged:

- `marks` insert on a container-nested span, and an annotation toggle (`marks` + `markDefs` inserts) on a container-nested block, the case where the "root block" the data patch applies on is the container itself and the block-relative path descends field-generically.
- `marks` unset two containers deep (`table > row > cell > block > span`).
- insert into a void block object's custom array (`image.tags[-1]`), a sidecar array that isn't `marks`/`markDefs`.
- unset of an element in a container-owned data array (`callout.tags[0]`) sitting *beside* the container's structural child field (`content`), pinning that the classifier distinguishes the two arrays on the same node.

Beyond documenting the shipped contract, these are the regression net for the planned replacement of the classifier/fallback machinery with field-generic handlers (tracked separately as a follow-up): tests that predate that refactor and pin today's observable behavior. No production code changes, no changeset.
