### PR TITLE
fix: emit item-keyed `markDefs` patches instead of whole-array sets

### DIFF
--- a/.changeset/guard-keyed-markdefs-unsets.md
+++ b/.changeset/guard-keyed-markdefs-unsets.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: guard outgoing keyed `markDefs` unsets against store-referenced definitions
+
+An upcoming `@portabletext/editor` release prunes unused annotation definitions as item-keyed `unset` patches instead of whole-array sets. A client that has diverged from the store can prune a definition the store's spans still reference, which would orphan another client's annotation. Outgoing keyed `markDefs` unsets are now dropped while the store's spans reference the definition, mirroring the existing guard on decomposed whole-array sets; at worst an unused definition lingers until a later converged session prunes it. Against current editor releases the guard is inert.

--- a/.changeset/markdefs-item-patches.md
+++ b/.changeset/markdefs-item-patches.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: emit item-keyed `markDefs` patches instead of whole-array sets
+
+Changing a block's annotations previously emitted a `set` of the whole `markDefs` array. When two clients annotated the same block concurrently, the last writer's array overwrote the other's at the server while both clients' span `marks` references survived, leaving annotations without definitions. Added definitions are now emitted as a `setIfMissing` plus an item `insert`, removed definitions as keyed `unset`s, and undoing those edits emits the item-keyed counterparts. Item-keyed operations merge at the server instead of overwriting.
+
+New definitions are prepended to `markDefs` instead of appended, so code that reads the array positionally sees new definitions first. Consumers observing `patch` or `mutation` events see the finer-grained shapes; explicit whole-array writes through `block.set` still emit a whole-array `set`.

--- a/.changeset/undo-step-boundaries.md
+++ b/.changeset/undo-step-boundaries.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep leading no-op operations from consuming undo-step boundaries
+
+A single undo could revert more than the most recent edit: when an editing flow's first operation was one that doesn't affect history (a zero-length text change, or an operation without an inverse), the following operations merged into the previous undo step. Undo now reverts exactly one step.
+
+Undo also restores the selection from before the step as it was when the edit began, instead of a mid-flow selection that may reference nodes the undo itself removes (which dropped the cursor entirely).

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -98,6 +98,7 @@ function performEventInternal({
 }: PerformEventArgs) {
   if (mode === 'send' && !isNativeBehaviorEvent(event)) {
     editor.undoStepId = defaultKeyGenerator()
+    editor.undoStepSelection = editor.snapshot.context.selection
   }
 
   if (debug.behaviors.enabled) {
@@ -269,6 +270,7 @@ function performEventInternal({
       if (actionSetIndex > 0) {
         // Since there are multiple action sets
         editor.undoStepId = defaultKeyGenerator()
+        editor.undoStepSelection = editor.snapshot.context.selection
 
         undoStepCreated = true
       }
@@ -282,6 +284,7 @@ function performEventInternal({
         // All actions performed recursively from now will be squashed into this
         // undo step
         editor.undoStepId = defaultKeyGenerator()
+        editor.undoStepSelection = editor.snapshot.context.selection
 
         undoStepCreated = true
       }

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -74,6 +74,7 @@ export function createEditorEngine(
   editor.verifiedUniqueChildGroups = new Set<string>()
   editor.remotePatches = []
   editor.undoStepId = undefined
+  editor.undoStepSelection = null
 
   editor.isDeferringMutations = false
   editor.isNormalizingNode = false

--- a/packages/editor/src/editor/subscriber.history.ts
+++ b/packages/editor/src/editor/subscriber.history.ts
@@ -100,7 +100,11 @@ export function subscribeHistory({
         operation.text.length === 0)
 
     if (isNoOp) {
-      previousUndoStepId = currentUndoStepId
+      // Deliberately not advancing `previousUndoStepId`: it tracks the
+      // last operation that affected history. Advancing it here would
+      // let a no-op leading a new undo step consume the step boundary,
+      // and the following real operations would merge into the previous
+      // step (undoing more than the last step's worth of changes).
       return
     }
 
@@ -118,7 +122,16 @@ export function subscribeHistory({
       previousUndoStepId,
       operationsInProgress: event.operationsInProgress,
       isNormalizingNode: event.isNormalizingNode,
-      selectionBeforeApply: event.beforeSelection,
+      // When this operation opens a new undo step, the step's pre-state
+      // selection is the one snapshotted when the undo step ID was
+      // minted: operation implementations may park the selection on
+      // transient nodes (removed again within the same step) before the
+      // first history-affecting operation applies.
+      selectionBeforeApply:
+        currentUndoStepId !== undefined &&
+        currentUndoStepId !== previousUndoStepId
+          ? editor.undoStepSelection
+          : event.beforeSelection,
     })
 
     // Make sure we don't exceed the maximum number of undo steps we want

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -1,13 +1,8 @@
-import {
-  insert,
-  set,
-  setIfMissing,
-  unset,
-  type Patch,
-} from '@portabletext/patches'
+import {insert, setIfMissing, unset, type Patch} from '@portabletext/patches'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import {
   insertNodePatch,
+  setNodePatch,
   textPatch,
 } from '../internal-utils/operation-to-patches'
 import {isEqualToEmptyEditor} from '../internal-utils/values'
@@ -77,7 +72,7 @@ export function subscribePatchGeneration({
         patches = [...patches, ...insertNodePatch(operation)]
         break
       case 'set':
-        patches = [...patches, set(operation.value, operation.path)]
+        patches = [...patches, ...setNodePatch(operation, previousValue)]
         break
       case 'unset':
         patches = [...patches, unset(operation.path)]

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -49,8 +49,19 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
         // `span.marks` or `block.markDefs`) rather than a structural
         // child. Apply the insert as a plain data patch on the root
         // block so the result matches what the datastore computed.
-        // These operations only arrive from remote patches, so no
-        // inverse is needed.
+        if (
+          !op.inverse &&
+          !editor.isProcessingRemoteChanges &&
+          typeof node._key === 'string'
+        ) {
+          // Unkeyed sidecar members can't be addressed for removal, so
+          // they carry no inverse; no local operation site inserts them.
+          op.inverse = {
+            type: 'unset',
+            path: [...path.slice(0, -1), {_key: node._key}],
+          }
+        }
+
         applyOnRootBlock(editor, path, {
           type: 'insert',
           path: path.slice(1),
@@ -295,15 +306,29 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
         // structural child. Removing it never affects the selection, so
         // apply it as a plain data patch on the root block.
         if (!op.inverse && !editor.isProcessingRemoteChanges) {
-          const arrayValue = getValue(
-            editor.snapshot.context.value,
-            path.slice(0, -1),
-          )
-          if (Array.isArray(arrayValue)) {
+          const removedMember = getValue(editor.snapshot.context.value, path)
+
+          if (isKeyedSegment(lastSegment) && removedMember !== undefined) {
+            // A keyed inverse keeps undo emitting item-level patches;
+            // restoring via a whole-array `set` would overwrite members
+            // another client wrote meanwhile.
             op.inverse = {
-              type: 'set',
-              path: path.slice(0, -1),
-              value: arrayValue,
+              type: 'insert',
+              path: [...path.slice(0, -1), 0],
+              position: 'before',
+              node: removedMember as Node,
+            }
+          } else {
+            const arrayValue = getValue(
+              editor.snapshot.context.value,
+              path.slice(0, -1),
+            )
+            if (Array.isArray(arrayValue)) {
+              op.inverse = {
+                type: 'set',
+                path: path.slice(0, -1),
+                value: arrayValue,
+              }
             }
           }
         }

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -8,7 +8,6 @@ import {applyInsertNodeAtPath} from '../../internal-utils/apply-insert-node'
 import {applyMergeNode} from '../../internal-utils/apply-merge-node'
 import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
 import {debug} from '../../internal-utils/debug'
-import {isEqualMarkDefs} from '../../internal-utils/equality'
 import {setNodeProperties} from '../../internal-utils/set-node-properties'
 import {getChildFieldName} from '../../paths/get-child-field-name'
 import {serializePath} from '../../paths/serialize-path'
@@ -367,8 +366,8 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Remove markDefs not in use
    */
   if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
-    const newMarkDefs = (node.markDefs || []).filter((def) => {
-      return node.children.find((child) => {
+    const unusedMarkDefs = (node.markDefs || []).filter((def) => {
+      return !node.children.find((child) => {
         return (
           isSpan({schema: editor.snapshot.context.schema}, child) &&
           Array.isArray(child.marks) &&
@@ -377,9 +376,17 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       })
     })
 
-    if (node.markDefs && !isEqualMarkDefs(newMarkDefs, node.markDefs)) {
+    if (unusedMarkDefs.length > 0) {
       debug.normalization('removing markDef not in use')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
+      for (const unusedMarkDef of unusedMarkDefs) {
+        // Keyed removal instead of setting the whole array: the emitted
+        // patch then only touches this definition, so it merges with
+        // definitions another client writes concurrently.
+        editor.apply({
+          type: 'unset',
+          path: [...path, 'markDefs', {_key: unusedMarkDef._key}],
+        })
+      }
       return
     }
   }

--- a/packages/editor/src/internal-utils/equality.ts
+++ b/packages/editor/src/internal-utils/equality.ts
@@ -179,7 +179,7 @@ function isEqualSpans(a: ChildLike, b: ChildLike): boolean {
   return isEqualProps(a, b, ['_key', '_type', 'text', 'marks'])
 }
 
-export function isEqualMarkDefs(
+function isEqualMarkDefs(
   a: Array<PortableTextObject>,
   b: Array<PortableTextObject>,
 ): boolean {

--- a/packages/editor/src/internal-utils/operation-to-patches.test.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.test.ts
@@ -12,7 +12,7 @@ import {createEditor} from '../engine/create-editor'
 import type {Node} from '../engine/interfaces/node'
 import {defaultKeyGenerator} from '../utils/key-generator'
 import {buildIndexMaps} from './build-index-maps'
-import {insertNodePatch, textPatch} from './operation-to-patches'
+import {insertNodePatch, setNodePatch, textPatch} from './operation-to-patches'
 
 function buildBlockIndexMap(
   schema: any,
@@ -411,5 +411,118 @@ describe('defensive setIfMissing patches', () => {
         },
       ])
     })
+  })
+})
+
+describe(setNodePatch.name, () => {
+  const markDefsPath = [{_key: 'b0'}, 'markDefs']
+
+  function blockWithMarkDefs(markDefs: Array<object> | undefined) {
+    return [
+      {
+        _type: 'block',
+        _key: 'b0',
+        children: [{_type: 'span', _key: 's0', text: 'foo', marks: []}],
+        style: 'normal',
+        ...(markDefs === undefined ? {} : {markDefs}),
+      },
+    ] as Array<PortableTextBlock>
+  }
+
+  test('Scenario: Creating an absent `markDefs` property emits a `setIfMissing`', () => {
+    expect(
+      setNodePatch(
+        {
+          type: 'set',
+          path: markDefsPath,
+          value: [],
+        },
+        blockWithMarkDefs(undefined),
+      ),
+    ).toEqual([
+      {
+        type: 'setIfMissing',
+        path: markDefsPath,
+        value: [],
+      },
+    ])
+  })
+
+  test('Scenario: Setting an existing `markDefs` property passes through as a plain set', () => {
+    expect(
+      setNodePatch(
+        {
+          type: 'set',
+          path: markDefsPath,
+          value: [],
+        },
+        blockWithMarkDefs([
+          {_key: 'l0', _type: 'link', href: 'https://example.com'},
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: 'set',
+        path: markDefsPath,
+        value: [],
+      },
+    ])
+  })
+
+  test('Scenario: Setting a non-empty array on an absent property passes through as a plain set', () => {
+    expect(
+      setNodePatch(
+        {
+          type: 'set',
+          path: markDefsPath,
+          value: [{_key: 'l0', _type: 'link', href: 'https://example.com'}],
+        },
+        blockWithMarkDefs(undefined),
+      ),
+    ).toEqual([
+      {
+        type: 'set',
+        path: markDefsPath,
+        value: [{_key: 'l0', _type: 'link', href: 'https://example.com'}],
+      },
+    ])
+  })
+
+  test('Scenario: Block missing from the pre-apply value passes through as a plain set', () => {
+    expect(
+      setNodePatch(
+        {
+          type: 'set',
+          path: [{_key: 'other-block'}, 'markDefs'],
+          value: [],
+        },
+        blockWithMarkDefs(undefined),
+      ),
+    ).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'other-block'}, 'markDefs'],
+        value: [],
+      },
+    ])
+  })
+
+  test('Scenario: Paths not ending in `markDefs` pass through as plain sets', () => {
+    expect(
+      setNodePatch(
+        {
+          type: 'set',
+          path: [{_key: 'b0'}, 'style'],
+          value: 'h1',
+        },
+        blockWithMarkDefs([]),
+      ),
+    ).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'b0'}, 'style'],
+        value: 'h1',
+      },
+    ])
   })
 })

--- a/packages/editor/src/internal-utils/operation-to-patches.ts
+++ b/packages/editor/src/internal-utils/operation-to-patches.ts
@@ -1,6 +1,7 @@
 import {
   diffMatchPatch,
   insert,
+  set,
   setIfMissing,
   type Patch,
 } from '@portabletext/patches'
@@ -10,9 +11,25 @@ import type {
   InsertOperation,
   InsertTextOperation,
   RemoveTextOperation,
+  SetOperation,
 } from '../engine/interfaces/operation'
+import type {Path} from '../engine/interfaces/path'
 import {getSpan} from '../traversal/get-span'
 import type {TraversalSnapshot} from '../traversal/traversal-snapshot'
+
+/**
+ * Mechanical operation-to-patch representation changes ONLY. Every
+ * function here maps one operation to its wire-format equivalent:
+ * offset-based text edits become `diffMatchPatch` (the patch vocabulary
+ * has no offset inserts), array inserts gain a defensive `setIfMissing`
+ * (the stored document may lack arrays the engine state has), and
+ * ensure-exists sets become `setIfMissing` (no operation vocabulary
+ * carries that intent).
+ *
+ * Never diff sibling state to reconstruct intent here. If a patch shape
+ * requires knowing more than the operation itself expresses, the
+ * operation site is emitting the wrong operation; fix it there.
+ */
 
 export function textPatch(
   snapshot: TraversalSnapshot,
@@ -50,4 +67,68 @@ export function insertNodePatch(operation: InsertOperation): Array<Patch> {
     setIfMissing([], arrayFieldPath),
     insert([operation.node], operation.position, operation.path),
   ]
+}
+
+export function setNodePatch(
+  operation: SetOperation,
+  beforeValue: Array<PortableTextBlock>,
+): Array<Patch> {
+  if (
+    operation.path.at(-1) === 'markDefs' &&
+    Array.isArray(operation.value) &&
+    operation.value.length === 0 &&
+    getValueAtPath(beforeValue, operation.path) === undefined &&
+    getValueAtPath(beforeValue, operation.path.slice(0, -1)) !== undefined
+  ) {
+    // Normalization ensures `markDefs` exists by setting `[]` on blocks
+    // that lack it, and there is no ensure-exists operation vocabulary to
+    // carry that intent. Translate it here: `setIfMissing` creates the
+    // property on the stored document without clobbering definitions
+    // another client may have written meanwhile.
+    return [setIfMissing([], operation.path)]
+  }
+
+  return [set(operation.value, operation.path)]
+}
+
+function getValueAtPath(value: unknown, path: Path): unknown {
+  let current: unknown = value
+
+  for (const segment of path) {
+    if (typeof segment === 'string') {
+      if (
+        typeof current !== 'object' ||
+        current === null ||
+        Array.isArray(current)
+      ) {
+        return undefined
+      }
+      current = (current as Record<string, unknown>)[segment]
+    } else if (typeof segment === 'number') {
+      if (!Array.isArray(current)) {
+        return undefined
+      }
+      current = current[segment]
+    } else if (Array.isArray(segment)) {
+      // index tuples address ranges, not single values
+      return undefined
+    } else {
+      if (!Array.isArray(current)) {
+        return undefined
+      }
+      const key = segment._key
+      current = current.find((item) => isKeyedObject(item) && item._key === key)
+    }
+  }
+
+  return current
+}
+
+function isKeyedObject(value: unknown): value is {_key: string} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '_key' in value &&
+    typeof (value as {_key: unknown})._key === 'string'
+  )
 }

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -4,6 +4,7 @@ import {isEnd} from '../engine/editor/is-end'
 import {isStart} from '../engine/editor/is-start'
 import {rangeRef} from '../engine/editor/range-ref'
 import {withoutNormalizing} from '../engine/editor/without-normalizing'
+import type {Node} from '../engine/interfaces/node'
 import {isBackwardRange} from '../engine/range/is-backward-range'
 import {isCollapsedRange} from '../engine/range/is-collapsed-range'
 import {isRange} from '../engine/range/is-range'
@@ -109,19 +110,15 @@ export const addAnnotationOperationImplementation: OperationImplementation<
       )
 
       if (existingMarkDef === undefined) {
-        setNodeProperties(
-          editor,
-          {
-            markDefs: [
-              ...markDefs,
-              {
-                ...parsedAnnotation,
-                _key: annotationKey,
-              },
-            ],
-          },
-          blockPath,
-        )
+        editor.apply({
+          type: 'insert',
+          path: [...blockPath, 'markDefs', 0],
+          position: 'before',
+          node: {
+            ...parsedAnnotation,
+            _key: annotationKey,
+          } as unknown as Node,
+        })
       }
 
       // Split text nodes at range boundaries

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -21,7 +21,6 @@ import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {deleteRange} from '../internal-utils/delete-range'
 import {isEqualChildren, isEqualMarks} from '../internal-utils/equality'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {toEngineBlock} from '../internal-utils/values'
 import {getEnclosingBlock} from '../traversal/get-enclosing-block'
 import {getParent} from '../traversal/get-parent'
@@ -480,13 +479,17 @@ function mergeTextBlockFragment(args: {
     endBlock,
   })
 
-  setNodeProperties(
-    editor,
-    {
-      markDefs: [...(endBlock.markDefs ?? []), ...(adjustedMarkDefs ?? [])],
-    },
-    endBlockPath,
-  )
+  for (const adjustedMarkDef of adjustedMarkDefs ?? []) {
+    // Keyed inserts instead of setting the unioned array: the emitted
+    // patches then only add the incoming definitions, so they merge with
+    // definitions another client writes concurrently.
+    editor.apply({
+      type: 'insert',
+      path: [...endBlockPath, 'markDefs', 0],
+      position: 'before',
+      node: adjustedMarkDef as unknown as Node,
+    })
+  }
 
   const atPathRef = pathRef(editor, at.path)
 

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -11,6 +11,7 @@ import type {
   TextBlockConfig,
 } from '../renderers/renderer.types'
 import type {ResolvedContainers} from '../schema/resolve-containers'
+import type {EditorSelection} from './editor'
 
 type HistoryItem = {
   operations: EngineOperation[]
@@ -77,6 +78,13 @@ export interface PortableTextEditorEngine extends DOMEditor {
   verifiedUniqueChildGroups: Set<string>
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
+  /**
+   * Engine selection snapshotted when `undoStepId` is minted. The step's
+   * pre-state selection for undo: by the time the first history-affecting
+   * operation applies, operation implementations may have parked the
+   * selection on transient nodes their own step removes again.
+   */
+  undoStepSelection: EditorSelection
 
   isDeferringMutations: boolean
   isNormalizingNode: boolean

--- a/packages/editor/tests/collaborative-editing.test.tsx
+++ b/packages/editor/tests/collaborative-editing.test.tsx
@@ -286,7 +286,7 @@ describe('Collaborative editing', () => {
 
       expect(emittedPatches).toEqual([
         {
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: blockKey}, 'markDefs'],
           value: [],
         },
@@ -1073,7 +1073,7 @@ describe('Collaborative editing', () => {
       // plus the typing patch
       expect(emittedPatches).toEqual([
         {
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: blockKey}, 'markDefs'],
           value: [],
         },
@@ -1203,7 +1203,7 @@ describe('Collaborative editing', () => {
           value: [],
         },
         {
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: blockKey}, 'markDefs'],
           value: [],
         },

--- a/packages/editor/tests/event.block.set.test.tsx
+++ b/packages/editor/tests/event.block.set.test.tsx
@@ -503,7 +503,7 @@ describe('event.block.set', () => {
         unset([{_key: 'k0'}]),
         unset([]),
         setIfMissing([], []),
-        set([], [{_key: textBlockKey}, 'markDefs']),
+        setIfMissing([], [{_key: textBlockKey}, 'markDefs']),
       ])
     })
 

--- a/packages/editor/tests/event.block.unset.test.tsx
+++ b/packages/editor/tests/event.block.unset.test.tsx
@@ -344,7 +344,7 @@ describe('event.block.unset', () => {
 
       expect(patches).toEqual([
         unset([{_key: textBlockKey}, 'markDefs']),
-        set([], [{_key: textBlockKey}, 'markDefs']),
+        setIfMissing([], [{_key: textBlockKey}, 'markDefs']),
       ])
     })
   })
@@ -426,7 +426,7 @@ describe('event.block.unset', () => {
           [{_key: 'k0'}],
         ),
         unset([{_key: 'k0'}]),
-        set([], [{_key: textBlockKey}, 'markDefs']),
+        setIfMissing([], [{_key: textBlockKey}, 'markDefs']),
       ])
     })
 

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -16,6 +16,99 @@ import type {EditorSelection} from '../src/types/editor'
 import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.undo', () => {
+  test('Scenario: Undoing a `child.set` that replaces an empty span\u2019s text', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const filledBlockKey = keyGenerator()
+    const filledSpanKey = keyGenerator()
+    const emptyBlockKey = keyGenerator()
+    const emptySpanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior<{text: string}>({
+              on: 'custom.insert text',
+              actions: [
+                ({event}) => [execute({type: 'insert.text', text: event.text})],
+              ],
+            }),
+            defineBehavior<{text: string}>({
+              on: 'custom.replace empty span',
+              actions: [
+                ({event}) => [
+                  execute({
+                    type: 'child.set',
+                    at: [
+                      {_key: emptyBlockKey},
+                      'children',
+                      {_key: emptySpanKey},
+                    ],
+                    props: {text: event.text},
+                  }),
+                ],
+              ],
+            }),
+          ]}
+        />
+      ),
+      initialValue: [
+        {
+          _key: filledBlockKey,
+          _type: 'block',
+          children: [
+            {_key: filledSpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: emptyBlockKey,
+          _type: 'block',
+          children: [{_key: emptySpanKey, _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: filledBlockKey}, 'children', {_key: filledSpanKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: filledBlockKey}, 'children', {_key: filledSpanKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'custom.insert text', text: '!'})
+
+    // Replacing an empty span's text leads with a zero-length
+    // `remove.text`, an operation that doesn't affect history. The
+    // following `insert.text` must still open its own undo step instead
+    // of merging into the previous one.
+    editor.send({type: 'custom.replace empty span', text: 'bar'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo!|', 'B: bar'].join('\n'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo!|', 'B: '].join('\n'),
+      )
+    })
+  })
+
   test('Scenario: Undoing action sets', async () => {
     const {editor, locator} = await createTestEditor({
       children: (

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -498,7 +498,7 @@ describe('event.insert.block', () => {
         },
         {
           origin: 'local',
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: 'k2'}, 'markDefs'],
           value: [],
         },
@@ -597,7 +597,7 @@ describe('event.insert.block', () => {
         },
         {
           origin: 'local',
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: 'k2'}, 'markDefs'],
           value: [],
         },

--- a/packages/editor/tests/event.patch.markdefs.test.tsx
+++ b/packages/editor/tests/event.patch.markdefs.test.tsx
@@ -1,0 +1,226 @@
+import type {Patch} from '@portabletext/patches'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {createTestEditor} from '../src/test/vitest'
+import {getTextSelection} from '../test-utils/text-selection'
+
+describe('event.patch markDefs', () => {
+  test('Scenario: Adding an annotation emits a keyed insert instead of a whole-array set', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'annotation.add',
+      at: getTextSelection(editor.getSnapshot().context, 'foo'),
+      annotation: {
+        name: 'link',
+        value: {href: 'https://example.com'},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          origin: 'local',
+          type: 'setIfMissing',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
+        {
+          origin: 'local',
+          type: 'insert',
+          position: 'before',
+          path: [{_key: blockKey}, 'markDefs', 0],
+          items: [{_key: 'k4', _type: 'link', href: 'https://example.com'}],
+        },
+        {
+          origin: 'local',
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
+          value: ['k4'],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Adding a second annotation inserts only the new definition', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const linkedSpanKey = keyGenerator()
+    const plainSpanKey = keyGenerator()
+    const existingDefKey = keyGenerator()
+    const patches: Array<Patch> = []
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {
+              _key: linkedSpanKey,
+              _type: 'span',
+              text: 'foo',
+              marks: [existingDefKey],
+            },
+            {_key: plainSpanKey, _type: 'span', text: ' bar', marks: []},
+          ],
+          markDefs: [
+            {_key: existingDefKey, _type: 'link', href: 'https://example.com'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'annotation.add',
+      at: getTextSelection(editor.getSnapshot().context, ' bar'),
+      annotation: {
+        name: 'link',
+        value: {href: 'https://other.example.com'},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          origin: 'local',
+          type: 'setIfMissing',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
+        {
+          origin: 'local',
+          type: 'insert',
+          position: 'before',
+          path: [{_key: blockKey}, 'markDefs', 0],
+          items: [
+            {_key: 'k6', _type: 'link', href: 'https://other.example.com'},
+          ],
+        },
+        {
+          origin: 'local',
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: plainSpanKey}, 'marks'],
+          value: ['k6'],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Emitted patches converge another editor on the same value', async () => {
+    const keyGeneratorA = createTestKeyGenerator()
+    const blockKey = keyGeneratorA()
+    const spanKey = keyGeneratorA()
+    const patches: Array<Patch> = []
+
+    const initialValue = [
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const schemaDefinition = defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const {editor: editorA} = await createTestEditor({
+      keyGenerator: keyGeneratorA,
+      schemaDefinition,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+      initialValue,
+    })
+    const {editor: editorB} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator('b'),
+      schemaDefinition,
+      initialValue,
+    })
+
+    editorA.send({
+      type: 'annotation.add',
+      at: getTextSelection(editorA.getSnapshot().context, 'foo'),
+      annotation: {
+        name: 'link',
+        value: {href: 'https://example.com'},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(patches.length).toEqual(3)
+    })
+
+    editorB.send({
+      type: 'patches',
+      patches: patches.map((patch) => ({...patch, origin: 'remote'})),
+      snapshot: editorB.getSnapshot().context.value,
+    })
+
+    await vi.waitFor(() => {
+      expect(editorB.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: spanKey, _type: 'span', text: 'foo', marks: ['k4']},
+          ],
+          markDefs: [{_key: 'k4', _type: 'link', href: 'https://example.com'}],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})

--- a/packages/editor/tests/event.patch.test.tsx
+++ b/packages/editor/tests/event.patch.test.tsx
@@ -697,7 +697,7 @@ describe('event.patch', () => {
         ]),
         set([], [{_key: blockKey}, 'children', {_key: span2Key}, 'marks']),
         unset([{_key: blockKey}, 'children', {_key: span2Key}]),
-        set([], [{_key: blockKey}, 'markDefs']),
+        unset([{_key: blockKey}, 'markDefs', {_key: linkKey}]),
         unset([]),
       ].map((patch) => ({...patch, origin: 'local'})),
     )

--- a/packages/editor/tests/overlapping-annotations.test.tsx
+++ b/packages/editor/tests/overlapping-annotations.test.tsx
@@ -142,20 +142,21 @@ describe('overlapping annotations', () => {
       }
 
       expect(block.markDefs).toEqual([
+        expect.objectContaining({
+          _type: 'comment',
+          text: 'Comment B',
+        }),
         {
           _key: commentKey,
           _type: 'comment',
           text: 'Comment A',
         },
-        expect.objectContaining({
-          _type: 'comment',
-          text: 'Comment B',
-        }),
       ])
 
-      expect(getTextMarks(editor.getSnapshot().context, 'bar')).toEqual(
-        block.markDefs?.map((markDef) => markDef._key),
-      )
+      expect(getTextMarks(editor.getSnapshot().context, 'bar')).toEqual([
+        commentKey,
+        block.markDefs?.at(0)?._key,
+      ])
     })
   })
 
@@ -258,11 +259,11 @@ describe('overlapping annotations', () => {
       expect(block.markDefs).toEqual([
         expect.objectContaining({
           _type: 'link',
-          href: 'https://portabletext.org',
+          href: 'https://sanity.io',
         }),
         expect.objectContaining({
           _type: 'link',
-          href: 'https://sanity.io',
+          href: 'https://portabletext.org',
         }),
       ])
     })

--- a/packages/editor/tests/self-solving.test.tsx
+++ b/packages/editor/tests/self-solving.test.tsx
@@ -44,7 +44,7 @@ describe('Feature: Self-solving', () => {
       origin: 'local',
     }
     const blockPatch: Patch = {
-      type: 'set',
+      type: 'setIfMissing',
       path: [{_key: blockKey}, 'markDefs'],
       value: [],
       origin: 'local',
@@ -793,7 +793,7 @@ describe('Feature: Self-solving', () => {
         },
         {
           origin: 'local',
-          type: 'set',
+          type: 'setIfMissing',
           path: [{_key: 'k5'}, 'markDefs'],
           value: [],
         },

--- a/packages/editor/tests/unique-sibling-keys.test.tsx
+++ b/packages/editor/tests/unique-sibling-keys.test.tsx
@@ -321,8 +321,8 @@ describe('unique sibling `_key`s', () => {
             {_type: 'span', _key: 'k7', text: 'bar', marks: ['k6']},
           ],
           markDefs: [
-            {_key: linkKey, _type: 'link', href: 'https://sanity.io'},
             {_key: 'k6', _type: 'link', href: 'https://sanity.io'},
+            {_key: linkKey, _type: 'link', href: 'https://sanity.io'},
           ],
           style: 'normal',
         },

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
@@ -326,6 +326,39 @@ describe(toMergeableMarkDefsPatches.name, () => {
     },
   ] as unknown as PortableTextBlock[]
 
+  test('keyed unsets of store-referenced definitions are dropped', () => {
+    expect(
+      toMergeableMarkDefsPatches(
+        [
+          {
+            type: 'unset',
+            path: [{_key: 'b1'}, 'markDefs', {_key: 'm1'}],
+          },
+        ],
+        () => storeValue,
+      ),
+    ).toEqual([])
+  })
+
+  test('keyed unsets of unreferenced definitions pass through', () => {
+    expect(
+      toMergeableMarkDefsPatches(
+        [
+          {
+            type: 'unset',
+            path: [{_key: 'b1'}, 'markDefs', {_key: 'm2'}],
+          },
+        ],
+        () => storeValue,
+      ),
+    ).toEqual([
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'markDefs', {_key: 'm2'}],
+      },
+    ])
+  })
+
   test('new definitions become inserts', () => {
     expect(
       toMergeableMarkDefsPatches(

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -400,6 +400,51 @@ export function toMergeableMarkDefsPatches(
 ): PtePatch[] {
   return patches.flatMap((patch): PtePatch[] => {
     if (
+      patch.type === 'unset' &&
+      patch.path.length >= 2 &&
+      patch.path.at(-2) === 'markDefs'
+    ) {
+      // The editor emits item-keyed `markDefs` unsets (normalization
+      // pruning definitions its spans no longer reference). The same
+      // referenced-keys guard as below applies: a diverged client prunes
+      // definitions the store's spans still reference, which would
+      // orphan the other client's marks. Dropping the unset leaves an
+      // unused definition behind at worst; normalization on a later
+      // converged session prunes it for real.
+      const keySegment = patch.path.at(-1)
+      const definitionKey =
+        typeof keySegment === 'object' &&
+        keySegment !== null &&
+        '_key' in keySegment
+          ? keySegment._key
+          : undefined
+
+      if (definitionKey !== undefined) {
+        const currentValue = getCurrentValue()
+        const storeBlock = currentValue
+          ? getValueAtPath(
+              currentValue as unknown as JSONValue,
+              patch.path.slice(0, -2),
+            )
+          : undefined
+
+        if (typeof storeBlock === 'object' && storeBlock !== null) {
+          const referencedKeys = new Set(
+            (
+              (storeBlock as {children?: Array<{marks?: string[]}>}).children ??
+              []
+            ).flatMap((child) => child.marks ?? []),
+          )
+          if (referencedKeys.has(definitionKey)) {
+            return []
+          }
+        }
+      }
+
+      return [patch]
+    }
+
+    if (
       patch.type !== 'set' ||
       patch.path.at(-1) !== 'markDefs' ||
       !Array.isArray(patch.value)


### PR DESCRIPTION
**Stacks on #2983 (undo-step boundaries) and #2984 (plugin guard).** The first two commits here are those PRs verbatim and disappear on rebase once they merge; review only the last commit in this PR. Both are extracted because they merge independently: #2983 fixes latent undo bugs reachable on `main` today, and #2984 must release ahead of this PR's editor change (the plugin's published `^7.x` peer range accepts the new emission, so a consumer upgrading the editor without the plugin would otherwise run the orphan race unguarded).

Two clients annotating the same block concurrently silently destroy each other's work: client A adds a comment annotation, client B links a word in the same block, and whoever flushes last wins. The loser's definition vanishes from the stored document while both clients' span `marks` references survive, leaving marks pointing at definitions that no longer exist. The concrete driver is the operational patch channel in #2977, which compensates for this outgoing shape channel-side (`toMergeableMarkDefsPatches`); fixing the emission in the engine pays for every multi-writer consumer at once, including two Studio users on the same block.

The granularity was lost at the operation level: every `markDefs` mutation funneled through `setNodeProperties`, which applies one `set` operation carrying the whole array, and patch generation echoed it verbatim. An earlier iteration of this PR fixed the symptom in the operation-to-patch layer by diffing the pre-apply value, but that reconstructs intent the operation sites had precisely and then erased, a translation layer compensating for the layer above it. The shipped shape moves the fix to the sites: `annotation.add` and the block-merge path in `insert.block` apply keyed `insert` operations, and the normalizer's unused-definition prune applies keyed `unset`s. The engine's sidecar routing (shipped in #2974 for remote patches) applies these locally unchanged, and now also computes item-keyed inverses so undo emits mergeable patches too instead of restoring whole arrays. Patch generation shrinks to mechanical representation changes, with the invariant pinned in a header comment: never diff sibling state to reconstruct intent here; if a patch needs more than the operation expresses, the operation site is emitting the wrong operation. One translation remains by necessity: normalization's ensure-`markDefs`-exists `set([], ...)` becomes `setIfMissing`, because no operation vocabulary carries ensure-exists intent, and a whole-array set of `[]` would clobber concurrent writers on documents that lack the property.

Inserts anchor on index 0 rather than on an existing definition's key: a keyed anchor diffed against this engine's state may no longer exist at the server by application time (the same divergence lesson as the repair-path discussion on #2977), while index 0 always resolves and `markDefs` order carries no meaning. New definitions therefore prepend instead of append, a value-visible order change pinned by re-pinned tests in `overlapping-annotations` and `unique-sibling-keys`. Explicit whole-array writes through `block.set` still emit a whole-array `set` (whole-property intent from a public API, and duplicate-key arrays, which the dedupe rule exists for, are inexpressible item-level).

Removing the always-applied whole-array set unmasked two latent history bugs, fixed in their own commit. The `isNoOp` early-return in the history subscriber advanced `previousUndoStepId`, so a no-op leading a new undo step consumed the step boundary and a single undo reverted more than one step's worth of changes. And a step's pre-state selection was captured from the first history-affecting operation, by which time operation implementations may have parked the selection on transient nodes their own step removes again; the engine now snapshots `undoStepSelection` when the undo step ID is minted. Both were masked on `main` because the redundant `markDefs` set reached the history subscriber first, creating the boundary and capturing the selection while it was still resolvable. The `event.history.undo`/`event.history.redo` suites pin the corrected behavior.

The third commit extends `plugin-sdk-value`'s referenced-keys guard to the new patch shape. The editor's keyed prune unsets passed through `toMergeableMarkDefsPatches` untouched, bypassing the guard that previously protected decomposed whole-array sets, and a diverged client could prune a definition the store's spans still reference, exactly the orphaned-mark failure the collision-matrix link scenarios caught (`orphan mark (no markDef)`). Keyed `markDefs` unsets now go through the same store-side check; a dropped prune leaves an unused definition behind at worst, which a later converged session's normalization removes. The full collision matrix and the two-client rig pass on the new emission.

The emit-to-apply round trip is pinned by the browser scenario "Emitted patches converge another editor on the same value" in `event.patch.markdefs.test.tsx`, and the ensure-exists translation by the `setNodePatch` unit matrix. The 12 existing tests pinning whole-array shapes are re-pinned; the remaining editor suites (857 unit, 1733 browser) and all `plugin-sdk-value` suites (192 across chromium, firefox and webkit) pass.

The one deliberately unsolved residual: the prune-vs-concurrent-reference race is inherent to `marks` being string references into a separate array, and fully closing it engine-side needs store knowledge the engine lacks. The channel-side guard covers the SDK path; deferred pruning as a general mechanism is tracked separately as a follow-up.
