### PR TITLE
fix: keep leading no-op operations from consuming undo-step boundaries

### DIFF
--- a/.changeset/undo-step-boundaries.md
+++ b/.changeset/undo-step-boundaries.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep leading no-op operations from consuming undo-step boundaries
+
+A single undo could revert more than the most recent edit: when an editing flow's first operation was one that doesn't affect history (a zero-length text change, or an operation without an inverse), the following operations merged into the previous undo step. Undo now reverts exactly one step.
+
+Undo also restores the selection from before the step as it was when the edit began, instead of a mid-flow selection that may reference nodes the undo itself removes (which dropped the cursor entirely).

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -101,6 +101,7 @@ export function performEvent({
 
   if (mode === 'send' && !isNativeBehaviorEvent(event)) {
     editor.undoStepId = defaultKeyGenerator()
+    editor.undoStepSelection = editor.snapshot.context.selection
   }
 
   if (debug.behaviors.enabled) {
@@ -270,6 +271,7 @@ export function performEvent({
       if (actionSetIndex > 0) {
         // Since there are multiple action sets
         editor.undoStepId = defaultKeyGenerator()
+        editor.undoStepSelection = editor.snapshot.context.selection
 
         undoStepCreated = true
       }
@@ -283,6 +285,7 @@ export function performEvent({
         // All actions performed recursively from now will be squashed into this
         // undo step
         editor.undoStepId = defaultKeyGenerator()
+        editor.undoStepSelection = editor.snapshot.context.selection
 
         undoStepCreated = true
       }

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -74,6 +74,7 @@ export function createEditorEngine(
   editor.verifiedUniqueChildGroups = new Set<string>()
   editor.remotePatches = []
   editor.undoStepId = undefined
+  editor.undoStepSelection = null
 
   editor.isDeferringMutations = false
   editor.lastSyncedValue = undefined

--- a/packages/editor/src/editor/subscriber.history.ts
+++ b/packages/editor/src/editor/subscriber.history.ts
@@ -100,7 +100,11 @@ export function subscribeHistory({
         operation.text.length === 0)
 
     if (isNoOp) {
-      previousUndoStepId = currentUndoStepId
+      // Deliberately not advancing `previousUndoStepId`: it tracks the
+      // last operation that affected history. Advancing it here would
+      // let a no-op leading a new undo step consume the step boundary,
+      // and the following real operations would merge into the previous
+      // step (undoing more than the last step's worth of changes).
       return
     }
 
@@ -118,7 +122,16 @@ export function subscribeHistory({
       previousUndoStepId,
       operationsInProgress: event.operationsInProgress,
       isNormalizingNode: event.isNormalizingNode,
-      selectionBeforeApply: event.beforeSelection,
+      // When this operation opens a new undo step, the step's pre-state
+      // selection is the one snapshotted when the undo step ID was
+      // minted: operation implementations may park the selection on
+      // transient nodes (removed again within the same step) before the
+      // first history-affecting operation applies.
+      selectionBeforeApply:
+        currentUndoStepId !== undefined &&
+        currentUndoStepId !== previousUndoStepId
+          ? editor.undoStepSelection
+          : event.beforeSelection,
     })
 
     // Make sure we don't exceed the maximum number of undo steps we want

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -11,6 +11,7 @@ import type {
   TextBlockConfig,
 } from '../renderers/renderer.types'
 import type {ResolvedContainers} from '../schema/resolve-containers'
+import type {EditorSelection} from './editor'
 
 type HistoryItem = {
   operations: EngineOperation[]
@@ -77,6 +78,13 @@ export interface PortableTextEditorEngine extends DOMEditor {
   verifiedUniqueChildGroups: Set<string>
   remotePatches: Array<RemotePatch>
   undoStepId: string | undefined
+  /**
+   * Engine selection snapshotted when `undoStepId` is minted. The step's
+   * pre-state selection for undo: by the time the first history-affecting
+   * operation applies, operation implementations may have parked the
+   * selection on transient nodes their own step removes again.
+   */
+  undoStepSelection: EditorSelection
 
   isDeferringMutations: boolean
   /**

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -16,6 +16,99 @@ import type {EditorSelection} from '../src/types/editor'
 import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.undo', () => {
+  test('Scenario: Undoing a `child.set` that replaces an empty span\u2019s text', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const filledBlockKey = keyGenerator()
+    const filledSpanKey = keyGenerator()
+    const emptyBlockKey = keyGenerator()
+    const emptySpanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior<{text: string}>({
+              on: 'custom.insert text',
+              actions: [
+                ({event}) => [execute({type: 'insert.text', text: event.text})],
+              ],
+            }),
+            defineBehavior<{text: string}>({
+              on: 'custom.replace empty span',
+              actions: [
+                ({event}) => [
+                  execute({
+                    type: 'child.set',
+                    at: [
+                      {_key: emptyBlockKey},
+                      'children',
+                      {_key: emptySpanKey},
+                    ],
+                    props: {text: event.text},
+                  }),
+                ],
+              ],
+            }),
+          ]}
+        />
+      ),
+      initialValue: [
+        {
+          _key: filledBlockKey,
+          _type: 'block',
+          children: [
+            {_key: filledSpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: emptyBlockKey,
+          _type: 'block',
+          children: [{_key: emptySpanKey, _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: filledBlockKey}, 'children', {_key: filledSpanKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: filledBlockKey}, 'children', {_key: filledSpanKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'custom.insert text', text: '!'})
+
+    // Replacing an empty span's text leads with a zero-length
+    // `remove.text`, an operation that doesn't affect history. The
+    // following `insert.text` must still open its own undo step instead
+    // of merging into the previous one.
+    editor.send({type: 'custom.replace empty span', text: 'bar'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo!|', 'B: bar'].join('\n'),
+      )
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo!|', 'B: '].join('\n'),
+      )
+    })
+  })
+
   test('Scenario: Undoing action sets', async () => {
     const {editor, locator} = await createTestEditor({
       children: (


### PR DESCRIPTION
A single undo can revert more than the most recent edit. The history subscriber's `isNoOp` early-return (operations without an inverse, zero-length text operations) advanced `previousUndoStepId` before bailing, so a no-op leading a new undo step consumed the step boundary: the next history-affecting operation saw `currentUndoStepId === previousUndoStepId` and merged into the previous step. One undo then reverted two edits' worth of changes. `previousUndoStepId` now only advances for operations that reach `createUndoSteps`, since its job is to track the last operation that affected history.

This is reachable on `main` through public API: `child.set` replacing a span's text leads with a `remove.text` of the old text, which is zero-length when the span was empty. The new scenario "Undoing a `child.set` that replaces an empty span's text" pins it: two edits through `execute` actions, one undo, only the second edit reverts. On `main` the same test fails with both edits reverted. The producer isn't unique to `child.set`: `applySplitNode` emits an unguarded zero-length `remove.text` when splitting a span at its end, which the annotation and block-merge flows reach today, masked only because an unconditionally applied whole-array `markDefs` set happens to hit the history subscriber first. #2982 removes that masking operation, which is how both defects surfaced; it stacks on this.

The same masking hid a second defect: a step's pre-state selection was captured from the first history-affecting operation's `beforeSelection`, but operation implementations can park the selection on transient nodes (created and removed within the same step) before that operation applies. Undo then restored a selection that no longer resolves and the cursor disappeared. The engine now snapshots its selection as `undoStepSelection` at the moment `editor.undoStepId` is minted, and the history subscriber uses that snapshot as the pre-state selection whenever an operation opens a new step. This half is exercised without the mask by the custom-event undo scenarios in #2982; on `main` no unmasked flow reaches it, so its pin lives there.

Net behavior unchanged for flows whose steps begin with a history-affecting operation; the full unit and browser suites pass without modification.
