### PR TITLE
fix(plugin-sdk-value): guard keyed `markDefs` unsets against store-referenced definitions

### DIFF
--- a/.changeset/guard-keyed-markdefs-unsets.md
+++ b/.changeset/guard-keyed-markdefs-unsets.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: guard outgoing keyed `markDefs` unsets against store-referenced definitions
+
+An upcoming `@portabletext/editor` release prunes unused annotation definitions as item-keyed `unset` patches instead of whole-array sets. A client that has diverged from the store can prune a definition the store's spans still reference, which would orphan another client's annotation. Outgoing keyed `markDefs` unsets are now dropped while the store's spans reference the definition, mirroring the existing guard on decomposed whole-array sets; at worst an unused definition lingers until a later converged session prunes it. Against current editor releases the guard is inert.

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
@@ -326,6 +326,39 @@ describe(toMergeableMarkDefsPatches.name, () => {
     },
   ] as unknown as PortableTextBlock[]
 
+  test('keyed unsets of store-referenced definitions are dropped', () => {
+    expect(
+      toMergeableMarkDefsPatches(
+        [
+          {
+            type: 'unset',
+            path: [{_key: 'b1'}, 'markDefs', {_key: 'm1'}],
+          },
+        ],
+        () => storeValue,
+      ),
+    ).toEqual([])
+  })
+
+  test('keyed unsets of unreferenced definitions pass through', () => {
+    expect(
+      toMergeableMarkDefsPatches(
+        [
+          {
+            type: 'unset',
+            path: [{_key: 'b1'}, 'markDefs', {_key: 'm2'}],
+          },
+        ],
+        () => storeValue,
+      ),
+    ).toEqual([
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'markDefs', {_key: 'm2'}],
+      },
+    ])
+  })
+
   test('new definitions become inserts', () => {
     expect(
       toMergeableMarkDefsPatches(

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -447,6 +447,51 @@ export function toMergeableMarkDefsPatches(
 ): PtePatch[] {
   return patches.flatMap((patch): PtePatch[] => {
     if (
+      patch.type === 'unset' &&
+      patch.path.length >= 2 &&
+      patch.path.at(-2) === 'markDefs'
+    ) {
+      // The editor emits item-keyed `markDefs` unsets (normalization
+      // pruning definitions its spans no longer reference). The same
+      // referenced-keys guard as below applies: a diverged client prunes
+      // definitions the store's spans still reference, which would
+      // orphan the other client's marks. Dropping the unset leaves an
+      // unused definition behind at worst; normalization on a later
+      // converged session prunes it for real.
+      const keySegment = patch.path.at(-1)
+      const definitionKey =
+        typeof keySegment === 'object' &&
+        keySegment !== null &&
+        '_key' in keySegment
+          ? keySegment._key
+          : undefined
+
+      if (definitionKey !== undefined) {
+        const currentValue = getCurrentValue()
+        const storeBlock = currentValue
+          ? getValueAtPath(
+              currentValue as unknown as JSONValue,
+              patch.path.slice(0, -2),
+            )
+          : undefined
+
+        if (typeof storeBlock === 'object' && storeBlock !== null) {
+          const referencedKeys = new Set(
+            (
+              (storeBlock as {children?: Array<{marks?: string[]}>}).children ??
+              []
+            ).flatMap((child) => child.marks ?? []),
+          )
+          if (referencedKeys.has(definitionKey)) {
+            return []
+          }
+        }
+      }
+
+      return [patch]
+    }
+
+    if (
       patch.type !== 'set' ||
       patch.path.at(-1) !== 'markDefs' ||
       !Array.isArray(patch.value)


### PR DESCRIPTION
Preparatory extraction from #2982, which changes the editor to emit normalization's unused-annotation-definition prunes as item-keyed `unset` patches instead of whole-array `markDefs` sets. Under that emission, a client that has diverged from the store (its span `marks` overwritten by another client's flush, its own definition now locally unused) prunes a definition the store's spans still reference. `toMergeableMarkDefsPatches` only decomposes whole-array sets, so the keyed unset passed through without the referenced-keys guard and orphaned the other client's annotation at the server; the collision-matrix link scenarios in this package caught exactly that (`orphan mark (no markDef)`) when run against #2982's emission.

Keyed `markDefs` unsets now route through the same store-side referenced-keys check as decomposed whole-array sets, and are dropped while the store's spans reference the definition. A dropped prune leaves an unused definition behind at worst, which normalization in a later converged session removes for real, strictly better than a dangling mark.

This lands and releases ahead of #2982 because of the published peer range: the plugin's `^7.x` peer accepts an editor with the new emission, so a consumer upgrading `@portabletext/editor` without upgrading this plugin would run the orphan race with no guard. Shipping the guard first closes that window. Against current editor releases the new branch is inert (keyed `markDefs` unsets don't occur), which is also why all suites here pass unchanged on `main`'s emission; the collision-matrix runs that exercise the guard live in #2982, which stacks on this.
