### PR TITLE
fix(plugin-sdk-value): stop dropping mutation flushes and stomping in-flight typing

### DIFF
--- a/.changeset/solo-typing-sync-fidelity.md
+++ b/.changeset/solo-typing-sync-fidelity.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: stop dropping mutation flushes and stomping in-flight typing during sync
+
+A single user typing (especially deleting and retyping) could see text
+reordered, duplicated, or resurrected. Two sync-machine bugs compounded:
+mutation flush events arriving in bursts were silently dropped by states
+without a handler, permanently diverging the store from the editor, and the
+whole-value repair ran while local edits were still in flight, diffing the
+editor against the lagging store and injecting stale text back into it.
+
+Every state now pushes mutation flushes, and the whole-value repair only
+runs when the editor is quiescent (on a store change while idle, plus a
+one-shot repair after a short idle delay).

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -555,6 +555,35 @@ export function scopeRemotePatches(
   return scoped
 }
 
+// Sync diagnostics, disabled unless `globalThis.__PTE_SYNC_DEBUG = true`
+// is set before load. Callers pass a thunk so detail computation is free
+// when the flag is off.
+function syncDebugEnabled(): boolean {
+  return (globalThis as {__PTE_SYNC_DEBUG?: boolean}).__PTE_SYNC_DEBUG === true
+}
+
+function syncDebug(kind: string, detail: () => Record<string, unknown>) {
+  if (syncDebugEnabled()) {
+    // biome-ignore lint/suspicious/noConsole: opt-in diagnostics channel
+    console.debug(`[pte-sync] ${kind} ${JSON.stringify(detail())}`)
+  }
+}
+
+function debugTextOf(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return ''
+  }
+  return value
+    .map((block) =>
+      Array.isArray((block as {children?: unknown}).children)
+        ? ((block as {children: Array<{text?: string}>}).children ?? [])
+            .map((child) => child.text ?? '')
+            .join('')
+        : '',
+    )
+    .join('\n')
+}
+
 function applySync({
   editor,
   getRemoteValue,
@@ -569,6 +598,13 @@ function applySync({
   }
 
   const snapshot = editor.getSnapshot().context.value
+  if (syncDebugEnabled()) {
+    const editorText = debugTextOf(snapshot)
+    const remoteText = debugTextOf(remoteValue)
+    if (editorText !== remoteText) {
+      syncDebug('applySync:texts-differ', () => ({editorText, remoteText}))
+    }
+  }
 
   let patches: PtePatch[]
   try {
@@ -586,6 +622,7 @@ function applySync({
   }
 
   if (patches.length) {
+    syncDebug('applySync:repair-patches', () => ({patches}))
     editor.send({type: 'patches', patches, snapshot})
 
     // Patch application is best-effort: the editor skips operations it
@@ -596,6 +633,10 @@ function applySync({
     // arbitrary divergence block by block.
     const valueAfterPatches = editor.getSnapshot().context.value
     if (diffValue(valueAfterPatches, remoteValue).length > 0) {
+      syncDebug('applySync:escalate-update-value', () => ({
+        editorText: debugTextOf(valueAfterPatches),
+        remoteText: debugTextOf(remoteValue),
+      }))
       editor.send({type: 'update value', value: remoteValue})
     }
   }
@@ -608,6 +649,10 @@ const listenToEditor = fromCallback<AnyEventObject, {editor: Editor}>(
     })
 
     const mutationSubscription = input.editor.on('mutation', (event) => {
+      syncDebug('event:mutation-flushed', () => ({
+        flushText: debugTextOf(event.value),
+        snapshotText: debugTextOf(input.editor.getSnapshot().context.value),
+      }))
       sendBack({
         type: 'mutation flushed',
         value: event.value,
@@ -639,6 +684,14 @@ const listenToRemotePatches = fromCallback<
     sendBack({type: 'remote patches received', patches})
   })
 })
+
+/**
+ * How long the machine must sit in 'idle' (no local keystrokes, no store
+ * events) before the one-shot whole-value repair runs. Long enough for the
+ * editor's external value snapshot to catch up after the last flush; short
+ * enough that residual divergence from concurrent editing heals promptly.
+ */
+const QUIESCENT_REPAIR_DELAY = 500
 
 const valueSyncMachine = setup({
   types: {
@@ -680,18 +733,11 @@ const valueSyncMachine = setup({
         getRemoteValue: context.getRemoteValue,
       })
     },
-    'defer then apply sync': ({context}) => {
-      queueMicrotask(() => {
-        applySync({
-          editor: context.editor,
-          getRemoteValue: context.getRemoteValue,
-        })
-      })
-    },
     'apply remote patches': ({context, event}) => {
       if (event.type !== 'remote patches received') {
         return
       }
+      syncDebug('apply-remote-patches', () => ({patches: event.patches}))
       const snapshot = context.editor.getSnapshot().context.value
       // The store already reflects this transaction, so it can serve as
       // the target for coalescing sidecar-array item operations (which
@@ -741,23 +787,50 @@ const valueSyncMachine = setup({
       }),
     },
   ],
-  // Operational patches from other clients apply immediately in every
-  // state; the editor merges them with any in-flight local changes.
-  // Application is best-effort, so each state also arranges a follow-up
-  // whole-value repair: immediately (deferred a microtask) when no local
-  // edits are in flight, or after the next mutation flush when they are.
+  // Two invariants, learned the hard way:
+  //
+  // 1. EVERY 'mutation flushed' event must be pushed, in every state. The
+  //    editor emits mutation events in bursts (one per input batch, e.g.
+  //    each backspace of a quick delete), and any state without a handler
+  //    silently drops the flush. A dropped flush permanently diverges the
+  //    store from the editor, and the whole-value repair then "heals" the
+  //    editor backwards, resurrecting deleted text.
+  // 2. The whole-value repair must only run when no local edits can be in
+  //    flight (quiescent 'idle'). Running it mid-typing diffs the editor
+  //    against a store that lags the user's keystrokes and stomps them.
+  //
+  // Operational patches from other clients still apply immediately in
+  // every state; the editor merges them with in-flight local changes.
   initial: 'idle',
   states: {
     'idle': {
+      // One-shot repair after a quiet period. Covers divergence left by
+      // best-effort patch application while local edits were in flight
+      // (those states never repair; see below) when no further store
+      // event arrives to trigger the on-change repair.
+      after: {
+        [QUIESCENT_REPAIR_DELAY]: {
+          actions: ['apply sync'],
+        },
+      },
       on: {
         'patch emitted': {
           target: 'local write',
         },
+        // Mutation events arrive in bursts (one per input batch), so a
+        // flush can land after a sibling flush already advanced the state.
+        'mutation flushed': {
+          target: 'pushing to remote',
+          actions: ['push to remote'],
+        },
         'remote value changed': {
           actions: ['apply sync'],
         },
+        // No immediate repair here: every remote patch batch also updates
+        // the store value, so the accompanying 'remote value changed'
+        // event runs the whole-value repair right after.
         'remote patches received': {
-          actions: ['apply remote patches', 'defer then apply sync'],
+          actions: ['apply remote patches'],
         },
       },
     },
@@ -782,11 +855,19 @@ const valueSyncMachine = setup({
         'patch emitted': {
           target: 'local write',
         },
+        'mutation flushed': {
+          actions: ['push to remote'],
+        },
+        // No repair on the push acknowledgment: the editor snapshot can
+        // lag the live document while the user keeps typing, so a diff
+        // against the store here resurrects deleted text and duplicates
+        // in-flight keystrokes. Once truly idle, the store change or the
+        // quiescent delay runs the repair with a caught-up snapshot.
         'remote value changed': {
           target: 'idle',
         },
         'remote patches received': {
-          actions: ['apply remote patches', 'defer then apply sync'],
+          actions: ['apply remote patches'],
         },
       },
     },
@@ -795,7 +876,7 @@ const valueSyncMachine = setup({
         'patch emitted': {},
         'mutation flushed': {
           target: 'pushing to remote',
-          actions: ['push to remote', 'defer then apply sync'],
+          actions: ['push to remote'],
         },
         'remote value changed': {},
         'remote patches received': {
@@ -977,18 +1058,23 @@ export function ValueSyncPlugin(props: ValueSyncConfig) {
 
           if (pushPatches && event.patches.length > 0) {
             try {
-              pushPatches(
-                toMergeableMarkDefsPatches(
-                  event.patches,
-                  context.getRemoteValue,
-                ),
+              const mergeable = toMergeableMarkDefsPatches(
+                event.patches,
+                context.getRemoteValue,
               )
+              syncDebug('push-patches', () => ({patches: mergeable}))
+              pushPatches(mergeable)
               return
             } catch {
               // fall back to pushing the whole value below
             }
           }
 
+          syncDebug('push-whole-value', () => ({
+            text: debugTextOf(
+              event.value ?? context.editor.getSnapshot().context.value,
+            ),
+          }))
           pushValue(event.value ?? context.editor.getSnapshot().context.value)
         },
       },

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -8,7 +8,7 @@ import {createTestKeyGenerator} from '@portabletext/test'
 import {createRef} from 'react'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {page} from 'vitest/browser'
+import {page, userEvent} from 'vitest/browser'
 import {ValueSyncPlugin} from './plugin.sdk-value'
 
 // ---- Mock value store ----
@@ -223,6 +223,76 @@ describe('ValueSyncPlugin', () => {
           selection: null,
         }),
       ).toEqual('B: Hello')
+    })
+  })
+
+  describe('solo typing fidelity', () => {
+    // Field regression: a single user typing with delete-and-retype bursts
+    // saw text reordered and duplicated. Two machine bugs compounded:
+    // 'mutation flushed' events arriving in bursts were dropped by states
+    // without a handler (their patches never pushed, so the store diverged),
+    // and the whole-value repair ran while local edits were in flight,
+    // diffing the editor against the diverged store and resurrecting
+    // deleted text. This test types in bursts that straddle flush timing
+    // and requires the editor, the store, and the expected text to agree.
+    test('delete-and-retype bursts converge to exactly what was typed', async () => {
+      const store = createMockPatchStore([])
+      const {editor, locator, unmount} = await createSyncedEditor({store})
+      cleanup = unmount
+
+      await vi.waitFor(() => {
+        expect(getEditorText(editor)).toEqual('B: |')
+      })
+      // Real key events matter here: each keystroke is its own operation,
+      // so a flush emits one mutation event per pending operation — the
+      // burst that used to hit states without a 'mutation flushed' handler.
+      // `editor.send` events coalesce into a single bulk and cannot
+      // reproduce the burst.
+      await userEvent.click(locator)
+
+      const settle = (ms: number) => new Promise((r) => setTimeout(r, ms))
+      const backspace = async (count: number) => {
+        for (let i = 0; i < count; i++) {
+          await userEvent.keyboard('{Backspace}')
+        }
+      }
+
+      // Interleave typing, deletes, and retypes across flush windows (the
+      // test-mode flush interval is 500ms, the typing debounce 250ms)
+      // without waiting for convergence in between.
+      await userEvent.type(locator, 'publish editors ')
+      await settle(300)
+      await userEvent.type(locator, 'deadline ')
+      await backspace(5)
+      await settle(120)
+      await userEvent.type(locator, 'line ')
+      await settle(300)
+      await userEvent.type(locator, 'sources ')
+      await backspace(8)
+      await settle(550)
+      await userEvent.type(locator, 'sources ')
+      await userEvent.type(locator, 'context')
+      await settle(120)
+      await backspace(3)
+      await settle(300)
+      await userEvent.type(locator, 'ext')
+
+      const expectedEditor = 'B: publish editors deadline sources context|'
+      const expectedStore = 'B: publish editors deadline sources context'
+
+      await vi.waitFor(
+        () => {
+          expect(getEditorText(editor)).toEqual(expectedEditor)
+          expect(
+            toTextspec({
+              value: store.getValue(),
+              schema: editor.getSnapshot().context.schema,
+              selection: null,
+            }),
+          ).toEqual(expectedStore)
+        },
+        {timeout: 5000},
+      )
     })
   })
 


### PR DESCRIPTION
## The bug

A single user typing normally, no collaboration involved, could see their text reordered, duplicated, or resurrected, most visibly after deleting a few characters and retyping them. The editor and the server converge on the mangled result, so it looks like this:

```
typed:  "...briefing exclusive sanity context briefing reporting briefing"
result: "...briefing exclusive e sanity context text briefing reing porting briefingfing"
```

Reported in the field against `@sanity/sdk-react@2.18.0` + `@portabletext/plugin-sdk-value@7.1.0` (video showed text going out of order while one person typed). Reproduced locally with a Playwright driver that types through the contenteditable with human keystroke timing and delete-and-retype bursts: **6 of 6 trials mangled** on those versions. The old whole-value plugin (7.0.34) mangled 1 of 4 trials with the same gesture, so this predates the patch channel but the patch channel made it consistent.

## Root cause

Two sync-machine bugs compounding (instrumented traces in the investigation showed both):

1. **Dropped mutation flushes.** The editor emits `mutation` events in bursts, one per pending operation, so a quick backspace run produces several flush events back to back. The machine only handled `mutation flushed` in `local write` and `pending sync`. A flush arriving in `pushing to remote` or `idle` (the very next event in a burst) was silently dropped: its patches never reached the store, and the store diverged from the editor permanently. The patch channel is more sensitive to this than the old plugin, because a whole-value push self-heals drift on the next flush while incremental patches accumulate it.

2. **Mid-typing whole-value repair.** The machine ran its editor-versus-store repair diff immediately after flushes (`defer then apply sync`) and on remote patch arrivals, while the user was still typing. Diffing against a store that lags the user's keystrokes (or has drifted per bug 1) injects the difference back into the editor as fake remote patches: it resurrects text the user just deleted and re-asserts stale word suffixes ("deadline" + "dline", "editors" + "s"). The next flush pushes the corruption to the server, and both sides converge on the mangled text.

## The fix

- `mutation flushed` now pushes in **every** state, so no flush is ever dropped.
- The whole-value repair only runs when the editor is quiescent: on a store change while `idle`, plus a one-shot repair after a short idle delay (500ms) to heal residual divergence from concurrent editing when no further store event arrives. All mid-typing repair triggers are removed.
- An opt-in sync diagnostics channel stays behind `globalThis.__PTE_SYNC_DEBUG` (zero cost when off); it is what made the traces above possible.

## Tests

- New browser regression test (`plugin.value-sync.browser.test.tsx`): drives real keystrokes via `userEvent` (each key its own operation, which is what produces the flush bursts), performs the delete-and-retype gesture across flush windows without waiting for convergence, and requires the editor, the store, and a keystroke-perfect expected text to all agree. Gate-checked: it fails on the previous machine in chromium, firefox, and webkit with the exact duplication signature from the field report, and passes with the fix.
- Full package suite green: 199 tests across all three browsers, types, lint, build.

## Verification beyond the unit level

Against real Content Lake with the external two-client harness (sanity-labs/pte-sdk-concurrent-repro):

- Solo-typing driver: 6/6 SAFE standalone and 6/6 SAFE embedded in a Studio tool (was 6/6 mangled).
- Full 17-scenario concurrent matrix: all typing/delete scenarios SAFE, 0 crashes, 0 server-document corruption; overlapping-formatting soft-loss rates unchanged. The repair-timing change does not regress two-client convergence.
- Verified end to end in the SDK kitchensink app against this build.

Independent of #2985 (different files); both can land in either order.
