### PR TITLE
fix: require covered text for `isActiveAnnotation`'s `'partial'` mode on expanded selections

### DIFF
--- a/.changeset/partial-annotation-covered-text.md
+++ b/.changeset/partial-annotation-covered-text.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: require covered text for `isActiveAnnotation`'s `'partial'` mode on expanded selections
+
+`isActiveAnnotation(name, {mode: 'partial'})` reported the annotation active when an expanded selection merely touched it at a zero-width boundary, selecting none of its text. It now answers true only when the selection covers at least one character of an annotated span, matching the documented "partially selected" contract.
+
+For collapsed selections the two modes now share the editor's canonical caret answer: active with the caret inside an annotated span, not active at its edges, matching typing semantics (annotations don't expand at their edges). Previously `'partial'` also counted a caret sitting exactly on an annotation's boundary.
+
+Behaviors built on the selector inherit the correction: adding an annotation with a selection that only borders an existing one no longer triggers the overlap-prevention removal cycle for that annotation.

--- a/packages/editor/src/selectors/selector.is-active-annotation.test.ts
+++ b/packages/editor/src/selectors/selector.is-active-annotation.test.ts
@@ -154,6 +154,168 @@ describe(isActiveAnnotation.name, () => {
   })
 
   describe('expanded selection', () => {
+    describe('selection touching the start of the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 0,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 0,
+            },
+          },
+        },
+      })
+
+      test('mode: full', () => {
+        expect(isActiveAnnotation('link')(snapshot)).toBe(false)
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          false,
+        )
+      })
+    })
+
+    describe('selection touching the end of the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 3,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: bazKey}],
+              offset: 4,
+            },
+          },
+        },
+      })
+
+      test('mode: full', () => {
+        expect(isActiveAnnotation('link')(snapshot)).toBe(false)
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          false,
+        )
+      })
+    })
+
+    describe('selection covering one character of the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 0,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 1,
+            },
+          },
+        },
+      })
+
+      test('mode: full', () => {
+        expect(isActiveAnnotation('link')(snapshot)).toBe(false)
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          true,
+        )
+      })
+    })
+
+    describe('collapsed selection in the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 1,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 1,
+            },
+          },
+        },
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          true,
+        )
+      })
+    })
+
+    describe('collapsed selection at the start of the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 0,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 0,
+            },
+          },
+        },
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          false,
+        )
+      })
+    })
+
+    describe('collapsed selection at the end of the annotation', () => {
+      const snapshot = createTestSnapshot({
+        context: {
+          schema,
+          value,
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 3,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: barKey}],
+              offset: 3,
+            },
+          },
+        },
+      })
+
+      test('mode: partial', () => {
+        expect(isActiveAnnotation('link', {mode: 'partial'})(snapshot)).toBe(
+          false,
+        )
+      })
+    })
+
     test('selection on the annotation', () => {
       const snapshot = createTestSnapshot({
         context: {

--- a/packages/editor/src/selectors/selector.is-active-annotation.ts
+++ b/packages/editor/src/selectors/selector.is-active-annotation.ts
@@ -1,8 +1,9 @@
-import {isTextBlock} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
 import type {EditorSelector} from '../editor/editor-selector'
 import {getActiveAnnotationsMarks} from './selector.get-active-annotation-marks'
 import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
 import {getSelectedValue} from './selector.get-selected-value'
+import {isSelectionExpanded} from './selector.is-selection-expanded'
 
 /**
  * Check whether an annotation is active in the given `snapshot`.
@@ -13,10 +14,13 @@ export function isActiveAnnotation(
   annotation: string,
   options?: {
     /**
-     * Choose whether the annotation has to take up the entire selection in the
-     * `snapshot` or if the annotation can be partially selected.
+     * Choose whether the annotation has to cover the entire selection
+     * (`'full'`) or whether the selection covering at least one character
+     * of the annotation suffices (`'partial'`). With a collapsed
+     * selection the modes agree: the annotation is active when the caret
+     * sits inside it, not at its edges.
      *
-     * Defaults to 'full'
+     * Defaults to `'full'`
      */
     mode?: 'partial' | 'full'
   },
@@ -24,16 +28,45 @@ export function isActiveAnnotation(
   return (snapshot) => {
     const mode = options?.mode ?? 'full'
 
-    if (mode === 'partial') {
+    if (mode === 'partial' && isSelectionExpanded(snapshot)) {
+      // An expanded selection "partially selects" the annotation when it
+      // covers at least one character of annotated text.
       const selectedValue = getSelectedValue(snapshot)
 
-      const selectionMarkDefs = selectedValue.flatMap((block) =>
-        isTextBlock(snapshot.context, block) ? (block.markDefs ?? []) : [],
-      )
+      return selectedValue.some((block) => {
+        if (!isTextBlock(snapshot.context, block)) {
+          return false
+        }
 
-      return selectionMarkDefs.some((markDef) => markDef._type === annotation)
+        const annotationKeys = new Set(
+          (block.markDefs ?? [])
+            .filter((markDef) => markDef._type === annotation)
+            .map((markDef) => markDef._key),
+        )
+
+        if (annotationKeys.size === 0) {
+          return false
+        }
+
+        return block.children.some(
+          (child) =>
+            isSpan(snapshot.context, child) &&
+            // Spans the selection only touches at a zero-width boundary
+            // survive the slice with empty text and intact `marks`,
+            // keeping their definitions alive through the slice's
+            // unused-definition pruning. A boundary touch selects nothing
+            // of the annotation, so those spans don't count.
+            child.text.length > 0 &&
+            child.marks?.some((mark) => annotationKeys.has(mark)),
+        )
+      })
     }
 
+    // `'partial'` with a collapsed selection falls through to here: a
+    // caret covers no characters, so the `'partial'`/`'full'` distinction
+    // is meaningless and both modes share the canonical caret answer this
+    // computes (active inside an annotated span, not at its edges, where
+    // typing doesn't extend the annotation either).
     const selectedBlocks = getSelectedTextBlocks(snapshot)
     const selectionMarkDefs = selectedBlocks.flatMap(
       (block) => block.node.markDefs ?? [],


### PR DESCRIPTION
`isActiveAnnotation(name, {mode: 'partial'})` reports an annotation active when an expanded selection merely touches it at a zero-width boundary, covering none of its text. The mode's implementation checks which `markDefs` survive `getSelectedValue`'s slice, and slicing prunes unused definitions, so its de-facto semantics are "a sliced span references a definition of this type". A span the selection only borders survives the slice with empty text and intact `marks`, keeping its definition alive. That violates the selector's documented contract ("the annotation can be partially selected": a boundary touch selects nothing), and it is fuel for non-terminating Behavior cycles: a guard built on `'partial'` keeps answering active while `annotation.remove` strips nothing from a boundary-touched span, which is one of the two recursion states #2985 diagnoses (the other, stale selection resolution, is that PR's own fix, along with the event-chain depth backstop).

For expanded selections the mode now requires at least one character of covered annotated text: a sliced span with non-empty text whose `marks` reference a definition of the type.

Collapsed selections get their own reasoning rather than the slice artifact they had: the partial/full distinction quantifies how much of the selection the annotation covers, which is meaningless at a caret, so `'partial'` now falls through to the same caret-activity machinery as `'full'`. Both modes give the editor's canonical caret answer: active inside an annotated span, not active at its edges, matching the already-pinned typing semantics (annotations don't expand at their edges). Previously `'partial'` counted a caret sitting exactly on an annotation's boundary as active, contradicting that canon. The alternative of making `'partial'` answer false for all collapsed selections was considered and rejected: the natural consumer of the mode is button state, and a button that goes dark when the selection collapses inside a link is a trap that would push every consumer into re-combining two modes by hand.

Extracted ahead of #2985 so the semantics fix lands on the public selector rather than beside it: after this merges, #2985's private `selectionCoversAnnotation` helper collapses into a plain `isActiveAnnotation(..., {mode: 'partial'})` call, and its collapsed/expanded branch also dissolves, since the selector now branches internally. The toolbar's `useMutuallyExclusiveAnnotation` also consumes `'partial'` and inherits the correction; unlike the core behavior it cannot recurse (its final action is `execute`, which bypasses the behavior chain), so what it gains is narrower: it stops raising a spurious no-op `annotation.remove` when the selection merely borders a mutually-exclusive annotation.

The boundary-touch and caret-edge pins in `selector.is-active-annotation.test.ts` fail on the previous implementation; the remaining unit (861) and browser (1730) suites pass without modification, so nothing outside those cases moves.
