### PR TITLE
fix(toolbar): forward `annotation.add` through the behavior chain in `useMutuallyExclusiveAnnotation`

### DIFF
--- a/.changeset/mutually-exclusive-annotation-forward.md
+++ b/.changeset/mutually-exclusive-annotation-forward.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/toolbar': patch
+---
+
+fix: let Core Behaviors expand collapsed selections before `useMutuallyExclusiveAnnotation` intercepts
+
+Adding an annotation whose toolbar schema type configures `mutuallyExclusive` silently did nothing when the selection was collapsed: the hook's behavior `execute`d the event before the Core Behavior that expands a collapsed selection to the caret word could run, so the operation annotated zero characters and the definition was pruned. An empty `mutuallyExclusive` array (deliberate config meaning "exclusive with nothing, same-type overlap allowed") hit the same path on every add.
+
+The behavior now declines collapsed selections: the Core Behavior expands them to the caret word and re-raises the add, which the hook then intercepts with the expanded selection. The configured exclusives are removed unconditionally (a no-op when inactive), and the event still `execute`s, preserving the design that the configured list fully replaces the default same-type exclusivity, an empty list keeps allowing same-type overlap.

--- a/apps/playground/src/toolbar/portable-text-toolbar.tsx
+++ b/apps/playground/src/toolbar/portable-text-toolbar.tsx
@@ -147,6 +147,8 @@ const extendAnnotation: ExtendAnnotationSchemaType = (annotation) => {
       defaultValues: {
         text: 'Consider rewriting this',
       },
+      // Deliberately empty: comments are exclusive with nothing, not
+      // even themselves, so they may overlap.
       mutuallyExclusive: [],
     }
   }

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:*",
+    "@portabletext/test": "workspace:*",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/react": "catalog:tooling",

--- a/packages/toolbar/src/use-mutually-exclusive-annotation.test.tsx
+++ b/packages/toolbar/src/use-mutually-exclusive-annotation.test.tsx
@@ -1,0 +1,301 @@
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {useMutuallyExclusiveAnnotation} from './use-mutually-exclusive-annotation'
+import type {ToolbarAnnotationSchemaType} from './use-toolbar-schema'
+
+const schemaDefinition = defineSchema({
+  annotations: [
+    {name: 'link', fields: [{name: 'href', type: 'string'}]},
+    {name: 'comment', fields: [{name: 'text', type: 'string'}]},
+    {name: 'highlight', fields: []},
+  ],
+})
+
+function commentSchemaType(
+  mutuallyExclusive: ReadonlyArray<string>,
+): ToolbarAnnotationSchemaType {
+  return {
+    name: 'comment',
+    fields: [{name: 'text', type: 'string'}],
+    mutuallyExclusive,
+  } as ToolbarAnnotationSchemaType
+}
+
+function MutuallyExclusiveProbe(props: {
+  schemaType: ToolbarAnnotationSchemaType
+}) {
+  useMutuallyExclusiveAnnotation({schemaType: props.schemaType})
+  return null
+}
+
+describe(useMutuallyExclusiveAnnotation.name, () => {
+  test('Scenario: Empty config does not bypass collapsed-selection expansion', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const bazKey = keyGenerator()
+    const linkKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      children: <MutuallyExclusiveProbe schemaType={commentSchemaType([])} />,
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: barKey, _type: 'span', text: 'bar', marks: [linkKey]},
+            {_key: bazKey, _type: 'span', text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_key: linkKey, _type: 'link', href: 'https://example.com'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 1,
+        },
+      },
+    })
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'comment', value: {text: 'a comment'}},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: barKey, _type: 'span', text: 'bar', marks: [linkKey, 'k7']},
+            {_key: bazKey, _type: 'span', text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_key: linkKey, _type: 'link', href: 'https://example.com'},
+            {_key: 'k7', _type: 'comment', text: 'a comment'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Empty config allows overlapping same-type annotations', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      children: <MutuallyExclusiveProbe schemaType={commentSchemaType([])} />,
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: spanKey, _type: 'span', text: 'foo bar baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 7,
+        },
+      },
+    })
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'comment', value: {text: 'first'}},
+    })
+    // The first add only split at offset 7, so `spanKey` now holds
+    // "foo bar"; selecting "bar" inside it overlaps the first comment.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 4,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 7,
+        },
+      },
+    })
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'comment', value: {text: 'second'}},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: spanKey, _type: 'span', text: 'foo ', marks: ['k4']},
+            {_key: 'k7', _type: 'span', text: 'bar', marks: ['k4', 'k6']},
+            {_key: 'k5', _type: 'span', text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_key: 'k4', _type: 'comment', text: 'first'},
+            {_key: 'k6', _type: 'comment', text: 'second'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Adding over an active exclusive removes it and adds the annotation', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const highlightKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      children: (
+        <MutuallyExclusiveProbe schemaType={commentSchemaType(['highlight'])} />
+      ),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: barKey, _type: 'span', text: 'bar', marks: [highlightKey]},
+          ],
+          markDefs: [{_key: highlightKey, _type: 'highlight'}],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 0,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'comment', value: {text: 'a comment'}},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: 'k7', _type: 'span', text: 'bar', marks: ['k6']},
+          ],
+          markDefs: [{_key: 'k6', _type: 'comment', text: 'a comment'}],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Collapsed caret in an active exclusive still adds the annotation', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const highlightKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      children: (
+        <MutuallyExclusiveProbe schemaType={commentSchemaType(['highlight'])} />
+      ),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: barKey, _type: 'span', text: 'bar', marks: [highlightKey]},
+          ],
+          markDefs: [{_key: highlightKey, _type: 'highlight'}],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          offset: 1,
+        },
+      },
+    })
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'comment', value: {text: 'a comment'}},
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo ', marks: []},
+            {_key: barKey, _type: 'span', text: 'bar', marks: ['k7']},
+          ],
+          markDefs: [{_key: 'k7', _type: 'comment', text: 'a comment'}],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})

--- a/packages/toolbar/src/use-mutually-exclusive-annotation.ts
+++ b/packages/toolbar/src/use-mutually-exclusive-annotation.ts
@@ -1,6 +1,6 @@
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, execute, raise} from '@portabletext/editor/behaviors'
-import {isActiveAnnotation} from '@portabletext/editor/selectors'
+import {isSelectionExpanded} from '@portabletext/editor/selectors'
 import {useEffect} from 'react'
 import type {ToolbarAnnotationSchemaType} from './use-toolbar-schema'
 
@@ -13,6 +13,9 @@ export function useMutuallyExclusiveAnnotation(props: {
     const mutuallyExclusive = props.schemaType.mutuallyExclusive
 
     if (!mutuallyExclusive) {
+      // Absent config keeps the Core Behavior default (self-exclusive).
+      // An empty array is deliberate "exclusive with nothing" config and
+      // must fall through to register; see `mutuallyExclusive`'s docs.
       return
     }
 
@@ -24,21 +27,29 @@ export function useMutuallyExclusiveAnnotation(props: {
             return false
           }
 
-          const activeMutuallyExclusive = mutuallyExclusive.filter(
-            (annotation) =>
-              isActiveAnnotation(annotation, {mode: 'partial'})(snapshot),
-          )
-
-          return {activeMutuallyExclusive}
+          // Declining collapsed selections lets the Core Behavior expand
+          // them to the caret word and re-raise the add; the re-raised,
+          // now-expanded add re-enters this chain and passes this guard.
+          // Intercepting the collapsed add directly would `execute` past
+          // that expansion and annotate nothing.
+          return isSelectionExpanded(snapshot)
         },
         actions: [
-          ({event}, {activeMutuallyExclusive}) => [
-            ...activeMutuallyExclusive.map((annotation) =>
+          ({event}) => [
+            // Unconditional removes: removing an annotation that isn't
+            // active is a harmless no-op, while checking activity up
+            // front invites the guard-versus-operation disagreement that
+            // made `preventOverlappingAnnotations` recurse.
+            ...mutuallyExclusive.map((annotation) =>
               raise({
                 type: 'annotation.remove',
                 annotation: {name: annotation},
               }),
             ),
+            // `execute` (not `forward`) is deliberate: it skips the Core
+            // Behavior that makes same-type annotations mutually
+            // exclusive, so the configured list fully replaces the
+            // default. An empty list therefore allows same-type overlap.
             execute(event),
           ],
         ],

--- a/packages/toolbar/src/use-toolbar-schema.ts
+++ b/packages/toolbar/src/use-toolbar-schema.ts
@@ -134,6 +134,18 @@ export type ToolbarAnnotationSchemaType = AnnotationSchemaType & {
   icon?: React.ComponentType
   defaultValues?: Record<string, unknown>
   shortcut?: KeyboardShortcut
+  /**
+   * The annotations this annotation cannot coexist with. The list
+   * replaces the default rule that an annotation is mutually exclusive
+   * with itself:
+   *
+   * - Absent: the default applies (adding the annotation removes
+   *   existing annotations of the same type in the selection).
+   * - `[]`: exclusive with nothing, not even itself, so same-type
+   *   annotations may overlap.
+   * - `['other']`: exclusive with exactly the listed annotations.
+   *   Include the annotation's own name to keep self-exclusivity.
+   */
   mutuallyExclusive?: ReadonlyArray<AnnotationDefinition['name']>
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1559,6 +1559,9 @@ importers:
       '@portabletext/schema':
         specifier: workspace:*
         version: link:../schema
+      '@portabletext/test':
+        specifier: workspace:*
+        version: link:../test
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 10.8.2(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@6.0.3)
@@ -17851,7 +17854,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.10(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.25)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
In the playground, placing a collapsed caret inside a linked word and adding a comment annotation from the toolbar silently does nothing: no comment definition, no mark, no error. The `pte:behaviors` trace shows the fingerprint, `annotation.add` goes from `send:synthetic` straight to `execute:synthetic` with no raised `select`/`annotation.add` pair between, meaning the Core Behavior that expands a collapsed selection to the caret word never ran.

The bypass is `useMutuallyExclusiveAnnotation`, and half of it is by design. Its `execute(event)` deliberately skips the Core Behavior that makes same-type annotations mutually exclusive, so the configured `mutuallyExclusive` list fully replaces that default: an empty array is meaningful config ("exclusive with nothing"), it is what lets the playground's comments overlap each other. But `execute` skips all remaining behaviors indiscriminately, including the collapsed-selection caret-word expansion, so any add with a collapsed caret annotated zero characters and normalization pruned the unused definition. A guard truthiness defect widened the blast radius: it returned `{activeMutuallyExclusive}` even when the activity filter yielded `[]`, an always-truthy object, so the bypass fired on every add for the schema type, which is how the playground's empty-array config armed it.

The fix keeps `execute` and its exclusivity-replacement semantics and makes the guard decline collapsed selections. The Core Behavior then expands the collapsed selection to the caret word and re-raises the add; raised events re-enter the behavior chain from the top, so the hook intercepts the re-raised add with the expanded selection and both the expansion and the replacement semantics run. The activity filter is gone: the configured exclusives are removed unconditionally, removing an inactive annotation no-ops, and filtering by activity before a remove is the guard-versus-operation disagreement pattern that produced non-terminating chains in the core overlap behavior (#2985). This also deletes the hook's dependency on `isActiveAnnotation`'s `'partial'` mode.

Four scenarios in `use-mutually-exclusive-annotation.test.tsx` pin the contract: empty config with a collapsed caret in a linked word (the reported case), empty config allowing two overlapping same-type comments (the design's purpose), an expanded add over an active exclusive (exclusive removed, annotation applied), and a collapsed caret inside an active exclusive (removal and caret-word-expanded add both land). On the previous implementation exactly the two collapsed scenarios fail, matching the diagnosis that the bug was collapsed-only. The full toolbar suite passes, and the playground keeps its deliberate `mutuallyExclusive: []`, now with a comment explaining what it means.
