### PR TITLE
fix: route `plugin-sdk-value` sync diagnostics through the `debug` library

### DIFF
--- a/.changeset/sdk-value-debug-namespaces.md
+++ b/.changeset/sdk-value-debug-namespaces.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: route sync diagnostics through the `debug` library
+
+The sync diagnostics channel is now enabled with `localStorage.debug = 'pte:plugin-sdk-value:*'` (before load) instead of the `globalThis.__PTE_SYNC_DEBUG` flag, which is removed. The log kinds become individually filterable namespaces (`pte:plugin-sdk-value:repair`, `:push`, `:remote`, `:mutation`), and enabling `pte:*` interleaves them with the editor's own debug output on one timeline. The channel stays free when disabled.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -108,7 +108,7 @@
     "@portabletext/schema": "workspace:^",
     "@portabletext/to-html": "^5.0.2",
     "@xstate/react": "catalog:",
-    "debug": "^4.4.3",
+    "debug": "catalog:",
     "scroll-into-view-if-needed": "^3.1.0",
     "xstate": "catalog:"
   },
@@ -118,7 +118,7 @@
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@textspec/notation": "^1.0.2",
-    "@types/debug": "^4.1.12",
+    "@types/debug": "catalog:",
     "@types/node": "catalog:tooling",
     "@types/react": "catalog:tooling",
     "@types/react-dom": "catalog:tooling",

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -67,6 +67,7 @@
     "@sanity/diff-patch": "^6.0.0",
     "@sanity/json-match": "^1.0.5",
     "@xstate/react": "catalog:",
+    "debug": "^4.4.3",
     "xstate": "catalog:"
   },
   "devDependencies": {
@@ -78,6 +79,7 @@
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/sdk-react": "^2.13.0",
     "@sanity/tsconfig": "catalog:tooling",
+    "@types/debug": "^4.1.12",
     "@types/react": "catalog:tooling",
     "@types/react-dom": "catalog:tooling",
     "@vitejs/plugin-react": "catalog:tooling",

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -67,7 +67,7 @@
     "@sanity/diff-patch": "^6.0.0",
     "@sanity/json-match": "^1.0.5",
     "@xstate/react": "catalog:",
-    "debug": "^4.4.3",
+    "debug": "catalog:",
     "xstate": "catalog:"
   },
   "devDependencies": {
@@ -79,7 +79,7 @@
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/sdk-react": "^2.13.0",
     "@sanity/tsconfig": "catalog:tooling",
-    "@types/debug": "^4.1.12",
+    "@types/debug": "catalog:",
     "@types/react": "catalog:tooling",
     "@types/react-dom": "catalog:tooling",
     "@vitejs/plugin-react": "catalog:tooling",

--- a/packages/plugin-sdk-value/src/debug.ts
+++ b/packages/plugin-sdk-value/src/debug.ts
@@ -1,0 +1,21 @@
+import rawDebug from 'debug'
+
+// Keep in sync with `packages/editor/src/internal-utils/debug.ts`: sharing
+// the `pte:` root lets `localStorage.debug = 'pte:*'` interleave this
+// plugin's sync traces with the editor's own output on one timeline.
+const rootName = 'pte:plugin-sdk-value:'
+
+function createDebugger(name: string): rawDebug.Debugger {
+  const namespace = `${rootName}${name}`
+  if (rawDebug && rawDebug.enabled(namespace)) {
+    return rawDebug(namespace)
+  }
+  return rawDebug(rootName)
+}
+
+export const debug = {
+  mutation: createDebugger('mutation'),
+  push: createDebugger('push'),
+  remote: createDebugger('remote'),
+  repair: createDebugger('repair'),
+}

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -31,6 +31,7 @@ import {
 import {useActorRef} from '@xstate/react'
 import {useCallback} from 'react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
+import {debug} from './debug'
 
 type InsertPatch = Required<Pick<SanityPatchOperations, 'insert'>>
 
@@ -555,20 +556,6 @@ export function scopeRemotePatches(
   return scoped
 }
 
-// Sync diagnostics, disabled unless `globalThis.__PTE_SYNC_DEBUG = true`
-// is set before load. Callers pass a thunk so detail computation is free
-// when the flag is off.
-function syncDebugEnabled(): boolean {
-  return (globalThis as {__PTE_SYNC_DEBUG?: boolean}).__PTE_SYNC_DEBUG === true
-}
-
-function syncDebug(kind: string, detail: () => Record<string, unknown>) {
-  if (syncDebugEnabled()) {
-    // biome-ignore lint/suspicious/noConsole: opt-in diagnostics channel
-    console.debug(`[pte-sync] ${kind} ${JSON.stringify(detail())}`)
-  }
-}
-
 function debugTextOf(value: unknown): string {
   if (!Array.isArray(value)) {
     return ''
@@ -598,11 +585,11 @@ function applySync({
   }
 
   const snapshot = editor.getSnapshot().context.value
-  if (syncDebugEnabled()) {
+  if (debug.repair.enabled) {
     const editorText = debugTextOf(snapshot)
     const remoteText = debugTextOf(remoteValue)
     if (editorText !== remoteText) {
-      syncDebug('applySync:texts-differ', () => ({editorText, remoteText}))
+      debug.repair('editor and store texts differ %o', {editorText, remoteText})
     }
   }
 
@@ -622,7 +609,7 @@ function applySync({
   }
 
   if (patches.length) {
-    syncDebug('applySync:repair-patches', () => ({patches}))
+    debug.repair('applying repair patches %o', patches)
     editor.send({type: 'patches', patches, snapshot})
 
     // Patch application is best-effort: the editor skips operations it
@@ -633,10 +620,12 @@ function applySync({
     // arbitrary divergence block by block.
     const valueAfterPatches = editor.getSnapshot().context.value
     if (diffValue(valueAfterPatches, remoteValue).length > 0) {
-      syncDebug('applySync:escalate-update-value', () => ({
-        editorText: debugTextOf(valueAfterPatches),
-        remoteText: debugTextOf(remoteValue),
-      }))
+      if (debug.repair.enabled) {
+        debug.repair('escalating to whole-value sync %o', {
+          editorText: debugTextOf(valueAfterPatches),
+          remoteText: debugTextOf(remoteValue),
+        })
+      }
       editor.send({type: 'update value', value: remoteValue})
     }
   }
@@ -649,10 +638,12 @@ const listenToEditor = fromCallback<AnyEventObject, {editor: Editor}>(
     })
 
     const mutationSubscription = input.editor.on('mutation', (event) => {
-      syncDebug('event:mutation-flushed', () => ({
-        flushText: debugTextOf(event.value),
-        snapshotText: debugTextOf(input.editor.getSnapshot().context.value),
-      }))
+      if (debug.mutation.enabled) {
+        debug.mutation('flushed %o', {
+          flushText: debugTextOf(event.value),
+          snapshotText: debugTextOf(input.editor.getSnapshot().context.value),
+        })
+      }
       sendBack({
         type: 'mutation flushed',
         value: event.value,
@@ -737,7 +728,7 @@ const valueSyncMachine = setup({
       if (event.type !== 'remote patches received') {
         return
       }
-      syncDebug('apply-remote-patches', () => ({patches: event.patches}))
+      debug.remote('applying remote patches %o', event.patches)
       const snapshot = context.editor.getSnapshot().context.value
       // The store already reflects this transaction, so it can serve as
       // the target for coalescing sidecar-array item operations (which
@@ -1062,7 +1053,7 @@ export function ValueSyncPlugin(props: ValueSyncConfig) {
                 event.patches,
                 context.getRemoteValue,
               )
-              syncDebug('push-patches', () => ({patches: mergeable}))
+              debug.push('pushing patches %o', mergeable)
               pushPatches(mergeable)
               return
             } catch {
@@ -1070,11 +1061,14 @@ export function ValueSyncPlugin(props: ValueSyncConfig) {
             }
           }
 
-          syncDebug('push-whole-value', () => ({
-            text: debugTextOf(
-              event.value ?? context.editor.getSnapshot().context.value,
-            ),
-          }))
+          if (debug.push.enabled) {
+            debug.push(
+              'pushing whole value %s',
+              debugTextOf(
+                event.value ?? context.editor.getSnapshot().context.value,
+              ),
+            )
+          }
           pushValue(event.value ?? context.editor.getSnapshot().context.value)
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1195,6 +1195,9 @@ importers:
       '@xstate/react':
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.4)
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
       xstate:
         specifier: 'catalog:'
         version: 5.32.4
@@ -1223,6 +1226,9 @@ importers:
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,15 @@ catalogs:
     '@sanity/types':
       specifier: ^6.1.0
       version: 6.1.0
+    '@types/debug':
+      specifier: ^4.1.12
+      version: 4.1.12
     '@xstate/react':
       specifier: ^6.1.0
       version: 6.1.0
+    debug:
+      specifier: ^4.4.3
+      version: 4.4.3
     react:
       specifier: ^19.2.7
       version: 19.2.7
@@ -549,7 +555,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.4)
       debug:
-        specifier: ^4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
       scroll-into-view-if-needed:
         specifier: ^3.1.0
@@ -574,7 +580,7 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@types/debug':
-        specifier: ^4.1.12
+        specifier: 'catalog:'
         version: 4.1.12
       '@types/node':
         specifier: catalog:tooling
@@ -1196,7 +1202,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.4)
       debug:
-        specifier: ^4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
       xstate:
         specifier: 'catalog:'
@@ -1227,7 +1233,7 @@ importers:
         specifier: catalog:tooling
         version: 2.1.0
       '@types/debug':
-        specifier: ^4.1.12
+        specifier: 'catalog:'
         version: 4.1.12
       '@types/react':
         specifier: ^19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,9 @@ catalog:
   "@sanity/diff-match-patch": ^3.2.0
   "@sanity/schema": ^6.1.0
   "@sanity/types": ^6.1.0
+  "@types/debug": ^4.1.12
   "@xstate/react": ^6.1.0
+  debug: ^4.4.3
   react: ^19.2.7
   react-dom: ^19.2.7
   xstate: ^5.32.4


### PR DESCRIPTION
Follow-up to the review discussion on #2986: the sync diagnostics channel moves from the bespoke `globalThis.__PTE_SYNC_DEBUG` flag onto the `debug` library, under `pte:plugin-sdk-value:*` namespaces mirroring editor core's `internal-utils/debug.ts` (with a keep-in-sync note pointing there).

The payoff beyond consistency is the shared `pte:` root: `localStorage.debug = 'pte:*'` now interleaves the plugin's sync traces with the editor's own `pte:mutation`/`pte:sync:value` output on one timeline, which is exactly the view that diagnosing flush-versus-push races needs, and was the view the recent solo-typing investigation had to reconstruct by hand. The seven log kinds collapse into four individually filterable namespaces: `repair` (diff-based repair, escalation, text divergence), `push` (patch and whole-value pushes), `remote` (incoming patch application), and `mutation` (flush contents versus live snapshot).

Zero-cost-when-off is preserved with the same pattern editor core uses: detail computation that exists only for logging (the `debugTextOf` walks) sits behind `.enabled` guards; plain-value log calls rely on the library's own cheap enabled check. The changeset notes the one observable delta for anyone who adopted the flag from #2986: `__PTE_SYNC_DEBUG` is removed, `localStorage.debug` replaces it with the same before-load ergonomics.

A second commit moves `debug`/`@types/debug` into the pnpm catalog: with two packages now declaring them, literal version strings are drift waiting to happen, and the catalog keeps the workspace on one version by construction, the same mechanism that pins `vite` for test tooling.

All plugin suites pass (199 across unit and three browsers).
