### PR TITLE
fix: reference root block objects by name at every nested position (v5 backport)

### DIFF
--- a/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
+++ b/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
@@ -67,5 +67,16 @@ describe('mutually-embedding block objects', () => {
     // Generous bound - the conversion takes ~1ms when linear, while the
     // unmemoized walk does not finish in any practical amount of time.
     expect(durationMs).toBeLessThan(2_000)
+
+    // The emitted definition must be small AS A TREE, not merely cheap to
+    // build. The memoized walk builds shared `OfDefinition` objects (a
+    // DAG) in linear time, but before root block objects referenced by
+    // name at every position, each type's single expansion inlined the
+    // expansions of every type not on its first-visit ancestor path:
+    // tens of megabytes serialized for these types, out-of-memory in
+    // real studios. Every consumer walks the tree (schema compilation,
+    // React, serialization), so tree size is the contract, and
+    // conversion time alone cannot pin it.
+    expect(JSON.stringify(schema).length).toBeLessThan(100_000)
   }, 10_000)
 })

--- a/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
+++ b/packages/sanity-bridge/src/sanity-schema-to-portable-text-schema.ts
@@ -102,6 +102,17 @@ function sanitySchemaTypeToSchema(
   // per-branch ancestor sets below enumerate every simple path through
   // mutually-embedding types, which grows combinatorially.
   const memo = new Map<SchemaType, OfDefinition>()
+  // The canonical instances of the root-level block object types. Members
+  // reaching one of these at any `of` position emit a bare `{type: name}`
+  // reference instead of an inline expansion: the root `blockObjects`
+  // entry materializes the fields exactly once. Without this, each type's
+  // single memoized expansion inlines the expansions of every type not on
+  // its first-visit ancestor path, and the emitted definition, while
+  // cheap to build as a shared DAG, is factorially large as a tree, which
+  // is what every consumer (schema compilation, React, serialization)
+  // walks. Keyed by instance so a same-named but structurally different
+  // inline declaration keeps its own inline shape.
+  const rootBlockObjects = new Set<SchemaType>(blockObjectTypes)
 
   return {
     block: {
@@ -129,21 +140,31 @@ function sanitySchemaTypeToSchema(
       name: annotation.name,
       title: annotation.title,
       fields: annotation.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set(), memo),
+        sanityFieldToSchemaField(field, new Set(), memo, rootBlockObjects),
       ),
     })),
     blockObjects: blockObjectTypes.map((blockObject) => ({
       name: blockObject.name,
       title: blockObject.title,
       fields: blockObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([blockObject.name]), memo),
+        sanityFieldToSchemaField(
+          field,
+          new Set([blockObject.name]),
+          memo,
+          rootBlockObjects,
+        ),
       ),
     })),
     inlineObjects: inlineObjectTypes.map((inlineObject) => ({
       name: inlineObject.name,
       title: inlineObject.title,
       fields: inlineObject.fields.map((field) =>
-        sanityFieldToSchemaField(field, new Set([inlineObject.name]), memo),
+        sanityFieldToSchemaField(
+          field,
+          new Set([inlineObject.name]),
+          memo,
+          rootBlockObjects,
+        ),
       ),
     })),
   }
@@ -168,6 +189,7 @@ function sanityFieldToSchemaField(
   },
   ancestorNames: ReadonlySet<string>,
   memo: Map<SchemaType, OfDefinition>,
+  rootBlockObjects: ReadonlySet<SchemaType>,
 ): FieldDefinition {
   if (field.type.jsonType === 'array') {
     const ofMembers = safeGetOf(field.type)
@@ -177,7 +199,12 @@ function sanityFieldToSchemaField(
       ...(field.type.title ? {title: field.type.title} : {}),
       of: ofMembers
         ? ofMembers.map((member) =>
-            sanityOfMemberToOfDefinition(member, ancestorNames, memo),
+            sanityOfMemberToOfDefinition(
+              member,
+              ancestorNames,
+              memo,
+              rootBlockObjects,
+            ),
           )
         : [],
     }
@@ -194,6 +221,7 @@ function sanityOfMemberToOfDefinition(
   memberType: SchemaType,
   ancestorNames: ReadonlySet<string>,
   memo: Map<SchemaType, OfDefinition>,
+  rootBlockObjects: ReadonlySet<SchemaType>,
 ): OfDefinition {
   if (findBlockType(memberType)) {
     return {type: 'block'}
@@ -208,9 +236,14 @@ function sanityOfMemberToOfDefinition(
     'fields' in memberType &&
     Array.isArray((memberType as ObjectSchemaType).fields)
 
-  if (!hasFields || ancestorNames.has(memberType.name)) {
+  if (
+    !hasFields ||
+    ancestorNames.has(memberType.name) ||
+    rootBlockObjects.has(memberType)
+  ) {
     // Bare reference. The editor's resolver looks up `memberType.name`
-    // in `blockObjects` / `inlineObjects`.
+    // in the root `blockObjects`. Root block objects take this branch at
+    // every nested position, not just on cycles; see `rootBlockObjects`.
     return {
       type: memberType.name,
       ...(memberType.title ? {title: memberType.title} : {}),
@@ -233,7 +266,7 @@ function sanityOfMemberToOfDefinition(
     name: memberType.name,
     ...(memberType.title ? {title: memberType.title} : {}),
     fields: (memberType as ObjectSchemaType).fields.map((field) =>
-      sanityFieldToSchemaField(field, nextAncestors, memo),
+      sanityFieldToSchemaField(field, nextAncestors, memo, rootBlockObjects),
     ),
   }
   memo.set(memberType, definition)


### PR DESCRIPTION
Backport of #2993 to the last Sanity-v5-compatible bridge line. Bridge 3.1.2 and later depend on `@sanity/types` v6, so v5 studios top out at 3.1.1, which carries the factorial definition-tree blow-up: conversion is fast (the memoized walk builds a shared DAG), but the emitted definition inlines each type's expansion at every position not covered by an ancestor cycle, and everything downstream walks it as a tree. Wide mutually recursive schemas freeze and OOM on document open, the same failure #2976 reports against the 3.2.x line.

Same fix as `main`: members that are root block objects emit a bare `{type: name}` reference at every position, keyed by canonical instance so same-named inline declarations keep their own shape. The era's own test suite passes unchanged, and the mutually-embedding benchmark gains the output-size bound, red on the unfixed converter (the size assertion fails), green with the fix.

Targets the `bridge-v5-lts` branch (cut from the `@portabletext/sanity-bridge@3.1.1` tag), not `main`. Publishing is a hand-publish from this branch after merge, changesets doesn't manage the old line. The version number needs a decision: `3.1.7` slots after the Sanity-6-only 3.1.2-3.1.6 and risks tilde-range floats mixing dependency majors, while an exact-pinned prerelease-style version (e.g. `3.1.2-v5-lts.1`) can never be range-matched and requires Studio v5 to pin it exactly, which is also the safer shape for Studio v5's own range (its current `^3.1.0` floats into the Sanity-6-only versions today).
