### PR TITLE
test: give the 1,600-type stack test a CI-sized timeout

### DIFF
--- a/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
+++ b/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
@@ -272,5 +272,10 @@ describe('mutually-embedding block objects', () => {
 
     expect(converted.blockObjects).toHaveLength(objectCount)
     expect(durationMs).toBeLessThan(10_000)
-  })
+    // The explicit test timeout exceeds the duration bound because
+    // `SanitySchema.compile` on 1,600 types runs before the measured
+    // window and dominates on slow CI runners; the test guards against
+    // stack overflow, not compile speed, and vitest's 5s default has
+    // flaked on CI where the whole test body takes ~7-8s.
+  }, 30_000)
 })


### PR DESCRIPTION
The `1,600 mutually-embedding types convert without overflowing the stack` test timed out on `main`'s unit job ([run](https://github.com/portabletext/editor/actions/runs/29838351022/job/88660459410)): it ran under vitest's 5s default while `SanitySchema.compile` on 1,600 types dominates the test body, ~0.5-0.8s locally, ~7-8s on a slow CI runner. Not a regression: with #2993's emission the conversion inside the test is about twice as fast as before (487ms vs 823ms locally); the compile phase outside the measured window is what blows the default budget.

The test now carries an explicit 30s timeout like its siblings. The 10s bound on the conversion duration itself is unchanged, it measures only the post-compile window, which is the thing the test actually guards.