### PR TITLE
fix: keep normalization fallout of remote changes local (normalization echo corruption)

### DIFF
--- a/packages/editor/src/editor/remote-patches.ts
+++ b/packages/editor/src/editor/remote-patches.ts
@@ -37,8 +37,25 @@ export function setupRemotePatches({
     let changed = false
 
     withRemoteChanges(editor, () => {
-      withoutNormalizing(editor, () => {
-        withoutPatching(editor, () => {
+      // `withoutPatching` must wrap `withoutNormalizing`, not the other way
+      // around: `withoutNormalizing` runs a final normalize pass on exit,
+      // and with the previous nesting that pass ran after patching was
+      // restored. Normalization fallout of remote application (e.g. merging
+      // adjacent same-mark spans a collaborator's formatting toggle left
+      // behind) was then emitted as local patches and pushed back to the
+      // server. Every receiving client pushed its own competing "cleanup"
+      // of the same structure, and the interleaved merges corrupted the
+      // shared document (fragments deleted after their text had moved,
+      // text applied twice). Normalization fallout of remote changes must
+      // stay local; the originating client runs the same normalization as
+      // a genuine local edit and pushes it, so the server still converges
+      // to the normalized form.
+      //
+      // NOTE (draft): blanket suppression conflicts with the self-solving
+      // documents contract; see the PR description for the enumeration and
+      // the proposed hold-and-discard alternative.
+      withoutPatching(editor, () => {
+        withoutNormalizing(editor, () => {
           pluginWithoutHistory(editor, () => {
             for (const patch of patches) {
               try {
@@ -59,9 +76,11 @@ export function setupRemotePatches({
             }
           })
         })
+        if (changed) {
+          normalize(editor)
+        }
       })
       if (changed) {
-        normalize(editor)
         editor.onChange()
       }
     })

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -600,10 +600,10 @@ function clearEditor({
   editorEngine: PortableTextEditorEngine
   doneSyncing: boolean
 }) {
-  withoutNormalizing(editorEngine, () => {
-    pluginWithoutHistory(editorEngine, () => {
-      withRemoteChanges(editorEngine, () => {
-        withoutPatching(editorEngine, () => {
+  withoutPatching(editorEngine, () => {
+    withoutNormalizing(editorEngine, () => {
+      pluginWithoutHistory(editorEngine, () => {
+        withRemoteChanges(editorEngine, () => {
           if (doneSyncing) {
             return
           }
@@ -640,9 +640,9 @@ function removeExtraBlocks({
 }) {
   let isChanged = false
 
-  withoutNormalizing(editorEngine, () => {
-    withRemoteChanges(editorEngine, () => {
-      withoutPatching(editorEngine, () => {
+  withoutPatching(editorEngine, () => {
+    withoutNormalizing(editorEngine, () => {
+      withRemoteChanges(editorEngine, () => {
         const childrenLength = editorEngine.snapshot.context.value.length
 
         if (value.length < childrenLength) {
@@ -707,9 +707,9 @@ function syncBlock({
         schemaTypes: context.schema,
       })
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
-          withoutPatching(editorEngine, () => {
+      withoutPatching(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
+          withRemoteChanges(editorEngine, () => {
             editorEngine.apply({
               type: 'insert',
               path: [editorEngine.snapshot.context.value.length],
@@ -788,9 +788,9 @@ function syncBlock({
     if (oldBlock._key === block._key && oldBlock._type === block._type) {
       debug.syncValue('Updating block', oldBlock, block)
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
-          withoutPatching(editorEngine, () => {
+      withoutPatching(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
+          withRemoteChanges(editorEngine, () => {
             updateBlock({
               context,
               editorEngine,
@@ -804,9 +804,9 @@ function syncBlock({
     } else {
       debug.syncValue('Replacing block', oldBlock, block)
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
-          withoutPatching(editorEngine, () => {
+      withoutPatching(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
+          withRemoteChanges(editorEngine, () => {
             replaceBlock({
               context,
               editorEngine,

--- a/packages/editor/tests/remote-patches-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches-normalization.test.tsx
@@ -1,0 +1,134 @@
+import type {Patch} from '@portabletext/patches'
+import {insert} from '@portabletext/patches'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Normalization fallout of remote patch application must stay local.
+ *
+ * When a collaborator's formatting toggle splits a span, the receiving
+ * editor's normalizer merges the resulting adjacent same-mark spans back
+ * together, which is correct local hygiene. But if those merge operations
+ * are emitted as local patches, every receiving client pushes its own
+ * competing "cleanup" of the same structure back to the server, and the
+ * interleaved merges corrupt the shared document (fragments unset after
+ * their text moved elsewhere, text applied twice). Field signature:
+ * formatting appears to work, then the formatted region's text is
+ * duplicated at the end of the block and the marks are gone.
+ */
+describe('remote patch application does not emit normalization patches', () => {
+  test('merging adjacent same-mark spans created by remote patches stays local', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: b1,
+          children: [{_type: 'span', _key: s1, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const emittedPatches: Patch[] = []
+    const patchSubscription = editor.on('patch', (event) => {
+      if ('patch' in event) {
+        emittedPatches.push(event.patch)
+      }
+    })
+    const emittedMutations: Patch[][] = []
+    const mutationSubscription = editor.on('mutation', (event) => {
+      emittedMutations.push(event.patches)
+    })
+
+    // A collaborator's split arrives: a second span with identical (empty)
+    // marks lands next to the existing one. The local normalizer merges the
+    // two spans into one.
+    editor.send({
+      type: 'patches',
+      patches: [
+        insert(
+          [{_type: 'span', _key: keyGenerator(), text: 'bar', marks: []}],
+          'after',
+          [{_key: b1}, 'children', {_key: s1}],
+        ),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      const block = editor.getSnapshot().context.value[0] as {
+        children: {text: string}[]
+      }
+      // normalized: the spans merged into one
+      expect(block.children).toHaveLength(1)
+      expect(block.children[0]!.text).toBe('foobar')
+    })
+
+    // The merge itself must not be broadcast: no local patches, no mutation.
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    expect(emittedPatches).toEqual([])
+    expect(emittedMutations).toEqual([])
+
+    patchSubscription.unsubscribe()
+    mutationSubscription.unsubscribe()
+  })
+
+  test('genuine local edits still emit patches after remote application', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: b1,
+          children: [{_type: 'span', _key: s1, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        insert(
+          [{_type: 'span', _key: keyGenerator(), text: 'bar', marks: []}],
+          'after',
+          [{_key: b1}, 'children', {_key: s1}],
+        ),
+      ],
+      snapshot: undefined,
+    })
+    await vi.waitFor(() => {
+      const block = editor.getSnapshot().context.value[0] as {
+        children: {text: string}[]
+      }
+      expect(block.children[0]!.text).toBe('foobar')
+    })
+
+    const emittedPatches: Patch[] = []
+    const subscription = editor.on('patch', (event) => {
+      if ('patch' in event) {
+        emittedPatches.push(event.patch)
+      }
+    })
+
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(emittedPatches.length).toBeGreaterThan(0)
+    })
+
+    subscription.unsubscribe()
+  })
+})


### PR DESCRIPTION
> **Draft on purpose.** The live fix works, but it is blunt and conflicts with the self-solving documents contract. It needs a call on the right mechanism before it can land. Everything here (repro, Studio comparison, traces, regression test, breakage analysis) is meant to hand you the problem fully cornered.

## The bug (SDK-path concurrent corruption; not observed in Studio)

Reported on `@portabletext/plugin-sdk-value@7.1.2` + `@portabletext/editor@7.10.10` after the two typing fixes landed: bolding/italicizing selected text "works briefly, but then the formatting is lost and all of the content from the selected text onward is duplicated and appended to the end"; repeated pastes while another user types multiply.

Reproduced on demand with a two-client human-gesture driver (`duo-typing.mjs format` in sanity-labs/pte-sdk-concurrent-repro): user A keyboard-selects a word and toggles bold while user B types in another block.

**Head-to-head on the same editor version (`@portabletext/editor@7.10.10`):**

| Target | format mode (A bold while B types) |
|---|---|
| Native Studio FormBuilder PTE (`sanity@6.5.0`, Structure form, no SDK) | **SAFE** (4/4) — block A text intact, correct bold split |
| SDK plugin path (`plugin-sdk-value@7.1.2`) | **MANGLED** (6/6) — block A truncated/scrambled (`…in the r`, `…rrant and it wants a taco estau`) |

So this is **not** a latent Studio PTE bug that somehow went unreported. Studio's FormBuilder + `@sanity/mutator` path does not reproduce the Axios format-corruption class under the same workload. The SDK value-plugin sync path does.

That also fits "why after 7.1.0": the operational patch channel made fine-grained normalize echoes into real competing writes. Pre-7.1.0 whole-value LWW mostly hid them.

Harness: `studio-native.mjs format` (Studio) vs `duo-typing.mjs format` (SDK), same seed/oracle.

## Root cause (from SDK-store-level traces of a corrupted trial)

**Every receiving editor on the SDK path pushes its own normalization of a collaborator's formatting.** The smoking gun, client B (typing only in block B) pushing edits to block A:

```
4.16 B PUSH: dmp spanA.text "+it wants ", unset children[71bc...]   ← merging A's fragments
5.70 B PUSH: dmp spanA.text "+rant and ", unset children[4ad6...]
7.44 B PUSH: dmp spanA.text "+estau",     unset children[36fb...]
```

A's bold toggle splits a span into keyed fragments. Those arrive at B as remote patches; B's normalizer merges the adjacent same-mark spans back together (correct local hygiene), but the merge operations are emitted as local patches and the plugin pushes them. A performs the same merge with different fragment keys. The interleaved competing merges (overlapping dmp inserts, unsets of each other's fragments) corrupt the server: fragments unset after their text already moved (truncation) or text applied twice (the duplication users see).

Mechanically, the leak is scope nesting: remote application runs under `withoutPatching`, but `withoutNormalizing` was outermost, and its exit normalize pass (plus the explicit `normalize` in `remote-patches.ts`) ran after patching was restored.

Studio likely survives the same editor behavior because its BufferedDocument / mutator path buffers, squashes, and rebases pending local mutations over arriving remotes before commit, so a receiver's normalize fallout often never lands as a competing write. The SDK plugin, by design after the 7.1.1 typing fix, pushes **every** mutation flush immediately and has no equivalent "hold normalize echo until rebase proves it is still needed" layer.

## What this draft does

Makes `withoutPatching` outermost at every remote-application site (`remote-patches.ts` and the five `sync-machine.ts` sites), so normalization fallout of remote changes stays local. The originator still pushes its own merge as a genuine local edit, so the server converges to the normalized form.

This stops the echo at the editor. It is one valid fix site, but given the Studio comparison it should be framed as **protecting the SDK sync path** (and any other consumer that eagerly commits every mutation), not as "Studio has this bug too."

## Verification (external harness, real Content Lake, local builds)

| Scenario | main / released | this branch |
|---|---|---|
| SDK format mode (select + bold toggle vs typing) | 6/6 corrupted | **SAFE** |
| Native Studio format mode (same gestures) | **SAFE** (no change expected) | n/a |
| solo typing / duo separate blocks / duo same block | clean | clean (unchanged) |

The new regression test (`remote-patches-normalization.test.tsx`) pins the leak: remote patches creating adjacent same-mark spans must produce zero locally emitted patches/mutations. It fails on main in all three browsers with exactly the two-write merge signature.

## Why it's a draft: the self-solving collision

Against a clean-main baseline (10 pre-existing browser-suite failures on my machine), this suppression newly breaks ~21 pinned tests, and they're not collateral: they're the self-solving documents contract (`normalization.test.tsx`, `self-solving.test.tsx`, `container-normalization.test.tsx`, `event.patches.test.tsx` normalization emissions, and the `collaborative-editing.test.tsx` deferred-normalization scenarios). Those tests deliberately assert that normalization fix-ups ARE emitted so broken documents heal.

The existing architecture already has the right idea for the pristine case: normalization patches are held in `pendingEvents` and `discard conflicting pending patches` drops them when a conflicting remote patch arrives. The failure mode fixed here is specifically **remote-triggered normalization during an already-dirty session**, which bypasses the hold and emits with the next flush.

So the likely correct mechanism, rather than this blanket suppression: extend the hold-and-discard treatment to normalization patches generated while `isProcessingRemoteChanges` (regardless of dirty state), so the originator's own merge ops discard them on arrival, and they still emit eventually if no one else fixes the document (self-solving preserved). That reaches into the deferral design in `editor-machine.ts`, which is why I'd rather hand it over than guess.

### Alternative framing (plugin / SDK, not core)

Because Studio does not reproduce this, another valid fix site is `plugin-sdk-value`: do not push mutations that are only the normalize fallout of a remote apply (or hold them until a mutator-style rebase shows they are still needed). That would mirror Studio's "buffer and rebase away" behavior without teaching the core editor to suppress self-solving emissions. Happy to pursue either site.

The driver reproduces the corruption in about 30 seconds per trial.