### PR TITLE
fix: skip cosmetic normalization while applying remote patches

### DIFF
--- a/.changeset/remote-patches-cosmetic-normalization.md
+++ b/.changeset/remote-patches-cosmetic-normalization.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: skip cosmetic normalization while applying remote patches
+
+Adjacent same-mark spans and empty sibling spans arriving through remote patches are now kept as-is instead of being merged away by the receiving editor. Those merges were emitted and pushed back at the originator, so two people editing the same block concurrently could see formatting silently revert and the tail of the block duplicate. The unmerged structure renders identically and is canonicalized on the block's next local edit; `update value` still normalizes loaded documents, and structural repairs (missing keys, types, required fields) still run on every path.

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -31,6 +31,27 @@ import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
 
+/**
+ * Normalization rules split into two classes. Repairs fix structure the
+ * engine cannot represent (missing `_key`/`_type`, duplicate keys, missing
+ * required fields, empty blocks, unbracketed inline objects) and always
+ * run. Cosmetic rules canonicalize structure that is already valid
+ * Portable Text (merging adjacent same-mark spans, dropping empty sibling
+ * spans) and must not run while applying remote patches: emitted text
+ * patches are `diffMatchPatch` against a keyed span's text, so the wire
+ * structure is the shared base between editor and store, and canonicalizing
+ * a collaborator's structure either forks that base (kept local) or makes
+ * every receiver a competing writer on the originator's spans (pushed).
+ * Non-canonical structure renders identically and re-canonicalizes on the
+ * block's next local edit. Value sync (`update value`) still canonicalizes
+ * (self-solving), but only because its normalize flush runs outside
+ * `withRemoteChanges`; a wrapper-nesting change in the sync machine would
+ * silently revoke that.
+ */
+function isCosmeticNormalizationSkipped(editor: Editor): boolean {
+  return editor.isProcessingRemoteChanges
+}
+
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
   entry,
@@ -55,7 +76,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Merge spans with same set of .marks
    */
-  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+  if (
+    !isCosmeticNormalizationSkipped(editor) &&
+    isTextBlock({schema: editor.snapshot.context.schema}, node)
+  ) {
     const children = getChildren(editor.snapshot, path)
 
     for (let i = 0; i < children.length - 1; i++) {
@@ -562,7 +586,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
       if (isSpan({schema: editor.snapshot.context.schema}, child)) {
         if (
           prev != null &&
-          isSpan({schema: editor.snapshot.context.schema}, prev)
+          isSpan({schema: editor.snapshot.context.schema}, prev) &&
+          // Only this merge/empty-drop arm is cosmetic; the inline-object
+          // bracketing below is a repair and keeps running.
+          !isCosmeticNormalizationSkipped(editor)
         ) {
           // Merge adjacent text nodes that are empty or match.
           if (child.text === '') {

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -1834,7 +1834,9 @@ describe('event.patches', () => {
     })
 
     // Unset _type: normalization restores it to span (parent is text block).
-    // Three adjacent spans with compatible marks get merged by normalization.
+    // The three adjacent compatible spans are NOT merged: cosmetic
+    // normalization is skipped while applying remote patches; only the
+    // repairs run.
     editor.send({
       type: 'patches',
       patches: [
@@ -1852,7 +1854,11 @@ describe('event.patches', () => {
         {
           _key: blockKey,
           _type: 'block',
-          children: [{_type: 'span', _key: span1Key, text: '', marks: []}],
+          children: [
+            {_type: 'span', _key: span1Key, text: '', marks: []},
+            {_type: 'span', _key: newInlineKey, text: '', marks: []},
+            {_type: 'span', _key: span2Key, text: '', marks: []},
+          ],
           markDefs: [],
           style: 'normal',
         },
@@ -5043,7 +5049,8 @@ describe('event.patches', () => {
         snapshot: undefined,
       })
 
-      // Adjacent spans with identical marks are merged by normalization
+      // The adjacent same-mark spans are NOT merged: cosmetic normalization
+      // is skipped while applying remote patches.
       await vi.waitFor(() => {
         expect(editor.getSnapshot().context.value).toEqual([
           {
@@ -5066,7 +5073,13 @@ describe('event.patches', () => {
                   {
                     _type: 'span',
                     _key: contentSpanKey,
-                    text: 'first second',
+                    text: 'first',
+                    marks: [],
+                  },
+                  {
+                    _type: 'span',
+                    _key: 'new-span',
+                    text: ' second',
                     marks: [],
                   },
                 ],

--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -1,0 +1,493 @@
+import {applyAll, type Patch} from '@portabletext/patches'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import type {MutationEvent, PatchEvent} from '../src/editor/relay'
+import {EventListenerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Pins the cosmetic-normalization contract of
+ * `isCosmeticNormalizationSkipped` (`engine/core/normalize-node.ts`): a
+ * collaborator's span structure arrives untouched, nothing is emitted for
+ * it, and it canonicalizes on the block's next local edit or via `update
+ * value`.
+ */
+describe('remote patches skip cosmetic normalization', () => {
+  test('a remote marks change does not merge the surrounding spans', async () => {
+    // The production trigger: a collaborator removes a decorator from the
+    // middle span, and the receiver observes the marks change before the
+    // collaborator's own merge fallout arrives.
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const bazKey = keyGenerator()
+    const patchEvents: Array<PatchEvent> = []
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patchEvents.push(event)
+            }
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: bazKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: barKey}, 'marks'],
+          value: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: []},
+            {_type: 'span', _key: bazKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // Negative assert: the sleep gives a would-be echo time to surface.
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(patchEvents).toEqual([])
+    expect(mutationEvents).toEqual([])
+  })
+
+  test('adjacent same-mark spans arriving via remote patches are kept', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const patchEvents: Array<PatchEvent> = []
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patchEvents.push(event)
+            }
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [{_type: 'span', _key: 'remoteSpan', text: 'bar', marks: []}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+            {_type: 'span', _key: 'remoteSpan', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // Negative assert: the old behavior pushed the merge back as a
+    // mutation. The sleep gives a would-be emission time to surface.
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(patchEvents).toEqual([])
+    expect(mutationEvents).toEqual([])
+  })
+
+  test('an empty span arriving via remote patches is kept', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const patchEvents: Array<PatchEvent> = []
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patchEvents.push(event)
+            }
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          position: 'after',
+          items: [{_type: 'span', _key: 'remoteSpan', text: '', marks: ['em']}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: 'remoteSpan', text: '', marks: ['em']},
+            {_type: 'span', _key: barKey, text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(patchEvents).toEqual([])
+    expect(mutationEvents).toEqual([])
+  })
+
+  test('the block re-canonicalizes on its next local edit', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [{_type: 'span', _key: 'remoteSpan', text: 'bar', marks: []}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.at(0)?.children).toHaveLength(2)
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foobar!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(mutationEvents.length).toBeGreaterThan(0)
+    })
+  })
+
+  test('a collaborator removing a decorator does not corrupt the document through a receiver echo', async () => {
+    // The end-to-end customer symptom. A collaborator un-bolds the middle
+    // of "foo|bar|baz": their editor emits `set marks: []` followed by its
+    // own local merge fallout (two text `diffMatchPatch`es and two
+    // `unset`s). Listeners deliver patches of one transaction across
+    // multiple events, so a receiver can observe the block between the
+    // marks change and the merge. A receiver that normalizes at that point
+    // emits its own mirror-image merge, and when the store applies that
+    // echo, the `diffMatchPatch`es re-insert text the collaborator's own
+    // merge already inserted: "foobarbaz" becomes "foobarbazbarbaz", the
+    // duplicated-tail corruption from the field report.
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+    const bazKey = keyGenerator()
+    const patchEvents: Array<PatchEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patchEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: bazKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    function diffMatchPatchFor(oldText: string, newText: string): string {
+      return stringifyPatches(makePatches(makeDiff(oldText, newText)))
+    }
+
+    // The collaborator's emission for the un-bold, verbatim shape of what
+    // `decorator.toggle` produces on their editor.
+    const collaboratorPatches: Array<Patch> = [
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'children', {_key: barKey}, 'marks'],
+        value: [],
+        origin: 'remote',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+        value: diffMatchPatchFor('foo', 'foobar'),
+        origin: 'remote',
+      },
+      {
+        type: 'unset',
+        path: [{_key: blockKey}, 'children', {_key: barKey}],
+        origin: 'remote',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+        value: diffMatchPatchFor('foobar', 'foobarbaz'),
+        origin: 'remote',
+      },
+      {
+        type: 'unset',
+        path: [{_key: blockKey}, 'children', {_key: bazKey}],
+        origin: 'remote',
+      },
+    ]
+
+    // What the document holds once the collaborator's transaction lands.
+    const documentValue = applyAll(
+      editor.getSnapshot().context.value,
+      collaboratorPatches,
+    )
+    expect(documentValue).toEqual([
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: fooKey, text: 'foobarbaz', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+
+    // Deliver the marks change in its own event, then the rest.
+    editor.send({
+      type: 'patches',
+      patches: [collaboratorPatches[0]!],
+      snapshot: undefined,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    editor.send({
+      type: 'patches',
+      patches: collaboratorPatches.slice(1),
+      snapshot: undefined,
+    })
+
+    // The receiver converges to the document byte-identically, without
+    // having normalized anything itself.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(documentValue)
+    })
+
+    // Negative assert: the sleep gives a would-be echo time to surface.
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(patchEvents).toEqual([])
+
+    // And therefore the document survives: applying the receiver's
+    // emissions (none) leaves it untouched. Before the fix the echo's
+    // `diffMatchPatch`es re-inserted "bar" and "baz" here.
+    const documentAfterEcho = applyAll(
+      documentValue,
+      patchEvents.map((event) => ({...event.patch})),
+    )
+    expect(documentAfterEcho).toEqual(documentValue)
+  })
+
+  test('`update value` still canonicalizes adjacent same-mark spans', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+      }),
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+            {_type: 'span', _key: 'otherSpan', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Two people editing the same block concurrently could watch formatting revert and the tail of the block duplicate: the receiving editor's normalizer merged adjacent same-mark spans created by composing remote patches with its own state, then pushed those merges back at the originator (diagnosed in #3000).

`normalizeNode`'s rules now split into two classes:

- **Repairs** fix structure the engine cannot represent: missing `_key`/`_type`, duplicate keys, missing required fields (`markDefs`, `style`, `text`, `marks`), empty blocks, unbracketed inline objects, orphaned annotation marks. These run on every path, unchanged.
- **Cosmetic canonicalization** rewrites structure that is already valid Portable Text: merging adjacent same-mark spans, dropping empty sibling spans.

Cosmetic rules still run for local edits (the merge is pushed as the author's own mutation) and on `update value` (self-solving keeps healing loaded documents). They are skipped in exactly one case: normalization triggered by applying remote patches, detected via the existing `editor.isProcessingRemoteChanges` flag. A collaborator's structure is kept as-is, renders identically, and is canonicalized by whoever edits that block next.

Skipping the merge, rather than suppressing its push (#3000's approach), is deliberate: emitted text patches are `diffMatchPatch` against a keyed span's text, so span structure is the shared base between editor and store. Merging a collaborator's spans is wrong whether the merge is pushed (competing writers, the duplication above) or kept local (the receiver's structure forks from the store and its next edit in that span misapplies).

Pinned in `remote-patches.cosmetic-normalization.test.tsx`, red without the gate, including the no-emission asserts and an `update value` pin that also guards the flag's scope (its flush runs outside `withRemoteChanges`; a wrapper-nesting refactor in the sync machine would go red here instead of silently disabling self-solving). Two pins in `event.patches.test.tsx` asserted merge-on-remote-apply and are re-pinned; their actual subjects (container traversal, `_type` repair) are unchanged. Full browser and unit suites green. With this, #3000's push-boundary gate has no echo left to drop.

The first commit carries the reproduction and is red by design; the fix commit turns it green. At the test commit, the end-to-end scenario (a collaborator's un-bold delivered across two listener events, the receiver echoing its mirror-image merge) fails with the field report's exact signature:

```diff
- "text": "foobarbaz",
+ "text": "foobarbazbarbaz",
```

The duplication needs no concurrent typing: the collaborator's own merge `diffMatchPatch`es ("insert `bar` after `foo`") re-apply against the receiver's already-merged text, and the receiver's echo does the same to the document. `git checkout HEAD~1` to witness it red.
