### PR TITLE
test: reproduce duplicate-text deletion swallowing a peer's concurrent insert

### DIFF
--- a/packages/plugin-sdk-value/src/plugin.two-client.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.two-client.browser.test.tsx
@@ -352,4 +352,81 @@ describe('two clients through a shared patch-channel store', () => {
 
     await settleAndAssertConvergence({server, editorA, editorB})
   })
+
+  test('deleting one of two exact duplicates while the peer types at the end', async () => {
+    // Field report: deleting text that exists as an exact duplicate during
+    // concurrent editing corrupts. The deletion travels as a
+    // `diffMatchPatch` whose context anchors are identical at both copies,
+    // so against a base shifted by the peer's typing it can anchor at the
+    // wrong copy and swallow the peer's text.
+    const copy = "I'm feeling pretty good honestly. "
+    const server = createTwoClientServer([makeBlock('b1', copy + copy)])
+    const {editorA, editorB, locatorA, locatorB, unmount} =
+      await renderTwoClients(server)
+    cleanup = unmount
+
+    // B types at the very end; A deletes the second copy. B's insert
+    // reaches the server first, so A's delete applies against a base
+    // shifted by text A never saw.
+    await locatorB.click()
+    selectRange(editorB, 'b1', 'b1-span', copy.length * 2, copy.length * 2)
+    editorB.send({type: 'insert.text', text: 'hi'})
+    await locatorA.click()
+    selectRange(editorA, 'b1', 'b1-span', copy.length, copy.length * 2)
+    editorA.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(server.storeA.pushPatches).toHaveBeenCalled()
+      expect(server.storeB.pushPatches).toHaveBeenCalled()
+    })
+
+    await settleAndAssertConvergence({server, editorA, editorB})
+
+    // One copy deleted, the peer's text kept.
+    const texts = server
+      .getServerValue()
+      .map((block) =>
+        ((block as {children?: Array<{text?: string}>}).children ?? [])
+          .map((child) => child.text ?? '')
+          .join(''),
+      )
+    expect(texts).toEqual([`${copy}hi`])
+  })
+
+  test('deleting one of two exact duplicates while the peer types inside the deleted copy', async () => {
+    const copy = "I'm feeling pretty good honestly. "
+    const server = createTwoClientServer([makeBlock('b1', copy + copy)])
+    const {editorA, editorB, locatorA, locatorB, unmount} =
+      await renderTwoClients(server)
+    cleanup = unmount
+
+    // B types twelve characters into the second copy; A deletes it. B's
+    // insert reaches the server first, so A's delete applies against a
+    // base shifted by text A never saw.
+    await locatorB.click()
+    selectRange(editorB, 'b1', 'b1-span', copy.length + 12, copy.length + 12)
+    editorB.send({type: 'insert.text', text: 'hi'})
+    await locatorA.click()
+    selectRange(editorA, 'b1', 'b1-span', copy.length, copy.length * 2)
+    editorA.send({type: 'delete'})
+
+    await vi.waitFor(() => {
+      expect(server.storeA.pushPatches).toHaveBeenCalled()
+      expect(server.storeB.pushPatches).toHaveBeenCalled()
+    })
+
+    await settleAndAssertConvergence({server, editorA, editorB})
+
+    // The delete wins the region, but the peer's text typed inside it
+    // should survive somewhere; at minimum nothing beyond the two intended
+    // edits may change. Pin the correct merge: one copy gone, "hi" kept.
+    const texts = server
+      .getServerValue()
+      .map((block) =>
+        ((block as {children?: Array<{text?: string}>}).children ?? [])
+          .map((child) => child.text ?? '')
+          .join(''),
+      )
+    expect(texts).toEqual([`${copy.slice(0, 12)}hi${copy.slice(12)}`])
+  })
 })


### PR DESCRIPTION
Red by design: this is a reproduction, not a fix. During a customer's collaborative session, deleting text that exists as an exact duplicate in the same block corrupted the result. Reproduced deterministically here, and the proven variant is nastier than the report: it is *convergent* silent data loss.

The mechanism is structural to the wire format. Deleting one of two exact copies travels as a `diffMatchPatch` whose context anchors are identical at both copies. When the peer's concurrent insert reaches the store first, the delete applies against a base shifted by text the deleter never saw, anchors at the wrong copy's tail, and consumes the peer's insert. `applyPatches` reports success, and server and both editors converge unanimously on the corrupted value: the peer's typed `"hi"` is gone, no divergence ever forms, and no repair machinery downstream can see anything to repair. A 30-line kernel probe against `applyPatches(parsePatch(...))` shows the same swallow with no editors involved.

Two choreographies are pinned in the two-client harness (`plugin.two-client.browser.test.tsx`): peer typing at the end of the block, and peer typing inside the to-be-deleted copy. Both fail on the final-text assert while `settleAndAssertConvergence` passes. Delivery order is load-bearing: with the delete arriving at the store first, both scenarios pass, which is why the existing convergence suite never caught this.

The fix conversation is architectural rather than local: `diffMatchPatch` context matching is definitionally ambiguous on repeated text, so candidates include tightening the offset hint, rejecting low-confidence fuzzy matches instead of applying them, or a different wire representation for deletions. Whichever design wins turns these tests green. Related: repeated paste under concurrent typing manufactures exactly the duplicate text this mechanism needs, so the two field reports compose.
