### PR TITLE
chore: add `racetrack` to the changesets `ignore` list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["docs", "playground", "example-basic"],
+  "ignore": ["docs", "playground", "example-basic", "racetrack"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always",
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
Renovate PRs that touch `racetrack`'s dependencies currently get a generated changeset with a `racetrack` patch entry (#3005 is the live example), so `changeset version` bumps a private app that is never published. The changeset workflow filters generated entries through the `ignore` list in `.changeset/config.json`, and the other private apps (`docs`, `playground`) are already there; `racetrack` just never got added.

Once this merges, ticking the rebase checkbox on #3005 makes the workflow regenerate its changeset without the `racetrack` entry. Nothing depends on `racetrack`, so ignoring it has no dependent-package implications.