### PR TITLE
fix: require a collapsed selection for the forward-delete empty-block hop

### DIFF
--- a/.changeset/delete-forward-expanded-selection.md
+++ b/.changeset/delete-forward-expanded-selection.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: require a collapsed selection for the forward-delete empty-block hop
+
+Selecting a range that ends in an empty block (highlighting empty lines, for example) and pressing Delete now deletes the whole range. Previously the forward-delete rule that hops a caret past an empty block also matched expanded selections, so only the block at the focus edge was affected and the covered empty lines remained. Backspace was unaffected.

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -4,6 +4,7 @@ import {getFocusChild} from '../selectors/selector.get-focus-child'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
 import {isAtTheStartOfBlock} from '../selectors/selector.is-at-the-start-of-block'
+import {isSelectionCollapsed} from '../selectors/selector.is-selection-collapsed'
 import {getSibling} from '../traversal/get-sibling'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
@@ -140,6 +141,10 @@ export const abstractDeleteBehaviors = [
           ...snapshot.context,
           selection: at,
         },
+      }
+
+      if (!isSelectionCollapsed(adjustedSnapshot)) {
+        return false
       }
 
       const focusTextBlock = getFocusTextBlock(adjustedSnapshot)

--- a/packages/editor/tests/event.delete.forward.test.tsx
+++ b/packages/editor/tests/event.delete.forward.test.tsx
@@ -213,4 +213,150 @@ describe('event.delete.forward', () => {
       ).toBe(true)
     })
   })
+
+  describe('expanded selection covering empty blocks', () => {
+    // Field report: pressing Enter a few times creates empty lines, the
+    // user highlights them and presses Delete, and the lines remain. Pins
+    // the collapsed-selection requirement on the forward-delete
+    // empty-block hop in `behavior.abstract.delete.ts`: without it, the
+    // hop intercepts an expanded selection ending at an empty block and
+    // replaces the range-delete with a single block hop.
+    function block(key: string, text: string) {
+      return {
+        _type: 'block',
+        _key: key,
+        children: [{_type: 'span', _key: `${key}-s`, text, marks: []}],
+        markDefs: [],
+        style: 'normal',
+      }
+    }
+
+    test('Scenario: gesture-deleting a selection that covers empty blocks', async () => {
+      const {editor, locator} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        initialValue: [
+          block('b1', 'before'),
+          block('e1', ''),
+          block('e2', ''),
+          block('e3', ''),
+          block('b2', 'after'),
+        ],
+      })
+
+      await userEvent.click(locator)
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 'b1-s'}],
+            offset: 6,
+          },
+          focus: {path: [{_key: 'b1'}, 'children', {_key: 'b1-s'}], offset: 6},
+        },
+      })
+      await userEvent.keyboard(
+        '{Shift>}{ArrowDown}{ArrowDown}{ArrowDown}{/Shift}',
+      )
+
+      // The keyboard selection reaches the last empty line before Delete.
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.selection?.focus.path).toEqual([
+          {_key: 'e3'},
+          'children',
+          {_key: 'e3-s'},
+        ])
+      })
+      await userEvent.keyboard('{Delete}')
+
+      // Deleting the range from the end of "before" to the start of the
+      // last empty line merges the endpoints: every covered empty block is
+      // gone.
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          block('b1', 'before'),
+          block('b2', 'after'),
+        ])
+      })
+    })
+
+    test("Scenario: synthetic `delete` with `direction: 'forward'` over the same range", async () => {
+      // The editable's expanded-selection branch sends exactly this event
+      // for the Delete key. Before the fix, the forward empty-block hop
+      // behavior matched on the focus block alone and replaced the
+      // range-delete.
+      const {editor} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        initialValue: [
+          block('b1', 'before'),
+          block('e1', ''),
+          block('e2', ''),
+          block('e3', ''),
+          block('b2', 'after'),
+        ],
+      })
+
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 'b1-s'}],
+            offset: 6,
+          },
+          focus: {path: [{_key: 'e3'}, 'children', {_key: 'e3-s'}], offset: 0},
+        },
+      })
+      editor.send({type: 'delete', direction: 'forward'})
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          block('b1', 'before'),
+          block('b2', 'after'),
+        ])
+      })
+    })
+
+    test('Scenario: the same gesture over non-empty lines deletes the range', async () => {
+      const {editor, locator} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator(),
+        initialValue: [
+          block('b1', 'before'),
+          block('t1', 'one'),
+          block('t2', 'two'),
+          block('t3', 'three'),
+          block('b2', 'after'),
+        ],
+      })
+
+      await userEvent.click(locator)
+      editor.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: 'b1'}, 'children', {_key: 'b1-s'}],
+            offset: 6,
+          },
+          focus: {path: [{_key: 'b1'}, 'children', {_key: 'b1-s'}], offset: 6},
+        },
+      })
+      await userEvent.keyboard(
+        '{Shift>}{ArrowDown}{ArrowDown}{ArrowDown}{/Shift}',
+      )
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.selection?.focus.path).toEqual([
+          {_key: 't3'},
+          'children',
+          {_key: 't3-s'},
+        ])
+      })
+      await userEvent.keyboard('{Delete}')
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          block('b1', 'before'),
+          block('b2', 'after'),
+        ])
+      })
+    })
+  })
 })


### PR DESCRIPTION
Field report: pressing Enter a few times creates empty lines, the user highlights them and presses Delete, and the lines remain. Reproduced with real gestures: keyboard-select from a text block down across three empty blocks, press Delete, and only the focus-edge block is affected while the fully covered empty blocks survive. Backspace works.

The diagnosis moved twice before landing. The editor's logical selection is verifiably expanded before the keypress, and the same gesture over non-empty lines deletes correctly, which pointed at DOM filler-node mapping. A synthetic probe then exonerated the DOM entirely: `delete` without a direction handles the exact range correctly, while `delete` with `direction: 'forward'`, precisely what the editable's expanded-selection branch sends for the Delete key, reproduces the gesture failure byte-for-byte. The bug is in the abstract `delete` behaviors.

The forward-delete rule that hops a caret past an empty block guards only on the event direction, the focus block being an empty text block, and a next sibling existing. All three hold for an expanded selection ending at an empty block's start, so the rule intercepted the event and replaced the range-delete with "delete the focus block, select the next block's start". Its sibling rules (backward merge, end-of-block merge) were immune by construction because `isAtTheStartOfBlock`/`isAtTheEndOfBlock` require a collapsed selection; `isEmptyTextBlock` is a node predicate with no selection sensitivity. The fix gives the rule the same collapsed requirement via `isSelectionCollapsed`, so expanded selections fall through to the default range-delete.

Net behavior change is confined to forward delete over an expanded selection whose focus block is an empty text block. Caret behavior is untouched (the empty-block hop still fires for collapsed selections, pinned by the existing behavior suites, all green) and Backspace was never affected. Three pins land in `event.delete.forward.test.tsx`, red without the guard: the real-gesture scenario, the synthetic `direction: 'forward'` contract, and the non-empty-lines control that is green throughout.
