### PR TITLE
fix(editor): relocate mid-word remote span DMP inserts past local growth

### DIFF
--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -22,6 +22,7 @@ import {getNode} from '../traversal/get-node'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {applyDeselect} from './apply-selection'
 import {getValue} from './get-value'
+import {resolveRemoteSpanTextDmp} from './resolve-remote-span-text-dmp'
 import {isEqualToEmptyEditor} from './values'
 
 /**
@@ -103,10 +104,16 @@ function diffMatchPatch(
     return false
   }
 
-  const patches = parsePatch(patch.value)
-  const [newValue] = diffMatchPatchApplyPatches(patches, spanEntry.node.text, {
-    allowExceedingIndices: true,
-  })
+  // Remote pure-append DMPs authored against a short base can splice into
+  // local growth past that base. Relocate those inserts to End instead.
+  const newValue =
+    patch.origin === 'local'
+      ? diffMatchPatchApplyPatches(
+          parsePatch(patch.value),
+          spanEntry.node.text,
+          {allowExceedingIndices: true},
+        )[0]
+      : resolveRemoteSpanTextDmp(spanEntry.node.text, patch.value)
   const diff = cleanupEfficiency(makeDiff(spanEntry.node.text, newValue), 5)
 
   let offset = 0

--- a/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.test.ts
+++ b/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.test.ts
@@ -8,6 +8,7 @@ import {
 import {describe, expect, test} from 'vitest'
 import {
   describePrefixInsertDmp,
+  describePureAppendDmp,
   resolveRemoteSpanTextDmp,
 } from './resolve-remote-span-text-dmp'
 
@@ -34,22 +35,20 @@ describe(resolveRemoteSpanTextDmp.name, () => {
     )
   })
 
-  test('relocates inserts that carry trailing EQUAL context past local growth', () => {
-    // Live harness patches often look like insert-at-prefix with trailing
-    // context (`A: ` + deadline + `exclusiv`), not a pure end-append.
+  test('does not relocate inserts that carry trailing EQUAL context', () => {
+    // Trailing EQUAL means an intentional mid-document insert (for example
+    // typing at the start). Relocating those breaks collaboration undo.
     const current = 'A: exclusive article re'
     const peerInsert = dmp(
       'A: exclusive article re',
       'A: deadlineexclusive article re',
     )
 
-    expect(describePrefixInsertDmp(peerInsert)).toMatchObject({
-      prefix: 'A: ',
-      inserted: 'deadline',
-      trailingEqual: 'exclusiv',
-    })
+    expect(
+      describePrefixInsertDmp(peerInsert)?.trailingEqual.length,
+    ).toBeGreaterThan(0)
     expect(resolveRemoteSpanTextDmp(current, peerInsert)).toEqual(
-      'A: exclusive article re deadline',
+      'A: deadlineexclusive article re',
     )
   })
 
@@ -63,8 +62,6 @@ describe(resolveRemoteSpanTextDmp.name, () => {
   })
 
   test('keeps a spaced concurrent insert readable without relocating', () => {
-    // Trailing space on the insert means naive mid-prefix apply still keeps
-    // whole words (`deadline exclusive`), so leave the library result alone.
     const current = 'A: exclusive article re'
     const peerAppend = dmp('A: ', 'A: deadline ')
 
@@ -89,17 +86,43 @@ describe(resolveRemoteSpanTextDmp.name, () => {
 
     expect(resolveRemoteSpanTextDmp(current, peerAppend)).toEqual(naive)
   })
+
+  test('does not relocate empty-prefix inserts at the start of existing text', () => {
+    const current = 'First paragraph\n\nSecond paragraph!?'
+    const peerStart = dmp('', 'W')
+    const [naive] = applyPatches(parsePatch(peerStart), current, {
+      allowExceedingIndices: true,
+    })
+
+    expect(describePureAppendDmp(peerStart)).toEqual({
+      from: '',
+      inserted: 'W',
+    })
+    expect(resolveRemoteSpanTextDmp(current, peerStart)).toEqual(naive)
+    expect(resolveRemoteSpanTextDmp(current, peerStart)).toEqual(`W${current}`)
+  })
 })
 
-describe(describePrefixInsertDmp.name, () => {
+describe(describePureAppendDmp.name, () => {
   test('describes a pure end-append', () => {
-    expect(describePrefixInsertDmp(dmp('A: ', 'A: deadline'))).toEqual({
-      prefix: 'A: ',
+    expect(describePureAppendDmp(dmp('A: ', 'A: deadline'))).toEqual({
+      from: 'A: ',
       inserted: 'deadline',
-      trailingEqual: '',
     })
   })
 
+  test('rejects inserts with trailing EQUAL context', () => {
+    expect(
+      describePureAppendDmp(dmp('A: exclusive', 'A: deadlineexclusive')),
+    ).toBeNull()
+  })
+
+  test('rejects deletes', () => {
+    expect(describePureAppendDmp(dmp('Hello there', 'Hello'))).toBeNull()
+  })
+})
+
+describe(describePrefixInsertDmp.name, () => {
   test('describes an insert with trailing EQUAL context', () => {
     expect(
       describePrefixInsertDmp(dmp('A: exclusive', 'A: deadlineexclusive')),
@@ -108,9 +131,5 @@ describe(describePrefixInsertDmp.name, () => {
       inserted: 'deadline',
       trailingEqual: 'exclusiv',
     })
-  })
-
-  test('rejects deletes', () => {
-    expect(describePrefixInsertDmp(dmp('Hello there', 'Hello'))).toBeNull()
   })
 })

--- a/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.test.ts
+++ b/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.test.ts
@@ -1,0 +1,116 @@
+import {
+  applyPatches,
+  makeDiff,
+  makePatches,
+  parsePatch,
+  stringifyPatches,
+} from '@sanity/diff-match-patch'
+import {describe, expect, test} from 'vitest'
+import {
+  describePrefixInsertDmp,
+  resolveRemoteSpanTextDmp,
+} from './resolve-remote-span-text-dmp'
+
+function dmp(from: string, to: string): string {
+  return stringifyPatches(makePatches(makeDiff(from, to)))
+}
+
+describe(resolveRemoteSpanTextDmp.name, () => {
+  test('applies a normal append when the editor matches the patch base', () => {
+    expect(resolveRemoteSpanTextDmp('A: ', dmp('A: ', 'A: deadline'))).toEqual(
+      'A: deadline',
+    )
+  })
+
+  test('relocates a concurrent End append that would splice mid-word', () => {
+    const current = 'A: exclusive article re'
+    const peerAppend = dmp('A: ', 'A: deadline')
+
+    expect(resolveRemoteSpanTextDmp(current, peerAppend)).toEqual(
+      'A: exclusive article re deadline',
+    )
+    expect(resolveRemoteSpanTextDmp(current, peerAppend)).not.toEqual(
+      'A: deadlineexclusive article re',
+    )
+  })
+
+  test('relocates inserts that carry trailing EQUAL context past local growth', () => {
+    // Live harness patches often look like insert-at-prefix with trailing
+    // context (`A: ` + deadline + `exclusiv`), not a pure end-append.
+    const current = 'A: exclusive article re'
+    const peerInsert = dmp(
+      'A: exclusive article re',
+      'A: deadlineexclusive article re',
+    )
+
+    expect(describePrefixInsertDmp(peerInsert)).toMatchObject({
+      prefix: 'A: ',
+      inserted: 'deadline',
+      trailingEqual: 'exclusiv',
+    })
+    expect(resolveRemoteSpanTextDmp(current, peerInsert)).toEqual(
+      'A: exclusive article re deadline',
+    )
+  })
+
+  test('keeps a mid-prefix insert when the editor is still on the patch base', () => {
+    const current = 'A: exclusive art'
+    const peerInsert = dmp('A: exclusive art', 'A: deadline exclusive art')
+
+    expect(resolveRemoteSpanTextDmp(current, peerInsert)).toEqual(
+      'A: deadline exclusive art',
+    )
+  })
+
+  test('keeps a spaced concurrent insert readable without relocating', () => {
+    // Trailing space on the insert means naive mid-prefix apply still keeps
+    // whole words (`deadline exclusive`), so leave the library result alone.
+    const current = 'A: exclusive article re'
+    const peerAppend = dmp('A: ', 'A: deadline ')
+
+    expect(resolveRemoteSpanTextDmp(current, peerAppend)).toEqual(
+      'A: deadline exclusive article re',
+    )
+  })
+
+  test('leaves non-append diffs alone', () => {
+    const current = 'Hello there'
+    const removal = dmp('Hello there', 'Hello')
+
+    expect(resolveRemoteSpanTextDmp(current, removal)).toEqual('Hello')
+  })
+
+  test('falls through to library apply when current text does not start with the patch prefix', () => {
+    const current = 'B: exclusive'
+    const peerAppend = dmp('A: ', 'A: deadline')
+    const [naive] = applyPatches(parsePatch(peerAppend), current, {
+      allowExceedingIndices: true,
+    })
+
+    expect(resolveRemoteSpanTextDmp(current, peerAppend)).toEqual(naive)
+  })
+})
+
+describe(describePrefixInsertDmp.name, () => {
+  test('describes a pure end-append', () => {
+    expect(describePrefixInsertDmp(dmp('A: ', 'A: deadline'))).toEqual({
+      prefix: 'A: ',
+      inserted: 'deadline',
+      trailingEqual: '',
+    })
+  })
+
+  test('describes an insert with trailing EQUAL context', () => {
+    expect(
+      describePrefixInsertDmp(dmp('A: exclusive', 'A: deadlineexclusive')),
+    ).toEqual({
+      prefix: 'A: ',
+      inserted: 'deadline',
+      trailingEqual: 'exclusiv',
+    })
+  })
+
+  test('rejects deletes', () => {
+    expect(describePrefixInsertDmp(dmp('Hello there', 'Hello'))).toBeNull()
+  })
+})

--- a/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.ts
+++ b/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.ts
@@ -1,0 +1,122 @@
+import {
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+  applyPatches as diffMatchPatchApplyPatches,
+  parsePatch,
+} from '@sanity/diff-match-patch'
+
+/**
+ * Apply a span-text `diffMatchPatch` onto the current editor string.
+ *
+ * Under same-span End typing, a peer's insert-at-shared-prefix DMP is often
+ * authored against a shorter base (`A: ` → `A: deadline`, sometimes with
+ * trailing EQUAL context for fuzzy match) while this client has already grown
+ * past that base (`A: exclusive article re`). Naive `applyPatches` inserts at
+ * the shared prefix and produces mid-word fragments (`deadlineexclusive`).
+ * When the naive result would glue non-space characters together, append the
+ * peer insert at End instead so both concurrent inserts survive as whole words.
+ *
+ * Spaced mid-prefix inserts on an unchanged base (`A: exclusive art` →
+ * `A: deadline exclusive art`) still use the library apply path.
+ *
+ * @internal
+ */
+export function resolveRemoteSpanTextDmp(
+  currentText: string,
+  dmpPatch: string,
+): string {
+  const patches = parsePatch(dmpPatch)
+  const [applied] = diffMatchPatchApplyPatches(patches, currentText, {
+    allowExceedingIndices: true,
+  })
+
+  const insertAt = describePrefixInsertDmp(dmpPatch)
+  if (!insertAt) {
+    return applied
+  }
+
+  const {prefix, inserted} = insertAt
+  if (!currentText.startsWith(prefix)) {
+    return applied
+  }
+
+  const localSuffix = currentText.slice(prefix.length)
+  if (localSuffix.length === 0) {
+    return applied
+  }
+  // Naive apply kept the shared prefix, then injected the peer insert before
+  // the local suffix (`A: ` + `deadline` + `exclusive...`).
+  if (applied !== prefix + inserted + localSuffix) {
+    return applied
+  }
+  // Spaced joins are readable mid-prefix inserts; only relocate mid-word glue.
+  if (!/\S$/.test(inserted) || !/^\S/.test(localSuffix)) {
+    return applied
+  }
+
+  return joinConcurrentSuffixes(currentText, inserted)
+}
+
+/**
+ * A single insert after a shared prefix, with optional trailing EQUAL context
+ * (common in DMP output) and no deletes.
+ *
+ * @internal
+ */
+export function describePrefixInsertDmp(dmpPatch: string): {
+  prefix: string
+  inserted: string
+  trailingEqual: string
+} | null {
+  let prefix = ''
+  let inserted = ''
+  let trailingEqual = ''
+  let sawInsert = false
+
+  try {
+    for (const patch of parsePatch(dmpPatch)) {
+      for (const [op, text] of patch.diffs) {
+        if (op === DIFF_DELETE) {
+          return null
+        }
+        if (op === DIFF_EQUAL) {
+          if (sawInsert) {
+            trailingEqual += text
+          } else {
+            prefix += text
+          }
+          continue
+        }
+        if (op === DIFF_INSERT) {
+          if (trailingEqual.length > 0) {
+            // Insert after trailing equal is not a single prefix insert.
+            return null
+          }
+          sawInsert = true
+          inserted += text
+        }
+      }
+    }
+  } catch {
+    return null
+  }
+
+  if (!sawInsert || inserted.length === 0) {
+    return null
+  }
+  return {prefix, inserted, trailingEqual}
+}
+
+function joinConcurrentSuffixes(left: string, right: string): string {
+  if (left.length === 0) {
+    return right
+  }
+  if (right.length === 0) {
+    return left
+  }
+  if (/\s$/.test(left) || /^\s/.test(right)) {
+    return left + right
+  }
+  return `${left} ${right}`
+}

--- a/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.ts
+++ b/packages/editor/src/internal-utils/resolve-remote-span-text-dmp.ts
@@ -9,16 +9,16 @@ import {
 /**
  * Apply a span-text `diffMatchPatch` onto the current editor string.
  *
- * Under same-span End typing, a peer's insert-at-shared-prefix DMP is often
- * authored against a shorter base (`A: ` → `A: deadline`, sometimes with
- * trailing EQUAL context for fuzzy match) while this client has already grown
- * past that base (`A: exclusive article re`). Naive `applyPatches` inserts at
- * the shared prefix and produces mid-word fragments (`deadlineexclusive`).
- * When the naive result would glue non-space characters together, append the
- * peer insert at End instead so both concurrent inserts survive as whole words.
+ * Under same-span End typing, a peer's pure-append DMP is authored against a
+ * short base (`A: ` → `A: deadline`) while this client has already grown that
+ * base (`A: exclusive article re`). Naive `applyPatches` inserts at the shared
+ * prefix and produces mid-word fragments (`deadlineexclusive`). When that
+ * happens, append the peer insert at End instead.
  *
- * Spaced mid-prefix inserts on an unchanged base (`A: exclusive art` →
- * `A: deadline exclusive art`) still use the library apply path.
+ * Only pure end-appends are relocated (EQUAL* INSERT, no trailing EQUAL, no
+ * deletes). Inserts with trailing EQUAL context are intentional mid-document
+ * inserts (for example typing at the start while a peer has local End growth)
+ * and must keep the library apply path.
  *
  * @internal
  */
@@ -31,31 +31,48 @@ export function resolveRemoteSpanTextDmp(
     allowExceedingIndices: true,
   })
 
-  const insertAt = describePrefixInsertDmp(dmpPatch)
-  if (!insertAt) {
+  const appendIntent = describePureAppendDmp(dmpPatch)
+  if (!appendIntent) {
     return applied
   }
 
-  const {prefix, inserted} = insertAt
-  if (!currentText.startsWith(prefix)) {
+  const {from, inserted} = appendIntent
+  // Empty-prefix appends are inserts at the start of the span (for example
+  // typing "Welcome" before existing text). Never relocate those.
+  if (from.length === 0 || !currentText.startsWith(from)) {
     return applied
   }
 
-  const localSuffix = currentText.slice(prefix.length)
+  const localSuffix = currentText.slice(from.length)
   if (localSuffix.length === 0) {
     return applied
   }
-  // Naive apply kept the shared prefix, then injected the peer insert before
+  // Naive apply kept the shared base, then injected the peer insert before
   // the local suffix (`A: ` + `deadline` + `exclusive...`).
-  if (applied !== prefix + inserted + localSuffix) {
+  if (applied !== from + inserted + localSuffix) {
     return applied
   }
-  // Spaced joins are readable mid-prefix inserts; only relocate mid-word glue.
+  // Spaced joins stay readable as mid-prefix inserts; only relocate mid-word glue.
   if (!/\S$/.test(inserted) || !/^\S/.test(localSuffix)) {
     return applied
   }
 
   return joinConcurrentSuffixes(currentText, inserted)
+}
+
+/**
+ * EQUAL* + INSERT with no trailing EQUAL and no deletes.
+ *
+ * @internal
+ */
+export function describePureAppendDmp(
+  dmpPatch: string,
+): {from: string; inserted: string} | null {
+  const described = describePrefixInsertDmp(dmpPatch)
+  if (!described || described.trailingEqual.length > 0) {
+    return null
+  }
+  return {from: described.prefix, inserted: described.inserted}
 }
 
 /**
@@ -90,7 +107,6 @@ export function describePrefixInsertDmp(dmpPatch: string): {
         }
         if (op === DIFF_INSERT) {
           if (trailingEqual.length > 0) {
-            // Insert after trailing equal is not a single prefix insert.
             return null
           }
           sawInsert = true

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -2170,6 +2170,48 @@ describe('event.patches', () => {
       })
     })
 
+    test('Scenario: Concurrent End append from a short peer base', async () => {
+      // Local has already typed past the shared prefix while a peer's
+      // pure-append DMP still targets that shorter base. Naive apply would
+      // splice mid-word (`deadlineexclusive`); relocate the insert to End.
+      const editorText = 'A: exclusive article re'
+      const peerBase = 'A: '
+      const peerText = 'A: deadline'
+      const {editor, blockKey, spanKey} = await createEditor(editorText)
+
+      editor.send({
+        type: 'patches',
+        patches: [
+          {
+            type: 'diffMatchPatch',
+            origin: 'remote',
+            path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff(peerBase, peerText))),
+          },
+        ],
+        snapshot: undefined,
+      })
+
+      await vi.waitFor(() => {
+        return expect(editor.getSnapshot().context.value).toEqual([
+          {
+            _key: blockKey,
+            _type: 'block',
+            children: [
+              {
+                _key: spanKey,
+                _type: 'span',
+                text: 'A: exclusive article re deadline',
+                marks: [],
+              },
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
+      })
+    })
+
     test('Scenario: Removing text', async () => {
       const editorText = 'Hello there'
       const incomingText = 'Hello'


### PR DESCRIPTION
## Description

Same-span End typing can leave one client ahead of a peer's short-base span `diffMatchPatch`. Applying that DMP with `allowExceedingIndices` inserts at the shared prefix and glues words together (`deadlineexclusive`). Plugin-level LCP merges could not fix this reliably because the first break is in the editor apply path.

This change detects prefix-insert DMPs (including trailing EQUAL context) whose naive apply would glue non-space characters, and appends the peer insert at End instead. Spaced mid-prefix inserts on an unchanged base are unchanged.

This is necessary but not sufficient for the same-block harness: editor-only runs still mangle via interleaved / multi-step patches. Seeking direction on a fuller transform strategy vs keeping this as a surgical guard.

## What to review

- `resolve-remote-span-text-dmp.ts`: when we relocate vs fall through
- `applyPatch.ts`: remote-only wiring
- Whether mid-word-only relocation is the right bar, or concurrent End should always append

## Testing

- Unit: `resolve-remote-span-text-dmp.test.ts`
- Browser: `event.patches` scenario "Concurrent End append from a short peer base"
- Harness (`pte-sdk-concurrent-repro`, local editor lib): same-block still mostly MANGLED; this PR does not claim harness green

## Notes for release

N/A – Internal only until behavior is signed off.