### PR TITLE
chore: group and fast-track `react-dom` with `react` in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,12 @@
     },
     {
       "description": "Ensure internal and important packages open a PRs right away, without waiting for manual approval",
-      "matchPackageNames": ["@portabletext/*", "react", "typescript"],
+      "matchPackageNames": [
+        "@portabletext/*",
+        "react",
+        "react-dom",
+        "typescript"
+      ],
       "dependencyDashboardApproval": false,
       "schedule": ["every weekday"]
     },
@@ -43,6 +48,11 @@
       "matchPackageNames": ["typescript"],
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group `react` and `react-dom`: React requires exact version parity between them at runtime, so they must bump atomically",
+      "matchPackageNames": ["react", "react-dom"],
+      "groupName": "react"
     },
     {
       "description": "Group Tailwind packages",


### PR DESCRIPTION
When react 19.2.8 came out, renovate opened #3005 bumping `react` alone and every test suite went red with "Incompatible React versions": React's dev runtime enforces exact version parity between `react` and `react-dom`, and the matching `react-dom` 19.2.8 update never arrived. It was sitting on the dependency dashboard as an unchecked approval checkbox the whole time (`renovate/react-dom-19.x`); #3005 was ultimately unblocked by bumping `react-dom` manually on the branch.

The config extends `:dependencyDashboardApproval`, so nothing gets a PR until approved on the dashboard, and the fast-track exemption lists packages by exact name: `react` matched, `react-dom` did not. Since the two packages were not grouped either, they could never ride in the same branch, so every future react patch would reproduce the same red PR.

The fix adds `react-dom` to the fast-track exemption and groups the two packages under one `react` branch, so they bump atomically in a single PR. Blast radius is confined to those two packages: react updates now arrive as one grouped weekday PR instead of a `react`-only one, and `react-dom` no longer waits for dashboard approval. All other approval gating, grouping, and semantic-commit rules are untouched.