### PR TITLE
test: pin the diff-value round-trip property for the revised patch pipeline

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -109,6 +109,8 @@
     "@portabletext/test": "workspace:^",
     "@rolldown/plugin-babel": "catalog:tooling",
     "@sanity/diff-match-patch": "catalog:",
+    "@sanity/diff-patch": "catalog:",
+    "@sanity/json-match": "catalog:",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "@textspec/notation": "^1.0.2",

--- a/packages/editor/src/internal-utils/diff-value-round-trip.test.ts
+++ b/packages/editor/src/internal-utils/diff-value-round-trip.test.ts
@@ -1,0 +1,25 @@
+import {applyAll} from '@portabletext/patches'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {diffValueToPatches} from '../../test-utils/diff-value-patches'
+import {generateValuePair} from '../../test-utils/generate-value-pairs'
+
+/**
+ * Store-side round-trip property for the revised patch pipeline (the
+ * transport `update value` will ride): diffing two values into patches and
+ * applying them to the first value must reproduce the second, byte-equal.
+ * `applyAll` is the reference application every patch consumer shares.
+ */
+describe('diffValue round-trip: applyAll', () => {
+  const seeds = Array.from({length: 500}, (_, index) => index + 1)
+
+  test.each(seeds)('seed %i', (seed) => {
+    const keyGenerator = createTestKeyGenerator(`seed${seed}-`)
+    const {fromValue, toValue} = generateValuePair(seed, keyGenerator)
+
+    const patches = diffValueToPatches(fromValue, toValue)
+    const roundTripped = applyAll(fromValue, patches)
+
+    expect(roundTripped).toEqual(toValue)
+  })
+})

--- a/packages/editor/test-utils/diff-value-patches.ts
+++ b/packages/editor/test-utils/diff-value-patches.ts
@@ -1,0 +1,160 @@
+import type {
+  InsertPatch as PteInsertPatch,
+  Patch as PtePatch,
+  Path,
+  PathSegment,
+} from '@portabletext/patches'
+import type {PortableTextBlock} from '@portabletext/schema'
+import {diffValue, type SanityPatchOperations} from '@sanity/diff-patch'
+import {
+  parsePath,
+  type ExprNode,
+  type PathNode,
+  type SegmentNode,
+  type ThisNode,
+} from '@sanity/json-match'
+
+/**
+ * Diffs two Portable Text values into editor patches: the transport the
+ * revised patch pipeline will ride (`update value` as
+ * `diffValue`-into-patches through the one applier).
+ *
+ * Keep in sync with `convertPatches`/`arrayifyPath` in
+ * `packages/plugin-sdk-value/src/plugin.sdk-value.tsx`, the same translation
+ * used by the SDK plugin's repair path. Deliberately duplicated (test-only,
+ * for now) instead of exported.
+ */
+export function diffValueToPatches(
+  fromValue: Array<PortableTextBlock>,
+  toValue: Array<PortableTextBlock>,
+): Array<PtePatch> {
+  return convertPatches(diffValue(fromValue, toValue))
+}
+
+const ARRAYIFY_ERROR_MESSAGE =
+  'Unexpected path format from diffValue output. Please report this issue.'
+
+function* getSegments(
+  node: PathNode,
+): Generator<Exclude<SegmentNode, ThisNode>> {
+  if (node.base) {
+    yield* getSegments(node.base)
+  }
+  if (node.segment.type !== 'This') {
+    yield node.segment
+  }
+}
+
+function isKeyPath(node: ExprNode): node is PathNode {
+  if (node.type !== 'Path') {
+    return false
+  }
+  if (node.base) {
+    return false
+  }
+  if (node.recursive) {
+    return false
+  }
+  if (node.segment.type !== 'Identifier') {
+    return false
+  }
+  return node.segment.name === '_key'
+}
+
+function arrayifyPath(pathExpr: string): Path {
+  const node = parsePath(pathExpr)
+  if (!node) {
+    return []
+  }
+  if (node.type !== 'Path') {
+    throw new Error(ARRAYIFY_ERROR_MESSAGE)
+  }
+
+  return Array.from(getSegments(node)).map((segment): PathSegment => {
+    if (segment.type === 'Identifier') {
+      return segment.name
+    }
+    if (segment.type !== 'Subscript') {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    if (segment.elements.length !== 1) {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+
+    const element = segment.elements[0]
+    if (element === undefined) {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    if (element.type === 'Number') {
+      return element.value
+    }
+
+    if (element.type !== 'Comparison') {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    if (element.operator !== '==') {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    const keyPathNode = [element.left, element.right].find(isKeyPath)
+    if (!keyPathNode) {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    const other = element.left === keyPathNode ? element.right : element.left
+    if (other.type !== 'String') {
+      throw new Error(ARRAYIFY_ERROR_MESSAGE)
+    }
+    return {_key: other.value}
+  })
+}
+
+function convertPatches(patches: SanityPatchOperations[]): PtePatch[] {
+  return patches.flatMap((operations) => {
+    return Object.entries(operations).flatMap(([type, values]): PtePatch[] => {
+      const origin = 'remote'
+
+      switch (type) {
+        case 'set':
+        case 'setIfMissing':
+        case 'diffMatchPatch':
+        case 'inc':
+        case 'dec': {
+          return Object.entries(values).map(
+            ([pathExpr, value]) =>
+              ({type, value, origin, path: arrayifyPath(pathExpr)}) as PtePatch,
+          )
+        }
+        case 'unset': {
+          if (!Array.isArray(values)) {
+            return []
+          }
+          return values.map(arrayifyPath).map((path) => ({type, origin, path}))
+        }
+        case 'insert': {
+          const {items, ...rest} = values as {
+            items: unknown[]
+          } & Record<string, string>
+          type InsertPosition = PteInsertPatch['position']
+          const position = Object.keys(rest).at(0) as InsertPosition | undefined
+
+          if (!position) {
+            return []
+          }
+          const pathExpr = rest[position]!
+          const insertPatch: PteInsertPatch = {
+            type,
+            origin,
+            position,
+            path: arrayifyPath(pathExpr),
+            items: items as PteInsertPatch['items'],
+          }
+
+          return [insertPatch]
+        }
+
+        default: {
+          return []
+        }
+      }
+    })
+  })
+}

--- a/packages/editor/test-utils/generate-value-pairs.ts
+++ b/packages/editor/test-utils/generate-value-pairs.ts
@@ -1,0 +1,325 @@
+import type {
+  PortableTextBlock,
+  PortableTextTextBlock,
+} from '@portabletext/schema'
+
+/**
+ * Deterministic Portable Text value-pair generator for round-trip property
+ * tests: `(value, mutated value)` pairs whose diff-into-patches must apply
+ * back to the mutated value exactly. Values stay within the fixture schema:
+ * decorators `strong`/`em`, annotation `link`, inline object `stock-ticker`,
+ * block object `image`.
+ */
+
+function createSeededRng(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    // Park-Miller LCG: deterministic across runs and platforms.
+    state = (state * 48271) % 2147483647
+    return state / 2147483647
+  }
+}
+
+type Rng = () => number
+
+function pick<Item>(rng: Rng, items: ReadonlyArray<Item>): Item {
+  return items[Math.floor(rng() * items.length)]!
+}
+
+function pickIndex(rng: Rng, length: number): number {
+  return Math.floor(rng() * length)
+}
+
+const WORDS = [
+  'alpha',
+  'bravo',
+  'charlie',
+  'delta',
+  'echo',
+  'foxtrot',
+  'golf',
+  'hotel',
+]
+
+function word(rng: Rng): string {
+  return pick(rng, WORDS)
+}
+
+function generateValue(
+  rng: Rng,
+  keyGenerator: () => string,
+): Array<PortableTextBlock> {
+  const blockCount = 1 + pickIndex(rng, 4)
+  const blocks: Array<PortableTextBlock> = []
+
+  for (let index = 0; index < blockCount; index++) {
+    if (rng() < 0.15) {
+      blocks.push({
+        _type: 'image',
+        _key: keyGenerator(),
+        url: `https://example.com/${word(rng)}.png`,
+      })
+      continue
+    }
+    blocks.push(generateTextBlock(rng, keyGenerator))
+  }
+
+  return blocks
+}
+
+function generateTextBlock(
+  rng: Rng,
+  keyGenerator: () => string,
+): PortableTextTextBlock {
+  const spanCount = 1 + pickIndex(rng, 3)
+  const markDefs: PortableTextTextBlock['markDefs'] = []
+  const children: PortableTextTextBlock['children'] = []
+
+  for (let index = 0; index < spanCount; index++) {
+    const marks: Array<string> = []
+    if (rng() < 0.3) {
+      marks.push(pick(rng, ['strong', 'em']))
+    }
+    if (rng() < 0.15) {
+      const defKey = keyGenerator()
+      markDefs.push({
+        _type: 'link',
+        _key: defKey,
+        href: `https://example.com/${word(rng)}`,
+      })
+      marks.push(defKey)
+    }
+    children.push({
+      _type: 'span',
+      _key: keyGenerator(),
+      text: `${word(rng)} ${word(rng)}`,
+      marks,
+    })
+    if (rng() < 0.1) {
+      children.push({
+        _type: 'stock-ticker',
+        _key: keyGenerator(),
+        symbol: word(rng).toUpperCase(),
+      })
+      children.push({_type: 'span', _key: keyGenerator(), text: '', marks: []})
+    }
+  }
+
+  const block: PortableTextTextBlock = {
+    _type: 'block',
+    _key: keyGenerator(),
+    children,
+    markDefs,
+    style: rng() < 0.2 ? 'h1' : 'normal',
+  }
+
+  if (rng() < 0.2) {
+    block.listItem = 'bullet'
+    block.level = 1
+  }
+
+  return block
+}
+
+function clone<Value>(value: Value): Value {
+  return structuredClone(value)
+}
+
+function isTextBlock(block: PortableTextBlock): block is PortableTextTextBlock {
+  return block._type === 'block'
+}
+
+type Mutation = (
+  value: Array<PortableTextBlock>,
+  rng: Rng,
+  keyGenerator: () => string,
+) => void
+
+const mutations: ReadonlyArray<Mutation> = [
+  function editSpanText(value, rng) {
+    const span = pickSpan(value, rng)
+    if (span) {
+      span.text = rng() < 0.5 ? `${span.text} ${word(rng)}` : word(rng)
+    }
+  },
+  function toggleDecorator(value, rng) {
+    const span = pickSpan(value, rng)
+    if (span) {
+      const decorator = pick(rng, ['strong', 'em'])
+      span.marks = span.marks?.includes(decorator)
+        ? span.marks.filter((mark) => mark !== decorator)
+        : [...(span.marks ?? []), decorator]
+    }
+  },
+  function addAnnotation(value, rng, keyGenerator) {
+    const block = pickTextBlock(value, rng)
+    const span = block ? pickSpanInBlock(block, rng) : undefined
+    if (block && span) {
+      const defKey = keyGenerator()
+      block.markDefs = [
+        ...(block.markDefs ?? []),
+        {_type: 'link', _key: defKey, href: `https://example.com/${word(rng)}`},
+      ]
+      span.marks = [...(span.marks ?? []), defKey]
+    }
+  },
+  function removeAnnotation(value, rng) {
+    const block = pickTextBlock(value, rng)
+    const def = block?.markDefs?.length ? pick(rng, block.markDefs) : undefined
+    if (block && def) {
+      block.markDefs = block.markDefs?.filter(
+        (candidate) => candidate._key !== def._key,
+      )
+      for (const child of block.children) {
+        if (Array.isArray(child.marks)) {
+          child.marks = child.marks.filter((mark) => mark !== def._key)
+        }
+      }
+    }
+  },
+  function insertTextBlock(value, rng, keyGenerator) {
+    value.splice(
+      pickIndex(rng, value.length + 1),
+      0,
+      generateTextBlock(rng, keyGenerator),
+    )
+  },
+  function insertBlockObject(value, rng, keyGenerator) {
+    value.splice(pickIndex(rng, value.length + 1), 0, {
+      _type: 'image',
+      _key: keyGenerator(),
+      url: `https://example.com/${word(rng)}.png`,
+    })
+  },
+  function removeBlock(value, rng) {
+    if (value.length > 1) {
+      value.splice(pickIndex(rng, value.length), 1)
+    }
+  },
+  function swapBlocks(value, rng) {
+    if (value.length > 1) {
+      const indexA = pickIndex(rng, value.length)
+      const indexB = pickIndex(rng, value.length)
+      const blockA = value[indexA]!
+      value[indexA] = value[indexB]!
+      value[indexB] = blockA
+    }
+  },
+  function rekeyBlock(value, rng, keyGenerator) {
+    const block = value[pickIndex(rng, value.length)]
+    if (block) {
+      block._key = keyGenerator()
+    }
+  },
+  function rekeyChild(value, rng, keyGenerator) {
+    const block = pickTextBlock(value, rng)
+    const child = block
+      ? block.children[pickIndex(rng, block.children.length)]
+      : undefined
+    if (child) {
+      child._key = keyGenerator()
+    }
+  },
+  function splitSpan(value, rng, keyGenerator) {
+    const block = pickTextBlock(value, rng)
+    if (!block) {
+      return
+    }
+    const index = pickIndex(rng, block.children.length)
+    const child = block.children[index]
+    if (child && child._type === 'span' && typeof child.text === 'string') {
+      const splitAt = Math.ceil(child.text.length / 2)
+      block.children.splice(
+        index,
+        1,
+        {...child, text: child.text.slice(0, splitAt)},
+        {
+          ...clone(child),
+          _key: keyGenerator(),
+          text: child.text.slice(splitAt),
+        },
+      )
+    }
+  },
+  function replaceAllChildren(value, rng, keyGenerator) {
+    const block = pickTextBlock(value, rng)
+    if (block) {
+      block.children = [
+        {
+          _type: 'span',
+          _key: keyGenerator(),
+          text: `${word(rng)} ${word(rng)} ${word(rng)}`,
+          marks: [],
+        },
+      ]
+      block.markDefs = []
+    }
+  },
+  function changeStyle(value, rng) {
+    const block = pickTextBlock(value, rng)
+    if (block) {
+      block.style = pick(rng, ['normal', 'h1', 'h2', 'blockquote'])
+    }
+  },
+  function toggleListItem(value, rng) {
+    const block = pickTextBlock(value, rng)
+    if (block) {
+      if (block.listItem) {
+        delete block.listItem
+        delete block.level
+      } else {
+        block.listItem = 'bullet'
+        block.level = 1 + pickIndex(rng, 2)
+      }
+    }
+  },
+]
+
+function pickTextBlock(
+  value: Array<PortableTextBlock>,
+  rng: Rng,
+): PortableTextTextBlock | undefined {
+  const textBlocks = value.filter(isTextBlock)
+  return textBlocks.length > 0 ? pick(rng, textBlocks) : undefined
+}
+
+type MutableSpan = {
+  _type: 'span'
+  _key: string
+  text: string
+  marks?: Array<string>
+}
+
+function pickSpanInBlock(
+  block: PortableTextTextBlock,
+  rng: Rng,
+): MutableSpan | undefined {
+  const spans = block.children.filter(
+    (child): child is MutableSpan => child._type === 'span',
+  )
+  return spans.length > 0 ? pick(rng, spans) : undefined
+}
+
+function pickSpan(value: Array<PortableTextBlock>, rng: Rng) {
+  const block = pickTextBlock(value, rng)
+  return block ? pickSpanInBlock(block, rng) : undefined
+}
+
+export function generateValuePair(
+  seed: number,
+  keyGenerator: () => string,
+): {
+  fromValue: Array<PortableTextBlock>
+  toValue: Array<PortableTextBlock>
+} {
+  const rng = createSeededRng(seed)
+  const fromValue = generateValue(rng, keyGenerator)
+  const toValue = clone(fromValue)
+  const mutationCount = 1 + pickIndex(rng, 3)
+
+  for (let index = 0; index < mutationCount; index++) {
+    pick(rng, mutations)(toValue, rng, keyGenerator)
+  }
+
+  return {fromValue, toValue}
+}

--- a/packages/editor/tests/diff-value.engine-round-trip.test.tsx
+++ b/packages/editor/tests/diff-value.engine-round-trip.test.tsx
@@ -1,0 +1,64 @@
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {createTestEditor} from '../src/test/vitest'
+import {diffValueToPatches} from '../test-utils/diff-value-patches'
+import {generateValuePair} from '../test-utils/generate-value-pairs'
+
+/**
+ * Engine-side round-trip property for the revised patch pipeline: the same
+ * diffed patches that round-trip through `applyAll` (see
+ * `diff-value-round-trip.test.ts`, 500 seeds green) must round-trip through
+ * the editor's own `patches` application. Seeds that fail here and not
+ * there localize a hole in the engine's patch application, the concrete
+ * work list for making application total.
+ */
+describe('diffValue round-trip: engine patches application', () => {
+  // Seeds 3, 6, 14, 18, 21, 33, and 38 generate a `fromValue` with
+  // adjacent same-mark spans. They were pinned as expected failures while
+  // mount-time canonicalization merged that adjacency (forking the
+  // engine's base from the diff's base); since cosmetic span normalization
+  // became local-edit fallout only, the whole corpus round-trips.
+  const seeds = Array.from({length: 40}, (_, index) => index + 1)
+
+  test.each(seeds)('seed %i', async (seed) => {
+    await roundTrip(seed)
+  })
+
+  async function roundTrip(seed: number) {
+    const keyGenerator = createTestKeyGenerator(`seed${seed}-`)
+    const {fromValue, toValue} = generateValuePair(seed, keyGenerator)
+
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(`editor${seed}-`),
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}, {name: 'em'}],
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+        inlineObjects: [
+          {name: 'stock-ticker', fields: [{name: 'symbol', type: 'string'}]},
+        ],
+        blockObjects: [
+          {name: 'image', fields: [{name: 'url', type: 'string'}]},
+        ],
+        styles: [
+          {name: 'normal'},
+          {name: 'h1'},
+          {name: 'h2'},
+          {name: 'blockquote'},
+        ],
+        lists: [{name: 'bullet'}],
+      }),
+      initialValue: fromValue,
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: diffValueToPatches(fromValue, toValue),
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(toValue)
+    })
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ catalogs:
     '@sanity/diff-match-patch':
       specifier: ^3.2.0
       version: 3.2.0
+    '@sanity/diff-patch':
+      specifier: ^6.0.0
+      version: 6.0.0
+    '@sanity/json-match':
+      specifier: ^1.0.5
+      version: 1.0.5
     '@sanity/schema':
       specifier: ^6.9.1
       version: 6.9.1
@@ -588,6 +594,12 @@ importers:
       '@sanity/diff-match-patch':
         specifier: 'catalog:'
         version: 3.2.0
+      '@sanity/diff-patch':
+        specifier: 'catalog:'
+        version: 6.0.0
+      '@sanity/json-match':
+        specifier: 'catalog:'
+        version: 1.0.5
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 12.1.0(@babel/runtime@7.28.4)(@tsdown/css@0.22.14)(@types/node@20.19.25)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
@@ -13340,7 +13352,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.25)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -13356,9 +13368,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@20.19.25)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
 catalog:
   "@floating-ui/dom": ^1.7.6
   "@sanity/diff-match-patch": ^3.2.0
+  "@sanity/diff-patch": ^6.0.0
+  "@sanity/json-match": ^1.0.5
   "@sanity/schema": ^6.9.1
   "@sanity/types": ^6.9.1
   "@types/debug": ^4.1.12
@@ -62,7 +64,6 @@ minimumReleaseAgeExclude:
   - react-dom
   - react-is
   - markdown-it@14.1.1
-  # Renovate security update: astro@7.1.0
   - astro@6.1.3 || 6.1.6 || 6.1.10 || 6.4.6 || 7.1.0
   - vite@7.3.2 || 7.3.5
   - turbo@2.9.14


### PR DESCRIPTION
First brick of the revised patch pipeline (the "one transport" unification): property tests that pin the round-trip fidelity of `diffValue`-into-editor-patches, the transport `update value` will eventually ride.

Store-side, 500 seeded value pairs: `applyAll(convert(diffValue(a, b)), a)` reproduces `b` exactly, across a 15-mutation generator (text edits, mark toggles, annotation add/remove, span splits, rekeys, block reorders/inserts/removals, inline and block objects, list/style changes). This is the reference application every patch consumer shares, and it is byte-faithful across the space.

Engine-side, 40 seeds through the editor's real `patches` event. The fuzz made its first discovery immediately, and it is architectural rather than an applier bug: 7 seeds fail because mount-time canonicalization merges adjacent same-mark spans in the initial value, so the engine's base diverges from the diff's base before any patch arrives, and the diff's keyed targets are gone. Correlation is exact, every failing seed has same-mark adjacency in `fromValue`, zero counterexamples. This empirically promotes "cosmetic normalization runs only as local-edit fallout" from desirable cleanup to a hard prerequisite of the one-transport architecture: `diff(engineValue, incoming)` requires the engine to byte-track the document.

The 7 seeds are committed as `test.fails`, green today, and the moment adoption-time cosmetics stop, vitest reports them as unexpectedly passing and they must be moved to the green set: the suite is its own acceptance test for that future change.

Deliberately minimal surface: `diffValueToPatches` duplicates the plugin's `convertPatches`/`arrayifyPath` into `test-utils` with keep-in-sync pointers (house rule: duplicate over export), and `@sanity/diff-patch`/`@sanity/json-match` enter as devDependencies only. No runtime code, no public API, no changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions and devDependency catalog entries; no runtime editor behavior or public exports change.
> 
> **Overview**
> Adds **property tests** for the planned `diffValue` → editor-patches transport (no production or public API changes).
> 
> **Store layer:** 500 seeded `(fromValue, toValue)` pairs from a deterministic fuzz generator (text, marks, annotations, blocks, rekeys, etc.). Asserts `applyAll(fromValue, diffValueToPatches(from, to))` equals `toValue` byte-for-byte.
> 
> **Engine layer:** 40 seeds mount the editor on `fromValue`, send the same patches via the `patches` event, and expect the snapshot value to match `toValue`—isolating gaps in engine patch application vs shared `applyAll`.
> 
> Test-only **`diffValueToPatches`** wraps `@sanity/diff-patch` and maps Sanity path strings to PTE paths (duplicated from the SDK value plugin’s `convertPatches` / `arrayifyPath`, with sync comments). **`@sanity/diff-patch`** and **`@sanity/json-match`** are added as editor **devDependencies** via the workspace catalog; lockfile updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b05108a1fa12378daf826d7cd30d1b4b228292e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->