### PR TITLE
fix: run cosmetic span normalization only as fallout of local edits

### DIFF
--- a/.changeset/cosmetic-normalization-local-only.md
+++ b/.changeset/cosmetic-normalization-local-only.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: run cosmetic span normalization only as fallout of local edits
+
+Loading a document (`initialValue`) or receiving an `update value` no longer merges adjacent same-mark spans or removes empty sibling spans: adopted span structure is kept as the document has it, on every path, and canonicalizes when a local edit next touches its block.
+
+Consumers with fragmented documents (for example CMS-migrated content with split spans) will no longer see a wave of span-merge mutations ride out with the first keystroke after opening. Structural repairs (missing keys, missing required fields, empty blocks) and `markDefs` housekeeping are unaffected.

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -600,9 +600,9 @@ function clearEditor({
   editorEngine: PortableTextEditorEngine
   doneSyncing: boolean
 }) {
-  withoutNormalizing(editorEngine, () => {
-    pluginWithoutHistory(editorEngine, () => {
-      withRemoteChanges(editorEngine, () => {
+  withRemoteChanges(editorEngine, () => {
+    withoutNormalizing(editorEngine, () => {
+      pluginWithoutHistory(editorEngine, () => {
         withoutPatching(editorEngine, () => {
           if (doneSyncing) {
             return
@@ -640,8 +640,8 @@ function removeExtraBlocks({
 }) {
   let isChanged = false
 
-  withoutNormalizing(editorEngine, () => {
-    withRemoteChanges(editorEngine, () => {
+  withRemoteChanges(editorEngine, () => {
+    withoutNormalizing(editorEngine, () => {
       withoutPatching(editorEngine, () => {
         const childrenLength = editorEngine.snapshot.context.value.length
 
@@ -708,8 +708,8 @@ function syncBlock({
         schemaTypes: context.schema,
       })
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             editorEngine.apply({
               type: 'insert',
@@ -795,8 +795,8 @@ function syncBlock({
     if (oldBlock._key === block._key && oldBlock._type === block._type) {
       debug.syncValue('Updating block', oldBlock, repairedBlock)
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             updateBlock({
               context,
@@ -811,8 +811,8 @@ function syncBlock({
     } else {
       debug.syncValue('Replacing block', oldBlock, repairedBlock)
 
-      withoutNormalizing(editorEngine, () => {
-        withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, () => {
+        withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             replaceBlock({
               context,

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -43,10 +43,10 @@ import type {WithEditorFirstArg} from '../utils/types'
  * a collaborator's structure either forks that base (kept local) or makes
  * every receiver a competing writer on the originator's spans (pushed).
  * Non-canonical structure renders identically and re-canonicalizes on the
- * block's next local edit. Value sync (`update value`) still canonicalizes
- * (self-solving), but only because its normalize flush runs outside
- * `withRemoteChanges`; a wrapper-nesting change in the sync machine would
- * silently revoke that.
+ * block's next local edit. This covers every adoption path: remote
+ * `patches` and value sync (`update value`) both flush normalization
+ * inside `withRemoteChanges`, so cosmetic rules run only as fallout of
+ * locally authored edits.
  */
 function isCosmeticNormalizationSkipped(editor: Editor): boolean {
   return editor.isProcessingRemoteChanges

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1829,7 +1829,7 @@ describe('event.update value: adjacent same-mark spans', () => {
     },
   ]
 
-  test('Scenario: updating with the stored split shape after the engine merged on load', async () => {
+  test('Scenario: updating with the stored split shape after a local edit merged the engine', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),
       schemaDefinition: defineSchema({
@@ -1838,8 +1838,23 @@ describe('event.update value: adjacent same-mark spans', () => {
       initialValue: splitValue,
     })
 
-    // The engine normalizes on load: the three adjacent `strong` spans
-    // merge into one.
+    // Adopted structure is kept as-is; the split shape survives the load.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(splitValue)
+    })
+
+    // A local edit dirties the block: the three adjacent `strong` spans
+    // merge as fallout, and the engine's shape now diverges from the
+    // stored one.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's4'}], offset: 1},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 's4'}], offset: 1},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([
         {
@@ -1847,7 +1862,7 @@ describe('event.update value: adjacent same-mark spans', () => {
           _type: 'block',
           children: [
             {_key: 's1', _type: 'span', text: 'C1C2C3', marks: ['strong']},
-            {_key: 's4', _type: 'span', text: 'D', marks: []},
+            {_key: 's4', _type: 'span', text: 'D!', marks: []},
             {_key: 's5', _type: 'span', text: 'E', marks: ['em']},
           ],
           markDefs: [],
@@ -1858,8 +1873,8 @@ describe('event.update value: adjacent same-mark spans', () => {
 
     // The consumer sends an update: a new block appended, while the
     // adjacent-span block is still in its stored (split) shape. The
-    // changed value forces a sync, and the untouched block diffs against
-    // the engine's merged shape.
+    // changed value forces a sync, and the block diffs against the
+    // engine's merged shape.
     const appendedBlock = {
       _key: 'b1',
       _type: 'block',
@@ -1872,24 +1887,20 @@ describe('event.update value: adjacent same-mark spans', () => {
       value: [...splitValue, appendedBlock],
     })
 
-    // The sync applies the split shape and the engine re-normalizes it to
-    // the merged shape; the sync actor survives.
-    await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual([
-        {
-          _key: 'b0',
-          _type: 'block',
-          children: [
-            {_key: 's1', _type: 'span', text: 'C1C2C3', marks: ['strong']},
-            {_key: 's4', _type: 'span', text: 'D', marks: []},
-            {_key: 's5', _type: 'span', text: 'E', marks: ['em']},
-          ],
-          markDefs: [],
-          style: 'normal',
-        },
-        appendedBlock,
-      ])
-    })
+    // The engine adopts the document's split shape as-is (the update is
+    // document truth, so the local `!` goes too) and the sync actor
+    // survives the shape mismatch.
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          ...splitValue,
+          appendedBlock,
+        ])
+      },
+      // The sync machine parks in `busy` while the local edit's emitted
+      // mutation flushes and re-checks on a 1s timer.
+      {timeout: 5000},
+    )
 
     // The sync actor is still alive: a later update still lands.
     editor.send({

--- a/packages/editor/tests/normalization.test.tsx
+++ b/packages/editor/tests/normalization.test.tsx
@@ -6,7 +6,7 @@ import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 
 describe('normalization', () => {
-  test('Scenario: spans with the same marks are merged', async () => {
+  test('Scenario: adjacent same-mark spans merge as fallout of a local edit', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
     const spanFooKey = keyGenerator()
@@ -31,6 +31,27 @@ describe('normalization', () => {
       }),
     })
 
+    // Adopted structure is kept as-is; cosmetic canonicalization only runs
+    // as fallout of locally authored edits.
+    await vi.waitFor(() => {
+      return expect(editor.getSnapshot().context.value).toEqual([block])
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
     await vi.waitFor(() => {
       return expect(editor.getSnapshot().context.value).toEqual([
         {
@@ -40,7 +61,7 @@ describe('normalization', () => {
               ...block.children[0],
               text: 'foobar',
             },
-            block.children[2],
+            {...block.children[2], text: 'baz!'},
           ],
         },
       ])
@@ -72,6 +93,21 @@ describe('normalization', () => {
       }),
     })
 
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
     await vi.waitFor(() => {
       return expect(editor.getSnapshot().context.value).toEqual([
         {
@@ -81,7 +117,7 @@ describe('normalization', () => {
               ...block.children[0],
               text: 'foobar',
             },
-            block.children[2],
+            {...block.children[2], text: 'baz!'},
           ],
         },
       ])
@@ -614,7 +650,7 @@ describe('normalization', () => {
     })
   })
 
-  test('Scenario: selection is preserved when spans merge during normalization', async () => {
+  test('Scenario: selection is preserved when a remote marks change creates same-mark adjacency', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
     const spanFooKey = keyGenerator()
@@ -683,18 +719,16 @@ describe('normalization', () => {
       ],
     })
 
+    // Adopted structure is kept as-is (no merge on adoption), so the
+    // caret's span survives untouched: no selection remapping needed.
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([
         {
           _type: 'block',
           _key: blockKey,
           children: [
-            {
-              _type: 'span',
-              _key: spanFooKey,
-              text: 'foobar',
-              marks: ['strong'],
-            },
+            {_type: 'span', _key: spanFooKey, text: 'foo', marks: ['strong']},
+            {_type: 'span', _key: spanBarKey, text: 'bar', marks: ['strong']},
           ],
           markDefs: [],
           style: 'normal',
@@ -703,12 +737,12 @@ describe('normalization', () => {
 
       expect(editor.getSnapshot().context.selection).toEqual({
         anchor: {
-          path: [{_key: blockKey}, 'children', {_key: spanFooKey}],
-          offset: 4,
+          path: [{_key: blockKey}, 'children', {_key: spanBarKey}],
+          offset: 1,
         },
         focus: {
-          path: [{_key: blockKey}, 'children', {_key: spanFooKey}],
-          offset: 4,
+          path: [{_key: blockKey}, 'children', {_key: spanBarKey}],
+          offset: 1,
         },
         backward: false,
       })

--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -450,7 +450,7 @@ describe('remote patches skip cosmetic normalization', () => {
     expect(documentAfterEcho).toEqual(documentValue)
   })
 
-  test('`update value` still canonicalizes adjacent same-mark spans', async () => {
+  test('`update value` keeps adjacent same-mark spans as-is', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
     const spanKey = keyGenerator()
@@ -478,12 +478,19 @@ describe('remote patches skip cosmetic normalization', () => {
       ],
     })
 
+    // Adopted structure is kept byte-for-byte: cosmetic canonicalization
+    // runs only as fallout of locally authored edits, on every adoption
+    // path. The engine's value must track the document exactly for
+    // diffed-value patches to target live keys.
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([
         {
           _type: 'block',
           _key: blockKey,
-          children: [{_type: 'span', _key: spanKey, text: 'foobar', marks: []}],
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+            {_type: 'span', _key: 'otherSpan', text: 'bar', marks: []},
+          ],
           markDefs: [],
           style: 'normal',
         },


### PR DESCRIPTION
Opening a fragmented document and typing one character currently pushes a document-wide wave of structural rewrites: mount-time normalization merges every block's adjacent same-mark spans, parks the fallout on the pristine editor, and the first keystroke flushes it all, rewriting blocks the user never touched.

The cause is a nesting order. The sync machine's five apply sites wrap `withoutNormalizing` outside `withRemoteChanges`, so the normalize flush runs after the remote flag is restored and the cosmetic gate from #3001 never sees value adoption. The fix reorders the wrappers so `withRemoteChanges` is outermost. History and patching wrappers keep their positions relative to the flush, so repair emission and undo semantics are byte-identical.

Net behavior change: adopted span structure (`initialValue`, `update value`) is kept as the document has it, adjacent same-mark spans and empty sibling spans no longer merge away on load, and canonicalizes only as fallout of a local edit to its block. Scoped to the two rules #3001 classified as cosmetic: structural repairs still run everywhere, and markDef GC and empty-span annotation stripping are deliberately untouched (their classification is a tracked open decision). Four pins of the old behavior are re-homed rather than deleted: the merge contracts re-trigger via local edits, the selection pin flips to the stronger no-remap contract, and the sync-survival scenario builds its shape mismatch from a local merge. Full suites green.

Independent of #3011, whose round-trip fuzz surfaced the bug (mount-time merging forks the engine's base from the document, so diffed patches target dead keys); its seven `test.fails` seeds graduate when that branch rebases over this fix.
