### PR TITLE
fix: normalize optional-field defaults only when a local edit touches the block

### DIFF
--- a/.changeset/normalize-defaults-on-touch.md
+++ b/.changeset/normalize-defaults-on-touch.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: normalize optional-field defaults only when a local edit touches the block
+
+Loading a document (`initialValue`) or receiving an `update value` no longer fills in missing `style`, `marks`, or `markDefs` fields: adopted blocks stay exactly as the document has them, in the editor's value too, and no patches are held back for them. When a local edit touches such a block, its defaults are filled in and emitted as part of that edit.
+
+Consumers reading `editor.getSnapshot().context.value` will see adopted blocks without these optional fields until the user edits them (renderers already default the fields at read time). The first edit after opening no longer flushes a document-wide wave of default writes; each block's defaults ride the edit that touches it. Validity-critical repairs (missing `_key`/`_type`/`text`, duplicate keys, empty blocks) still run on every path.

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -31,27 +31,6 @@ import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
 
-/**
- * Normalization rules split into two classes. Repairs fix structure the
- * engine cannot represent (missing `_key`/`_type`, duplicate keys, missing
- * required fields, empty blocks, unbracketed inline objects) and always
- * run. Cosmetic rules canonicalize structure that is already valid
- * Portable Text (merging adjacent same-mark spans, dropping empty sibling
- * spans) and must not run while applying remote patches: emitted text
- * patches are `diffMatchPatch` against a keyed span's text, so the wire
- * structure is the shared base between editor and store, and canonicalizing
- * a collaborator's structure either forks that base (kept local) or makes
- * every receiver a competing writer on the originator's spans (pushed).
- * Non-canonical structure renders identically and re-canonicalizes on the
- * block's next local edit. This covers every adoption path: remote
- * `patches` and value sync (`update value`) both flush normalization
- * inside `withRemoteChanges`, so cosmetic rules run only as fallout of
- * locally authored edits.
- */
-function isCosmeticNormalizationSkipped(editor: Editor): boolean {
-  return editor.isProcessingRemoteChanges
-}
-
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
   entry,
@@ -77,7 +56,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Merge spans with same set of .marks
    */
   if (
-    !isCosmeticNormalizationSkipped(editor) &&
+    !editor.isProcessingRemoteChanges &&
     isTextBlock({schema: editor.snapshot.context.schema}, node)
   ) {
     const children = getChildren(editor.snapshot, path)
@@ -283,6 +262,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Add missing .markDefs to text block nodes
    */
   if (
+    !editor.isProcessingRemoteChanges &&
     isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
     !Array.isArray(node.markDefs)
   ) {
@@ -295,6 +275,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Add missing .style to text block nodes
    */
   if (
+    !editor.isProcessingRemoteChanges &&
     isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
     typeof node.style === 'undefined'
   ) {
@@ -329,6 +310,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
    * Add missing .marks to span nodes
    */
   if (
+    !editor.isProcessingRemoteChanges &&
     isSpan({schema: editor.snapshot.context.schema}, node) &&
     !Array.isArray(node.marks)
   ) {
@@ -587,9 +569,9 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
         if (
           prev != null &&
           isSpan({schema: editor.snapshot.context.schema}, prev) &&
-          // Only this merge/empty-drop arm is cosmetic; the inline-object
+          // Only this merge/empty-drop arm defers; the inline-object
           // bracketing below is a repair and keeps running.
-          !isCosmeticNormalizationSkipped(editor)
+          !editor.isProcessingRemoteChanges
         ) {
           // Merge adjacent text nodes that are empty or match.
           if (child.text === '') {

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -82,6 +82,16 @@ export interface PortableTextEditorEngine extends DOMEditor {
   isNormalizingNode: boolean
   isPatching: boolean
   isPerformingBehaviorOperation: boolean
+  /**
+   * True while the editor applies content that arrived from outside:
+   * remote `patches` and value sync.
+   *
+   * Normalization reads this flag to leave adopted content alone. While
+   * it is set, only repairs of invalid structure run (missing `_key` or
+   * `text`, empty blocks). Optional fix-ups (merging same-mark spans,
+   * filling in `style`/`marks`/`markDefs` defaults) wait until a local
+   * edit touches the block and then emit as part of that edit.
+   */
   isProcessingRemoteChanges: boolean
   isRedoing: boolean
   isUndoing: boolean

--- a/packages/editor/tests/PortableTextEditor.test.tsx
+++ b/packages/editor/tests/PortableTextEditor.test.tsx
@@ -43,7 +43,7 @@ describe('initialization', () => {
     const onChange = vi.fn()
     const editorRef = createRef<PortableTextEditor>()
 
-    await createTestEditor({
+    const {editor} = await createTestEditor({
       children: (
         <>
           <EventListenerPlugin on={onChange} />
@@ -53,7 +53,8 @@ describe('initialization', () => {
       initialValue,
     })
 
-    const normalizedEditorValue = [{...initialValue[0], style: 'normal'}]
+    // Adoption keeps the value exactly as given: the missing `style` is
+    // not filled in on load.
     await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({
         type: 'value changed',
@@ -61,10 +62,132 @@ describe('initialization', () => {
       })
     })
     if (editorRef.current) {
-      expect(PortableTextEditor.getValue(editorRef.current)).toStrictEqual(
-        normalizedEditorValue,
-      )
+      expect(PortableTextEditor.getValue(editorRef.current)).toStrictEqual([
+        ...initialValue,
+      ])
     }
+
+    // A local edit touching the block fills in and emits the missing
+    // `style` as part of that edit, and the editor's own document agrees.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 5},
+        focus: {path: [{_key: '123'}, 'children', {_key: '567'}], offset: 5},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        type: 'patch',
+        patch: {
+          type: 'set',
+          path: [{_key: '123'}, 'style'],
+          value: 'normal',
+          origin: 'local',
+        },
+      })
+      if (editorRef.current) {
+        expect(PortableTextEditor.getValue(editorRef.current)).toStrictEqual([
+          {
+            _key: '123',
+            _type: 'block',
+            markDefs: [],
+            children: [{_key: '567', _type: 'span', text: 'Hello!', marks: []}],
+            style: 'normal',
+          },
+        ])
+      }
+    })
+  })
+
+  it('keeps untouched blocks byte-identical: an edit elsewhere emits none of their default fills', async () => {
+    const completeBlock: PortableTextBlock = {
+      _key: 'aaa',
+      _type: 'block',
+      style: 'normal',
+      markDefs: [],
+      children: [{_key: 'a1', _type: 'span', text: 'Alpha', marks: []}],
+    }
+    const bareBlock: PortableTextBlock = {
+      // Missing `style`, `markDefs`, and the span's `marks`: the shape an
+      // API-created document ships with.
+      _key: 'bbb',
+      _type: 'block',
+      children: [{_key: 'b1', _type: 'span', text: 'Beta'}],
+    }
+    const onChange = vi.fn()
+    const editorRef = createRef<PortableTextEditor>()
+
+    const {editor} = await createTestEditor({
+      children: (
+        <>
+          <EventListenerPlugin on={onChange} />
+          <InternalPortableTextEditorRefPlugin ref={editorRef} />
+        </>
+      ),
+      initialValue: [completeBlock, bareBlock],
+    })
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        type: 'value changed',
+        value: [completeBlock, bareBlock],
+      })
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'aaa'}, 'children', {_key: 'a1'}], offset: 5},
+        focus: {path: [{_key: 'aaa'}, 'children', {_key: 'a1'}], offset: 5},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      if (editorRef.current) {
+        expect(PortableTextEditor.getValue(editorRef.current)).toStrictEqual([
+          {
+            ...completeBlock,
+            children: [{_key: 'a1', _type: 'span', text: 'Alpha!', marks: []}],
+          },
+          bareBlock,
+        ])
+      }
+    })
+
+    // The parked-wave regression shape: before defaults were deferred to
+    // local edits, the first keystroke flushed fills for blocks the user
+    // never touched.
+    expect(onChange).not.toHaveBeenCalledWith({
+      type: 'patch',
+      patch: {
+        type: 'set',
+        path: [{_key: 'bbb'}, 'style'],
+        value: 'normal',
+        origin: 'local',
+      },
+    })
+    expect(onChange).not.toHaveBeenCalledWith({
+      type: 'patch',
+      patch: {
+        type: 'set',
+        path: [{_key: 'bbb'}, 'markDefs'],
+        value: [],
+        origin: 'local',
+      },
+    })
+    expect(onChange).not.toHaveBeenCalledWith({
+      type: 'patch',
+      patch: {
+        type: 'set',
+        path: [{_key: 'bbb'}, 'children', {_key: 'b1'}, 'marks'],
+        value: [],
+        origin: 'local',
+      },
+    })
   })
 
   it('takes initial selection from props', async () => {

--- a/packages/editor/tests/block-index-map-path-keyed.test.tsx
+++ b/packages/editor/tests/block-index-map-path-keyed.test.tsx
@@ -46,12 +46,17 @@ describe('blockIndexMap is keyed by path with bare-_key read fallback', () => {
       expect(editor.getSnapshot().context.value).toHaveLength(2)
     })
 
-    expect([...editor.getSnapshot().blockIndexMap]).toEqual([
-      ['[_key=="b0"]', 0],
-      ['[_key=="b0"].children[_key=="s0"]', 0],
-      ['[_key=="k2"]', 1],
-      ['[_key=="k2"].children[_key=="k3"]', 0],
-    ])
+    // Map insertion order follows normalization visits; with defaults
+    // deferred to local edits, `b0`'s child entry is re-registered by the
+    // split and iterates last. The entries and indexes are what matter.
+    expect(new Map(editor.getSnapshot().blockIndexMap)).toEqual(
+      new Map([
+        ['[_key=="b0"]', 0],
+        ['[_key=="b0"].children[_key=="s0"]', 0],
+        ['[_key=="k2"]', 1],
+        ['[_key=="k2"].children[_key=="k3"]', 0],
+      ]),
+    )
   })
 
   test('Scenario: delete.block clears the removed entry and shifts the survivor', async () => {

--- a/packages/editor/tests/collaborative-editing.test.tsx
+++ b/packages/editor/tests/collaborative-editing.test.tsx
@@ -235,9 +235,7 @@ describe('Collaborative editing', () => {
           {
             _type: 'block',
             _key: blockKey,
-            children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
-            markDefs: [],
-            style: 'normal',
+            children: [{_key: spanKey, _type: 'span', text: 'foo'}],
           },
         ])
       })
@@ -259,8 +257,7 @@ describe('Collaborative editing', () => {
           {
             _type: 'block',
             _key: blockKey,
-            children: [{_key: spanKey, _type: 'span', text: 'bar', marks: []}],
-            markDefs: [],
+            children: [{_key: spanKey, _type: 'span', text: 'bar'}],
             style: 'normal',
           },
         ])
@@ -284,18 +281,25 @@ describe('Collaborative editing', () => {
         ])
       })
 
+      // The typing patch first, then the block's deferred defaults riding
+      // the same edit.
       expect(emittedPatches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'markDefs'],
-          value: [],
-        },
         diffMatchPatch('bar', 'barb', [
           {_key: blockKey},
           'children',
           {_key: spanKey},
           'text',
         ]),
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
+          value: [],
+        },
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
         diffMatchPatch('barb', 'barba', [
           {_key: blockKey},
           'children',
@@ -308,6 +312,18 @@ describe('Collaborative editing', () => {
           {_key: spanKey},
           'text',
         ]),
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_key: spanKey, _type: 'span', text: 'barbaz', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
 
@@ -394,9 +410,7 @@ describe('Collaborative editing', () => {
           {
             _type: 'block',
             _key: blockKey,
-            children: [
-              {_key: spanKey, _type: 'span', text: 'hello', marks: []},
-            ],
+            children: [{_key: spanKey, _type: 'span', text: 'hello'}],
             markDefs: [],
             style: 'normal',
           },
@@ -421,20 +435,32 @@ describe('Collaborative editing', () => {
         ])
       })
 
-      // Should include the deferred marks normalization patch (unrelated path)
-      // plus the typing patch
+      // The typing patch first, then the span's deferred `marks` default
+      // riding the same edit.
       expect(emittedPatches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
-          value: [],
-        },
         diffMatchPatch('hello', 'hello!', [
           {_key: blockKey},
           'children',
           {_key: spanKey},
           'text',
         ]),
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
+          value: [],
+        },
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_key: spanKey, _type: 'span', text: 'hello!', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
 
@@ -802,7 +828,7 @@ describe('Collaborative editing', () => {
             _type: 'block',
             _key: blockKey,
             children: [
-              {_key: span1Key, _type: 'span', text: 'Price: ', marks: []},
+              {_key: span1Key, _type: 'span', text: 'Price: '},
               {_key: stockTickerKey, _type: 'stock-ticker', symbol: 'GOOG'},
               {_key: span2Key, _type: 'span', text: '', marks: []},
             ],
@@ -832,20 +858,36 @@ describe('Collaborative editing', () => {
         ])
       })
 
-      // Should include the deferred marks normalization patch (unrelated child)
-      // plus the typing patch
+      // The typing patch first, then the span's deferred `marks` default
+      // riding the same edit.
       expect(emittedPatches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', {_key: span1Key}, 'marks'],
-          value: [],
-        },
         diffMatchPatch('Price: ', 'Price: x', [
           {_key: blockKey},
           'children',
           {_key: span1Key},
           'text',
         ]),
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: span1Key}, 'marks'],
+          value: [],
+        },
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_key: span1Key, _type: 'span', text: 'Price: x', marks: []},
+            {_key: stockTickerKey, _type: 'stock-ticker', symbol: 'GOOG'},
+            {_key: span2Key, _type: 'span', text: '', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
 
@@ -1045,7 +1087,6 @@ describe('Collaborative editing', () => {
             children: [
               {_key: spanKey, _type: 'span', text: 'hello', marks: []},
             ],
-            markDefs: [],
             style: 'normal',
           },
         ])
@@ -1069,20 +1110,32 @@ describe('Collaborative editing', () => {
         ])
       })
 
-      // Should include the deferred markDefs patch (unrelated path)
-      // plus the typing patch
+      // The typing patch first, then the block's deferred `markDefs`
+      // default riding the same edit.
       expect(emittedPatches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'markDefs'],
-          value: [],
-        },
         diffMatchPatch('hello', 'hello!', [
           {_key: blockKey},
           'children',
           {_key: spanKey},
           'text',
         ]),
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_key: spanKey, _type: 'span', text: 'hello!', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
 
@@ -1170,8 +1223,7 @@ describe('Collaborative editing', () => {
           {
             _type: 'block',
             _key: blockKey,
-            children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
-            markDefs: [],
+            children: [{_key: spanKey, _type: 'span', text: 'foo'}],
             style: 'h1',
           },
         ])
@@ -1194,9 +1246,17 @@ describe('Collaborative editing', () => {
       })
 
       // Should include markDefs and marks patches, but NOT the style patch
-      // Note: marks patch comes before markDefs because normalization processes
-      // spans before block-level properties
+      // The typing patch first, then the block's deferred defaults riding
+      // the same edit (marks before markDefs: normalization processes spans
+      // before block-level properties). The remote `style` change is not
+      // overwritten: the style rule sees the field present and stays quiet.
       expect(emittedPatches).toEqual([
+        diffMatchPatch('foo', 'foo!', [
+          {_key: blockKey},
+          'children',
+          {_key: spanKey},
+          'text',
+        ]),
         {
           type: 'set',
           path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
@@ -1207,12 +1267,18 @@ describe('Collaborative editing', () => {
           path: [{_key: blockKey}, 'markDefs'],
           value: [],
         },
-        diffMatchPatch('foo', 'foo!', [
-          {_key: blockKey},
-          'children',
-          {_key: spanKey},
-          'text',
-        ]),
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_key: spanKey, _type: 'span', text: 'foo!', marks: []}],
+          markDefs: [],
+          style: 'h1',
+        },
       ])
     })
 
@@ -1445,9 +1511,7 @@ describe('Collaborative editing', () => {
           {
             _type: 'block',
             _key: block1Key,
-            children: [
-              {_key: span1Key, _type: 'span', text: 'first', marks: []},
-            ],
+            children: [{_key: span1Key, _type: 'span', text: 'first'}],
             markDefs: [],
             style: 'normal',
           },
@@ -1490,20 +1554,43 @@ describe('Collaborative editing', () => {
         ])
       })
 
-      // Should include the deferred marks patch (different block)
-      // plus the typing patch
+      // The typing patch first, then the block's deferred `marks` default
+      // riding the same edit.
       expect(emittedPatches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: block1Key}, 'children', {_key: span1Key}, 'marks'],
-          value: [],
-        },
         diffMatchPatch('first', 'first!', [
           {_key: block1Key},
           'children',
           {_key: span1Key},
           'text',
         ]),
+        {
+          type: 'set',
+          path: [{_key: block1Key}, 'children', {_key: span1Key}, 'marks'],
+          value: [],
+        },
+      ])
+
+      // The engine's own document agrees with the emitted patches: the
+      // healed defaults are present in the value, not just on the wire.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: block1Key,
+          children: [
+            {_key: span1Key, _type: 'span', text: 'first!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: block2Key,
+          children: [
+            {_key: span2Key, _type: 'span', text: 'updated', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
   })

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -629,9 +629,7 @@ describe('event.drag.drop', () => {
         {
           _key: blockKey,
           _type: 'block',
-          children: [
-            {_key: spanKey, _type: 'span', text: 'foo bar baz', marks: []},
-          ],
+          children: [{_key: spanKey, _type: 'span', text: 'foo bar baz'}],
           markDefs: [],
           style: 'normal',
         },

--- a/packages/editor/tests/event.paste.test.tsx
+++ b/packages/editor/tests/event.paste.test.tsx
@@ -109,9 +109,7 @@ describe('event.clipboard.paste', () => {
         {
           _key: blockKey,
           _type: 'block',
-          children: [
-            {_key: spanKey, _type: 'span', text: 'foo bar baz', marks: []},
-          ],
+          children: [{_key: spanKey, _type: 'span', text: 'foo bar baz'}],
           markDefs: [],
           style: 'normal',
         },
@@ -143,9 +141,7 @@ describe('event.clipboard.paste', () => {
         {
           _key: blockKey,
           _type: 'block',
-          children: [
-            {_key: spanKey, _type: 'span', text: 'foo bar baz', marks: []},
-          ],
+          children: [{_key: spanKey, _type: 'span', text: 'foo bar baz'}],
           markDefs: [],
           style: 'normal',
         },

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -637,8 +637,6 @@ describe('event.patches', () => {
           children: [
             {_type: 'span', _key: aKey, text: 'abc', marks: ['strong']},
           ],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -761,8 +759,6 @@ describe('event.patches', () => {
           _type: 'block',
           _key: 'k0',
           children: [{_type: 'span', _key: 'k1', text: 'bar', marks: []}],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -800,8 +796,6 @@ describe('event.patches', () => {
               _map: {foo: 'bar'},
             },
           ],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -833,8 +827,6 @@ describe('event.patches', () => {
               _map: {foo: 'bar'},
             },
           ],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -1502,8 +1494,6 @@ describe('event.patches', () => {
             {_type: 'stock-ticker', _key: 'new key'},
             {_type: 'span', _key: span2Key, text: '', marks: []},
           ],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -1559,8 +1549,6 @@ describe('event.patches', () => {
             {_type: 'new type', _key: stockTickerKey},
             {_type: 'span', _key: span2Key, text: '', marks: []},
           ],
-          markDefs: [],
-          style: 'normal',
         },
       ])
     })
@@ -1856,7 +1844,7 @@ describe('event.patches', () => {
           _type: 'block',
           children: [
             {_type: 'span', _key: span1Key, text: '', marks: []},
-            {_type: 'span', _key: newInlineKey, text: '', marks: []},
+            {_type: 'span', _key: newInlineKey, text: ''},
             {_type: 'span', _key: span2Key, text: '', marks: []},
           ],
           markDefs: [],

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -573,24 +573,6 @@ describe('event.update value', () => {
           },
         },
         {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k2'}, 'markDefs'],
-            value: [],
-            inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k2'}, 'style'],
-            value: 'normal',
-            inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
-          },
-        },
-        {
           type: 'invalid value',
           resolution: {
             action: 'Remove the block',
@@ -621,6 +603,139 @@ describe('event.update value', () => {
         },
       ])
     })
+
+    const eventsBeforeEdit = events.length
+    // Provoke the deferred healing: a local edit touching the block fills
+    // in and emits its missing defaults as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+        focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    // The full stream of the healing edit: the user's insert, then the
+    // block's deferred defaults, then the patches and the mutation that
+    // carries them all.
+    await vi.waitFor(() => {
+      expect(events.slice(eventsBeforeEdit)).toEqual([
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+            focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+            backward: false,
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'insert.text',
+            path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+            offset: 3,
+            text: '!',
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k2'}, 'markDefs'],
+            value: [],
+            inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k2'}, 'style'],
+            value: 'normal',
+            inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'diffMatchPatch',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'children', {_key: 'k3'}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'markDefs'],
+            value: [],
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'style'],
+            value: 'normal',
+          },
+        },
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 4},
+            focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 4},
+            backward: false,
+          },
+        },
+        {
+          type: 'mutation',
+          patches: [
+            {
+              type: 'diffMatchPatch',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'children', {_key: 'k3'}, 'text'],
+              value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'markDefs'],
+              value: [],
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'style'],
+              value: 'normal',
+            },
+          ],
+          value: [
+            {
+              _key: 'k2',
+              _type: 'block',
+              children: [{_key: 'k3', _type: 'span', text: 'foo!', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+    // The engine's own document agrees with the emitted patches: the
+    // healed defaults are present in the value, not just on the wire.
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k2',
+        _type: 'block',
+        children: [{_key: 'k3', _type: 'span', text: 'foo!', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
   })
 
   test('Scenario: Updating span with reordered marks', async () => {

--- a/packages/editor/tests/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/tests/pteWarningsSelfSolving.test.tsx
@@ -88,7 +88,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
 
     const onChange = vi.fn()
 
-    await createTestEditor({
+    const {editor} = await createTestEditor({
       children: (
         <>
           <EventListenerPlugin on={onChange} />
@@ -117,6 +117,48 @@ describe('when PTE would display warnings, instead it self solves', () => {
                 _key: 'def',
                 _type: 'span',
                 text: 'No markDefs',
+                marks: [],
+              },
+            ],
+            // Focusing does not dirty the block, so the missing `markDefs`
+            // stays exactly as the document has it until a local edit.
+            style: 'normal',
+          },
+        ])
+      }
+    })
+
+    // Provoke the self-solving: a local edit touching the block fills in
+    // and emits the missing `markDefs` as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'abc'}, 'children', {_key: 'def'}], offset: 11},
+        focus: {path: [{_key: 'abc'}, 'children', {_key: 'def'}], offset: 11},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        type: 'patch',
+        patch: {
+          type: 'set',
+          path: [{_key: 'abc'}, 'markDefs'],
+          value: [],
+          origin: 'local',
+        },
+      })
+      if (editorRef.current) {
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'abc',
+            _type: 'block',
+            children: [
+              {
+                _key: 'def',
+                _type: 'span',
+                text: 'No markDefs!',
                 marks: [],
               },
             ],

--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -5,6 +5,11 @@ import {describe, expect, test, vi} from 'vitest'
 import {defineSchema} from '../src'
 import type {MutationEvent, PatchEvent} from '../src/editor/relay'
 import {EventListenerPlugin} from '../src/plugins'
+import {
+  getMarkState,
+  isActiveAnnotation,
+  isActiveDecorator,
+} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
 
 /**
@@ -492,6 +497,179 @@ describe('remote patches skip cosmetic normalization', () => {
             {_type: 'span', _key: 'otherSpan', text: 'bar', marks: []},
           ],
           markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})
+
+/**
+ * Adopted structure is kept as the document has it, so adjacent same-mark
+ * siblings persist until a local edit touches their block. Mark and
+ * annotation logic must compute correctly over that structure, and the
+ * first local touch canonicalizes it as fallout of the edit.
+ */
+describe('mark state over adopted same-mark siblings', () => {
+  test('caret at the boundary sees the shared decorator and typing continues it', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 'a', text: 'foo', marks: ['strong']},
+            {_type: 'span', _key: 'b', text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+      },
+    })
+    expect(getMarkState(editor.getSnapshot())).toEqual({
+      state: 'unchanged',
+      marks: ['strong'],
+    })
+    expect(isActiveDecorator('strong')(editor.getSnapshot())).toBe(true)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'b'}], offset: 0},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'b'}], offset: 0},
+      },
+    })
+    expect(getMarkState(editor.getSnapshot())).toEqual({
+      state: 'changed',
+      previousMarks: ['strong'],
+      marks: ['strong'],
+    })
+
+    // Typing at the boundary continues the decorator, and the edit
+    // canonicalizes the block: the siblings merge as local fallout.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+      },
+    })
+    editor.send({type: 'insert.text', text: 'X'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 'a', text: 'fooXbar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('a selection across the siblings reports the decorator and toggling strips both', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 'a', text: 'foo', marks: ['strong']},
+            {_type: 'span', _key: 'b', text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 0},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'b'}], offset: 3},
+      },
+    })
+    expect(getMarkState(editor.getSnapshot())).toEqual({
+      state: 'unchanged',
+      marks: ['strong'],
+    })
+
+    editor.send({type: 'decorator.toggle', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [{_type: 'span', _key: 'a', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('siblings sharing an annotation stay one annotation and merge on touch', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 'a', text: 'foo', marks: ['m1']},
+            {_type: 'span', _key: 'b', text: 'bar', marks: ['m1']},
+          ],
+          markDefs: [{_type: 'link', _key: 'm1', href: 'https://example.com'}],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 'a'}], offset: 3},
+      },
+    })
+    expect(getMarkState(editor.getSnapshot())).toEqual({
+      state: 'unchanged',
+      marks: ['m1'],
+    })
+    expect(isActiveAnnotation('link')(editor.getSnapshot())).toBe(true)
+
+    editor.send({type: 'insert.text', text: 'Y'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b0',
+          children: [
+            {_type: 'span', _key: 'a', text: 'fooYbar', marks: ['m1']},
+          ],
+          markDefs: [{_type: 'link', _key: 'm1', href: 'https://example.com'}],
           style: 'normal',
         },
       ])

--- a/packages/editor/tests/self-solving.test.tsx
+++ b/packages/editor/tests/self-solving.test.tsx
@@ -37,12 +37,6 @@ describe('Feature: Self-solving', () => {
         style: 'normal',
       },
     ]
-    const spanPatch: Patch = {
-      type: 'set',
-      path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
-      value: [],
-      origin: 'local',
-    }
     const blockPatch: Patch = {
       type: 'set',
       path: [{_key: blockKey}, 'markDefs'],
@@ -104,35 +98,16 @@ describe('Feature: Self-solving', () => {
     })
 
     await vi.waitFor(() => {
+      // The deferred `markDefs` default rides the same edit that dirtied
+      // the block, after the user's own patch.
       expect(patchEvents).toEqual([
-        {type: 'patch', patch: spanPatch},
-        {type: 'patch', patch: blockPatch},
         {type: 'patch', patch: strongPatch},
+        {type: 'patch', patch: blockPatch},
       ])
       expect(mutationEvents).toEqual([
         {
           type: 'mutation',
-          patches: [spanPatch, blockPatch],
-          value: [
-            {
-              _key: blockKey,
-              _type: 'block',
-              children: [
-                {
-                  _key: spanKey,
-                  _type: 'span',
-                  text: 'foo',
-                  marks: [],
-                },
-              ],
-              style: 'normal',
-              markDefs: [],
-            },
-          ],
-        },
-        {
-          type: 'mutation',
-          patches: [strongPatch],
+          patches: [strongPatch, blockPatch],
           value: [
             {
               _key: blockKey,
@@ -175,7 +150,7 @@ describe('Feature: Self-solving', () => {
       },
     ]
 
-    const {locator} = await createTestEditor({
+    const {editor, locator} = await createTestEditor({
       keyGenerator,
       initialValue,
       children: (
@@ -198,41 +173,31 @@ describe('Feature: Self-solving', () => {
     await userEvent.type(locator, 'f')
 
     await vi.waitFor(() => {
+      // The deferred `style` default rides the same edit that dirtied the
+      // block, after the user's typing patch.
       expect(patches).toEqual([
+        {
+          origin: 'local',
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'f'))),
+        },
         {
           origin: 'local',
           type: 'set',
           path: [{_key: blockKey}, 'style'],
           value: 'normal',
         },
+      ])
+
+      // The engine's own document agrees with the emitted patches.
+      expect(editor.getSnapshot().context.value).toEqual([
         {
-          origin: 'local',
-          type: 'unset',
-          path: [],
-        },
-        {
-          origin: 'local',
-          type: 'setIfMissing',
-          path: [],
-          value: [],
-        },
-        {
-          origin: 'local',
-          type: 'insert',
-          path: [0],
-          position: 'before',
-          items: [
-            {
-              ...initialValue[0],
-              style: 'normal',
-            },
-          ],
-        },
-        {
-          origin: 'local',
-          type: 'diffMatchPatch',
-          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
-          value: stringifyPatches(makePatches(makeDiff('', 'f'))),
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'f', marks: []}],
+          markDefs: [],
+          style: 'normal',
         },
       ])
     })

--- a/packages/editor/tests/setup.test.tsx
+++ b/packages/editor/tests/setup.test.tsx
@@ -62,10 +62,10 @@ describe('Setup', () => {
       expect(toTextspec(editor.getSnapshot().context)).toEqual('B: foo')
     })
 
-    expect(events.slice(0, 7)).toEqual([
-      // Sync applies the valid first block (replacing the seed block `k5`,
-      // with parse fix-ups for the missing `markDefs`/`style`), then stops
-      // at the unknown block object.
+    expect(events.slice(0, 4)).toEqual([
+      // Sync applies the valid first block (replacing the seed block `k5`;
+      // the missing `markDefs`/`style` defaults are deferred until a local
+      // edit touches the block), then stops at the unknown block object.
       {
         type: 'operation',
         operation: {type: 'unset', path: [{_key: 'k5'}]},
@@ -81,36 +81,6 @@ describe('Setup', () => {
             _type: 'block',
             children: [{_type: 'span', _key: 'k1', text: 'foo'}],
           },
-        },
-      },
-      {
-        type: 'operation',
-        operation: {
-          type: 'set',
-          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'marks'],
-          value: [],
-          inverse: {
-            type: 'unset',
-            path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'marks'],
-          },
-        },
-      },
-      {
-        type: 'operation',
-        operation: {
-          type: 'set',
-          path: [{_key: 'k0'}, 'markDefs'],
-          value: [],
-          inverse: {type: 'unset', path: [{_key: 'k0'}, 'markDefs']},
-        },
-      },
-      {
-        type: 'operation',
-        operation: {
-          type: 'set',
-          path: [{_key: 'k0'}, 'style'],
-          value: 'normal',
-          inverse: {type: 'unset', path: [{_key: 'k0'}, 'style']},
         },
       },
       {

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -1,5 +1,6 @@
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
+import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import type {EditorEmittedEvent} from '../src/editor/relay'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
@@ -41,7 +42,7 @@ describe('Value validation', () => {
   test('Scenario: Initial value with `null` child in second block results in a validation error', async () => {
     const keyGenerator = createTestKeyGenerator()
     const events: Array<EditorEmittedEvent> = []
-    await createTestEditor({
+    const {editor} = await createTestEditor({
       keyGenerator,
       initialValue: [
         {
@@ -69,9 +70,9 @@ describe('Value validation', () => {
     await vi.waitFor(() => {
       expect(events).toEqual([
         // Value sync removes the editor's seed block (`k3`: the initial
-        // value consumed `k0`-`k2`), inserts the valid first block, and
-        // parse fix-ups set the missing `markDefs`/`style`. The second,
-        // invalid block is never inserted.
+        // value consumed `k0`-`k2`) and inserts the valid first block as-is
+        // (missing `markDefs`/`style` are filled in on the first local
+        // edit). The second, invalid block is never inserted.
         {
           type: 'operation',
           operation: {type: 'unset', path: [{_key: 'k3'}]},
@@ -87,24 +88,6 @@ describe('Value validation', () => {
               _key: 'k0',
               children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
             },
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k0'}, 'markDefs'],
-            value: [],
-            inverse: {type: 'unset', path: [{_key: 'k0'}, 'markDefs']},
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k0'}, 'style'],
-            value: 'normal',
-            inverse: {type: 'unset', path: [{_key: 'k0'}, 'style']},
           },
         },
         {
@@ -135,6 +118,139 @@ describe('Value validation', () => {
         {type: 'ready'},
       ])
     })
+
+    const eventsBeforeEdit = events.length
+    // Provoke the deferred healing: a local edit touching the block
+    // fills in and emits its missing defaults as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    // The full stream of the healing edit: the user's insert, then the
+    // block's deferred defaults, then the patches and the mutation that
+    // carries them all.
+    await vi.waitFor(() => {
+      expect(events.slice(eventsBeforeEdit)).toEqual([
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+            focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+            backward: false,
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'insert.text',
+            path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+            offset: 3,
+            text: '!',
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k0'}, 'markDefs'],
+            value: [],
+            inverse: {type: 'unset', path: [{_key: 'k0'}, 'markDefs']},
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k0'}, 'style'],
+            value: 'normal',
+            inverse: {type: 'unset', path: [{_key: 'k0'}, 'style']},
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'diffMatchPatch',
+            origin: 'local',
+            path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k0'}, 'markDefs'],
+            value: [],
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k0'}, 'style'],
+            value: 'normal',
+          },
+        },
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+            focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 4},
+            backward: false,
+          },
+        },
+        {
+          type: 'mutation',
+          patches: [
+            {
+              type: 'diffMatchPatch',
+              origin: 'local',
+              path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+              value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k0'}, 'markDefs'],
+              value: [],
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k0'}, 'style'],
+              value: 'normal',
+            },
+          ],
+          value: [
+            {
+              _key: 'k0',
+              _type: 'block',
+              children: [{_key: 'k1', _type: 'span', text: 'foo!', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+    // The engine's own document agrees with the emitted patches: the
+    // healed defaults are present in the value, not just on the wire.
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k0',
+        _type: 'block',
+        children: [{_key: 'k1', _type: 'span', text: 'foo!', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
   })
 
   test('Scenario: Setting child to `null` results in a validation error', async () => {
@@ -195,24 +311,6 @@ describe('Value validation', () => {
             path: [0],
             position: 'before',
             node: syncedBlock,
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: blockKey}, 'markDefs'],
-            value: [],
-            inverse: {type: 'unset', path: [{_key: blockKey}, 'markDefs']},
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: blockKey}, 'style'],
-            value: 'normal',
-            inverse: {type: 'unset', path: [{_key: blockKey}, 'style']},
           },
         },
         {type: 'value changed', value: [syncedBlock]},
@@ -281,6 +379,163 @@ describe('Value validation', () => {
         'B: foo[strong:bar]',
       )
     })
+
+    const eventsBeforeEdit = events.length
+    // Provoke the deferred healing: a local edit touching the block fills
+    // in and emits its missing defaults as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    // The full stream of the healing edit: the user's insert, then the
+    // block's deferred defaults, then the patches and the mutation that
+    // carries them all.
+    await vi.waitFor(() => {
+      expect(events.slice(eventsBeforeEdit)).toEqual([
+        {
+          type: 'selection',
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 3,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 3,
+            },
+            backward: false,
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'insert.text',
+            path: [{_key: blockKey}, 'children', {_key: fooKey}],
+            offset: 3,
+            text: '!',
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: blockKey}, 'markDefs'],
+            value: [],
+            inverse: {type: 'unset', path: [{_key: blockKey}, 'markDefs']},
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: blockKey}, 'style'],
+            value: 'normal',
+            inverse: {type: 'unset', path: [{_key: blockKey}, 'style']},
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'diffMatchPatch',
+            origin: 'local',
+            path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: blockKey}, 'markDefs'],
+            value: [],
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: blockKey}, 'style'],
+            value: 'normal',
+          },
+        },
+        {
+          type: 'selection',
+          selection: {
+            anchor: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 4,
+            },
+            focus: {
+              path: [{_key: blockKey}, 'children', {_key: fooKey}],
+              offset: 4,
+            },
+            backward: false,
+          },
+        },
+        {
+          type: 'mutation',
+          patches: [
+            {
+              type: 'diffMatchPatch',
+              origin: 'local',
+              path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+              value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: blockKey}, 'markDefs'],
+              value: [],
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: blockKey}, 'style'],
+              value: 'normal',
+            },
+          ],
+          value: [
+            {
+              _key: blockKey,
+              _type: 'block',
+              children: [
+                {_key: fooKey, _type: 'span', text: 'foo!', marks: []},
+                {_key: barKey, _type: 'span', text: 'bar', marks: ['strong']},
+              ],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+    // The engine's own document agrees with the emitted patches: the
+    // healed defaults are present in the value, not just on the wire.
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: blockKey,
+        _type: 'block',
+        children: [
+          {_key: fooKey, _type: 'span', text: 'foo!', marks: []},
+          {_key: barKey, _type: 'span', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
   })
 
   test('Scenario: New block with `null` child results in a validation error', async () => {
@@ -341,24 +596,6 @@ describe('Value validation', () => {
           },
         },
         {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k2'}, 'markDefs'],
-            value: [],
-            inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
-          },
-        },
-        {
-          type: 'operation',
-          operation: {
-            type: 'set',
-            path: [{_key: 'k2'}, 'style'],
-            value: 'normal',
-            inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
-          },
-        },
-        {
           type: 'invalid value',
           resolution: {
             action: 'Remove the item',
@@ -385,5 +622,137 @@ describe('Value validation', () => {
         },
       ])
     })
+    const eventsBeforeEdit = events.length
+    // Provoke the deferred healing: a local edit touching the block fills
+    // in and emits its missing defaults as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+        focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    // The full stream of the healing edit: the user's insert, then the
+    // block's deferred defaults, then the patches and the mutation that
+    // carries them all.
+    await vi.waitFor(() => {
+      expect(events.slice(eventsBeforeEdit)).toEqual([
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+            focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 3},
+            backward: false,
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'insert.text',
+            path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+            offset: 3,
+            text: '!',
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k2'}, 'markDefs'],
+            value: [],
+            inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
+          },
+        },
+        {
+          type: 'operation',
+          operation: {
+            type: 'set',
+            path: [{_key: 'k2'}, 'style'],
+            value: 'normal',
+            inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'diffMatchPatch',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'children', {_key: 'k3'}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'markDefs'],
+            value: [],
+          },
+        },
+        {
+          type: 'patch',
+          patch: {
+            type: 'set',
+            origin: 'local',
+            path: [{_key: 'k2'}, 'style'],
+            value: 'normal',
+          },
+        },
+        {
+          type: 'selection',
+          selection: {
+            anchor: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 4},
+            focus: {path: [{_key: 'k2'}, 'children', {_key: 'k3'}], offset: 4},
+            backward: false,
+          },
+        },
+        {
+          type: 'mutation',
+          patches: [
+            {
+              type: 'diffMatchPatch',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'children', {_key: 'k3'}, 'text'],
+              value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'markDefs'],
+              value: [],
+            },
+            {
+              type: 'set',
+              origin: 'local',
+              path: [{_key: 'k2'}, 'style'],
+              value: 'normal',
+            },
+          ],
+          value: [
+            {
+              _key: 'k2',
+              _type: 'block',
+              children: [{_key: 'k3', _type: 'span', text: 'foo!', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ])
+    })
+    // The engine's own document agrees with the emitted patches: the
+    // healed defaults are present in the value, not just on the wire.
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _key: 'k2',
+        _type: 'block',
+        children: [{_key: 'k3', _type: 'span', text: 'foo!', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
   })
 })


### PR DESCRIPTION
Opening a document with blocks missing `style`, `marks`, or `markDefs` does two dangerous things: the engine fills the defaults in immediately, so its value diverges from the stored document the moment it loads, and it parks the resulting patches on the pristine editor, so the first keystroke flushes a document-wide wave of default writes onto blocks the user never touched. This is the still-reachable half of the divergence class whose span-merge half died in #3013; a production report has since shown what the divergence does downstream (Studio re-applying the affected blocks on every sync, unmounting open dialogs).

The fix: content taken in from outside is kept exactly as it is; normalization happens only as part of local edits, and only on the blocks they touch. Three one-line gates skip the default rules while adopting outside content (`initialValue`, `update value`, remote patches), the same gate the cosmetic span rules already use. A local edit that touches a block fills its defaults right then, emitted as part of that edit.

Untouched blocks stay byte-identical to the document, so diff-based consumers (the SDK repair machinery, value diffing) see equality instead of stable divergence, and nothing is parked for them. Validity-critical repairs (`_key`/`_type`/`text` mints, duplicate keys, empty blocks) still run on every path. The contract is pinned directly: editing one block emits none of a bare sibling's fills and leaves it byte-identical, red on `main`.

Companion: #3030 keeps toolbar style selectors coherent once defaults are deferred (`getActiveStyle` reads a missing `style` as the sub-schema default). It merges first; this PR makes its changed read reachable.
