### PR TITLE
fix(plugin-sdk-value): prevent transient duplicate remote pastes

### DIFF
--- a/.changeset/remote-paste-staging.md
+++ b/.changeset/remote-paste-staging.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: prevent transient duplicate text after a remote paste

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -381,6 +381,48 @@ export function toEngineSafePatches(
 }
 
 /**
+ * A text paste can stage a temporary span and remove it in the same local
+ * flush. The SDK may emit the insert before that cleanup even though its
+ * current value already reflects the completed transaction.
+ */
+function filterInsertsMissingFromRemoteValue(
+  patches: PtePatch[],
+  remoteValue: PortableTextBlock[],
+): PtePatch[] {
+  return patches.flatMap((patch): PtePatch[] => {
+    if (patch.type !== 'insert') {
+      return [patch]
+    }
+
+    const parentValue = getValueAtPath(
+      remoteValue as unknown as JSONValue,
+      patch.path.slice(0, -1),
+    )
+    if (!Array.isArray(parentValue)) {
+      return [patch]
+    }
+
+    const items = patch.items.filter((item) => {
+      const itemKey = getKey(item)
+      if (!itemKey) {
+        return true
+      }
+      return parentValue.some((candidate) => getKey(candidate) === itemKey)
+    })
+
+    return items.length > 0 ? [{...patch, items}] : []
+  })
+}
+
+function getKey(value: JSONValue): string | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined
+  }
+  const key = (value as {_key?: unknown})._key
+  return typeof key === 'string' ? key : undefined
+}
+
+/**
  * The editor writes `markDefs` as whole-array `set`s. Two clients
  * formatting the same block concurrently then overwrite each other's
  * arrays at the server (last writer wins) while both clients' span
@@ -838,9 +880,11 @@ const valueSyncMachine = setup({
       const coalesced = remoteValue
         ? toEngineSafePatches(event.patches, remoteValue)
         : event.patches
-      const patches = coalesced.filter((patch) =>
-        canApplyToValue(patch, snapshot),
-      )
+      const patches = (
+        remoteValue
+          ? filterInsertsMissingFromRemoteValue(coalesced, remoteValue)
+          : coalesced
+      ).filter((patch) => canApplyToValue(patch, snapshot))
       if (patches.length === 0) {
         return
       }

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -657,6 +657,43 @@ describe('ValueSyncPlugin', () => {
       expect(store.pushValue).not.toHaveBeenCalled()
     })
 
+    test('does not render a staging span absent from the remote value', async () => {
+      const initialValue = [makeBlock('b1', 'A: ')]
+      const finalValue = [makeBlock('b1', 'A: ALPHA')]
+      const store = createMockPatchStore(initialValue)
+      const {editor, unmount} = await createSyncedEditor({store})
+      cleanup = unmount
+
+      await vi.waitFor(() => {
+        expect(getEditorText(editor)).toEqual('B: A: ')
+      })
+
+      store.receiveRemoteTransaction(finalValue, [
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}],
+          items: [
+            {
+              _type: 'span',
+              _key: 'staging-span',
+              text: 'ALPHA',
+              marks: [],
+            },
+          ] as unknown as JSONValue[],
+        },
+        {
+          type: 'diffMatchPatch',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}, 'text'],
+          value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+        },
+      ])
+
+      expect(getEditorText(editor)).toEqual('B: A: ALPHA')
+    })
+
     test('remote text set applies to a specific span', async () => {
       const store = createMockPatchStore([
         makeBlock('b1', 'First'),


### PR DESCRIPTION
## Description

Remote clipboard pastes can arrive as a temporary span insert followed by a text diff, while the cleanup unset reaches peers later. Receivers briefly rendered the pasted text twice.

Filter keyed inserted items that are absent from the SDK's current value before applying remote patches. The text diff still applies immediately.

## What to review

- `packages/plugin-sdk-value/src/plugin.sdk-value.tsx`: filters transient staged inserts from incoming remote patches.
- `packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx`: covers the staged insert plus text-diff sequence.

## Testing

- `pnpm test:unit`
- `pnpm test:browser:chromium`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm build`
- Live two-browser clipboard-paste trace against the local build

## Notes for release

Prevents remote editors from briefly displaying pasted plain text twice.