### PR TITLE
fix: cancel net-zero insert/unset pairs when flushing mutations

### DIFF
--- a/.changeset/cancel-net-zero-mutation-patches.md
+++ b/.changeset/cancel-net-zero-mutation-patches.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: cancel net-zero insert/unset pairs when flushing mutations
+
+Edits that create and discard content within one flush, such as a paste whose text merges into an existing span, previously emitted `mutation` events carrying the scratch work: keyed inserts followed by the unsets retracting them. Receivers applying those patches in slices could transiently render the discarded content, for example a remote paste briefly showing its text twice.
+
+Emitted mutations now carry only the net change. Code observing `mutation` events sees fewer patches for such edits, and a mutation whose patches all cancel out is not emitted at all. Individual `patch` events are unchanged.

--- a/packages/editor/src/editor/mutation-batcher.ts
+++ b/packages/editor/src/editor/mutation-batcher.ts
@@ -2,6 +2,7 @@ import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import {isNormalizing} from '../engine/editor/is-normalizing'
+import {cancelNetZeroPatches} from '../internal-utils/cancel-net-zero-patches'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
 import type {Relay} from './relay'
@@ -122,11 +123,19 @@ export function createMutationBatcher({
     editorEngine.isDeferringMutations = false
 
     for (const bulk of mutations) {
+      const patches = cancelNetZeroPatches(bulk.patches)
+
+      if (patches.length === 0) {
+        // Every patch in the bulk cancelled out: the mutation nets to
+        // nothing, so there is nothing to tell consumers.
+        continue
+      }
+
       // The editor machine still gates mutations through its setup states
       // and re-emits them to the relay.
       editorActor.send({
         type: 'mutation',
-        patches: bulk.patches,
+        patches,
         value: bulk.value,
       })
     }

--- a/packages/editor/src/internal-utils/cancel-net-zero-patches.test.ts
+++ b/packages/editor/src/internal-utils/cancel-net-zero-patches.test.ts
@@ -1,0 +1,327 @@
+import type {Patch} from '@portabletext/patches'
+import {describe, expect, test} from 'vitest'
+import {cancelNetZeroPatches} from './cancel-net-zero-patches'
+
+describe('cancelNetZeroPatches', () => {
+  test('cancels an inserted-then-unset span, leaving the net change', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'ALPHA', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual([
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+        origin: 'local',
+      },
+    ])
+  })
+
+  test('cancels the full paste emission shape, both transient spans', () => {
+    // The eight patches a merged `insert.blocks` emits: `k4` is the empty
+    // split-remainder span, `k3` the pasted span, both merged away by
+    // normalization within the same flush.
+    const patches: Array<Patch> = [
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'markDefs'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'setIfMissing',
+        path: [{_key: 'b1'}, 'children'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'k4', marks: [], text: ''}],
+        origin: 'local',
+      },
+      {
+        type: 'setIfMissing',
+        path: [{_key: 'b1'}, 'children'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'k3', text: 'ALPHA', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'k3'}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'k4'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'markDefs'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'setIfMissing',
+        path: [{_key: 'b1'}, 'children'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'setIfMissing',
+        path: [{_key: 'b1'}, 'children'],
+        value: [],
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+        origin: 'local',
+      },
+    ])
+  })
+
+  test('drops patches scoped inside the cancelled item', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: '', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}, 'text'],
+        value: 'scratch',
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual([])
+  })
+
+  test('removes only the cancelled item from a multi-item insert', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [
+          {_type: 'span', _key: 'x1', text: 'keep', marks: []},
+          {_type: 'span', _key: 'x2', text: 'scratch', marks: []},
+        ],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x2'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual([
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'keep', marks: []}],
+        origin: 'local',
+      },
+    ])
+  })
+
+  test('bails when the key anchors another insert', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'scratch', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'y1', text: 'anchored', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual(patches)
+  })
+
+  test('bails when the key is referenced outside the insert/unset window', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'scratch', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}, 'text'],
+        value: 'after the window',
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual(patches)
+  })
+
+  test('keeps an unset of a key the flush never inserted', () => {
+    // A plain local deletion: the unset targets pre-existing content and
+    // must pass through untouched.
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual(patches)
+  })
+
+  test('does not pair an unset that precedes the insert', () => {
+    // Remove-then-recreate with the same key nets to a replacement, not
+    // to nothing.
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'recreated', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual(patches)
+  })
+
+  test('cancels the first pair and keeps a re-insert of the same key', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'scratch', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b1'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'final', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual([
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'final', marks: []}],
+        origin: 'local',
+      },
+    ])
+  })
+
+  test('treats same key under different parents as different items', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'x1', text: 'scratch', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b2'}, 'children', {_key: 'x1'}],
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toEqual(patches)
+  })
+
+  test('returns the input untouched when nothing cancels', () => {
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: '@@ -1,3 +1,4 @@\n foo\n+b\n',
+        origin: 'local',
+      },
+    ]
+
+    expect(cancelNetZeroPatches(patches)).toBe(patches)
+  })
+})

--- a/packages/editor/src/internal-utils/cancel-net-zero-patches.ts
+++ b/packages/editor/src/internal-utils/cancel-net-zero-patches.ts
@@ -1,0 +1,186 @@
+import type {Patch, Path} from '@portabletext/patches'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+
+type Creation = {
+  insertIndex: number
+  itemIndex: number
+  unsetIndex?: number
+}
+
+/**
+ * Removes patches that sum to nothing within one mutation flush: a keyed
+ * item that is both inserted and unset contributed nothing to the net
+ * change, and neither did any patch scoped inside it. Receivers whose
+ * delivery slices a transaction otherwise render the transient item (a
+ * paste, for example, stages a temporary span and merges it away in the
+ * same flush).
+ *
+ * Cancellation assumes keys inserted during a flush are fresh, which the
+ * key generator guarantees. It bails per key when anything outside the
+ * insert/unset window references the key, or when another insert uses the
+ * key as its `before`/`after` anchor, since cancelling an anchor target
+ * would dangle the reference.
+ */
+export function cancelNetZeroPatches(patches: Array<Patch>): Array<Patch> {
+  const creations = new Map<string, Array<Creation>>()
+
+  patches.forEach((patch, patchIndex) => {
+    if (patch.type !== 'insert') {
+      return
+    }
+    const parentId = serializePath(patch.path.slice(0, -1))
+    patch.items.forEach((item, itemIndex) => {
+      const key = getItemKey(item)
+      if (key === undefined) {
+        return
+      }
+      const id = `${parentId}/k:${key}`
+      const existing = creations.get(id)
+      if (existing) {
+        existing.push({insertIndex: patchIndex, itemIndex})
+      } else {
+        creations.set(id, [{insertIndex: patchIndex, itemIndex}])
+      }
+    })
+  })
+
+  if (creations.size === 0) {
+    return patches
+  }
+
+  patches.forEach((patch, patchIndex) => {
+    if (patch.type !== 'unset') {
+      return
+    }
+    const lastSegment = patch.path.at(-1)
+    if (!isKeyedSegment(lastSegment)) {
+      return
+    }
+    const id = `${serializePath(patch.path.slice(0, -1))}/k:${lastSegment._key}`
+    const creation = creations
+      .get(id)
+      ?.find(
+        (candidate) =>
+          candidate.unsetIndex === undefined &&
+          candidate.insertIndex < patchIndex,
+      )
+    if (creation) {
+      creation.unsetIndex = patchIndex
+    }
+  })
+
+  const droppedPatchIndexes = new Set<number>()
+  const droppedInsertItems = new Map<number, Set<number>>()
+
+  for (const [id, creationList] of creations) {
+    const key = id.slice(id.lastIndexOf('/k:') + 3)
+
+    for (const creation of creationList) {
+      if (creation.unsetIndex === undefined) {
+        continue
+      }
+      const insertIndex = creation.insertIndex
+      const unsetIndex = creation.unsetIndex
+
+      let bail = false
+      const scopedPatchIndexes = new Set<number>()
+
+      patches.forEach((patch, patchIndex) => {
+        if (patchIndex === insertIndex || patchIndex === unsetIndex) {
+          return
+        }
+        const role = getReferenceRole(patch, key)
+        if (role === 'none') {
+          return
+        }
+        if (
+          role === 'anchor' ||
+          patchIndex < insertIndex ||
+          patchIndex > unsetIndex
+        ) {
+          bail = true
+          return
+        }
+        scopedPatchIndexes.add(patchIndex)
+      })
+
+      if (bail) {
+        continue
+      }
+
+      const existingItems = droppedInsertItems.get(creation.insertIndex)
+      if (existingItems) {
+        existingItems.add(creation.itemIndex)
+      } else {
+        droppedInsertItems.set(
+          creation.insertIndex,
+          new Set([creation.itemIndex]),
+        )
+      }
+      droppedPatchIndexes.add(unsetIndex)
+      for (const scopedPatchIndex of scopedPatchIndexes) {
+        droppedPatchIndexes.add(scopedPatchIndex)
+      }
+    }
+  }
+
+  if (droppedPatchIndexes.size === 0 && droppedInsertItems.size === 0) {
+    return patches
+  }
+
+  return patches.flatMap((patch, patchIndex) => {
+    if (droppedPatchIndexes.has(patchIndex)) {
+      return []
+    }
+    const droppedItems = droppedInsertItems.get(patchIndex)
+    if (droppedItems && patch.type === 'insert') {
+      const items = patch.items.filter(
+        (_, itemIndex) => !droppedItems.has(itemIndex),
+      )
+      return items.length > 0 ? [{...patch, items}] : []
+    }
+    return [patch]
+  })
+}
+
+function getReferenceRole(
+  patch: Patch,
+  key: string,
+): 'none' | 'scoped' | 'anchor' {
+  const keyedSegmentIndex = patch.path.findIndex(
+    (segment) => isKeyedSegment(segment) && segment._key === key,
+  )
+  if (keyedSegmentIndex === -1) {
+    return 'none'
+  }
+  if (patch.type === 'insert' && keyedSegmentIndex === patch.path.length - 1) {
+    // The insert positions its items `before`/`after` the key.
+    return 'anchor'
+  }
+  return 'scoped'
+}
+
+function getItemKey(item: unknown): string | undefined {
+  if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+    return undefined
+  }
+  const key = (item as {_key?: unknown})._key
+  return typeof key === 'string' ? key : undefined
+}
+
+function serializePath(path: Path): string {
+  return path
+    .map((segment) => {
+      if (isKeyedSegment(segment)) {
+        return `k:${segment._key}`
+      }
+      if (typeof segment === 'number') {
+        return `i:${segment}`
+      }
+      if (typeof segment === 'string') {
+        return `s:${segment}`
+      }
+      return `t:${segment.join(':')}`
+    })
+    .join('/')
+}

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -263,4 +263,90 @@ describe('event.mutation', () => {
       expect(mutationEvents.length).toBe(2)
     })
   })
+
+  test('Scenario: A merged insert does not emit its transient spans', async () => {
+    // Inserting text that merges into an existing same-mark span stages
+    // temporary spans and merges them away within the same flush. The
+    // emitted mutation carries only the net change: receivers whose
+    // delivery slices a transaction would otherwise render the transient
+    // spans (a remote paste briefly showing its text twice).
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'A: ', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    const mutations: Array<Array<Patch>> = []
+    editor.on('mutation', (event) => {
+      mutations.push(event.patches)
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
+      },
+    })
+    editor.send({
+      type: 'insert.blocks',
+      blocks: [
+        {
+          _type: 'block',
+          children: [{_type: 'span', text: 'ALPHA', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      placement: 'auto',
+    })
+
+    await vi.waitFor(() => {
+      expect(mutations).toEqual([
+        [
+          {
+            type: 'set',
+            path: [{_key: 'b1'}, 'markDefs'],
+            value: [],
+            origin: 'local',
+          },
+          {
+            type: 'setIfMissing',
+            path: [{_key: 'b1'}, 'children'],
+            value: [],
+            origin: 'local',
+          },
+          {
+            type: 'setIfMissing',
+            path: [{_key: 'b1'}, 'children'],
+            value: [],
+            origin: 'local',
+          },
+          {
+            type: 'diffMatchPatch',
+            path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+            value: '@@ -1,3 +1,8 @@\n A: \n+ALPHA\n',
+            origin: 'local',
+          },
+        ],
+      ])
+    })
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'b1',
+        children: [{_type: 'span', _key: 's1', text: 'A: ALPHA', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
 })


### PR DESCRIPTION
When someone pastes text into a paragraph, remote peers can briefly see the pasted text twice before it snaps back to normal. #3017 fixed this receiver-side for SDK consumers by filtering incoming inserts absent from the store's settled value; this PR fixes the sender so the transient content is never published in the first place, for every consumer.

The emission is the problem. A paste whose text merges into an existing same-mark span stages temporary spans and merges them away within one flush: the mutation carried all eight patches of that narration, two keyed inserts (the pasted span and an empty split remainder), the neighbor's `diffMatchPatch`, and two unsets retracting the inserts. Those pairs sum to nothing, and the store's final state is identical with or without them. But a receiver applies patches against its own engine state in the order delivered, and when delivery slices the transaction it renders the intermediate states. A probe with a `MutationObserver` on a receiving editor confirmed the split of responsibility: handed all the patches in one send, the DOM passes through exactly one state; handed them across sends, it paints the duplicate. The editor renders atomically per batch, so the only defense that works for every delivery is to not emit the scratch work.

`cancelNetZeroPatches` runs where a bulk flushes in the mutation batcher: a keyed item that is both inserted and unset within the flush is cancelled, together with every patch scoped inside it, and pairing is sequential so a re-insert of the same key survives as the net change. Two conservative guards keep it honest, pinned by unit tests over synthetic flushes: it bails per key when the key anchors another insert (cancelling an anchor target would dangle the reference) and when anything references the key outside the insert/unset window (a remove-then-recreate nets to a replacement, not to nothing). It assumes flush-created keys are fresh, which the key generator guarantees. A bulk whose patches all cancel is not emitted. The browser pin in `event.mutation.test.tsx` asserts the paste emission collapses to the single text diff, with the engine value agreeing.

Blast radius: document state is byte-identical by construction, undo is untouched (history is built from engine operations, not emitted patches), and individual `patch` events keep the full narration; only the `mutation` stream, which is what channels push to remotes, carries the collapsed form. All existing suites pass unmodified, editor and `plugin-sdk-value` alike, including the #3017 test: no existing pin ever asserted a mutation containing transient content. The one observable delta beyond fewer patches is that an edit whose patches fully cancel emits no mutation at all, which is the correct statement of "nothing changed".
