### PR TITLE
docs(editor): add missing plugins to reference list

### DIFF
--- a/apps/docs/src/content/docs/editor/reference/plugins.mdx
+++ b/apps/docs/src/content/docs/editor/reference/plugins.mdx
@@ -52,6 +52,11 @@ function LogTextPlugin() {
     href="https://github.com/portabletext/editor/tree/main/packages/plugin-character-pair-decorator"
   />
   <LinkCard
+    title="@portabletext/plugin-dnd"
+    description="Track the drop position during drag and drop for custom drop indicators."
+    href="https://github.com/portabletext/editor/tree/main/packages/plugin-dnd"
+  />
+  <LinkCard
     title="@portabletext/plugin-emoji-picker"
     description="Easily configure an Emoji Picker for the Portable Text Editor."
     href="https://github.com/portabletext/editor/tree/main/packages/plugin-emoji-picker"
@@ -60,6 +65,11 @@ function LogTextPlugin() {
     title="@portabletext/plugin-input-rule"
     description="Easily configure Input Rules in the Portable Text Editor."
     href="https://github.com/portabletext/editor/tree/main/packages/plugin-input-rule"
+  />
+  <LinkCard
+    title="@portabletext/plugin-list-index"
+    description="Compute the list index of each list item for custom list rendering."
+    href="https://github.com/portabletext/editor/tree/main/packages/plugin-list-index"
   />
   <LinkCard
     title="@portabletext/plugin-markdown-shortcuts"
@@ -80,6 +90,11 @@ function LogTextPlugin() {
     title="@portabletext/plugin-sdk-value"
     description="Connects a Portable Text Editor with a Sanity document using the SDK."
     href="https://github.com/portabletext/editor/tree/main/packages/plugin-sdk-value"
+  />
+  <LinkCard
+    title="@portabletext/plugin-table"
+    description="Tables as real Portable Text, edited with spreadsheet-grade selection."
+    href="https://github.com/portabletext/editor/tree/main/packages/plugin-table"
   />
   <LinkCard
     title="@portabletext/plugin-typeahead-picker"


### PR DESCRIPTION
## Description

The [Plugins reference page](https://github.com/portabletext/editor/blob/main/apps/docs/src/content/docs/editor/reference/plugins.mdx) lists 9 plugins, but the monorepo currently publishes 12 `@portabletext/plugin-*` packages. This adds the three missing entries so the page matches what's actually available in `packages/`:

| Package | Description |
| --- | --- |
| `@portabletext/plugin-dnd` | Track the drop position during drag and drop for custom drop indicators |
| `@portabletext/plugin-list-index` | Compute the list index of each list item for custom list rendering |
| `@portabletext/plugin-table` | Tables as real Portable Text, edited with spreadsheet-grade selection |

Each new `LinkCard` keeps the existing alphabetical order and reuses the package's own `package.json` description. All three are published (`private: false`).

## What's changed

- Added `LinkCard` entries for `plugin-dnd`, `plugin-list-index`, and `plugin-table` to the "Available plugins" grid.

Docs-only change; no code affected.