### PR TITLE
docs: add a Containers concept page and a render-props migration guide

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
               label: 'Guides',
               items: [
                 {slug: 'editor/guides/custom-rendering'},
+                {slug: 'editor/guides/migrate-render-props'},
                 {slug: 'editor/guides/customize-toolbar'},
                 {slug: 'editor/guides/create-behavior'},
                 {slug: 'editor/guides/behavior-cheat-sheet'},

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -112,6 +112,7 @@ export default defineConfig({
               items: [
                 {slug: 'editor/concepts/portabletext'},
                 {slug: 'editor/concepts/behavior'},
+                {slug: 'editor/concepts/containers'},
               ],
             },
             {

--- a/apps/docs/src/content/docs/editor/concepts/containers.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/containers.mdx
@@ -246,66 +246,9 @@ function TextBlock(props: TextBlockRenderProps) {
 
 Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
 
-### Route legacy render props into registrations
-
-An existing editor typically renders every custom object through the same two callbacks: `renderBlock` for block objects and `renderChild` for inline objects, one generic implementation regardless of `_type`. `defineBlockObject` and `defineInlineObject` accept the catch-all `type: '*'` for exactly this shape of code: one registration matches every object type that has no more specific registration, so your generic renderers route straight through:
-
-```tsx
-const nodes = [
-  defineBlockObject({
-    type: '*',
-    render: ({attributes, children, node}) => (
-      <div {...attributes}>
-        {/* Whatever your `renderBlock` callback returned. */}
-        <BlockObjectPreview node={node} />
-        {children}
-      </div>
-    ),
-  }),
-  defineInlineObject({
-    type: '*',
-    render: ({attributes, children, node}) => (
-      <span {...attributes}>
-        {/* Whatever your `renderChild` callback returned. */}
-        <InlineObjectPreview node={node} />
-        {children}
-      </span>
-    ),
-  }),
-]
-```
-
-For text blocks, `type: 'block'` is all you need. The engine's legacy composition nests style innermost, list item around it, and the block wrapper outermost; reproduce that order in the registration:
-
-```tsx
-const nodes = [
-  defineTextBlock({
-    type: 'block',
-    render: ({attributes, children, node}) => {
-      let content = children
-
-      if (node.style !== undefined) {
-        // Whatever your `renderStyle` callback returned.
-        content = <StyleWrapper style={node.style}>{content}</StyleWrapper>
-      }
-
-      if (node.listItem !== undefined) {
-        // Whatever your `renderListItem` callback returned.
-        content = (
-          <ListItemWrapper listItem={node.listItem} level={node.level ?? 1}>
-            {content}
-          </ListItemWrapper>
-        )
-      }
-
-      // Whatever your `renderBlock` callback wrapped around it all.
-      return <div {...attributes}>{content}</div>
-    },
-  }),
-]
-```
-
-The render props carry `node`, `path`, `focused`, and `selected`, so your existing components get the same information the legacy callbacks received. Once every kind you use is registered, the legacy props can come off `<PortableTextEditable>` entirely.
+:::note[Migrating from the render props?]
+If your editor renders through the legacy props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`), each has a registration equivalent, and the engine dispatches per `_type`, so you can migrate one kind at a time. The [migration guide](/editor/guides/migrate-render-props/) walks through it.
+:::
 
 ## Editing follows the sub-schema
 

--- a/apps/docs/src/content/docs/editor/concepts/containers.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/containers.mdx
@@ -1,0 +1,461 @@
+---
+title: Containers
+description: Nest editable rich text inside custom structures like callouts, code blocks, and tables, while the value stays plain Portable Text.
+sidebar:
+  order: 2
+---
+
+A container is a block object that holds editable rich text: one of its fields is an array whose members include text blocks (or further containers). Containers are how callouts carry editable paragraphs, code blocks carry editable lines, and tables carry editable cells, without leaving Portable Text.
+
+## Containers are plain Portable Text
+
+There is no editor-specific data format. A container in the value is an ordinary object block whose field happens to hold more blocks:
+
+```json
+{
+  "_type": "callout",
+  "_key": "a1b2c3",
+  "tone": "note",
+  "content": [
+    {
+      "_type": "block",
+      "_key": "d4e5f6",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "g7h8i9",
+          "text": "Editable text inside the callout.",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ]
+}
+```
+
+Serializers and queries see nested Portable Text, nothing more. What makes it a _container_ is that the editor knows to render the `content` array as an editable region instead of treating `callout` as an opaque block object.
+
+## Declare the schema
+
+A container starts in the schema: a block object with an array field whose `of` includes a `{type: 'block'}` member.
+
+```ts
+import {defineSchema} from '@portabletext/editor'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [
+        {name: 'tone', type: 'string'},
+        {name: 'content', type: 'array', of: [{type: 'block'}]},
+      ],
+    },
+  ],
+})
+```
+
+The nested `{type: 'block'}` member declares the _sub-schema_ for text inside the container. Each of `styles`, `decorators`, `annotations`, `lists`, and `inlineObjects` resolves independently:
+
+- **Declared** on the nested block, it overrides for that property.
+- **Declared empty** (`decorators: []`), it forbids that property inside the container.
+- **Absent**, it inherits from the nearest enclosing container that declares one, falling back to the root schema.
+
+This is how a code block restricts its lines to a `code` style with no decorators while the rest of the document keeps its full schema. The complete resolution rules live in the [`@portabletext/schema` README](https://github.com/portabletext/editor/tree/main/packages/schema#containers-and-sub-schemas).
+
+## Register the container
+
+The schema declares what a container _allows_; a registration tells the editor to _render_ it as one. Create the registration with `defineContainer` and mount it with `NodePlugin`:
+
+```tsx
+import {
+  defineContainer,
+  EditorProvider,
+  PortableTextEditable,
+} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
+
+// Module scope: a new array identity re-registers the nodes on every render.
+const nodes = [
+  defineContainer({
+    type: 'callout',
+    arrayField: 'content',
+    render: ({attributes, children, selected}) => (
+      <aside {...attributes} data-selected={selected ? '' : undefined}>
+        <span contentEditable={false}>💡</span>
+        {children}
+      </aside>
+    ),
+  }),
+]
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <NodePlugin nodes={nodes} />
+      <PortableTextEditable />
+    </EditorProvider>
+  )
+}
+```
+
+The render contract:
+
+- Spread `attributes` onto your outer element so the engine can track the node.
+- Render `children` where the editable content goes; the engine fills it with the container's blocks.
+- Mark any chrome that is not editable content (icons, buttons, drag handles) with `contentEditable={false}`.
+- `renderDefault` renders the engine's minimal wrapper; call it to fall back or wrap the default. It does not chain to a globally-registered render: the engine default is the canonical fallback at any position.
+
+Omitting `render` falls through to the engine default, so a registration can exist purely to mark the field as editable.
+
+Registering a container also normalizes the value: existing blocks of the registered type are seeded down to a cursor-ready structure, so a bare `table` block gains a `rows` array holding an empty row, cell, and text block.
+
+## Nest containers
+
+Containers nest through the `of` array, which scopes registrations to positions inside the parent. A table is three containers deep:
+
+```tsx
+defineContainer({
+  type: 'table',
+  arrayField: 'rows',
+  render: ({attributes, children}) => <table {...attributes}>{children}</table>,
+  of: [
+    defineContainer({
+      type: 'row',
+      arrayField: 'cells',
+      render: ({attributes, children}) => <tr {...attributes}>{children}</tr>,
+      of: [
+        defineContainer({
+          type: 'cell',
+          arrayField: 'content',
+          render: ({attributes, children}) => (
+            <td {...attributes}>{children}</td>
+          ),
+        }),
+      ],
+    }),
+  ],
+})
+```
+
+Nesting isn't limited to containers: `of` accepts any block-level registration, `defineContainer`, `defineTextBlock`, and `defineBlockObject`, so anything can render differently inside a container than in the rest of the document. A code block can render each line without paragraph spacing, and a callout can render images compactly. Inline kinds scope the same way one level down, through a text block's own `of`, which takes `defineSpan` and `defineInlineObject` registrations (a `code-span` inside a code block, for example).
+
+Scope is one level deep: an `of` override applies to the container's immediate children only, and anything nested deeper falls through to the global registrations. An image inside a table cell sees the cell's `of`, not the table's.
+
+## Registrations opt into the new render pipeline
+
+The editor has two rendering paths: the render props on `<PortableTextEditable>` are the older one, and registrations replace them rather than compose with them. Registering nodes with `NodePlugin` opts those positions, and everything rendered inside them, into the editor's new render pipeline, and that changes who owns what. Your `render` owns the outer wrapper entirely: the engine emits only `data-pt-*` attributes, and the node render props on `<PortableTextEditable>`, `renderBlock`, `renderStyle`, `renderListItem`, and `renderChild`, do not compose for registered nodes. Span-level rendering keeps working: `renderDecorator`, `renderAnnotation`, `renderPlaceholder`, and range decorations fire on the spans inside `children` regardless of who renders the block.
+
+The pipeline boundary is the subtree. Inside a registered container, unregistered node types render through the engine defaults, never through the node render props, so registering a container usually means bringing a `defineTextBlock` (and registrations for anything else that renders inside it) along with it.
+
+Each kind of node has its own registration factory, and they mount together through one `NodePlugin`:
+
+```tsx
+import {
+  defineBlockObject,
+  defineContainer,
+  defineTextBlock,
+} from '@portabletext/editor'
+
+const nodes = [
+  // A container: a block object with an editable child array.
+  defineContainer({
+    type: 'callout',
+    arrayField: 'content',
+    render: ({attributes, children}) => (
+      <aside {...attributes}>{children}</aside>
+    ),
+  }),
+  // Text blocks. `block` is the text block type at every nesting level,
+  // so this one registration covers paragraphs at the top level and
+  // inside the callout alike.
+  defineTextBlock({
+    type: 'block',
+    render: ({attributes, children, node}) => (
+      <div {...attributes} data-style={node.style}>
+        {children}
+      </div>
+    ),
+  }),
+  // A non-editable void block. Render `children` as well: the engine
+  // mounts its internals through them.
+  defineBlockObject({
+    type: 'image',
+    render: ({attributes, children, node}) => (
+      <figure {...attributes}>
+        <img src={String(node.src)} alt="" contentEditable={false} />
+        {children}
+      </figure>
+    ),
+  }),
+]
+```
+
+Owning the wrapper means owning things the engine used to do for you. The two that surprise people:
+
+**List rendering.** The engine's default list-item wrapping and ordered-list numbering do not apply to custom text-block renders. Your render handles `node.listItem` and `node.level`, and [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, correct across nesting, remote edits, and non-list blocks interrupting a list.
+
+**Drop indicators.** The engine renders no drop-indicator chrome for registered nodes: where a dragged block would land is pointer-driven UI, deliberately yours. [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's public `drag.*` events.
+
+Both plugins follow the same pattern: a provider inside `EditorProvider`, and a hook read from your render, called from a component the render returns, not inline in the `render` callback, since hooks can't run there:
+
+```tsx
+import type {TextBlockRenderProps} from '@portabletext/editor'
+import {DndProvider, useDropPosition} from '@portabletext/plugin-dnd'
+import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'
+
+const nodes = [
+  defineTextBlock({
+    type: 'block',
+    render: (props) => <TextBlock {...props} />,
+  }),
+]
+
+function TextBlock(props: TextBlockRenderProps) {
+  // The 1-based position within the list, or `undefined` for a block
+  // that is not a list item.
+  const listIndex = useListIndex(props.path)
+  // `'start' | 'end'` while a block drag hovers this block.
+  const dropPosition = useDropPosition(props.path)
+
+  return (
+    <div {...props.attributes} style={{position: 'relative'}}>
+      {listIndex !== undefined ? (
+        <span contentEditable={false}>{listIndex}. </span>
+      ) : null}
+      {props.children}
+      {dropPosition ? <DropIndicator edge={dropPosition} /> : null}
+    </div>
+  )
+}
+```
+
+```tsx
+<EditorProvider initialConfig={{schemaDefinition}}>
+  <ListIndexProvider>
+    <DndProvider>
+      <PortableTextEditable />
+    </DndProvider>
+  </ListIndexProvider>
+  <NodePlugin nodes={nodes} />
+</EditorProvider>
+```
+
+Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
+
+### Route legacy render props into registrations
+
+An existing editor typically renders every custom object through the same two callbacks: `renderBlock` for block objects and `renderChild` for inline objects, one generic implementation regardless of `_type`. `defineBlockObject` and `defineInlineObject` accept the catch-all `type: '*'` for exactly this shape of code: one registration matches every object type that has no more specific registration, so your generic renderers route straight through:
+
+```tsx
+const nodes = [
+  defineBlockObject({
+    type: '*',
+    render: ({attributes, children, node}) => (
+      <div {...attributes}>
+        {/* Whatever your `renderBlock` callback returned. */}
+        <BlockObjectPreview node={node} />
+        {children}
+      </div>
+    ),
+  }),
+  defineInlineObject({
+    type: '*',
+    render: ({attributes, children, node}) => (
+      <span {...attributes}>
+        {/* Whatever your `renderChild` callback returned. */}
+        <InlineObjectPreview node={node} />
+        {children}
+      </span>
+    ),
+  }),
+]
+```
+
+For text blocks, `type: 'block'` is all you need. The engine's legacy composition nests style innermost, list item around it, and the block wrapper outermost; reproduce that order in the registration:
+
+```tsx
+const nodes = [
+  defineTextBlock({
+    type: 'block',
+    render: ({attributes, children, node}) => {
+      let content = children
+
+      if (node.style !== undefined) {
+        // Whatever your `renderStyle` callback returned.
+        content = <StyleWrapper style={node.style}>{content}</StyleWrapper>
+      }
+
+      if (node.listItem !== undefined) {
+        // Whatever your `renderListItem` callback returned.
+        content = (
+          <ListItemWrapper listItem={node.listItem} level={node.level ?? 1}>
+            {content}
+          </ListItemWrapper>
+        )
+      }
+
+      // Whatever your `renderBlock` callback wrapped around it all.
+      return <div {...attributes}>{content}</div>
+    },
+  }),
+]
+```
+
+The render props carry `node`, `path`, `focused`, and `selected`, so your existing components get the same information the legacy callbacks received. Once every kind you use is registered, the legacy props can come off `<PortableTextEditable>` entirely.
+
+## Editing follows the sub-schema
+
+Inside a container, the editor resolves the schema at the caret, not the top-level schema. A code block whose sub-schema declares no decorators won't accept bold, whether from the keyboard, the toolbar, or a paste.
+
+Schema-aware plugins get the same gating for free, because their callbacks receive the sub-schema at the caret as `context.schema`. Take a schema whose code block forbids decorators, and a Markdown shortcut configured by schema lookup:
+
+```tsx
+import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  blockObjects: [
+    {
+      name: 'code-block',
+      fields: [
+        {
+          name: 'lines',
+          type: 'array',
+          // The code line allows a `code` style and no decorators.
+          of: [{type: 'block', styles: [{name: 'code'}], decorators: []}],
+        },
+      ],
+    },
+  ],
+})
+```
+
+```tsx
+<MarkdownShortcutsPlugin
+  boldDecorator={({context}) =>
+    context.schema.decorators.find((decorator) => decorator.name === 'strong')
+      ?.name
+  }
+/>
+```
+
+The callback runs against the schema at the caret. In a regular paragraph the lookup finds `strong`, so typing `**bold**` applies the decorator. Inside a code-block line the sub-schema declares `decorators: []`, the lookup returns `undefined`, and the shortcut skips itself. Nothing was configured per container: **the schema is the feature flag**, and the lookup is what reads it.
+
+Your own code can resolve the schema at any position with `getPathSubSchema` from `@portabletext/editor/traversal`.
+
+## Registration validation
+
+A container registration that doesn't match the schema is skipped with a `console.warn` naming the actual mismatch: an unknown type, a missing field, a field that isn't an array, or an array of primitives only. The editor keeps working; the type renders as an ordinary block object until the registration and schema agree.
+
+## A complete example
+
+Everything above composes in one `nodes` array. This editor renders text blocks and images everywhere, and a callout that renders the same `image` type compactly inside itself:
+
+```tsx
+import {
+  defineBlockObject,
+  defineContainer,
+  defineSchema,
+  defineTextBlock,
+  EditorProvider,
+  PortableTextEditable,
+} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}],
+  styles: [{name: 'normal'}, {name: 'h2'}],
+  blockObjects: [
+    {name: 'image', fields: [{name: 'src', type: 'string'}]},
+    {
+      name: 'callout',
+      fields: [
+        {name: 'tone', type: 'string'},
+        {
+          name: 'content',
+          type: 'array',
+          // The callout holds text blocks and images.
+          of: [{type: 'block'}, {type: 'image'}],
+        },
+      ],
+    },
+  ],
+})
+
+const nodes = [
+  // Text blocks, at the root and inside the callout alike.
+  defineTextBlock({
+    type: 'block',
+    render: ({attributes, children, node}) =>
+      node.style === 'h2' ? (
+        <h2 {...attributes}>{children}</h2>
+      ) : (
+        <p {...attributes}>{children}</p>
+      ),
+  }),
+  // Images at the root: full width.
+  defineBlockObject({
+    type: 'image',
+    render: ({attributes, children, node}) => (
+      <figure {...attributes}>
+        <img
+          src={String(node.src)}
+          alt=""
+          contentEditable={false}
+          style={{width: '100%'}}
+        />
+        {children}
+      </figure>
+    ),
+  }),
+  // The callout, with a positional override: the same `image` type
+  // renders compactly inside it.
+  defineContainer({
+    type: 'callout',
+    arrayField: 'content',
+    render: ({attributes, children}) => (
+      <aside {...attributes}>
+        <span contentEditable={false}>💡</span>
+        {children}
+      </aside>
+    ),
+    of: [
+      defineBlockObject({
+        type: 'image',
+        render: ({attributes, children, node}) => (
+          <span {...attributes}>
+            <img
+              src={String(node.src)}
+              alt=""
+              contentEditable={false}
+              style={{height: '4rem'}}
+            />
+            {children}
+          </span>
+        ),
+      }),
+    ],
+  }),
+]
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <NodePlugin nodes={nodes} />
+      <PortableTextEditable />
+    </EditorProvider>
+  )
+}
+```
+
+An `image` block at the document root renders through the global registration, full width. The same `_type: 'image'` inside the callout's `content` hits the positional override first and renders compact. The text block registration needs no positional counterpart: `type: 'block'` already covers both scopes.
+
+Positional overrides only need to carry what they change: an `of` entry that omits `render` falls through to the global registration's render, so a positional registration never has to re-implement what the global one already does.
+
+## Containers in practice
+
+[`@portabletext/plugin-table`](https://github.com/portabletext/editor/tree/main/packages/plugin-table) is built entirely on this API: three nested containers plus behaviors and UI. It's both a ready-made table editor and the reference for what containers can carry. The [Portable Text Playground](https://playground.portabletext.org/) ships container examples you can try, callouts, code blocks, fact boxes, and tables.

--- a/apps/docs/src/content/docs/editor/concepts/index.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/index.mdx
@@ -9,6 +9,10 @@ Learn about the building blocks of Portable Text and how the editor works.
 
 The parts that make up the Portable Text Editor: schema, styles, decorators, annotations, lists, block objects, inline objects, and how they connect. Includes a glossary of common terms.
 
+### [Containers](/editor/concepts/containers/)
+
+Nest editable rich text inside custom structures like callouts, code blocks, and tables, while the value stays plain Portable Text.
+
 ### [Behaviors](/editor/concepts/behavior/)
 
 How behaviors work in the editor. Events, guards, and actions: the pattern that lets you customize how users interact with the editor.

--- a/apps/docs/src/content/docs/editor/getting-started.mdx
+++ b/apps/docs/src/content/docs/editor/getting-started.mdx
@@ -21,7 +21,7 @@ If you already have Portable Text content and want to display it, see [Render Po
 :::
 
 :::note[Prerequisites]
-This guide covers `@portabletext/editor` **v6.x**, `@portabletext/toolbar` **v7.x**, and `@portabletext/keyboard-shortcuts` **v2.x**. Requires React 18+. Check the [editor changelog](https://github.com/portabletext/editor/releases) for breaking changes.
+This guide covers `@portabletext/editor` **v7.x**, `@portabletext/toolbar` **v8.x**, and `@portabletext/keyboard-shortcuts` **v2.x**. Requires React 19.2.7+. Check the [editor changelog](https://github.com/portabletext/editor/releases) for breaking changes.
 :::
 
 You'll need to:

--- a/apps/docs/src/content/docs/editor/getting-started.mdx
+++ b/apps/docs/src/content/docs/editor/getting-started.mdx
@@ -445,6 +445,11 @@ Learn more about [behaviors](/editor/concepts/behavior/) and how to [create your
     href="/editor/guides/custom-rendering/"
   />
   <LinkCard
+    title="Nest rich text with containers"
+    description="Callouts, code blocks, and tables that carry editable Portable Text."
+    href="/editor/concepts/containers/"
+  />
+  <LinkCard
     title="Further customize the toolbar"
     description="Dive deeper into toolbar customization."
     href="/editor/guides/customize-toolbar/"

--- a/apps/docs/src/content/docs/editor/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/editor/guides/behavior-cheat-sheet.mdx
@@ -11,7 +11,7 @@ import {PackageManagers} from 'starlight-package-managers'
 Below are some common behavior examples. You can also find a list of core behaviors [on GitHub](https://github.com/portabletext/editor/tree/main/packages/editor/src/behaviors).
 
 :::note[Prerequisites]
-These recipes are written for `@portabletext/editor` **v6.x** ([changelog](https://github.com/portabletext/editor/releases)).
+These recipes are written for `@portabletext/editor` **v7.x** ([changelog](https://github.com/portabletext/editor/releases)).
 :::
 
 To add these to your editor, first import `defineBehavior` as well as the `BehaviorPlugin`.

--- a/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
+++ b/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
@@ -8,7 +8,7 @@ import {LinkCard} from '@astrojs/starlight/components'
 Behaviors add functionality to the Portable Text Editor (PTE) in a declarative way.
 
 :::note[Prerequisites]
-This guide covers `@portabletext/editor` **v6.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 18+.
+This guide covers `@portabletext/editor` **v7.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.7+.
 :::
 
 For a deep dive into behaviors and how they work, check out [Behaviors](/editor/concepts/behavior/).

--- a/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
+++ b/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
@@ -10,7 +10,7 @@ import {LinkCard} from '@astrojs/starlight/components'
 The Portable Text Editor handles text blocks (paragraphs, headings, lists) by default. To add structured content like images, code blocks, or calls to action, you define custom block types in your schema and tell the editor how to render and insert them.
 
 :::note[Prerequisites]
-This guide covers `@portabletext/editor` **v6.x** and `@portabletext/toolbar` **v7.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 18+. You should be familiar with the [getting started guide](/editor/getting-started/) and [custom rendering](/editor/guides/custom-rendering/).
+This guide covers `@portabletext/editor` **v7.x** and `@portabletext/toolbar` **v8.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.7+. You should be familiar with the [getting started guide](/editor/getting-started/) and [custom rendering](/editor/guides/custom-rendering/).
 :::
 
 ## How custom blocks work

--- a/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
+++ b/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
@@ -361,6 +361,11 @@ The image block sits between text blocks. The stock ticker sits inside a text bl
   href="/editor/guides/custom-rendering/"
 />
 <LinkCard
+  title="Containers"
+  description="Make a block object carry editable rich text: callouts, code blocks, and tables."
+  href="/editor/concepts/containers/"
+/>
+<LinkCard
   title="Customize the toolbar"
   description="Build custom toolbars with hooks, keyboard shortcuts, and schema extensions."
   href="/editor/guides/customize-toolbar/"

--- a/apps/docs/src/content/docs/editor/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/editor/guides/custom-rendering.md
@@ -8,7 +8,7 @@ sidebar:
 The Portable Text Editor gives you control of how it renders each schema type element. You need to explicitly tell it what. These choices have no impact on the Portable Text output—they only affect how the editor itself renders content.
 
 :::note[Prerequisites]
-This guide covers `@portabletext/editor` **v6.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 18+.
+This guide covers `@portabletext/editor` **v7.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.7+.
 :::
 
 :::note[Two rendering systems]
@@ -30,7 +30,7 @@ All the different render functions passed to `PortableTextEditable` can be defin
 
 Most follow the same pattern of reading `props` and conditionally rendering elements based on schema data.
 
-Lists are a bit unique. Portable Text has no concept of block nesting, so the solution is to use pure CSS to style them. We suggest [including this example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) or similar to manage list rendering.
+Lists are a bit unique. A list in Portable Text is flat: a run of sibling text blocks carrying `listItem` and `level`, with no wrapper node. ([Containers](/editor/concepts/containers/) nest blocks through object fields, but lists stay flat.) Visual nesting comes from CSS. We suggest [including this example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) or similar to manage list rendering.
 
 Here are basic implementations of some core types:
 

--- a/apps/docs/src/content/docs/editor/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/editor/guides/custom-rendering.md
@@ -11,6 +11,10 @@ The Portable Text Editor gives you control of how it renders each schema type el
 This guide covers `@portabletext/editor` **v6.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 18+.
 :::
 
+:::note[Two rendering systems]
+The render props on this page are the editor's original rendering API, and they keep working. The editor also has node registrations (`defineTextBlock`, `defineBlockObject`, and friends), a newer pipeline that powers [containers](/editor/concepts/containers/) and owns the wrapper entirely where registered. To move an editor from these render props onto registrations, follow the [migration guide](/editor/guides/migrate-render-props/).
+:::
+
 The following props can be passed to the `PortableTextEditable` component:
 
 - `renderAnnotation`: For annotations (e.g., hyperlinks).

--- a/apps/docs/src/content/docs/editor/guides/customize-toolbar.mdx
+++ b/apps/docs/src/content/docs/editor/guides/customize-toolbar.mdx
@@ -8,7 +8,7 @@ import {PackageManagers} from 'starlight-package-managers'
 The [getting started guide](/editor/getting-started/) introduces the basics of setting up toolbar components. This guide provides some extra context, best practices, and patterns to get you started.
 
 :::note[Prerequisites]
-This guide covers `@portabletext/toolbar` **v7.x** and `@portabletext/keyboard-shortcuts` **v2.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires `@portabletext/editor` v6.x and React 18+.
+This guide covers `@portabletext/toolbar` **v8.x** and `@portabletext/keyboard-shortcuts` **v2.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires `@portabletext/editor` v7.x and React 19.2.7+.
 :::
 
 ## Render the toolbar inside the provider

--- a/apps/docs/src/content/docs/editor/guides/index.mdx
+++ b/apps/docs/src/content/docs/editor/guides/index.mdx
@@ -9,6 +9,10 @@ Practical guides for customizing and extending the Portable Text Editor.
 
 Change how the editor renders and styles text. Covers render props for blocks, spans, decorators, annotations, list items, placeholders, and range decorations.
 
+### [Migrate render props to node registrations](/editor/guides/migrate-render-props/)
+
+Move an editor from the render props on `PortableTextEditable` to `defineX` node registrations, one kind at a time.
+
 ### [Customize the toolbar](/editor/guides/customize-toolbar/)
 
 Build custom toolbars using `@portabletext/toolbar` hooks. Covers decorator buttons, style selectors, keyboard shortcuts, undo/redo, and reflecting editor state.

--- a/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
+++ b/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
@@ -1,0 +1,229 @@
+---
+title: Migrate render props to node registrations
+description: Move an editor from the render props on PortableTextEditable to defineX node registrations, one kind at a time.
+---
+
+The editor has two ways to render a document's nodes (text blocks, block objects, inline objects, and spans): the render props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`), and node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`, `defineContainer`) mounted through `NodePlugin`. Registrations are how [containers](/editor/concepts/containers/) render, and for a registered node they own the wrapper entirely: those four render props do not compose with them.
+
+This guide migrates each render prop to its registration. You don't have to do it in one go.
+
+## What maps to what
+
+| Legacy                                                                        | New                                                                                                                                       |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderStyle`, `renderListItem`, `renderBlock` (for text blocks)              | `defineTextBlock({type: 'block'})`                                                                                                        |
+| `renderBlock` (for block objects)                                             | `defineBlockObject`, per type or `type: '*'`                                                                                              |
+| `renderChild` (for inline objects)                                            | `defineInlineObject`, per type or `type: '*'`                                                                                             |
+| `renderChild` (for spans)                                                     | `defineSpan({type: 'span'})`                                                                                                              |
+| `renderDecorator`, `renderAnnotation`, `renderPlaceholder`, range decorations | Unchanged, keep them                                                                                                                      |
+| Engine list wrapping and numbering                                            | Your text block render + [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) |
+| Engine drop indicator                                                         | [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd)                                        |
+
+## Migrate one kind at a time
+
+The engine dispatches per `_type`: a node renders through a registration when one matches its type (or a `'*'` catch-all for its kind), and at the top level falls back to the legacy pipeline when none does. Registering block objects doesn't affect how text blocks render, so you can migrate kind by kind and keep the remaining render props in place until their kind is migrated.
+
+One boundary to plan around: a registration claims everything rendered inside it. Inside a registered [container](/editor/concepts/containers/), unregistered types render through the engine defaults, not through your remaining render props, so when a container enters the picture mid-migration, register everything that renders inside it in the same step. The same applies one level down: a registered text block claims its inline children, and `renderChild` stops firing for the spans and inline objects inside it. That is why the steps below migrate inline objects and spans before text blocks.
+
+## Step 1: block objects
+
+The legacy `renderBlock` handles text blocks and block objects in one callback, branching on `schemaType`:
+
+```tsx
+const renderBlock: RenderBlockFunction = (props) => {
+  if (props.schemaType.name === 'image' && isImage(props.value)) {
+    return (
+      <div style={{border: '1px solid #ccc', padding: '0.5em'}}>
+        <img src={props.value.src} alt={props.value.alt || ''} />
+      </div>
+    )
+  }
+  // Default case for text blocks
+  return <div style={{marginBlockEnd: '0.5em'}}>{props.children}</div>
+}
+```
+
+The registration splits that branch into kinds. A block object registers by its type, no `isImage` guard needed, the registration _is_ the type match:
+
+```tsx
+import {defineBlockObject} from '@portabletext/editor'
+
+const imageBlock = defineBlockObject({
+  type: 'image',
+  render: ({attributes, children, node}) => (
+    <div {...attributes} style={{border: '1px solid #ccc', padding: '0.5em'}}>
+      <img
+        src={String(node.src)}
+        alt={String(node.alt ?? '')}
+        contentEditable={false}
+      />
+      {children}
+    </div>
+  ),
+})
+```
+
+Three contract differences from the legacy callback: spread `attributes` onto your outer element, render `children` even though the block is a void (the engine mounts its internals through them), and mark the visible content `contentEditable={false}` while keeping the outer element editable, the engine anchors the caret through it. This mirrors the engine's own default block-object render.
+
+If you render every block object the same way, a preview card, say, the catch-all `type: '*'` matches every block object type that has no more specific registration, which is the direct equivalent of the generic legacy callback:
+
+```tsx
+const blockObjectFallback = defineBlockObject({
+  type: '*',
+  render: ({attributes, children, node}) => (
+    <div {...attributes}>
+      <div contentEditable={false}>
+        <BlockObjectPreview node={node} />
+      </div>
+      {children}
+    </div>
+  ),
+})
+```
+
+Per-type registrations and the catch-all compose: register `image` specifically and `'*'` for the rest.
+
+## Step 2: inline objects
+
+`renderChild` migrates the same way. Before:
+
+```tsx
+const renderChild: RenderChildFunction = (props) => {
+  if (props.schemaType.name === 'stock-ticker' && isStockTicker(props.value)) {
+    return <span className="ticker">{props.value.symbol}</span>
+  }
+  return props.children
+}
+```
+
+After, per type or catch-all:
+
+```tsx
+import {defineInlineObject} from '@portabletext/editor'
+
+const stockTicker = defineInlineObject({
+  type: 'stock-ticker',
+  render: ({attributes, children, node}) => (
+    <span {...attributes} className="ticker">
+      {String(node.symbol)}
+      {children}
+    </span>
+  ),
+})
+```
+
+Unlike block objects, inline objects need no `contentEditable={false}`: the engine's outer attributes already carry non-editability, and your content inherits it. The legacy default case (`return props.children`) disappears: spans keep rendering through the engine and the span-level render props, and only registered inline object types hit your render.
+
+## Step 3: spans, if you customized them
+
+Most editors never touch how spans render: decorators and annotations are the span-level props' job, and those keep working. But the legacy `renderChild` also fired for the spans themselves, and if yours wrapped them, the registration equivalent is `defineSpan`:
+
+```tsx
+import {defineSpan} from '@portabletext/editor'
+
+const span = defineSpan({
+  type: 'span',
+  render: ({attributes, children}) => (
+    <span {...attributes} className="leaf">
+      {children}
+    </span>
+  ),
+})
+```
+
+A registered span owns the outer wrapper, and `children` arrive with `renderDecorator` and `renderAnnotation` already applied, the same composition the legacy pipeline produced inside the span. `'span'` is the span type at the top level; text blocks can positionally register renamed span-like types through their own `of` (a `code-span` inside a code block's line, say), which is a [containers](/editor/concepts/containers/) concern rather than a migration one.
+
+## Step 4: text blocks
+
+Text blocks register as `type: 'block'`, which is the text block type at every nesting level, top level and inside containers alike. The registration's render owns the whole wrapper, so the three legacy callbacks fold into one function. Reproduce the engine's legacy composition order: style innermost, list item around it, block wrapper outermost.
+
+:::note[Why pass `type` at all?]
+If the text block is always `block` and the span is always `span`, the parameter looks redundant. It exists because registrations live in a type-keyed registry with two tiers: `'*'` is an optional catch-all, matching any type of that kind without a more specific registration, and positional overrides can register renamed types at that scope: block-level kinds through a container's `of`, inline kinds through a text block's `of`. `'block'` and `'span'` are simply those kinds' canonical names at the top level.
+:::
+
+Before:
+
+```tsx
+const renderStyle: RenderStyleFunction = (props) => {
+  if (props.schemaType.value === 'h1') {
+    return <h1>{props.children}</h1>
+  }
+  if (props.schemaType.value === 'blockquote') {
+    return <blockquote>{props.children}</blockquote>
+  }
+  return <>{props.children}</>
+}
+
+const renderListItem: RenderListItemFunction = (props) => (
+  <ListItemWrapper level={props.level}>{props.children}</ListItemWrapper>
+)
+
+// Plus the text-block default case of the `renderBlock` from step 1:
+// <div style={{marginBlockEnd: '0.5em'}}>{props.children}</div>
+```
+
+After:
+
+```tsx
+import {defineTextBlock} from '@portabletext/editor'
+
+const textBlock = defineTextBlock({
+  type: 'block',
+  render: ({attributes, children, node}) => {
+    let content = children
+
+    // Your `renderStyle` logic, innermost.
+    if (node.style === 'h1') {
+      content = <h1>{content}</h1>
+    } else if (node.style === 'blockquote') {
+      content = <blockquote>{content}</blockquote>
+    }
+
+    // Your `renderListItem` logic around it.
+    if (node.listItem !== undefined) {
+      content = (
+        <ListItemWrapper level={node.level ?? 1}>{content}</ListItemWrapper>
+      )
+    }
+
+    // Your `renderBlock` default case, outermost.
+    return (
+      <div {...attributes} style={{marginBlockEnd: '0.5em'}}>
+        {content}
+      </div>
+    )
+  },
+})
+```
+
+The render props carry `node`, `path`, `focused`, and `selected`, so components you already have keep receiving the information the legacy callbacks gave them.
+
+## Step 5: reclaim the engine's chrome
+
+Under the legacy pipeline the engine wrapped list items and numbered ordered lists for you, and drew a drop indicator during block drags. Under registrations both are yours. [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, and [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's `drag.*` events. Both follow the same pattern, a provider inside `EditorProvider` and a hook read from a component your render returns; the [containers page](/editor/concepts/containers/#registrations-opt-into-the-new-render-pipeline) has the worked example and each plugin's README carries the full recipe.
+
+## Step 6: mount and clean up
+
+Mount every registration through one `NodePlugin` with a stable identity, and drop the migrated render props:
+
+```tsx
+// Plus `span` from step 3, if you needed it.
+const nodes = [imageBlock, blockObjectFallback, stockTicker, textBlock]
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <NodePlugin nodes={nodes} />
+      <PortableTextEditable
+        // These keep working and stay:
+        renderDecorator={renderDecorator}
+        renderAnnotation={renderAnnotation}
+        renderPlaceholder={renderPlaceholder}
+        // renderBlock, renderChild, renderStyle, renderListItem: removed
+      />
+    </EditorProvider>
+  )
+}
+```
+
+`renderDecorator`, `renderAnnotation`, `renderPlaceholder`, and range decorations are span-level: they fire on the spans inside `children` no matter who renders the block, so they are not part of this migration.

--- a/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
+++ b/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
@@ -13,7 +13,7 @@ The Portable Text Editor ships with testing infrastructure you can use for your 
 Both approaches use Vitest Browser Mode with Playwright, running tests against a real browser.
 
 :::note[Prerequisites]
-This guide covers `@portabletext/editor` **v6.x** and `racejar` **v2.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires Vitest with Browser Mode and Playwright.
+This guide covers `@portabletext/editor` **v7.x** and `racejar` **v2.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires Vitest with Browser Mode and Playwright.
 :::
 
 ## Setup

--- a/apps/docs/src/content/docs/editor/index.mdx
+++ b/apps/docs/src/content/docs/editor/index.mdx
@@ -5,7 +5,7 @@ description: A headless, schema-driven block content editor for React. Officiall
 
 The Portable Text Editor (`@portabletext/editor`) is the officially supported editor for working with [Portable Text](/specification/) content. It's a headless block content editor for React: you bring the UI, the editor handles the editing.
 
-You configure the editor by declaring a [schema](/editor/concepts/portabletext/) of styles, decorators, annotations, lists, block objects, and inline objects. Rendering is yours to control through render props on `PortableTextEditable`. Interactions are extensible through the [Behavior API](/editor/concepts/behavior/) and a growing set of [plugins](/editor/reference/plugins/). The companion [`@portabletext/toolbar`](/editor/reference/toolbar/) package gives you headless hooks for building toolbar UI.
+You configure the editor by declaring a [schema](/editor/concepts/portabletext/) of styles, decorators, annotations, lists, block objects, and inline objects. Rendering is yours to control through node registrations and render props on `PortableTextEditable`, and [containers](/editor/concepts/containers/) let structures like callouts, code blocks, and tables carry editable rich text. Interactions are extensible through the [Behavior API](/editor/concepts/behavior/) and a growing set of [plugins](/editor/reference/plugins/). The companion [`@portabletext/toolbar`](/editor/reference/toolbar/) package gives you headless hooks for building toolbar UI.
 
 ### [Getting started](/editor/getting-started/)
 
@@ -13,7 +13,7 @@ Install the editor, define a schema, and build your first toolbar.
 
 ### [Concepts](/editor/concepts/)
 
-How the schema, decorators, annotations, and behaviors fit together.
+How the schema, decorators, annotations, containers, and behaviors fit together.
 
 ### [Guides](/editor/guides/)
 


### PR DESCRIPTION
Initial pass at docs for the new Container API: https://portable-text-editor-documentation-git-docs-containers-page.sanity.build/editor/concepts/containers/

<img width="1245" height="1070" alt="Screenshot 2026-07-24 at 12 06 19" src="https://github.com/user-attachments/assets/0d53eacd-c275-4a76-9a06-1c2f38ed307b" />

Containers make the editor understand how to render and traverse into nested editable structures. But there's more to it than that. The Container API provides full control of the rendering, which doesn't really compose with the legacy render callbacks. Therefore, there's also a [migration guide](https://portable-text-editor-documentation-git-docs-containers-page.sanity.build/editor/guides/migrate-render-props/) that explains the new node registration concept in more detail and in comparison to the legacy render callbacks.

The migration guide is called out inside the Containers page like this:

<img width="755" height="206" alt="Screenshot 2026-07-24 at 12 09 42" src="https://github.com/user-attachments/assets/4e84440c-4a60-4d4e-867c-78de57a603c6" />

