### PR TITLE
fix(plugin-sdk-value): prevent transient text loss on remote span splits

### DIFF
--- a/.changeset/remote-decorator-flash.md
+++ b/.changeset/remote-decorator-flash.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: prevent remote decorator toggles from transiently dropping the formatted word

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -64,6 +64,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@portabletext/patches": "workspace:^",
     "@sanity/diff-patch": "^6.0.0",
     "@sanity/json-match": "^1.0.5",
     "@xstate/react": "catalog:",
@@ -72,7 +73,6 @@
   },
   "devDependencies": {
     "@portabletext/editor": "workspace:^",
-    "@portabletext/patches": "workspace:^",
     "@portabletext/schema": "workspace:^",
     "@portabletext/test": "workspace:^",
     "@sanity/diff-match-patch": "catalog:",

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -4,11 +4,12 @@ import {
   type PortableTextBlock,
   type Patch as PtePatch,
 } from '@portabletext/editor'
-import type {
-  JSONValue,
-  Path,
-  PathSegment,
-  InsertPatch as PteInsertPatch,
+import {
+  applyAll,
+  type JSONValue,
+  type Path,
+  type PathSegment,
+  type InsertPatch as PteInsertPatch,
 } from '@portabletext/patches'
 import {diffValue, type SanityPatchOperations} from '@sanity/diff-patch'
 import {
@@ -381,9 +382,12 @@ export function toEngineSafePatches(
 }
 
 /**
- * A text paste can stage a temporary span and remove it in the same local
- * flush. The SDK may emit the insert before that cleanup even though its
- * current value already reflects the completed transaction.
+ * Drops insert items whose `_key` is absent from the remote value. A text
+ * paste can stage a temporary span and remove it again within the same
+ * transaction; applying the insert without the cleanup would flash the
+ * staged content. Callers must only run this once the store value reflects
+ * the transaction the patches belong to (see `'apply remote patches'`),
+ * otherwise every legitimately new node would be dropped.
  */
 function filterInsertsMissingFromRemoteValue(
   patches: PtePatch[],
@@ -556,6 +560,36 @@ export function canApplyToValue(
     default:
       return true
   }
+}
+
+/**
+ * Filters a patch batch down to the patches that can resolve (see
+ * `canApplyToValue`), checking each patch against the value as it stands
+ * after the preceding patches applied. A transaction routinely inserts a
+ * node and then addresses it, e.g. a span split followed by a `marks` set
+ * on the new span, so checking every patch against the starting value
+ * would drop valid operations.
+ */
+function filterResolvablePatches(
+  patches: PtePatch[],
+  value: PortableTextBlock[] | undefined,
+): PtePatch[] {
+  let projected = value
+  const resolvable: PtePatch[] = []
+  for (const patch of patches) {
+    if (!canApplyToValue(patch, projected)) {
+      continue
+    }
+    resolvable.push(patch)
+    if (projected) {
+      try {
+        projected = applyAll(projected, [patch])
+      } catch {
+        // the engine applies best-effort too; keep the projection as-is
+      }
+    }
+  }
+  return resolvable
 }
 
 /**
@@ -872,23 +906,33 @@ const valueSyncMachine = setup({
         return
       }
       debug.remote('applying remote patches %o', event.patches)
-      const snapshot = context.editor.getSnapshot().context.value
-      // The store already reflects this transaction, so it can serve as
-      // the target for coalescing sidecar-array item operations (which
-      // the engine misroutes) into whole-property sets.
-      const remoteValue = context.getRemoteValue()
-      const coalesced = remoteValue
-        ? toEngineSafePatches(event.patches, remoteValue)
-        : event.patches
-      const patches = (
-        remoteValue
-          ? filterInsertsMissingFromRemoteValue(coalesced, remoteValue)
-          : coalesced
-      ).filter((patch) => canApplyToValue(patch, snapshot))
-      if (patches.length === 0) {
-        return
-      }
-      context.editor.send({type: 'patches', patches, snapshot})
+      // The SDK emits `remote-patches` while it is still computing the
+      // state update for that transaction, so the store value visible at
+      // this moment does not include it yet. The commit lands within the
+      // same synchronous task, so after one microtask the store reflects
+      // the transaction, whether the event announced a fresh transaction
+      // or replayed one the store already had. Only then can the store
+      // value serve as the reference for dropping inserts the transaction
+      // itself cleaned up again, and as the target for coalescing
+      // sidecar-array item operations (which the engine misroutes) into
+      // whole-property sets.
+      queueMicrotask(() => {
+        const snapshot = context.editor.getSnapshot().context.value
+        const remoteValue = context.getRemoteValue()
+        const coalesced = remoteValue
+          ? toEngineSafePatches(event.patches, remoteValue)
+          : event.patches
+        const patches = filterResolvablePatches(
+          remoteValue
+            ? filterInsertsMissingFromRemoteValue(coalesced, remoteValue)
+            : coalesced,
+          snapshot,
+        )
+        if (patches.length === 0) {
+          return
+        }
+        context.editor.send({type: 'patches', patches, snapshot})
+      })
     },
   },
   actors: {

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -79,11 +79,15 @@ function createMockPatchStore(initialValue: PortableTextBlock[] = []) {
       }
     },
     getValue: () => value,
-    // Simulate patches arriving from another client: apply them to the store
-    // value and emit through both channels, patches first, like the real SDK.
-    // Application is best-effort per patch, mirroring the server's json-match
-    // semantics where patches whose paths don't resolve are no-ops.
+    // Simulate a transaction arriving from another client. Mirrors the real
+    // SDK's ordering: the `remote-patches` event fires while the SDK is still
+    // computing the state update for that transaction, so subscribers observe
+    // the pre-transaction value during the event; the value commit and its
+    // notification follow. Application is best-effort per patch, mirroring
+    // the server's json-match semantics where patches whose paths don't
+    // resolve are no-ops.
     receiveRemotePatches: (patches: PtePatch[]) => {
+      patchSubscriber?.(patches)
       for (const patch of patches) {
         try {
           value = applyAll(value, [patch])
@@ -91,7 +95,6 @@ function createMockPatchStore(initialValue: PortableTextBlock[] = []) {
           // the server would no-op this patch
         }
       }
-      patchSubscriber?.(patches)
       valueSubscriber?.()
     },
     // Simulate a remote transaction whose patches don't resolve against this
@@ -691,7 +694,119 @@ describe('ValueSyncPlugin', () => {
         },
       ])
 
+      // patch application waits one microtask for the store commit
+      await Promise.resolve()
+
       expect(getEditorText(editor)).toEqual('B: A: ALPHA')
+    })
+
+    test('a remote mid-span decorator toggle applies without a transient flash', async () => {
+      // Field regression: editor A bolds the word "before" in the middle of
+      // a span; on editor B the word vanished ("…quarterly report dawn.")
+      // for a beat before the whole-value repair restored it. The patches
+      // below are the bold transaction as a real editor emits it: two text
+      // shrinks on the original span, two inserts of the split-off spans,
+      // then a `marks` set on the new middle span. The SDK emits the
+      // `remote-patches` event while it is still computing the state update
+      // for the transaction, so the store value does not reflect it during
+      // the event; filtering the inserts against that stale value dropped
+      // the new spans while the text shrinks still applied.
+      const text =
+        'ALPHA The newsroom shipped its quarterly report before dawn.'
+      const store = createMockPatchStore([makeBlock('b1', text)])
+      const {editor, unmount} = await createSyncedEditor({
+        store,
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      })
+      cleanup = unmount
+
+      await vi.waitFor(() => {
+        expect(getEditorText(editor)).toEqual(`B: ${text}`)
+      })
+
+      store.receiveRemotePatches([
+        {
+          type: 'diffMatchPatch',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}, 'text'],
+          value: '@@ -51,10 +51,4 @@\n fore\n- dawn.\n',
+        },
+        {
+          type: 'setIfMissing',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children'],
+          value: [],
+        },
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}],
+          items: [
+            {_type: 'span', _key: 's-dawn', marks: [], text: ' dawn.'},
+          ] as unknown as JSONValue[],
+        },
+        {
+          type: 'diffMatchPatch',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}, 'text'],
+          value: '@@ -45,10 +45,4 @@\n ort \n-before\n',
+        },
+        {
+          type: 'setIfMissing',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children'],
+          value: [],
+        },
+        {
+          type: 'insert',
+          origin: 'remote',
+          position: 'after',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}],
+          items: [
+            {_type: 'span', _key: 's-before', marks: [], text: 'before'},
+          ] as unknown as JSONValue[],
+        },
+        {
+          type: 'set',
+          origin: 'remote',
+          path: [{_key: 'b1'}, 'children', {_key: 's-before'}, 'marks'],
+          value: ['strong'],
+        },
+      ])
+
+      // One microtask for the store commit to land; the transaction must
+      // then have applied in full. Sampling any later would miss the flash,
+      // because the whole-value repair heals it within a few hundred
+      // milliseconds.
+      await Promise.resolve()
+
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: 'b1-span',
+              text: 'ALPHA The newsroom shipped its quarterly report ',
+              marks: [],
+            },
+            {
+              _type: 'span',
+              _key: 's-before',
+              text: 'before',
+              marks: ['strong'],
+            },
+            {_type: 'span', _key: 's-dawn', text: ' dawn.', marks: []},
+          ],
+        },
+      ])
+      // the transaction arrived over the patch channel; nothing pushed back
+      expect(store.pushPatches).not.toHaveBeenCalled()
+      expect(store.pushValue).not.toHaveBeenCalled()
     })
 
     test('remote text set applies to a specific span', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1228,6 +1228,9 @@ importers:
 
   packages/plugin-sdk-value:
     dependencies:
+      '@portabletext/patches':
+        specifier: workspace:*
+        version: link:../patches
       '@sanity/diff-patch':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1247,9 +1250,6 @@ importers:
       '@portabletext/editor':
         specifier: workspace:*
         version: link:../editor
-      '@portabletext/patches':
-        specifier: workspace:*
-        version: link:../patches
       '@portabletext/schema':
         specifier: workspace:^
         version: link:../schema


### PR DESCRIPTION
## Description

The SDK emits `remote-patches` document events while it is still computing the state update for that transaction, so the store value visible during the event does not include the transaction yet. The plugin filtered incoming inserts against that stale value, dropping the spans a remote decorator toggle splits off. Peers briefly rendered the sentence without the formatted word (for example "quarterly report dawn." instead of "quarterly report **before** dawn.") until the whole-value repair healed it up to a second later. A second gate compounded it: patch resolvability was checked against the pre-batch editor value, which drops patches that depend on earlier patches in the same batch, such as the `marks` set on a just-inserted span.

Remote patch application now waits one microtask so the store commit lands first. The insert filter's assumption then holds for fresh and replayed transactions alike, which keeps the duplicate-paste fix from #3017 intact. Resolvability is checked against a running projection of the batch instead of the starting value.

## What to review

- `packages/plugin-sdk-value/src/plugin.sdk-value.tsx`: the deferred `'apply remote patches'` action and the new progressive `filterResolvablePatches` helper.
- `packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx`: the mock patch store now delivers with the SDK's real ordering (patch event before value commit); the new test replays a captured mid-span bold transaction and asserts the editor never renders the transient state.
- `packages/plugin-sdk-value/package.json`: `@portabletext/patches` moved to `dependencies` because `applyAll` is now a runtime import.

## Testing

- `pnpm test:unit`
- `pnpm test:browser:chromium` (the two `collision-matrix` multi-round link tests fail identically on `main`; unrelated)
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm build`

## Notes for release

Prevents remote editors from briefly dropping the formatted word when a collaborator toggles a decorator in the middle of a span.