### PR TITLE
fix: prevent the native event when a matched Behavior's actions return nothing

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: prevent the native event when a matched Behavior's actions return nothing

--- a/packages/editor/src/behaviors/behavior.perform-event.ts
+++ b/packages/editor/src/behaviors/behavior.perform-event.ts
@@ -219,9 +219,7 @@ export function performEvent({
     // action prevented
     defaultBehaviorOverwritten = true
 
-    if (eventBehavior.actions.length === 0) {
-      nativeEventPrevented = true
-    }
+    nativeEventPrevented = true
 
     let actionSetIndex = -1
 

--- a/packages/editor/tests/behavior.native-event-prevented.test.tsx
+++ b/packages/editor/tests/behavior.native-event-prevented.test.tsx
@@ -1,0 +1,113 @@
+import {describe, expect, test} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {forward} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {createTestEditor} from '../src/test/vitest'
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: 'k0',
+    children: [{_type: 'span', _key: 'k1', text: 'foo'}],
+  },
+]
+
+/**
+ * Records `defaultPrevented` for the first Tab keydown that reaches `document`.
+ * Listening on `document` in the bubble phase means the editor's own handler on
+ * the editable element has already run by the time this fires.
+ */
+function recordTabPrevented() {
+  const seen: Array<boolean> = []
+
+  function listener(event: KeyboardEvent) {
+    if (event.key === 'Tab') {
+      seen.push(event.defaultPrevented)
+    }
+  }
+
+  document.addEventListener('keydown', listener)
+
+  return {
+    seen,
+    stop: () => document.removeEventListener('keydown', listener),
+  }
+}
+
+describe('repro #2271', () => {
+  test('BASELINE `actions: []` prevents the native event', async () => {
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'keyboard.keydown',
+              guard: ({event}) => event.originEvent.key === 'Tab',
+              actions: [],
+            }),
+          ]}
+        />
+      ),
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+
+    const recorder = recordTabPrevented()
+    await userEvent.keyboard('{Tab}')
+    recorder.stop()
+
+    expect(recorder.seen).toEqual([true])
+  })
+
+  test('BUG `actions: [() => []]` should prevent the native event too', async () => {
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'keyboard.keydown',
+              guard: ({event}) => event.originEvent.key === 'Tab',
+              actions: [() => []],
+            }),
+          ]}
+        />
+      ),
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+
+    const recorder = recordTabPrevented()
+    await userEvent.keyboard('{Tab}')
+    recorder.stop()
+
+    expect(recorder.seen).toEqual([true])
+  })
+
+  test('REGRESSION GUARD `forward` must NOT prevent the native event', async () => {
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'keyboard.keydown',
+              guard: ({event}) => event.originEvent.key === 'Tab',
+              actions: [({event}) => [forward(event)]],
+            }),
+          ]}
+        />
+      ),
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+
+    const recorder = recordTabPrevented()
+    await userEvent.keyboard('{Tab}')
+    recorder.stop()
+
+    expect(recorder.seen).toEqual([false])
+  })
+})


### PR DESCRIPTION
Fixes #2271.

```diff
     // This Behavior now "owns" the event and we can consider the default
     // action prevented
     defaultBehaviorOverwritten = true

-    if (eventBehavior.actions.length === 0) {
-      nativeEventPrevented = true
-    }
+    nativeEventPrevented = true
```

The comment above it already said this. Claim the event as soon as the guard matches, and leave the assignment inside the action loop as the only thing that can lower it again, which is how `forward` already gets its way.

I tried the post-loop fix from the issue first. It fixes the reported case and breaks `forward`, because once the loop has exited, false-because-forward and false-because-nothing-ran are the same value and the override flips both.

Tests are in `packages/editor/tests/behavior.native-event-prevented.test.tsx`. Three cases, each pressing Tab for real and reading `defaultPrevented` off the event once it reaches `document`. On unfixed `main` the `[() => []]` case fails and the other two pass. On the post-loop version the `forward` case fails instead. That third test passes on `main`, so on its own it proves nothing, it is only there to catch the override.

Browser suite 1752 passing, unit 872, lint and types clean.

One behaviour change worth flagging: an action set that throws leaves `actions` empty, so it now prevents where `main` did not. I think that is right, since a Behavior that just crashed should not hand the keystroke back to the browser, but it is a judgement call and I am happy to special-case it.
