### PR TITLE
docs: document how Behaviors claim the native event

### DIFF
--- a/apps/docs/src/content/docs/editor/concepts/behavior.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/behavior.mdx
@@ -132,6 +132,23 @@ const raisedUppercaseA = defineBehavior({
 })
 ```
 
+### Claiming the native event
+
+When a Behavior's guard matches an event that carries a native event (a `keyboard.keydown`, for example), the Behavior claims it: the editor calls `preventDefault()` and the browser's default action is suppressed. The action sets can revise that claim. Every action set that returns actions casts a vote, and the last vote wins:
+
+| The action set             | Native default              |
+| -------------------------- | --------------------------- |
+| contains `raise`/`execute` | prevented                   |
+| contains only `forward`    | passes down the chain       |
+| contains only `effect`s    | prevented                   |
+| returns nothing, or throws | keeps the previous decision |
+
+Within one set, `raise` and `execute` outrank `forward`: a set that both mutates and forwards still prevents the default.
+
+`forward` does not mean "let the browser act". It means "no opinion at this level": the event moves on to the next Behavior in the chain, which makes its own decision, and the browser's default only survives when no Behavior along the chain claims the event.
+
+Multiple action sets are also an undo boundary: each set after the first starts a new undo step. [`@portabletext/plugin-input-rule`](https://github.com/portabletext/editor/tree/main/packages/plugin-input-rule) uses this to let the typed text land as its own undo step before a second set transforms it, so undo peels the transformation off first.
+
 ## Selectors
 
 Selectors are pure functions that derive state from the editor snapshot (`snapshot` in the examples). A collection of selectors is included with the core library.

--- a/packages/editor/tests/behavior.native-event-prevented.test.tsx
+++ b/packages/editor/tests/behavior.native-event-prevented.test.tsx
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {forward} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
@@ -35,8 +35,8 @@ function recordTabPrevented() {
   }
 }
 
-describe('repro #2271', () => {
-  test('BASELINE `actions: []` prevents the native event', async () => {
+describe('claiming the native event', () => {
+  test('Scenario: an empty `actions` array claims the native event', async () => {
     const {locator} = await createTestEditor({
       children: (
         <BehaviorPlugin
@@ -61,7 +61,7 @@ describe('repro #2271', () => {
     expect(recorder.seen).toEqual([true])
   })
 
-  test('BUG `actions: [() => []]` should prevent the native event too', async () => {
+  test('Scenario: an action set returning no actions claims the native event', async () => {
     const {locator} = await createTestEditor({
       children: (
         <BehaviorPlugin
@@ -86,7 +86,9 @@ describe('repro #2271', () => {
     expect(recorder.seen).toEqual([true])
   })
 
-  test('REGRESSION GUARD `forward` must NOT prevent the native event', async () => {
+  test('Scenario: a `forward`-only action set leaves the native event unclaimed', async () => {
+    // Passes even without the guard-time claim; it exists to catch fixes
+    // that flip `forward`'s abstention into a claim.
     const {locator} = await createTestEditor({
       children: (
         <BehaviorPlugin
@@ -109,5 +111,46 @@ describe('repro #2271', () => {
     recorder.stop()
 
     expect(recorder.seen).toEqual([false])
+  })
+
+  test('Scenario: a throwing action set keeps the claim on the native event', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'keyboard.keydown',
+              guard: ({event}) => event.originEvent.key === 'Tab',
+              actions: [
+                () => {
+                  throw new Error('action set crashed')
+                },
+              ],
+            }),
+          ]}
+        />
+      ),
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+
+    const recorder = recordTabPrevented()
+    await userEvent.keyboard('{Tab}')
+    recorder.stop()
+
+    // The guard claimed the event; the crash is reported through
+    // `console.error`, not used as a reason to hand the keystroke back
+    // to the browser.
+    expect(recorder.seen).toEqual([true])
+    expect(consoleError).toHaveBeenCalledWith(
+      new Error(
+        'Evaluating actions for "keyboard.keydown" failed due to: action set crashed',
+      ),
+    )
+
+    consoleError.mockRestore()
   })
 })


### PR DESCRIPTION
Follow-up to #3027, which shipped one flagged-but-unpinned semantic delta and surfaced that the native-event prevention model is documented nowhere outside `behavior.perform-event.ts`. Rebased on `main` with #3027 merged: the diff is the new test plus the renames, and the docs section.

The `test:` commit pins the delta: a throwing action set keeps the claim the guard made, the crash is reported through `console.error`, and the keystroke is not handed back to the browser. Red on the pre-#3027 mechanism (verified by reverting `behavior.perform-event.ts` and watching it fail alongside #3027's own empty-set test), green with it. The sibling tests are renamed to state the contracts they pin rather than the issue-fix narrative.

The `docs:` commit adds a "Claiming the native event" section to the Behavior concept page: a matched guard claims the event, each action set that returns actions casts the deciding vote and the last vote wins, `raise`/`execute` outrank `forward` within a set, `forward` means "no opinion at this level" rather than "let the browser act", and multiple action sets double as undo-step boundaries, with `plugin-input-rule`'s forward-then-transform composition as the worked example. Built with `CHECK_LINKS=1`.

Test-and-docs only; no changeset.


