### PR TITLE
fix: report the sub-schema default style from `getActiveStyle` for blocks missing `style`

### DIFF
--- a/.changeset/getactivestyle-missing-style-default.md
+++ b/.changeset/getactivestyle-missing-style-default.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: report the sub-schema default style from `getActiveStyle` for blocks missing `style`
+
+`getActiveStyle` now reports the block's sub-schema default style (its first declared style) when the block carries no `style` field, instead of `undefined`. Observable for values adopted without the field; toolbar style selectors stay populated on such blocks. A sub-schema declaring no styles still reports `undefined`.

--- a/packages/editor/src/selectors/selector.get-active-style.test.ts
+++ b/packages/editor/src/selectors/selector.get-active-style.test.ts
@@ -1,0 +1,117 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {expect, test} from 'vitest'
+import {createTestSnapshot} from '../../test-utils/create-test-snapshot'
+import {resolveTestbedContainers} from '../traversal/node-traversal-testbed'
+import {getActiveStyle} from './selector.get-active-style'
+
+test('getActiveStyle: a block missing `style` reads as the schema default', () => {
+  const schema = compileSchema(
+    defineSchema({styles: [{name: 'normal'}, {name: 'h1'}]}),
+  )
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+      },
+    },
+  })
+
+  expect(getActiveStyle(snapshot)).toBe('normal')
+})
+
+test('getActiveStyle: a selection across a styled block and one missing `style` agrees on the default', () => {
+  const schema = compileSchema(
+    defineSchema({styles: [{name: 'normal'}, {name: 'h1'}]}),
+  )
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          _key: 'b2',
+          children: [{_type: 'span', _key: 's2', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 1},
+        focus: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 2},
+      },
+    },
+  })
+
+  expect(getActiveStyle(snapshot)).toBe('normal')
+})
+
+test('getActiveStyle: a block missing `style` inside a container reads the sub-schema default', () => {
+  const schema = compileSchema(
+    defineSchema({
+      styles: [{name: 'normal'}, {name: 'h1'}],
+      blockObjects: [
+        {
+          name: 'code-block',
+          fields: [
+            {
+              name: 'lines',
+              type: 'array',
+              of: [{type: 'block', styles: [{name: 'code'}]}],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const containers = resolveTestbedContainers(schema, [
+    {kind: 'container', type: 'code-block', arrayField: 'lines'},
+  ])
+  const snapshot = createTestSnapshot({
+    context: {
+      schema,
+      containers,
+      value: [
+        {
+          _type: 'code-block',
+          _key: 'c1',
+          lines: [
+            {
+              _type: 'block',
+              _key: 'b1',
+              children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+              markDefs: [],
+            },
+          ],
+        },
+      ],
+      selection: {
+        anchor: {
+          path: [{_key: 'c1'}, 'lines', {_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: 'c1'}, 'lines', {_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 1,
+        },
+      },
+    },
+  })
+
+  expect(getActiveStyle(snapshot)).toBe('code')
+})

--- a/packages/editor/src/selectors/selector.get-active-style.ts
+++ b/packages/editor/src/selectors/selector.get-active-style.ts
@@ -20,7 +20,12 @@ export const getActiveStyle: EditorSelector<PortableTextTextBlock['style']> = (
     return undefined
   }
 
-  const firstStyle = firstTextBlock.node.style
+  // A block without a `style` reads as its sub-schema's default (the
+  // first declared style), the same value normalization fills in when a
+  // local edit touches the block.
+  const firstStyle =
+    firstTextBlock.node.style ??
+    getPathSubSchema(snapshot, firstTextBlock.path).styles.at(0)?.name
 
   if (!firstStyle) {
     return undefined
@@ -34,7 +39,14 @@ export const getActiveStyle: EditorSelector<PortableTextTextBlock['style']> = (
     ),
   )
 
-  if (inScopeBlocks.every((block) => block.node.style === firstStyle)) {
+  if (
+    inScopeBlocks.every(
+      (block) =>
+        (block.node.style ??
+          getPathSubSchema(snapshot, block.path).styles.at(0)?.name) ===
+        firstStyle,
+    )
+  ) {
     return firstStyle
   }
 

--- a/packages/editor/tests/event.style.toggle.test.tsx
+++ b/packages/editor/tests/event.style.toggle.test.tsx
@@ -1,0 +1,62 @@
+import {defineSchema} from '@portabletext/schema'
+import {expect, test, vi} from 'vitest'
+import {getActiveStyle} from '../src/selectors/selector.get-active-style'
+import {createTestEditor} from '../src/test/vitest'
+
+const blockMissingStyle = {
+  _key: 'b0',
+  _type: 'block',
+  markDefs: [],
+  children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+}
+
+test('Scenario: toggling the default style on a block missing `style` is a no-op that keeps reading as the default', async () => {
+  const {editor} = await createTestEditor({
+    schemaDefinition: defineSchema({
+      styles: [{name: 'normal'}, {name: 'h2'}],
+    }),
+    initialValue: [blockMissingStyle],
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 1},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 1},
+    },
+  })
+  // The missing `style` reads as the default, so the toggle takes the
+  // active branch: `style.remove` unsets the field, and unsetting a
+  // field the block never had applies nothing, so nothing dirties and
+  // no touch-fill runs. No write for a visual no-op.
+  editor.send({type: 'style.toggle', style: 'normal'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([blockMissingStyle])
+    expect(getActiveStyle(editor.getSnapshot())).toBe('normal')
+  })
+})
+
+test('Scenario: toggling a non-default style on a block missing `style` sets it', async () => {
+  const {editor} = await createTestEditor({
+    schemaDefinition: defineSchema({
+      styles: [{name: 'normal'}, {name: 'h2'}],
+    }),
+    initialValue: [blockMissingStyle],
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 1},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 1},
+    },
+  })
+  editor.send({type: 'style.toggle', style: 'h2'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {...blockMissingStyle, style: 'h2'},
+    ])
+  })
+})


### PR DESCRIPTION
Extracted from #3016 because it's an independent mechanism with its own blast radius: a read-time change to a public selector, not part of the normalization deferral. #3016 has merged, so the gap this closes is now live on `main`; this should merge before the next release so both ship together.

`getActiveStyle` reads `block.node.style` raw. That was safe while adoption filled defaults, a style-less block was unreachable at rest, but #3016 defers those fills to local edits, so adopted API-created blocks now sit without a `style` indefinitely and the raw read reports `undefined`: toolbar style selectors go empty for a caret in a block that reads and edits as its default style.

A missing `style` now reads as the block's sub-schema default (its first declared style), resolved with the same `getPathSubSchema(...).styles.at(0)` expression the fill uses, so the selector reports the value an edit would materialize. Both the first-block read and the every-block agreement check default the same way, so mixed selections agree. Pinned at the root, across a mixed selection, and inside a container whose sub-schema's first style differs.

Blocks carrying `style` read exactly as before; a sub-schema declaring no styles still reports `undefined`.

