### PR TITLE
test: pin that later action sets see prior sets' normalization fallout

### DIFF
--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -256,6 +256,92 @@ describe('Behavior API', () => {
     expect(sideEffectB).toHaveBeenCalled()
   })
 
+  test('Scenario: later action sets see the normalization fallout of previous sets', async () => {
+    let firstSetValue: unknown
+    let secondSetValue: unknown
+
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: 's0', _type: 'span', text: 'foo', marks: ['strong']},
+            {_key: 's1', _type: 'span', text: 'bar', marks: []},
+          ],
+        },
+      ],
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.clear formatting',
+              actions: [
+                ({snapshot}) => {
+                  firstSetValue = snapshot.context.value
+                  // Stripping `strong` from `s0` leaves two adjacent spans
+                  // with equal `marks`, the shape the cosmetic same-mark
+                  // merge canonicalizes as fallout of local edits.
+                  return [
+                    raise({type: 'decorator.remove', decorator: 'strong'}),
+                  ]
+                },
+                ({snapshot}) => {
+                  secondSetValue = snapshot.context.value
+                  return []
+                },
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 3},
+      },
+    })
+    editor.send({type: 'custom.clear formatting'})
+
+    await vi.waitFor(() => {
+      // The first set reads the guard-time world: both spans, `strong`
+      // intact.
+      expect(firstSetValue).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: 's0', _type: 'span', text: 'foo', marks: ['strong']},
+            {_key: 's1', _type: 'span', text: 'bar', marks: []},
+          ],
+        },
+      ])
+      // The second set's snapshot is created after the first set's
+      // operations and their normalization flushed: the spans arrive
+      // already merged.
+      expect(secondSetValue).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: 's0', _type: 'span', text: 'foobar', marks: []}],
+        },
+      ])
+      // The editor itself agrees with what the second set saw.
+      expect(editor.getSnapshot().context.value).toEqual(secondSetValue)
+    })
+  })
+
   test('Scenario: Empty action sets stop event propagation', async () => {
     const {editor, locator} = await createTestEditor({
       children: (


### PR DESCRIPTION
Pins a contract the Behavior docs and tests stated nowhere: action sets after the first receive a freshly created snapshot, which includes the *normalization fallout* of the previous set's operations, not just the operations themselves.

The probe strips a decorator in set 1, leaving two adjacent spans with equal `marks`. Set 2's snapshot arrives with the cosmetic same-mark merge already applied: one span, the survivor's key, concatenated text. The test also pins the boundary's other half, set 1 reads the guard-time value, and asserts the editor's own value agrees with what set 2 saw.

Test-only; no changeset.
