### PR TITLE
fix: run `markDef` and empty-span-annotation cleanup only as fallout of local edits

### DIFF
--- a/.changeset/cleanup-normalization-on-touch.md
+++ b/.changeset/cleanup-normalization-on-touch.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: run `markDef` and empty-span-annotation cleanup only as fallout of local edits
+
+Unused and duplicate `markDefs`, and annotations on empty spans, are no longer cleaned up while adopting outside content or applying a collaborator's patches: adopted blocks keep those shapes exactly as the document has them. A local edit touching the block still cleans them up, emitted as part of that edit. Note that unused `markDefs` arriving via `initialValue` or `update value` are still pruned at ingress by value validation.

--- a/.changeset/upsert-markdef-inserts.md
+++ b/.changeset/upsert-markdef-inserts.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: stop concurrent annotation edits from duplicating mark definitions
+
+When two people annotated at the same time, the same mark definition could be saved into the document twice. When the sync layer re-sends a definition it now replaces its earlier copy instead of adding a second one.

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -322,7 +322,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove annotations from empty spans
    */
-  if (isSpan({schema: editor.snapshot.context.schema}, node)) {
+  if (
+    !editor.isProcessingRemoteChanges &&
+    isSpan({schema: editor.snapshot.context.schema}, node)
+  ) {
     const blockPath = parentPath(path)
     const blockEntry = getTextBlock(editor.snapshot, blockPath)
     if (!blockEntry) {
@@ -350,7 +353,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove duplicate markDefs
    */
-  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+  if (
+    !editor.isProcessingRemoteChanges &&
+    isTextBlock({schema: editor.snapshot.context.schema}, node)
+  ) {
     const markDefs = node.markDefs ?? []
     const markDefKeys = new Set<string>()
     const newMarkDefs: Array<PortableTextObject> = []
@@ -372,7 +378,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   /**
    * Remove markDefs not in use
    */
-  if (isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+  if (
+    !editor.isProcessingRemoteChanges &&
+    isTextBlock({schema: editor.snapshot.context.schema}, node)
+  ) {
     const newMarkDefs = (node.markDefs || []).filter((def) => {
       return node.children.find((child) => {
         return (

--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -13,11 +13,11 @@ import {
 import {createTestEditor} from '../src/test/vitest'
 
 /**
- * Pins the cosmetic-normalization contract of
- * `isCosmeticNormalizationSkipped` (`engine/core/normalize-node.ts`): a
- * collaborator's span structure arrives untouched, nothing is emitted for
- * it, and it canonicalizes on the block's next local edit or via `update
- * value`.
+ * Pins the cosmetic-normalization contract (`engine/core/normalize-node.ts`):
+ * a collaborator's span structure and a document's untidy-but-valid shapes
+ * (unused/duplicate `markDefs`, annotations on empty spans) arrive
+ * untouched, nothing is emitted for them, and the block canonicalizes on
+ * its next local edit.
  */
 describe('remote patches skip cosmetic normalization', () => {
   test('a remote marks change does not merge the surrounding spans', async () => {
@@ -510,6 +510,246 @@ describe('remote patches skip cosmetic normalization', () => {
  * annotation logic must compute correctly over that structure, and the
  * first local touch canonicalizes it as fallout of the edit.
  */
+describe('adoption and remote patches skip markDef and annotation cleanup', () => {
+  test('a remote marks change does not prune the markDef it leaves unused', async () => {
+    // The interleave hazard: a collaborator removes an annotation as two
+    // patches (clear the mark, unset the definition). Between them the
+    // definition is unused, and a receiver pruning it would race the
+    // collaborator's own unset.
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const patchEvents: Array<PatchEvent> = []
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patchEvents.push(event)
+            }
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({annotations: [{name: 'link'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: ['m0']},
+          ],
+          markDefs: [{_key: 'm0', _type: 'link'}],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'marks'],
+          value: [],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [{_key: 'm0', _type: 'link'}],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // Deterministic negative assert: a local edit flushes through the same
+    // ordered channel, so a would-be echo of the remote patch would surface
+    // no later than the edit's own emission. The edit also completes the
+    // lifecycle: touching the block prunes the now-unused definition as the
+    // author's own, emitted cleanup.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patchEvents.map((event) => event.patch)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          origin: 'local',
+        },
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+          origin: 'local',
+        },
+      ])
+    })
+    await vi.waitFor(() => {
+      expect(mutationEvents.flatMap((event) => event.patches)).toEqual(
+        patchEvents.map((event) => event.patch),
+      )
+    })
+  })
+
+  test('`update value` keeps duplicate markDefs as-is', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({annotations: [{name: 'link'}]}),
+    })
+
+    const storedValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: ['m0']}],
+        markDefs: [
+          {_key: 'm0', _type: 'link'},
+          {_key: 'm0', _type: 'link'},
+        ],
+        style: 'normal',
+      },
+    ]
+
+    editor.send({type: 'update value', value: storedValue})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(storedValue)
+    })
+  })
+
+  test('an empty annotated span arriving via `initialValue` keeps its marks', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const emptyKey = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [
+          {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+          {_type: 'span', _key: emptyKey, text: '', marks: ['m0']},
+        ],
+        markDefs: [{_key: 'm0', _type: 'link'}],
+        style: 'normal',
+      },
+    ]
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({annotations: [{name: 'link'}]}),
+      initialValue,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('the untidy block re-canonicalizes on its next local edit', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const emptyKey = keyGenerator()
+    const mutationEvents: Array<MutationEvent> = []
+
+    const {editor} = await createTestEditor({
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutationEvents.push(event)
+            }
+          }}
+        />
+      ),
+      keyGenerator,
+      schemaDefinition: defineSchema({annotations: [{name: 'link'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: emptyKey, text: '', marks: ['m0']},
+          ],
+          markDefs: [
+            {_key: 'm0', _type: 'link'},
+            {_key: 'm0', _type: 'link'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      // The local edit runs all three cleanup rules as its fallout: the empty
+      // span loses its annotation and merges away, the duplicate def
+      // dedupes, and the now-unused def prunes.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: fooKey, text: 'foo!', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(mutationEvents.length).toBeGreaterThan(0)
+    })
+  })
+})
+
 describe('mark state over adopted same-mark siblings', () => {
   test('caret at the boundary sees the shared decorator and typing continues it', async () => {
     const {editor} = await createTestEditor({

--- a/packages/plugin-sdk-value/src/plugin.collision-matrix.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.collision-matrix.browser.test.tsx
@@ -853,31 +853,6 @@ describe('multi-round link overlap', () => {
     )
   }
 
-  function withoutDuplicateMarkDefs(
-    blocks: PortableTextBlock[],
-  ): PortableTextBlock[] {
-    return blocks.map((block) => {
-      const markDefs = (block as {markDefs?: Array<{_key: string}>}).markDefs
-
-      if (!Array.isArray(markDefs)) {
-        return block
-      }
-
-      const seenKeys = new Set<string>()
-
-      return {
-        ...block,
-        markDefs: markDefs.filter((markDef) => {
-          if (seenKeys.has(markDef._key)) {
-            return false
-          }
-          seenKeys.add(markDef._key)
-          return true
-        }),
-      }
-    })
-  }
-
   async function waitForNewPush(store: Store, baseline: number) {
     await vi.waitFor(
       () => {
@@ -937,12 +912,9 @@ describe('multi-round link overlap', () => {
           server.deliverAll()
           expect(server.hasPendingDeliveries()).toBe(false)
 
-          // Known limitation, not a regression gate: repeated concurrent
-          // link toggles can leave duplicate markDef entries (same `_key`,
-          // same fields) in the server document. Editors normalize the
-          // duplicates away locally and the repair sync never rewrites
-          // them, so the comparison dedupes the server value.
-          const serverValue = withoutDuplicateMarkDefs(server.getServerValue())
+          // Upserted def inserts self-clean re-sends, so the server value
+          // must be duplicate-free and the editors must mirror it exactly.
+          const serverValue = server.getServerValue()
           expect(editorA.getSnapshot().context.value).toEqual(serverValue)
           expect(editorB.getSnapshot().context.value).toEqual(serverValue)
         },

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.test.ts
@@ -343,6 +343,14 @@ describe(toMergeableMarkDefsPatches.name, () => {
         () => storeValue,
       ),
     ).toEqual([
+      // The keyed unset makes the insert an upsert: a re-send self-cleans
+      // an earlier copy the store view failed to show, instead of stacking
+      // a duplicate.
+      {
+        type: 'unset',
+        origin: undefined,
+        path: [{_key: 'b1'}, 'markDefs', {_key: 'new'}],
+      },
       {
         type: 'insert',
         origin: undefined,

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -487,6 +487,22 @@ export function toMergeableMarkDefsPatches(
 
     const inserted = local.filter((item) => !storeByKey.has(item._key))
     if (inserted.length > 0) {
+      for (const item of inserted) {
+        if (item._key === undefined) {
+          continue
+        }
+        // The store view can wrongly lack an in-flight insert (a colliding
+        // transaction makes the optimistic rebase fail silently), so a
+        // re-send would stack a duplicate. The keyed unset makes the
+        // insert an upsert: it is a no-op while the key is absent, and
+        // the client's own transactions apply in order, so a re-send
+        // self-cleans any earlier copy instead of duplicating it.
+        ops.push({
+          type: 'unset',
+          origin,
+          path: [...patch.path, {_key: item._key}],
+        })
+      }
       ops.push({
         type: 'insert',
         origin,


### PR DESCRIPTION
The three cleanup rules (remove annotations from empty spans, remove duplicate `markDefs`, remove unused `markDefs`) were the last normalization still running on adopted and remote content, silently canonicalizing documents in-engine while the stored value kept the original shapes: the same divergence class behind the dialog-teardown field report. They are cosmetic by that class's own definition, so they get the same `isProcessingRemoteChanges` gate as the rest; local edits keep cleaning up, and untidy blocks re-canonicalize on touch as the author's own emission.

The gate immediately exposed a real bug it had been hiding: concurrent link editing writes the same `markDef` into the stored document twice (a collision makes the client's optimistic store view drop an in-flight insert, so the next flush re-sends it). The second commit fixes that writer: `toMergeableMarkDefsPatches` puts a keyed unset in front of every definition insert, so a re-send replaces its earlier copy instead of stacking a duplicate.

Pins: remote patches and adoption leave all three untidy shapes byte-identical with nothing emitted (red on `main`), a local edit runs all three rules as its fallout, and the collision-matrix tests drop their `withoutDuplicateMarkDefs` crutch and assert the raw server value, becoming the regression gate for the double-write.

The other half of the duplicate-`markDefs` story, repairing documents that already carry them, is #3034, stacked on this.
