### PR TITLE
fix: auto-resolve duplicate `markDefs` at value ingress

### DIFF
--- a/.changeset/dedupe-markdefs-ingress.md
+++ b/.changeset/dedupe-markdefs-ingress.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: repair duplicate `markDefs` when a value arrives
+
+A document arriving with the same mark definition twice (same `_key`) is repaired on arrival: the first copy wins, and the repair is written back with the user's first edit. Duplicate keys made patch addressing ambiguous, so unlike the deferred cleanup rules this one is treated as a validity repair.

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -230,6 +230,40 @@ export function validateValue(
           ),
         ]
 
+        // Duplicate `markDef` keys make keyed addressing ambiguous (a patch
+        // targeting `markDefs[_key=="x"]` can hit either copy). The repair
+        // is a whole-array `set` because keyed unsets would be ambiguous
+        // against the duplicates themselves.
+        if (Array.isArray(blk.markDefs) && blk.markDefs.length > 0) {
+          const seenMarkDefKeys = new Set<string>()
+          const dedupedMarkDefs = blk.markDefs.filter((def) => {
+            if (seenMarkDefKeys.has(def._key)) {
+              return false
+            }
+            seenMarkDefKeys.add(def._key)
+            return true
+          })
+          if (dedupedMarkDefs.length !== blk.markDefs.length) {
+            resolution = {
+              autoResolve: true,
+              patches: [set(dedupedMarkDefs, [{_key: blk._key}, 'markDefs'])],
+              description: `Block with _key '${blk._key}' contains duplicate mark definitions.`,
+              action: 'Remove duplicate mark definitions',
+              item: blk,
+              i18n: {
+                description:
+                  'inputs.portable-text.invalid-value.duplicate-mark-defs.description',
+                action:
+                  'inputs.portable-text.invalid-value.duplicate-mark-defs.action',
+                values: {
+                  key: blk._key,
+                },
+              },
+            }
+            return true
+          }
+        }
+
         // Test that all markDefs are in use (remove orphaned markDefs)
         if (Array.isArray(blk.markDefs) && blk.markDefs.length > 0) {
           const unusedMarkDefs: string[] = [

--- a/packages/editor/tests/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/tests/pteWarningsSelfSolving.test.tsx
@@ -375,6 +375,70 @@ describe('when PTE would display warnings, instead it self solves', () => {
     })
   })
 
+  it('removes duplicate markDefs', async () => {
+    const editorRef: RefObject<PortableTextEditor | null> = createRef()
+    const linkDef = {
+      _key: 'ghi',
+      _type: 'link',
+      href: 'https://sanity.io',
+    }
+    const initialValue = [
+      {
+        _key: 'abc',
+        _type: 'block',
+        style: 'normal',
+        // The same definition twice: keyed addressing against it is
+        // ambiguous, so ingress repairs it, first copy wins.
+        markDefs: [linkDef, linkDef],
+        children: [
+          {
+            _key: 'def',
+            _type: 'span',
+            marks: ['ghi'],
+            text: 'Hello',
+          },
+        ],
+      },
+    ]
+
+    const onChange = vi.fn()
+
+    await createTestEditor({
+      children: (
+        <>
+          <EventListenerPlugin on={onChange} />
+          <InternalPortableTextEditorRefPlugin ref={editorRef} />
+        </>
+      ),
+      initialValue,
+    })
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({type: 'ready'})
+    })
+    await vi.waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'abc',
+            _type: 'block',
+            children: [
+              {
+                _key: 'def',
+                _type: 'span',
+                text: 'Hello',
+                marks: ['ghi'],
+              },
+            ],
+            markDefs: [linkDef],
+            style: 'normal',
+          },
+        ])
+      }
+    })
+  })
+
   it('allows undefined value', async () => {
     const editorRef: RefObject<PortableTextEditor | null> = createRef()
     const onChange = vi.fn()

--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -618,7 +618,11 @@ describe('adoption and remote patches skip markDef and annotation cleanup', () =
     })
   })
 
-  test('`update value` keeps duplicate markDefs as-is', async () => {
+  test('`update value` repairs duplicate markDefs at ingress', async () => {
+    // Duplicate keys are structural, not cosmetic: patch addressing against
+    // them is ambiguous. Unlike the gated cleanup rules, they are repaired
+    // at ingress. On a pristine editor the repair's write parks and rides
+    // the first local edit, like the other validity repairs.
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()
     const spanKey = keyGenerator()
@@ -628,23 +632,36 @@ describe('adoption and remote patches skip markDef and annotation cleanup', () =
       schemaDefinition: defineSchema({annotations: [{name: 'link'}]}),
     })
 
-    const storedValue = [
-      {
-        _type: 'block',
-        _key: blockKey,
-        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: ['m0']}],
-        markDefs: [
-          {_key: 'm0', _type: 'link'},
-          {_key: 'm0', _type: 'link'},
-        ],
-        style: 'normal',
-      },
-    ]
-
-    editor.send({type: 'update value', value: storedValue})
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: ['m0']},
+          ],
+          markDefs: [
+            {_key: 'm0', _type: 'link'},
+            {_key: 'm0', _type: 'link'},
+          ],
+          style: 'normal',
+        },
+      ],
+    })
 
     await vi.waitFor(() => {
-      expect(editor.getSnapshot().context.value).toEqual(storedValue)
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: ['m0']},
+          ],
+          markDefs: [{_key: 'm0', _type: 'link'}],
+          style: 'normal',
+        },
+      ])
     })
   })
 
@@ -705,13 +722,32 @@ describe('adoption and remote patches skip markDef and annotation cleanup', () =
             {_type: 'span', _key: fooKey, text: 'foo', marks: []},
             {_type: 'span', _key: emptyKey, text: '', marks: ['m0']},
           ],
-          markDefs: [
-            {_key: 'm0', _type: 'link'},
-            {_key: 'm0', _type: 'link'},
-          ],
+          markDefs: [{_key: 'm0', _type: 'link'}],
           style: 'normal',
         },
       ],
+    })
+
+    // Duplicates can only reach the engine via remote patches now (ingress
+    // dedupes adoption), and the gate keeps them there until a local edit.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [
+            {_key: 'm0', _type: 'link'},
+            {_key: 'm0', _type: 'link'},
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.at(0)?.markDefs).toHaveLength(2)
     })
 
     editor.send({


### PR DESCRIPTION
Extracted from #3033 as its own mechanism: a new `validateValue` auto-resolution, not part of the cleanup gating or the emission fix. Based on #3033's branch so the diff shows only this commit; GitHub retargets to `main` when #3033 merges.

Duplicate `markDef` keys are structural, not cosmetic: a patch addressing `markDefs[_key=="x"]` can hit either copy. A value arriving with duplicates is now repaired on arrival, first copy wins, via a whole-array `set` (keyed unsets would themselves be ambiguous against the duplicates). Without this, a document that already carries duplicates keeps them in-engine until a local edit touches that block; with it, the ambiguity never enters the session.

Two honest scope notes. Auto-resolutions never surface in Studio's invalid-value UI (they apply as a `console.warn` plus ordinary patches), so the new i18n keys are inert metadata and no Studio version dependency exists. And the repair's outbound write follows the existing auto-resolve semantics: on `update value` it emits and heals the stored document; on initial load it repairs the engine's copy while the write parks, the same first-load behavior as the long-standing orphaned-`markDefs` resolution.

Pinned: `pteWarningsSelfSolving` gains the dedupe repair scenario, and the gated-normalization suite's adoption pin re-homes from "keeps duplicates as-is" to "repairs at ingress", with the on-touch scenario building its duplicate state through a remote patch, the one path that (deliberately) bypasses ingress.
