### PR TITLE
feat(plugin-sdk-value): show remote carets and report presence

### DIFF
--- a/.changeset/sdk-presence-in-value-plugin.md
+++ b/.changeset/sdk-presence-in-value-plugin.md
@@ -1,0 +1,15 @@
+---
+'@portabletext/plugin-sdk-value': minor
+---
+
+feat: add presence, and `SDKPortableTextEditable`
+
+Other people's carets now show up in a Portable Text field, and the local user's caret is reported so they show up elsewhere, including in the Studio.
+
+`SDKPortableTextEditable` replaces `PortableTextEditable` and does all of it: value sync both ways, presence reporting, and drawing remote carets. It names the document and field once, so a separate `SDKValuePlugin` is no longer needed. Any `rangeDecorations` you pass are kept and merged with the presence carets rather than replaced.
+
+Remote carets are drawn with a built-in caret component, so presence works without styling anything. Pass `renderCursor` to replace it, or `renderCursor={null}` to report presence without drawing carets.
+
+`SDKPresencePlugin` and `useSDKPresenceCursors` are available for apps that render `PortableTextEditable` themselves.
+
+The `@sanity/sdk-react` peer range moves to `^2.19.0`, which is where the presence hooks were added.

--- a/packages/plugin-sdk-value/README.md
+++ b/packages/plugin-sdk-value/README.md
@@ -2,7 +2,9 @@
 
 > Connect a Portable Text Editor with a Sanity document using the SDK
 
-The SDK Value plugin provides seamless two-way synchronization between a Portable Text Editor instance and a specific field in a Sanity document. This enables real-time collaboration and ensures that changes made through the editor are immediately reflected in the document, and vice versa.
+Two-way synchronization between a Portable Text Editor and a field in a Sanity
+document, plus presence: other people's carets show up in the field, and the
+local user's caret shows up for them, including in the Studio.
 
 ## Installation
 
@@ -15,24 +17,22 @@ npm install @portabletext/plugin-sdk-value
 - **Two-way synchronization**: Changes in the editor update the document, and document changes update the editor
 - **Real-time updates**: Automatically handles patches from external sources (other users, mutations, etc.)
 - **Optimistic updates**: Provides smooth user experience with immediate local updates
+- **Presence**: Reports where the local user is editing, and draws other people's carets
 
 ## Usage
 
-Import the `SDKValuePlugin` React component and place it inside the `EditorProvider`. The plugin requires document handle properties and a path to specify which field to synchronize:
+Use `SDKPortableTextEditable` in place of `PortableTextEditable`, inside the
+`EditorProvider`. It names the document and field once and wires up value sync,
+presence reporting, and remote carets:
 
 ```tsx
-import {
-  defineSchema,
-  EditorProvider,
-  PortableTextEditable,
-} from '@portabletext/editor'
-import {SDKValuePlugin} from '@portabletext/plugin-sdk-value'
+import {defineSchema, EditorProvider} from '@portabletext/editor'
+import {SDKPortableTextEditable} from '@portabletext/plugin-sdk-value'
 
 function MyEditor() {
   return (
     <EditorProvider initialConfig={{schemaDefinition: defineSchema({})}}>
-      <PortableTextEditable />
-      <SDKValuePlugin
+      <SDKPortableTextEditable
         documentId="my-document-id"
         documentType="myDocumentType"
         path="content"
@@ -42,23 +42,101 @@ function MyEditor() {
 }
 ```
 
+That is all of it. Remote carets are drawn with a built-in caret, so nothing has
+to be styled to get presence working.
+
+Every other prop is forwarded to `PortableTextEditable` untouched. Any
+`rangeDecorations` you pass are kept and merged with the presence carets rather
+than replaced.
+
+### Styling the caret
+
+The built-in caret is deliberately plain: a coloured line with a dot above it and
+the participant's name on hover. Colours come from a small fixed palette, keyed on
+the user, so one person in two tabs gets one colour. Pass `renderCursor` to
+replace it:
+
+```tsx
+<SDKPortableTextEditable
+  {...documentHandle}
+  path="content"
+  renderCursor={({user}) =>
+    (props) => (
+      <MyCaret label={user.profile.displayName}>{props.children}</MyCaret>
+    )}
+/>
+```
+
+Your component receives the decorated text as `children` and should render it.
+Pass `renderCursor={null}` to draw no carets at all while still reporting the
+local user's presence, which is what you want if you only care about keeping the
+document in sync.
+
+### Rendering the editable yourself
+
+`SDKValuePlugin` still works as a sibling component if you would rather keep
+control of `PortableTextEditable`. Pair it with `SDKPresencePlugin` to report
+presence, and `useSDKPresenceCursors` for remote carets:
+
+```tsx
+function MyEditor(props: DocumentHandle) {
+  const cursors = useSDKPresenceCursors({
+    ...props,
+    path: 'content',
+    renderCursor:
+      ({user}) =>
+      (cursorProps) => <Caret user={user}>{cursorProps.children}</Caret>,
+  })
+
+  return (
+    <EditorProvider initialConfig={{schemaDefinition: defineSchema({})}}>
+      <PortableTextEditable rangeDecorations={cursors} />
+      <SDKValuePlugin {...props} path="content" />
+      <SDKPresencePlugin {...props} path="content" />
+    </EditorProvider>
+  )
+}
+```
+
 ## Props
 
-The `SDKValuePlugin` component accepts a [Document Handle](https://www.sanity.io/docs/app-sdk/document-handles) plus an additional `path` parameter:
+`SDKPortableTextEditable` accepts a
+[Document Handle](https://www.sanity.io/docs/app-sdk/document-handles), every
+`PortableTextEditable` prop, and:
 
-| Prop           | Type                | Description                                                        |
-| -------------- | ------------------- | ------------------------------------------------------------------ |
-| `documentId`   | `string`            | The document ID                                                    |
-| `documentType` | `string`            | The document type                                                  |
-| `path`         | `string`            | [JSONMatch][json-match] path expression to the Portable Text field |
-| `dataset`      | `string` (optional) | Dataset name (if different from configured default)                |
-| `projectId`    | `string` (optional) | Project ID (if different from configured default)                  |
+| Prop           | Type                          | Description                                                                      |
+| -------------- | ----------------------------- | -------------------------------------------------------------------------------- |
+| `documentId`   | `string`                      | The document ID                                                                  |
+| `documentType` | `string`                      | The document type                                                                |
+| `path`         | `string`                      | [JSONMatch][json-match] path expression to the Portable Text field               |
+| `renderCursor` | `function \| null` (optional) | Draws one remote participant's caret. Omit for the built-in one, `null` for none |
+| `dataset`      | `string` (optional)           | Dataset name (if different from configured default)                              |
+| `projectId`    | `string` (optional)           | Project ID (if different from configured default)                                |
+| `perspective`  | `string \| object` (optional) | Which document to sync and report: draft, published, or a release                |
 
 [json-match]: https://www.sanity.io/docs/content-lake/json-match
+
+## Notes on presence
+
+Carets are drawn with the built-in component unless you pass `renderCursor`, and
+are collapsed to a single point at the participant's focus. Presence
+answers where someone is, so decorating their whole selection would highlight
+text the local user never selected. The Studio does the same.
+
+Participants are counted by session, not by person. The same user in two tabs
+draws two carets, in the same colour. Group by `user.sanityUserId` in your own
+`renderCursor` if you would rather show one.
+
+The local user is never included, so an app does not draw its own caret.
+
+Which document is reported follows the handle's `perspective`, or the ambient one
+from `ResourceProvider`. Pass the plain document id and let the perspective
+select the draft, the published document, or a release version. This matters for
+the Studio, whose field indicators compare the exact document id its form is on.
 
 ## Requirements
 
 This plugin requires:
 
-- `@sanity/sdk-react` for document state management
+- `@sanity/sdk-react` 2.19 or newer, where the presence hooks were added
 - The document must exist in the Sanity dataset

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -77,7 +77,7 @@
     "@portabletext/test": "workspace:^",
     "@sanity/diff-match-patch": "catalog:",
     "@sanity/pkg-utils": "catalog:tooling",
-    "@sanity/sdk-react": "^2.13.0",
+    "@sanity/sdk-react": "^2.19.0",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/debug": "catalog:",
     "@types/react": "catalog:tooling",
@@ -99,7 +99,7 @@
   },
   "peerDependencies": {
     "@portabletext/editor": "workspace:^",
-    "@sanity/sdk-react": "^2.1.2",
+    "@sanity/sdk-react": "^2.19.0",
     "react": "^19.2",
     "react-dom": "^19.2"
   },

--- a/packages/plugin-sdk-value/src/index.ts
+++ b/packages/plugin-sdk-value/src/index.ts
@@ -1,1 +1,13 @@
+export {
+  SDKPresencePlugin,
+  useSDKPresenceCursors,
+  type RenderCursorFunction,
+  type SDKPresencePluginProps,
+  type SDKRemoteCursor,
+  type UseSDKPresenceCursorsOptions,
+} from './plugin.sdk-presence'
 export {SDKValuePlugin, ValueSyncPlugin} from './plugin.sdk-value'
+export {
+  SDKPortableTextEditable,
+  type SDKPortableTextEditableProps,
+} from './sdk-editable'

--- a/packages/plugin-sdk-value/src/plugin.presence-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.presence-sync.browser.test.tsx
@@ -1,0 +1,181 @@
+import {EditorProvider, PortableTextEditable} from '@portabletext/editor'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {useMemo, type PropsWithChildren, type ReactElement} from 'react'
+import {describe, expect, test} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {page} from 'vitest/browser'
+import {useRemoteCursors} from './plugin.presence-sync'
+import {renderDefaultCursor} from './presence-caret'
+import type {RemoteCursor} from './presence-cursors'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+})
+
+const initialValue: PortableTextBlock[] = [
+  {
+    _type: 'block',
+    _key: 'block-1',
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: 'span-1', text: 'Hello world', marks: []}],
+  },
+]
+
+function caretAt(offset: number): RemoteCursor['selection'] {
+  const path = [{_key: 'block-1'}, 'children', {_key: 'span-1'}]
+  return {anchor: {path, offset}, focus: {path, offset}}
+}
+
+function Harness(props: {
+  cursors: readonly RemoteCursor[]
+  useDefaultCaret?: boolean
+}) {
+  const cursors = useMemo(() => props.cursors, [props.cursors])
+  const rangeDecorations = useRemoteCursors({
+    cursors,
+    renderCursor: props.useDefaultCaret
+      ? (renderDefaultCursor as (
+          cursor: RemoteCursor,
+        ) => (componentProps: PropsWithChildren) => ReactElement)
+      : (cursor) => (componentProps: PropsWithChildren) => (
+          <span data-testid={`caret-${cursor.sessionId}`}>
+            {componentProps.children}
+          </span>
+        ),
+  })
+
+  return (
+    <PortableTextEditable
+      data-testid="editable"
+      rangeDecorations={rangeDecorations}
+    />
+  )
+}
+
+async function renderEditor(
+  cursors: readonly RemoteCursor[],
+  options: {useDefaultCaret?: boolean} = {},
+) {
+  const result = await render(
+    <EditorProvider initialConfig={{schemaDefinition, initialValue}}>
+      <Harness cursors={cursors} useDefaultCaret={options.useDefaultCaret} />
+    </EditorProvider>,
+  )
+
+  await expect.element(page.getByTestId('editable')).toBeInTheDocument()
+
+  return result
+}
+
+describe('useRemoteCursors in a real editor', () => {
+  test('draws a caret for a remote participant', async () => {
+    await renderEditor([{sessionId: 'session-a', selection: caretAt(5)}])
+
+    await expect
+      .element(page.getByTestId('caret-session-a'))
+      .toBeInTheDocument()
+  })
+
+  test('draws nothing for a participant with no selection', async () => {
+    await renderEditor([{sessionId: 'session-a', selection: null}])
+
+    await expect
+      .element(page.getByTestId('caret-session-a'))
+      .not.toBeInTheDocument()
+  })
+
+  test('draws one caret per session, so two tabs of one person show twice', async () => {
+    await renderEditor([
+      {sessionId: 'session-a', selection: caretAt(2)},
+      {sessionId: 'session-b', selection: caretAt(8)},
+    ])
+
+    await expect
+      .element(page.getByTestId('caret-session-a'))
+      .toBeInTheDocument()
+    await expect
+      .element(page.getByTestId('caret-session-b'))
+      .toBeInTheDocument()
+  })
+})
+
+function participant(
+  sessionId: string,
+  userId: string,
+  displayName: string,
+  offset: number,
+): RemoteCursor {
+  return {
+    sessionId,
+    selection: caretAt(offset),
+    user: {sanityUserId: userId, profile: {displayName}},
+  } as unknown as RemoteCursor
+}
+
+function caretColorOf(sessionId: string): string {
+  const element = page.getByTestId(`presence-caret-${sessionId}`).element()
+  return getComputedStyle(element).borderLeftColor
+}
+
+describe('the default caret', () => {
+  const cursor = participant('session-a', 'user-abc', 'Ada Lovelace', 5)
+
+  test('draws without the app providing a caret component', async () => {
+    await renderEditor([cursor], {useDefaultCaret: true})
+
+    await expect
+      .element(page.getByTestId('presence-caret-session-a'))
+      .toBeInTheDocument()
+  })
+
+  test('is not editable, so the local cursor cannot land inside it', async () => {
+    await renderEditor([cursor], {useDefaultCaret: true})
+
+    await expect
+      .element(page.getByTestId('presence-caret-session-a'))
+      .toHaveAttribute('contenteditable', 'false')
+  })
+
+  test('names the participant on its dot, for hover', async () => {
+    await renderEditor([cursor], {useDefaultCaret: true})
+
+    await expect
+      .element(page.getByTestId('presence-caret-dot-session-a'))
+      .toHaveAttribute('title', 'Ada Lovelace')
+  })
+})
+
+describe('the default caret colour', () => {
+  test('matches for one person in two tabs, so they read as the same user', async () => {
+    await renderEditor(
+      [
+        participant('session-a', 'user-abc', 'Ada Lovelace', 2),
+        participant('session-b', 'user-abc', 'Ada Lovelace', 8),
+      ],
+      {useDefaultCaret: true},
+    )
+
+    await expect
+      .element(page.getByTestId('presence-caret-session-b'))
+      .toBeInTheDocument()
+
+    expect(caretColorOf('session-a')).toBe(caretColorOf('session-b'))
+  })
+
+  test('differs between two people, so they can be told apart', async () => {
+    await renderEditor(
+      [
+        participant('session-a', 'user-abc', 'Ada Lovelace', 2),
+        participant('session-b', 'user-xyz', 'Grace Hopper', 8),
+      ],
+      {useDefaultCaret: true},
+    )
+
+    await expect
+      .element(page.getByTestId('presence-caret-session-b'))
+      .toBeInTheDocument()
+
+    expect(caretColorOf('session-a')).not.toBe(caretColorOf('session-b'))
+  })
+})

--- a/packages/plugin-sdk-value/src/plugin.presence-sync.tsx
+++ b/packages/plugin-sdk-value/src/plugin.presence-sync.tsx
@@ -1,0 +1,89 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type EditorSelection,
+  type RangeDecoration,
+} from '@portabletext/editor'
+import {getSelection} from '@portabletext/editor/selectors'
+import {isEqualSelections} from '@portabletext/editor/utils'
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+  type ReactElement,
+} from 'react'
+import {
+  recordCursorMove,
+  toRangeDecorations,
+  type CursorOverride,
+  type RemoteCursor,
+} from './presence-cursors'
+
+/**
+ * Options for {@link useRemoteCursors}.
+ *
+ * @public
+ */
+export interface UseRemoteCursorsOptions<TCursor extends RemoteCursor> {
+  /**
+   * The remote participants to draw. Keep this array referentially stable, for
+   * example with `useMemo`, so that decorations are not rebuilt on every
+   * render.
+   */
+  cursors: readonly TCursor[]
+  renderCursor: (cursor: TCursor) => (props: PropsWithChildren) => ReactElement
+}
+
+/**
+ * The local user's selection, deduped by value.
+ *
+ * The editor produces a fresh selection object on every snapshot change, so
+ * subscribing to it directly would report presence far more often than the
+ * caret actually moves.
+ *
+ * @public
+ */
+export function useLocalSelection(): EditorSelection {
+  const editor = useEditor()
+  // Direction is ignored, which `isEqualSelections` already does: a caret is
+  // drawn at the focus point, so reversing a selection moves nothing.
+  return useEditorSelector(editor, getSelection, isEqualSelections)
+}
+
+/**
+ * Turns remote cursors into range decorations, keeping each caret anchored as
+ * the local user edits.
+ *
+ * Knows nothing about Sanity or the SDK, so it can also drive carets from
+ * another source or from a test fixture. `useSDKPresenceCursors` is the version
+ * wired to SDK presence.
+ *
+ * @public
+ */
+export function useRemoteCursors<TCursor extends RemoteCursor>(
+  options: UseRemoteCursorsOptions<TCursor>,
+): RangeDecoration[] {
+  const {cursors, renderCursor} = options
+  // Only the moved carets need to survive a render. Where every caret is drawn
+  // is derived from them plus the latest report, so there is no state to keep
+  // in step with the incoming cursors.
+  const [overrides, setOverrides] =
+    useState<ReadonlyMap<string, CursorOverride>>(EMPTY_OVERRIDES)
+
+  const onCursorMoved = useCallback(
+    (cursor: TCursor, selection: EditorSelection) => {
+      setOverrides((previous) =>
+        recordCursorMove(previous, cursors, cursor, selection),
+      )
+    },
+    [cursors],
+  )
+
+  return useMemo(
+    () => toRangeDecorations({cursors, overrides, renderCursor, onCursorMoved}),
+    [cursors, overrides, renderCursor, onCursorMoved],
+  )
+}
+
+const EMPTY_OVERRIDES: ReadonlyMap<string, CursorOverride> = new Map()

--- a/packages/plugin-sdk-value/src/plugin.sdk-presence.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-presence.tsx
@@ -1,0 +1,153 @@
+import type {EditorSelection, RangeDecoration} from '@portabletext/editor'
+import {
+  usePresenceForDocument,
+  useReportPresence,
+  type DocumentHandle,
+  type UseReportPresenceOptions,
+} from '@sanity/sdk-react'
+import {useMemo, type PropsWithChildren, type ReactElement} from 'react'
+import {useLocalSelection, useRemoteCursors} from './plugin.presence-sync'
+import {arrayifyPath} from './plugin.sdk-value'
+
+/**
+ * `@sanity/sdk-react` exports the presence hooks and their option types but not
+ * the presence data types, so these are derived from what it does export.
+ */
+type DocumentPresence = ReturnType<
+  typeof usePresenceForDocument
+>['presence'][number]
+
+/**
+ * Draws one remote participant's caret. This package has no opinion about how a
+ * caret looks, so it is the caller's to provide.
+ *
+ * @public
+ */
+export type RenderCursorFunction = (
+  cursor: SDKRemoteCursor,
+) => (props: PropsWithChildren) => ReactElement
+
+/**
+ * A remote participant's caret, together with who they are.
+ *
+ * Declared in full rather than extending the internal cursor type, so nothing in
+ * the public API refers to a type consumers cannot import.
+ *
+ * @public
+ */
+export interface SDKRemoteCursor {
+  /**
+   * Identifies one editing session rather than one person. The same user in two
+   * tabs reports two sessions and therefore draws two carets.
+   */
+  sessionId: string
+  /**
+   * Where the participant last reported their selection.
+   */
+  selection: EditorSelection
+  user: DocumentPresence['user']
+}
+
+/**
+ * Props for {@link SDKPresencePlugin}.
+ *
+ * @public
+ */
+export interface SDKPresencePluginProps extends DocumentHandle {
+  /**
+   * The document path of the Portable Text field, for example `content`. The
+   * same form `SDKValuePlugin` takes.
+   */
+  path: string
+}
+
+/**
+ * Options for {@link useSDKPresenceCursors}.
+ *
+ * @public
+ */
+export interface UseSDKPresenceCursorsOptions extends DocumentHandle {
+  path: string
+  renderCursor: RenderCursorFunction
+}
+
+/**
+ * Reports the local user's caret in a Portable Text field, so other people in
+ * the same document can see where they are.
+ *
+ * Place it inside `EditorProvider`. Prefer `SDKPortableTextEditable`, which
+ * reports and draws in one component; reach for this when you render
+ * `PortableTextEditable` yourself.
+ *
+ * Which document is reported follows the handle's perspective, or the ambient
+ * one from `ResourceProvider`. Pass the plain document id and let the
+ * perspective select the draft, the published document, or a release version.
+ *
+ * @public
+ */
+export function SDKPresencePlugin(props: SDKPresencePluginProps) {
+  const {path, ...handle} = props
+  const selection = useLocalSelection()
+  const fieldPath = useFieldPath(path)
+
+  useReportPresence({...handle, path: fieldPath, selection})
+
+  return null
+}
+
+/**
+ * Other people's carets in a Portable Text field, as range decorations.
+ *
+ * Pass the result to `<PortableTextEditable rangeDecorations={...} />`, or use
+ * `SDKPortableTextEditable` and skip the wiring. Each caret stays anchored as
+ * the local user types, and disappears when the participant leaves or their
+ * session expires.
+ *
+ * The local user is never included, so an app does not draw its own caret.
+ * Participants are counted by session, so the same person in two tabs draws two
+ * carets.
+ *
+ * @public
+ */
+export function useSDKPresenceCursors(
+  options: UseSDKPresenceCursorsOptions,
+): RangeDecoration[] {
+  const {path, renderCursor, ...handle} = options
+  const fieldPath = useFieldPath(path)
+  // Exact id matching: a caret reported while editing a draft must not be drawn
+  // in a release version of the same document, where the text differs.
+  const {presence} = usePresenceForDocument({
+    ...handle,
+    path: fieldPath,
+    excludeVersions: true,
+  })
+
+  const cursors = useMemo(
+    () =>
+      presence.flatMap((participant): SDKRemoteCursor[] =>
+        participant.selection
+          ? [
+              {
+                sessionId: participant.sessionId,
+                selection: participant.selection,
+                user: participant.user,
+              },
+            ]
+          : [],
+      ),
+    [presence],
+  )
+
+  return useRemoteCursors({cursors, renderCursor})
+}
+
+/**
+ * The SDK's presence hooks address fields by path array, because a field-level
+ * path inside Portable Text needs keyed segments. This package takes the same
+ * string expression as `SDKValuePlugin` everywhere and converts here.
+ */
+function useFieldPath(
+  path: string,
+): NonNullable<UseReportPresenceOptions['path']> {
+  return useMemo(() => arrayifyPath(path), [path])
+}

--- a/packages/plugin-sdk-value/src/presence-caret.test.ts
+++ b/packages/plugin-sdk-value/src/presence-caret.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+import {getCaretColor} from './presence-caret'
+
+describe('getCaretColor', () => {
+  it('gives the same user the same colour every time', () => {
+    expect(getCaretColor('user-abc')).toBe(getCaretColor('user-abc'))
+  })
+
+  it('always returns a colour, whatever the id looks like', () => {
+    for (const id of [
+      '',
+      'a',
+      'user-abc',
+      'p8xDvUMxC',
+      '你好',
+      '0'.repeat(500),
+    ]) {
+      expect(getCaretColor(id)).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+
+  it('spreads a realistic set of users across several colours', () => {
+    const ids = Array.from({length: 12}, (_, index) => `user-${index}`)
+
+    const colors = new Set(ids.map(getCaretColor))
+
+    // Not one colour for everyone, which is what a broken hash would give.
+    expect(colors.size).toBeGreaterThan(2)
+  })
+
+  it('does not collapse ids that differ only by order', () => {
+    // A sum-of-characters hash would give these the same colour.
+    expect(getCaretColor('ab')).not.toBe(getCaretColor('ba'))
+  })
+})

--- a/packages/plugin-sdk-value/src/presence-caret.tsx
+++ b/packages/plugin-sdk-value/src/presence-caret.tsx
@@ -1,0 +1,90 @@
+import type {PropsWithChildren} from 'react'
+import type {RenderCursorFunction, SDKRemoteCursor} from './plugin.sdk-presence'
+
+/**
+ * Mid-tone hues, so a caret stays legible whether the app is light or dark. This
+ * package cannot read the app's theme, so it does not try.
+ */
+const CARET_COLORS = [
+  '#e0508a',
+  '#c05fd8',
+  '#7c66e8',
+  '#2f8fdd',
+  '#1f9c8f',
+  '#4f9c2f',
+  '#c98a1c',
+  '#d4603a',
+]
+
+const DOT_SIZE = 6
+
+/**
+ * Picks a stable colour for a participant.
+ *
+ * Keyed on the user rather than the session, so one person in two tabs draws two
+ * carets in the same colour. The Studio colours by user for the same reason.
+ *
+ * @public
+ */
+export function getCaretColor(userId: string): string {
+  let hash = 0
+  for (let index = 0; index < userId.length; index++) {
+    hash = (hash * 31 + userId.charCodeAt(index)) % 1000003
+  }
+  return CARET_COLORS[hash % CARET_COLORS.length]
+}
+
+/**
+ * Draws a remote caret when no `renderCursor` was given: a coloured line with a
+ * dot above it, and the participant's name on hover.
+ *
+ * Deliberately plain, and styled inline so it needs no stylesheet. Pass your own
+ * `renderCursor` to match your design.
+ *
+ * @public
+ */
+export const renderDefaultCursor: RenderCursorFunction =
+  (cursor) => (props) => (
+    <DefaultCaret cursor={cursor}>{props.children}</DefaultCaret>
+  )
+
+function DefaultCaret(props: PropsWithChildren<{cursor: SDKRemoteCursor}>) {
+  const {cursor, children} = props
+  const color = getCaretColor(cursor.user.sanityUserId)
+  const displayName = cursor.user.profile.displayName
+
+  return (
+    <>
+      <span
+        // Without this the caret becomes editable content and the local user can
+        // put their own cursor inside it.
+        contentEditable={false}
+        data-testid={`presence-caret-${cursor.sessionId}`}
+        style={{
+          borderLeft: `2px solid ${color}`,
+          marginLeft: -1,
+          position: 'relative',
+          // The line must not swallow clicks meant for the text under it.
+          pointerEvents: 'none',
+        }}
+      >
+        <span
+          data-testid={`presence-caret-dot-${cursor.sessionId}`}
+          style={{
+            backgroundColor: color,
+            borderRadius: '50%',
+            height: DOT_SIZE,
+            left: -1,
+            pointerEvents: 'auto',
+            position: 'absolute',
+            top: -(DOT_SIZE - 1),
+            transform: 'translateX(-50%)',
+            width: DOT_SIZE,
+          }}
+          title={displayName}
+        />
+      </span>
+      {children}
+    </>
+  )
+}

--- a/packages/plugin-sdk-value/src/presence-cursors.test.ts
+++ b/packages/plugin-sdk-value/src/presence-cursors.test.ts
@@ -1,0 +1,235 @@
+import type {EditorSelection} from '@portabletext/editor'
+import {createElement, type PropsWithChildren, type ReactElement} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+import {
+  collapseToCaret,
+  recordCursorMove,
+  resolveCursorSelection,
+  toRangeDecorations,
+  type CursorOverride,
+  type RemoteCursor,
+} from './presence-cursors'
+
+function span(
+  anchorOffset: number,
+  focusOffset: number,
+  key = 'span-1',
+): NonNullable<EditorSelection> {
+  const path = [{_key: 'block-1'}, 'children', {_key: key}]
+  return {
+    anchor: {path, offset: anchorOffset},
+    focus: {path, offset: focusOffset},
+  }
+}
+
+function renderCursor(): (props: PropsWithChildren) => ReactElement {
+  return (props) => createElement('span', null, props.children)
+}
+
+function overridesOf(
+  ...entries: Array<[string, CursorOverride]>
+): ReadonlyMap<string, CursorOverride> {
+  return new Map(entries)
+}
+
+describe('collapseToCaret', () => {
+  it('leaves an absent selection absent', () => {
+    expect(collapseToCaret(null)).toBeNull()
+  })
+
+  it('puts both points at the focus, so no text reads as selected', () => {
+    expect(collapseToCaret(span(2, 7))).toEqual({
+      anchor: span(2, 7).focus,
+      focus: span(2, 7).focus,
+    })
+  })
+
+  it('leaves an already collapsed selection where it is', () => {
+    expect(collapseToCaret(span(4, 4))).toEqual(span(4, 4))
+  })
+})
+
+describe('resolveCursorSelection', () => {
+  it('collapses a fresh report when nothing has moved it', () => {
+    const cursor: RemoteCursor = {sessionId: 'a', selection: span(2, 6)}
+
+    expect(resolveCursorSelection(cursor, undefined)).toEqual(
+      collapseToCaret(span(2, 6)),
+    )
+  })
+
+  it('keeps a locally moved caret while the participant reports the same selection', () => {
+    const cursor: RemoteCursor = {sessionId: 'a', selection: span(1, 1)}
+    // A fresh object with identical values, which is what every heartbeat sends.
+    const override: CursorOverride = {reported: span(1, 1), current: span(9, 9)}
+
+    expect(resolveCursorSelection(cursor, override)).toEqual(span(9, 9))
+  })
+
+  it('drops a locally moved caret once the participant actually moves', () => {
+    const cursor: RemoteCursor = {sessionId: 'a', selection: span(3, 3)}
+    const override: CursorOverride = {reported: span(1, 1), current: span(9, 9)}
+
+    expect(resolveCursorSelection(cursor, override)).toEqual(span(3, 3))
+  })
+
+  it('treats a move to a different span as a move, comparing keys not identity', () => {
+    // Paths carry `{_key}` objects, so a value comparison is what makes a report
+    // from a different span read as a move rather than as the same position.
+    const override: CursorOverride = {
+      reported: span(1, 1, 'span-1'),
+      current: span(9, 9),
+    }
+    const cursor: RemoteCursor = {
+      sessionId: 'a',
+      selection: span(1, 1, 'span-2'),
+    }
+
+    expect(resolveCursorSelection(cursor, override)).toEqual(
+      span(1, 1, 'span-2'),
+    )
+  })
+
+  it('has nothing to draw for a participant who cleared their selection', () => {
+    expect(
+      resolveCursorSelection({sessionId: 'a', selection: null}, undefined),
+    ).toBeNull()
+  })
+})
+
+describe('recordCursorMove', () => {
+  const cursor: RemoteCursor = {sessionId: 'a', selection: span(1, 1)}
+  const cursors = [cursor]
+
+  it('records the move against the selection it moved from', () => {
+    const next = recordCursorMove(new Map(), cursors, cursor, span(5, 5))
+
+    expect(next.get('a')).toEqual({reported: span(1, 1), current: span(5, 5)})
+  })
+
+  it('collapses a range the editor reports', () => {
+    const next = recordCursorMove(new Map(), cursors, cursor, span(5, 9))
+
+    expect(next.get('a')?.current).toEqual(collapseToCaret(span(5, 9)))
+  })
+
+  it('returns the same map when the caret did not actually move', () => {
+    const overrides = overridesOf([
+      'a',
+      {reported: span(1, 1), current: span(5, 5)},
+    ])
+
+    expect(recordCursorMove(overrides, cursors, cursor, span(5, 5))).toBe(
+      overrides,
+    )
+  })
+
+  it('re-records when the participant has reported a new selection since', () => {
+    const overrides = overridesOf([
+      'a',
+      {reported: span(1, 1), current: span(5, 5)},
+    ])
+    const moved: RemoteCursor = {sessionId: 'a', selection: span(3, 3)}
+
+    const next = recordCursorMove(overrides, [moved], moved, span(5, 5))
+
+    expect(next.get('a')).toEqual({reported: span(3, 3), current: span(5, 5)})
+  })
+
+  it('forgets participants who have left, so overrides stay bounded', () => {
+    const overrides = overridesOf(
+      ['a', {reported: span(1, 1), current: span(5, 5)}],
+      ['gone', {reported: span(2, 2), current: span(7, 7)}],
+    )
+
+    const next = recordCursorMove(overrides, cursors, cursor, span(6, 6))
+
+    expect([...next.keys()]).toEqual(['a'])
+  })
+})
+
+describe('toRangeDecorations', () => {
+  const cursors: RemoteCursor[] = [
+    {sessionId: 'a', selection: span(1, 1)},
+    {sessionId: 'b', selection: span(2, 2)},
+  ]
+
+  it('draws one decoration per participant, tagged with the session', () => {
+    const decorations = toRangeDecorations({
+      cursors,
+      overrides: new Map(),
+      renderCursor,
+    })
+
+    expect(decorations).toHaveLength(2)
+    expect(decorations.map((decoration) => decoration.payload)).toEqual([
+      {sessionId: 'a'},
+      {sessionId: 'b'},
+    ])
+    expect(decorations[0].selection).toEqual(span(1, 1))
+  })
+
+  it('draws a moved caret where it was moved to', () => {
+    const overrides = overridesOf([
+      'a',
+      {reported: span(1, 1), current: span(9, 9)},
+    ])
+
+    const [decoration] = toRangeDecorations({
+      cursors,
+      overrides,
+      renderCursor,
+    })
+
+    expect(decoration.selection).toEqual(span(9, 9))
+  })
+
+  it('skips a participant with no caret to draw', () => {
+    const decorations = toRangeDecorations({
+      cursors: [{sessionId: 'a', selection: null}, cursors[1]],
+      overrides: new Map(),
+      renderCursor,
+    })
+
+    expect(decorations.map((decoration) => decoration.payload)).toEqual([
+      {sessionId: 'b'},
+    ])
+  })
+
+  it('reports moves against the right participant', () => {
+    const onCursorMoved = vi.fn()
+
+    const decorations = toRangeDecorations({
+      cursors,
+      overrides: new Map(),
+      renderCursor,
+      onCursorMoved,
+    })
+    decorations[1].onMoved?.({
+      rangeDecoration: decorations[1],
+      newSelection: span(4, 4),
+      origin: 'local',
+    })
+
+    expect(onCursorMoved).toHaveBeenCalledWith(cursors[1], span(4, 4))
+  })
+
+  it('leaves onMoved unset when the caller does not want moves', () => {
+    const [decoration] = toRangeDecorations({
+      cursors: [cursors[0]],
+      overrides: new Map(),
+      renderCursor,
+    })
+
+    expect(decoration.onMoved).toBeUndefined()
+  })
+
+  it('takes the component from renderCursor, once per participant', () => {
+    const render = vi.fn(renderCursor)
+
+    toRangeDecorations({cursors, overrides: new Map(), renderCursor: render})
+
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render).toHaveBeenCalledWith(cursors[0])
+  })
+})

--- a/packages/plugin-sdk-value/src/presence-cursors.ts
+++ b/packages/plugin-sdk-value/src/presence-cursors.ts
@@ -1,0 +1,159 @@
+import type {EditorSelection, RangeDecoration} from '@portabletext/editor'
+import {isEqualSelections} from '@portabletext/editor/utils'
+import type {PropsWithChildren, ReactElement} from 'react'
+
+/**
+ * A remote participant's position in the editor.
+ *
+ * @public
+ */
+export interface RemoteCursor {
+  /**
+   * Identifies one editing session rather than one person. The same user in two
+   * tabs reports two sessions and therefore draws two carets.
+   */
+  sessionId: string
+  /**
+   * The selection the participant last reported, or `null` when they have none.
+   */
+  selection: EditorSelection
+}
+
+/**
+ * Where the local editor has pushed a remote caret, and the reported selection
+ * it was pushed from.
+ *
+ * Typing above or inside a remote caret moves it, and the editor reports the
+ * new position through `onMoved`. Keeping the selection it moved from is what
+ * lets a later report from that participant take over again.
+ *
+ * @public
+ */
+export interface CursorOverride {
+  reported: EditorSelection
+  current: EditorSelection
+}
+
+/**
+ * Options for {@link toRangeDecorations}.
+ *
+ * @public
+ */
+export interface RangeDecorationOptions<TCursor extends RemoteCursor> {
+  cursors: readonly TCursor[]
+  overrides: ReadonlyMap<string, CursorOverride>
+  /**
+   * Builds the component that draws one caret. The plugin has no opinion about
+   * how a caret looks, so this is the caller's to provide.
+   */
+  renderCursor: (cursor: TCursor) => (props: PropsWithChildren) => ReactElement
+  onCursorMoved?: (cursor: TCursor, selection: EditorSelection) => void
+}
+
+/**
+ * Reduces a selection to a caret at its focus point.
+ *
+ * Presence answers where someone is, so decorating their whole selection would
+ * highlight text the local user never selected. The Studio collapses the same
+ * way, which keeps the two consistent when both are open on a document.
+ *
+ * @public
+ */
+export function collapseToCaret(selection: EditorSelection): EditorSelection {
+  if (selection === null) {
+    return null
+  }
+  return {anchor: selection.focus, focus: selection.focus}
+}
+
+/**
+ * Where one remote caret should be drawn.
+ *
+ * A caret the local editor has moved keeps that moved position for as long as
+ * the participant keeps reporting the same selection. A changed report wins,
+ * because the participant has actually moved.
+ *
+ * @public
+ */
+export function resolveCursorSelection(
+  cursor: RemoteCursor,
+  override: CursorOverride | undefined,
+): EditorSelection {
+  if (override && isEqualSelections(override.reported, cursor.selection)) {
+    return override.current
+  }
+  return collapseToCaret(cursor.selection)
+}
+
+/**
+ * Records where the editor moved a caret to.
+ *
+ * Overrides for sessions that are no longer present are dropped, so a long
+ * editing session does not accumulate one entry per participant who ever
+ * visited. Returns the map untouched when nothing changed.
+ *
+ * @public
+ */
+export function recordCursorMove(
+  overrides: ReadonlyMap<string, CursorOverride>,
+  cursors: readonly RemoteCursor[],
+  cursor: RemoteCursor,
+  selection: EditorSelection,
+): ReadonlyMap<string, CursorOverride> {
+  const moved = collapseToCaret(selection)
+  const existing = overrides.get(cursor.sessionId)
+  const alreadyRecorded =
+    existing !== undefined &&
+    isEqualSelections(existing.reported, cursor.selection) &&
+    isEqualSelections(existing.current, moved)
+
+  const live = new Set(cursors.map((candidate) => candidate.sessionId))
+  const staleKeys = [...overrides.keys()].filter((key) => !live.has(key))
+
+  if (alreadyRecorded && staleKeys.length === 0) {
+    return overrides
+  }
+
+  const next = new Map(overrides)
+  for (const key of staleKeys) {
+    next.delete(key)
+  }
+  next.set(cursor.sessionId, {reported: cursor.selection, current: moved})
+  return next
+}
+
+/**
+ * Maps remote cursors to range decorations for
+ * `<PortableTextEditable rangeDecorations={...} />`.
+ *
+ * Participants with no caret to draw are skipped, so someone who clears their
+ * selection stops drawing without being treated as having left.
+ *
+ * @public
+ */
+export function toRangeDecorations<TCursor extends RemoteCursor>(
+  options: RangeDecorationOptions<TCursor>,
+): RangeDecoration[] {
+  const {cursors, overrides, renderCursor, onCursorMoved} = options
+  const decorations: RangeDecoration[] = []
+
+  for (const cursor of cursors) {
+    const selection = resolveCursorSelection(
+      cursor,
+      overrides.get(cursor.sessionId),
+    )
+    if (selection === null) {
+      continue
+    }
+    decorations.push({
+      component: renderCursor(cursor),
+      selection,
+      payload: {sessionId: cursor.sessionId},
+      onMoved: onCursorMoved
+        ? (details) => onCursorMoved(cursor, details.newSelection)
+        : undefined,
+    })
+  }
+
+  return decorations
+}

--- a/packages/plugin-sdk-value/src/sdk-editable.test.ts
+++ b/packages/plugin-sdk-value/src/sdk-editable.test.ts
@@ -1,0 +1,193 @@
+import type {RangeDecoration} from '@portabletext/editor'
+import type {DocumentHandle} from '@sanity/sdk-react'
+import {describe, expect, it} from 'vitest'
+import type {RenderCursorFunction} from './plugin.sdk-presence'
+import {renderDefaultCursor} from './presence-caret'
+import {
+  mergePresenceDecorations,
+  resolveCursorRenderer,
+  splitEditableProps,
+  type SDKPortableTextEditableProps,
+} from './sdk-editable'
+
+function decoration(testId: string): RangeDecoration {
+  return {
+    component: (props) => props.children as never,
+    selection: null,
+    payload: {testId},
+  }
+}
+
+describe('splitEditableProps', () => {
+  const props: SDKPortableTextEditableProps = {
+    'documentId': 'doc-1',
+    'documentType': 'post',
+    'path': 'content',
+    // The full handle, since any of these reaching the DOM is a React warning
+    // and a broken document reference.
+    'projectId': 'project-1',
+    'dataset': 'production',
+    'perspective': 'drafts',
+    'liveEdit': false,
+    'resourceName': 'resource-1',
+    // Genuine editable props
+    'style': {minHeight: 120},
+    'data-testid': 'editable',
+  } as SDKPortableTextEditableProps
+
+  it('keeps every handle field out of what reaches the editable', () => {
+    // `satisfies` makes this list exhaustive: adding a field to `DocumentHandle`
+    // breaks compilation here until it is also pulled out in the component, which
+    // is what stops a new field being forwarded to the DOM as an attribute.
+    const handleKeys = {
+      dataset: true,
+      documentId: true,
+      documentType: true,
+      liveEdit: true,
+      perspective: true,
+      projectId: true,
+      resource: true,
+      resourceName: true,
+      source: true,
+    } satisfies {[Key in keyof DocumentHandle]-?: true}
+
+    // Every handle key has to be present in the input, or a field the component
+    // forgets to pull out would be absent from the result for the wrong reason.
+    const withEveryHandleField = {
+      ...props,
+      ...Object.fromEntries(Object.keys(handleKeys).map((key) => [key, 'set'])),
+      path: 'content',
+    } as SDKPortableTextEditableProps
+
+    const {editableProps} = splitEditableProps(withEveryHandleField)
+
+    for (const key of Object.keys(handleKeys)) {
+      expect(editableProps).not.toHaveProperty(key)
+    }
+  })
+
+  it('keeps its own props out of what reaches the editable', () => {
+    const {editableProps} = splitEditableProps({
+      ...props,
+      renderCursor: () => (cursorProps) => cursorProps.children as never,
+      rangeDecorations: [decoration('caller')],
+    })
+
+    expect(editableProps).not.toHaveProperty('path')
+    expect(editableProps).not.toHaveProperty('renderCursor')
+    expect(editableProps).not.toHaveProperty('rangeDecorations')
+  })
+
+  it('forwards everything else untouched', () => {
+    const {editableProps} = splitEditableProps(props)
+
+    expect(editableProps).toEqual({
+      'style': {minHeight: 120},
+      'data-testid': 'editable',
+    })
+  })
+
+  it('collects the handle so the document is addressed correctly', () => {
+    const {handle, path} = splitEditableProps(props)
+
+    expect(path).toBe('content')
+    expect(handle.documentId).toBe('doc-1')
+    expect(handle.documentType).toBe('post')
+    expect(handle.projectId).toBe('project-1')
+    expect(handle.dataset).toBe('production')
+    expect(handle.resourceName).toBe('resource-1')
+  })
+
+  it('omits handle fields the caller never passed', () => {
+    // The SDK resolves an ambient perspective from `ResourceProvider` with
+    // `Object.hasOwn`, so a `perspective: undefined` key overrides the context
+    // value instead of deferring to it. Same for the resource fields, which
+    // decide the project and dataset.
+    const {handle} = splitEditableProps({
+      documentId: 'doc-1',
+      documentType: 'post',
+      path: 'content',
+    } as SDKPortableTextEditableProps)
+
+    expect(Object.keys(handle).sort()).toEqual(['documentId', 'documentType'])
+    expect('perspective' in handle).toBe(false)
+  })
+
+  it('forwards an explicitly undefined perspective, matching a direct hook call', () => {
+    // Passing `perspective={maybeUndefined}` here has to behave exactly as
+    // passing it straight to the SDK hook does: the key is present, so it wins
+    // over the context. Switching this to a value check would quietly diverge.
+    const {handle} = splitEditableProps({
+      documentId: 'doc-1',
+      documentType: 'post',
+      path: 'content',
+      perspective: undefined,
+    } as SDKPortableTextEditableProps)
+
+    expect('perspective' in handle).toBe(true)
+  })
+
+  it('carries the perspective through, which decides the document reported', () => {
+    const {handle} = splitEditableProps({
+      ...props,
+      perspective: {releaseName: 'autumn'},
+    })
+
+    expect(handle.perspective).toEqual({releaseName: 'autumn'})
+  })
+})
+
+describe('mergePresenceDecorations', () => {
+  const caller = [decoration('caller')]
+  const cursors = [decoration('cursor-a'), decoration('cursor-b')]
+
+  it("appends carets after the caller's own decorations", () => {
+    const merged = mergePresenceDecorations(caller, cursors, true)
+
+    expect(merged?.map((item) => item.payload?.['testId'])).toEqual([
+      'caller',
+      'cursor-a',
+      'cursor-b',
+    ])
+  })
+
+  it('does not drop the caller decorations, which replacing would', () => {
+    const merged = mergePresenceDecorations(caller, cursors, true)
+
+    expect(merged).toContain(caller[0])
+  })
+
+  it('returns just the carets when the caller passed none', () => {
+    expect(mergePresenceDecorations(undefined, cursors, true)).toEqual(cursors)
+  })
+
+  it('leaves the caller decorations alone when no caret component was given', () => {
+    expect(mergePresenceDecorations(caller, cursors, false)).toBe(caller)
+  })
+
+  it('stays undefined when there is nothing at all to draw', () => {
+    expect(mergePresenceDecorations(undefined, cursors, false)).toBeUndefined()
+  })
+})
+
+describe('resolveCursorRenderer', () => {
+  const custom: RenderCursorFunction = () => (props) => props.children as never
+
+  it('draws the built-in caret when the app gave none', () => {
+    const resolved = resolveCursorRenderer(undefined)
+
+    expect(resolved.renderCursor).toBe(renderDefaultCursor)
+    expect(resolved.drawCursors).toBe(true)
+  })
+
+  it("uses the app's caret when it gave one", () => {
+    const resolved = resolveCursorRenderer(custom)
+
+    expect(resolved.renderCursor).toBe(custom)
+    expect(resolved.drawCursors).toBe(true)
+  })
+
+  it('draws nothing when carets are switched off with null', () => {
+    expect(resolveCursorRenderer(null).drawCursors).toBe(false)
+  })
+})

--- a/packages/plugin-sdk-value/src/sdk-editable.tsx
+++ b/packages/plugin-sdk-value/src/sdk-editable.tsx
@@ -1,0 +1,199 @@
+import {
+  PortableTextEditable,
+  type PortableTextEditableProps,
+  type RangeDecoration,
+} from '@portabletext/editor'
+import type {DocumentHandle} from '@sanity/sdk-react'
+import {useMemo} from 'react'
+import {
+  SDKPresencePlugin,
+  useSDKPresenceCursors,
+  type RenderCursorFunction,
+} from './plugin.sdk-presence'
+import {SDKValuePlugin} from './plugin.sdk-value'
+import {renderDefaultCursor} from './presence-caret'
+
+/**
+ * Props for {@link SDKPortableTextEditable}.
+ *
+ * @public
+ */
+export interface SDKPortableTextEditableProps
+  extends
+    DocumentHandle,
+    // `resource` is both a document handle field and an RDFa HTML attribute, so
+    // the handle wins. Dropping the attribute costs nothing in an editor.
+    Omit<PortableTextEditableProps, keyof DocumentHandle> {
+  /**
+   * The document path of the Portable Text field, for example `content`.
+   */
+  path: string
+  /**
+   * Draws one remote participant's caret. Omit it for the built-in caret, which
+   * needs no styling of your own. Pass `null` to draw no carets at all while
+   * still reporting the local user's presence.
+   */
+  renderCursor?: RenderCursorFunction | null
+}
+
+/**
+ * What {@link splitEditableProps} pulls apart.
+ *
+ * @internal
+ */
+export interface SplitEditableProps {
+  handle: DocumentHandle
+  path: string
+  renderCursor: RenderCursorFunction | null | undefined
+  rangeDecorations: RangeDecoration[] | undefined
+  editableProps: Omit<
+    PortableTextEditableProps,
+    keyof DocumentHandle | 'rangeDecorations'
+  >
+}
+
+/**
+ * A `PortableTextEditable` wired to a Sanity document: the field's value syncs
+ * both ways, the local user's caret is reported, and other people's carets are
+ * drawn.
+ *
+ * Place it inside `EditorProvider` in place of `PortableTextEditable`. Every
+ * other prop is forwarded untouched, and `rangeDecorations` you pass are kept
+ * and merged with the presence carets rather than replaced.
+ *
+ * Nothing else is needed: this replaces a separate `SDKValuePlugin`.
+ *
+ * @example
+ * ```tsx
+ * <EditorProvider initialConfig={{schemaDefinition}}>
+ *   <SDKPortableTextEditable
+ *     {...documentHandle}
+ *     path="content"
+ *     renderCursor={({user}) => (props) => (
+ *       <Caret user={user}>{props.children}</Caret>
+ *     )}
+ *   />
+ * </EditorProvider>
+ * ```
+ *
+ * @public
+ */
+export function SDKPortableTextEditable(props: SDKPortableTextEditableProps) {
+  const {handle, path, renderCursor, rangeDecorations, editableProps} =
+    splitEditableProps(props)
+
+  const renderer = resolveCursorRenderer(renderCursor)
+
+  const cursors = useSDKPresenceCursors({
+    ...handle,
+    path,
+    renderCursor: renderer.renderCursor,
+  })
+
+  const decorations = useMemo(
+    () =>
+      mergePresenceDecorations(rangeDecorations, cursors, renderer.drawCursors),
+    [cursors, rangeDecorations, renderer.drawCursors],
+  )
+
+  return (
+    <>
+      <PortableTextEditable {...editableProps} rangeDecorations={decorations} />
+      <SDKValuePlugin {...handle} path={path} />
+      <SDKPresencePlugin {...handle} path={path} />
+    </>
+  )
+}
+
+/**
+ * Splits the props into the document handle, this component's own props, and
+ * what is forwarded to `PortableTextEditable`. Keeping handle fields out of the
+ * forwarded set is what stops them reaching the DOM as attributes.
+ *
+ * @internal
+ */
+export function splitEditableProps(
+  props: SDKPortableTextEditableProps,
+): SplitEditableProps {
+  const {
+    documentId,
+    documentType,
+    projectId,
+    dataset,
+    resource,
+    resourceName,
+    source,
+    liveEdit,
+    perspective,
+    path,
+    renderCursor,
+    rangeDecorations,
+    ...editableProps
+  } = props
+
+  return {
+    // Only the fields the caller actually passed. The SDK resolves an ambient
+    // perspective and resource from context with `Object.hasOwn`, so forwarding
+    // `perspective: undefined` would override what `ResourceProvider` set rather
+    // than defer to it, and the field would sync and report against the draft
+    // instead of the release the app is showing.
+    handle: {
+      documentId,
+      documentType,
+      ...('projectId' in props && {projectId}),
+      ...('dataset' in props && {dataset}),
+      ...('resource' in props && {resource}),
+      ...('resourceName' in props && {resourceName}),
+      ...('source' in props && {source}),
+      ...('liveEdit' in props && {liveEdit}),
+      ...('perspective' in props && {perspective}),
+    },
+    path,
+    renderCursor,
+    rangeDecorations,
+    editableProps,
+  }
+}
+
+/**
+ * Decides which caret component to draw with, and whether to draw at all.
+ *
+ * Presence is subscribed to either way, because hooks cannot be called
+ * conditionally, so switching carets off discards the decorations rather than
+ * skipping the work.
+ *
+ * @internal
+ */
+export function resolveCursorRenderer(
+  renderCursor: RenderCursorFunction | null | undefined,
+): {renderCursor: RenderCursorFunction; drawCursors: boolean} {
+  return {
+    renderCursor: renderCursor ?? renderDefaultCursor,
+    drawCursors: renderCursor !== null,
+  }
+}
+
+/**
+ * Appends the presence carets to whatever decorations the caller passed, so
+ * theirs survive. The Studio merges the same way. When carets are switched off
+ * the caller's own decorations pass straight through.
+ *
+ * @internal
+ */
+export function mergePresenceDecorations(
+  rangeDecorations: RangeDecoration[] | undefined,
+  cursors: RangeDecoration[],
+  drawCursors: boolean,
+): RangeDecoration[] | undefined {
+  if (!drawCursors) {
+    return rangeDecorations
+  }
+  return [...(rangeDecorations ?? []), ...cursors]
+}
+
+/**
+ * Splitting the props by hand is what keeps document handle fields off the DOM,
+ * so every field has to be listed above. `sdk-editable.test.ts` fails to compile
+ * if `DocumentHandle` gains one. Note that `@sanity/sdk-react` adds fields to the
+ * core handle, so it has to be read from there.
+ */

--- a/packages/plugin-sdk-value/src/selection-compatibility.test.ts
+++ b/packages/plugin-sdk-value/src/selection-compatibility.test.ts
@@ -1,0 +1,44 @@
+import type {EditorSelection} from '@portabletext/editor'
+import type {UseReportPresenceOptions} from '@sanity/sdk-react'
+import {describe, expect, it} from 'vitest'
+
+/**
+ * The SDK carries a Portable Text selection over the presence wire, and the
+ * editor consumes the same shape as a range decoration. This plugin passes
+ * values straight through in both directions rather than converting them, so
+ * the two types have to stay structurally identical. The two functions below
+ * are the whole conversion, and they stop compiling if either side drifts.
+ */
+type ReportedSelection = UseReportPresenceOptions['selection']
+
+function asEditorSelection(
+  reported: NonNullable<ReportedSelection>,
+): EditorSelection {
+  return reported
+}
+
+function asReportedSelection(selection: EditorSelection): ReportedSelection {
+  return selection
+}
+
+describe('selection compatibility', () => {
+  it('passes a reported selection to the editor unchanged', () => {
+    const reported = {
+      anchor: {
+        path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}],
+        offset: 3,
+      },
+      focus: {
+        path: [{_key: 'block-1'}, 'children', {_key: 'span-1'}],
+        offset: 7,
+      },
+      backward: false,
+    }
+
+    expect(asEditorSelection(reported)).toBe(reported)
+  })
+
+  it('passes an editor selection to the wire unchanged, including an empty one', () => {
+    expect(asReportedSelection(null)).toBeNull()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1263,8 +1263,8 @@ importers:
         specifier: catalog:tooling
         version: 10.8.2(@types/babel__core@7.20.5)(@types/node@24.12.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@6.0.3)
       '@sanity/sdk-react':
-        specifier: ^2.13.0
-        version: 2.13.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
+        specifier: ^2.19.0
+        version: 2.19.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -2696,12 +2696,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -4979,6 +4973,10 @@ packages:
     resolution: {integrity: sha512-DrQqLAes7W9Ek2iKgTZ+ffY1v3DURJ6//iXJZMEQSUeRbxls2ifRTdV1gRS26v8nMkL0OCH+WCoUUseD4vhuQQ==}
     engines: {node: '>=20'}
 
+  '@sanity/client@7.26.0':
+    resolution: {integrity: sha512-7GEzTFRY6kWRjHbJYUDEGKPXHVl/XItGpV5LYCLcWMvBlgfujXuAjdp4hJVZqX8F8OtBzIFqdhiSn5Kh5u/V5Q==}
+    engines: {node: '>=20'}
+
   '@sanity/comlink@4.0.1':
     resolution: {integrity: sha512-vdGOd6sxNjqTo2H3Q3L2/Gepy+cDBiQ1mr9ck7c/A9o4NnmBLoDliifsNHIwgNwBUz37oH4+EIz/lIjNy8hSew==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -4995,8 +4993,8 @@ packages:
     resolution: {integrity: sha512-oJ5kZQV6C/DAlcpRLEU7AcVWXrSPuJb3Z1TQ9tm/qZOVWJENwWln45jtepQEYolTIuGx9jUlhYUi3hGIkOt8RA==}
     engines: {node: '>=18.2'}
 
-  '@sanity/eventsource@5.0.2':
-    resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
+  '@sanity/eventsource@5.0.4':
+    resolution: {integrity: sha512-NT6XrTJePJd7q1ZdTqB3NsTyNNOe9R2zMkg4Hlkqwb0LL6UmekVamAD46yjSJ+HbRyXAKLl1Rb65xZBdzC1f8Q==}
 
   '@sanity/generate-help-url@4.0.0':
     resolution: {integrity: sha512-Ooa4xkLT3TLaX+mw/13fq3IeGdnAkx4rbpVASvRVixzBBvvcL6jPqj50fjlCd+EhgB5GRXBCNNAy/hWXwjZEUA==}
@@ -5015,6 +5013,9 @@ packages:
 
   '@sanity/media-library-types@1.4.0':
     resolution: {integrity: sha512-DZwNT+dDSc1JPW4e7U5C+IJELq5IAeU2A1UcY1079gl+Hakx2USvu5LyY1hrjb1eifRPAhL8uwOVcMNBUmSmzg==}
+
+  '@sanity/media-library-types@1.6.0':
+    resolution: {integrity: sha512-1Nqw8GSUr7E8AFue9luyTOM4Ev0ZlJ35SHcQrHZ6T68G5llfXw99e3GkLXzk6qYFk9r9fJaBTSpW5IyO2mObZQ==}
 
   '@sanity/message-protocol@0.23.0':
     resolution: {integrity: sha512-UfQDuWRzbK4dRTfLURGCZo7ZlR0sK+2lwT2QMAfqsM5kMq5GR31lbX4LMcSw27h7rwUv8ZSf1hBEbluVpgRmlg==}
@@ -5035,7 +5036,6 @@ packages:
   '@sanity/pkg-utils@10.8.2':
     resolution: {integrity: sha512-rHCXdCnr2qF3pjKwCZ268znjUbFNqBnU9pC73OAX8zrJTaC+shiiJ/S6Z0E0yHHTrjajN7upOUwP0u4dp+UZ+Q==}
     engines: {node: '>=20.19 <22 || >=22.12'}
-    deprecated: 'UNSUPPORTED: Versions before v11 are no longer maintained or updated and will not receive fixes. Upgrade to @sanity/pkg-utils v11.'
     hasBin: true
     peerDependencies:
       babel-plugin-react-compiler: '*'
@@ -5052,14 +5052,14 @@ packages:
   '@sanity/schema@6.1.0':
     resolution: {integrity: sha512-+/nIeQrkUJDWBBnKUP4F0TxFaxi16UrtfckrbTSLH4wd8mWUtrPdnxmzMTedQ2dhMj3VRLMuuu1+h/lh3iy50Q==}
 
-  '@sanity/sdk-react@2.13.0':
-    resolution: {integrity: sha512-A8atYKn9kmdefqDe1v8pykaW6PVjQz+RTyasNftiZlEZVH689WUNSHfcLIt3JouREiiaH/jx0Svj4AcrXykH7w==}
+  '@sanity/sdk-react@2.19.0':
+    resolution: {integrity: sha512-dphdWEAY7vO3i9Y4Eht85LJnezqwAhTH2U/7iewMMqLXBYPrfRHIEium2eTWb5rX7UpigiqRcJpREi9ZkcKjBA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@sanity/sdk@2.13.0':
-    resolution: {integrity: sha512-dTaAW4vc0ZZQ/H5IqKWS1GAjHlmgLkxQAe3ai+G2do7Yco0f4gpx4YZ3sn+eBINRct/Nm9JXXSxAcLU/zpDmiw==}
+  '@sanity/sdk@2.19.0':
+    resolution: {integrity: sha512-UOrxOmISioW22b0IyGgkRJCk1VnzmevH7jY8WZpANStmwa/4lsujRNlWOYeW3IguhIz0HptgtVfRXXyZwr9UXQ==}
 
   '@sanity/signed-urls@2.0.4':
     resolution: {integrity: sha512-wH7L9iOxQDVTa7COVEXoknalNgjpqxLJoOcZYQa3D/2JVEQOGUm82RgFVgZkKoclhQ8Y8dBby+KPkFoIDoUc1g==}
@@ -5076,13 +5076,13 @@ packages:
   '@sanity/tsconfig@2.1.0':
     resolution: {integrity: sha512-Cnz0EycMsfeILkxL/gYzzfPs511OzP3sjQxU4XkDtujdiFAc+bteMYXi4/SJ83m98cXLum63HbHDk+he6AbbIA==}
 
-  '@sanity/types@5.31.1':
-    resolution: {integrity: sha512-Tl5+C6KTfGO1+QdbHFFaJd9Wyncbz2yznGg1P06JvBfzpexSdBVz476QyDtWBQaCtSkTk8eXzrwPVvW5emA8/g==}
+  '@sanity/types@6.1.0':
+    resolution: {integrity: sha512-EtkC/oB1585wkTEiVyuBsIJYLGlbNldWzMuYPvi91WKBGhMyJ1OJqMfpZDcqWpsvTqjV8TH+/YlVwi+CQBKcTA==}
     peerDependencies:
       '@types/react': ^19.2.17
 
-  '@sanity/types@6.1.0':
-    resolution: {integrity: sha512-EtkC/oB1585wkTEiVyuBsIJYLGlbNldWzMuYPvi91WKBGhMyJ1OJqMfpZDcqWpsvTqjV8TH+/YlVwi+CQBKcTA==}
+  '@sanity/types@6.8.0':
+    resolution: {integrity: sha512-VvhWNrupGjXxytz/tRbjOHeEHctUsZqf7AF+eT1MxP0pgOdhtRlXsroV6e4Uayoux/cbbuYTX5JpCnW6cAuZYw==}
     peerDependencies:
       '@types/react': ^19.2.17
 
@@ -6454,8 +6454,8 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
-  get-it@8.7.3:
-    resolution: {integrity: sha512-Fcv6n05iKMY/obxWb7wL0T8xOiUN/5ptBlg/Vf2WAvfs175wAV7Qf+UtWKp7Jdneu+KbUe6MIL0js2WBzoAoyg==}
+  get-it@8.8.1:
+    resolution: {integrity: sha512-t8HkAfY0DkInjAv3o4EzkjJ/9vD1PWXMlX3ASzQ6yN1QlmYN8z2ISRD7BCf/rGC73TYPbbN7FsnOV7jw90a9Yg==}
     engines: {node: '>=14.0.0'}
 
   get-latest-version@6.0.1:
@@ -6545,6 +6545,10 @@ packages:
   groq-js@1.30.2:
     resolution: {integrity: sha512-FqF7NNzBxya6Oq4VkTl9lg3W5Gjd3Cjwc6Et2OeAcTdmHOClwcYeAZkWR6wIm+KPtvESSYtzP59aj/+9egOKZQ==}
     engines: {node: '>= 14'}
+
+  groq-js@2.0.0:
+    resolution: {integrity: sha512-kj56ZjnOFbgDt91zYwQ10jsVUtVGJqAKfRbAir0EvTK84O5ZsSyc0rDEm2P3jmAJkxs4X1DOG8vtaYJQIA/XCA==}
+    engines: {node: '>=22.12'}
 
   groq@3.88.1-typegen-experimental.0:
     resolution: {integrity: sha512-6TZD6H1y3P7zk0BQharjFa7BOivV9nFL6KKVZbRZRH0yOSSyu2xHglTO48b1/2mCEdYoBQpvE7rjCDUf6XmQYQ==}
@@ -7153,9 +7157,6 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -7867,8 +7868,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-compiler-runtime@19.1.0-rc.2:
-    resolution: {integrity: sha512-852AwyIsbWJ5o1LkQVAZsVK3iLjMxOfKZuxqeGd/RfD+j1GqHb6j3DSHLtpu4HhFbQHsP2DzxjJyKR6luv4D8w==}
+  react-compiler-runtime@1.0.0:
+    resolution: {integrity: sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
@@ -9683,15 +9684,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -10242,11 +10243,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
-
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.4(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
@@ -12522,7 +12518,7 @@ snapshots:
   '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.2)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       workerpool: 9.3.4
     optionalDependencies:
@@ -12739,8 +12735,15 @@ snapshots:
 
   '@sanity/client@7.22.1':
     dependencies:
-      '@sanity/eventsource': 5.0.2
-      get-it: 8.7.3
+      '@sanity/eventsource': 5.0.4
+      get-it: 8.8.1
+      nanoid: 3.3.12
+      rxjs: 7.8.2
+
+  '@sanity/client@7.26.0':
+    dependencies:
+      '@sanity/eventsource': 5.0.4
+      get-it: 8.8.1
       nanoid: 3.3.12
       rxjs: 7.8.2
 
@@ -12760,7 +12763,7 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
 
-  '@sanity/eventsource@5.0.2':
+  '@sanity/eventsource@5.0.4':
     dependencies:
       '@types/event-source-polyfill': 1.0.5
       '@types/eventsource': 1.1.15
@@ -12772,7 +12775,7 @@ snapshots:
   '@sanity/id-utils@1.0.0':
     dependencies:
       '@sanity/uuid': 3.0.2
-      lodash: 4.17.21
+      lodash: 4.18.1
       ts-brand: 0.2.0
 
   '@sanity/image-url@2.1.1':
@@ -12783,6 +12786,8 @@ snapshots:
 
   '@sanity/media-library-types@1.4.0': {}
 
+  '@sanity/media-library-types@1.6.0': {}
+
   '@sanity/message-protocol@0.23.0':
     dependencies:
       '@sanity/comlink': 4.0.1
@@ -12790,7 +12795,7 @@ snapshots:
   '@sanity/mutate@0.18.1(xstate@5.32.4)':
     dependencies:
       '@isaacs/ttlcache': 2.1.5
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.26.0
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
@@ -12939,29 +12944,28 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/sdk-react@2.13.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)':
+  '@sanity/sdk-react@2.19.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)':
     dependencies:
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.26.0
       '@sanity/message-protocol': 0.23.0
-      '@sanity/sdk': 2.13.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
-      '@sanity/types': 5.31.1(@types/react@19.2.17)
+      '@sanity/sdk': 2.19.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)
+      '@sanity/types': 6.8.0(@types/react@19.2.17)
       groq: 3.88.1-typegen-experimental.0
       react: 19.2.7
-      react-compiler-runtime: 19.1.0-rc.2(react@19.2.7)
+      react-compiler-runtime: 1.0.0(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
       react-error-boundary: 6.1.2(react@19.2.7)
       rxjs: 7.8.2
     transitivePeerDependencies:
       - '@types/react'
       - immer
-      - supports-color
       - use-sync-external-store
       - xstate
 
-  '@sanity/sdk@2.13.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)':
+  '@sanity/sdk@2.19.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))(xstate@5.32.4)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.26.0
       '@sanity/comlink': 4.0.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
@@ -12971,9 +12975,9 @@ snapshots:
       '@sanity/message-protocol': 0.23.0
       '@sanity/mutate': 0.18.1(xstate@5.32.4)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
-      '@sanity/types': 5.31.1(@types/react@19.2.17)
+      '@sanity/types': 6.8.0(@types/react@19.2.17)
       groq: 3.88.1-typegen-experimental.0
-      groq-js: 1.30.2
+      groq-js: 2.0.0
       reselect: 5.1.1
       rxjs: 7.8.2
       zustand: 5.0.14(@types/react@19.2.17)(immer@11.0.1)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -12981,7 +12985,6 @@ snapshots:
       - '@types/react'
       - immer
       - react
-      - supports-color
       - use-sync-external-store
       - xstate
 
@@ -12999,16 +13002,16 @@ snapshots:
 
   '@sanity/tsconfig@2.1.0': {}
 
-  '@sanity/types@5.31.1(@types/react@19.2.17)':
+  '@sanity/types@6.1.0(@types/react@19.2.17)':
     dependencies:
       '@sanity/client': 7.22.1
       '@sanity/media-library-types': 1.4.0
       '@types/react': 19.2.17
 
-  '@sanity/types@6.1.0(@types/react@19.2.17)':
+  '@sanity/types@6.8.0(@types/react@19.2.17)':
     dependencies:
-      '@sanity/client': 7.22.1
-      '@sanity/media-library-types': 1.4.0
+      '@sanity/client': 7.26.0
+      '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.17
 
   '@sanity/uuid@3.0.2':
@@ -13435,7 +13438,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -13485,7 +13488,7 @@ snapshots:
   '@vanilla-extract/integration@8.0.10':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
       '@vanilla-extract/css': 1.21.0
       dedent: 1.7.0
@@ -13513,9 +13516,9 @@ snapshots:
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -13525,9 +13528,9 @@ snapshots:
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -13537,9 +13540,9 @@ snapshots:
 
   '@vitejs/plugin-react@5.2.0(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -14390,7 +14393,7 @@ snapshots:
 
   eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -14654,7 +14657,7 @@ snapshots:
 
   get-east-asian-width@1.5.0: {}
 
-  get-it@8.7.3:
+  get-it@8.8.1:
     dependencies:
       decompress-response: 7.0.0
       is-retry-allowed: 2.2.0
@@ -14663,10 +14666,10 @@ snapshots:
 
   get-latest-version@6.0.1:
     dependencies:
-      get-it: 8.7.3
+      get-it: 8.8.1
       registry-auth-token: 5.1.1
       registry-url: 7.2.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   get-nonce@1.0.1: {}
 
@@ -14766,6 +14769,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  groq-js@2.0.0:
+    dependencies:
+      obug: 2.1.3
 
   groq@3.88.1-typegen-experimental.0: {}
 
@@ -15515,8 +15522,6 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -16583,7 +16588,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  react-compiler-runtime@19.1.0-rc.2(react@19.2.7):
+  react-compiler-runtime@1.0.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -17763,7 +17768,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
@@ -17794,7 +17799,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.2.4


### PR DESCRIPTION
## What

Presence in a Portable Text field. Other people's carets show up where they are editing, and the local user's caret is reported so they show up for everyone else, including in the Studio.

`SDKPortableTextEditable` replaces `PortableTextEditable` and wires up all of it, so the document and field are named once:

```tsx
<EditorProvider initialConfig={{schemaDefinition}}>
  <SDKPortableTextEditable documentId={id} documentType="post" path="content" />
</EditorProvider>
```

That's value sync, presence reporting, and visible carets. A separate `SDKValuePlugin` is no longer needed alongside it.

## Why it lives here, and why one component

Presence started as a separate `plugin-sdk-presence` package. It moved here because splitting it made the developer pass the same handle and path twice, once to the editable and once to the value plugin, for two features that almost always ship together.

The single-component shape is what makes presence automatic, and it isn't about packaging. `rangeDecorations` is a prop on `PortableTextEditable` with no plugin API behind it, so a sibling plugin can never draw carets on its own. The Studio has the same constraint and solves it the same way: `PortableTextInput` owns the render and concatenates its presence decorations with the caller's. This does that, so `rangeDecorations` you pass are kept and merged rather than replaced.

Alternatives rejected:

- **Cursor hook in `@sanity/sdk-react`.** `RangeDecoration` is an editor type, so the SDK would need `@portabletext/editor` as a peer while this package needs the SDK. A mutual peer dependency across two separately released repos.
- **A plugin API for range decorations in `@portabletext/editor`.** The better long-term answer, and it would help diff decorations and search highlighting too, but the decorations actor is created inside `Editable` from the prop, so it's a real API change rather than something a plugin can do. Worth its own issue.
- **Keeping presence in its own package.** Cleaner in principle, worse in practice: a presence-only consumer would still install `xstate`, `@sanity/diff-patch`, and `@sanity/json-match` for value-sync machinery it never uses.

## Breaking-ish

The `@sanity/sdk-react` peer range moves from `^2.1.2` to `^2.19.0`, which is where the presence hooks were added. Existing installs are untouched; npm consumers upgrading this package will need to bump the SDK too, and pnpm/yarn will warn.

## What to review

- `src/presence-cursors.ts` is the whole model, pure and framework-free: collapse a selection to a caret, compare selections by value, resolve where each caret draws, record moves, build decorations.
- `src/sdk-editable.tsx` is the wrapper. The prop split is the risky part, since handle fields must not reach the DOM. `UnhandledHandleKeys` is a compile-time assertion that fails if `DocumentHandle` gains a field. It already earned its place: `@sanity/sdk-react`'s `DocumentHandle` extends the core one with `resourceName`, which I'd missed. Note also that `resource` is both a handle field and an RDFa HTML attribute, so the handle wins via `Omit`.
- `src/presence-caret.tsx` is the built-in caret, ported from Studio's `UserPresenceCursor` without `@sanity/ui`, styled-components, or motion. Two structural details are load-bearing: the caret is a zero-width sibling before `children`, not a wrapper, and it needs `contentEditable={false}` or the local user can put their own cursor inside someone else's caret.
- `src/selection-compatibility.test.ts` pins that the SDK's wire selection and `EditorSelection` stay mutually assignable, since the plugin passes values through in both directions rather than converting.

## Testing

96 unit tests and 183 browser tests across Chromium, Firefox, and WebKit. The pre-existing value-sync and collision-matrix suites are unchanged and still pass.

Mutation tested throughout. Ten mutations of the caret model and wrapper logic are all caught. Two initially survived and both were my own bad tests: a "same colour in two tabs" test that called the colour function twice and asserted nothing about the component, and no coverage of the wrapper defaulting to the built-in caret. The first is now a browser test rendering two sessions of one user plus a second user and comparing computed colours; the second is covered by extracting `resolveCursorRenderer` and testing all three cases.

Also verified by hand against a real socket, running the SDK kitchensink's Portable Text route against this branch in two browser tabs.

One thing worth knowing if you test it: two editors in the same tab cannot see each other. Presence stores are keyed only by project and dataset in a module-level registry, so they share one store and one session id, and a session ignores its own reports. Use two tabs, or a tab plus a Studio.