### PR TITLE
test: anchor remote-patch echo asserts on deterministic flush points

### DIFF
--- a/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
+++ b/packages/editor/tests/remote-patches.cosmetic-normalization.test.tsx
@@ -91,10 +91,89 @@ describe('remote patches skip cosmetic normalization', () => {
       ])
     })
 
-    // Negative assert: the sleep gives a would-be echo time to surface.
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    expect(patchEvents).toEqual([])
-    expect(mutationEvents).toEqual([])
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: bazKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: bazKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patchEvents.map((event) => event.patch)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: bazKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('baz', 'baz!'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foobar'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(
+            makePatches(makeDiff('foobar', 'foobarbaz!')),
+          ),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: bazKey}],
+          origin: 'local',
+        },
+      ])
+    })
+    await vi.waitFor(() => {
+      expect(mutationEvents.flatMap((event) => event.patches)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: bazKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('baz', 'baz!'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foobar'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: barKey}],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(
+            makePatches(makeDiff('foobar', 'foobarbaz!')),
+          ),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: bazKey}],
+          origin: 'local',
+        },
+      ])
+    })
   })
 
   test('adjacent same-mark spans arriving via remote patches are kept', async () => {
@@ -161,11 +240,63 @@ describe('remote patches skip cosmetic normalization', () => {
       ])
     })
 
-    // Negative assert: the old behavior pushed the merge back as a
-    // mutation. The sleep gives a would-be emission time to surface.
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    expect(patchEvents).toEqual([])
-    expect(mutationEvents).toEqual([])
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patchEvents.map((event) => event.patch)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', 'bar!'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foobar!'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          origin: 'local',
+        },
+      ])
+    })
+    await vi.waitFor(() => {
+      expect(mutationEvents.flatMap((event) => event.patches)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', 'bar!'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foobar!'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          origin: 'local',
+        },
+      ])
+    })
   })
 
   test('an empty span arriving via remote patches is kept', async () => {
@@ -237,9 +368,51 @@ describe('remote patches skip cosmetic normalization', () => {
       ])
     })
 
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    expect(patchEvents).toEqual([])
-    expect(mutationEvents).toEqual([])
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patchEvents.map((event) => event.patch)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          origin: 'local',
+        },
+      ])
+    })
+    await vi.waitFor(() => {
+      expect(mutationEvents.flatMap((event) => event.patches)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', {_key: 'remoteSpan'}],
+          origin: 'local',
+        },
+      ])
+    })
   })
 
   test('the block re-canonicalizes on its next local edit', async () => {
@@ -428,7 +601,25 @@ describe('remote patches skip cosmetic normalization', () => {
       patches: [collaboratorPatches[0]!],
       snapshot: undefined,
     })
-    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // The interleave window: the marks change has landed, the merge
+    // fallout has not. All three spans are still present and unmerged.
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: []},
+            {_type: 'span', _key: bazKey, text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
     editor.send({
       type: 'patches',
       patches: collaboratorPatches.slice(1),
@@ -441,18 +632,51 @@ describe('remote patches skip cosmetic normalization', () => {
       expect(editor.getSnapshot().context.value).toEqual(documentValue)
     })
 
-    // Negative assert: the sleep gives a would-be echo time to surface.
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    expect(patchEvents).toEqual([])
+    // Everything the receiver emitted while converging: patches relay
+    // synchronously off the same apply cycle that produced the value
+    // above, so this is already final for that cycle. The receiver
+    // normalized nothing itself, so there is no echo to emit.
+    const patchEventsFromRemoteConvergence = patchEvents.map(
+      (event) => event.patch,
+    )
+    expect(patchEventsFromRemoteConvergence).toEqual([])
 
-    // And therefore the document survives: applying the receiver's
-    // emissions (none) leaves it untouched. Before the fix the echo's
+    // The document survives: applying the receiver's emissions (asserted
+    // empty above) leaves it untouched. Before the fix the echo's
     // `diffMatchPatch`es re-inserted "bar" and "baz" here.
     const documentAfterEcho = applyAll(
       documentValue,
-      patchEvents.map((event) => ({...event.patch})),
+      patchEventsFromRemoteConvergence,
     )
     expect(documentAfterEcho).toEqual(documentValue)
+
+    // The empty snapshot above pins the apply cycle; this edit pins later
+    // ticks, since an echo must surface no later than the edit's own emission.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 9,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: fooKey}],
+          offset: 9,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(patchEvents.map((event) => event.patch)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: fooKey}, 'text'],
+          value: diffMatchPatchFor('foobarbaz', 'foobarbaz!'),
+          origin: 'local',
+        },
+      ])
+    })
   })
 
   test('`update value` keeps adjacent same-mark spans as-is', async () => {
@@ -575,11 +799,6 @@ describe('adoption and remote patches skip markDef and annotation cleanup', () =
       ])
     })
 
-    // Deterministic negative assert: a local edit flushes through the same
-    // ordered channel, so a would-be echo of the remote patch would surface
-    // no later than the edit's own emission. The edit also completes the
-    // lifecycle: touching the block prunes the now-unused definition as the
-    // author's own, emitted cleanup.
     editor.send({
       type: 'select',
       at: {
@@ -612,9 +831,20 @@ describe('adoption and remote patches skip markDef and annotation cleanup', () =
       ])
     })
     await vi.waitFor(() => {
-      expect(mutationEvents.flatMap((event) => event.patches)).toEqual(
-        patchEvents.map((event) => event.patch),
-      )
+      expect(mutationEvents.flatMap((event) => event.patches)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo', 'foo!'))),
+          origin: 'local',
+        },
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+          origin: 'local',
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
The pre-#3033 tests in `remote-patches.cosmetic-normalization.test.tsx` guarded their "no echo was emitted" asserts with 250ms sleeps. The mutation batcher's test-mode flush interval is 500ms, so those asserts could pass on a broken build whose echo mutation flushes at the interval: the sleeps made the tests slow and weak at the same time.

Every wait in the file is now deterministic, using the pattern #3033 introduced a few tests further down: after the remote patches settle, a local edit flushes through the same ordered patch channel and the full emission list is pinned, giving a would-be echo a hard deadline to appear by; the debounced mutation channel gets its own `vi.waitFor` against the same literal list. The 100ms intermediate-state wait became a `vi.waitFor` on the observable intermediate value, strictly stronger since it also pins that the spans are still unmerged at that point.

The decorator-removal test keeps its original contract: the convergence-window patch events are snapshotted, asserted empty, and replayed for the document-corruption check. One hardening rides along: the pre-existing exemplar's mutation assert compared channel-to-channel per poll; it now pins the literal list, closing a residual same-cycle-echo hole. All 13 tests green across three consecutive chromium runs; types and format clean.
