### PR TITLE
refactor: drive normalization from an ordered rule table

### DIFF
--- a/packages/editor/src/engine/core/normalize-node.test.ts
+++ b/packages/editor/src/engine/core/normalize-node.test.ts
@@ -1,0 +1,227 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+  type PortableTextTextBlock,
+} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {createEditor} from '../create-editor'
+import {normalize} from '../editor/normalize'
+import type {Editor} from '../interfaces/editor'
+import type {Node} from '../interfaces/node'
+import type {Path} from '../interfaces/path'
+import {normalizeRuleTableForTesting} from './normalize-node'
+
+const schema = compileSchema(defineSchema({}))
+
+// Keep in sync with `createBareEditor` in `operation-channel.test.ts`; not
+// extracted to a shared helper so each suite can drift independently.
+function createBareEditor(value: Array<PortableTextBlock>): Editor {
+  const editor = createEditor()
+
+  editor.containers = new Map()
+  editor.blockIndexMap = new Map()
+  editor.listIndexMap = new Map()
+  editor.verifiedUniqueChildGroups = new Set()
+  editor.snapshot = {
+    blockIndexMap: editor.blockIndexMap,
+    context: {
+      containers: new Map(),
+      converters: [],
+      keyGenerator: createTestKeyGenerator(),
+      readOnly: false,
+      schema,
+      selection: null,
+      value,
+    },
+    decoratorState: {},
+    // The bare engine editor lacks the fields that `withDOM` and
+    // `createEditorEngine` assign. Only the snapshot fields used by
+    // `normalizeNode` and `apply` are needed here.
+  } as Editor['snapshot']
+
+  return editor
+}
+
+describe('normalizeRuleTableForTesting', () => {
+  test('rule ids and their remote-change gate, in table order', () => {
+    expect(normalizeRuleTableForTesting).toEqual([
+      ['root.no-blocks', true],
+      ['text-block.merge-same-mark-spans', false],
+      ['node.missing-type', true],
+      ['node.missing-key', true],
+      ['node.duplicate-sibling-key', true],
+      ['text-block.missing-mark-defs', false],
+      ['text-block.missing-style', false],
+      ['span.missing-text', true],
+      ['span.missing-marks', false],
+      ['span.empty-with-annotations', false],
+      ['text-block.duplicate-mark-defs', false],
+      ['text-block.unused-mark-defs', false],
+      ['span.opaque-to-later-rules', true],
+      ['container.missing-child-array', true],
+      ['container.duplicate-child-key', true],
+      ['text-block.children-not-array', true],
+      ['text-block.no-children', true],
+      ['text-block.adjacent-spans', 'partial'],
+    ])
+  })
+})
+
+describe('normalizeNode ordering', () => {
+  test('a node missing both `_type` and `_key` is repaired in table order and then trips `span.missing-text` and `span.missing-marks`', () => {
+    const editor = createBareEditor([
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{} as unknown as Node],
+      },
+    ])
+
+    normalize(editor, {force: true})
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k0', text: '', marks: []}],
+      },
+    ])
+
+    // `node.missing-type` runs before `node.missing-key` in table order: it
+    // sets `_type` on the entry path as given, unresolved keyed segment and
+    // all (the child has no `_key` yet, so that segment serializes as `{}`).
+    // Only `node.missing-key`, run next, walks the tree to resolve that
+    // segment to a numeric index before minting the key. Swapping those two
+    // rows doesn't change the final tree (both eventually get set either
+    // way), so this also pins the exact operation sequence, not just the
+    // end state.
+    expect(editor.operations).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {}, '_type'],
+        value: 'span',
+        inverse: {
+          type: 'unset',
+          path: [{_key: 'b1'}, 'children', {}, '_type'],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', 0, '_key'],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [{_key: 'b1'}, 'children', 0, '_key'],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 'k0'}, 'text'],
+        value: '',
+        inverse: {
+          type: 'unset',
+          path: [{_key: 'b1'}, 'children', {_key: 'k0'}, 'text'],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 'k0'}, 'marks'],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [{_key: 'b1'}, 'children', {_key: 'k0'}, 'marks'],
+        },
+      },
+    ])
+  })
+})
+
+describe('normalizeNode remote-changes gate', () => {
+  test('a `false` rule is skipped, a `true` rule still runs, and the `partial` rule only defers its gated arm', () => {
+    const editor = createBareEditor([
+      {
+        _type: 'block',
+        markDefs: [],
+        children: [
+          // Bracketing this against a leading span is the `partial` rule's
+          // ungated arm; it must run even while remote changes are applied.
+          {_type: 'stock-ticker', _key: 'o1'} as unknown as Node,
+          // Adjacent spans with equal marks are the `partial` rule's gated
+          // (merge) arm; it must not run while remote changes are applied.
+          {_type: 'span', _key: 's1', text: 'foo', marks: []},
+          {_type: 'span', _key: 's2', text: 'foo', marks: []},
+        ],
+      } as unknown as PortableTextBlock,
+    ])
+
+    // `withRemoteChanges` (`engine-plugin.remote-changes.ts`) just toggles
+    // this plain boolean; set it directly since there's no DOM-wired editor
+    // here to call it through.
+    editor.isProcessingRemoteChanges = true
+
+    normalize(editor, {force: true})
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        // `node.missing-key` (`true`) mints the missing block key despite
+        // remote-changes mode.
+        _key: 'k0',
+        markDefs: [],
+        // `.style` stays missing: `text-block.missing-style` (`false`) is
+        // skipped in remote-changes mode.
+        children: [
+          // Inserted by the `partial` rule's ungated bracketing arm.
+          {_type: 'span', _key: 'k1', text: '', marks: []},
+          {_type: 'stock-ticker', _key: 'o1'},
+          // Stay unmerged: the `partial` rule's gated arm is skipped.
+          {_type: 'span', _key: 's1', text: 'foo', marks: []},
+          {_type: 'span', _key: 's2', text: 'foo', marks: []},
+        ],
+      },
+    ])
+  })
+})
+
+describe('normalizeNode span pass-through', () => {
+  test('a span entry with empty text and a dangling annotation mark normalizes to no operations, locally and remotely', () => {
+    // The mark doesn't resolve to any of the block's `markDefs`, so
+    // `span.empty-with-annotations` leaves it alone even though the text is
+    // empty (see that rule's comment). Every other span/text-block rule
+    // already sees a fully valid span, so nothing in the table has
+    // anything to repair; this holds whether or not a rule explicitly stops
+    // the walk at spans, so it doesn't pin table structure.
+    const value: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: '', marks: ['dangling-annotation']},
+        ],
+      },
+    ]
+
+    for (const isProcessingRemoteChanges of [false, true]) {
+      const editor = createBareEditor(structuredClone(value))
+      editor.isProcessingRemoteChanges = isProcessingRemoteChanges
+
+      const spanEntry: [Node, Path] = [
+        (editor.snapshot.context.value[0] as PortableTextTextBlock)
+          .children[0] as Node,
+        [{_key: 'b1'}, 'children', {_key: 's1'}],
+      ]
+      editor.normalizeNode(spanEntry)
+
+      expect(editor.operations).toEqual([])
+      expect(editor.snapshot.context.value).toEqual(value)
+    }
+  })
+})

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -31,622 +31,923 @@ import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
 
+type NormalizeEntry = Parameters<Editor['normalizeNode']>[0]
+
+type NormalizeRule = {
+  id: string
+  runsDuringRemoteChanges: boolean | 'partial'
+  normalize: (editor: Editor, entry: NormalizeEntry) => boolean
+}
+
+/**
+ * Ordered table of normalization repairs. `normalizeNode` walks it in order
+ * and stops at the first rule that reports a repair. `runsDuringRemoteChanges`
+ * decides whether a rule is skipped entirely while `editor.isProcessingRemoteChanges`
+ * is true; `'partial'` rules always run and gate their own sub-parts
+ * internally (see `normalizeTextBlockAdjacentSpans`).
+ */
+const NORMALIZE_RULES: ReadonlyArray<NormalizeRule> = [
+  {
+    id: 'root.no-blocks',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeRootNoBlocks,
+  },
+  {
+    id: 'text-block.merge-same-mark-spans',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeTextBlockMergeSameMarkSpans,
+  },
+  {
+    id: 'node.missing-type',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeNodeMissingType,
+  },
+  {
+    id: 'node.missing-key',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeNodeMissingKey,
+  },
+  {
+    id: 'node.duplicate-sibling-key',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeNodeDuplicateSiblingKey,
+  },
+  {
+    id: 'text-block.missing-mark-defs',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeTextBlockMissingMarkDefs,
+  },
+  {
+    id: 'text-block.missing-style',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeTextBlockMissingStyle,
+  },
+  {
+    id: 'span.missing-text',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeSpanMissingText,
+  },
+  {
+    id: 'span.missing-marks',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeSpanMissingMarks,
+  },
+  {
+    id: 'span.empty-with-annotations',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeSpanEmptyWithAnnotations,
+  },
+  {
+    id: 'text-block.duplicate-mark-defs',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeTextBlockDuplicateMarkDefs,
+  },
+  {
+    id: 'text-block.unused-mark-defs',
+    runsDuringRemoteChanges: false,
+    normalize: normalizeTextBlockUnusedMarkDefs,
+  },
+  {
+    // Spans match no later rule today, but only via `_type` exclusivity that
+    // lives in `isObject`/`isTextBlockNode`; this row makes the walk stop
+    // rather than lean on that.
+    id: 'span.opaque-to-later-rules',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeSpanOpaqueToLaterRules,
+  },
+  {
+    id: 'container.missing-child-array',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeContainerMissingChildArray,
+  },
+  {
+    id: 'container.duplicate-child-key',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeContainerDuplicateChildKey,
+  },
+  {
+    id: 'text-block.children-not-array',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeTextBlockChildrenNotArray,
+  },
+  {
+    id: 'text-block.no-children',
+    runsDuringRemoteChanges: true,
+    normalize: normalizeTextBlockNoChildren,
+  },
+  {
+    id: 'text-block.adjacent-spans',
+    runsDuringRemoteChanges: 'partial',
+    normalize: normalizeTextBlockAdjacentSpans,
+  },
+]
+
+/**
+ * `NORMALIZE_RULES` is module-private so consumers can't depend on rule
+ * order or internals. Tests still need to pin the table's shape, so this
+ * derives a copy of its `id`/`runsDuringRemoteChanges` pairs under this
+ * unambiguously-internal name.
+ *
+ * @internal
+ */
+export const normalizeRuleTableForTesting = NORMALIZE_RULES.map(
+  (rule) => [rule.id, rule.runsDuringRemoteChanges] as const,
+)
+
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
   entry,
 ) => {
+  for (const rule of NORMALIZE_RULES) {
+    if (
+      rule.runsDuringRemoteChanges === false &&
+      editor.isProcessingRemoteChanges
+    ) {
+      continue
+    }
+
+    if (rule.normalize(editor, entry)) {
+      return
+    }
+  }
+}
+
+/**
+ * Add a placeholder block when the editor is empty.
+ */
+function normalizeRootNoBlocks(editor: Editor, entry: NormalizeEntry) {
+  const [node] = entry
+
+  if (!isEditor(node) || node.snapshot.context.value.length !== 0) {
+    return false
+  }
+
+  withoutPatching(editor, () => {
+    applyInsertNodeAtPath(editor, createPlaceholderBlock(editor.snapshot), [0])
+  })
+  return true
+}
+
+/**
+ * Merge spans with the same set of `.marks`.
+ */
+function normalizeTextBlockMergeSameMarkSpans(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (!isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  const children = getChildren(editor.snapshot, path)
+
+  for (let i = 0; i < children.length - 1; i++) {
+    const {node: child} = children[i]!
+    const {node: nextNode, path: nextChildPath} = children[i + 1]!
+
+    if (
+      isSpan({schema: editor.snapshot.context.schema}, child) &&
+      isSpan({schema: editor.snapshot.context.schema}, nextNode) &&
+      child.marks?.every((mark) => nextNode.marks?.includes(mark)) &&
+      nextNode.marks?.every((mark) => child.marks?.includes(mark))
+    ) {
+      debug.normalization('merging spans with same marks')
+      applyMergeNode(editor, nextChildPath, child.text.length)
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Normalize missing `_type` based on context.
+ */
+function normalizeNodeMissingType(editor: Editor, entry: NormalizeEntry) {
   const [node, path] = entry
   const nodeRecord = node as Record<string, unknown>
 
-  /**
-   * Add a placeholder block when the editor is empty
-   */
-  if (isEditor(node) && node.snapshot.context.value.length === 0) {
-    withoutPatching(editor, () => {
-      applyInsertNodeAtPath(
-        editor,
-        createPlaceholderBlock(editor.snapshot),
-        [0],
-      )
-    })
-    return
+  if (nodeRecord['_type'] !== undefined || path.length === 0) {
+    return false
   }
 
-  /**
-   * Merge spans with same set of .marks
-   */
+  const parent = getNode(editor.snapshot, parentPath(path))
+
+  // Children of text blocks default to the span type.
   if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlock({schema: editor.snapshot.context.schema}, node)
+    parent &&
+    isTextBlock({schema: editor.snapshot.context.schema}, parent.node)
   ) {
-    const children = getChildren(editor.snapshot, path)
-
-    for (let i = 0; i < children.length - 1; i++) {
-      const {node: child} = children[i]!
-      const {node: nextNode, path: nextChildPath} = children[i + 1]!
-
-      if (
-        isSpan({schema: editor.snapshot.context.schema}, child) &&
-        isSpan({schema: editor.snapshot.context.schema}, nextNode) &&
-        child.marks?.every((mark) => nextNode.marks?.includes(mark)) &&
-        nextNode.marks?.every((mark) => child.marks?.includes(mark))
-      ) {
-        debug.normalization('merging spans with same marks')
-        applyMergeNode(editor, nextChildPath, child.text.length)
-        return
-      }
-    }
-  }
-
-  // Normalize missing _type based on context.
-  if (nodeRecord['_type'] === undefined && path.length > 0) {
-    const parent = getNode(editor.snapshot, parentPath(path))
-
-    // Children of text blocks default to the span type.
-    if (
-      parent &&
-      isTextBlock({schema: editor.snapshot.context.schema}, parent.node)
-    ) {
-      debug.normalization('Setting span type on node without a type')
-      editor.apply({
-        type: 'set',
-        path: [...path, '_type'],
-        value: editor.snapshot.context.schema.span.name,
-        inverse: {type: 'unset', path: [...path, '_type']},
-      })
-      return
-    }
-
-    // Everything else defaults to the text block type.
-    debug.normalization('Setting block type on node without a type')
+    debug.normalization('Setting span type on node without a type')
     editor.apply({
       type: 'set',
       path: [...path, '_type'],
-      value: editor.snapshot.context.schema.block.name,
+      value: editor.snapshot.context.schema.span.name,
       inverse: {type: 'unset', path: [...path, '_type']},
     })
-    return
+    return true
   }
 
-  // Set missing _key on any non-editor node.
-  // Uses numeric index in the path because the node has no _key to
-  // address it by. Any ancestor segments with undefined _key are also
-  // resolved to numeric indices.
-  if (nodeRecord['_key'] === undefined && path.length > 0) {
-    const newKey = editor.snapshot.context.keyGenerator()
-    debug.normalization('Setting missing key on node')
+  // Everything else defaults to the text block type.
+  debug.normalization('Setting block type on node without a type')
+  editor.apply({
+    type: 'set',
+    path: [...path, '_type'],
+    value: editor.snapshot.context.schema.block.name,
+    inverse: {type: 'unset', path: [...path, '_type']},
+  })
+  return true
+}
 
-    // Build a fully resolved path by walking the tree from the root,
-    // replacing any undefined keyed segments with numeric indices.
-    const numericPath: Path = []
-    let currentNode: Node | undefined
+/**
+ * Set missing `_key` on any non-editor node. Uses a numeric index in the
+ * path because the node has no `_key` to address it by. Any ancestor
+ * segments with undefined `_key` are also resolved to numeric indices.
+ */
+function normalizeNodeMissingKey(editor: Editor, entry: NormalizeEntry) {
+  const [node, path] = entry
+  const nodeRecord = node as Record<string, unknown>
 
-    for (const segment of path) {
-      if (typeof segment === 'string') {
-        // Field name: descend into the field
-        if (currentNode) {
-          numericPath.push(segment)
-        }
-        continue
-      }
+  if (nodeRecord['_key'] !== undefined || path.length === 0) {
+    return false
+  }
 
-      // Determine the siblings array at this level
-      const siblings: ArrayLike<Node> = currentNode
-        ? (((currentNode as Record<string, unknown>)[
-            numericPath[numericPath.length - 1] as string
-          ] as ArrayLike<Node>) ?? [])
-        : editor.snapshot.context.value
+  const newKey = editor.snapshot.context.keyGenerator()
+  debug.normalization('Setting missing key on node')
 
-      if (isKeyedSegment(segment) && segment._key !== undefined) {
+  // Build a fully resolved path by walking the tree from the root,
+  // replacing any undefined keyed segments with numeric indices.
+  const numericPath: Path = []
+  let currentNode: Node | undefined
+
+  for (const segment of path) {
+    if (typeof segment === 'string') {
+      // Field name: descend into the field
+      if (currentNode) {
         numericPath.push(segment)
-        currentNode = Array.prototype.find.call(
-          siblings,
-          (child: Node) => child._key === segment._key,
-        )
-      } else {
-        // Undefined _key or numeric: resolve to numeric index
-        let index = typeof segment === 'number' ? segment : -1
-        if (index === -1) {
-          for (let i = 0; i < siblings.length; i++) {
-            if ((siblings[i] as Node)._key === undefined) {
-              index = i
-              break
-            }
-          }
-        }
-        if (index !== -1) {
-          numericPath.push(index)
-          currentNode = siblings[index] as Node
-        }
       }
+      continue
     }
 
+    // Determine the siblings array at this level
+    const siblings: ArrayLike<Node> = currentNode
+      ? (((currentNode as Record<string, unknown>)[
+          numericPath[numericPath.length - 1] as string
+        ] as ArrayLike<Node>) ?? [])
+      : editor.snapshot.context.value
+
+    if (isKeyedSegment(segment) && segment._key !== undefined) {
+      numericPath.push(segment)
+      currentNode = Array.prototype.find.call(
+        siblings,
+        (child: Node) => child._key === segment._key,
+      )
+    } else {
+      // Undefined _key or numeric: resolve to numeric index
+      let index = typeof segment === 'number' ? segment : -1
+      if (index === -1) {
+        for (let i = 0; i < siblings.length; i++) {
+          if ((siblings[i] as Node)._key === undefined) {
+            index = i
+            break
+          }
+        }
+      }
+      if (index !== -1) {
+        numericPath.push(index)
+        currentNode = siblings[index] as Node
+      }
+    }
+  }
+
+  editor.apply({
+    type: 'set',
+    path: [...numericPath, '_key'],
+    value: newKey,
+    inverse: {type: 'unset', path: [...numericPath, '_key']},
+  })
+  return true
+}
+
+/**
+ * Fix duplicate `_key` among siblings.
+ */
+function normalizeNodeDuplicateSiblingKey(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+  const nodeRecord = node as Record<string, unknown>
+
+  if (path.length === 0 || nodeRecord['_key'] === undefined) {
+    return false
+  }
+
+  const parent = getParent(editor.snapshot, path)
+  const key = nodeRecord['_key'] as string
+  // The child array holding this node is the field segment right after
+  // the parent's path. Read it straight off the parent node rather than
+  // re-resolving children from the root through the schema; fall back to
+  // `getChildren` only if that field isn't a plain array.
+  const childFieldName = parent
+    ? (path[parent.path.length] as string)
+    : undefined
+  const rawSiblings =
+    parent && typeof childFieldName === 'string'
+      ? (parent.node as Record<string, unknown>)[childFieldName]
+      : undefined
+  const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
+    ? editor.snapshot.context.value
+    : Array.isArray(rawSiblings)
+      ? (rawSiblings as ReadonlyArray<{_key?: string}>)
+      : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
+
+  // A group of zero or one child can't hold a duplicate key, so it needs
+  // neither a scan nor a cache entry: re-checking it is already O(1). This
+  // is the common shape for container fields (a row's single cell, a
+  // cell's single content block) and single-span text blocks, so only
+  // genuinely multi-child groups ever cost a serialized id.
+  if (siblingNodes.length <= 1) {
+    return false
+  }
+
+  // Identify the group by its serialized path (the root group is `''`).
+  // The verdict survives edits elsewhere in the tree: it is dropped only
+  // when the op stream sees this group's own membership change (see
+  // `subscribeUpdateValue`). Verifying a group is O(siblings); caching
+  // the verdict keeps a bulk insert of n pre-keyed siblings at O(n)
+  // instead of O(n^2).
+  const groupId =
+    parent && typeof childFieldName === 'string'
+      ? serializePath([...parent.path, childFieldName])
+      : ''
+
+  if (editor.verifiedUniqueChildGroups.has(groupId)) {
+    return false
+  }
+
+  const seenKeys = new Set<string>()
+  let groupIsUnique = true
+  let duplicateIndexOfKey = -1
+
+  for (let index = 0; index < siblingNodes.length; index++) {
+    const siblingKey = siblingNodes[index]?._key
+    if (siblingKey === undefined) {
+      continue
+    }
+    if (seenKeys.has(siblingKey)) {
+      groupIsUnique = false
+      // The second occurrence of this node's own key is the one the
+      // previous per-node implementation renamed; preserve that so
+      // generated keys land on the same node.
+      if (siblingKey === key && duplicateIndexOfKey === -1) {
+        duplicateIndexOfKey = index
+      }
+    } else {
+      seenKeys.add(siblingKey)
+    }
+  }
+
+  if (duplicateIndexOfKey !== -1) {
+    const newKey = editor.snapshot.context.keyGenerator()
+    debug.normalization('Fixing duplicate key on node')
+    const numericPath: Path =
+      parent && typeof childFieldName === 'string'
+        ? [...parent.path, childFieldName, duplicateIndexOfKey]
+        : [duplicateIndexOfKey]
     editor.apply({
       type: 'set',
       path: [...numericPath, '_key'],
       value: newKey,
-      inverse: {type: 'unset', path: [...numericPath, '_key']},
-    })
-    return
-  }
-
-  // Fix duplicate _key among siblings
-  if (path.length > 0 && nodeRecord['_key'] !== undefined) {
-    const parent = getParent(editor.snapshot, path)
-    const key = nodeRecord['_key'] as string
-    // The child array holding this node is the field segment right after
-    // the parent's path. Read it straight off the parent node rather than
-    // re-resolving children from the root through the schema; fall back to
-    // `getChildren` only if that field isn't a plain array.
-    const childFieldName = parent
-      ? (path[parent.path.length] as string)
-      : undefined
-    const rawSiblings =
-      parent && typeof childFieldName === 'string'
-        ? (parent.node as Record<string, unknown>)[childFieldName]
-        : undefined
-    const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
-      ? editor.snapshot.context.value
-      : Array.isArray(rawSiblings)
-        ? (rawSiblings as ReadonlyArray<{_key?: string}>)
-        : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
-
-    // A group of zero or one child can't hold a duplicate key, so it needs
-    // neither a scan nor a cache entry: re-checking it is already O(1). This
-    // is the common shape for container fields (a row's single cell, a
-    // cell's single content block) and single-span text blocks, so only
-    // genuinely multi-child groups ever cost a serialized id.
-    if (siblingNodes.length > 1) {
-      // Identify the group by its serialized path (the root group is `''`).
-      // The verdict survives edits elsewhere in the tree: it is dropped only
-      // when the op stream sees this group's own membership change (see
-      // `subscribeUpdateValue`). Verifying a group is O(siblings); caching
-      // the verdict keeps a bulk insert of n pre-keyed siblings at O(n)
-      // instead of O(n^2).
-      const groupId =
-        parent && typeof childFieldName === 'string'
-          ? serializePath([...parent.path, childFieldName])
-          : ''
-
-      if (!editor.verifiedUniqueChildGroups.has(groupId)) {
-        const seenKeys = new Set<string>()
-        let groupIsUnique = true
-        let duplicateIndexOfKey = -1
-
-        for (let index = 0; index < siblingNodes.length; index++) {
-          const siblingKey = siblingNodes[index]?._key
-          if (siblingKey === undefined) {
-            continue
-          }
-          if (seenKeys.has(siblingKey)) {
-            groupIsUnique = false
-            // The second occurrence of this node's own key is the one the
-            // previous per-node implementation renamed; preserve that so
-            // generated keys land on the same node.
-            if (siblingKey === key && duplicateIndexOfKey === -1) {
-              duplicateIndexOfKey = index
-            }
-          } else {
-            seenKeys.add(siblingKey)
-          }
-        }
-
-        if (duplicateIndexOfKey !== -1) {
-          const newKey = editor.snapshot.context.keyGenerator()
-          debug.normalization('Fixing duplicate key on node')
-          const numericPath: Path =
-            parent && typeof childFieldName === 'string'
-              ? [...parent.path, childFieldName, duplicateIndexOfKey]
-              : [duplicateIndexOfKey]
-          editor.apply({
-            type: 'set',
-            path: [...numericPath, '_key'],
-            value: newKey,
-            inverse: {
-              type: 'set',
-              path: [...numericPath, '_key'],
-              value: key,
-            },
-          })
-          return
-        }
-
-        if (groupIsUnique) {
-          editor.verifiedUniqueChildGroups.add(groupId)
-        }
-      }
-    }
-  }
-
-  /**
-   * Add missing .markDefs to text block nodes
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
-    !Array.isArray(node.markDefs)
-  ) {
-    debug.normalization('adding .markDefs to block node')
-    setNodeProperties(editor, {markDefs: []}, path)
-    return
-  }
-
-  /**
-   * Add missing .style to text block nodes
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
-    typeof node.style === 'undefined'
-  ) {
-    const defaultStyle = getPathSubSchema(editor.snapshot, path).styles.at(
-      0,
-    )?.name
-    if (defaultStyle) {
-      debug.normalization('adding .style to block node')
-      setNodeProperties(editor, {style: defaultStyle}, path)
-      return
-    }
-  }
-
-  /**
-   * Add missing .text to span nodes
-   */
-  if (
-    isSpanNode(editor.snapshot.context, node) &&
-    typeof node.text !== 'string'
-  ) {
-    debug.normalization('Adding .text to span node')
-    editor.apply({
-      type: 'set',
-      path: [...path, 'text'],
-      value: '',
-      inverse: {type: 'unset', path: [...path, 'text']},
-    })
-    return
-  }
-
-  /**
-   * Add missing .marks to span nodes
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isSpan({schema: editor.snapshot.context.schema}, node) &&
-    !Array.isArray(node.marks)
-  ) {
-    debug.normalization('Adding .marks to span node')
-    setNodeProperties(editor, {marks: []}, path)
-    return
-  }
-
-  /**
-   * Remove annotations from empty spans
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isSpan({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const blockPath = parentPath(path)
-    const blockEntry = getTextBlock(editor.snapshot, blockPath)
-    if (!blockEntry) {
-      return
-    }
-    // Only treat a mark as an annotation if it points to one of the
-    // block's `markDefs`. A mark that doesn't resolve might be a decorator
-    // from another schema (one that was removed here, or one a collaborator
-    // has that we don't), so it is left alone.
-    const annotations = node.marks?.filter((mark) =>
-      blockEntry.node.markDefs?.some((markDef) => markDef._key === mark),
-    )
-
-    if (node.text === '' && annotations && annotations.length > 0) {
-      debug.normalization('removing annotations from empty span node')
-      setNodeProperties(
-        editor,
-        {marks: node.marks?.filter((mark) => !annotations.includes(mark))},
-        path,
-      )
-      return
-    }
-  }
-
-  /**
-   * Remove duplicate markDefs
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlock({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const markDefs = node.markDefs ?? []
-    const markDefKeys = new Set<string>()
-    const newMarkDefs: Array<PortableTextObject> = []
-
-    for (const markDef of markDefs) {
-      if (!markDefKeys.has(markDef._key)) {
-        markDefKeys.add(markDef._key)
-        newMarkDefs.push(markDef)
-      }
-    }
-
-    if (markDefs.length !== newMarkDefs.length) {
-      debug.normalization('removing duplicate markDefs')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
-      return
-    }
-  }
-
-  /**
-   * Remove markDefs not in use
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlock({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const newMarkDefs = (node.markDefs || []).filter((def) => {
-      return node.children.find((child) => {
-        return (
-          isSpan({schema: editor.snapshot.context.schema}, child) &&
-          Array.isArray(child.marks) &&
-          child.marks.includes(def._key)
-        )
-      })
-    })
-
-    if (node.markDefs && !isEqualMarkDefs(newMarkDefs, node.markDefs)) {
-      debug.normalization('removing markDef not in use')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
-      return
-    }
-  }
-
-  if (isSpanNode({schema: editor.snapshot.context.schema}, node)) {
-    /**
-     * Add missing .text to span nodes
-     */
-    if (typeof node.text !== 'string') {
-      debug.normalization('Adding .text to span node')
-      editor.apply({
+      inverse: {
         type: 'set',
-        path: [...path, 'text'],
-        value: '',
-        inverse: {type: 'unset', path: [...path, 'text']},
-      })
-      return
-    }
-
-    return
-  }
-
-  // Container normalization: ensure the child array field exists and is
-  // non-empty.
-  if (isObject(editor.snapshot, node)) {
-    const resolved = resolveContainerByPath(
-      {
-        containers: editor.containers,
-        schema: editor.snapshot.context.schema,
-        value: editor.snapshot.context.value,
+        path: [...numericPath, '_key'],
+        value: key,
       },
+    })
+    return true
+  }
+
+  if (groupIsUnique) {
+    editor.verifiedUniqueChildGroups.add(groupId)
+  }
+
+  return false
+}
+
+/**
+ * Add missing `.markDefs` to text block nodes.
+ */
+function normalizeTextBlockMissingMarkDefs(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (
+    !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+    Array.isArray(node.markDefs)
+  ) {
+    return false
+  }
+
+  debug.normalization('adding .markDefs to block node')
+  setNodeProperties(editor, {markDefs: []}, path)
+  return true
+}
+
+/**
+ * Add missing `.style` to text block nodes.
+ */
+function normalizeTextBlockMissingStyle(editor: Editor, entry: NormalizeEntry) {
+  const [node, path] = entry
+
+  if (
+    !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+    typeof node.style !== 'undefined'
+  ) {
+    return false
+  }
+
+  const defaultStyle = getPathSubSchema(editor.snapshot, path).styles.at(
+    0,
+  )?.name
+  if (!defaultStyle) {
+    return false
+  }
+
+  debug.normalization('adding .style to block node')
+  setNodeProperties(editor, {style: defaultStyle}, path)
+  return true
+}
+
+/**
+ * Add missing `.text` to span nodes.
+ */
+function normalizeSpanMissingText(editor: Editor, entry: NormalizeEntry) {
+  const [node, path] = entry
+
+  if (
+    !isSpanNode(editor.snapshot.context, node) ||
+    typeof node.text === 'string'
+  ) {
+    return false
+  }
+
+  debug.normalization('Adding .text to span node')
+  editor.apply({
+    type: 'set',
+    path: [...path, 'text'],
+    value: '',
+    inverse: {type: 'unset', path: [...path, 'text']},
+  })
+  return true
+}
+
+/**
+ * Add missing `.marks` to span nodes.
+ */
+function normalizeSpanMissingMarks(editor: Editor, entry: NormalizeEntry) {
+  const [node, path] = entry
+
+  if (
+    !isSpan({schema: editor.snapshot.context.schema}, node) ||
+    Array.isArray(node.marks)
+  ) {
+    return false
+  }
+
+  debug.normalization('Adding .marks to span node')
+  setNodeProperties(editor, {marks: []}, path)
+  return true
+}
+
+/**
+ * Remove annotations from empty spans.
+ */
+function normalizeSpanEmptyWithAnnotations(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  const blockPath = parentPath(path)
+  const blockEntry = getTextBlock(editor.snapshot, blockPath)
+  if (!blockEntry) {
+    return false
+  }
+
+  // Only treat a mark as an annotation if it points to one of the
+  // block's `markDefs`. A mark that doesn't resolve might be a decorator
+  // from another schema (one that was removed here, or one a collaborator
+  // has that we don't), so it is left alone.
+  const annotations = node.marks?.filter((mark) =>
+    blockEntry.node.markDefs?.some((markDef) => markDef._key === mark),
+  )
+
+  if (node.text === '' && annotations && annotations.length > 0) {
+    debug.normalization('removing annotations from empty span node')
+    setNodeProperties(
+      editor,
+      {marks: node.marks?.filter((mark) => !annotations.includes(mark))},
       path,
-      node,
     )
-    const arrayField =
-      resolved && 'container' in resolved ? resolved.field : undefined
+    return true
+  }
 
-    if (arrayField) {
-      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
-      const needsField = !Array.isArray(fieldValue)
-      const needsChild = needsField || fieldValue.length === 0
+  return false
+}
 
-      if (needsChild) {
-        const acceptsBlocks = arrayField.of.some(
-          (definition) => definition.type === 'block',
-        )
-        const firstChildType = arrayField.of.at(0)
+/**
+ * Remove duplicate markDefs.
+ */
+function normalizeTextBlockDuplicateMarkDefs(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
 
-        let childNode: Node | undefined
-        if (acceptsBlocks) {
-          childNode = createPlaceholderBlock(editor.snapshot, [
-            ...path,
-            arrayField.name,
-            0,
-          ])
-        } else if (firstChildType && firstChildType.type !== 'block') {
-          // For inline declarations (`type: 'object'`), the actual type
-          // identity is in `name`. For bare references (any other `type`),
-          // the type itself is the identity.
-          const childTypeName =
-            firstChildType.type === 'object' && 'name' in firstChildType
-              ? firstChildType.name
-              : firstChildType.type
-          childNode = {
-            _type: childTypeName,
-            _key: editor.snapshot.context.keyGenerator(),
-          } as Node
-        }
+  if (!isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
 
-        if (needsField && childNode) {
-          // Set the field with its initial child in a single operation
-          // instead of two (set empty array + insert child).
-          setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
-          return
-        }
+  const markDefs = node.markDefs ?? []
+  const markDefKeys = new Set<string>()
+  const newMarkDefs: Array<PortableTextObject> = []
 
-        if (needsField) {
-          setNodeProperties(editor, {[arrayField.name]: []}, path)
-          return
-        }
-
-        if (childNode) {
-          editor.apply({
-            type: 'insert',
-            path: [...path, arrayField.name, 0],
-            node: childNode,
-            position: 'before',
-          })
-          return
-        }
-      }
+  for (const markDef of markDefs) {
+    if (!markDefKeys.has(markDef._key)) {
+      markDefKeys.add(markDef._key)
+      newMarkDefs.push(markDef)
     }
   }
 
-  // Fix duplicate _key among children of container/object nodes.
-  // The sibling-level handler above catches duplicates when each child is
-  // visited individually, but container children may not be visited if
-  // containers gates traversal. Handle it at the parent level as well.
-  if (isObject(editor.snapshot, node)) {
-    const children = [...getChildren(editor.snapshot, path)]
-
-    if (children.length > 1) {
-      const seen = new Map<string, number>()
-
-      for (let i = 0; i < children.length; i++) {
-        const key = children[i]!.node._key
-        if (key !== undefined && seen.has(key)) {
-          const newKey = editor.snapshot.context.keyGenerator()
-          debug.normalization('Fixing duplicate key on container child')
-          // Use numeric index to address the duplicate since keyed path
-          // is ambiguous for nodes with the same key.
-          const arrayFieldName = getChildFieldName(
-            editor.snapshot.context,
-            path,
-          )
-          if (arrayFieldName) {
-            editor.apply({
-              type: 'set',
-              path: [...path, arrayFieldName, i, '_key'],
-              value: newKey,
-              inverse: {
-                type: 'set',
-                path: [...path, arrayFieldName, i, '_key'],
-                value: key,
-              },
-            })
-            return
-          }
-        }
-        if (key !== undefined) {
-          seen.set(key, i)
-        }
-      }
-    }
-
-    return
+  if (markDefs.length !== newMarkDefs.length) {
+    debug.normalization('removing duplicate markDefs')
+    setNodeProperties(editor, {markDefs: newMarkDefs}, path)
+    return true
   }
 
-  // Text blocks must always have at least one child span.
-  if (isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
-    // We will have to refetch the element any time we modify its children
-    // since it clones to a new immutable reference when we do.
-    let element = node as unknown as PortableTextTextBlock
+  return false
+}
 
-    // Runtime data can arrive without children (e.g. after an unset patch).
-    if (!Array.isArray(element.children)) {
-      editor.apply({
-        type: 'set',
-        path: [...path, 'children'],
-        value: [],
-        inverse: {type: 'unset', path: [...path, 'children']},
-      })
-      return
-    }
+/**
+ * Remove markDefs not in use.
+ */
+function normalizeTextBlockUnusedMarkDefs(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
 
-    // Ensure that text blocks have at least one child.
-    if (element.children.length === 0) {
-      const child = createSpanNode(editor.snapshot.context)
-      editor.apply({
-        type: 'insert',
-        path: [...path, 'children', 0],
-        node: child,
-        position: 'before',
-      })
-      const refetched = getTextBlock(editor.snapshot, path)?.node
-      if (!refetched) {
-        return
+  if (!isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  const newMarkDefs = (node.markDefs || []).filter((def) => {
+    return node.children.find((child) => {
+      return (
+        isSpan({schema: editor.snapshot.context.schema}, child) &&
+        Array.isArray(child.marks) &&
+        child.marks.includes(def._key)
+      )
+    })
+  })
+
+  if (node.markDefs && !isEqualMarkDefs(newMarkDefs, node.markDefs)) {
+    debug.normalization('removing markDef not in use')
+    setNodeProperties(editor, {markDefs: newMarkDefs}, path)
+    return true
+  }
+
+  return false
+}
+
+function normalizeSpanOpaqueToLaterRules(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node] = entry
+
+  return isSpanNode(editor.snapshot.context, node)
+}
+
+/**
+ * Container normalization: ensure the child array field exists and is
+ * non-empty.
+ */
+function normalizeContainerMissingChildArray(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (!isObject(editor.snapshot, node)) {
+    return false
+  }
+
+  const resolved = resolveContainerByPath(
+    {
+      containers: editor.containers,
+      schema: editor.snapshot.context.schema,
+      value: editor.snapshot.context.value,
+    },
+    path,
+    node,
+  )
+  const arrayField =
+    resolved && 'container' in resolved ? resolved.field : undefined
+
+  if (!arrayField) {
+    return false
+  }
+
+  const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+  const needsField = !Array.isArray(fieldValue)
+  const needsChild = needsField || fieldValue.length === 0
+
+  if (!needsChild) {
+    return false
+  }
+
+  const acceptsBlocks = arrayField.of.some(
+    (definition) => definition.type === 'block',
+  )
+  const firstChildType = arrayField.of.at(0)
+
+  let childNode: Node | undefined
+  if (acceptsBlocks) {
+    childNode = createPlaceholderBlock(editor.snapshot, [
+      ...path,
+      arrayField.name,
+      0,
+    ])
+  } else if (firstChildType && firstChildType.type !== 'block') {
+    // For inline declarations (`type: 'object'`), the actual type
+    // identity is in `name`. For bare references (any other `type`),
+    // the type itself is the identity.
+    const childTypeName =
+      firstChildType.type === 'object' && 'name' in firstChildType
+        ? firstChildType.name
+        : firstChildType.type
+    childNode = {
+      _type: childTypeName,
+      _key: editor.snapshot.context.keyGenerator(),
+    } as Node
+  }
+
+  if (needsField && childNode) {
+    // Set the field with its initial child in a single operation
+    // instead of two (set empty array + insert child).
+    setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
+    return true
+  }
+
+  if (needsField) {
+    setNodeProperties(editor, {[arrayField.name]: []}, path)
+    return true
+  }
+
+  if (childNode) {
+    editor.apply({
+      type: 'insert',
+      path: [...path, arrayField.name, 0],
+      node: childNode,
+      position: 'before',
+    })
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Fix duplicate `_key` among children of container/object nodes.
+ * The sibling-level handler above catches duplicates when each child is
+ * visited individually, but container children may not be visited if
+ * containers gates traversal. Handle it at the parent level as well.
+ */
+function normalizeContainerDuplicateChildKey(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (!isObject(editor.snapshot, node)) {
+    return false
+  }
+
+  const children = [...getChildren(editor.snapshot, path)]
+
+  if (children.length <= 1) {
+    return false
+  }
+
+  const seen = new Map<string, number>()
+
+  for (let i = 0; i < children.length; i++) {
+    const key = children[i]!.node._key
+    if (key !== undefined && seen.has(key)) {
+      const newKey = editor.snapshot.context.keyGenerator()
+      debug.normalization('Fixing duplicate key on container child')
+      // Use numeric index to address the duplicate since keyed path
+      // is ambiguous for nodes with the same key.
+      const arrayFieldName = getChildFieldName(editor.snapshot.context, path)
+      if (arrayFieldName) {
+        editor.apply({
+          type: 'set',
+          path: [...path, arrayFieldName, i, '_key'],
+          value: newKey,
+          inverse: {
+            type: 'set',
+            path: [...path, arrayFieldName, i, '_key'],
+            value: key,
+          },
+        })
+        return true
       }
-      element = refetched
     }
+    if (key !== undefined) {
+      seen.set(key, i)
+    }
+  }
 
-    // Since we'll be applying operations while iterating, we also modify
-    // `n` when adding/removing nodes.
-    for (let n = 0; n < element.children.length; n++) {
-      const child = element.children[n]!
+  return false
+}
 
-      const prev: Node | undefined = element.children[n - 1]
-      const childPath = [...path, 'children', {_key: child._key}]
+/**
+ * Text blocks must always have a `.children` array. Runtime data can arrive
+ * without it (e.g. after an unset patch).
+ */
+function normalizeTextBlockChildrenNotArray(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
 
-      if (isSpan({schema: editor.snapshot.context.schema}, child)) {
-        if (
-          prev != null &&
-          isSpan({schema: editor.snapshot.context.schema}, prev) &&
-          // Only this merge/empty-drop arm defers; the inline-object
-          // bracketing below is a repair and keeps running.
-          !editor.isProcessingRemoteChanges
-        ) {
-          // Merge adjacent text nodes that are empty or match.
-          if (child.text === '') {
-            editor.apply({type: 'unset', path: childPath})
-            const refetched = getTextBlock(editor.snapshot, path)?.node
-            if (!refetched) {
-              return
-            }
-            element = refetched
-            n--
-          } else if (prev.text === '') {
-            const prevPath = [...path, 'children', {_key: prev._key}]
-            editor.apply({type: 'unset', path: prevPath})
-            const refetched = getTextBlock(editor.snapshot, path)?.node
-            if (!refetched) {
-              return
-            }
-            element = refetched
-            n--
-          } else if (textEquals(child, prev, {loose: true})) {
-            applyMergeNode(editor, childPath, prev.text.length)
-            const refetched = getTextBlock(editor.snapshot, path)?.node
-            if (!refetched) {
-              return
-            }
-            element = refetched
-            n--
-          }
-        }
-      } else if (isObject(editor.snapshot, child)) {
-        if (
-          prev == null ||
-          !isSpan({schema: editor.snapshot.context.schema}, prev)
-        ) {
-          const newChild = createSpanNode(editor.snapshot.context)
-          editor.apply({
-            type: 'insert',
-            path: childPath,
-            node: newChild,
-            position: 'before',
-          })
+  if (!isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  if (Array.isArray((node as unknown as PortableTextTextBlock).children)) {
+    return false
+  }
+
+  editor.apply({
+    type: 'set',
+    path: [...path, 'children'],
+    value: [],
+    inverse: {type: 'unset', path: [...path, 'children']},
+  })
+  return true
+}
+
+/**
+ * Text blocks must always have at least one child span.
+ */
+function normalizeTextBlockNoChildren(editor: Editor, entry: NormalizeEntry) {
+  const [node, path] = entry
+
+  if (!isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  const element = node as unknown as PortableTextTextBlock
+  if (!Array.isArray(element.children) || element.children.length !== 0) {
+    return false
+  }
+
+  const child = createSpanNode(editor.snapshot.context)
+  editor.apply({
+    type: 'insert',
+    path: [...path, 'children', 0],
+    node: child,
+    position: 'before',
+  })
+  return true
+}
+
+/**
+ * Walk a text block's children, merging/dropping empty adjacent spans and
+ * bracketing inline objects with spans on either side. Mutates mid-walk and
+ * refetches the block after every operation since it clones to a new
+ * immutable reference; `n` is adjusted alongside the underlying array so the
+ * loop keeps visiting the same logical positions. Only the span-merge/empty-
+ * drop arm defers to remote changes; the inline-object bracketing arm is a
+ * repair and always runs, so this stays a single `'partial'` rule rather
+ * than being split by arm.
+ */
+function normalizeTextBlockAdjacentSpans(
+  editor: Editor,
+  entry: NormalizeEntry,
+) {
+  const [node, path] = entry
+
+  if (!isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
+    return false
+  }
+
+  // We will have to refetch the element any time we modify its children
+  // since it clones to a new immutable reference when we do.
+  let element = node as unknown as PortableTextTextBlock
+
+  if (!Array.isArray(element.children) || element.children.length === 0) {
+    return false
+  }
+
+  let appliedRepair = false
+
+  // Since we'll be applying operations while iterating, we also modify
+  // `n` when adding/removing nodes.
+  for (let n = 0; n < element.children.length; n++) {
+    const child = element.children[n]!
+
+    const prev: Node | undefined = element.children[n - 1]
+    const childPath = [...path, 'children', {_key: child._key}]
+
+    if (isSpan({schema: editor.snapshot.context.schema}, child)) {
+      if (
+        prev != null &&
+        isSpan({schema: editor.snapshot.context.schema}, prev) &&
+        // Only this merge/empty-drop arm defers; the inline-object
+        // bracketing below is a repair and keeps running.
+        !editor.isProcessingRemoteChanges
+      ) {
+        // Merge adjacent text nodes that are empty or match.
+        if (child.text === '') {
+          editor.apply({type: 'unset', path: childPath})
+          appliedRepair = true
           const refetched = getTextBlock(editor.snapshot, path)?.node
           if (!refetched) {
-            return
+            return true
           }
           element = refetched
-          n++
-        }
-        if (n === element.children.length - 1) {
-          const newChild = createSpanNode(editor.snapshot.context)
-          editor.apply({
-            type: 'insert',
-            path: [...path, 'children', {_key: element.children[n]!._key}],
-            node: newChild,
-            position: 'after',
-          })
+          n--
+        } else if (prev.text === '') {
+          const prevPath = [...path, 'children', {_key: prev._key}]
+          editor.apply({type: 'unset', path: prevPath})
+          appliedRepair = true
           const refetched = getTextBlock(editor.snapshot, path)?.node
           if (!refetched) {
-            return
+            return true
           }
           element = refetched
-          n++
+          n--
+        } else if (textEquals(child, prev, {loose: true})) {
+          applyMergeNode(editor, childPath, prev.text.length)
+          appliedRepair = true
+          const refetched = getTextBlock(editor.snapshot, path)?.node
+          if (!refetched) {
+            return true
+          }
+          element = refetched
+          n--
         }
       }
+    } else if (isObject(editor.snapshot, child)) {
+      if (
+        prev == null ||
+        !isSpan({schema: editor.snapshot.context.schema}, prev)
+      ) {
+        const newChild = createSpanNode(editor.snapshot.context)
+        editor.apply({
+          type: 'insert',
+          path: childPath,
+          node: newChild,
+          position: 'before',
+        })
+        appliedRepair = true
+        const refetched = getTextBlock(editor.snapshot, path)?.node
+        if (!refetched) {
+          return true
+        }
+        element = refetched
+        n++
+      }
+      if (n === element.children.length - 1) {
+        const newChild = createSpanNode(editor.snapshot.context)
+        editor.apply({
+          type: 'insert',
+          path: [...path, 'children', {_key: element.children[n]!._key}],
+          node: newChild,
+          position: 'after',
+        })
+        appliedRepair = true
+        const refetched = getTextBlock(editor.snapshot, path)?.node
+        if (!refetched) {
+          return true
+        }
+        element = refetched
+        n++
+      }
     }
-
-    return
   }
+
+  return appliedRepair
 }

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -13,6 +13,8 @@ import {subscribeToOperations, type OperationEvent} from './operation-channel'
 
 const schema = compileSchema(defineSchema({}))
 
+// Keep in sync with `createBareEditor` in `normalize-node.test.ts`; not
+// extracted to a shared helper so each suite can drift independently.
 function createBareEditor(value: Array<PortableTextBlock>): Editor {
   const editor = createEditor()
 

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -72,6 +72,9 @@ export function validateValue(
         return true
       }
       // Test that every block has a _key prop
+      // Same defect as normalize rule `node.missing-key` (which repairs it
+      // unconditionally, local or remote); policy at this entrance is
+      // reject-with-suggested-patch. Keep ids in sync with NORMALIZE_RULES.
       if (!blk._key || typeof blk._key !== 'string') {
         resolution = {
           patches: [set({...blk, _key: keyGenerator()}, [index])],
@@ -113,6 +116,9 @@ export function validateValue(
         }
 
         // If the block has no `_type`, but aside from that is a valid Portable Text block
+        // Same defect as normalize rule `node.missing-type` (which repairs it
+        // unconditionally, local or remote); policy at this entrance is
+        // reject-with-suggested-patch. Keep ids in sync with NORMALIZE_RULES.
         if (
           !blk._type &&
           isTextBlock({schema: types}, {...blk, _type: types.block.name})
@@ -136,6 +142,9 @@ export function validateValue(
           return true
         }
 
+        // Same defect as normalize rule `node.missing-type` (which repairs it
+        // unconditionally, local or remote); policy at this entrance is
+        // reject-with-suggested-patch. Keep ids in sync with NORMALIZE_RULES.
         if (!blk._type) {
           resolution = {
             patches: [unset([{_key: blk._key}])],
@@ -173,6 +182,10 @@ export function validateValue(
       if (blk._type === types.block.name) {
         const textBlock = blk as PortableTextTextBlock
         // Test that it has a valid children property (array)
+        // Same defect as normalize rule `text-block.children-not-array` (which
+        // repairs it unconditionally, local or remote); policy at this
+        // entrance is reject-with-suggested-patch. Keep ids in sync with
+        // NORMALIZE_RULES.
         if (textBlock.children && !Array.isArray(textBlock.children)) {
           resolution = {
             patches: [set({children: []}, [{_key: textBlock._key}])],
@@ -191,6 +204,11 @@ export function validateValue(
           return true
         }
         // Test that children is set and lengthy
+        // Same defect as normalize rules `text-block.children-not-array`
+        // (the `undefined` half) and `text-block.no-children` (the
+        // empty-array half), both of which repair it unconditionally, local
+        // or remote; policy at this entrance is reject-with-suggested-patch.
+        // Keep ids in sync with NORMALIZE_RULES.
         if (
           textBlock.children === undefined ||
           (Array.isArray(textBlock.children) && textBlock.children.length === 0)
@@ -231,6 +249,10 @@ export function validateValue(
         ]
 
         // Test that all markDefs are in use (remove orphaned markDefs)
+        // Same defect as normalize rule `text-block.unused-mark-defs` (which
+        // defers this repair while `isProcessingRemoteChanges`); policy at
+        // this entrance is reject-with-suggested-patch. Keep ids in sync
+        // with NORMALIZE_RULES.
         if (Array.isArray(blk.markDefs) && blk.markDefs.length > 0) {
           const unusedMarkDefs: string[] = [
             ...new Set(
@@ -286,6 +308,10 @@ export function validateValue(
               return true
             }
 
+            // Same defect as normalize rule `node.missing-key` (which
+            // repairs it unconditionally, local or remote); policy at this
+            // entrance is reject-with-suggested-patch. Keep ids in sync with
+            // NORMALIZE_RULES.
             if (!child._key || typeof child._key !== 'string') {
               const newChild = {...child, _key: keyGenerator()}
               resolution = {
@@ -309,6 +335,10 @@ export function validateValue(
             }
 
             // Verify that children have valid types
+            // Same defect as normalize rule `node.missing-type` (which
+            // repairs it unconditionally, local or remote); policy at this
+            // entrance is reject-with-suggested-patch. Keep ids in sync with
+            // NORMALIZE_RULES.
             if (!child._type) {
               resolution = {
                 patches: [
@@ -354,6 +384,10 @@ export function validateValue(
             }
 
             // Verify that spans have .text property that is a string
+            // Same defect as normalize rule `span.missing-text` (which
+            // repairs it unconditionally, local or remote); policy at this
+            // entrance is reject-with-suggested-patch. Keep ids in sync with
+            // NORMALIZE_RULES.
             if (
               child._type === types.span.name &&
               typeof child.text !== 'string'

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -86,11 +86,9 @@ export interface PortableTextEditorEngine extends DOMEditor {
    * True while the editor applies content that arrived from outside:
    * remote `patches` and value sync.
    *
-   * Normalization reads this flag to leave adopted content alone. While
-   * it is set, only repairs of invalid structure run (missing `_key` or
-   * `text`, empty blocks). Optional fix-ups (merging same-mark spans,
-   * filling in `style`/`marks`/`markDefs` defaults) wait until a local
-   * edit touches the block and then emit as part of that edit.
+   * Normalization reads this flag to leave adopted content alone for the
+   * duration. Which repairs run anyway and which wait for a local edit is
+   * a per-rule policy; see `NORMALIZE_RULES` in `normalize-node.ts`.
    */
   isProcessingRemoteChanges: boolean
   isRedoing: boolean

--- a/packages/editor/src/utils/parse-blocks.ts
+++ b/packages/editor/src/utils/parse-blocks.ts
@@ -249,6 +249,9 @@ function parseTextBlock({
     }
   }
 
+  // Same defect as normalize rule `node.missing-key` (which repairs it
+  // unconditionally, local or remote); policy at this entrance is to mint a
+  // key while parsing. Keep ids in sync with NORMALIZE_RULES.
   const _key =
     typeof block['_key'] === 'string' ? block['_key'] : keyGenerator()
 
@@ -282,6 +285,11 @@ function parseTextBlock({
           },
         ]
 
+  // Same defect as the inline-object-bracketing arm of normalize rule
+  // `text-block.adjacent-spans` (which always repairs it, unlike that
+  // rule's span-merge arm which defers during remote changes); policy at
+  // this entrance is to bracket while parsing. Keep ids in sync with
+  // NORMALIZE_RULES.
   const normalizedChildren = options.normalize
     ? // Ensure that inline objects re surrounded by spans
       children.reduce<Array<PortableTextObject | PortableTextSpan>>(
@@ -329,6 +337,10 @@ function parseTextBlock({
   }
 
   if (typeof block['markDefs'] === 'object' && block['markDefs'] !== null) {
+    // Same defect as normalize rule `text-block.unused-mark-defs` (which
+    // defers this repair while `isProcessingRemoteChanges`); policy at this
+    // entrance is to filter while parsing, when `removeUnusedMarkDefs` is
+    // requested. Keep ids in sync with NORMALIZE_RULES.
     parsedBlock.markDefs = options.removeUnusedMarkDefs
       ? markDefs.filter((markDef) => marks.includes(markDef._key))
       : markDefs
@@ -501,10 +513,17 @@ function parseSpanInternal({
     return undefined
   }
 
+  // Same defect as normalize rule `node.missing-type` (which infers the
+  // span type for children of a text block, unconditionally, local or
+  // remote); policy at this entrance is to infer while parsing. Keep ids in
+  // sync with NORMALIZE_RULES.
   if (typeof span['_type'] !== 'string') {
     if (typeof span['text'] === 'string') {
       return {
         _type: schema.span.name as 'span',
+        // Same defect as normalize rule `node.missing-key` (which repairs it
+        // unconditionally, local or remote); policy at this entrance is to
+        // mint a key while parsing. Keep ids in sync with NORMALIZE_RULES.
         _key: typeof span['_key'] === 'string' ? span['_key'] : keyGenerator(),
         text: span['text'],
         marks,
@@ -517,7 +536,13 @@ function parseSpanInternal({
 
   return {
     _type: schema.span.name as 'span',
+    // Same defect as normalize rule `node.missing-key` (which repairs it
+    // unconditionally, local or remote); policy at this entrance is to mint
+    // a key while parsing. Keep ids in sync with NORMALIZE_RULES.
     _key: typeof span['_key'] === 'string' ? span['_key'] : keyGenerator(),
+    // Same defect as normalize rule `span.missing-text` (which repairs it
+    // unconditionally, local or remote); policy at this entrance is to fill
+    // in empty text while parsing. Keep ids in sync with NORMALIZE_RULES.
     text: typeof span['text'] === 'string' ? span['text'] : '',
     marks,
     ...(options.validateFields ? {} : customFields),
@@ -701,6 +726,9 @@ function parseObject({
 
   return {
     _type: schemaType.name,
+    // Same defect as normalize rule `node.missing-key` (which repairs it
+    // unconditionally, local or remote); policy at this entrance is to mint
+    // a key while parsing. Keep ids in sync with NORMALIZE_RULES.
     _key: typeof _key === 'string' ? _key : keyGenerator(),
     ...values,
   }


### PR DESCRIPTION
Answering "what rules does the editor uphold, and when do they run" today requires reading a 652-line `normalizeNode` walker with ~17 rules as ordered if-blocks, eight inline remote-change guards, and a prose enumeration of the gating policy in `types/editor-engine.ts` that turned out to have drifted from the implementation — proof that a non-executed description of these rules rots.

Each rule is now a named function in an ordered, module-private `NORMALIZE_RULES` table (`{id, runsDuringRemoteChanges, normalize}`) that the walker executes, so the manifest cannot drift. The gates hoist into the table column; `text-block.adjacent-spans` is `'partial'`, keeping its arm-level split (merge gated, inline-object bracketing not). The rotten comment now points at the table. Nothing is exported: rule ids would freeze as public surface mid-flux, and nothing registers rules dynamically, so there is no registration API.

The ids double as a shared defect vocabulary: the overlapping checks in `validateValue` and `parse-blocks` are tagged with keep-in-sync comments naming the same ids and both entrance policies (comment-only). The verified policy disagreements between validation and normalization are deliberately untouched — surfaced as vocabulary, audited separately.

Zero semantic delta, pinned four ways: the `[id, gate]` pairs as literal data, rule order (fails on a row swap, executed), runtime gate enforcement including the `'partial'` arm split, and span pass-through emitting nothing in both modes. Full unit (879) and chromium (1,764) suites green with identical counts.
