### PR TITLE
docs: document node 24 requirement and cloud dev setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,23 @@ Guidance for coding agents working on the Portable Text Editor monorepo.
   `fix: only rewrite the DOM selection when it disagrees with the model`.
 - User-facing changes ship a changeset (`.changeset/*.md`); tests, tooling,
   and internal refactors do not.
+
+## Cursor Cloud specific instructions
+
+- Use Node 24 (the nvm default). The VM's baseline `node` on `PATH`
+  (`/exec-daemon/node`) is v22.14, whose V8 predates duplicate named capture
+  groups; under it `@portabletext/plugin-character-pair-decorator`'s
+  `regex.character-pair` unit suite throws `Duplicate capture group name` and
+  `pnpm test:unit` fails. Interactive shells source `~/.bashrc` → nvm and pick
+  up the Node 24 default automatically; if a command lands on v22.14, run
+  `nvm use 24` first. CI runs the suite on `lts/*` (Node 24).
+- Browser tests (`.test.tsx`, e.g. `pnpm test:browser:chromium`) need the
+  Playwright Chromium browser; it is provisioned by the startup update script.
+  Only Chromium is installed, so `test:browser:firefox` / `:webkit` need their
+  browsers added first (`pnpm exec playwright install firefox webkit`).
+- The runnable demo app is `playground`: `pnpm dev:playground` serves it at
+  `http://localhost:5173/` (Vite). `apps/docs` (`pnpm dev:docs`) and
+  `examples/basic` (`pnpm dev:example-basic`) are the other runnable targets;
+  there is no backend, database, or env/secret to configure.
+- `pnpm install` prints an "Ignored build scripts: esbuild" warning. It is
+  benign here — builds, Vite, and tests all work without approving it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cursor Cloud development environment for the Portable Text Editor monorepo, and records the durable, non-obvious learnings in `AGENTS.md`.

The only code change is an added `## Cursor Cloud specific instructions` section in `AGENTS.md`. Everything else is environment configuration captured via the VM update script (not committed to the repo).

## Key finding: Node 24 is required

The VM's baseline `node` on `PATH` (`/exec-daemon/node`) is v22.14, whose V8 (12.4) predates **duplicate named capture groups**. Under it, `@portabletext/plugin-character-pair-decorator`'s `regex.character-pair` unit suite throws `Duplicate capture group name` and `pnpm test:unit` fails. CI runs the suite on `lts/*` (Node 24), which passes. The environment is configured to default to Node 24 via nvm.

## What was set up

- Node 24 (nvm default) — interactive shells source `~/.bashrc` → nvm and pick it up automatically.
- `pnpm install` (pnpm 10.25.0, already present).
- Playwright Chromium browser for `test:browser:chromium`.

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Install | `pnpm install` | success |
| Build | `pnpm build` | 27/27 tasks |
| Lint | `pnpm check:lint` | pass |
| Types | `pnpm check:types` | pass |
| Format | `pnpm check:format` | pass |
| Unit tests | `pnpm test:unit` (Node 24) | 36/36 tasks pass |
| Browser tests | `pnpm --filter @portabletext/plugin-character-pair-decorator test:browser:chromium` | pass |
| Run app | `pnpm dev:playground` | serves at `http://localhost:5173/` |

## Hello-world demo

Typed `Hello Portable Text` into the Playground editor, applied bold via `Ctrl+B` (rendered bold, live JSON output showed `"marks": ["strong"]`), then added a second line `This editor works!`.

[playground_editor_hello_world.mp4](https://cursor.com/agents/bc-96b9a643-e564-4c40-b4d0-e3432def2cad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayground_editor_hello_world.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96b9a643-e564-4c40-b4d0-e3432def2cad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b9a643-e564-4c40-b4d0-e3432def2cad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

