### PR TITLE
refactor: describe normalizations as corrections in an ordered store

### DIFF
--- a/packages/editor/src/engine/core/corrections.test.ts
+++ b/packages/editor/src/engine/core/corrections.test.ts
@@ -1,0 +1,214 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import {createEditor} from '../create-editor'
+import {normalize} from '../editor/normalize'
+import type {Editor} from '../interfaces/editor'
+import {CORRECTIONS} from './corrections'
+
+const schema = compileSchema(defineSchema({}))
+
+type Fixture = Record<string, unknown>
+
+// Keep in sync with `normalize-corrections.equivalence.test.ts`'s
+// `createBareEditor`: this one skips `containers`, since none of the
+// fixtures here exercise container corrections.
+function createBareEditor(value: ReadonlyArray<Fixture>): Editor {
+  const editor = createEditor()
+
+  editor.containers = new Map()
+  editor.blockIndexMap = new Map()
+  editor.listIndexMap = new Map()
+  editor.verifiedUniqueChildGroups = new Set()
+  editor.snapshot = {
+    blockIndexMap: editor.blockIndexMap,
+    context: {
+      containers: new Map(),
+      converters: [],
+      keyGenerator: createTestKeyGenerator(),
+      readOnly: false,
+      schema,
+      selection: null,
+      value: value as unknown as Array<PortableTextBlock>,
+    },
+    decoratorState: {},
+  } as Editor['snapshot']
+
+  return editor
+}
+
+describe('CORRECTIONS', () => {
+  test('names and types match today\u2019s if-chain order exactly', () => {
+    expect(
+      CORRECTIONS.map((correction) => [correction.name, correction.type]),
+    ).toEqual([
+      ['root.no-blocks', 'structural'],
+      ['node.missing-type', 'structural'],
+      ['node.missing-key', 'structural'],
+      ['node.duplicate-sibling-key', 'structural'],
+      ['text-block.missing-mark-defs', 'cosmetic'],
+      ['text-block.missing-style', 'cosmetic'],
+      ['span.missing-text', 'structural'],
+      ['span.missing-marks', 'cosmetic'],
+      ['span.empty-with-annotations', 'cosmetic'],
+      ['text-block.duplicate-mark-defs', 'cosmetic'],
+      ['text-block.unused-mark-defs', 'cosmetic'],
+      ['container.missing-child-array', 'structural'],
+      ['container.duplicate-child-key', 'structural'],
+      ['text-block.children-not-array', 'structural'],
+      ['text-block.no-children', 'structural'],
+    ])
+  })
+})
+
+describe('scheduling', () => {
+  test('while processing remote changes, a cosmetic correction is skipped but a structural one still runs', () => {
+    const editor = createBareEditor([
+      {
+        // Missing `_key` (`node.missing-key`, structural) and missing
+        // `style` (`text-block.missing-style`, cosmetic) on the same node.
+        _type: 'block',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ])
+
+    editor.isProcessingRemoteChanges = true
+    normalize(editor, {force: true})
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ])
+  })
+
+  test('a group with a duplicate elsewhere is not cached, even when the node visited first is itself unique', () => {
+    const value = [
+      {
+        _type: 'block',
+        _key: 'dup',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'a', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'unique',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'b', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'dup',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's2', text: 'c', marks: []}],
+      },
+    ]
+    const editor = createBareEditor(value)
+
+    // Visit the unique node directly: `correct` scans the whole group, not
+    // just this node's own key, so it must see the duplicate at index 0/2
+    // and refuse to cache the group as verified-unique.
+    editor.normalizeNode([editor.snapshot.context.value[1]!, [1]])
+    expect(editor.verifiedUniqueChildGroups).toEqual(new Set())
+
+    // The duplicate must still get fixed on this later visit - a wrongly
+    // cached group above would make `tryCorrection` skip `correct` here too.
+    editor.normalizeNode([editor.snapshot.context.value[0]!, [0]])
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'dup',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: 'a', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'unique',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'b', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'k0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's2', text: 'c', marks: []}],
+      },
+    ])
+  })
+
+  test('a verified-unique group is cached, and a later visit to the group skips `correct` entirely', () => {
+    const value = [
+      {
+        _type: 'block',
+        _key: 'a',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'b',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: '', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'c',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's2', text: '', marks: []}],
+      },
+    ]
+    const editor = createBareEditor(value)
+
+    editor.normalizeNode([editor.snapshot.context.value[0]!, [0]])
+    expect(editor.verifiedUniqueChildGroups).toEqual(new Set(['']))
+
+    // Introduce a duplicate directly on the value, bypassing `editor.apply`
+    // (which would invalidate the cache entry). If the memo actually gates
+    // `correct`, this duplicate is never touched by the visit below.
+    ;(editor.snapshot.context.value[2] as {_key: string})._key = 'a'
+
+    editor.normalizeNode([editor.snapshot.context.value[2]!, [2]])
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'a',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'b',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: '', marks: []}],
+      },
+      {
+        _type: 'block',
+        _key: 'a',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's2', text: '', marks: []}],
+      },
+    ])
+  })
+})

--- a/packages/editor/src/engine/core/corrections.ts
+++ b/packages/editor/src/engine/core/corrections.ts
@@ -1,0 +1,779 @@
+import type {PortableTextObject} from '@portabletext/schema'
+import {isSpan, isTextBlock} from '@portabletext/schema'
+import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
+import {isEqualMarkDefs} from '../../internal-utils/equality'
+import {getChildFieldName} from '../../paths/get-child-field-name'
+import {serializePath} from '../../paths/serialize-path'
+import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
+import {getChildren} from '../../traversal/get-children'
+import {getNode} from '../../traversal/get-node'
+import {getParent} from '../../traversal/get-parent'
+import {getPathSubSchema} from '../../traversal/get-path-sub-schema'
+import {getTextBlock} from '../../traversal/get-text-block'
+import {isObject} from '../../traversal/is-object'
+import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
+import {isEditor} from '../editor/is-editor'
+import type {Editor} from '../interfaces/editor'
+import type {Node} from '../interfaces/node'
+import type {EngineOperation} from '../interfaces/operation'
+import type {Path} from '../interfaces/path'
+import {createSpanNode} from '../node/create-span-node'
+import {isSpanNode} from '../node/is-span-node'
+import {isTextBlockNode} from '../node/is-text-block-node'
+import {parentPath} from '../path/parent-path'
+
+/**
+ * The node a correction inspects, and the tools it needs to describe a
+ * repair. `node` is `Editor` only for the root (`path` empty) case; every
+ * other correction sees a plain content `Node`.
+ */
+export type CorrectionContext = {
+  editor: Editor
+  node: Editor | Node
+  path: Path
+}
+
+/**
+ * A repair that is pure given `CorrectionContext`: given the node at `path`,
+ * decide whether it is defective and, if so, describe the fix as a list of
+ * operations, without mutating anything the fix doesn't return. The one
+ * exception is `duplicateSiblingKey`, which writes `verifiedUniqueChildGroups`
+ * directly instead of returning it as an operation (see the inline
+ * justification on that write).
+ *
+ * `undefined` means "not my defect" - the executor tries the next
+ * correction. A non-empty array is the fix; the executor applies each
+ * operation in order and lets the fixed-point normalize loop re-enter, so a
+ * correction never needs to predict the tree shape its own fix produces.
+ */
+export type Correction = {
+  name: string
+  /**
+   * `structural` corrections repair invalid data shapes (a node the schema
+   * or engine cannot render at all) and always run. `cosmetic` corrections
+   * fill in optional defaults and are skipped while
+   * `editor.isProcessingRemoteChanges`, so adopting remote content doesn't
+   * fight the collaborator who is mid-edit on the same node.
+   */
+  type: 'structural' | 'cosmetic'
+  /**
+   * Applies the fix without emitting patches for it. Used only by
+   * `root.no-blocks`: the placeholder block is a local presentation detail,
+   * not a change the document's collaborators should see.
+   */
+  suppressPatches?: boolean
+  /**
+   * Identifies the sibling group this correction just verified, so the
+   * executor can skip re-invoking `correct` for the same group next time
+   * (see `verifiedUniqueChildGroups` on `Editor`). Returns `undefined` when
+   * the check is cheap enough that memoizing it isn't worth a cache entry.
+   */
+  memoKey?: (context: CorrectionContext) => string | undefined
+  correct: (context: CorrectionContext) => Array<EngineOperation> | undefined
+}
+
+function defineCorrection(correction: Correction): Correction {
+  return correction
+}
+
+/**
+ * Build the `set`/`unset` operation for a single property change, or
+ * `undefined` if `value` already matches what's on the node. Mirrors the
+ * single-property case of `setNodeProperties` (every correction here only
+ * ever changes one property at a time), returning the operation instead of
+ * applying it.
+ */
+function setPropertyOp(
+  node: Editor | Node,
+  path: Path,
+  key: string,
+  value: unknown,
+): EngineOperation | undefined {
+  const nodeRecord = node as Record<string, unknown>
+
+  // Unreachable at every current call site: each one passes either a
+  // freshly built array or a value already known to differ from what's on
+  // the node. Kept as a defensive no-op guard, mirroring `setNodeProperties`.
+  if (value === nodeRecord[key]) {
+    return undefined
+  }
+
+  if (value != null) {
+    const hadProperty = Object.prototype.hasOwnProperty.call(nodeRecord, key)
+    return {
+      type: 'set',
+      path: [...path, key],
+      value,
+      inverse: hadProperty
+        ? {type: 'set', path: [...path, key], value: nodeRecord[key]}
+        : {type: 'unset', path: [...path, key]},
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(nodeRecord, key)) {
+    return {
+      type: 'unset',
+      path: [...path, key],
+      inverse: {type: 'set', path: [...path, key], value: nodeRecord[key]},
+    }
+  }
+
+  return undefined
+}
+
+export const rootNoBlocks = defineCorrection({
+  name: 'root.no-blocks',
+  type: 'structural',
+  suppressPatches: true,
+  correct: ({node}) => {
+    if (!isEditor(node) || node.snapshot.context.value.length !== 0) {
+      return undefined
+    }
+
+    const placeholder = createPlaceholderBlock(node.snapshot)
+    const spanKey = (placeholder.children[0] as {_key: string})._key
+    const point = {
+      path: [{_key: placeholder._key}, 'children', {_key: spanKey}],
+      offset: 0,
+    }
+
+    return [
+      {type: 'insert', path: [0], node: placeholder, position: 'before'},
+      {
+        // Unconditional `properties: null` mirrors `applySelect`'s
+        // no-current-selection branch. This correction only runs once the
+        // value is empty, and whatever selection endpoint pointed into the
+        // now-gone last block was already nulled by the removal (see the
+        // transform-selection branch in `apply-operation.ts`), so there is
+        // never a prior selection to diff against here.
+        type: 'set.selection',
+        properties: null,
+        newProperties: {anchor: point, focus: point},
+      },
+    ]
+  },
+})
+
+const missingType = defineCorrection({
+  name: 'node.missing-type',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    const nodeRecord = node as Record<string, unknown>
+    if (nodeRecord['_type'] !== undefined || path.length === 0) {
+      return undefined
+    }
+
+    const parent = getNode(editor.snapshot, parentPath(path))
+
+    // Children of text blocks default to the span type.
+    if (
+      parent &&
+      isTextBlock({schema: editor.snapshot.context.schema}, parent.node)
+    ) {
+      return [
+        {
+          type: 'set',
+          path: [...path, '_type'],
+          value: editor.snapshot.context.schema.span.name,
+          inverse: {type: 'unset', path: [...path, '_type']},
+        },
+      ]
+    }
+
+    // Everything else defaults to the text block type.
+    return [
+      {
+        type: 'set',
+        path: [...path, '_type'],
+        value: editor.snapshot.context.schema.block.name,
+        inverse: {type: 'unset', path: [...path, '_type']},
+      },
+    ]
+  },
+})
+
+const missingKey = defineCorrection({
+  name: 'node.missing-key',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    const nodeRecord = node as Record<string, unknown>
+    if (nodeRecord['_key'] !== undefined || path.length === 0) {
+      return undefined
+    }
+
+    const newKey = editor.snapshot.context.keyGenerator()
+
+    // Build a fully resolved path by walking the tree from the root,
+    // replacing any undefined keyed segments with numeric indices.
+    const numericPath: Path = []
+    let currentNode: Node | undefined
+
+    for (const segment of path) {
+      if (typeof segment === 'string') {
+        // Field name: descend into the field
+        if (currentNode) {
+          numericPath.push(segment)
+        }
+        continue
+      }
+
+      // Determine the siblings array at this level
+      const siblings: ArrayLike<Node> = currentNode
+        ? (((currentNode as Record<string, unknown>)[
+            numericPath[numericPath.length - 1] as string
+          ] as ArrayLike<Node>) ?? [])
+        : editor.snapshot.context.value
+
+      if (isKeyedSegment(segment) && segment._key !== undefined) {
+        numericPath.push(segment)
+        currentNode = Array.prototype.find.call(
+          siblings,
+          (child: Node) => child._key === segment._key,
+        )
+      } else {
+        // Undefined _key or numeric: resolve to numeric index
+        let index = typeof segment === 'number' ? segment : -1
+        if (index === -1) {
+          for (let i = 0; i < siblings.length; i++) {
+            if ((siblings[i] as Node)._key === undefined) {
+              index = i
+              break
+            }
+          }
+        }
+        if (index !== -1) {
+          numericPath.push(index)
+          currentNode = siblings[index] as Node
+        }
+      }
+    }
+
+    return [
+      {
+        type: 'set',
+        path: [...numericPath, '_key'],
+        value: newKey,
+        inverse: {type: 'unset', path: [...numericPath, '_key']},
+      },
+    ]
+  },
+})
+
+type SiblingGroup = {
+  groupId: string
+  siblingNodes: ReadonlyArray<{_key?: string}>
+  parentNodePath: Path | undefined
+  childFieldName: string | undefined
+  key: string
+}
+
+/**
+ * Resolve the sibling group a node belongs to, or `undefined` when the
+ * group can't hold a duplicate (missing key, root node, or a group of zero
+ * or one child - the common shape for container fields and single-span
+ * text blocks). Shared by `duplicateSiblingKey`'s `correct` and `memoKey` so
+ * both agree on exactly which groups are cacheable.
+ */
+function resolveSiblingGroup(
+  context: CorrectionContext,
+): SiblingGroup | undefined {
+  const {editor, node, path} = context
+  const nodeRecord = node as Record<string, unknown>
+
+  if (path.length === 0 || nodeRecord['_key'] === undefined) {
+    return undefined
+  }
+
+  const parent = getParent(editor.snapshot, path)
+  const key = nodeRecord['_key'] as string
+  // The child array holding this node is the field segment right after
+  // the parent's path. Read it straight off the parent node rather than
+  // re-resolving children from the root through the schema; fall back to
+  // `getChildren` only if that field isn't a plain array.
+  const childFieldName = parent
+    ? (path[parent.path.length] as string)
+    : undefined
+  const rawSiblings =
+    parent && typeof childFieldName === 'string'
+      ? (parent.node as Record<string, unknown>)[childFieldName]
+      : undefined
+  const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
+    ? editor.snapshot.context.value
+    : Array.isArray(rawSiblings)
+      ? (rawSiblings as ReadonlyArray<{_key?: string}>)
+      : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
+
+  if (siblingNodes.length <= 1) {
+    return undefined
+  }
+
+  // Identify the group by its serialized path (the root group is `''`).
+  const groupId =
+    parent && typeof childFieldName === 'string'
+      ? serializePath([...parent.path, childFieldName])
+      : ''
+
+  return {
+    groupId,
+    siblingNodes,
+    parentNodePath: parent?.path,
+    childFieldName,
+    key,
+  }
+}
+
+const duplicateSiblingKey = defineCorrection({
+  name: 'node.duplicate-sibling-key',
+  type: 'structural',
+  memoKey: (context) => resolveSiblingGroup(context)?.groupId,
+  correct: (context) => {
+    const group = resolveSiblingGroup(context)
+    if (!group) {
+      return undefined
+    }
+
+    const {editor} = context
+    const {groupId, siblingNodes, parentNodePath, childFieldName, key} = group
+
+    const seenKeys = new Set<string>()
+    let groupIsUnique = true
+    let duplicateIndexOfKey = -1
+
+    for (let index = 0; index < siblingNodes.length; index++) {
+      const siblingKey = siblingNodes[index]?._key
+      if (siblingKey === undefined) {
+        continue
+      }
+      if (seenKeys.has(siblingKey)) {
+        groupIsUnique = false
+        // The second occurrence of this node's own key is the one the
+        // previous per-node implementation renamed; preserve that so
+        // generated keys land on the same node.
+        if (siblingKey === key && duplicateIndexOfKey === -1) {
+          duplicateIndexOfKey = index
+        }
+      } else {
+        seenKeys.add(siblingKey)
+      }
+    }
+
+    if (duplicateIndexOfKey !== -1) {
+      const newKey = editor.snapshot.context.keyGenerator()
+      const numericPath: Path =
+        parentNodePath && typeof childFieldName === 'string'
+          ? [...parentNodePath, childFieldName, duplicateIndexOfKey]
+          : [duplicateIndexOfKey]
+      return [
+        {
+          type: 'set',
+          path: [...numericPath, '_key'],
+          value: newKey,
+          inverse: {
+            type: 'set',
+            path: [...numericPath, '_key'],
+            value: key,
+          },
+        },
+      ]
+    }
+
+    // Verifying a group is O(siblings); caching the verdict keeps a bulk
+    // insert of n pre-keyed siblings at O(n) instead of O(n^2). Written
+    // here (not by the executor off a bare `undefined` return) because
+    // only the full scan above knows the group is actually unique: a node
+    // whose own key isn't part of any duplicate also returns `undefined`
+    // while `groupIsUnique` is false, and caching that would hide a real
+    // duplicate elsewhere in the group from later visits.
+    if (groupIsUnique) {
+      editor.verifiedUniqueChildGroups.add(groupId)
+    }
+
+    return undefined
+  },
+})
+
+const missingMarkDefs = defineCorrection({
+  name: 'text-block.missing-mark-defs',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+      Array.isArray(node.markDefs)
+    ) {
+      return undefined
+    }
+
+    const op = setPropertyOp(node, path, 'markDefs', [])
+    return op ? [op] : undefined
+  },
+})
+
+const missingStyle = defineCorrection({
+  name: 'text-block.missing-style',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+      typeof node.style !== 'undefined'
+    ) {
+      return undefined
+    }
+
+    const defaultStyle = getPathSubSchema(editor.snapshot, path).styles.at(
+      0,
+    )?.name
+    if (!defaultStyle) {
+      return undefined
+    }
+
+    const op = setPropertyOp(node, path, 'style', defaultStyle)
+    return op ? [op] : undefined
+  },
+})
+
+const spanMissingText = defineCorrection({
+  name: 'span.missing-text',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    if (
+      !isSpanNode(editor.snapshot.context, node) ||
+      typeof node.text === 'string'
+    ) {
+      return undefined
+    }
+
+    return [
+      {
+        type: 'set',
+        path: [...path, 'text'],
+        value: '',
+        inverse: {type: 'unset', path: [...path, 'text']},
+      },
+    ]
+  },
+})
+
+const spanMissingMarks = defineCorrection({
+  name: 'span.missing-marks',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (
+      !isSpan({schema: editor.snapshot.context.schema}, node) ||
+      Array.isArray(node.marks)
+    ) {
+      return undefined
+    }
+
+    const op = setPropertyOp(node, path, 'marks', [])
+    return op ? [op] : undefined
+  },
+})
+
+const spanEmptyWithAnnotations = defineCorrection({
+  name: 'span.empty-with-annotations',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (!isSpan({schema: editor.snapshot.context.schema}, node)) {
+      return undefined
+    }
+
+    const blockPath = parentPath(path)
+    const blockEntry = getTextBlock(editor.snapshot, blockPath)
+    if (!blockEntry) {
+      return undefined
+    }
+
+    // Only treat a mark as an annotation if it points to one of the
+    // block's `markDefs`. A mark that doesn't resolve might be a decorator
+    // from another schema (one that was removed here, or one a collaborator
+    // has that we don't), so it is left alone.
+    const annotations = node.marks?.filter((mark) =>
+      blockEntry.node.markDefs?.some((markDef) => markDef._key === mark),
+    )
+
+    if (node.text !== '' || !annotations || annotations.length === 0) {
+      return undefined
+    }
+
+    const op = setPropertyOp(
+      node,
+      path,
+      'marks',
+      node.marks?.filter((mark) => !annotations.includes(mark)),
+    )
+    return op ? [op] : undefined
+  },
+})
+
+const duplicateMarkDefs = defineCorrection({
+  name: 'text-block.duplicate-mark-defs',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (!isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+      return undefined
+    }
+
+    const markDefs = node.markDefs ?? []
+    const markDefKeys = new Set<string>()
+    const newMarkDefs: Array<PortableTextObject> = []
+
+    for (const markDef of markDefs) {
+      if (!markDefKeys.has(markDef._key)) {
+        markDefKeys.add(markDef._key)
+        newMarkDefs.push(markDef)
+      }
+    }
+
+    if (markDefs.length === newMarkDefs.length) {
+      return undefined
+    }
+
+    const op = setPropertyOp(node, path, 'markDefs', newMarkDefs)
+    return op ? [op] : undefined
+  },
+})
+
+const unusedMarkDefs = defineCorrection({
+  name: 'text-block.unused-mark-defs',
+  type: 'cosmetic',
+  correct: ({editor, node, path}) => {
+    if (!isTextBlock({schema: editor.snapshot.context.schema}, node)) {
+      return undefined
+    }
+
+    const newMarkDefs = (node.markDefs || []).filter((def) => {
+      return node.children.find((child) => {
+        return (
+          isSpan({schema: editor.snapshot.context.schema}, child) &&
+          Array.isArray(child.marks) &&
+          child.marks.includes(def._key)
+        )
+      })
+    })
+
+    if (!node.markDefs || isEqualMarkDefs(newMarkDefs, node.markDefs)) {
+      return undefined
+    }
+
+    const op = setPropertyOp(node, path, 'markDefs', newMarkDefs)
+    return op ? [op] : undefined
+  },
+})
+
+const containerMissingChildArray = defineCorrection({
+  name: 'container.missing-child-array',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    if (!isObject(editor.snapshot, node)) {
+      return undefined
+    }
+
+    const resolved = resolveContainerByPath(
+      {
+        containers: editor.containers,
+        schema: editor.snapshot.context.schema,
+        value: editor.snapshot.context.value,
+      },
+      path,
+      node,
+    )
+    const arrayField =
+      resolved && 'container' in resolved ? resolved.field : undefined
+
+    if (!arrayField) {
+      return undefined
+    }
+
+    const fieldValue = (node as Record<string, unknown>)[arrayField.name]
+    const needsField = !Array.isArray(fieldValue)
+    const needsChild = needsField || fieldValue.length === 0
+
+    if (!needsChild) {
+      return undefined
+    }
+
+    const acceptsBlocks = arrayField.of.some(
+      (definition) => definition.type === 'block',
+    )
+    const firstChildType = arrayField.of.at(0)
+
+    let childNode: Node | undefined
+    if (acceptsBlocks) {
+      childNode = createPlaceholderBlock(editor.snapshot, [
+        ...path,
+        arrayField.name,
+        0,
+      ])
+    } else if (firstChildType && firstChildType.type !== 'block') {
+      // For inline declarations (`type: 'object'`), the actual type
+      // identity is in `name`. For bare references (any other `type`),
+      // the type itself is the identity.
+      const childTypeName =
+        firstChildType.type === 'object' && 'name' in firstChildType
+          ? firstChildType.name
+          : firstChildType.type
+      childNode = {
+        _type: childTypeName,
+        _key: editor.snapshot.context.keyGenerator(),
+      } as Node
+    }
+
+    if (needsField && childNode) {
+      // Set the field with its initial child in a single operation
+      // instead of two (set empty array + insert child).
+      const op = setPropertyOp(node, path, arrayField.name, [childNode])
+      return op ? [op] : undefined
+    }
+
+    if (needsField) {
+      const op = setPropertyOp(node, path, arrayField.name, [])
+      return op ? [op] : undefined
+    }
+
+    if (childNode) {
+      return [
+        {
+          type: 'insert',
+          path: [...path, arrayField.name, 0],
+          node: childNode,
+          position: 'before',
+        },
+      ]
+    }
+
+    return undefined
+  },
+})
+
+const containerDuplicateChildKey = defineCorrection({
+  name: 'container.duplicate-child-key',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    // The sibling-level correction above catches duplicates when each
+    // child is visited individually, but container children may not be
+    // visited if containers gates traversal. Handle it at the parent
+    // level as well.
+    if (!isObject(editor.snapshot, node)) {
+      return undefined
+    }
+
+    const children = [...getChildren(editor.snapshot, path)]
+
+    if (children.length <= 1) {
+      return undefined
+    }
+
+    const seen = new Map<string, number>()
+
+    for (let i = 0; i < children.length; i++) {
+      const key = children[i]!.node._key
+      if (key !== undefined && seen.has(key)) {
+        const newKey = editor.snapshot.context.keyGenerator()
+        // Use numeric index to address the duplicate since keyed path
+        // is ambiguous for nodes with the same key.
+        const arrayFieldName = getChildFieldName(editor.snapshot.context, path)
+        if (arrayFieldName) {
+          return [
+            {
+              type: 'set',
+              path: [...path, arrayFieldName, i, '_key'],
+              value: newKey,
+              inverse: {
+                type: 'set',
+                path: [...path, arrayFieldName, i, '_key'],
+                value: key,
+              },
+            },
+          ]
+        }
+      }
+      if (key !== undefined) {
+        seen.set(key, i)
+      }
+    }
+
+    return undefined
+  },
+})
+
+const textBlockChildrenNotArray = defineCorrection({
+  name: 'text-block.children-not-array',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    if (
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+      Array.isArray(node.children)
+    ) {
+      return undefined
+    }
+
+    // Runtime data can arrive without children (e.g. after an unset patch).
+    return [
+      {
+        type: 'set',
+        path: [...path, 'children'],
+        value: [],
+        inverse: {type: 'unset', path: [...path, 'children']},
+      },
+    ]
+  },
+})
+
+const textBlockNoChildren = defineCorrection({
+  name: 'text-block.no-children',
+  type: 'structural',
+  correct: ({editor, node, path}) => {
+    if (
+      !isTextBlockNode({schema: editor.snapshot.context.schema}, node) ||
+      !Array.isArray(node.children) ||
+      node.children.length !== 0
+    ) {
+      return undefined
+    }
+
+    // Only the span insert is returned here; the rest of what the old
+    // per-child loop did for a freshly-seeded block (merges, bracketing)
+    // falls out of the fixed-point re-entry that follows this insert.
+    const child = createSpanNode(editor.snapshot.context)
+    return [
+      {
+        type: 'insert',
+        path: [...path, 'children', 0],
+        node: child,
+        position: 'before',
+      },
+    ]
+  },
+})
+
+/**
+ * All node-shape repairs `normalizeNode` runs, in the order the executor
+ * tries them. Two repairs stay imperative in `normalize-node.ts` instead of
+ * appearing here: the same-marks span merge, because it needs
+ * `applyMergeNode`, which isn't expressible as a plain `EngineOperation`
+ * list yet; and the late per-child merge/bracket loop, because it mutates
+ * and refetches the block node mid-loop, which the fixed-point re-entry
+ * model doesn't support - only that loop's merge/drop arm shares the
+ * `applyMergeNode` dependency (see the keep-in-sync comments there).
+ *
+ * `rootNoBlocks` is also exported on its own: the executor runs it before
+ * the imperative merge step, and takes the rest of the loop order from
+ * `CORRECTIONS.slice(1)`.
+ */
+export const CORRECTIONS: ReadonlyArray<Correction> = [
+  rootNoBlocks,
+  missingType,
+  missingKey,
+  duplicateSiblingKey,
+  missingMarkDefs,
+  missingStyle,
+  spanMissingText,
+  spanMissingMarks,
+  spanEmptyWithAnnotations,
+  duplicateMarkDefs,
+  unusedMarkDefs,
+  containerMissingChildArray,
+  containerDuplicateChildKey,
+  textBlockChildrenNotArray,
+  textBlockNoChildren,
+]

--- a/packages/editor/src/engine/core/normalize-corrections.equivalence.test.ts
+++ b/packages/editor/src/engine/core/normalize-corrections.equivalence.test.ts
@@ -1,0 +1,2346 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test} from 'vitest'
+import type {Container} from '../../renderers/renderer.types'
+import {
+  resolveContainers,
+  resolveContainersRich,
+} from '../../schema/resolve-containers'
+import {createEditor} from '../create-editor'
+import {normalize} from '../editor/normalize'
+import type {Editor} from '../interfaces/editor'
+import type {EngineOperation} from '../interfaces/operation'
+import {subscribeToOperations} from './operation-channel'
+
+const schema = compileSchema(
+  defineSchema({
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    inlineObjects: [{name: 'stock-ticker'}],
+    blockObjects: [
+      {name: 'image'},
+      {
+        name: 'gallery',
+        fields: [{name: 'items', type: 'array', of: [{type: 'block'}]}],
+      },
+      {
+        name: 'note-board',
+        fields: [
+          {
+            name: 'notes',
+            type: 'array',
+            of: [{type: 'object', name: 'note', fields: []}],
+          },
+        ],
+      },
+    ],
+  }),
+)
+
+const rawContainers: ReadonlyArray<Container> = [
+  {kind: 'container', type: 'gallery', arrayField: 'items'},
+  {kind: 'container', type: 'note-board', arrayField: 'notes'},
+]
+
+/**
+ * Fixtures deliberately violate `PortableTextBlock` (missing `_key`,
+ * `_type`, `children` as a non-array, ...) - that's the runtime data these
+ * corrections exist to repair. `Fixture` is the honest type for them; the
+ * single cast at the editor boundary below is the only place that lies
+ * about it.
+ */
+type Fixture = Record<string, unknown>
+
+// Keep in sync with `corrections.test.ts`'s `createBareEditor`: this one
+// additionally wires up `containers` for the container-correction fixtures
+// above, which that file's schema doesn't need.
+function createBareEditor(value: ReadonlyArray<Fixture>): Editor {
+  const keyGenerator = createTestKeyGenerator()
+  const editor = createEditor()
+  editor.containers = resolveContainersRich(schema, rawContainers)
+  editor.blockIndexMap = new Map()
+  editor.listIndexMap = new Map()
+  editor.verifiedUniqueChildGroups = new Set()
+  editor.snapshot = {
+    blockIndexMap: editor.blockIndexMap,
+    context: {
+      containers: resolveContainers(schema, rawContainers),
+      converters: [],
+      keyGenerator,
+      readOnly: false,
+      schema,
+      value: value as unknown as Array<PortableTextBlock>,
+      selection: null,
+    },
+    decoratorState: {},
+  } as Editor['snapshot']
+  return editor
+}
+
+function runNormalize(
+  value: ReadonlyArray<Fixture>,
+  options: {remote?: boolean} = {},
+) {
+  const editor = createBareEditor(structuredClone(value))
+  const operations: Array<EngineOperation> = []
+  subscribeToOperations(editor, (event) => operations.push(event.operation))
+  if (options.remote) {
+    editor.isProcessingRemoteChanges = true
+  }
+  normalize(editor, {force: true})
+  return {operations, value: editor.snapshot.context.value}
+}
+
+describe('normalize-node corrections equivalence', () => {
+  test('empty editor gets a placeholder block', () => {
+    // `root.no-blocks` is reactive, not a static defect a force-normalize
+    // scan discovers: an editor whose value starts at `[]` has no nodes
+    // for `getNodes` to seed `dirtyPaths` from (see `normalize.ts`'s
+    // `force` branch), so force-normalizing an already-empty value is a
+    // no-op. The real trigger is an operation that empties a
+    // previously-nonempty value, dirtying the root path. Removing the
+    // only block reproduces that.
+    const editor = createBareEditor([
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+      },
+    ])
+    const operations: Array<EngineOperation> = []
+    subscribeToOperations(editor, (event) => operations.push(event.operation))
+
+    editor.apply({type: 'unset', path: [{_key: 'b0'}]})
+
+    // `after` listeners observe a normalization fix's events before the
+    // triggering operation's own `after` event (see `operation-channel.ts`),
+    // so the reactive placeholder insert and selection nest ahead of the
+    // `unset` that triggered them.
+    expect(operations).toEqual([
+      {
+        type: 'insert',
+        path: [0],
+        position: 'before',
+        node: {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+        },
+        inverse: {type: 'unset', path: [{_key: 'k0'}]},
+      },
+      {
+        type: 'set.selection',
+        properties: null,
+        newProperties: {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        },
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b0'}],
+        inverse: {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          node: {
+            _type: 'block',
+            _key: 'b0',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+          },
+        },
+      },
+    ])
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+      },
+    ])
+  })
+
+  test('empty editor gets a placeholder block while processing remote changes', () => {
+    // `root.no-blocks` is `structural`, so unlike the cosmetic corrections
+    // it must still fire here: an editor left with zero blocks has nothing
+    // to render regardless of who emptied it.
+    const editor = createBareEditor([
+      {
+        _type: 'block',
+        _key: 'b0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's0', text: '', marks: []}],
+      },
+    ])
+    editor.isProcessingRemoteChanges = true
+    const operations: Array<EngineOperation> = []
+    subscribeToOperations(editor, (event) => operations.push(event.operation))
+
+    editor.apply({type: 'unset', path: [{_key: 'b0'}]})
+
+    // `apply-operation.ts` only fills in an operation's `inverse` when
+    // `!editor.isProcessingRemoteChanges` - remote-origin changes don't
+    // need a locally-computed undo step - so every recorded op here is
+    // missing the `inverse` its local counterpart above has.
+    expect(operations).toEqual([
+      {
+        type: 'insert',
+        path: [0],
+        position: 'before',
+        node: {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+        },
+      },
+      {
+        type: 'set.selection',
+        properties: null,
+        newProperties: {
+          anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+          focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        },
+      },
+      {
+        type: 'unset',
+        path: [{_key: 'b0'}],
+      },
+    ])
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+      },
+    ])
+  })
+
+  test('adjacent empty spans (several in a row)', () => {
+    const value = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: []},
+          {_type: 'span', _key: 's2', text: '', marks: []},
+          {_type: 'span', _key: 's3', text: '', marks: []},
+          {_type: 'span', _key: 's4', text: '', marks: []},
+          {_type: 'span', _key: 's5', text: 'b', marks: []},
+        ],
+      },
+    ]
+    expect(runNormalize(value).operations).toEqual([
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's2',
+            text: '',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's3',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's3',
+            text: '',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's4',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's4',
+            text: '',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 1,
+        text: 'b',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's5',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's5',
+            text: 'b',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+    ]) // adjacent-empty-spans (local)
+    expect(runNormalize(value, {remote: true}).operations).toEqual([]) // adjacent-empty-spans (remote)
+  })
+
+  test('deep-equal span runs N=4', () => {
+    const value = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: ['strong']},
+          {_type: 'span', _key: 's2', text: 'b', marks: ['strong']},
+          {_type: 'span', _key: 's3', text: 'c', marks: ['strong']},
+          {_type: 'span', _key: 's4', text: 'd', marks: ['strong']},
+        ],
+      },
+    ]
+    expect(runNormalize(value).operations).toEqual([
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 1,
+        text: 'b',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's2',
+            text: 'b',
+            marks: ['strong'],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 2,
+        text: 'c',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's3',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's3',
+            text: 'c',
+            marks: ['strong'],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 3,
+        text: 'd',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's4',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's4',
+            text: 'd',
+            marks: ['strong'],
+          },
+          position: 'after',
+        },
+      },
+    ]) // deep-equal-span-runs (local)
+    expect(runNormalize(value, {remote: true}).operations).toEqual([]) // deep-equal-span-runs (remote)
+  })
+
+  test('spans differing only in marks order', () => {
+    const value = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: ['strong', 'em']},
+          {_type: 'span', _key: 's2', text: 'b', marks: ['em', 'strong']},
+        ],
+      },
+    ]
+    expect(runNormalize(value).operations).toEqual([
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 1,
+        text: 'b',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's2',
+            text: 'b',
+            marks: ['em', 'strong'],
+          },
+          position: 'after',
+        },
+      },
+    ]) // marks-order (local)
+    expect(runNormalize(value, {remote: true}).operations).toEqual([]) // marks-order (remote)
+  })
+
+  test('inline objects leading/trailing/adjacent/lone', () => {
+    const leading = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'stock-ticker', _key: 'o1'},
+          {_type: 'span', _key: 's1', text: 'a', marks: []},
+        ],
+      },
+    ]
+    expect(runNormalize(leading).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // inline-object-leading (local)
+    expect(runNormalize(leading, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+      },
+    ]) // inline-object-leading (remote)
+
+    const trailing = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: []},
+          {_type: 'stock-ticker', _key: 'o1'},
+        ],
+      },
+    ]
+    expect(runNormalize(trailing).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'after',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // inline-object-trailing (local)
+    expect(runNormalize(trailing, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'after',
+      },
+    ]) // inline-object-trailing (remote)
+
+    const adjacent = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: []},
+          {_type: 'stock-ticker', _key: 'o1'},
+          {_type: 'stock-ticker', _key: 'o2'},
+          {_type: 'span', _key: 's2', text: 'b', marks: []},
+        ],
+      },
+    ]
+    expect(runNormalize(adjacent).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o2',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // inline-object-adjacent (local)
+    expect(runNormalize(adjacent, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o2',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+      },
+    ]) // inline-object-adjacent (remote)
+
+    const lone = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'stock-ticker', _key: 'o1'}],
+      },
+    ]
+    expect(runNormalize(lone).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k1',
+          text: '',
+          marks: [],
+        },
+        position: 'after',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k1',
+            },
+          ],
+        },
+      },
+    ]) // inline-object-lone (local)
+    expect(runNormalize(lone, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+      },
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'o1',
+          },
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k1',
+          text: '',
+          marks: [],
+        },
+        position: 'after',
+      },
+    ]) // inline-object-lone (remote)
+  })
+
+  test('missing key/type', () => {
+    const missingBlockKey = [
+      {
+        _type: 'block',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingBlockKey).operations).toEqual([
+      {
+        type: 'set',
+        path: [0, '_key'],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [0, '_key'],
+        },
+      },
+    ]) // missing-block-key (local)
+    expect(runNormalize(missingBlockKey, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [0, '_key'],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [0, '_key'],
+        },
+      },
+    ]) // missing-block-key (remote)
+
+    const missingChildKey = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingChildKey).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            0,
+            '_key',
+          ],
+        },
+      },
+    ]) // missing-child-key (local)
+    expect(runNormalize(missingChildKey, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            0,
+            '_key',
+          ],
+        },
+      },
+    ]) // missing-child-key (remote)
+
+    const missingBlockType = [
+      {
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingBlockType).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          '_type',
+        ],
+        value: 'block',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            '_type',
+          ],
+        },
+      },
+    ]) // missing-block-type (local)
+    expect(runNormalize(missingBlockType, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          '_type',
+        ],
+        value: 'block',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            '_type',
+          ],
+        },
+      },
+    ]) // missing-block-type (remote)
+
+    const missingChildType = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_key: 's1', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingChildType).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          '_type',
+        ],
+        value: 'span',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            '_type',
+          ],
+        },
+      },
+    ]) // missing-child-type (local)
+    expect(runNormalize(missingChildType, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          '_type',
+        ],
+        value: 'span',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            '_type',
+          ],
+        },
+      },
+    ]) // missing-child-type (remote)
+  })
+
+  test('duplicate sibling keys, duplicate container-child keys', () => {
+    const dupSibling = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a', marks: []},
+          {_type: 'span', _key: 's1', text: 'b', marks: []},
+        ],
+      },
+    ]
+    expect(runNormalize(dupSibling).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          1,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            1,
+            '_key',
+          ],
+          value: 's1',
+        },
+      },
+      {
+        type: 'insert.text',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+        ],
+        offset: 1,
+        text: 'b',
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 'k0',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 'k0',
+            text: 'b',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+    ]) // duplicate-sibling-key (local)
+    expect(runNormalize(dupSibling, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          1,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            1,
+            '_key',
+          ],
+          value: 's1',
+        },
+      },
+    ]) // duplicate-sibling-key (remote)
+
+    const dupContainerChild = [
+      {
+        _type: 'gallery',
+        _key: 'g1',
+        items: [
+          {
+            _type: 'block',
+            _key: 'gb1',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 'gs1', text: 'a', marks: []}],
+          },
+          {
+            _type: 'block',
+            _key: 'gb1',
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: 'gs2', text: 'b', marks: []}],
+          },
+        ],
+      },
+    ]
+    expect(runNormalize(dupContainerChild).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+          1,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'g1',
+            },
+            'items',
+            1,
+            '_key',
+          ],
+          value: 'gb1',
+        },
+      },
+    ]) // duplicate-container-child-key (local)
+    expect(runNormalize(dupContainerChild, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+          1,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'g1',
+            },
+            'items',
+            1,
+            '_key',
+          ],
+          value: 'gb1',
+        },
+      },
+    ]) // duplicate-container-child-key (remote)
+  })
+
+  test('missing style/marks/markDefs/text, children non-array/empty', () => {
+    const missingMarkDefs = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingMarkDefs).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+        },
+      },
+    ]) // missing-mark-defs (local)
+    expect(runNormalize(missingMarkDefs, {remote: true}).operations).toEqual([]) // missing-mark-defs (remote)
+
+    const missingStyle = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingStyle).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'style',
+        ],
+        value: 'normal',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'style',
+          ],
+        },
+      },
+    ]) // missing-style (local)
+    expect(runNormalize(missingStyle, {remote: true}).operations).toEqual([]) // missing-style (remote)
+
+    const missingMarks = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', text: 'a'}],
+      },
+    ]
+    expect(runNormalize(missingMarks).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          'marks',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            'marks',
+          ],
+        },
+      },
+    ]) // missing-marks (local)
+    expect(runNormalize(missingMarks, {remote: true}).operations).toEqual([]) // missing-marks (remote)
+
+    const missingText = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', marks: []}],
+      },
+    ]
+    expect(runNormalize(missingText).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          'text',
+        ],
+        value: '',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            'text',
+          ],
+        },
+      },
+    ]) // missing-text (local)
+    expect(runNormalize(missingText, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          'text',
+        ],
+        value: '',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            'text',
+          ],
+        },
+      },
+    ]) // missing-text (remote)
+
+    const childrenNonArray = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: 'not-an-array',
+      },
+    ]
+    expect(runNormalize(childrenNonArray).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+          ],
+        },
+      },
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // children-non-array (local)
+    expect(runNormalize(childrenNonArray, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+          ],
+        },
+      },
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+      },
+    ]) // children-non-array (remote)
+
+    const childrenEmpty = [
+      {_type: 'block', _key: 'b1', style: 'normal', markDefs: [], children: []},
+    ]
+    expect(runNormalize(childrenEmpty).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // children-empty (local)
+    expect(runNormalize(childrenEmpty, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+      },
+    ]) // children-empty (remote)
+  })
+
+  test('unused + duplicate markDefs, annotations on empty span', () => {
+    const link1 = {_key: 'm1', _type: 'link', href: 'https://a'}
+    const link2 = {_key: 'm2', _type: 'link', href: 'https://b'}
+    const dupMarkDefs = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [link1, {...link1}],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: ['m1']}],
+      },
+    ]
+    expect(runNormalize(dupMarkDefs).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [
+          {
+            _key: 'm1',
+            _type: 'link',
+            href: 'https://a',
+          },
+        ],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+          value: [
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'https://a',
+            },
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'https://a',
+            },
+          ],
+        },
+      },
+    ]) // duplicate-mark-defs (local)
+    expect(runNormalize(dupMarkDefs, {remote: true}).operations).toEqual([]) // duplicate-mark-defs (remote)
+
+    const unusedMarkDefs = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [link1, link2],
+        children: [{_type: 'span', _key: 's1', text: 'a', marks: ['m1']}],
+      },
+    ]
+    expect(runNormalize(unusedMarkDefs).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [
+          {
+            _key: 'm1',
+            _type: 'link',
+            href: 'https://a',
+          },
+        ],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+          value: [
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'https://a',
+            },
+            {
+              _key: 'm2',
+              _type: 'link',
+              href: 'https://b',
+            },
+          ],
+        },
+      },
+    ]) // unused-mark-defs (local)
+    expect(runNormalize(unusedMarkDefs, {remote: true}).operations).toEqual([]) // unused-mark-defs (remote)
+
+    const annotationsOnEmptySpan = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [link1],
+        children: [{_type: 'span', _key: 's1', text: '', marks: ['m1']}],
+      },
+    ]
+    expect(runNormalize(annotationsOnEmptySpan).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          'marks',
+        ],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            'marks',
+          ],
+          value: ['m1'],
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+          value: [
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'https://a',
+            },
+          ],
+        },
+      },
+    ]) // annotations-on-empty-span (local)
+    expect(
+      runNormalize(annotationsOnEmptySpan, {remote: true}).operations,
+    ).toEqual([]) // annotations-on-empty-span (remote)
+  })
+
+  test('container missing child array', () => {
+    const containerEmpty = [{_type: 'gallery', _key: 'g1', items: []}]
+    expect(runNormalize(containerEmpty).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+          0,
+        ],
+        node: {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: '',
+              marks: [],
+            },
+          ],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'g1',
+            },
+            'items',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // container-missing-child-array-empty (local)
+    expect(runNormalize(containerEmpty, {remote: true}).operations).toEqual([
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+          0,
+        ],
+        node: {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: '',
+              marks: [],
+            },
+          ],
+        },
+        position: 'before',
+      },
+    ]) // container-missing-child-array-empty (remote)
+
+    const containerNoField = [{_type: 'gallery', _key: 'g1'}]
+    expect(runNormalize(containerNoField).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+        ],
+        value: [
+          {
+            _type: 'block',
+            _key: 'k0',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {
+                _type: 'span',
+                _key: 'k1',
+                text: '',
+                marks: [],
+              },
+            ],
+          },
+        ],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'g1',
+            },
+            'items',
+          ],
+        },
+      },
+    ]) // container-missing-child-array-no-field (local)
+    expect(runNormalize(containerNoField, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'g1',
+          },
+          'items',
+        ],
+        value: [
+          {
+            _type: 'block',
+            _key: 'k0',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {
+                _type: 'span',
+                _key: 'k1',
+                text: '',
+                marks: [],
+              },
+            ],
+          },
+        ],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'g1',
+            },
+            'items',
+          ],
+        },
+      },
+    ]) // container-missing-child-array-no-field (remote)
+  })
+
+  test('container missing child array, non-block child type', () => {
+    // `note-board`'s `notes` field only accepts `note` (an inline object,
+    // not `block`), exercising the correction's other child-creation
+    // branch: a bare `{_type, _key}` object instead of a placeholder block.
+    const noteBoardEmpty = [{_type: 'note-board', _key: 'nb1', notes: []}]
+    expect(runNormalize(noteBoardEmpty).operations).toEqual([
+      {
+        type: 'insert',
+        path: [{_key: 'nb1'}, 'notes', 0],
+        node: {_type: 'note', _key: 'k0'},
+        position: 'before',
+        inverse: {type: 'unset', path: [{_key: 'nb1'}, 'notes', {_key: 'k0'}]},
+      },
+    ])
+  })
+
+  test('composite fixture tripping several rules', () => {
+    const composite = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        markDefs: [],
+        children: [
+          {_type: 'span', text: 'a', marks: []},
+          {_type: 'span', _key: 's2', text: '', marks: []},
+        ],
+      },
+    ]
+    expect(runNormalize(composite).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            0,
+            '_key',
+          ],
+        },
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's2',
+            text: '',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'style',
+        ],
+        value: 'normal',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'style',
+          ],
+        },
+      },
+    ]) // composite (local)
+    expect(runNormalize(composite, {remote: true}).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+          '_key',
+        ],
+        value: 'k0',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            0,
+            '_key',
+          ],
+        },
+      },
+    ]) // composite (remote)
+  })
+
+  test('worst-case convergence', () => {
+    const worst = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'normal',
+        markDefs: [],
+        children: 'not-an-array',
+      },
+    ]
+    expect(runNormalize(worst).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+          ],
+        },
+      },
+      {
+        type: 'insert',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          0,
+        ],
+        node: {
+          _type: 'span',
+          _key: 'k0',
+          text: '',
+          marks: [],
+        },
+        position: 'before',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 'k0',
+            },
+          ],
+        },
+      },
+    ]) // worst-case-children-not-array (local)
+
+    const manyDefects = [
+      {
+        _type: 'block',
+        _key: 'b1',
+        markDefs: [
+          {_key: 'm1', _type: 'link', href: 'x'},
+          {_key: 'm1', _type: 'link', href: 'x'},
+        ],
+        children: [
+          {_type: 'span', _key: 's1', text: 'a'},
+          {_type: 'span', _key: 's2', text: '', marks: ['m1']},
+        ],
+      },
+    ]
+    expect(runNormalize(manyDefects).operations).toEqual([
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+          'marks',
+        ],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's2',
+            },
+            'marks',
+          ],
+          value: ['m1'],
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's1',
+          },
+          'marks',
+        ],
+        value: [],
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+            'marks',
+          ],
+        },
+      },
+      {
+        type: 'unset',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'children',
+          {
+            _key: 's2',
+          },
+        ],
+        inverse: {
+          type: 'insert',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'children',
+            {
+              _key: 's1',
+            },
+          ],
+          node: {
+            _type: 'span',
+            _key: 's2',
+            text: '',
+            marks: [],
+          },
+          position: 'after',
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'style',
+        ],
+        value: 'normal',
+        inverse: {
+          type: 'unset',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'style',
+          ],
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [
+          {
+            _key: 'm1',
+            _type: 'link',
+            href: 'x',
+          },
+        ],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+          value: [
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'x',
+            },
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'x',
+            },
+          ],
+        },
+      },
+      {
+        type: 'set',
+        path: [
+          {
+            _key: 'b1',
+          },
+          'markDefs',
+        ],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [
+            {
+              _key: 'b1',
+            },
+            'markDefs',
+          ],
+          value: [
+            {
+              _key: 'm1',
+              _type: 'link',
+              href: 'x',
+            },
+          ],
+        },
+      },
+    ]) // worst-case-many-defects (local)
+  })
+})

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -1,59 +1,97 @@
-import type {
-  PortableTextObject,
-  PortableTextTextBlock,
-} from '@portabletext/schema'
+import type {PortableTextTextBlock} from '@portabletext/schema'
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {withoutPatching} from '../../engine-plugins/engine-plugin.without-patching'
-import {applyInsertNodeAtPath} from '../../internal-utils/apply-insert-node'
 import {applyMergeNode} from '../../internal-utils/apply-merge-node'
-import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
 import {debug} from '../../internal-utils/debug'
-import {isEqualMarkDefs} from '../../internal-utils/equality'
-import {setNodeProperties} from '../../internal-utils/set-node-properties'
-import {getChildFieldName} from '../../paths/get-child-field-name'
-import {serializePath} from '../../paths/serialize-path'
-import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
 import {getChildren} from '../../traversal/get-children'
-import {getNode} from '../../traversal/get-node'
-import {getParent} from '../../traversal/get-parent'
-import {getPathSubSchema} from '../../traversal/get-path-sub-schema'
 import {getTextBlock} from '../../traversal/get-text-block'
 import {isObject} from '../../traversal/is-object'
-import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
-import {isEditor} from '../editor/is-editor'
 import type {Editor} from '../interfaces/editor'
 import type {Node} from '../interfaces/node'
-import type {Path} from '../interfaces/path'
 import {createSpanNode} from '../node/create-span-node'
-import {isSpanNode} from '../node/is-span-node'
 import {isTextBlockNode} from '../node/is-text-block-node'
-import {parentPath} from '../path/parent-path'
 import {textEquals} from '../text/text-equals'
 import type {WithEditorFirstArg} from '../utils/types'
+import {
+  CORRECTIONS,
+  type Correction,
+  type CorrectionContext,
+  rootNoBlocks,
+} from './corrections'
+
+/**
+ * Run one correction. `undefined` from `correct` means "not my defect" -
+ * the caller tries the next one. A returned operation list is the fix:
+ * applied in order (under `withoutPatching` when the correction asks for
+ * it), then control returns to the fixed-point normalize loop, which
+ * re-visits whatever the fix left dirty.
+ *
+ * Cosmetic corrections are skipped while adopting remote content (see
+ * `Correction['type']`); structural ones always run. `memoKey` below is the
+ * other scheduling rule: it skips a correction whose sibling group a prior
+ * visit already verified unique (see `verifiedUniqueChildGroups`).
+ */
+function tryCorrection(
+  correction: Correction,
+  context: CorrectionContext,
+): boolean {
+  const {editor} = context
+
+  if (correction.type === 'cosmetic' && editor.isProcessingRemoteChanges) {
+    return false
+  }
+
+  if (correction.memoKey) {
+    const key = correction.memoKey(context)
+    if (key !== undefined && editor.verifiedUniqueChildGroups.has(key)) {
+      return false
+    }
+  }
+
+  const operations = correction.correct(context)
+  if (operations === undefined) {
+    return false
+  }
+
+  debug.normalization(correction.name)
+
+  const applyOperations = () => {
+    for (const operation of operations) {
+      editor.apply(operation)
+    }
+  }
+
+  if (correction.suppressPatches) {
+    withoutPatching(editor, applyOperations)
+  } else {
+    applyOperations()
+  }
+
+  return true
+}
+
+// `rootNoBlocks` (`CORRECTIONS[0]`) runs before the imperative same-marks
+// merge below; every other correction runs after it, in `CORRECTIONS` order.
+const remainingCorrections = CORRECTIONS.slice(1)
 
 export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   editor,
   entry,
 ) => {
   const [node, path] = entry
-  const nodeRecord = node as Record<string, unknown>
+  const context: CorrectionContext = {editor, node, path}
 
-  /**
-   * Add a placeholder block when the editor is empty
-   */
-  if (isEditor(node) && node.snapshot.context.value.length === 0) {
-    withoutPatching(editor, () => {
-      applyInsertNodeAtPath(
-        editor,
-        createPlaceholderBlock(editor.snapshot),
-        [0],
-      )
-    })
+  if (tryCorrection(rootNoBlocks, context)) {
     return
   }
 
   /**
    * Merge spans with same set of .marks
+   *
+   * Stays imperative: `applyMergeNode` pre-transforms refs/selection with
+   * merge semantics and isn't expressible as a plain `EngineOperation`.
+   * Once `merge` is a first-class operation, this can become a correction
+   * like the others.
    */
   if (
     !editor.isProcessingRemoteChanges &&
@@ -78,493 +116,33 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     }
   }
 
-  // Normalize missing _type based on context.
-  if (nodeRecord['_type'] === undefined && path.length > 0) {
-    const parent = getNode(editor.snapshot, parentPath(path))
-
-    // Children of text blocks default to the span type.
-    if (
-      parent &&
-      isTextBlock({schema: editor.snapshot.context.schema}, parent.node)
-    ) {
-      debug.normalization('Setting span type on node without a type')
-      editor.apply({
-        type: 'set',
-        path: [...path, '_type'],
-        value: editor.snapshot.context.schema.span.name,
-        inverse: {type: 'unset', path: [...path, '_type']},
-      })
-      return
-    }
-
-    // Everything else defaults to the text block type.
-    debug.normalization('Setting block type on node without a type')
-    editor.apply({
-      type: 'set',
-      path: [...path, '_type'],
-      value: editor.snapshot.context.schema.block.name,
-      inverse: {type: 'unset', path: [...path, '_type']},
-    })
-    return
-  }
-
-  // Set missing _key on any non-editor node.
-  // Uses numeric index in the path because the node has no _key to
-  // address it by. Any ancestor segments with undefined _key are also
-  // resolved to numeric indices.
-  if (nodeRecord['_key'] === undefined && path.length > 0) {
-    const newKey = editor.snapshot.context.keyGenerator()
-    debug.normalization('Setting missing key on node')
-
-    // Build a fully resolved path by walking the tree from the root,
-    // replacing any undefined keyed segments with numeric indices.
-    const numericPath: Path = []
-    let currentNode: Node | undefined
-
-    for (const segment of path) {
-      if (typeof segment === 'string') {
-        // Field name: descend into the field
-        if (currentNode) {
-          numericPath.push(segment)
-        }
-        continue
-      }
-
-      // Determine the siblings array at this level
-      const siblings: ArrayLike<Node> = currentNode
-        ? (((currentNode as Record<string, unknown>)[
-            numericPath[numericPath.length - 1] as string
-          ] as ArrayLike<Node>) ?? [])
-        : editor.snapshot.context.value
-
-      if (isKeyedSegment(segment) && segment._key !== undefined) {
-        numericPath.push(segment)
-        currentNode = Array.prototype.find.call(
-          siblings,
-          (child: Node) => child._key === segment._key,
-        )
-      } else {
-        // Undefined _key or numeric: resolve to numeric index
-        let index = typeof segment === 'number' ? segment : -1
-        if (index === -1) {
-          for (let i = 0; i < siblings.length; i++) {
-            if ((siblings[i] as Node)._key === undefined) {
-              index = i
-              break
-            }
-          }
-        }
-        if (index !== -1) {
-          numericPath.push(index)
-          currentNode = siblings[index] as Node
-        }
-      }
-    }
-
-    editor.apply({
-      type: 'set',
-      path: [...numericPath, '_key'],
-      value: newKey,
-      inverse: {type: 'unset', path: [...numericPath, '_key']},
-    })
-    return
-  }
-
-  // Fix duplicate _key among siblings
-  if (path.length > 0 && nodeRecord['_key'] !== undefined) {
-    const parent = getParent(editor.snapshot, path)
-    const key = nodeRecord['_key'] as string
-    // The child array holding this node is the field segment right after
-    // the parent's path. Read it straight off the parent node rather than
-    // re-resolving children from the root through the schema; fall back to
-    // `getChildren` only if that field isn't a plain array.
-    const childFieldName = parent
-      ? (path[parent.path.length] as string)
-      : undefined
-    const rawSiblings =
-      parent && typeof childFieldName === 'string'
-        ? (parent.node as Record<string, unknown>)[childFieldName]
-        : undefined
-    const siblingNodes: ReadonlyArray<{_key?: string}> = !parent
-      ? editor.snapshot.context.value
-      : Array.isArray(rawSiblings)
-        ? (rawSiblings as ReadonlyArray<{_key?: string}>)
-        : getChildren(editor.snapshot, parent.path).map((entry) => entry.node)
-
-    // A group of zero or one child can't hold a duplicate key, so it needs
-    // neither a scan nor a cache entry: re-checking it is already O(1). This
-    // is the common shape for container fields (a row's single cell, a
-    // cell's single content block) and single-span text blocks, so only
-    // genuinely multi-child groups ever cost a serialized id.
-    if (siblingNodes.length > 1) {
-      // Identify the group by its serialized path (the root group is `''`).
-      // The verdict survives edits elsewhere in the tree: it is dropped only
-      // when the op stream sees this group's own membership change (see
-      // `subscribeUpdateValue`). Verifying a group is O(siblings); caching
-      // the verdict keeps a bulk insert of n pre-keyed siblings at O(n)
-      // instead of O(n^2).
-      const groupId =
-        parent && typeof childFieldName === 'string'
-          ? serializePath([...parent.path, childFieldName])
-          : ''
-
-      if (!editor.verifiedUniqueChildGroups.has(groupId)) {
-        const seenKeys = new Set<string>()
-        let groupIsUnique = true
-        let duplicateIndexOfKey = -1
-
-        for (let index = 0; index < siblingNodes.length; index++) {
-          const siblingKey = siblingNodes[index]?._key
-          if (siblingKey === undefined) {
-            continue
-          }
-          if (seenKeys.has(siblingKey)) {
-            groupIsUnique = false
-            // The second occurrence of this node's own key is the one the
-            // previous per-node implementation renamed; preserve that so
-            // generated keys land on the same node.
-            if (siblingKey === key && duplicateIndexOfKey === -1) {
-              duplicateIndexOfKey = index
-            }
-          } else {
-            seenKeys.add(siblingKey)
-          }
-        }
-
-        if (duplicateIndexOfKey !== -1) {
-          const newKey = editor.snapshot.context.keyGenerator()
-          debug.normalization('Fixing duplicate key on node')
-          const numericPath: Path =
-            parent && typeof childFieldName === 'string'
-              ? [...parent.path, childFieldName, duplicateIndexOfKey]
-              : [duplicateIndexOfKey]
-          editor.apply({
-            type: 'set',
-            path: [...numericPath, '_key'],
-            value: newKey,
-            inverse: {
-              type: 'set',
-              path: [...numericPath, '_key'],
-              value: key,
-            },
-          })
-          return
-        }
-
-        if (groupIsUnique) {
-          editor.verifiedUniqueChildGroups.add(groupId)
-        }
-      }
-    }
-  }
-
-  /**
-   * Add missing .markDefs to text block nodes
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
-    !Array.isArray(node.markDefs)
-  ) {
-    debug.normalization('adding .markDefs to block node')
-    setNodeProperties(editor, {markDefs: []}, path)
-    return
-  }
-
-  /**
-   * Add missing .style to text block nodes
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlockNode({schema: editor.snapshot.context.schema}, node) &&
-    typeof node.style === 'undefined'
-  ) {
-    const defaultStyle = getPathSubSchema(editor.snapshot, path).styles.at(
-      0,
-    )?.name
-    if (defaultStyle) {
-      debug.normalization('adding .style to block node')
-      setNodeProperties(editor, {style: defaultStyle}, path)
+  for (const correction of remainingCorrections) {
+    if (tryCorrection(correction, context)) {
       return
     }
   }
 
-  /**
-   * Add missing .text to span nodes
-   */
-  if (
-    isSpanNode(editor.snapshot.context, node) &&
-    typeof node.text !== 'string'
-  ) {
-    debug.normalization('Adding .text to span node')
-    editor.apply({
-      type: 'set',
-      path: [...path, 'text'],
-      value: '',
-      inverse: {type: 'unset', path: [...path, 'text']},
-    })
-    return
-  }
+  // Everything from here down is gated on `isTextBlockNode`. A span or an
+  // object node reaching this point already exhausted the corrections that
+  // match its shape above (`span.missing-text` etc. for spans;
+  // `container.missing-child-array` etc., gated on `isObject`, for
+  // objects), so neither can still be dirty here - there is nothing left
+  // for either shape to fall through to.
 
   /**
-   * Add missing .marks to span nodes
+   * Text blocks must always have at least one child span.
+   *
+   * Stays imperative: mutates and refetches `element` while iterating (a
+   * fix can shift or remove nodes at the current index), which the
+   * fixed-point re-entry model doesn't support mid-loop. Promoting
+   * `merge` to an `EngineOperation` would let the merge/drop arm become a
+   * correction; the bracketing arm has no such dependency but is left
+   * alongside it for now.
    */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isSpan({schema: editor.snapshot.context.schema}, node) &&
-    !Array.isArray(node.marks)
-  ) {
-    debug.normalization('Adding .marks to span node')
-    setNodeProperties(editor, {marks: []}, path)
-    return
-  }
-
-  /**
-   * Remove annotations from empty spans
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isSpan({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const blockPath = parentPath(path)
-    const blockEntry = getTextBlock(editor.snapshot, blockPath)
-    if (!blockEntry) {
-      return
-    }
-    // Only treat a mark as an annotation if it points to one of the
-    // block's `markDefs`. A mark that doesn't resolve might be a decorator
-    // from another schema (one that was removed here, or one a collaborator
-    // has that we don't), so it is left alone.
-    const annotations = node.marks?.filter((mark) =>
-      blockEntry.node.markDefs?.some((markDef) => markDef._key === mark),
-    )
-
-    if (node.text === '' && annotations && annotations.length > 0) {
-      debug.normalization('removing annotations from empty span node')
-      setNodeProperties(
-        editor,
-        {marks: node.marks?.filter((mark) => !annotations.includes(mark))},
-        path,
-      )
-      return
-    }
-  }
-
-  /**
-   * Remove duplicate markDefs
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlock({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const markDefs = node.markDefs ?? []
-    const markDefKeys = new Set<string>()
-    const newMarkDefs: Array<PortableTextObject> = []
-
-    for (const markDef of markDefs) {
-      if (!markDefKeys.has(markDef._key)) {
-        markDefKeys.add(markDef._key)
-        newMarkDefs.push(markDef)
-      }
-    }
-
-    if (markDefs.length !== newMarkDefs.length) {
-      debug.normalization('removing duplicate markDefs')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
-      return
-    }
-  }
-
-  /**
-   * Remove markDefs not in use
-   */
-  if (
-    !editor.isProcessingRemoteChanges &&
-    isTextBlock({schema: editor.snapshot.context.schema}, node)
-  ) {
-    const newMarkDefs = (node.markDefs || []).filter((def) => {
-      return node.children.find((child) => {
-        return (
-          isSpan({schema: editor.snapshot.context.schema}, child) &&
-          Array.isArray(child.marks) &&
-          child.marks.includes(def._key)
-        )
-      })
-    })
-
-    if (node.markDefs && !isEqualMarkDefs(newMarkDefs, node.markDefs)) {
-      debug.normalization('removing markDef not in use')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
-      return
-    }
-  }
-
-  if (isSpanNode({schema: editor.snapshot.context.schema}, node)) {
-    /**
-     * Add missing .text to span nodes
-     */
-    if (typeof node.text !== 'string') {
-      debug.normalization('Adding .text to span node')
-      editor.apply({
-        type: 'set',
-        path: [...path, 'text'],
-        value: '',
-        inverse: {type: 'unset', path: [...path, 'text']},
-      })
-      return
-    }
-
-    return
-  }
-
-  // Container normalization: ensure the child array field exists and is
-  // non-empty.
-  if (isObject(editor.snapshot, node)) {
-    const resolved = resolveContainerByPath(
-      {
-        containers: editor.containers,
-        schema: editor.snapshot.context.schema,
-        value: editor.snapshot.context.value,
-      },
-      path,
-      node,
-    )
-    const arrayField =
-      resolved && 'container' in resolved ? resolved.field : undefined
-
-    if (arrayField) {
-      const fieldValue = (node as Record<string, unknown>)[arrayField.name]
-      const needsField = !Array.isArray(fieldValue)
-      const needsChild = needsField || fieldValue.length === 0
-
-      if (needsChild) {
-        const acceptsBlocks = arrayField.of.some(
-          (definition) => definition.type === 'block',
-        )
-        const firstChildType = arrayField.of.at(0)
-
-        let childNode: Node | undefined
-        if (acceptsBlocks) {
-          childNode = createPlaceholderBlock(editor.snapshot, [
-            ...path,
-            arrayField.name,
-            0,
-          ])
-        } else if (firstChildType && firstChildType.type !== 'block') {
-          // For inline declarations (`type: 'object'`), the actual type
-          // identity is in `name`. For bare references (any other `type`),
-          // the type itself is the identity.
-          const childTypeName =
-            firstChildType.type === 'object' && 'name' in firstChildType
-              ? firstChildType.name
-              : firstChildType.type
-          childNode = {
-            _type: childTypeName,
-            _key: editor.snapshot.context.keyGenerator(),
-          } as Node
-        }
-
-        if (needsField && childNode) {
-          // Set the field with its initial child in a single operation
-          // instead of two (set empty array + insert child).
-          setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
-          return
-        }
-
-        if (needsField) {
-          setNodeProperties(editor, {[arrayField.name]: []}, path)
-          return
-        }
-
-        if (childNode) {
-          editor.apply({
-            type: 'insert',
-            path: [...path, arrayField.name, 0],
-            node: childNode,
-            position: 'before',
-          })
-          return
-        }
-      }
-    }
-  }
-
-  // Fix duplicate _key among children of container/object nodes.
-  // The sibling-level handler above catches duplicates when each child is
-  // visited individually, but container children may not be visited if
-  // containers gates traversal. Handle it at the parent level as well.
-  if (isObject(editor.snapshot, node)) {
-    const children = [...getChildren(editor.snapshot, path)]
-
-    if (children.length > 1) {
-      const seen = new Map<string, number>()
-
-      for (let i = 0; i < children.length; i++) {
-        const key = children[i]!.node._key
-        if (key !== undefined && seen.has(key)) {
-          const newKey = editor.snapshot.context.keyGenerator()
-          debug.normalization('Fixing duplicate key on container child')
-          // Use numeric index to address the duplicate since keyed path
-          // is ambiguous for nodes with the same key.
-          const arrayFieldName = getChildFieldName(
-            editor.snapshot.context,
-            path,
-          )
-          if (arrayFieldName) {
-            editor.apply({
-              type: 'set',
-              path: [...path, arrayFieldName, i, '_key'],
-              value: newKey,
-              inverse: {
-                type: 'set',
-                path: [...path, arrayFieldName, i, '_key'],
-                value: key,
-              },
-            })
-            return
-          }
-        }
-        if (key !== undefined) {
-          seen.set(key, i)
-        }
-      }
-    }
-
-    return
-  }
-
-  // Text blocks must always have at least one child span.
   if (isTextBlockNode({schema: editor.snapshot.context.schema}, node)) {
     // We will have to refetch the element any time we modify its children
     // since it clones to a new immutable reference when we do.
     let element = node as unknown as PortableTextTextBlock
-
-    // Runtime data can arrive without children (e.g. after an unset patch).
-    if (!Array.isArray(element.children)) {
-      editor.apply({
-        type: 'set',
-        path: [...path, 'children'],
-        value: [],
-        inverse: {type: 'unset', path: [...path, 'children']},
-      })
-      return
-    }
-
-    // Ensure that text blocks have at least one child.
-    if (element.children.length === 0) {
-      const child = createSpanNode(editor.snapshot.context)
-      editor.apply({
-        type: 'insert',
-        path: [...path, 'children', 0],
-        node: child,
-        position: 'before',
-      })
-      const refetched = getTextBlock(editor.snapshot, path)?.node
-      if (!refetched) {
-        return
-      }
-      element = refetched
-    }
 
     // Since we'll be applying operations while iterating, we also modify
     // `n` when adding/removing nodes.


### PR DESCRIPTION
Answering "what corrections does the editor make to a document, and when" today means tracing 652 lines of `normalizeNode` control flow: ~17 repairs as ordered if-blocks applying operations imperatively mid-walk, with eight inline remote-change gates deciding which of them run on remote fallout.

A correction is now a set of operations, nothing more. `corrections.ts` describes 15 of the repairs as data — `{name, type, correct: (context) => operations | undefined}` in one ordered array — and `normalizeNode` becomes the executor. Scheduling derives from the classification: `structural` corrections (the engine cannot hold the document otherwise) run on every walk, `cosmetic` ones (canonicalization of valid content) only as local-edit fallout, which reproduces the old gates exactly. Definition metadata carries what a pure repair cannot: patch suppression for the empty-editor placeholder, and the verified-unique-keys memo, generalized as `memoKey`. Nothing is exported; the store is closed by design.

Two repairs stay imperative at their original positions — the same-mark span merge and the per-child merge/drop/bracket loop — because they depend on `applyMergeNode`'s ref pre-transformation and mid-loop refetching. They convert when `merge` becomes a first-class `EngineOperation` (next increment).

The first commit is the guardrail: an op-stream equivalence harness (52 op-stream assertions across 14 defect fixtures, in both local and remote mode, generated against `main` and verified green there) passes unchanged after the restructure. Full unit (893) and chromium (1,764) suites green with identical counts. Three non-API deltas are disclosed in the commit body: per-rule debug strings became correction names, one provably unreachable check is dropped, and two explicit early-returns are replaced by the type-exclusivity invariant that made them redundant.
