### PR TITLE
fix: re-resolve the caret when remote patches move, absorb, or split off its span

### DIFF
--- a/.changeset/remote-merge-caret-recovery.md
+++ b/.changeset/remote-merge-caret-recovery.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: re-resolve the caret when remote patches move, absorb, or split off its span
+
+When a collaborator's edit merges the span the caret sits in (for example unbolding text so adjacent spans join), merges its block into the previous one with Backspace, or splits the block before the caret with Enter, the caret now keeps its text position instead of jumping to a span boundary. In the split case the caret follows the content it sat in into the new block; previously it stayed clamped at the end of the truncated block. Recovery is scoped to the caret's block and its adjacent siblings and only applies when the text mapping is exact; in every other case, including duplicate span keys elsewhere in the document (which block splits produce routinely), the previous behavior stands.

--- a/packages/editor/src/editor/remote-patches.ts
+++ b/packages/editor/src/editor/remote-patches.ts
@@ -1,13 +1,30 @@
 import type {Patch} from '@portabletext/patches'
+import {
+  isSpan,
+  isTextBlock,
+  type PortableTextTextBlock,
+} from '@portabletext/schema'
 import {withRemoteChanges} from '../engine-plugins/engine-plugin.remote-changes'
 import {pluginWithoutHistory} from '../engine-plugins/engine-plugin.without-history'
 import {withoutPatching} from '../engine-plugins/engine-plugin.without-patching'
 import {normalize} from '../engine/editor/normalize'
 import {withoutNormalizing} from '../engine/editor/without-normalizing'
+import {applySelect} from '../internal-utils/apply-selection'
 import {createApplyPatch} from '../internal-utils/applyPatch'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
+import {serializePath} from '../paths/serialize-path'
+import {getNode} from '../traversal/get-node'
+import {getSibling} from '../traversal/get-sibling'
+import type {BlockOffset} from '../types/block-offset'
+import type {EditorSelectionPoint} from '../types/editor'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
+import type {Path} from '../types/paths'
+import {
+  blockOffsetToSpanSelectionPoint,
+  spanSelectionPointToBlockOffset,
+} from '../utils/util.block-offset'
+import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {EditorActor} from './editor-machine'
 
 /**
@@ -36,6 +53,8 @@ export function setupRemotePatches({
     bufferedPatches = []
     let changed = false
 
+    const capturedSelection = captureSelectionForRecovery(editor)
+
     withRemoteChanges(editor, () => {
       withoutNormalizing(editor, () => {
         withoutPatching(editor, () => {
@@ -62,6 +81,7 @@ export function setupRemotePatches({
       })
       if (changed) {
         normalize(editor)
+        recoverSelectionAfterRemotePatches(editor, capturedSelection)
         editor.onChange()
       }
     })
@@ -84,4 +104,366 @@ export function setupRemotePatches({
       subscription.unsubscribe()
     }
   })
+}
+
+type CapturedSelectionPoint = {
+  spanKey: string
+  spanText: string
+  spanOffset: number
+  blockPathKey: string
+  blockOffset: BlockOffset
+  blockText: string
+  previousSiblingBlock:
+    | {
+        path: Path
+        text: string
+      }
+    | undefined
+  nextSiblingBlockPathKey: string | undefined
+}
+
+type CapturedSelection = {
+  anchor: CapturedSelectionPoint | undefined
+  focus: CapturedSelectionPoint | undefined
+}
+
+/**
+ * Remote patches carry state deltas, not position mappings: a collaborator's
+ * span merge or block merge arrives as delete + insert, so the generic
+ * per-op selection transforms collapse the local caret to a boundary
+ * instead of following the content. Capture enough identity before the
+ * batch (leaf key, offset within the leaf, and the caret's position
+ * expressed as a character offset in the block's text) to re-resolve the
+ * caret afterwards when, and only when, the mapping is exact.
+ */
+function captureSelectionForRecovery(
+  editor: Pick<PortableTextEditorEngine, 'snapshot'>,
+): CapturedSelection | undefined {
+  const selection = editor.snapshot.context.selection
+
+  if (!selection) {
+    return undefined
+  }
+
+  return {
+    anchor: captureSelectionPoint(editor, selection.anchor),
+    focus: captureSelectionPoint(editor, selection.focus),
+  }
+}
+
+function captureSelectionPoint(
+  editor: Pick<PortableTextEditorEngine, 'snapshot'>,
+  selectionPoint: EditorSelectionPoint,
+): CapturedSelectionPoint | undefined {
+  const spanSegment = selectionPoint.path.at(-1)
+
+  if (!isKeyedSegment(spanSegment)) {
+    return undefined
+  }
+
+  const blockOffset = spanSelectionPointToBlockOffset({
+    snapshot: editor.snapshot,
+    selectionPoint,
+  })
+
+  if (!blockOffset) {
+    return undefined
+  }
+
+  const blockEntry = getNode(editor.snapshot, blockOffset.path)
+
+  if (!blockEntry || !isTextBlock(editor.snapshot.context, blockEntry.node)) {
+    return undefined
+  }
+
+  const spanEntry = getNode(editor.snapshot, selectionPoint.path)
+
+  if (!spanEntry || !isSpan(editor.snapshot.context, spanEntry.node)) {
+    return undefined
+  }
+
+  // Merges only ever move content into the previous sibling (see
+  // `applyMergeNode`), so the previous sibling's identity and text are the
+  // only neighborhood needed to recover from a remote block merge.
+  const previousSibling = getSibling(editor.snapshot, blockOffset.path, {
+    direction: 'previous',
+  })
+  const previousSiblingBlock =
+    previousSibling &&
+    isTextBlock(editor.snapshot.context, previousSibling.node)
+      ? {
+          path: previousSibling.path,
+          text: getConcatenatedSpanText(editor, previousSibling.node),
+        }
+      : undefined
+
+  // A remote split moves the block's tail into a freshly inserted next
+  // sibling. Remembering who the next sibling was at capture time is what
+  // distinguishes "a new block appeared holding my tail" from "my tail was
+  // deleted and the old next sibling coincidentally matches it".
+  const nextSibling = getSibling(editor.snapshot, blockOffset.path, {
+    direction: 'next',
+  })
+
+  return {
+    spanKey: spanSegment._key,
+    spanText: spanEntry.node.text,
+    spanOffset: selectionPoint.offset,
+    blockPathKey: serializePath(blockOffset.path),
+    blockOffset,
+    blockText: getConcatenatedSpanText(editor, blockEntry.node),
+    previousSiblingBlock,
+    nextSiblingBlockPathKey: nextSibling
+      ? serializePath(nextSibling.path)
+      : undefined,
+  }
+}
+
+function recoverSelectionAfterRemotePatches(
+  editor: PortableTextEditorEngine,
+  capturedSelection: CapturedSelection | undefined,
+): void {
+  if (!capturedSelection) {
+    return
+  }
+
+  const selection = editor.snapshot.context.selection
+
+  if (!selection) {
+    return
+  }
+
+  const anchor = recoverSelectionPoint(
+    editor,
+    selection.anchor,
+    capturedSelection.anchor,
+  )
+  const focus = recoverSelectionPoint(
+    editor,
+    selection.focus,
+    capturedSelection.focus,
+  )
+
+  if (anchor === selection.anchor && focus === selection.focus) {
+    return
+  }
+
+  applySelect(editor, {anchor, focus})
+}
+
+function recoverSelectionPoint(
+  editor: PortableTextEditorEngine,
+  currentPoint: EditorSelectionPoint,
+  capturedPoint: CapturedSelectionPoint | undefined,
+): EditorSelectionPoint {
+  if (!capturedPoint) {
+    return currentPoint
+  }
+
+  const currentSpanSegment = currentPoint.path.at(-1)
+  const currentBlockOffset = isKeyedSegment(currentSpanSegment)
+    ? spanSelectionPointToBlockOffset({
+        snapshot: editor.snapshot,
+        selectionPoint: currentPoint,
+      })
+    : undefined
+
+  if (
+    isKeyedSegment(currentSpanSegment) &&
+    currentSpanSegment._key === capturedPoint.spanKey &&
+    currentBlockOffset &&
+    serializePath(currentBlockOffset.path) === capturedPoint.blockPathKey
+  ) {
+    const splitPoint = recoverSplitTail(editor, capturedPoint)
+
+    if (splitPoint) {
+      return splitPoint
+    }
+
+    // The caret is still inside the leaf it started in, under the same
+    // block. The per-op transforms handled any text shifts (remote typing
+    // arrives as offset-precise ops via `diffMatchPatch` replay), so their
+    // result is trusted.
+    return currentPoint
+  }
+
+  // Splitting a block reuses the span's `_key` in the new block, so
+  // documents routinely contain doc-wide duplicate span keys and a key
+  // match alone proves nothing. The search is therefore scoped to where a
+  // merge can actually move the caret's span (its own block and the
+  // previous sibling) and requires the span's text to match too.
+  const spanMatches = [
+    findSpanInBlock(editor, capturedPoint.blockOffset.path, capturedPoint),
+    capturedPoint.previousSiblingBlock
+      ? findSpanInBlock(
+          editor,
+          capturedPoint.previousSiblingBlock.path,
+          capturedPoint,
+        )
+      : undefined,
+  ].filter((match) => match !== undefined)
+
+  if (spanMatches.length === 1) {
+    // The leaf survived but moved to the previous sibling (a remote block
+    // merge moves children with their keys intact).
+    return spanMatches[0]!
+  }
+
+  if (spanMatches.length === 0) {
+    const blockEntry = getNode(editor.snapshot, capturedPoint.blockOffset.path)
+
+    if (
+      blockEntry &&
+      isTextBlock(editor.snapshot.context, blockEntry.node) &&
+      getConcatenatedSpanText(editor, blockEntry.node) ===
+        capturedPoint.blockText
+    ) {
+      // The leaf is gone but the block's text is unchanged: a remote span
+      // merge absorbed the leaf into a sibling. The caret's character
+      // position within the block maps exactly onto the merged spans.
+      const spanPoint = blockOffsetToSpanSelectionPoint({
+        snapshot: editor.snapshot,
+        blockOffset: capturedPoint.blockOffset,
+        direction: 'forward',
+      })
+
+      if (spanPoint) {
+        return spanPoint
+      }
+    }
+
+    const previousSiblingBlock = capturedPoint.previousSiblingBlock
+    const previousBlockEntry = previousSiblingBlock
+      ? getNode(editor.snapshot, previousSiblingBlock.path)
+      : undefined
+
+    if (
+      !blockEntry &&
+      previousSiblingBlock &&
+      previousBlockEntry &&
+      isTextBlock(editor.snapshot.context, previousBlockEntry.node) &&
+      getConcatenatedSpanText(editor, previousBlockEntry.node) ===
+        previousSiblingBlock.text + capturedPoint.blockText
+    ) {
+      // The caret's block is gone and the previous sibling's text is now
+      // exactly the concatenation of the two blocks' texts: a remote block
+      // merge (followed by their normalizer's span merge, which is why the
+      // span key search found nothing). The caret's character position
+      // maps exactly, shifted by the previous block's original text.
+      const spanPoint = blockOffsetToSpanSelectionPoint({
+        snapshot: editor.snapshot,
+        blockOffset: {
+          path: previousSiblingBlock.path,
+          offset:
+            previousSiblingBlock.text.length + capturedPoint.blockOffset.offset,
+        },
+        direction: 'forward',
+      })
+
+      if (spanPoint) {
+        return spanPoint
+      }
+    }
+  }
+
+  // Ambiguous or inexact: any further recovery would be guesswork, so the
+  // generic transform's boundary collapse stands.
+  return currentPoint
+}
+
+/**
+ * A remote split truncates the caret's block and moves the tail into a
+ * newly inserted next sibling. When the caret sat inside the moved tail,
+ * the generic transforms clamp it to the truncated block's end; the exact
+ * position is in the new block, shifted by the kept prefix's length. The
+ * mapping only applies when it is exact: the old block text must be
+ * precisely the kept text plus the new sibling's text, the sibling must
+ * not have existed at capture time, and the caret must have sat past the
+ * kept prefix.
+ */
+function recoverSplitTail(
+  editor: Pick<PortableTextEditorEngine, 'snapshot'>,
+  capturedPoint: CapturedSelectionPoint,
+): EditorSelectionPoint | undefined {
+  const blockEntry = getNode(editor.snapshot, capturedPoint.blockOffset.path)
+
+  if (!blockEntry || !isTextBlock(editor.snapshot.context, blockEntry.node)) {
+    return undefined
+  }
+
+  const keptText = getConcatenatedSpanText(editor, blockEntry.node)
+
+  if (capturedPoint.blockOffset.offset <= keptText.length) {
+    return undefined
+  }
+
+  const nextSibling = getSibling(editor.snapshot, blockEntry.path, {
+    direction: 'next',
+  })
+
+  if (
+    !nextSibling ||
+    !isTextBlock(editor.snapshot.context, nextSibling.node) ||
+    serializePath(nextSibling.path) === capturedPoint.nextSiblingBlockPathKey
+  ) {
+    return undefined
+  }
+
+  if (
+    keptText + getConcatenatedSpanText(editor, nextSibling.node) !==
+    capturedPoint.blockText
+  ) {
+    return undefined
+  }
+
+  return blockOffsetToSpanSelectionPoint({
+    snapshot: editor.snapshot,
+    blockOffset: {
+      path: nextSibling.path,
+      offset: capturedPoint.blockOffset.offset - keptText.length,
+    },
+    direction: 'forward',
+  })
+}
+
+function findSpanInBlock(
+  editor: Pick<PortableTextEditorEngine, 'snapshot'>,
+  blockPath: Path,
+  capturedPoint: CapturedSelectionPoint,
+): EditorSelectionPoint | undefined {
+  const blockEntry = getNode(editor.snapshot, blockPath)
+
+  if (!blockEntry || !isTextBlock(editor.snapshot.context, blockEntry.node)) {
+    return undefined
+  }
+
+  for (const child of blockEntry.node.children) {
+    if (
+      isSpan(editor.snapshot.context, child) &&
+      child._key === capturedPoint.spanKey &&
+      child.text === capturedPoint.spanText
+    ) {
+      return {
+        path: [...blockEntry.path, 'children', {_key: child._key}],
+        offset: Math.min(capturedPoint.spanOffset, child.text.length),
+      }
+    }
+  }
+
+  return undefined
+}
+
+function getConcatenatedSpanText(
+  editor: Pick<PortableTextEditorEngine, 'snapshot'>,
+  block: PortableTextTextBlock,
+): string {
+  let text = ''
+
+  for (const child of block.children) {
+    if (isSpan(editor.snapshot.context, child)) {
+      text += child.text
+    }
+  }
+
+  return text
 }

--- a/packages/editor/tests/selection-after-remote-patches.test.tsx
+++ b/packages/editor/tests/selection-after-remote-patches.test.tsx
@@ -1,9 +1,9 @@
-import {diffMatchPatch, insert, unset} from '@portabletext/patches'
+import {diffMatchPatch, insert, set, unset} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import {createTestEditor} from '../src/test/vitest'
+import {createTestEditor, createTestEditors} from '../src/test/vitest'
 import {whenTheCaretIsPutAfter} from '../test-utils/caret-placement'
 import {getSelectionAfterText} from '../test-utils/text-selection'
 import {toTextspec} from '../test-utils/to-textspec'
@@ -431,7 +431,7 @@ describe('Feature: Selection adjustment after remote patches', () => {
     })
   })
 
-  test('Scenario: Remote split of block where cursor is', async () => {
+  test('Scenario: Remote split with the caret in the moved tail follows the content into the new block', async () => {
     const keyGenerator = createTestKeyGenerator()
     const b1 = keyGenerator()
     const s1 = keyGenerator()
@@ -492,14 +492,14 @@ describe('Feature: Selection adjustment after remote patches', () => {
 
     await vi.waitFor(() => {
       expect(toTextspec(editor.getSnapshot().context)).toEqual(
-        ['B: foo|', 'B: bar'].join('\n'),
+        ['B: foo', 'B: bar|'].join('\n'),
       )
     })
 
     await vi.waitFor(() => {
       const adjustedSelection = getSelectionAfterText(
         editor.getSnapshot().context,
-        'foo',
+        'bar',
       )
       expect(editor.getSnapshot().context.selection).toEqual(adjustedSelection)
     })
@@ -681,6 +681,430 @@ describe('Feature: Selection adjustment after remote patches', () => {
         {_key: newSpan},
       ])
       expect(selection?.focus.offset).toBe(0)
+    })
+  })
+
+  test('Scenario: Remote span merge keeps the caret at its text position', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+    const s2 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [
+          {_type: 'span', _key: s1, text: 'foo', marks: []},
+          {_type: 'span', _key: s2, text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      schemaDefinition: defineSchema({
+        decorators: [{name: 'strong'}],
+      }),
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'b')
+
+    // What a collaborator's editor emits when they unbold "bar": the mark
+    // change, then their normalizer's span merge as a text patch on the
+    // surviving span plus an unset of the absorbed one.
+    editor.send({
+      type: 'patches',
+      patches: [
+        set([], [{_key: b1}, 'children', {_key: s2}, 'marks']),
+        diffMatchPatch('foo', 'foobar', [
+          {_key: b1},
+          'children',
+          {_key: s1},
+          'text',
+        ]),
+        unset([{_key: b1}, 'children', {_key: s2}]),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: b1,
+          children: [{_type: 'span', _key: s1, text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The block's text is unchanged by the merge, so the caret belongs at
+    // the same text position: after "foob", not at the end of the merged
+    // span.
+    await vi.waitFor(() => {
+      const expectedSelection = getSelectionAfterText(
+        editor.getSnapshot().context,
+        'foob',
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
+    })
+  })
+
+  test('Scenario: Remote block merge keeps the caret in its span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+    const b2 = keyGenerator()
+    const s2 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [{_type: 'span', _key: s1, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: b2,
+        children: [{_type: 'span', _key: s2, text: 'bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'b')
+
+    // What a collaborator's editor emits when they press Backspace at the
+    // start of the second block: the block merge moves the children (keys
+    // intact) into the previous block and unsets the emptied block.
+    editor.send({
+      type: 'patches',
+      patches: [
+        insert([{_type: 'span', _key: s2, text: 'bar', marks: []}], 'after', [
+          {_key: b1},
+          'children',
+          {_key: s1},
+        ]),
+        unset([{_key: b2}]),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: b1,
+          children: [
+            {_type: 'span', _key: s1, text: 'foo', marks: []},
+            {_type: 'span', _key: s2, text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The caret's span survived the move with its key intact, so the caret
+    // belongs where it was: inside that span, after the "b".
+    await vi.waitFor(() => {
+      const selection = editor.getSnapshot().context.selection
+      expect(selection?.focus.path).toEqual([
+        {_key: b1},
+        'children',
+        {_key: s2},
+      ])
+      expect(selection?.focus.offset).toBe(1)
+    })
+  })
+
+  test('Scenario: Remote block merge followed by span merge keeps the caret at its text position', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+    const b2 = keyGenerator()
+    const s2 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [{_type: 'span', _key: s1, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: b2,
+        children: [{_type: 'span', _key: s2, text: 'bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'b')
+
+    // What a collaborator's editor emits when they press Backspace at the
+    // start of the second block and the spans carry the same marks: the
+    // block merge moves the span into the previous block, then their
+    // normalizer merges the now-adjacent same-marked spans, absorbing the
+    // moved span into the first one.
+    editor.send({
+      type: 'patches',
+      patches: [
+        insert([{_type: 'span', _key: s2, text: 'bar', marks: []}], 'after', [
+          {_key: b1},
+          'children',
+          {_key: s1},
+        ]),
+        unset([{_key: b2}]),
+        diffMatchPatch('foo', 'foobar', [
+          {_key: b1},
+          'children',
+          {_key: s1},
+          'text',
+        ]),
+        unset([{_key: b1}, 'children', {_key: s2}]),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: b1,
+          children: [{_type: 'span', _key: s1, text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The merged block's text is the concatenation of the two blocks'
+    // texts, so the caret's character position maps exactly: after "foob".
+    await vi.waitFor(() => {
+      const expectedSelection = getSelectionAfterText(
+        editor.getSnapshot().context,
+        'foob',
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
+    })
+  })
+
+  test('Scenario: Remote split before the caret moves the caret into the new block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [{_type: 'span', _key: s1, text: 'foobar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'foob')
+
+    const newBlockKey = keyGenerator()
+
+    // What a collaborator's editor emits when they press Enter between
+    // "foo" and "bar": the original span is truncated to the first half
+    // and the second half moves to a new block. The split reuses the
+    // span's `_key` in the new block.
+    editor.send({
+      type: 'patches',
+      patches: [
+        diffMatchPatch('foobar', 'foo', [
+          {_key: b1},
+          'children',
+          {_key: s1},
+          'text',
+        ]),
+        insert(
+          [
+            {
+              _type: 'block',
+              _key: newBlockKey,
+              children: [{_type: 'span', _key: s1, text: 'bar', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          'after',
+          [{_key: b1}],
+        ),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: b|ar'].join('\n'),
+      )
+    })
+
+    await vi.waitFor(() => {
+      const expectedSelection = getSelectionAfterText(
+        editor.getSnapshot().context,
+        'b',
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
+    })
+  })
+
+  test('Scenario: Two editors: a real split via Enter moves the caret into the new block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [{_type: 'span', _key: s1, text: 'foobar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator, editorB} = await createTestEditors({
+      keyGenerator,
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'foob')
+
+    // Editor B splits the block between "foo" and "bar" through its full
+    // editing pipeline; the harness relays its mutation to editor A as
+    // remote patches, whatever their real shape is.
+    editorB.send({
+      type: 'select',
+      at: getSelectionAfterText(editorB.getSnapshot().context, 'foo'),
+    })
+    editorB.send({type: 'insert.break'})
+
+    await vi.waitFor(() => {
+      expect(toTextspec(editor.getSnapshot().context)).toEqual(
+        ['B: foo', 'B: b|ar'].join('\n'),
+      )
+    })
+  })
+
+  test('Scenario: Remote block delete never follows a duplicate span key across the document', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const b1 = keyGenerator()
+    // Splitting a block reuses the span `_key` in the new block, so
+    // real documents contain doc-wide duplicate span keys. The caret's
+    // span key existing elsewhere must never make the caret jump there.
+    const duplicateSpanKey = keyGenerator()
+    const b2 = keyGenerator()
+    const s2 = keyGenerator()
+    const b3 = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: b1,
+        children: [
+          {_type: 'span', _key: duplicateSpanKey, text: 'foo', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: b2,
+        children: [{_type: 'span', _key: s2, text: 'mid', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: b3,
+        children: [
+          {_type: 'span', _key: duplicateSpanKey, text: 'bar', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+    })
+
+    await userEvent.click(locator)
+    await whenTheCaretIsPutAfter(editor, 'b')
+
+    editor.send({
+      type: 'patches',
+      patches: [unset([{_key: b3}])],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: b1,
+          children: [
+            {_type: 'span', _key: duplicateSpanKey, text: 'foo', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: b2,
+          children: [{_type: 'span', _key: s2, text: 'mid', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The deleted block's content is gone (not merged anywhere), so no
+    // exact mapping exists and the generic fallback stands: the caret
+    // collapses into the adjacent block, never onto the same-keyed span
+    // in the first block.
+    await vi.waitFor(() => {
+      const expectedSelection = getSelectionAfterText(
+        editor.getSnapshot().context,
+        'mid',
+      )
+      expect(editor.getSnapshot().context.selection).toEqual(expectedSelection)
     })
   })
 })


### PR DESCRIPTION
Put your caret after the `b` in "foo**bar**" and let a collaborator unbold "bar": their editor merges the now-identical spans, the merge crosses the wire as a text patch plus an `unset`, and your caret jumps to the end of the word. The same collapse hits a collaborator's Backspace joining two blocks (with same marks the sender also span-merges in the same batch, so the caret lands in the previous block at a meaningless offset) and a collaborator's Enter before your caret, which clamps a caret sitting in the moved tail to the truncated block's end instead of following it into the new block. Sanity patches carry state deltas, not position mappings, so by the time the batch arrives the edit's intent is gone and the generic per-op selection transforms can only collapse the caret to a boundary.

The fix recovers the position instead of inferring the intent. Before applying a remote batch, `setupRemotePatches` captures the caret's span `_key` and text, its offsets (in the span and in the block's text), and the adjacent sibling blocks. Afterwards, recovery runs only inside the neighborhood a structural edit can actually reach: a key-and-text match in the captured block or its previous sibling is followed; a dead span whose block text is unchanged, a dead block whose previous sibling now holds exactly the concatenated text, or a truncated block whose freshly inserted next sibling holds exactly the removed tail each re-resolve through `blockOffsetToSpanSelectionPoint`. Anything inexact keeps the generic result.

The neighborhood scoping is load-bearing: splitting a block reuses the span `_key` in the new block, so real documents routinely contain doc-wide duplicate span keys and a doc-wide key match proves nothing; a dedicated scenario pins that a remote block delete never follows the caret's key to an unrelated same-keyed span. One deliberate policy change is included: the existing split scenario pinned the clamp at the truncated block's end, and a caret inside the moved tail now follows its content into the new block. Each recovery is pinned red-first, including a two-editor scenario in which a real `insert.break` on one editor relays its actual mutation patches to the other; the remaining scenarios pass unchanged.
