### PR TITLE
docs: add agent skills for tests, comments, commits, and changesets

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: changesets
+description: How to write changesets in the Portable Text Editor monorepo. Use whenever adding a .changeset/*.md file or deciding whether a change needs one. Covers bump selection (patch/minor/none), the subject-mirrors-commit rule, consumer-facing prose style, and API changesets, with real exemplars from the repo history.
+---
+
+# Writing PTE changesets
+
+## When and what bump
+
+- **One changeset per user-facing change.** Filename is slug-style, describing the change (`get-sibling-map-fallback.md`, `catalog-cross-kind.md`), not the ticket/PR.
+- `fix:` / user-visible refactor → **patch**. New API → **minor**.
+- **No changeset** for: internal-only refactors, tests, CI/tooling, dependency regrouping with no resolved-version change.
+- **New packages get no changeset**: v1.0.0 is hand-published from the branch before the PR merges (`plugin-typeahead-picker` precedent); changesets manage it from 1.0.0 on.
+- Corollary: a commit that ships a changeset is `fix:`/`feat:` (see the `commits` skill).
+
+## Shape
+
+```
+---
+'@portabletext/editor': patch
+---
+
+<commit subject, verbatim, prefix and backticks included>
+
+<blank line>
+
+<1–2 paragraphs for the CONSUMER: present tense, observable behavior>
+```
+
+- First line repeats the commit subject **verbatim**. Since the frontmatter names the package, the commit subject (and thus this line) uses bare `fix:`/`feat:`, no scope.
+- The prose is written for the consumer reading a changelog: what they observe, in present tense ("Backspacing through empty blocks ... no longer slows down"). Not the diagnosis, not test references, not PR numbers, not internal function archaeology, that lives in the commit body and PR description.
+- **API changesets enumerate the exact exported names** and show a fenced usage example. Include a resolution-order list when the API has ordering semantics (see the `defineX` render-prop-types and `'*'` catch-all entries in `editor/CHANGELOG.md`).
+- Call out the upgrade action explicitly when the change shifts something consumers iterate, switch over, or type against: "Code that iterates the map will see the new serialized-path keys", "exhaustive switches over `event.type` gain a case".
+- Perf fixes state the numbers.
+- Behavioral deltas that ride along are named explicitly ("One narrow behavioral fix rides along: ...").
+- Small self-explanatory changes can be **subject-only**.
+
+## Exemplars (real, from the repo history)
+
+### patch: perf fix with numbers + a rides-along delta
+
+```md
+---
+'@portabletext/editor': patch
+---
+
+fix(perf): resolve the `unset` selection fallback's nearest spans without a document scan
+
+Backspacing through empty blocks, and any other edit that removes the node the selection sits in, no longer slows down with document size. Previously each such removal scanned the document from the start to find the nearest span; in large documents this made deleting empty lines feel sluggish (~267ms per backspace at 8,000 blocks, now ~20ms).
+
+One narrow behavioral fix rides along: when the removed node was addressed by a numeric path, the fallback previously moved the selection to the document's first span; it now moves it to the actual nearest span.
+```
+
+Why it's good: observable symptom first ("backspacing ... no longer slows down"), numbers with context, and the semantic delta explicitly fenced off.
+
+### minor: new API with enumerated name + example
+
+````md
+---
+'@portabletext/editor': minor
+---
+
+feat: add `editor.dom.getPointAtCoordinates`
+
+Pass viewport coordinates (for example a pointer event's `clientX`/`clientY`) and get back where a click at those coordinates would place the caret, as an editor selection point, or `null` when the coordinates don't hit the editor's content:
+
+```ts
+const point = editor.dom.getPointAtCoordinates({
+  x: event.clientX,
+  y: event.clientY,
+})
+// {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3}
+```
+````
+
+It's the counterpart of `editor.dom.getSelectionRect`: that one turns a selection into pixels, this one turns pixels back into a point. Behavior guards and actions get it on their `dom` argument.
+
+````
+
+Why it's good: the export is named, the example shows input AND output shape, and the
+"counterpart of" framing places the API in the consumer's existing mental model.
+
+### patch: behavior fix, consumer-observable framing
+
+```md
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve `getSibling` when `blockIndexMap` misses or disagrees with the tree
+
+`getSibling` previously returned `undefined` for siblings the tree
+plainly has when the anchor's path was absent from the block-index
+map, and could return the wrong sibling when the map was stale. It now
+verifies the mapped position against the tree and falls back to a
+linear scan, matching `getNode` and `getChildren`. Paths addressing
+the anchor by numeric index now resolve instead of returning
+`undefined`.
+````
+
+Why it's good: states the wrong observable outputs (`undefined` where a sibling exists, wrong sibling), then the new contract, and anchors it to sibling APIs the consumer already trusts ("matching `getNode` and `getChildren`").
+
+## Anti-patterns
+
+- First line paraphrasing instead of mirroring the commit subject.
+- Diagnosis prose ("the bug was in `updateBlock`'s reconcile...") — consumers don't care where it was, only what changed for them.
+- Referencing tests, PR numbers, or Linear tickets.
+- A changeset for an internal refactor "just in case" — no observable change, no changeset.
+- Bumping minor for a fix because it "feels big"; size ≠ semver.
+
+## The canon
+
+Past changesets are consumed on release; `packages/*/CHANGELOG.md` is where they accumulate. The `7.x` entries in `editor/CHANGELOG.md` are the reference set.

--- a/.agents/skills/code-comments/SKILL.md
+++ b/.agents/skills/code-comments/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: code-comments
+description: How to write and review code comments in the Portable Text Editor monorepo. Use when writing code comments or judging comment quality. Covers the why-only rule, JSDoc-as-consumer-docs, and untouchable directives.
+---
+
+# PTE code comments
+
+## The bar
+
+A comment is a failure of every better channel. Before writing one, check where the information actually belongs:
+
+1. **The code.** A name, an extracted helper, or a stronger assertion often removes the need. If the mechanism can be named, name it.
+2. **The test.** Structure that an assertion defends needs no prose: deleting the "mysterious" line makes the pinned expectation fail, and the failure explains the line better than a comment would.
+3. **The commit body.** Diagnosis, justification, comparison with what the code used to do: all diff-relative narrative lives there.
+4. **Docs/skills.** A house pattern gets documented once, where it is defined, never re-explained at every use site. The same comment appearing N times is a pattern that wants a name, not N comments.
+
+What remains after those four channels is the legitimate comment: the fact a competent reader **cannot recover from the code and would act wrongly without**: a browser quirk, a spec constraint, a deliberate-looking-accidental choice, an invariant the code relies on but does not check. "Explains why" is necessary but not sufficient; comprehension speed alone does not earn one. The test is concrete: what wrong action does this comment prevent? No answer, no comment.
+
+## The rules
+
+- Delete comments that restate the code. `// increment the counter` above `counter++` is noise. So is any comment a rename would make redundant.
+- **Never reference ticket IDs (Linear, Jira, anything) in code comments.** The codebase stands on its own; a ticket system is invisible to external contributors, dies on migrations, and the commit that introduced the line already links the context. Name the CONDITION instead of the ticket: "once `merge` is a first-class operation, this becomes a correction", not "EDEX-1919 promotes `merge`...". Same rule as commits, branches, and PRs.
+- **Comments describe the present, never the diff.** A comment that argues for the new code against code that is no longer there ("Deterministic negative assert: ...", deterministic relative to a deleted sleep) is commit-body material wearing a comment's clothes. The tell: a label or contrast that only means something to someone who saw the old version.
+- Comments for an if statement go **inside** the if statement, not above it.
+- Use backticks around code identifiers: `` `markDefs` ``, not markDefs.
+- Rewrites are dense one-liners where possible: present tense, mechanism not narrative, no "we need to" preamble. "Chrome collapses the selection on `blur`; restore it before applying" beats three sentences of story.
+- A comment that mixes a real why with restated what gets rewritten down to the why, then re-tested against the bar: the residue must still prevent a wrong action, or it goes too.
+
+## JSDoc is consumer documentation
+
+JSDoc on exported symbols (especially `@public`) is rendered by typedoc onto portabletext.org. It is not a code comment; it is the docs site. Different bar entirely:
+
+- The why-only rule does not apply. Describe behavior at the surface the consumer sees, not internal mechanism.
+- Deleting or trimming it changes the published docs, so removal is an API-documentation decision, never comment cleanup. When it is wrong, improve it.
+- `@example` blocks are valuable; keep and fix them rather than remove.
+- `@deprecated` tags and their migration pointers are load-bearing API surface: consumers and tooling act on them. Keep them accurate.
+
+## Not comments: machine-read directives
+
+Some things look like comments but are instructions to tools, and editing or deleting them changes behavior (suppressed errors resurface, coverage changes, formatting shifts). The rules above do not apply to:
+
+- Directives: `@ts-expect-error`, `@ts-ignore`, `biome-ignore`, `oxlint`, `eslint-disable`, `prettier-ignore`, `/// <reference`, `v8 ignore`, `c8 ignore`, `istanbul ignore`
+- `keep-in-sync` pointers: they pin deliberate duplication across packages (see the `writing-tests` skill), and deleting one silently breaks the contract that keeps the copies aligned

--- a/.agents/skills/commits/SKILL.md
+++ b/.agents/skills/commits/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: commits
+description: How to write commit messages in the Portable Text Editor monorepo. Use whenever committing here. Covers subject conventions, the dense mechanism-first body shape, commit-type selection (including the changeset⇒fix/feat rule), splitting, and fixup discipline, with real exemplars from the repo history.
+---
+
+# Writing PTE commits
+
+## Subject
+
+- Conventional, lowercase, imperative: `fix:`, `feat:`, `refactor:`, `test:`, `chore:`, `docs:`.
+- Scope when package-specific (`fix(sanity-bridge):`, `chore(deps):`), **but**: when the commit ships a changeset, the changeset frontmatter already names the package, so the scope is redundant, use bare `fix:` / `feat:`.
+- The subject names the **actual mechanism or contract**, never vague intent:
+  - ✅ `fix: return a path that identifies the node from getNode`
+  - ✅ `fix: only rewrite the DOM selection when it disagrees with the model`
+  - ❌ `fix: getNode path bug`, ❌ `fix: improve selection handling`
+- Backticks around code identifiers in subject and body.
+- **Never reference Linear ticket IDs** in subjects, bodies, or branch names. Branches are named after the change (`fix-inline-object-drag-selection`), not the ticket.
+
+## Type selection
+
+- A commit that ships a **changeset is `fix:` or `feat:`**, never `refactor:`/`chore:`. The changeset is the tell: releasable change ⇒ fix/feat.
+- `chore(deps):` for dependency/config work with no published-code change (no changeset).
+- Renovate-adjacent nuance: `fix(deps)` cuts a patch release via the changeset bot; don't hand it to tooling-only bumps.
+
+## Body
+
+Dense technical prose, wrapped at ~72 columns, structured as:
+
+1. **Old mechanism and why it was wrong**, with the precise failure sequence, name the functions, the inputs, and what the wrong output was.
+2. **The new mechanism.**
+3. **Explicitly scoped behavioral deltas**: "Net behavior unchanged", "Emitted patches only change in the narrow case of...", "One narrow behavioral fix rides along: ...".
+
+Trivial commits get **no body**. One logical change per commit: tests pinning a contract get their own `test:` commit; refactors are split from fixes.
+
+Once a PR is **in review**, follow-ups are `fixup!` commits (`git commit --fixup <sha>`), squashed with `git rebase -i --autosquash` before merge. Before review, fold changes into the logical commit they belong to. Merge-time history is clean logical commits, never a trail of "address review feedback".
+
+## Exemplars (real, from the repo)
+
+### fix with a lying-contract framing (`24996df6b`)
+
+```
+fix: return a path that identifies the node from `getNode`
+
+`getNode(snapshot, path)` follows a path through the editor value and
+returns the deepest node it reaches. When the input path ended on a
+field-name string — e.g. `[{_key: 'image1'}, 'caption']` pointing
+into a block object's primitive field — the walker still resolved to
+the block but returned the input path verbatim, including the
+trailing field name. The contract was lying: `entry.path` didn't
+identify `entry.node`, and downstream composition (`isBlock(entry.path)`,
+`getEnclosingBlock(entry.path)`) misclassified the entry because it
+saw the field-suffixed path instead of the node's path.
+
+Strip trailing field-name segments from the returned path. `getNode`
+now returns a path that identifies the node it found: feeding
+`entry.path` back into `getNode` resolves to the same node.
+
+Includes test coverage for block-object, span, and inline-object
+paths with trailing primitive fields, and a round-trip assertion.
+```
+
+Why it's good: names the function and its contract, gives a concrete input, states the downstream blast radius, then the fix as an invariant ("feeding `entry.path` back...").
+
+### fix with a precise failure sequence + scoped delta (`46593d537`)
+
+```
+fix: write a `text`-named field on an inline object during value sync
+
+When the editor received an updated value, `updateBlock`'s child
+reconcile stripped `text` from every changed child before
+`setNodeProperties`, then re-applied it only for spans via an
+`insert.text` operation. On an inline object `text` is an ordinary
+field, so it was stripped but never written back: the field's new
+value silently never reached the editor, even though the incoming
+value carried it. A field by any other name (`caption`, etc.) synced
+fine because only `text` was special-cased.
+
+Strip `text` only when the child is a span (spans own their text via
+text operations); on a non-span child `text` flows through
+`setNodeProperties` like any other property.
+
+Net behavior unchanged for spans and for inline objects without a
+`text` field.
+```
+
+Why it's good: the failure sequence is step-by-step (stripped → re-applied only for spans → never written back), includes the discriminating observation ("a field by any other name synced fine"), and closes with the exact blast-radius scoping.
+
+### fix where the "why the old code was wrong" is subtle (`f2420072a`)
+
+```
+fix: only rewrite the DOM selection when it disagrees with the model
+
+`validateSelection` compared the model's canonical DOM range against the
+live DOM range by `startOffset`/`endOffset` alone, ignoring the
+containers. A browser representing the same selection with element-level
+endpoints (as browsers do when a selection sweeps across table cells) was
+misread as out of sync, and the "fix" (`removeAllRanges` + `addRange`)
+reset the in-progress native drag, collapsing the selection, and
+destroyed backwardness (a `Range` carries no direction).
+
+The validator now maps the live DOM selection back through
+`toEditorSelection` and compares editor selections: equivalent
+representations are left alone, and the DOM is only rewritten when the
+two genuinely disagree about meaning. Passing the `DOMSelection` (not
+`getRangeAt(0)`) also routes Firefox's multi-range table selections
+through the engine's existing compat. Pinned by a test expressing the
+same selection with element-level endpoints and asserting it survives
+validation (red on the old comparison), plus one pinning that genuine
+desyncs are still rewritten.
+```
+
+Why it's good: explains why the naive comparison was wrong (equivalent representations), names each consequence of the false positive, and points at both tests, the one that falsifies the old behavior and the one pinning the still-wanted behavior.
+
+## Anti-patterns
+
+- Subject naming the symptom or the ticket ("fix drag bug", "EDEX-1301").
+- Bodies that restate the diff ("changed X to Y") without the failure sequence.
+- Mixing a refactor into a fix commit, or tests into either.
+- `refactor:`/`chore:` on a commit that carries a changeset.
+- "Address review feedback" commits surviving to merge.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: writing-tests
+description: How to write tests in the Portable Text Editor monorepo. Use whenever writing or editing tests in PTE packages. Covers test placement, harnesses, deterministic fixtures, and the house assertion style (no indirection, full values with toEqual).
+---
+
+# Writing PTE tests
+
+## Test placement
+
+**Before writing any test, find its existing home.** Always search for an established suite covering the domain (`ls tests/ | grep -i <topic>`, `rg -l <mechanism> tests/`) and read its scenario list before creating a file. The canonical suites are broad (`behavior-api.test.tsx` carries 30+ Behavior contract scenarios); a contract pin belongs next to its siblings, where reviewers and future failures will look for it. A new file is the exception, for a genuinely new domain, not the default. Also check whether the contract is already pinned in a different form before adding it at all.
+
+The file extension is the discriminator, never a `.browser` suffix:
+
+- `*.test.tsx` runs in the browser project (playwright: chromium, firefox, webkit)
+- `*.test.ts` runs in the unit project (node)
+- `*.test-d.ts` is type-level, using `expectTypeOf` from vitest
+- `gherkin-tests/*.feature` + racejar for behavior specs (`Feature({featureText, stepDefinitions, parameterTypes})`)
+
+When scaffolding a new package, mirror `plugin-typeahead-picker`'s vitest config, not `plugin-sdk-value`.
+
+## Harnesses
+
+- **Editor integration tests**: `createTestEditor` from `@portabletext/editor/test/vitest` (inside the editor package: `../src/test/vitest`). Returns `{editor, locator}`. Plugins and probes go in as `children`, but note they mount as siblings _after_ `PortableTextEditable`; a provider that must wrap the editable needs a hand-rolled render with a comment explaining why.
+- **Selector/pure-function tests**: `createTestSnapshot` (in the editor package: `test-utils/create-test-snapshot`; in plugins: duplicate it locally on public types, it is ~30 lines).
+- **Keys**: always `createTestKeyGenerator` from `@portabletext/test`. It is deterministic (`k0`, `k1`, ...), which is what makes full-literal assertions possible. Generated keys may be asserted literally.
+
+## Triggers
+
+- Real user interaction via `userEvent` (`userEvent.type(locator, 'foo')`). Typing with no caret set lands at the block start.
+- Everything else via `editor.send({type: ...})` with full payloads. This includes native-shaped events: `drag.dragover`, `drag.drop` etc. accept complete `position`/`dragOrigin`/`originEvent` objects, so no DOM event simulation is ever needed.
+- Async settling via `vi.waitFor` around the assertion that proves the trigger landed. Debounced channels (the mutation batcher) need their own `vi.waitFor`; comparing them synchronously after another assertion passes is a race.
+- **Never sleep** (`setTimeout`, arbitrary delays), even for negative asserts. To prove "nothing was emitted", create a deterministic flush point: perform a local edit through the same ordered channel and assert the full emission list contains exactly that edit's patches, a would-be echo would have to surface no later than the edit's own emission. This also upgrades the negative assert to a full-value pin.
+
+## Assertion style: no indirection, full values
+
+- Assert **complete literal values with `toEqual`**: the full value array, the full event array, the full operation objects. Deterministic keys make this possible. A full-value assertion pins ordering, count, and content at once, and drift shows up as a readable diff.
+- Do **not** build summarizer helpers (string transcripts, custom matchers, mapping functions) between the collected data and the assertion. The reader should see exactly what the editor emitted.
+- `expect.objectContaining` / `expect.any(String)` are last resorts for genuinely nondeterministic fields, used per-field, never to avoid writing out a value.
+- For value-shape assertions where the full tree is noise, use `toTextspec(editor.getSnapshot().context)` and assert the textspec string (`'B: foo bar|'`), which is itself a full-value assertion in compact notation.
+- Exact-sequence event tests (`EventListenerPlugin` collecting `EditorEmittedEvent`s) assert the whole sequence; do not filter event types out to make assertions easier.
+
+## Structure
+
+- `test('Scenario: ...')` naming for integration tests; plain `test(...)` with the function name for unit tests of a single function (`describe(buildIndexMaps.name, ...)`).
+- A quote character inside a test name is solved by switching the string's quotes (`"...set's fallout..."`), never with `\u` escapes or backslash-escaping. Prettier keeps whichever quote style avoids the escape.
+- Tests first, helpers below (per repo AGENTS.md: helper functions below main functions).
+- Fixtures are plain functions returning complete objects (`function block(key, text): PortableTextBlock`), local to the test file.
+- Comments explain why, placed inside the scope they explain, not above it.
+- When test code duplicates production logic from elsewhere (a copied helper in a plugin), port the source's test suite wholesale as the drift alarm, with a header comment naming the source and the keep-in-sync contract.
+
+## Gates before pushing
+
+From the package: `pnpm check:types`, `pnpm check:lint`, `pnpm check:react-compiler`, `pnpm test:unit`, `pnpm test:browser` (or `:chromium` while iterating), `pnpm build`. From the repo root: `pnpm check:knip`. The unit project fails on "no tests found": a package with only browser tests needs at least one `.test.ts`, which the drift-alarm suite usually provides.

--- a/.claude/skills/changesets
+++ b/.claude/skills/changesets
@@ -1,0 +1,1 @@
+../../.agents/skills/changesets

--- a/.claude/skills/code-comments
+++ b/.claude/skills/code-comments
@@ -1,0 +1,1 @@
+../../.agents/skills/code-comments

--- a/.claude/skills/commits
+++ b/.claude/skills/commits
@@ -1,0 +1,1 @@
+../../.agents/skills/commits

--- a/.claude/skills/writing-tests
+++ b/.claude/skills/writing-tests
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-tests


### PR DESCRIPTION
This repo's conventions for tests, comments, commits, and changesets have so far lived only in AGENTS.md as terse hard-rule summaries. The fuller versions (which suite a test belongs in and why, what a comment must prevent to earn its place, the commit body shape, changeset bump selection) existed only outside the repo, so agents and contributors could not reach them.

This promotes four convention skills into the repo as `.agents/skills/*/SKILL.md`, the same layout the `sanity` monorepo uses: `.agents/skills` is picked up natively by agents that read that directory, and committed symlinks under `.claude/skills` (next to the existing `product-copy-assistant` skill) expose the same files to Claude Code. AGENTS.md stays as the summary layer; the skills carry the detail and the exemplars, which are real commits and changesets from this repo's history.

No code or behavior changes; the diff is four markdown files and four symlinks.
