### PR TITLE
fix: treat `undefined` and `[]` as equal empty values in value sync

### DIFF
--- a/.changeset/empty-value-update-equality.md
+++ b/.changeset/empty-value-update-equality.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: treat `undefined` and `[]` as equal empty values in value sync
+
+An `update value` event carrying an empty array no longer clears text the user has typed when the editor's last synced value was `undefined`. Both shapes mean "empty", so the update is now a no-op instead of counting as a remote change that wipes local content. This could surface as typed text suddenly disappearing in Sanity Studio when a stale document snapshot presented an empty field as `[]` after a dropped listener connection.
+
+A genuine remote clear, where the previously synced value was non-empty, still empties the editor as before.

--- a/packages/editor/src/internal-utils/equality.ts
+++ b/packages/editor/src/internal-utils/equality.ts
@@ -12,7 +12,10 @@ export function isEqualValues(
   b: Array<PortableTextBlock | Node> | undefined,
 ): boolean {
   if (!a || !b) {
-    return a === b
+    // `undefined` and `[]` both mean "empty value". Treating them as
+    // different makes the sync machine count an empty→empty value update
+    // as a remote change and clear locally typed content.
+    return (a?.length ?? 0) === (b?.length ?? 0)
   }
 
   if (a.length !== b.length) {

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -2316,6 +2316,178 @@ describe('event.update value: auto-resolved invalid blocks', () => {
     })
   })
 
+  test('Scenario: Clearing synced value with an empty array', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The existing clearing scenarios all spell "empty" as `undefined`;
+    // this pins that the `[]` shape clears a non-empty synced value too.
+    editor.send({type: 'update value', value: []})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k2',
+          _type: 'block',
+          children: [{_key: 'k3', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Clearing locally typed text with an empty array after the value echoed back', async () => {
+    const mutations: Array<MutationEvent> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutations.push(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(mutations.length).toBeGreaterThan(0)
+    })
+
+    // The controlled-host flow: the host receives the mutation and echoes
+    // the value back down. After the echo the machine holds a non-empty
+    // synced value, so a later `[]` is a genuine remote clear.
+    editor.send({type: 'update value', value: mutations[0]!.value})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    editor.send({type: 'update value', value: []})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k2',
+          _type: 'block',
+          children: [{_key: 'k3', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Stale `undefined` update does not clear locally typed text', async () => {
+    const mutations: Array<MutationEvent> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutations.push(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(mutations.length).toBeGreaterThan(0)
+    })
+
+    // The other spelling of the stale empty snapshot. Must behave exactly
+    // like the `[]` shape: local text survives.
+    editor.send({type: 'update value', value: undefined})
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Empty array update on a pristine editor keeps the placeholder', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+    })
+
+    editor.send({type: 'update value', value: []})
+
+    // The sentinel edit pins placeholder identity: if the `[]` had counted
+    // as a remote change, the clear would have minted a fresh placeholder
+    // block (`k2`/`k3`) and the typed text would land there.
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
   test('Scenario: Stale empty array update does not clear locally typed text', async () => {
     const mutations: Array<MutationEvent> = []
     const {editor, locator} = await createTestEditor({

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1,6 +1,7 @@
 import {createTestKeyGenerator} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
 import {
   defineSchema,
   type EditorEmittedEvent,
@@ -2311,6 +2312,52 @@ describe('event.update value: auto-resolved invalid blocks', () => {
       expect(patches).toEqual([sentinelPatch])
       expect(mutations.map((mutation) => mutation.patches)).toEqual([
         [sentinelPatch],
+      ])
+    })
+  })
+
+  test('Scenario: Stale empty array update does not clear locally typed text', async () => {
+    const mutations: Array<MutationEvent> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'mutation') {
+              mutations.push(event)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    // Wait for the mutation flush so the sync machine is not busy and acts
+    // on the incoming value right away.
+    await vi.waitFor(() => {
+      expect(mutations.length).toBeGreaterThan(0)
+    })
+
+    // A stale snapshot can present an empty field as `[]` even though the
+    // editor mounted with `undefined` (observed in Studio after a dropped
+    // listener connection). Both shapes mean "empty", so the update must
+    // not count as a remote change that clears the locally typed text.
+    editor.send({type: 'update value', value: []})
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
       ])
     })
   })


### PR DESCRIPTION
Typing into an empty Portable Text field can lose the typed text: when the host application sends an `update value` event with `[]` while the editor mounted with `undefined` and has never synced a non-empty value, the editor clears everything the user wrote. In Sanity Studio this surfaced as text vanishing from a brand-new document moments after typing, when a stale snapshot presented the still-empty field as `[]` after a dropped listener connection.

The asymmetry sits in `isEqualValues`, which short-circuited a missing side with `a === b`, so `undefined` and `[]` compared as different. The sync machine's `is new value` guard compares the incoming value against `previousValue`, which stays `undefined` on an editor that mounted without a value. An incoming `[]` therefore counted as a new remote value and `clearEditor` unset every block, wiping local content. The same stale snapshot delivered as `undefined` was a no-op; only the `[]` shape was destructive.

`isEqualValues` now compares lengths when either side is missing: `undefined` and `[]` are equal, and a missing side never equals a non-empty one. A genuine remote clear, where the previously synced value was non-empty, still differs by length and empties the editor as before; the existing "Clearing lonely text block" and "Clearing lonely block object" scenarios pin that. The fix is pinned by a browser test that types into an empty editor, waits for the mutation flush, sends `update value` with `[]`, and asserts the typed text survives a subsequent edit; it fails on the old comparison.
