### PR TITLE
docs: state the `update value` reconciliation contract on the event type

### DIFF
--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -27,6 +27,26 @@ export type EditorEvent =
   | ExternalEditorEvent
   | ExternalBehaviorEvent
   | {
+      /**
+       * Hands the editor the host's latest snapshot of the value so it can
+       * reconcile. This is not a setter: the snapshot is compared against
+       * the previous snapshot the host sent, not against the editor's
+       * current content, and only the remote change that comparison implies
+       * is applied. A snapshot equal to the previous one is ignored, even
+       * if the editor's content has since diverged from it through local
+       * edits.
+       *
+       * Reconciliation is not an edit: it emits no `patch` or `mutation`
+       * events and adds no history step. While local changes are in
+       * flight, it is deferred until they have flushed. `undefined` and
+       * `[]` are the same empty snapshot: sending either when the previous
+       * snapshot was also empty is a no-op and never clears locally typed
+       * content.
+       *
+       * To change content programmatically, use editing events so the
+       * change flows through behaviors and emits patches; to reset the
+       * editor wholesale, remount it with a fresh `initialValue`.
+       */
       type: 'update value'
       value: Array<PortableTextBlock> | undefined
     }


### PR DESCRIPTION
The `update value` variant of `EditorEvent` carried no JSDoc, so the event name was its entire documentation, and the name reads as a controlled-component setter ("make the editor's value this"). The actual contract is snapshot reconciliation, and every way the two readings differ is an observable behavior: the snapshot is diffed against the previous snapshot rather than the editor's content, a repeated snapshot is ignored even when the editor has drifted, reconciliation defers while local changes are in flight, it emits no `patch`/`mutation` events and no history step, and `undefined` and `[]` are the same empty snapshot (#3046).

This documents the existing contract on the type where consumers hover; no behavior changes and no changeset. It also points programmatic-edit and wholesale-reset use cases at their proper tools (editing events, remount with `initialValue`), since misusing the sync channel for edits silently diverges the host's stored value.
