### PR TITLE
fix: treat a pristine block from value sync as persisted content

### DIFF
--- a/.changeset/pristine-block-provenance.md
+++ b/.changeset/pristine-block-provenance.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: treat a pristine block from value sync as persisted content
+
+Typing into an empty-looking block that arrived through an `update value` event no longer re-emits `setIfMissing` and an `insert` for that block. Previously the block was mistaken for the editor's own local placeholder, and the first edit inserted a copy of it into a document that already contained its `_key`, producing duplicate-key content that breaks keyed patch addressing from then on. This could occur when another client stored an empty Portable Text field as a single empty block instead of unsetting it.
+
+The same misjudgment affected incoming patches: a remote root-level `insert` arriving next to such a block removed it locally, leaving the editor briefly missing a block the document still has until the next value sync repaired it. The block now survives the insert.
+
+One narrow behavioral delta rides along: deleting all content back down to exactly such a synced-in empty block no longer emits `unset` for the field; the document keeps the empty block it already had.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -76,6 +76,7 @@ export function createEditorEngine(
   editor.undoStepId = undefined
 
   editor.isDeferringMutations = false
+  editor.lastSyncedValue = undefined
   editor.isNormalizingNode = false
   editor.isPatching = true
   editor.isPerformingBehaviorOperation = false

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -6,6 +6,7 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import {subscribeToOperations} from '../engine/core/operation-channel'
+import {isEqualValues} from '../internal-utils/equality'
 import {
   insertNodePatch,
   textPatch,
@@ -45,11 +46,21 @@ export function subscribePatchGeneration({
 
     const editorWasEmpty =
       previousValue.length === 1 &&
-      isEqualToEmptyEditor(initialValue, previousValue, schema)
+      isEqualToEmptyEditor(initialValue, previousValue, schema) &&
+      !isEqualValues({schema}, editor.lastSyncedValue, previousValue)
 
     const editorIsEmpty =
       editor.snapshot.context.value.length === 1 &&
-      isEqualToEmptyEditor(initialValue, editor.snapshot.context.value, schema)
+      isEqualToEmptyEditor(
+        initialValue,
+        editor.snapshot.context.value,
+        schema,
+      ) &&
+      !isEqualValues(
+        {schema},
+        editor.lastSyncedValue,
+        editor.snapshot.context.value,
+      )
 
     // If the editor was empty and now isn't, insert the placeholder into it.
     if (

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -160,6 +160,10 @@ export const syncMachine = setup({
         return event.value
       },
     }),
+    'record synced value on engine': ({context, event}) => {
+      assertEvent(event, 'done syncing')
+      context.editorEngine.lastSyncedValue = event.value
+    },
     'emit done syncing value': emit({
       type: 'done syncing value',
     }),
@@ -401,7 +405,11 @@ export const syncMachine = setup({
         'done syncing': [
           {
             guard: 'value changed while syncing',
-            actions: ['assign previous value', 'assign initial value synced'],
+            actions: [
+              'assign previous value',
+              'record synced value on engine',
+              'assign initial value synced',
+            ],
             target: 'syncing',
             reenter: true,
           },
@@ -410,6 +418,7 @@ export const syncMachine = setup({
             actions: [
               'clear pending value',
               'assign previous value',
+              'record synced value on engine',
               'assign initial value synced',
             ],
           },

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -21,6 +21,7 @@ import type {Node} from '../engine/interfaces/node'
 import {getNode} from '../traversal/get-node'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {applyDeselect} from './apply-selection'
+import {isEqualValues} from './equality'
 import {getValue} from './get-value'
 import {isEqualToEmptyEditor} from './values'
 
@@ -149,6 +150,11 @@ function insertPatch(
       context.initialValue,
       editor.snapshot.context.value,
       context.schema,
+    ) &&
+    !isEqualValues(
+      {schema: context.schema},
+      editor.lastSyncedValue,
+      editor.snapshot.context.value,
     )
 
   const arrayFieldPath = patch.path.slice(0, -1)

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -79,6 +79,11 @@ export interface PortableTextEditorEngine extends DOMEditor {
   undoStepId: string | undefined
 
   isDeferringMutations: boolean
+  /**
+   * The last host value written in by value sync. A pristine block equal
+   * to it is persisted content, not the local placeholder.
+   */
+  lastSyncedValue: Array<PortableTextBlock> | undefined
   isNormalizingNode: boolean
   isPatching: boolean
   isPerformingBehaviorOperation: boolean

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5338,4 +5338,44 @@ describe('event.patches', () => {
       })
     })
   })
+
+  test('Scenario: Typing into a pristine `initialValue` block', async () => {
+    const patches: Array<Patch> = []
+    const {locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'a')
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'a'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
 })

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5339,6 +5339,135 @@ describe('event.patches', () => {
     })
   })
 
+  test('Scenario: Typing into a pristine block synced in via `update value`', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'a')
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'a'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Remote `insert` next to a pristine block synced in via `update value`', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _key: 'c0',
+              _type: 'block',
+              children: [{_key: 'c1', _type: 'span', text: 'foo', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'c0',
+          _type: 'block',
+          children: [{_key: 'c1', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
   test('Scenario: Typing into a pristine `initialValue` block', async () => {
     const patches: Array<Patch> = []
     const {locator} = await createTestEditor({


### PR DESCRIPTION
A Portable Text field whose stored value is a single empty block (a shape PTE never writes itself, since it unsets on empty, but API writers and migrations do) corrupts on first edit: typing one character emits `setIfMissing` plus an `insert` for a block whose `_key` the document already contains, leaving two blocks with the same key. Every keyed-path patch after that resolves to the first match, so subsequent edits can land on the wrong block.

The editor maintains the placeholder fiction: a block it minted locally is not in the document, so the first edit must retroactively insert it, and inbound handling may discard it. To tell that placeholder apart from identical-looking persisted content, both consumers of the check compared against the mount-time `initialValue` alone, a proxy that lies for pristine blocks arriving through value sync. Patch generation re-inserted the block (the duplicate-key corruption above); `insertPatch` removed it after applying a remote root-level insert, locally deleting a block the document still has and diverging until the next value sync repaired it.

The fix gives both consumers the missing fact instead of a better guess: the sync machine records the last host value on the engine (`lastSyncedValue`, the same channel as `isDeferringMutations`, written on every completed sync), and a pristine block equal to it counts as persisted. Each direction is pinned by a test that fails without the fix (the duplicate insert and the remote-insert removal); the `initialValue` direction is pinned as unchanged.

One narrow behavioral delta rides along: deleting back down to exactly such a synced-in empty block no longer emits `unset([])` for the field; the document keeps the `[emptyBlock]` shape it already had. Preserving the shape PTE did not create seemed more honest than "healing" it as a side effect of an unrelated edit.
