### PR TITLE
docs: add a `reviewing-prs` skill that routes a PR to the canonical skills

### DIFF
--- a/.agents/skills/reviewing-prs/SKILL.md
+++ b/.agents/skills/reviewing-prs/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: reviewing-prs
+description: Review a PR in this repo against the house conventions before it is marked ready. Use when asked to review, pre-flight, or check a PR ("review this PR", "pre-flight", "is this PR ready"), and as a self-check before handing off any PR. Routes each artifact in the diff to its canonical skill (commits, changesets, writing-tests, code-comments) and verifies the PR's claims empirically instead of stylistically.
+---
+
+# Reviewing PTE PRs
+
+This skill owns the review _procedure_. The rules live in the canonical
+skills; read each one before auditing its artifact, and cite it in
+findings. Never restate a rule from memory: memory is how drift starts.
+
+## Gather
+
+- `gh pr view <n>` (title, body, draft state) and `gh pr diff <n>`.
+- `git log origin/main..HEAD --format='%h %s'` plus each commit's body.
+- Bucket the changed files: source, tests, `.changeset/*.md`, docs, config.
+
+## Route each artifact to its skill
+
+Read the skill, then audit the artifact against it:
+
+- **Commits** → `commits`: subjects name the mechanism; a commit carrying a
+  changeset is `fix:`/`feat:`; contract pins sit in their own `test:`
+  commit while regression tests ride the fix; no ticket IDs anywhere;
+  `fixup!` discipline once in review.
+- **Changesets** → `changesets`: present iff the change is user-facing;
+  first line mirrors the commit subject verbatim; consumer-observable
+  prose; rides-along deltas named explicitly.
+- **Test files** → `writing-tests`: canonical suite placement; every
+  integration test is its own `Scenario:`; deterministic keys; full-value
+  `toEqual`; no sleeps; no summarizer indirection; comments held to the
+  source-file bar.
+- **Comments in the diff** → `code-comments`: default is no comment;
+  why-only; nothing diff-relative; if the commit body already tells it,
+  the comment is a duplicate and goes.
+- **PR body**: draft state, narrative shape, no internal context (no
+  ticket IDs, customers, support threads), semantic deltas volunteered,
+  one-screen budget. (Canonical conventions live outside the repo; when
+  they are not available, audit against this list.)
+
+## Verify claims empirically
+
+A stylistic pass is half a review. For every claim the PR makes, find the
+evidence or produce it:
+
+- A claimed regression test must be red pre-fix: check out the pre-fix
+  source (or revert the fix hunks in the working tree) and run it, unless
+  the PR or commit body records the red run.
+- Run the gates the diff touches: `check:types`, `check:lint`,
+  `check:format`, `check:knip`, and the affected package's test suites.
+- Spot-check "full value" assertions for smuggled partial matchers.
+- A named behavioral delta must have a test proving the _new_ behavior;
+  an unnamed one found in the diff is a blocker, not a nit.
+
+## Report
+
+- Findings ordered: **blocker** / **should-fix** / **nit**. Each names
+  `file:line`, the rule (skill and section), and the concrete fix.
+- End with a verdict: ready to hand off, or the shortest list of changes
+  that gets there.
+- When asked to fix rather than report, apply the findings and re-run the
+  gates; history is rewritten (fold, not append) while the PR is a draft.
+
+## Anti-patterns
+
+- Rubber-stamping with a summary of the diff instead of an audit.
+- Restating skill rules from memory instead of reading the skill.
+- Style opinions not backed by a skill: raise them as questions, not
+  findings.
+- Reviewing the investigation instead of the change: the diff, its
+  commits, and its claims are the review surface.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -41,7 +41,9 @@ When scaffolding a new package, mirror `plugin-typeahead-picker`'s vitest config
 
 ## Structure
 
-- `test('Scenario: ...')` naming for integration tests; plain `test(...)` with the function name for unit tests of a single function (`describe(buildIndexMaps.name, ...)`).
+- `test('Scenario: ...')` naming for integration tests; plain `test(...)` with the function name for unit tests of a single function (`describe(buildIndexMaps.name, ...)`). Every integration test carries its own `Scenario:`; a `describe` may group by mechanism or function name but never carries the scenario, narration, or a comment preamble.
+- Test files hold comments to the same bar as source files: the default is none. The scenario name and the full-value assertions are the documentation; narrative about why a contract exists belongs in the commit body, not in a comment above the test.
+- A known-broken contract is pinned with `test.fails` asserting the desired behavior: it documents the bug executably, and the fix flips it to a plain `test` (CI reports it as unexpectedly passing until someone does).
 - A quote character inside a test name is solved by switching the string's quotes (`"...set's fallout..."`), never with `\u` escapes or backslash-escaping. Prettier keeps whichever quote style avoids the escape.
 - Tests first, helpers below (per repo AGENTS.md: helper functions below main functions).
 - Fixtures are plain functions returning complete objects (`function block(key, text): PortableTextBlock`), local to the test file.


### PR DESCRIPTION
Two skill changes, both fallout from reviewing #3050.

The writing-tests skill implied but never stated the rules that let narrated `describe` wrappers and comment walls into a test file: every integration test now explicitly carries its own `Scenario:`, `describe` may group but never narrates, and test files hold comments to the same bar as source files, with contract narrative living in the commit body. The `test.fails` convention for pinning known-broken contracts executably is recorded alongside, since it earned its keep in the same PR.

The new `reviewing-prs` skill closes the structural gap that let those violations reach human review: every existing skill fires when its artifact is written, but nothing re-reads them against a finished diff. The skill deliberately owns only the procedure (gather the diff and commits, route each artifact to its canonical skill, verify the PR's claims empirically, report findings with severity and a verdict) and defers every rule to the skill it routes to, so the rules cannot fork. Its one substantive addition is the empirical-verification step: a claimed regression test gets run against pre-fix code, gates get re-run, and a behavioral delta without a test is a blocker.
