### PR TITLE
test: budget two browser test waits above their unavoidable cost

### DIFF
--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -173,9 +173,10 @@ describe('event.update value', () => {
           },
         ])
       },
-      {
-        timeout: 1100,
-      },
+      // The sync machine parks in `busy` while the insert's emitted
+      // mutation flushes and re-checks on a 1s timer, so the value cannot
+      // land sooner than that.
+      {timeout: 5000},
     )
   })
 

--- a/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
+++ b/packages/plugin-sdk-value/src/plugin.value-sync.browser.test.tsx
@@ -296,7 +296,12 @@ describe('ValueSyncPlugin', () => {
         },
         {timeout: 5000},
       )
-    })
+      // The explicit test timeout is generous because the bursts above are
+      // ~70 real key events, each a round-trip to the browser whose cost
+      // scales with machine load: the interaction takes ~3s idle but has
+      // measured ~13s on CI, and vitest's 15s default leaves too little
+      // room for the convergence wait on top of that.
+    }, 60_000)
   })
 
   describe('remote changes apply to editor', () => {


### PR DESCRIPTION
Two browser tests carry timeouts smaller than the work they wait on, so they fail on CI whenever a runner is slow. Both failed on the release PR [#3052](https://github.com/portabletext/editor/pull/3052), whose diff is only version bumps and changelogs, against source that had passed all three browsers minutes earlier on [#3050](https://github.com/portabletext/editor/pull/3050) and on `main`.

## `Scenario: updating block object property` (webkit)

The test sends `insert.block object` and an `update value` back to back. The insert leaves a mutation unflushed, so the sync machine's `is busy` guard holds and it parks in `busy`, which waits a fixed 1s before re-checking. The updated value cannot reach the engine sooner than that, and the wait allowed 1100ms.

Measured convergence on an idle machine:

| Browser | Convergence | Slack under the old 1100ms budget |
| :--- | ---: | ---: |
| chromium | 1003ms | 97ms |
| firefox | 1007ms | 93ms |
| webkit | 1032ms | 68ms |

Probing the same wait at 1000ms fails deterministically in all three browsers, confirming the floor sits above the 1s timer. Budgeted at 5000ms, matching the two sibling scenarios in the file that already wait out that timer and say so.

## `delete-and-retype bursts converge to exactly what was typed` (firefox)

The test drives ~70 real key events through `userEvent`, each a round-trip to the browser, before waiting up to 5s for the editor and the store to agree. The interaction cost scales with how loaded the machine is: ~3.2s idle, 6.3s under local contention, and 12.76s on the CI firefox job. The run that reported 15042ms ran out vitest's 15s default part-way through the bursts and failed with `Test timed out in 15000ms`, never reaching the convergence assertion.

Given an explicit 60s budget covering the bursts plus the convergence wait. Forcing the ambient default below the interaction cost reproduces the CI failure at the same line and shows the budget clearing it:

```
=== WITHOUT FIX (ambient default forced to 3000ms) ===
 × delete-and-retype bursts converge to exactly what was typed 3003ms
   → Test timed out in 3000ms.
    241|     test('delete-and-retype bursts converge to exactly what was typed'…
      Tests  1 failed | 22 skipped (23)

=== WITH FIX (same forced default) ===
 ✓ delete-and-retype bursts converge to exactly what was typed 3234ms
      Tests  1 passed | 22 skipped (23)
```

## Verification

Both files pass in chromium, firefox and webkit. Full suites: `@portabletext/editor` browser in chromium (195 files, 1772 tests) and webkit (1752 passed, 21 skipped), `@portabletext/plugin-sdk-value` browser in firefox (61 tests). `check:format`, `check:types`, `check:lint`, `check:react-compiler`, `check:knip` and both packages' unit projects are green.

On this PR's CI, both jobs that failed on #3052 now pass: **Browser tests (firefox)** and **Browser tests (webkit)**.

No changeset: these are test-budget changes with no published-code effect.

## Out of scope

**The chromium job on this PR hit a third, unrelated flake**, already present on `main`-based branches before this change: the vitest browser connection dies mid-run and aborts everything, with no test failing.

```
Caused by: Error: [vitest] Browser connection was closed while running tests. Was the page closed unexpectedly?
Caused by: Error: [birpc] rpc is closed, cannot call "createTesters"
 Test Files  156 passed (195)
```

The same signature appears on [`test-placeholder-provenance-footgun`](https://github.com/portabletext/editor/actions/runs/31162212146) (08:33) and [`docs-update-value-contract`](https://github.com/portabletext/editor/actions/runs/31151853653) (05:49), both chromium, both hours before this branch existed. It is a browser-process/transport failure rather than a timeout, it does not reproduce locally, and any mitigation would be speculative config tuning with a real CI-time cost, so it is left for its own investigation rather than guessed at here.

Also left alone: the `settle` sleeps inside the burst test. They pace the typing across flush windows rather than waiting for an outcome, so they are the mechanism under test, not a settling shortcut. Worth noting separately that `packages/editor`'s browser project retries firefox 3× while `packages/plugin-sdk-value`'s has no retry, which is why that firefox timeout surfaced with no safety net.

