### PR TITLE
test: pin dropping a block image onto an inline object staying a block

### DIFF
--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -1424,4 +1424,132 @@ describe('event.drag.drop', () => {
       ])
     })
   })
+
+  test('Scenario: Dropping block image onto inline object inserts as block, not inline', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const stockTickerKey = keyGenerator()
+    const barKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+        inlineObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', text: 'foo', marks: []},
+            {
+              _type: 'image',
+              _key: stockTickerKey,
+              src: 'https://example.com/inline.jpg',
+            },
+            {_key: barKey, _type: 'span', text: 'bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/block.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {
+        path: [{_key: imageKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: imageKey}],
+        offset: 0,
+      },
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: imageSelection})
+
+    await vi.waitFor(() => {
+      const selection = editor.getSnapshot().context.selection
+      expect(selection).toEqual({
+        ...imageSelection,
+        backward: false,
+      })
+    })
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {
+        type: 'serialize',
+        originEvent: 'drag.dragstart',
+      },
+    })
+
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {
+        dataTransfer,
+      },
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: stockTickerKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: stockTickerKey}],
+            offset: 0,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/block.jpg',
+        },
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [
+            {_key: fooKey, _type: 'span', marks: [], text: 'foo'},
+            {
+              _key: stockTickerKey,
+              _type: 'image',
+              src: 'https://example.com/inline.jpg',
+            },
+            {_key: barKey, _type: 'span', marks: [], text: 'bar'},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
When a schema declares the same type name (for example `image`) as both a block object and an inline object, dropping the block variant onto an inline object used to convert it into an inline object: the `insert.block` start/end resolution could match inline nodes when the drop position pointed at one. The bug no longer reproduces on current `main` (verified by running this exact test against `main` without any fix, chromium and firefox both green), so #2364, which carried the fix and this test, was closed. Nothing pinned the now-correct behavior, though, and the same-named block/inline shape is easy to regress. This lands the regression test on its own: drop a block image onto an inline image, assert the value keeps it as a top-level block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified.
> 
> **Overview**
> Adds a **regression test** in `event.drag.drop.test.tsx` for drag-and-drop when the schema defines the same type name (e.g. `image`) as both a block and an inline object.
> 
> The scenario drags a **top-level block image** and drops it on an **inline image** inside a text block. The assertion pins correct behavior: the moved content remains a **root-level block** (placed before the text block), and the existing inline image is untouched—not coerced into inline placement at the drop target.
> 
> No runtime or editor logic changes; this only locks in behavior that already passes on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b73772900ac866708fd5126ecf43563863e3b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->