### PR TITLE
test: pin selection surviving an action set that swaps the selected block

### DIFF
--- a/packages/editor/tests/selection-validation.test.tsx
+++ b/packages/editor/tests/selection-validation.test.tsx
@@ -1,6 +1,10 @@
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
+import {execute} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 
 const initialValue = [
@@ -94,5 +98,113 @@ describe('selection validation', () => {
     const domSelection = window.getSelection()
     expect(domSelection?.focusNode).toBe(textNode)
     expect(domSelection?.focusOffset).toBe(3)
+  })
+
+  test('Scenario: An action set that swaps a block keeps selection on the new block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const newBlockKey = 'newBlock'
+    const newSpanKey = 'newSpan'
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'custom.swap-image',
+              actions: [
+                () => [
+                  execute({
+                    type: 'insert.block',
+                    block: {
+                      _key: newBlockKey,
+                      _type: 'block',
+                      children: [
+                        {_key: newSpanKey, _type: 'span', text: '', marks: []},
+                      ],
+                      markDefs: [],
+                      style: 'normal',
+                    },
+                    placement: 'after',
+                    select: 'start',
+                  }),
+                  execute({
+                    type: 'delete.block',
+                    at: [{_key: imageKey}],
+                  }),
+                ],
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: imageKey}], offset: 0},
+        focus: {path: [{_key: imageKey}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.anchor.path).toEqual([
+        {_key: imageKey},
+      ])
+    })
+
+    editor.send({type: 'custom.swap-image'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foo'}],
+        },
+        {
+          _key: newBlockKey,
+          _type: 'block',
+          children: [{_key: newSpanKey, _type: 'span', text: '', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [{_key: newBlockKey}, 'children', {_key: newSpanKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: newBlockKey}, 'children', {_key: newSpanKey}],
+        offset: 0,
+      },
+      backward: false,
+    })
   })
 })


### PR DESCRIPTION
A behavior action set that deletes the selected block and inserts a replacement used to trip `validateSelection`'s catch path while the DOM lagged behind React's commit: the editor deselected and the caret jumped to the top of the document (the workaround shipped in a consumer was pre-emptively clearing and re-selecting in a microtask). The catch path has been benign since the selection-validation rework — it skips the DOM sync for that tick and the MutationObserver retries after the commit — so the scenario now holds on `main`, verified by running this test against `main` unmodified. Nothing pinned it, though, and the machine's raced-ahead-of-React timing is easy to regress. This lands the regression pin: swap the selected block inside one action set, assert the value and that the selection lands on the replacement block's span.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior modifications.
> 
> **Overview**
> Adds a **regression test** in `selection-validation.test.tsx` for a timing edge case: when a behavior action set **inserts a replacement block** (with `select: 'start'`) and **deletes** the previously selected block in one batch, the editor selection must end on the new block’s span—not deselect or jump to the document top.
> 
> The test wires a custom `custom.swap-image` behavior via `BehaviorPlugin`, selects an image block, fires the swap, and asserts both the updated document value and that `context.selection` points at the replacement text block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f6c77be65cd9f684cd6c2a6fb84a3ff20e8abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->