### PR TITLE
feat(playground): visualize and insert invisible characters

### DIFF
--- a/.changeset/zero-advance-caret-boundary.md
+++ b/.changeset/zero-advance-caret-boundary.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve leaf-boundary carets past zero-advance leaves
+
+When a decoration or mark boundary isolates a run of zero-width characters (a soft hyphen, a zero-width space) into its own leaf, the caret placed after that run now paints at the start of the following text instead of collapsing onto the same position as the caret before it. Clicking or arrowing between such a character and the text after it now shows the caret where the model actually is. Selection edges and selection rects that end at such a boundary paint past it the same way.

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -57,6 +57,10 @@ import {
 } from './feature-flags'
 import {FullscreenProvider, FullscreenToggle, useFullscreen} from './fullscreen'
 import {highlightMachine} from './highlight-json-machine'
+import {
+  InsertInvisibleCharacterButtons,
+  useInvisibleCharacterDecorations,
+} from './invisible-characters'
 import {MentionPickerPlugin} from './mention-picker'
 import type {EditorActorRef} from './playground-machine'
 import {
@@ -158,6 +162,7 @@ export function Editor(props: {
                       })
                     }}
                   />
+                  <InsertInvisibleCharacterButtons />
                 </PortableTextToolbar>
               </FullscreenAwareToolbarWrapper>
             ) : null}
@@ -224,6 +229,7 @@ function FullscreenAwareEditable(props: {
   loading: boolean
 }) {
   const {isFullscreen} = useFullscreen()
+  const invisibleCharacterDecorations = useInvisibleCharacterDecorations()
   const wrapperClasses = isFullscreen
     ? 'flex gap-2 items-stretch flex-1 min-h-0'
     : 'flex gap-2 items-center'
@@ -240,7 +246,10 @@ function FullscreenAwareEditable(props: {
         <EditorFeatureFlagsContext.Provider value={props.featureFlags}>
           <PortableTextEditable
             className={editableClasses}
-            rangeDecorations={props.rangeDecorations}
+            rangeDecorations={[
+              ...props.rangeDecorations,
+              ...invisibleCharacterDecorations,
+            ]}
             renderAnnotation={renderAnnotation}
             renderBlock={RenderBlock}
             renderDecorator={renderDecorator}

--- a/apps/playground/src/invisible-characters.tsx
+++ b/apps/playground/src/invisible-characters.tsx
@@ -1,0 +1,156 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type RangeDecoration,
+} from '@portabletext/editor'
+import {SpaceIcon, WrapTextIcon} from 'lucide-react'
+import {useMemo} from 'react'
+import {TooltipTrigger} from 'react-aria-components'
+import {Button} from './primitives/button'
+import {Tooltip} from './primitives/tooltip'
+
+const invisibleCharacterGlyphs = new Map<
+  string,
+  {glyph: string; zeroWidth: boolean}
+>([
+  ['\u00AD', {glyph: '¬', zeroWidth: true}],
+  ['\u00A0', {glyph: '°', zeroWidth: false}],
+])
+
+const invisibleCharacterRegex = new RegExp(
+  `[${[...invisibleCharacterGlyphs.keys()].join('')}]`,
+  'g',
+)
+
+export function useInvisibleCharacterDecorations(): Array<RangeDecoration> {
+  const editor = useEditor()
+  const value = useEditorSelector(editor, (snapshot) => snapshot.context.value)
+
+  return useMemo(() => {
+    const decorations: Array<RangeDecoration> = []
+
+    for (const block of value ?? []) {
+      if (!Array.isArray(block.children)) {
+        continue
+      }
+
+      for (const child of block.children) {
+        if (typeof child.text !== 'string') {
+          continue
+        }
+
+        for (const match of child.text.matchAll(invisibleCharacterRegex)) {
+          const character = invisibleCharacterGlyphs.get(match[0])
+
+          if (!character) {
+            continue
+          }
+
+          const markerSide = character.zeroWidth
+            ? match.index > 0
+              ? ('start' as const)
+              : ('end' as const)
+            : null
+          const path = [{_key: block._key}, 'children', {_key: child._key}]
+
+          decorations.push({
+            component: (props) => (
+              <InvisibleCharacter
+                glyph={character.glyph}
+                markerSide={markerSide}
+              >
+                {props.children}
+              </InvisibleCharacter>
+            ),
+            selection: {
+              anchor: {path, offset: match.index},
+              focus: {path, offset: match.index + 1},
+            },
+          })
+        }
+      }
+    }
+
+    return decorations
+  }, [value])
+}
+
+function InvisibleCharacter(props: {
+  glyph: string
+  markerSide: 'start' | 'end' | null
+  children?: React.ReactNode
+}) {
+  const wrapperPadding =
+    props.markerSide === 'start'
+      ? 'ps-[1ch]'
+      : props.markerSide === 'end'
+        ? 'pe-[1ch]'
+        : ''
+  const markerPosition =
+    props.markerSide === 'start'
+      ? 'start-0 w-[1ch]'
+      : props.markerSide === 'end'
+        ? 'end-0 w-[1ch]'
+        : 'inset-x-0'
+
+  return (
+    <span
+      className={`relative rounded-xs bg-sky-100 dark:bg-sky-900/50 ${wrapperPadding}`}
+    >
+      {props.children}
+      <span
+        contentEditable={false}
+        className={`absolute inset-y-0 flex items-center justify-center text-sky-600 dark:text-sky-400 pointer-events-none select-none ${markerPosition}`}
+      >
+        {props.glyph}
+      </span>
+    </span>
+  )
+}
+
+export function InsertInvisibleCharacterButtons() {
+  return (
+    <>
+      <InsertInvisibleCharacterButton
+        character={'\u00AD'}
+        icon={<WrapTextIcon className="size-4" />}
+        description="Insert soft hyphen"
+      />
+      <InsertInvisibleCharacterButton
+        character={'\u00A0'}
+        icon={<SpaceIcon className="size-4" />}
+        description="Insert non-breaking space"
+      />
+    </>
+  )
+}
+
+function InsertInvisibleCharacterButton(props: {
+  character: string
+  icon: React.ReactNode
+  description: string
+}) {
+  const editor = useEditor()
+  const disabled = useEditorSelector(
+    editor,
+    (snapshot) => snapshot.context.readOnly || !snapshot.context.selection,
+  )
+
+  return (
+    <TooltipTrigger>
+      <Button
+        aria-label={props.description}
+        isDisabled={disabled}
+        variant="secondary"
+        size="sm"
+        onPress={() => {
+          editor.send({type: 'insert.text', text: props.character})
+          editor.send({type: 'focus'})
+        }}
+      >
+        {props.icon}
+      </Button>
+      <Tooltip>{props.description}</Tooltip>
+    </TooltipTrigger>
+  )
+}

--- a/packages/editor/src/engine/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/engine/dom/plugin/dom-editor.ts
@@ -37,6 +37,8 @@ import {IS_ANDROID, IS_CHROME, IS_FIREFOX} from '../utils/environment'
 
 export type Action = {at?: Point | Range; run: () => void}
 
+const zeroAdvanceText = /^[\u00AD\u200B\u2060\uFEFF]+$/
+
 /**
  * A DOM-specific version of the `Editor` interface.
  */
@@ -425,6 +427,23 @@ export const DOMEditor: DOMEditorInterface = {
       const end = start + trueLength
 
       if (point.offset <= end) {
+        if (
+          point.offset === end &&
+          length > 0 &&
+          !text.hasAttribute('data-pt-zero-width') &&
+          zeroAdvanceText.test(domNode.textContent) &&
+          texts
+            .slice(i + 1)
+            .some((laterLeaf) => !laterLeaf.hasAttribute('data-pt-zero-width'))
+        ) {
+          // A zero-advance leaf (soft hyphens, zero-width spaces) paints
+          // its start and end at the same x. The next leaf's start is the
+          // same model point but paints distinctly, after any decoration
+          // chrome wrapping the zero-advance leaf.
+          start = end
+          continue
+        }
+
         const offset = Math.min(length, Math.max(0, point.offset - start))
         domPoint = [domNode, offset]
         break

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -702,3 +702,307 @@ describe('RangeDecorations inside editable containers', () => {
     )
   })
 })
+
+describe('caret painting at zero-advance leaf boundaries', () => {
+  test('Scenario: The caret after a decorated soft hyphen paints in the following text', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: 'foo\u00ADbar'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 3, focus: 4}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const afterSoftHyphen = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 4,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: afterSoftHyphen, focus: afterSoftHyphen},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: 'bar', offset: 0})
+    })
+
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {
+        path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+        offset: 4,
+      },
+      focus: {
+        path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+        offset: 4,
+      },
+      backward: false,
+    })
+  })
+
+  test('Scenario: The caret after a decorated zero-width run paints in the following text', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [
+            {_type: 'span', _key: 'a1', text: 'foo\u200B\u2060\uFEFFbar'},
+          ],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 3, focus: 6}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const afterRun = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 6,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: afterRun, focus: afterRun},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: 'bar', offset: 0})
+    })
+  })
+
+  test('Scenario: The caret before a decorated soft hyphen paints in the preceding text', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: 'foo\u00ADbar'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 3, focus: 4}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const beforeSoftHyphen = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 3,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: beforeSoftHyphen, focus: beforeSoftHyphen},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: 'foo', offset: 3})
+    })
+  })
+
+  test('Scenario: The caret after a block-leading decorated soft hyphen paints in the following text', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: '\u00ADbar'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 0, focus: 1}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const afterSoftHyphen = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 1,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: afterSoftHyphen, focus: afterSoftHyphen},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: 'bar', offset: 0})
+    })
+  })
+
+  test('Scenario: The caret before a block-leading decorated soft hyphen stays on its text node', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: '\u00ADbar'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 0, focus: 1}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const beforeSoftHyphen = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 0,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: beforeSoftHyphen, focus: beforeSoftHyphen},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: '\u00AD', offset: 0})
+    })
+  })
+
+  test('Scenario: The caret after a block-ending decorated soft hyphen stays on its text node', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: 'foo\u00AD'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: decorateRange({anchor: 3, focus: 4}),
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    const afterSoftHyphen = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 4,
+    }
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: afterSoftHyphen, focus: afterSoftHyphen},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: '\u00AD', offset: 1})
+    })
+  })
+
+  test('Scenario: The caret after a block-ending decorated soft hyphen ignores trailing spacer leaves', async () => {
+    const collapsedEnd = {
+      path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+      offset: 4,
+    }
+    const {editor, locator} = await createTestEditor({
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'a',
+          children: [{_type: 'span', _key: 'a1', text: 'foo\u00AD'}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations: [
+          ...decorateRange({anchor: 3, focus: 4}),
+          {
+            component: (props: {children?: ReactNode}) => (
+              <span data-testid="collapsed-decoration">{props.children}</span>
+            ),
+            selection: {anchor: collapsedEnd, focus: collapsedEnd},
+          },
+        ],
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    editor.send({type: 'focus'})
+    editor.send({
+      type: 'select',
+      at: {anchor: collapsedEnd, focus: collapsedEnd},
+    })
+
+    await vi.waitFor(() => {
+      expect(domCaret()).toEqual({text: '\u00AD', offset: 1})
+    })
+  })
+
+  function decorateRange(offsets: {anchor: number; focus: number}) {
+    return [
+      {
+        component: (props: {children?: ReactNode}) => (
+          <span data-testid="range-decoration">{props.children}</span>
+        ),
+        selection: {
+          anchor: {
+            path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+            offset: offsets.anchor,
+          },
+          focus: {
+            path: [{_key: 'a'}, 'children', {_key: 'a1'}],
+            offset: offsets.focus,
+          },
+        },
+      },
+    ]
+  }
+
+  function domCaret() {
+    const selection = window.getSelection()
+    return {
+      text: selection?.anchorNode?.textContent,
+      offset: selection?.anchorOffset,
+    }
+  }
+})


### PR DESCRIPTION
Proof of concept: make soft hyphens and non-breaking spaces visible in the playground, and give the toolbar a way to insert them.

The rendering rides on `rangeDecorations`. A hook scans the editor value for `\u00AD` and `\u00A0` and derives one `RangeDecoration` per occurrence, concatenated with the manually added decorations before they reach `PortableTextEditable`. The decoration component keeps the real character in the DOM and absolutely positions a `contentEditable={false}` marker glyph over it (`¬` for the soft hyphen, `°` for the non-breaking space), the same pattern the placeholder in `render.leaf.tsx` uses: the engine's text node stays untouched, the marker is chrome. Two toolbar buttons (`SHY`, `NBSP`) insert the characters via `insert.text`.

The soft hyphen exposed an engine limitation, so this PR carries one engine commit with a changeset. Chromium drops the character at rendering: zero advance width regardless of styling, so its own text node gives the caret a single paintable x, and `toDOMPoint` resolved every leaf boundary to the previous leaf's end, painting the caret after a decorated soft hyphen at the same position as the caret before it. The engine commit resolves a boundary at the end of a zero-advance-only leaf to the next leaf's start when a later leaf with model text exists: the same model point, painted after the decoration chrome. Zero-width spacer leaves are transparent to the rule, so a trailing collapsed-decoration spacer does not attract the caret. On top of that, the wrapper holds the glyph in `1ch` of padding on the side chosen by position in the span, so the neighbor leaf paints one caret side and the character's text node paints the other. A soft hyphen alone in a span remains degenerate: both caret positions share one x.

Seven scenarios pin the engine rule: the after-cases (mid-span, block-leading, a `\u200B\u2060\uFEFF` run) fail on the old resolution, and the before-cases, the block-ending case, and the trailing-spacer case pin what must not change; the mid-span case also asserts the model selection survives the round trip. The editor package's full chromium browser suite and unit suite pass; the new tests pass on chromium and firefox, and CI covers webkit (the local Playwright build does not launch it). One known UX cost, probed and understood: shift+arrow across a visualized soft hyphen spends one press crossing the glyph, because the padding visually separates two model-equivalent DOM caret positions. The model stays correct, the engine commit is not the cause (sequences are identical with and without it), and only the playground chrome exhibits it. Still open: decoration cost on large documents (one decoration per occurrence splits leaves, and the scan re-runs on every value change). If the PoC holds up, the productized shape is a `@portabletext/plugin-invisible-characters` package exposing the hook with a configurable character set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core editor selection-to-DOM mapping (`toDOMPoint`), which affects caret and range painting everywhere; behavior is narrow and heavily tested but still touches a sensitive path.
> 
> **Overview**
> Adds a playground PoC that **highlights soft hyphens and non-breaking spaces** via `rangeDecorations` (glyph overlay on the real character) and **toolbar actions** to insert `\u00AD` and `\u00A0`.
> 
> Fixes **`@portabletext/editor` DOM mapping** in `toDOMPoint`: when the model offset sits at the end of a leaf whose text is only zero-advance characters (soft hyphen, ZWSP, etc.) and a normal text leaf follows, the caret is painted on the **next leaf’s start** instead of sharing the same x as the position before the run. Trailing `data-pt-zero-width` spacer leaves are skipped so collapsed-decoration spacers do not steal the caret.
> 
> **Seven browser tests** lock in caret DOM position for decorated soft hyphens and zero-width runs (before/after, block-leading/ending, trailing spacer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b1badb7c46491671d436ba94ce30e6086a39d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
