### PR TITLE
chore(renovate): title `@types/*` bumps as `chore`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -80,6 +80,11 @@
       "matchPackageNames": ["/vitest/"],
       "groupName": "vitest",
       "semanticCommitType": "chore"
+    },
+    {
+      "description": "`@types/*` are devDependencies in every published package (they all bundle their own declarations), so a bump changes nothing a consumer can observe. Always `chore`: these are catalog-managed, and catalog updates edit `pnpm-workspace.yaml`, bypassing the `matchFileNames`+`matchDepTypes` rules above and inheriting the preset's `fix` default, which made the changeset bot cut empty patch releases",
+      "matchPackageNames": ["@types/*"],
+      "semanticCommitType": "chore"
     }
   ]
 }


### PR DESCRIPTION
Renovate titled the `@types/debug` bump (#3059) as `fix(deps)`, so the changeset bot cut patch releases of `@portabletext/editor` and `@portabletext/plugin-sdk-value` for a change with nothing consumer-observable in it: `@types/*` packages are devDependencies in every published package, and each package bundles its own declarations.

The existing rules already scope `fix` to `dependencies`/`peerDependencies` of published packages, but they match on `matchFileNames`, and `@types/*` entries are catalog-managed: Renovate edits `pnpm-workspace.yaml`, which no file rule covers, so the preset's `fix` default won. The new rule matches on package name instead, which catches catalog updates, and titles them `chore`, which the changeset workflow ignores.

Verified that no published package has `@types/*` outside devDependencies. After this merges, a dashboard rebase of #3059 should retitle it and drop its changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Renovate commit semantics; no runtime or published package behavior changes.
> 
> **Overview**
> Adds a Renovate **package rule** so any **`@types/*`** update is committed as **`chore`**, not **`fix(deps)`**.
> 
> Catalog-managed `@types` bumps only touch **`pnpm-workspace.yaml`**, so they skipped the existing **`matchFileNames` + `matchDepTypes`** rules that keep **`fix`** for real runtime deps. That let Renovate use the preset default **`fix`**, which triggered the changeset bot to cut **patch releases** even though `@types/*` are **dev-only** and published packages ship their own types—nothing consumers see changes.
> 
> The rule matches on **package name** (like the existing Vitest rule), so catalog `@types` PRs stay **`chore`** and the release workflow ignores them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adefadc38b71e98eb1c1f40078f0490e658ae3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->