### PR TITLE
chore: drop the `@types/debug` changeset

### DIFF
--- a/.changeset/dependencies-GH-3059.md
+++ b/.changeset/dependencies-GH-3059.md
@@ -1,6 +1,0 @@
----
-"@portabletext/editor": patch
-"@portabletext/plugin-sdk-value": patch
----
-
-fix(deps): update dependency @types/debug to ^4.1.13


### PR DESCRIPTION
#3059 merged with its bot-attached changeset before the `@types/*` Renovate rule (#3063) could retitle it. `@types/debug` is a devDependency in both named packages, so the changeset schedules patch releases of `@portabletext/editor` and `@portabletext/plugin-sdk-value` containing nothing a consumer can observe. Removing it; the open Version Packages PR updates itself on the next changesets run.

The other pending `dependencies-GH-*` changesets are runtime deps (`xstate`, `@floating-ui/dom`, `markdown-it`, `react`, sanity monorepo) and are correct to release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no runtime or API changes.
> 
> **Overview**
> Removes **`.changeset/dependencies-GH-3059.md`**, which would have triggered patch releases of **`@portabletext/editor`** and **`@portabletext/plugin-sdk-value`** for a **`@types/debug`** devDependency bump from merged PR #3059.
> 
> That changeset was redundant for consumers—type-only dev deps don’t affect published package behavior—so dropping it avoids empty patch releases while the Version Packages PR can refresh on the next Changesets run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d412fc62499c1ee69f38f436b5b18dd29f4b4957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->