### PR TITLE
fix(playground): render the inline image object with `inline-grid`

### DIFF
--- a/apps/playground/src/plugins/plugin.inline-objects.tsx
+++ b/apps/playground/src/plugins/plugin.inline-objects.tsx
@@ -29,7 +29,7 @@ const mentionStyle = tv({
 })
 
 const inlineImageStyle = tv({
-  base: 'max-w-35 grid grid-cols-[auto_1fr] items-start gap-1 border-2 border-gray-300 dark:border-gray-600 rounded text-sm',
+  base: 'max-w-35 inline-grid grid-cols-[auto_1fr] items-start gap-1 border-2 border-gray-300 dark:border-gray-600 rounded text-sm',
   variants: {
     selected: {
       true: 'border-blue-300 dark:border-blue-600',


### PR DESCRIPTION
In the playground, an inline image inserted into a paragraph rendered on its own line instead of flowing with the surrounding text, unlike the stock-ticker and mention inline objects.

The image chip's wrapper span used `grid` for its two-column layout (thumbnail plus truncated source). `display: grid` generates a block-level box, so the browser broke the line before and after the chip. The other inline objects flow correctly because they use `inline-flex`.

The fix swaps `grid` for `inline-grid`: same two-column layout, inline-level outer box. Playground-only, no published package touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change in the playground demo plugin only; no published packages or runtime logic affected.
> 
> **Overview**
> Fixes inline **image** chips in the playground editor so they sit on the same line as surrounding paragraph text instead of breaking onto their own line.
> 
> The image chip wrapper’s Tailwind classes change from **`grid`** to **`inline-grid`**, keeping the thumbnail + source two-column layout while using an inline-level box—aligned with how stock-ticker and mention objects use **`inline-flex`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d39c820e06c259f286688db2deea4769124bbb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->