### PR TITLE
chore(markdown): update @portabletext/toolkit to v6

### DIFF
--- a/.changeset/nine-pears-repeat.md
+++ b/.changeset/nine-pears-repeat.md
@@ -1,0 +1,9 @@
+---
+"@portabletext/markdown": major
+---
+
+Node.js 22.12 or later is now required
+
+`@portabletext/toolkit` has required Node.js 22.12 since v6, so continuing to advertise support for Node.js 20.19 here was incorrect. Node.js 20 reached end of life in April 2026.
+
+If you build on Node.js 20, upgrade to 22.12 or later before taking this version.

--- a/.changeset/tricky-pots-shake.md
+++ b/.changeset/tricky-pots-shake.md
@@ -1,0 +1,7 @@
+---
+"@portabletext/markdown": patch
+---
+
+Update `@portabletext/toolkit` to v6
+
+Nothing changes in the markdown output. The headline fix in v6 is to `nestLists()`, which this package does not use, since markdown expresses list depth through indentation and reads each block's `level` directly.

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@mdit/plugin-alert": "^0.23.2",
     "@portabletext/schema": "workspace:^",
-    "@portabletext/toolkit": "^5.0.2",
+    "@portabletext/toolkit": "catalog:",
     "markdown-it": "^14.3.0"
   },
   "devDependencies": {
@@ -69,7 +69,7 @@
     "vitest": "catalog:tooling"
   },
   "engines": {
-    "node": ">=20.19 <22 || >=22.12"
+    "node": ">=22.12"
   },
   "inlinedDependencies": {
     "@portabletext/types": "4.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@floating-ui/dom':
       specifier: ^1.8.0
       version: 1.8.0
+    '@portabletext/toolkit':
+      specifier: ^6.0.0
+      version: 6.0.0
     '@sanity/diff-match-patch':
       specifier: ^3.2.0
       version: 3.2.0
@@ -737,8 +740,8 @@ importers:
         specifier: workspace:^
         version: link:../schema
       '@portabletext/toolkit':
-        specifier: ^5.0.2
-        version: 5.0.2
+        specifier: 'catalog:'
+        version: 6.0.0
       markdown-it:
         specifier: ^14.3.0
         version: 14.3.0
@@ -3403,6 +3406,10 @@ packages:
   '@portabletext/toolkit@5.0.2':
     resolution: {integrity: sha512-Njc1LE1PMJkTx/wEPqZ6sOWGgFgX2B47fxpOQ/Ia4ByhsZoA5Sq8dNvvV5F052j/xE8TbOLiBEjS848FkKADDQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
+
+  '@portabletext/toolkit@6.0.0':
+    resolution: {integrity: sha512-+qSqe0KnefuZfNLUhzQRTpbSKxslZof+3pNwxg0DC8dfZ1yLKyyBUw6iR7EpDL+SJlrnpiBfEcfmEuFitK1NSQ==}
+    engines: {node: '>=22.12'}
 
   '@portabletext/types@4.0.2':
     resolution: {integrity: sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==}
@@ -10804,6 +10811,10 @@ snapshots:
     dependencies:
       '@portabletext/types': 4.0.2
 
+  '@portabletext/toolkit@6.0.0':
+    dependencies:
+      '@portabletext/types': 4.0.2
+
   '@portabletext/types@4.0.2': {}
 
   '@publint/pack@0.1.6':
@@ -13364,7 +13375,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.25)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -13380,9 +13391,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.25)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 
 catalog:
   "@floating-ui/dom": ^1.8.0
+  "@portabletext/toolkit": ^6.0.0
   "@sanity/diff-match-patch": ^3.2.0
   "@sanity/diff-patch": ^6.0.0
   "@sanity/json-match": ^1.0.5


### PR DESCRIPTION
Updates `@portabletext/markdown` to `@portabletext/toolkit@6.0.0`. It is the only package in this repo that depends on the toolkit.

## The list fix does not affect this package

The headline change in toolkit v6 is to `nestLists()`, which fills in list levels that were never authored so nesting depth always matches `level`. **This package never calls `nestLists()`.** Markdown expresses list depth through indentation, so `DefaultListItemRenderer` reads each block's `level` directly and emits `'   '.repeat(level - 1)`.

All 292 tests pass unchanged, `tsc` and `biome lint` are clean.

## Node version

The toolkit has required Node.js 22.12 since v6, so `engines.node` for `@portabletext/markdown` goes from `>=20.19 <22 || >=22.12` to `>=22.12`. Advertising support for Node.js 20.19 while depending on a package that requires 22.12 was incorrect, and Node.js 20 reached end of life in April 2026.

**Only `@portabletext/markdown` is changed.** The other 22 packages here still declare `>=20.19 <22 || >=22.12`. They all currently share one range, which suggests they are kept in lockstep, so bringing the rest along is a repo-wide call rather than something to fold into this PR. Happy to do it as a follow-up if that is the direction.

## Note on `pnpm-workspace.yaml`

`pnpm add` wanted to reformat the whole file, switching every quoted key from double to single quotes and dropping the `# Renovate security update: sharp@0.35.0` comment. I reverted that and added the single catalog line by hand, so the diff is one line.

## Unrelated pre-existing bug found while testing

Not fixed here, and not caused by this change, but worth recording.

Round-tripping a list that starts deeper than level 1, or that skips levels, is lossy. Because the indent is computed from the absolute `level` rather than the depth relative to the list actually emitted, `portableTextToMarkdown` produces indentation that CommonMark reads as something else.

Input: a `number` item at level 3, then level 1, then a `bullet` at level 1, a level 4 item, and back to level 1. Output:

```
      1. Starts at level 3
1. Back to level 1
- Bullet level 1
         - Jumps to level 4
- Bullet level 1 again
```

Feeding that straight back through `markdownToPortableText`:

- `Starts at level 3` has a 6 space indent with no preceding list, so it parses as an **indented code block** and stops being a list item at all
- `Jumps to level 4` has a 9 space indent, so it is absorbed into the previous item as literal text, `"Bullet level 1\n- Jumps to level 4"`, rather than becoming a nested item

This is the same class of problem as portabletext/toolkit#100, just in a different renderer: a level jump greater than one is not translated into a single step of nesting. The fix would be to indent by the depth actually emitted rather than by `level - 1`. Let me know if you want that as a separate PR.
