### PR TITLE
fix(markdown): serialize lists that start deep or skip levels

### DIFF
--- a/.changeset/great-jars-repeat.md
+++ b/.changeset/great-jars-repeat.md
@@ -1,0 +1,27 @@
+---
+"@portabletext/markdown": patch
+---
+
+Fix lists that start deeper than level 1, or skip levels, serializing to broken Markdown
+
+`portableTextToMarkdown` indented each list item by its absolute `level`, at three spaces per level. Markdown cannot express depth that way: indentation is relative to the list item above, and a first item indented four spaces or more is a code block, not a list.
+
+A list item at level 3 with nothing above it produced six spaces of indent, so reading it back gave a code block instead of a list item, losing the item. A jump from level 1 to level 4 produced nine spaces, which was absorbed into the previous item as literal text rather than becoming a nested item.
+
+Each jump to a deeper level is now a single step of nesting, however many levels it spans, so the output is valid Markdown that reads back as the same list structure. List numbering follows the list an item is actually rendered into, rather than its `level`.
+
+Given a `number` item at level 3 followed by one at level 1, then a `bullet` at level 1, one at level 4, and one back at level 1:
+
+```md
+1. Starts at level 3
+2. Back to level 1
+- Bullet level 1
+   - Jumps to level 4
+- Bullet level 1 again
+```
+
+Previously the first line was indented into a code block and `Jumps to level 4` was swallowed into the line above it.
+
+Lists that start at level 1 and change one level at a time are unaffected.
+
+Custom list item renderers receive a new `listDepth` option carrying the depth to indent by. `value.level` is unchanged.

--- a/packages/markdown/src/from-portable-text/build-list-index-map.ts
+++ b/packages/markdown/src/from-portable-text/build-list-index-map.ts
@@ -10,20 +10,48 @@ import {defaultKeyGenerator} from '../key-generator'
 const schema = compileSchema(defineSchema({}))
 
 /**
- * Builds a map of list item `_key`s to their index.
+ * Builds a map of list item `_key`s to their index, and a map of list item
+ * `_key`s to the depth they should be rendered at.
+ *
+ * The depth is not the same as the block's `level`. A list can start at a level
+ * deeper than 1, and can skip levels, but Markdown has no way to express either:
+ * indentation is relative to the list item above, and indenting a first item by
+ * four spaces or more makes it a code block rather than a list. So each jump to a
+ * deeper level counts as a single step of nesting, however many levels it spans.
  *
  * Mutates the blocks in place by adding a `_key` if necessary.
  */
 export function buildListIndexMap<
   Block extends TypedObject = PortableTextBlock | ArbitraryTypedObject,
->(blocks: Array<Block>): Map<string, number> {
+>(
+  blocks: Array<Block>,
+): {listIndexMap: Map<string, number>; listDepthMap: Map<string, number>} {
   const levelIndexMaps = new Map<string, Map<number, number>>()
   const listIndexMap = new Map<string, number>()
+  const listDepthMap = new Map<string, number>()
+
+  // Levels of the list items this one is nested inside, shallowest first
+  let levelStack: Array<number> = []
+
+  function depthOf(level: number): number {
+    let deepest = levelStack.at(-1)
+
+    while (deepest !== undefined && deepest > level) {
+      levelStack.pop()
+      deepest = levelStack.at(-1)
+    }
+
+    if (deepest !== level) {
+      levelStack.push(level)
+    }
+
+    return levelStack.length - 1
+  }
 
   let previousListItem:
     | {
         listItem: string
-        level: number
+        depth: number
       }
     | undefined
 
@@ -42,6 +70,7 @@ export function buildListIndexMap<
     if (!isTextBlock({schema}, block)) {
       levelIndexMaps.clear()
       previousListItem = undefined
+      levelStack = []
 
       continue
     }
@@ -50,9 +79,13 @@ export function buildListIndexMap<
     if (block.listItem === undefined || block.level === undefined) {
       levelIndexMaps.clear()
       previousListItem = undefined
+      levelStack = []
 
       continue
     }
+
+    const depth = depthOf(block.level)
+    listDepthMap.set(block._key, depth)
 
     // If we encounter a new list item, we set the initial index to 1 for the
     // list type on that level.
@@ -60,14 +93,14 @@ export function buildListIndexMap<
       const listIndex = 1
       const levelIndexMap =
         levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-      levelIndexMap.set(block.level, listIndex)
+      levelIndexMap.set(depth, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
       listIndexMap.set(block._key, listIndex)
 
       previousListItem = {
         listItem: block.listItem,
-        level: block.level,
+        depth,
       }
 
       continue
@@ -77,57 +110,57 @@ export function buildListIndexMap<
     // need to reset the level index map for that type.
     if (
       previousListItem.listItem === block.listItem &&
-      previousListItem.level < block.level
+      previousListItem.depth < depth
     ) {
       const listIndex = 1
       const levelIndexMap =
         levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-      levelIndexMap.set(block.level, listIndex)
+      levelIndexMap.set(depth, listIndex)
       levelIndexMaps.set(block.listItem, levelIndexMap)
 
       listIndexMap.set(block._key, listIndex)
 
       previousListItem = {
         listItem: block.listItem,
-        level: block.level,
+        depth,
       }
 
       continue
     }
 
-    // Reset other list types at current level and deeper
+    // Reset other list types at current depth and deeper
     levelIndexMaps.forEach((levelIndexMap, listItem) => {
       if (listItem === block.listItem) {
         return
       }
 
       // Reset all levels that are >= current level
-      const levelsToDelete: number[] = []
+      const depthsToDelete: number[] = []
 
-      levelIndexMap.forEach((_, level) => {
-        if (level >= block.level!) {
-          levelsToDelete.push(level)
+      levelIndexMap.forEach((_, existingDepth) => {
+        if (existingDepth >= depth) {
+          depthsToDelete.push(existingDepth)
         }
       })
 
-      levelsToDelete.forEach((level) => {
-        levelIndexMap.delete(level)
+      depthsToDelete.forEach((depthToDelete) => {
+        levelIndexMap.delete(depthToDelete)
       })
     })
 
     const levelIndexMap =
       levelIndexMaps.get(block.listItem) ?? new Map<number, number>()
-    const levelCounter = levelIndexMap.get(block.level) ?? 0
-    levelIndexMap.set(block.level, levelCounter + 1)
+    const levelCounter = levelIndexMap.get(depth) ?? 0
+    levelIndexMap.set(depth, levelCounter + 1)
     levelIndexMaps.set(block.listItem, levelIndexMap)
 
     listIndexMap.set(block._key, levelCounter + 1)
 
     previousListItem = {
       listItem: block.listItem,
-      level: block.level,
+      depth,
     }
   }
 
-  return listIndexMap
+  return {listIndexMap, listDepthMap}
 }

--- a/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
+++ b/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
@@ -101,8 +101,8 @@ export function portableTextToMarkdown<
   }
   const renderBlockSpacing = options.blockSpacing ?? DefaultBlockSpacingRenderer
 
-  const listIndexMap = buildListIndexMap(blocks)
-  const renderNode = createRenderNode(renderers, listIndexMap)
+  const {listIndexMap, listDepthMap} = buildListIndexMap(blocks)
+  const renderNode = createRenderNode(renderers, listIndexMap, listDepthMap)
 
   return blocks
     .map((node, index) => {

--- a/packages/markdown/src/from-portable-text/render-node.ts
+++ b/packages/markdown/src/from-portable-text/render-node.ts
@@ -29,6 +29,7 @@ interface SerializedBlock {
 export const createRenderNode = (
   renderers: PortableTextRenderers,
   listIndexMap: Map<string, number>,
+  listDepthMap: Map<string, number>,
 ): RenderNode => {
   function renderNode<N extends TypedObject>(options: Serializable<N>): string {
     const {node, index, isInline} = options
@@ -91,6 +92,7 @@ export const createRenderNode = (
       value: node,
       index,
       listIndex: node._key ? listIndexMap.get(node._key) : undefined,
+      listDepth: node._key ? listDepthMap.get(node._key) : undefined,
       isInline: false,
       renderNode,
       children,

--- a/packages/markdown/src/from-portable-text/renderers/list-item.ts
+++ b/packages/markdown/src/from-portable-text/renderers/list-item.ts
@@ -7,10 +7,11 @@ export const DefaultListItemRenderer: PortableTextListItemRenderer = ({
   children,
   value,
   listIndex,
+  listDepth,
 }) => {
   const listStyle = value.listItem || 'bullet'
-  const level = value.level || 1
-  const indent = '   '.repeat(level - 1)
+  const depth = listDepth ?? (value.level || 1) - 1
+  const indent = '   '.repeat(depth)
 
   if (listStyle === 'number') {
     return `${indent}${listIndex ?? 1}. ${children}`

--- a/packages/markdown/src/from-portable-text/types.ts
+++ b/packages/markdown/src/from-portable-text/types.ts
@@ -158,6 +158,15 @@ export interface PortableTextRendererOptions<T> {
   listIndex?: number | undefined
 
   /**
+   * How deeply the list item should be indented, starting at 0.
+   *
+   * This is not the same as the block's `level`. A list can start deeper than
+   * level 1, and can skip levels, neither of which Markdown can express, so each
+   * jump to a deeper level counts as a single step of nesting.
+   */
+  listDepth?: number | undefined
+
+  /**
    * Whether or not this node is "inline" - ie as a child of a text block,
    * alongside text spans, or a block in and of itself.
    */

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -682,6 +682,76 @@ describe(portableTextToMarkdown.name, () => {
     })
   })
 
+  describe('lists with skipped levels', () => {
+    const listItem = (text: string, level: number, style = 'bullet') => ({
+      _type: 'block',
+      _key: text,
+      style: 'normal',
+      listItem: style,
+      level,
+      children: [{_type: 'span', _key: `s-${text}`, text, marks: []}],
+      markDefs: [],
+    })
+
+    test('a list starting deeper than level 1 is not indented into a code block', () => {
+      expect(portableTextToMarkdown([listItem('foo', 3)])).toBe('- foo')
+    })
+
+    test('a jump of more than one level indents a single step', () => {
+      expect(
+        portableTextToMarkdown([
+          listItem('foo', 1),
+          listItem('bar', 4),
+          listItem('baz', 1),
+        ]),
+      ).toBe(['- foo', '   - bar', '- baz'].join('\n'))
+    })
+
+    test('numbered lists starting deep keep their marker', () => {
+      expect(
+        portableTextToMarkdown([
+          listItem('foo', 3, 'number'),
+          listItem('bar', 1, 'number'),
+        ]),
+      ).toBe(['1. foo', '2. bar'].join('\n'))
+    })
+
+    test('intermediate levels still nest one step at a time', () => {
+      expect(
+        portableTextToMarkdown([
+          listItem('foo', 1),
+          listItem('bar', 2),
+          listItem('baz', 5),
+          listItem('qux', 2),
+        ]),
+      ).toBe(['- foo', '   - bar', '      - baz', '   - qux'].join('\n'))
+    })
+
+    test('round-trips back to portable text with the same structure', () => {
+      const markdown = portableTextToMarkdown([
+        listItem('foo', 3),
+        listItem('bar', 1),
+        listItem('baz', 4),
+      ])
+      const portableText = markdownToPortableText(markdown)
+
+      expect(
+        portableText.map((block) => ({
+          listItem: 'listItem' in block ? block.listItem : undefined,
+          level: 'level' in block ? block.level : undefined,
+          text:
+            'children' in block && Array.isArray(block.children)
+              ? block.children.map((child) => child.text).join('')
+              : undefined,
+        })),
+      ).toEqual([
+        {listItem: 'bullet', level: 1, text: 'foo'},
+        {listItem: 'bullet', level: 1, text: 'bar'},
+        {listItem: 'bullet', level: 2, text: 'baz'},
+      ])
+    })
+  })
+
   describe('lists', () => {
     const markdown = ['- foo', '   - bar', '      - baz'].join('\n')
 


### PR DESCRIPTION
Fixes lists that start deeper than level 1, or skip levels, serializing to Markdown that does not read back as a list. Same class of bug as portabletext/toolkit#100, in a different renderer.

## The bug

`DefaultListItemRenderer` indented each item by its absolute `level`, three spaces per level:

```ts
const indent = '   '.repeat(level - 1)
```

Markdown cannot express depth that way. Indentation is relative to the list item above, and a first item indented four spaces or more is an indented code block, not a list.

Feeding a `number` item at level 3, then level 1, then a `bullet` at level 1, one at level 4, and one back at level 1 through `portableTextToMarkdown` produced:

```
      1. Starts at level 3
1. Back to level 1
- Bullet level 1
         - Jumps to level 4
- Bullet level 1 again
```

Reading that straight back with `markdownToPortableText` lost two of the five items:

- `Starts at level 3` has a six space indent with no preceding list, so it parsed as a **code block** and stopped being a list item
- `Jumps to level 4` has a nine space indent, so it was absorbed into the previous item as literal text, `"Bullet level 1\n- Jumps to level 4"`

## The fix

`buildListIndexMap` now also computes the depth each item should render at. Every jump to a deeper level counts as **one** step of nesting, however many levels it spans, and returning to a shallower level pops back to the matching ancestor. The default renderer indents by that depth instead of by `level`.

List numbering is keyed off the same depth, so items rendered into one list are numbered as one sequence. Keying it off `level` while rendering by depth would have let two items sit in the same visual list with independent counters.

Same input now:

```
1. Starts at level 3
2. Back to level 1
- Bullet level 1
   - Jumps to level 4
- Bullet level 1 again
```

All five items survive the round-trip, at levels 1, 1, 1, 2, 1.

## Why collapse rather than pad

The toolkit fixes this in HTML by generating the missing levels as empty `<li>` wrappers, because HTML has no other way to nest a list. Markdown does not have that constraint, and padding would mean emitting empty `- ` bullets into what is meant to be human-editable source. Collapsing produces exactly what someone would write by hand. The trade-off is that absolute `level` values are normalised on the round-trip, which seems right given a gap is usually an authoring artifact.

## Scope

- Lists that start at level 1 and change one level at a time are **unaffected**. All 292 existing tests pass untouched, plus 5 new ones.
- Custom list item renderers get a new optional `listDepth` prop with the depth to indent by. `value.level` is unchanged, so existing custom renderers keep working exactly as before.
- **`packages/plugin-list-index` is deliberately left alone.** It holds a duplicate of the engine's index computation, with a drift alarm in its test suite saying to update both together. That does not apply here: the editor indents by `level`, so keying its numbering off `level` is correct there. Only Markdown needs the collapse. Flagging it so nobody re-syncs the two by reflex.

## Verification

- `@portabletext/markdown`: 297 tests pass, up from 292
- `@portabletext/plugin-list-index`: 32 pass
- `@portabletext/editor` unit: 1375 pass, no type errors
- `tsc --noEmit` and `biome lint` clean

## Not included

This deliberately does **not** bump `@portabletext/toolkit` to v6, which was the original reason I was in here. `@portabletext/markdown` never calls `nestLists()`, so v6 changes nothing for it, and bumping this package alone would take its dependency range and Node floor out of sync with the other 22 packages in the monorepo. That is better done as a repo-wide sweep. See the closed #3066.
