### PR TITLE
feat: convert GFM tables by default

### DIFF
--- a/.changeset/markdown-default-tables.md
+++ b/.changeset/markdown-default-tables.md
@@ -1,0 +1,12 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: convert GFM tables by default
+
+`markdownToPortableText` now converts GFM pipe tables to a `table` block object out of the box, matching the shape `@portabletext/plugin-table` expects: `headerRows`, an optional `alignment` array, and `rows` of `row` objects holding `cell` objects with a `value` array of Portable Text blocks. This only kicks in when the schema declares a `table` block object with a `rows` field; a schema without that keeps flattening table cells into plain blocks, as before. A consumer-supplied `types.table` matcher still wins over the default.
+
+`portableTextToMarkdown` now renders `table` block objects back to GFM by default too, instead of a fenced JSON block. A value that isn't table-shaped falls back to the fenced JSON rendering. A consumer-supplied `types.table` renderer still wins over the default.
+
+`DefaultTableRenderer` now treats a missing or non-positive `headerRows` as headerless, rather than promoting the first row to a header. `markdownToPortableText` always sets `headerRows` explicitly, so converting GFM to Portable Text and back is unaffected.
+

--- a/apps/docs/src/content/docs/rendering/markdown.mdx
+++ b/apps/docs/src/content/docs/rendering/markdown.mdx
@@ -29,7 +29,7 @@ const markdown = portableTextToMarkdown(blocks)
 
 ## Custom type renderers
 
-Custom block types (objects in the blocks array) are not rendered by default. Register a renderer for each type you use.
+Custom block types (objects in the blocks array) are not rendered by default, with one exception: `table` renders as GFM Markdown out of the box. Register a renderer for other types you use.
 
 ```ts
 portableTextToMarkdown(blocks, {
@@ -76,7 +76,6 @@ import {
   DefaultHorizontalRuleRenderer,
   DefaultHtmlRenderer,
   DefaultImageRenderer,
-  DefaultTableRenderer,
   portableTextToMarkdown,
 } from '@portabletext/markdown'
 
@@ -87,19 +86,20 @@ portableTextToMarkdown(blocks, {
     'horizontal-rule': DefaultHorizontalRuleRenderer,
     'html': DefaultHtmlRenderer,
     'image': DefaultImageRenderer,
-    'table': DefaultTableRenderer,
   },
 })
 ```
 
-| Renderer                        | Expected fields         | Output                 |
-| ------------------------------- | ----------------------- | ---------------------- |
-| `DefaultCalloutRenderer`        | `tone`, `content`       | `> [!TYPE]\n> content` |
-| `DefaultCodeBlockRenderer`      | `code`, `language?`     | ` ```lang\ncode\n``` ` |
-| `DefaultHorizontalRuleRenderer` | (none required)         | `---`                  |
-| `DefaultHtmlRenderer`           | `html`                  | Raw HTML string        |
-| `DefaultImageRenderer`          | `src`, `alt?`, `title?` | `![alt](src "title")`  |
-| `DefaultTableRenderer`          | `rows`, `headerRows?`   | Markdown table         |
+`table` uses `DefaultTableRenderer` automatically; supply your own `table` renderer to override how tables serialize.
+
+| Renderer                        | Expected fields         | Output                         |
+| ------------------------------- | ----------------------- | ------------------------------ |
+| `DefaultCalloutRenderer`        | `tone`, `content`       | `> [!TYPE]\n> content`         |
+| `DefaultCodeBlockRenderer`      | `code`, `language?`     | ` ```lang\ncode\n``` `         |
+| `DefaultHorizontalRuleRenderer` | (none required)         | `---`                          |
+| `DefaultHtmlRenderer`           | `html`                  | Raw HTML string                |
+| `DefaultImageRenderer`          | `src`, `alt?`, `title?` | `![alt](src "title")`          |
+| `DefaultTableRenderer`          | `rows`, `headerRows?`   | Markdown table (on by default) |
 
 ## Renderer map keys
 
@@ -135,11 +135,11 @@ By default, unknown types render as JSON code blocks. Unknown marks, block style
 | Code blocks      |      ✅\*      |
 | Horizontal rules |      ✅\*      |
 | Images           |      ✅\*      |
-| Tables           |      ✅\*      |
+| Tables           |       ✅       |
 | HTML blocks      |      ✅\*      |
 | Callouts         |      ✅\*      |
 
-\* Requires registering the built-in renderer (see above).
+\* Requires registering the built-in renderer (see above). Tables render by default.
 
 :::note
 This package uses markdown-it as its Markdown parser. Remark and unified plugins are not compatible.

--- a/apps/playground/src/previews/markdown-options.ts
+++ b/apps/playground/src/previews/markdown-options.ts
@@ -1,7 +1,6 @@
 import {
   DefaultCalloutRenderer,
   DefaultHorizontalRuleRenderer,
-  DefaultTableRenderer,
   type PortableTextRenderers,
   type PortableTextTypeRenderer,
 } from '@portabletext/markdown'
@@ -42,8 +41,6 @@ export const markdownOptions: Partial<PortableTextRenderers> = {
     },
 
     'callout': DefaultCalloutRenderer,
-
-    'table': DefaultTableRenderer,
 
     // No native markdown for fact-box. Render inner content as a
     // collapsible `<details>` block so the preview still surfaces the

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -75,7 +75,7 @@ const markdown = portableTextToMarkdown([
 | Code blocks      | ✅                       | ✅\*                     |
 | Horizontal rules | ✅                       | ✅\*                     |
 | Images           | ✅                       | ✅\*                     |
-| Tables           | ✅\*                     | ✅\*                     |
+| Tables           | ✅                       | ✅                       |
 | HTML blocks      | ✅                       | ✅\*                     |
 | Callouts         | ✅\*                     | ✅\*                     |
 
@@ -162,14 +162,14 @@ Out of the box, the library includes sensible defaults for both. Customize them 
 
 The default schema includes the following definitions:
 
-| Type            | Values                                                                                                                                                                                                                                  |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `styles`        | `'normal'`, `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'`, `'blockquote'`                                                                                                                                                              |
-| `lists`         | `'number'`, `'bullet'`                                                                                                                                                                                                                  |
-| `decorators`    | `'strong'`, `'em'`, `'code'`, `'strike-through'`                                                                                                                                                                                        |
-| `annotations`   | `'link'` (fields: `'href'`, `'title'`)                                                                                                                                                                                                  |
-| `blockObjects`  | `'code'` (fields: `'language'`, `'code'`), `'image'` (fields: `'src'`, `'alt'`, `'title'`), `'horizontal-rule'`, `'html'` (fields: `'html'`), `'table'` (fields: `'headerRows'`, `'rows'`), `'callout'` (fields: `'tone'`, `'content'`) |
-| `inlineObjects` | `'image'` (fields: `'src'`, `'alt'`, `'title'`)                                                                                                                                                                                         |
+| Type            | Values                                                                                                                                                                                                                                                                                                  |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `styles`        | `'normal'`, `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'`, `'blockquote'`                                                                                                                                                                                                                              |
+| `lists`         | `'number'`, `'bullet'`                                                                                                                                                                                                                                                                                  |
+| `decorators`    | `'strong'`, `'em'`, `'code'`, `'strike-through'`                                                                                                                                                                                                                                                        |
+| `annotations`   | `'link'` (fields: `'href'`, `'title'`)                                                                                                                                                                                                                                                                  |
+| `blockObjects`  | `'code'` (fields: `'language'`, `'code'`), `'image'` (fields: `'src'`, `'alt'`, `'title'`), `'horizontal-rule'`, `'html'` (fields: `'html'`), `'table'` (fields: `'headerRows'`, `'alignment'`, `'rows'` of `'row'` of `'cells'` of `'cell'` of `'value'`), `'callout'` (fields: `'tone'`, `'content'`) |
+| `inlineObjects` | `'image'` (fields: `'src'`, `'alt'`, `'title'`)                                                                                                                                                                                                                                                         |
 
 To use a custom Schema, import `compileSchema` and `defineSchema` from `@portabletext/schema`:
 
@@ -218,6 +218,7 @@ Matchers map Markdown concepts to Portable Text types defined in the Schema. Eac
 |            | `image`          | `![alt](src)`           | `'image'`           |
 |            | `html`           | HTML blocks             | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.       | `'callout'`         |
+|            | `table`          | GFM pipe tables         | `'table'`           |
 |            | `blockquote`     | `>` blockquotes         | `'blockquote'`      |
 |            | `list`           | `- ` or `1. ` lists     | `'list'`            |
 
@@ -246,7 +247,9 @@ markdownToPortableText(markdown, {
 
 > **Note:** Checking if the type exists in the schema isn't required, but it's good practice. Returning `undefined` gracefully skips unsupported types.
 
-**Table matcher:** Markdown tables are parsed but there's no default matcher. Provide one if your schema includes tables:
+**Table matcher:** GFM pipe tables convert by default, in the canonical shape `@portabletext/plugin-table` expects: a `table` block object (`headerRows`, `rows`), each row a `row` object (`cells`), each cell a `cell` object (`value`, an array of Portable Text blocks; a cell holding a single image becomes a standalone block-level `image` object instead of a text block wrapping it). `alignment` is a `@portabletext/markdown` extension field; `@portabletext/plugin-table` ignores it. This needs no configuration when the schema declares a `table` block object with a `rows` field (see `blockObjects` above). A schema whose `table` doesn't declare `rows`, or that doesn't declare `table` at all, keeps the pre-default behavior: the table's cell content flattens into top-level blocks, in reading order.
+
+Provide your own matcher to map onto a differently-shaped `table` type:
 
 ```ts
 markdownToPortableText(markdown, {
@@ -451,6 +454,7 @@ The conversion is driven by **Renderers**: functions that render Portable Text e
 
 | Group               | Renderer         | Renders                           | Output                   |
 | ------------------- | ---------------- | --------------------------------- | ------------------------ |
+| `types`             | `table`          | `table` block objects             | Markdown table           |
 | `block`             | `normal`         | Paragraphs                        | `{children}`             |
 |                     | `h1`–`h6`        | Headings                          | `# `–`###### `           |
 |                     | `blockquote`     | Blockquotes                       | `> {children}`           |
@@ -486,6 +490,11 @@ portableTextToMarkdown(blocks, {
   },
 })
 ```
+
+`table` block objects render as GFM tables by default; a value that isn't
+table-shaped (no `rows` array of row-shaped objects) falls back to the JSON
+code block `unknownType` renders. Provide your own `types.table` renderer to
+override how tables serialize.
 
 **Custom block styles:** Override how block styles render:
 

--- a/packages/markdown/src/default-schema.ts
+++ b/packages/markdown/src/default-schema.ts
@@ -122,12 +122,48 @@ export const defaultHtmlObjectDefinition = {
   fields: [{name: 'html', type: 'string'}],
 } as const satisfies BlockObjectDefinition
 
-const defaultTableObjectDefinition = {
+/**
+ * Mirrors the canonical shape `@portabletext/plugin-table` expects: `table`
+ * (`headerRows`, `rows`), `row` (`cells`), `cell` (`value`, text blocks or
+ * standalone `image` objects). `alignment` is a `@portabletext/markdown`
+ * extension field; `@portabletext/plugin-table` ignores it. Keep this in
+ * sync with `packages/plugin-table/src/table-config.ts`'s
+ * `defaultTableConfig`.
+ */
+export const defaultTableObjectDefinition = {
   name: 'table',
   fields: [
     {name: 'headerRows', type: 'number'},
     {name: 'alignment', type: 'array'},
-    {name: 'rows', type: 'array'},
+    {
+      name: 'rows',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'row',
+          fields: [
+            {
+              name: 'cells',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'cell',
+                  fields: [
+                    {
+                      name: 'value',
+                      type: 'array',
+                      of: [{type: 'block'}, {type: 'image'}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 } as const satisfies BlockObjectDefinition
 

--- a/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
+++ b/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
@@ -34,11 +34,16 @@ import {
   DefaultNormalRenderer,
   DefaultUnknownStyleRenderer,
 } from './renderers/style'
-import {DefaultUnknownTypeRenderer} from './renderers/type'
+import {
+  DefaultTableRenderer,
+  DefaultUnknownTypeRenderer,
+} from './renderers/type'
 import type {PortableTextRenderers} from './types'
 
 const defaultRenderers: PortableTextRenderers = {
-  types: {},
+  types: {
+    table: DefaultTableRenderer,
+  },
 
   block: {
     normal: DefaultNormalRenderer,

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -1,3 +1,4 @@
+import {isTypedObject} from '@portabletext/schema'
 import type {PortableTextBlock, TypedObject} from '@portabletext/types'
 import {
   escapeImageAndLinkText,
@@ -49,15 +50,48 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
 }
 
 /**
+ * A table is table-shaped when everything the renderer dereferences is
+ * there: `rows` an array of typed objects with a `cells` array, every cell
+ * a typed object whose `value` array holds typed objects (`renderNode`'s
+ * input contract). The predicate narrows to exactly what `renderTable`
+ * consumes, so the renderer needs no casts. A malformed `table` value
+ * (e.g. a consumer's differently-shaped `table` type) falls back to the
+ * fenced-JSON path instead of throwing.
+ */
+function isTableShaped(value: unknown): value is TableShaped {
+  const rows = (value as {rows?: unknown} | null)?.rows
+  return (
+    Array.isArray(rows) &&
+    rows.every(
+      (row) =>
+        isTypedObject(row) &&
+        Array.isArray(row['cells']) &&
+        row['cells'].every(
+          (cell) =>
+            isTypedObject(cell) &&
+            Array.isArray(cell['value']) &&
+            cell['value'].every(isTypedObject),
+        ),
+    )
+  )
+}
+
+type TableShaped = {
+  headerRows?: unknown
+  alignment?: unknown
+  rows: Array<{cells: Array<{value: Array<TypedObject>}>}>
+}
+
+/**
  * Renders a Portable Text table block-object back to Markdown.
  *
- * The PT `headerRows` field decides the header. `headerRows === 0` is an
- * explicit headerless table: GFM has no headerless form, so an empty header
- * row is emitted and every row goes in the body (that empty header reads back
- * as `headerRows: 0` via `markdownToPortableText`). Any other value
- * (`undefined` or `>= 1`) promotes `rows[0]` to the header. GFM allows exactly
- * one header row, so header rows beyond the first flatten into the body,
- * lossy, but the extra rows stay on the Portable Text side.
+ * The PT `headerRows` field decides the header. Missing `headerRows` and
+ * `headerRows === 0` both render headerless: GFM has no headerless form, so
+ * an empty header row is emitted and every row goes in the body (that empty
+ * header reads back as `headerRows: 0` via `markdownToPortableText`).
+ * `headerRows >= 1` promotes `rows[0]` to the header. GFM allows exactly one
+ * header row, so header rows beyond the first flatten into the body, lossy,
+ * but the extra rows stay on the Portable Text side.
  *
  * Asymmetric tables (rows of varying cell counts) are widened to match
  * the row with the most cells. Narrower rows are padded with empty cells
@@ -76,17 +110,29 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
       value: Array<PortableTextBlock>
     }>
   }>
-}> = ({value, renderNode}) => {
-  const rows = value.rows as Array<{
-    _key: string
-    _type: 'row'
-    cells: Array<{
-      _type: 'cell'
-      _key: string
-      value: Array<{_type: string; children?: Array<unknown>}>
-    }>
-  }>
-  const alignment = value.alignment
+}> = (options) => {
+  const {value, renderNode} = options
+
+  if (!isTableShaped(value)) {
+    return DefaultUnknownTypeRenderer(options)
+  }
+
+  return renderTable(value, renderNode)
+}
+
+function renderTable(
+  value: TableShaped,
+  renderNode: Parameters<PortableTextTypeRenderer>[0]['renderNode'],
+): string {
+  const rows = value.rows
+  // `alignment` is an extension field, not part of the table shape: junk
+  // here should not send an otherwise valid table to the fenced-JSON path,
+  // so it is normalized away instead of guarded (`{}.at` would throw below).
+  const alignment: ReadonlyArray<unknown> | undefined = Array.isArray(
+    value.alignment,
+  )
+    ? value.alignment
+    : undefined
 
   const headerRow = rows.at(0)
 
@@ -95,13 +141,11 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   }
 
   // Helper to extract text from cell blocks
-  const getCellText = (
-    cellBlocks: Array<{_type: string; children?: Array<unknown>}>,
-  ): string => {
+  const getCellText = (cellBlocks: Array<TypedObject>): string => {
     return cellBlocks
       .map((block, index) =>
         renderNode({
-          node: block as {_type: string},
+          node: block,
           index,
           isInline: false,
           renderNode,
@@ -150,9 +194,11 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
   })
   const delimiter = `|${separators.join('|')}|`
 
-  if (value.headerRows === 0) {
-    // Explicit headerless table: emit an empty header row and keep every row
-    // in the body.
+  const hasHeader = (Number(value.headerRows) || 0) >= 1
+
+  if (!hasHeader) {
+    // Headerless table: emit an empty header row and keep every row in the
+    // body.
     lines.push(renderCells([]))
     lines.push(delimiter)
     for (const row of rows) {

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -4543,12 +4543,13 @@ describe(markdownToPortableText.name, () => {
       ])
     })
 
-    test('no table matcher', () => {
+    test('schema without `table` flattens', () => {
       const keyGenerator = createTestKeyGenerator()
       const markdown = ['| A | B |', '|---|---|', '| 1 | 2 |'].join('\n')
       expect(
         markdownToPortableText(markdown, {
           keyGenerator,
+          schema: compileSchema(defineSchema({})),
         }),
       ).toEqual([
         {
@@ -4736,6 +4737,241 @@ describe(markdownToPortableText.name, () => {
       expect(result.at(0) as Record<string, unknown>).not.toHaveProperty(
         'alignment',
       )
+    })
+
+    describe('zero-config (default schema)', () => {
+      test('GFM table with alignment converts to the canonical table object', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const markdown = ['| L | R |', '| :--- | ---: |', '| foo | bar |'].join(
+          '\n',
+        )
+
+        expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+          {
+            _key: 'k14',
+            _type: 'table',
+            headerRows: 1,
+            alignment: ['left', 'right'],
+            rows: [
+              {
+                _key: 'k6',
+                _type: 'row',
+                cells: [
+                  {
+                    _type: 'cell',
+                    _key: 'k2',
+                    value: [
+                      {
+                        _type: 'block',
+                        _key: 'k0',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k1', text: 'L', marks: []},
+                        ],
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                  {
+                    _type: 'cell',
+                    _key: 'k5',
+                    value: [
+                      {
+                        _type: 'block',
+                        _key: 'k3',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k4', text: 'R', marks: []},
+                        ],
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                _key: 'k13',
+                _type: 'row',
+                cells: [
+                  {
+                    _type: 'cell',
+                    _key: 'k9',
+                    value: [
+                      {
+                        _type: 'block',
+                        _key: 'k7',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k8', text: 'foo', marks: []},
+                        ],
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                  {
+                    _type: 'cell',
+                    _key: 'k12',
+                    value: [
+                      {
+                        _type: 'block',
+                        _key: 'k10',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k11', text: 'bar', marks: []},
+                        ],
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+      })
+
+      test('headerless GFM table (empty header row) converts to headerRows: 0', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const markdown = ['|  |  |', '| --- | --- |', '| foo | bar |'].join(
+          '\n',
+        )
+
+        expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+          {
+            _key: 'k13',
+            _type: 'table',
+            headerRows: 0,
+            rows: [
+              {
+                _key: 'k12',
+                _type: 'row',
+                cells: [
+                  {
+                    _type: 'cell',
+                    _key: 'k8',
+                    value: [
+                      {
+                        _type: 'block',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k7', text: 'foo', marks: []},
+                        ],
+                        _key: 'k6',
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                  {
+                    _type: 'cell',
+                    _key: 'k11',
+                    value: [
+                      {
+                        _type: 'block',
+                        style: 'normal',
+                        children: [
+                          {_type: 'span', _key: 'k10', text: 'bar', marks: []},
+                        ],
+                        _key: 'k9',
+                        markDefs: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+      })
+
+      test('`types: {table: undefined}` opts out and flattens', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const markdown = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n')
+
+        expect(
+          markdownToPortableText(markdown, {
+            keyGenerator,
+            types: {table: undefined},
+          }),
+        ).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k1', text: 'A', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k3',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k4', text: 'B', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k7',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k8', text: '1', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k10',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k11', text: '2', marks: []}],
+            markDefs: [],
+          },
+        ])
+      })
+
+      test('a differently-shaped schema `table` (no `rows` field) flattens instead of losing content', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const schema = compileSchema(
+          defineSchema({
+            ...defaultSchema,
+            blockObjects: [
+              ...defaultSchema.blockObjects.filter(
+                (blockObject) => blockObject.name !== 'table',
+              ),
+              {name: 'table', fields: [{name: 'data', type: 'string'}]},
+            ],
+          }),
+        )
+        const markdown = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n')
+
+        expect(
+          markdownToPortableText(markdown, {keyGenerator, schema}),
+        ).toEqual([
+          {
+            _type: 'block',
+            _key: 'k0',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k1', text: 'A', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k3',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k4', text: 'B', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k7',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k8', text: '1', marks: []}],
+            markDefs: [],
+          },
+          {
+            _type: 'block',
+            _key: 'k10',
+            style: 'normal',
+            children: [{_type: 'span', _key: 'k11', text: '2', marks: []}],
+            markDefs: [],
+          },
+        ])
+      })
     })
   })
 

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1453,17 +1453,7 @@ describe(portableTextToMarkdown.name, () => {
         },
       })
 
-      test('default renderer', () => {
-        const markdownOut = [
-          '```json',
-          JSON.stringify(portableText.at(0), null, 2),
-          '```',
-        ].join('\n')
-
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
-      })
-
-      test('pluggable default renderer', () => {
+      test('renders as GFM by default', () => {
         const markdownOut = [
           '| Header 1 | Header 2 |',
           '| --- | --- |',
@@ -1471,12 +1461,18 @@ describe(portableTextToMarkdown.name, () => {
           '| Cell 3 | Cell 4 |',
         ].join('\n')
 
+        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
+      })
+
+      test('`types: {table: undefined}` opts out and falls back to fenced JSON', () => {
+        const markdownOut = [
+          '```json',
+          JSON.stringify(portableText.at(0), null, 2),
+          '```',
+        ].join('\n')
+
         expect(
-          portableTextToMarkdown(portableText, {
-            types: {
-              table: DefaultTableRenderer,
-            },
-          }),
+          portableTextToMarkdown(portableText, {types: {table: undefined}}),
         ).toBe(markdownOut)
       })
     })
@@ -1584,10 +1580,11 @@ describe(portableTextToMarkdown.name, () => {
         },
       ]
 
-      test('headerRows undefined promotes the first row to header', () => {
+      test('headerRows undefined renders headerless, same as headerRows 0', () => {
         const markdownOut = [
-          '| Cell 1 | Cell 2 |',
+          '|  |  |',
           '| --- | --- |',
+          '| Cell 1 | Cell 2 |',
           '| Cell 3 | Cell 4 |',
         ].join('\n')
 
@@ -1818,6 +1815,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           rows: [
             {
               _type: 'row',
@@ -1888,6 +1886,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           rows: [
             {
               _type: 'row',
@@ -2008,6 +2007,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           rows: [
             {
               _type: 'row',
@@ -2128,6 +2128,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           rows: [
             {
               _type: 'row',
@@ -2198,6 +2199,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           rows: [
             {
               _type: 'row',
@@ -2271,6 +2273,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           alignment: ['left', 'center', 'right', null],
           rows: [
             {
@@ -2472,6 +2475,7 @@ describe(portableTextToMarkdown.name, () => {
         {
           _type: 'table',
           _key: keyGenerator(),
+          headerRows: 1,
           alignment: [null, null, 'right'],
           rows: [
             {
@@ -2552,6 +2556,112 @@ describe(portableTextToMarkdown.name, () => {
             },
           }),
         ).toBe(['| A | B | C |', '| --- | --- | ---: |'].join('\n'))
+      })
+    })
+
+    describe('zero-config default table', () => {
+      test('renders a canonical table object as GFM', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const cell = (text: string) => ({
+          _type: 'cell',
+          _key: keyGenerator(),
+          value: [
+            {
+              _type: 'block',
+              _key: keyGenerator(),
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {_type: 'span', _key: keyGenerator(), text, marks: []},
+              ],
+            },
+          ],
+        })
+        const portableText = [
+          {
+            _type: 'table',
+            _key: keyGenerator(),
+            headerRows: 1,
+            rows: [
+              {_type: 'row', _key: keyGenerator(), cells: [cell('foo')]},
+              {_type: 'row', _key: keyGenerator(), cells: [cell('bar')]},
+            ],
+          },
+        ]
+
+        expect(portableTextToMarkdown(portableText)).toBe(
+          ['| foo |', '| --- |', '| bar |'].join('\n'),
+        )
+      })
+
+      test('MD -> PT -> MD round-trip is stable for a table with alignment', () => {
+        const markdown = ['| L | R |', '| :--- | ---: |', '| foo | bar |'].join(
+          '\n',
+        )
+
+        const portableText = markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+        })
+
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
+      })
+
+      test('malformed table value (no `rows` array) falls back to fenced JSON', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const value = {_type: 'table', _key: keyGenerator(), headerRows: 1}
+
+        expect(portableTextToMarkdown([value])).toBe(
+          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        )
+      })
+
+      test.each([
+        ['cell without `value`', {rows: [{cells: [{_key: 'foo'}]}]}],
+        ['cell `value` is not an array', {rows: [{cells: [{value: 'foo'}]}]}],
+        ['`cells` contains `null`', {rows: [{cells: [null]}]}],
+        ['cell `value` contains `null`', {rows: [{cells: [{value: [null]}]}]}],
+      ])('malformed table value (%s) falls back to fenced JSON', (_, table) => {
+        const keyGenerator = createTestKeyGenerator()
+        const value = {_type: 'table', _key: keyGenerator(), ...table}
+
+        expect(portableTextToMarkdown([value])).toBe(
+          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        )
+      })
+
+      test('non-array `alignment` is ignored, the table still renders', () => {
+        const keyGenerator = createTestKeyGenerator()
+        const value = {
+          _type: 'table',
+          _key: keyGenerator(),
+          headerRows: 1,
+          alignment: {},
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      children: [
+                        {_type: 'span', _key: keyGenerator(), text: 'foo'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }
+
+        expect(portableTextToMarkdown([value])).toBe(
+          ['| foo |', '| --- |'].join('\n'),
+        )
       })
     })
   })

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -22,6 +22,7 @@ import {
   defaultSchema,
   defaultStrikeThroughDecoratorDefinition,
   defaultStrongDecoratorDefinition,
+  defaultTableObjectDefinition,
   defaultTaskListItemDefinition,
   defaultUnorderedListItemDefinition,
   h1StyleDefinition,
@@ -149,6 +150,23 @@ const imageBlockMatcher: ObjectMatcher<
   return imageObject
 }
 
+const tableBlockMatcher: ObjectMatcher<
+  ExtractValue<typeof defaultTableObjectDefinition>
+> = ({context, value, isInline}) => {
+  const defaultMatcher = buildObjectMatcher(defaultTableObjectDefinition)
+  const tableObject = defaultMatcher({context, value, isInline})
+
+  if (!tableObject) {
+    return undefined
+  }
+
+  if (!('rows' in tableObject)) {
+    return undefined
+  }
+
+  return tableObject
+}
+
 const defaultOptions = {
   schema: defaultSchema,
   keyGenerator: defaultKeyGenerator,
@@ -185,6 +203,7 @@ const defaultOptions = {
     html: buildObjectMatcher(defaultHtmlObjectDefinition),
     image: imageBlockMatcher,
     callout: buildObjectMatcher(defaultCalloutObjectDefinition),
+    table: tableBlockMatcher,
   },
 } as const satisfies Options
 

--- a/packages/plugin-table/src/behaviors/serialize.test.tsx
+++ b/packages/plugin-table/src/behaviors/serialize.test.tsx
@@ -179,21 +179,8 @@ describe('rectangular selection copy/cut', () => {
           ],
         },
       ])
-      // The core markdown converter renders tables as fenced JSON unless
-      // the app registers `DefaultTableRenderer` (the playground does). The
-      // concern here is rectangle scoping, so parse the fence and assert
-      // the same rectangle-only table.
       const markdown = dataTransfer.getData('text/markdown')
-      expect(
-        JSON.parse(markdown.replace(/^```json\n/, '').replace(/\n```$/, '')),
-      ).toEqual({
-        _type: 'table',
-        _key: 't0',
-        rows: [
-          {_type: 'row', _key: 'r0', cells: [cell('c00', 'A')]},
-          {_type: 'row', _key: 'r1', cells: [cell('c10', 'C')]},
-        ],
-      })
+      expect(markdown).toBe(['|  |', '| --- |', '| A |', '| C |'].join('\n'))
     })
   })
 


### PR DESCRIPTION
GFM tables now convert to and from Portable Text out of the box in `@portabletext/markdown`, in the shape `@portabletext/plugin-table` expects. Both directions were opt-in: without a `types.table` matcher the parser flattened table cells into plain text blocks, and since `portableTextToMarkdown` registers no default type renderers, a `table` block rendered as fenced JSON. The odd part was that everything else already existed. The opt-in parser output was already byte-for-byte canonical (`table.rows[] → row.cells[] → cell.value[]` plus `headerRows` and a per-column `alignment` extension), and `DefaultTableRenderer` already consumed it. So this is default registration plus a truthful schema declaration, not a new transform.

The registrations are guarded, because both directions dispatch on the `_type` name alone. The default matcher only fires when the passed schema declares a `table` block object that keeps a `rows` field; a table-less schema, or a consumer whose `table` is shaped differently, keeps the flatten path (the naive version silently emptied such tables on paste, pinned by a test now). The default renderer falls back to fenced JSON when the value is not table-shaped instead of throwing. Consumer-supplied `types.table` wins in both directions; there is no dedicated opt-out switch, since every realistic dissenter wants a different output (custom matcher or renderer), not none, and the schema gate plus shape guards already cover the rest.

One semantic delta rides along: `DefaultTableRenderer` now treats missing or non-positive `headerRows` as headerless, mirroring `plugin-table`, instead of promoting the first row to a GFM header. Without this, copying a default-created `plugin-table` table (which omits `headerRows`) would turn its first data row into a header and the round-trip would come back with `headerRows: 1`. The parser always emits `headerRows` explicitly, so pure markdown round-trips are unchanged.

`@portabletext/editor`'s markdown clipboard picks both defaults up: table copy is GFM instead of fenced JSON, and GFM paste produces `plugin-table`-compatible values when the editor schema declares `table`. Both packages ship a minor.

Known ceiling: a standalone image inside a table cell still renders as fenced JSON within the GFM cell, because image has no default renderer yet. Mirroring the remaining default type renderers is a natural follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c92c337ef9fe57137285f7db0321f4a33828d980. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->