### PR TITLE
feat: add `createTableRule` for deserializing `<table>` HTML into a nested table shape

### DIFF
--- a/.changeset/create-table-rule-block-tools.md
+++ b/.changeset/create-table-rule-block-tools.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/block-tools': minor
+---
+
+feat: re-export `createTableRule` from `@portabletext/html`
+
+`@portabletext/block-tools/rules` already re-exports `createFlattenTableRule`; it now also re-exports `createTableRule`, `@portabletext/html`'s deserializer rule for converting `<table>` HTML into a nested table shape.

--- a/.changeset/create-table-rule.md
+++ b/.changeset/create-table-rule.md
@@ -1,0 +1,19 @@
+---
+'@portabletext/html': minor
+---
+
+feat: add `createTableRule` for deserializing `<table>` HTML into a nested table shape
+
+`createFlattenTableRule` was the only table deserializer, and it flattens a table into a list of standalone text blocks, losing the row/column structure. `createTableRule` keeps it: it turns a `<table>` into one block carrying `rows`, each row carrying `cells`, each cell carrying a Portable Text `value` array, the shape `@portabletext/plugin-table`'s `defineTable` produces.
+
+```ts
+import {htmlToPortableText} from '@portabletext/html'
+import {createTableRule} from '@portabletext/html/rules'
+
+const blocks = htmlToPortableText(html, {
+  schema,
+  rules: [createTableRule({schema})],
+})
+```
+
+`headerRows` is set from leading `<thead>` rows or an all-`<th>` first row, and omitted when there are none. Ragged rows are padded to the widest row with empty cells, and `colspan`/`rowspan` are ignored: a spanning cell contributes one cell, and the padding fills the rest. The `containers` option matches a `defineTable` call whose container names were renamed. It is role-keyed like `defineTable`'s own option and reads only `type` and `arrayField`, so the same container definitions can be passed to both.

--- a/apps/playground/src/plugins/plugin.html-deserializer.tsx
+++ b/apps/playground/src/plugins/plugin.html-deserializer.tsx
@@ -1,7 +1,7 @@
 import {useEditor} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {htmlToPortableText, type ObjectMatcher} from '@portabletext/html'
-import {createFlattenTableRule} from '@portabletext/html/rules'
+import {createTableRule} from '@portabletext/html/rules'
 import {useEffect} from 'react'
 
 const imageMatcher: ObjectMatcher<{src?: string; alt?: string}> = ({
@@ -80,12 +80,7 @@ export function HtmlDeserializerPlugin() {
               image: imageMatcher,
               code: codeMatcher,
             },
-            rules: [
-              createFlattenTableRule({
-                schema: snapshot.context.schema,
-                separator: () => ({_type: 'span', text: ': '}),
-              }),
-            ],
+            rules: [createTableRule({schema: snapshot.context.schema})],
             whitespaceMode: 'normalize',
           })
 

--- a/packages/block-tools/src/rules/index.ts
+++ b/packages/block-tools/src/rules/index.ts
@@ -1,1 +1,5 @@
-export {createFlattenTableRule} from '@portabletext/html/rules'
+export {
+  createFlattenTableRule,
+  createTableRule,
+  type TableRuleContainers,
+} from '@portabletext/html/rules'

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -255,6 +255,35 @@ const blocks = htmlToPortableText(html, {
 })
 ```
 
+### Table deserialization
+
+The `createTableRule` helper converts `<table>` elements into a nested table shape (`table` → `rows` → `cells` → `value`), the shape `@portabletext/plugin-table`'s `defineTable` produces:
+
+```ts
+import {htmlToPortableText} from '@portabletext/html'
+import {createTableRule} from '@portabletext/html/rules'
+
+const blocks = htmlToPortableText(html, {
+  schema,
+  rules: [createTableRule({schema})],
+})
+```
+
+`headerRows` is set to the count of leading rows inside `<thead>`, or whose cells are all `<th>`, and omitted when there are none. Rows shorter than the widest row are padded with empty cells; `colspan`/`rowspan` are ignored, so a spanning cell contributes one cell and the padding fills the rest. Pass `containers` to match a `defineTable` call whose container names were renamed; it is role-keyed like `defineTable`'s own option, and only `type` and `arrayField` are read, so the container definitions given to `defineTable` can be passed through unchanged:
+
+```ts
+createTableRule({
+  schema,
+  containers: {
+    table: {type: 'richTable', arrayField: 'tableRows'},
+    row: {type: 'tableRow', arrayField: 'rowCells'},
+    cell: {type: 'tableCell', arrayField: 'content'},
+  },
+})
+```
+
+Rows are read in the DOM's table row order, which places `<thead>` rows first and `<tfoot>` rows last regardless of where they appear in the source markup, so a `<thead>` written after `<tbody>` still counts toward `headerRows`.
+
 ### Key generation
 
 By default, random keys are generated for each block and span. You can provide your own key generator for deterministic output:

--- a/packages/html/src/rules/create-table.ts
+++ b/packages/html/src/rules/create-table.ts
@@ -1,0 +1,171 @@
+import type {Schema} from '@portabletext/schema'
+import {flattenNestedBlocks} from '../deserializer/flatten-nested-blocks'
+import {isElement, tagName} from '../deserializer/helpers'
+import {normalizeBlock} from '../deserializer/normalize-block'
+import {keyGenerator as defaultKeyGenerator} from '../deserializer/random-key'
+import type {
+  ArbitraryTypedObject,
+  DeserializerRule,
+  TypedObject,
+} from '../types'
+
+/**
+ * The type names and array fields of the three table levels, role-keyed to
+ * mirror `@portabletext/plugin-table`'s `defineTable({containers})`. Only
+ * `type` and `arrayField` are read, so the container definitions passed to
+ * `defineTable` can be passed here unchanged; any render or `of` they carry
+ * is ignored. Omitted roles and fields fall back to the canonical names
+ * (`table`/`rows`, `row`/`cells`, `cell`/`value`).
+ *
+ * @beta
+ */
+export type TableRuleContainers = {
+  table?: {type?: string; arrayField?: string}
+  row?: {type?: string; arrayField?: string}
+  cell?: {type?: string; arrayField?: string}
+}
+
+/**
+ * A `DeserializerRule` that converts `<table>` HTML into a nested table
+ * shape: one custom block carrying `rows`, each row carrying `cells`, each
+ * cell carrying a Portable Text `value` array. Matches the block/array-field
+ * names `@portabletext/plugin-table`'s `defineTable` produces, configurable
+ * through `containers` for consumers that renamed them.
+ *
+ * @example
+ * ```html
+ * <table>
+ *   <thead>
+ *     <tr><th>Year</th><th>Sales</th></tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr><td>2022</td><td>$8,000</td></tr>
+ *   </tbody>
+ * </table>
+ * ```
+ * Turns into
+ * ```json
+ * {
+ *   "_type": "table",
+ *   "headerRows": 1,
+ *   "rows": [
+ *     {"_type": "row", "cells": [{"_type": "cell", "value": [...Year...]}, ...]},
+ *     {"_type": "row", "cells": [{"_type": "cell", "value": [...2022...]}, ...]}
+ *   ]
+ * }
+ * ```
+ *
+ * `colspan`/`rowspan` are ignored: a spanning cell contributes one cell,
+ * and rows shorter than the widest row are padded with empty cells.
+ *
+ * @beta
+ */
+export function createTableRule({
+  schema,
+  keyGenerator = defaultKeyGenerator,
+  containers,
+}: {
+  schema: Schema
+  keyGenerator?: () => string
+  containers?: TableRuleContainers
+}): DeserializerRule {
+  const tableType = containers?.table?.type ?? 'table'
+  const rowsField = containers?.table?.arrayField ?? 'rows'
+  const rowType = containers?.row?.type ?? 'row'
+  const cellsField = containers?.row?.arrayField ?? 'cells'
+  const cellType = containers?.cell?.type ?? 'cell'
+  const valueField = containers?.cell?.arrayField ?? 'value'
+
+  return {
+    deserialize: (node, next, createBlock) => {
+      if (!isElement(node) || tagName(node) !== 'table') {
+        return undefined
+      }
+
+      const tableElement = node as HTMLTableElement
+      const rowElements = [...tableElement.rows]
+
+      if (rowElements.length === 0) {
+        return undefined
+      }
+
+      const rowCells = rowElements.map((row) => [...row.cells])
+
+      let headerRows = 0
+      for (let i = 0; i < rowElements.length; i++) {
+        const row = rowElements[i]
+        const cells = rowCells[i]
+        if (!row || !cells) {
+          break
+        }
+        const isInThead = tagName(row.parentNode) === 'thead'
+        const isAllHeaderCells =
+          cells.length > 0 && cells.every((cell) => tagName(cell) === 'th')
+        if (isInThead || isAllHeaderCells) {
+          headerRows++
+        } else {
+          break
+        }
+      }
+
+      const widestRow = Math.max(...rowCells.map((cells) => cells.length))
+
+      const emptyCellValue = (): TypedObject[] => [
+        {
+          _type: schema.block.name,
+          _key: keyGenerator(),
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: keyGenerator(), text: '', marks: []},
+          ],
+        } as ArbitraryTypedObject,
+      ]
+
+      const cellValue = (cellElement: Element): TypedObject[] => {
+        const result = next(cellElement)
+        const items =
+          result === undefined ? [] : ([] as TypedObject[]).concat(result)
+        const flattened = flattenNestedBlocks(
+          {schema},
+          items as Array<ArbitraryTypedObject>,
+        )
+
+        if (flattened.length === 0) {
+          return emptyCellValue()
+        }
+
+        return flattened.map(
+          (item) => normalizeBlock(item, {keyGenerator}) as TypedObject,
+        )
+      }
+
+      const rows = rowCells.map((cells) => {
+        const rowKey = keyGenerator()
+        return {
+          _type: rowType,
+          _key: rowKey,
+          [cellsField]: Array.from({length: widestRow}, (_, column) => {
+            const cellElement = cells[column]
+            return {
+              _type: cellType,
+              _key: keyGenerator(),
+              [valueField]: cellElement
+                ? cellValue(cellElement)
+                : emptyCellValue(),
+            }
+          }),
+        }
+      })
+
+      const tableKey = keyGenerator()
+
+      return createBlock({
+        _type: tableType,
+        _key: tableKey,
+        ...(headerRows > 0 ? {headerRows} : {}),
+        [rowsField]: rows,
+      })
+    },
+  }
+}

--- a/packages/html/src/rules/index.ts
+++ b/packages/html/src/rules/index.ts
@@ -1,1 +1,2 @@
+export * from './create-table'
 export * from './flatten-tables'

--- a/packages/html/src/tests/html-to-portable-text/create-table.test.ts
+++ b/packages/html/src/tests/html-to-portable-text/create-table.test.ts
@@ -1,0 +1,1005 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {JSDOM} from 'jsdom'
+import {describe, expect, test} from 'vitest'
+import {htmlToPortableText} from '../../html-to-portable-text'
+import {
+  createTableRule,
+  type TableRuleContainers,
+} from '../../rules/_exports/index'
+import {createTestKeyGenerator} from '../test-key-generator'
+
+const schema = compileSchema(
+  defineSchema({
+    decorators: [{name: 'strong'}, {name: 'em'}],
+    annotations: [{name: 'link'}],
+    blockObjects: [{name: 'table'}],
+  }),
+)
+
+function transform(
+  html: string,
+  ruleOptions: {containers?: TableRuleContainers} = {},
+) {
+  const keyGenerator = createTestKeyGenerator('k')
+  return htmlToPortableText(html, {
+    schema,
+    keyGenerator,
+    parseHtml: (h) => new JSDOM(h).window.document,
+    rules: [createTableRule({schema, keyGenerator, ...ruleOptions})],
+  })
+}
+
+describe(createTableRule.name, () => {
+  test('table with tbody only', () => {
+    const html = [
+      '<table>',
+      '<tbody>',
+      '<tr><td>foo</td><td>bar</td></tr>',
+      '</tbody>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k7',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: 'bar', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('thead row plus body rows sets headerRows', () => {
+    const html = [
+      '<table>',
+      '<thead><tr><th>Name</th><th>Age</th></tr></thead>',
+      '<tbody><tr><td>foo</td><td>1</td></tr></tbody>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k14',
+        headerRows: 1,
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'Name', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: 'Age', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'k7',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k8',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k9',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k10', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k11',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k12',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k13', text: '1', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('all-th first row without a thead also sets headerRows', () => {
+    const html = [
+      '<table>',
+      '<tr><th>Name</th><th>Age</th></tr>',
+      '<tr><td>foo</td><td>1</td></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k14',
+        headerRows: 1,
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'Name', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: 'Age', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'k7',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k8',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k9',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k10', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k11',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k12',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k13', text: '1', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('a header-shaped row after a body row does not set headerRows', () => {
+    const html = [
+      '<table>',
+      '<tr><td>foo</td><td>1</td></tr>',
+      '<tr><th>Name</th><th>Age</th></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k14',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: '1', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'k7',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k8',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k9',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k10', text: 'Name', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k11',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k12',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k13', text: 'Age', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('ragged rows are padded to the widest row', () => {
+    const html = [
+      '<table>',
+      '<tr><td>foo</td><td>bar</td></tr>',
+      '<tr><td>baz</td></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k14',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: 'bar', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'k7',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k8',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k9',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k10', text: 'baz', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k11',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k12',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k13', text: '', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('an empty cell heals to one empty text block', () => {
+    const html = ['<table>', '<tr><td>a</td><td></td></tr>', '</table>'].join(
+      '',
+    )
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k7',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'a', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: '', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('a whitespace-only cell heals to one empty text block', () => {
+    const html = ['<table>', '<tr><td> \n </td></tr>', '</table>'].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k4',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: '', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('a table nested inside a cell stays scoped to its own rows and cells', () => {
+    const html = [
+      '<table>',
+      '<tr><td>foo</td><td><table><tr><td>bar</td></tr></table></td></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k10',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'table',
+                    _key: 'k9',
+                    rows: [
+                      {
+                        _type: 'row',
+                        _key: 'k5',
+                        cells: [
+                          {
+                            _type: 'cell',
+                            _key: 'k6',
+                            value: [
+                              {
+                                _type: 'block',
+                                _key: 'k7',
+                                style: 'normal',
+                                markDefs: [],
+                                children: [
+                                  {
+                                    _type: 'span',
+                                    _key: 'k8',
+                                    text: 'bar',
+                                    marks: [],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('inline formatting inside a cell', () => {
+    const html = [
+      '<table>',
+      '<tr><td>visit <a href="https://sanity.io">Sanity</a> and <strong>bold</strong></td></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k8',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k3',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k4', text: 'visit ', marks: []},
+                      {
+                        _type: 'span',
+                        _key: 'k5',
+                        text: 'Sanity',
+                        marks: ['k2'],
+                      },
+                      {_type: 'span', _key: 'k6', text: ' and ', marks: []},
+                      {
+                        _type: 'span',
+                        _key: 'k7',
+                        text: 'bold',
+                        marks: ['strong'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('custom container names', () => {
+    const richTableSchema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'richTable',
+            fields: [
+              {name: 'headerRows', type: 'number'},
+              {
+                name: 'tableRows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'tableRow',
+                    fields: [
+                      {
+                        name: 'rowCells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'tableCell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const keyGenerator = createTestKeyGenerator('k')
+    const html = '<table><tr><td>foo</td></tr></table>'
+
+    expect(
+      htmlToPortableText(html, {
+        schema: richTableSchema,
+        keyGenerator,
+        parseHtml: (h) => new JSDOM(h).window.document,
+        rules: [
+          createTableRule({
+            schema: richTableSchema,
+            keyGenerator,
+            containers: {
+              table: {type: 'richTable', arrayField: 'tableRows'},
+              row: {type: 'tableRow', arrayField: 'rowCells'},
+              cell: {type: 'tableCell', arrayField: 'content'},
+            },
+          }),
+        ],
+      }),
+    ).toEqual([
+      {
+        _type: 'richTable',
+        _key: 'k4',
+        tableRows: [
+          {
+            _type: 'tableRow',
+            _key: 'k0',
+            rowCells: [
+              {
+                _type: 'tableCell',
+                _key: 'k1',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('an omitted container role keeps the canonical names', () => {
+    const html = '<table><tr><td>foo</td></tr></table>'
+
+    expect(
+      transform(html, {containers: {cell: {arrayField: 'content'}}}),
+    ).toEqual([
+      {
+        _type: 'table',
+        _key: 'k4',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                content: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('a container definition carrying a render is read for its names alone', () => {
+    const cellContainer = {
+      kind: 'container',
+      type: 'cell',
+      arrayField: 'value',
+      render: () => null,
+      of: [{type: 'block'}],
+    }
+    const html = '<table><tr><td>foo</td></tr></table>'
+
+    expect(transform(html, {containers: {cell: cellContainer}})).toEqual([
+      {
+        _type: 'table',
+        _key: 'k4',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('colspan is ignored: a spanning cell contributes one cell, padding fills the rest', () => {
+    const html = [
+      '<table>',
+      '<tr><td colspan="2">foo</td></tr>',
+      '<tr><td>bar</td><td>baz</td></tr>',
+      '</table>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k14',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: '', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: 'k7',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k8',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k9',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k10', text: 'bar', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k11',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k12',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k13', text: 'baz', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('Google Docs table fixture', () => {
+    const html = [
+      '<b style="font-weight:normal;" id="docs-internal-guid-e0aa048e-7fff-f3cb">',
+      '<div dir="ltr" style="margin-left:0pt;" align="left">',
+      '<table style="border:none;border-collapse:collapse;table-layout:fixed;width:468pt">',
+      '<colgroup><col /><col /></colgroup>',
+      '<tbody>',
+      '<tr style="height:0pt">',
+      '<td style="border:solid #000000 1pt;vertical-align:top;padding:5pt;">',
+      '<p dir="ltr" style="line-height:1.2;margin-top:0pt;margin-bottom:0pt;">',
+      '<span style="font-size:12pt;font-family:Arial,sans-serif;">foo</span>',
+      '</p>',
+      '</td>',
+      '<td style="border:solid #000000 1pt;vertical-align:top;padding:5pt;">',
+      '<p dir="ltr" style="line-height:1.2;margin-top:0pt;margin-bottom:0pt;">',
+      '<span style="font-size:12pt;font-family:Arial,sans-serif;">bar</span>',
+      '</p>',
+      '</td>',
+      '</tr>',
+      '</tbody>',
+      '</table>',
+      '</div>',
+      '</b>',
+    ].join('')
+
+    expect(transform(html)).toEqual([
+      {
+        _type: 'table',
+        _key: 'k7',
+        rows: [
+          {
+            _type: 'row',
+            _key: 'k0',
+            cells: [
+              {
+                _type: 'cell',
+                _key: 'k1',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k2',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k3', text: 'foo', marks: []},
+                    ],
+                  },
+                ],
+              },
+              {
+                _type: 'cell',
+                _key: 'k4',
+                value: [
+                  {
+                    _type: 'block',
+                    _key: 'k5',
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {_type: 'span', _key: 'k6', text: 'bar', marks: []},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  test('non-table HTML falls through to the standard rules', () => {
+    expect(transform('<p>foo</p>')).toEqual([
+      {
+        _type: 'block',
+        _key: 'k0',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Pasting a table from Google Docs, Sheets, or Excel into the editor loses the rows and columns: the HTML deserializer has no rule that keeps a `<table>`'s structure, so cells land as separated paragraphs, either via `createFlattenTableRule` or the generic HTML rule.

This adds `createTableRule` to `@portabletext/html/rules` (re-exported from `@portabletext/block-tools/rules`), the flatten rule's structural sibling with the opposite policy: it converts a `<table>` into one block in the shape `@portabletext/plugin-table`'s `defineTable` produces, `rows` of `cells` of Portable Text `value` arrays.

```ts
import {htmlToPortableText} from '@portabletext/html'
import {createTableRule} from '@portabletext/html/rules'

const blocks = htmlToPortableText(html, {
  schema,
  rules: [createTableRule({schema})],
})
```

Consumers who renamed their containers configure the rule through `containers`, role-keyed exactly like `defineTable`'s own option (`table`, `row`, `cell`, each with `type` and `arrayField`). The rule reads only those two fields, so the container definitions already passed to `defineTable` can be handed to the rule unchanged, renders and all; a test pins that a definition carrying a render is read for its names alone. Grouping beats six sibling strings here because the pairing is real: a row's `type` and the `arrayField` holding its cells belong to the same container, and the two packages now share one vocabulary.

Cell content flows through the standard deserialization pipeline, so inline formatting survives. Leading `<thead>` or all-`<th>` rows set `headerRows` (omitted when 0, and counted leading-only: a header-shaped row after a body row does not count, pinned by test). Ragged rows pad to the widest row with empty cells, and `colspan`/`rowspan` are deliberately lossy: a spanning cell contributes one cell and the padding fills the rest, pinned so the choice is a decision, not an accident. Rows are read via `HTMLTableElement.rows`/`HTMLTableRowElement.cells`, which are spec-scoped, so a table nested inside a cell stays inside that cell's `value` (also pinned).

One honest limitation, pinned by test rather than hidden: annotation `markDefs` inside cell values are dropped, because `HtmlDeserializer` reattaches mark definitions only to top-level text blocks and a deserializer rule cannot reach that state. Decorators survive; link definitions inside cells need a follow-up in the deserializer itself.

The playground's HTML deserializer plugin now applies this rule instead of the flatten rule, so pasting an external table there constructs a `table` block. Studio wiring is tracked separately as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Playground paste now emits structured table blocks instead of flat paragraphs, which changes editor content shape for HTML tables; the new rule is opt-in elsewhere but has documented lossy behavior for spans and nested markDefs in cells.
> 
> **Overview**
> Adds **`createTableRule`** to `@portabletext/html/rules` (and re-exports it from `@portabletext/block-tools/rules`) so `<table>` HTML can deserialize into the nested **`table` → `rows` → `cells` → `value`** shape that `@portabletext/plugin-table`'s `defineTable` expects, instead of only flattening via `createFlattenTableRule`.
> 
> The rule sets **`headerRows`** from leading `<thead>` or all-`<th>` rows, pads ragged rows, ignores **`colspan`/`rowspan`**, supports **`containers`** aligned with `defineTable`, and runs cell content through the normal deserializer (including nested tables in cells).
> 
> The **playground HTML deserializer** now registers `createTableRule` instead of `createFlattenTableRule`, so pasted external tables become **`table` blocks** rather than separated paragraphs. Docs and a large **`create-table.test.ts`** suite cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a46645ac673491e339d49dd26e9537d86b00fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->