### PR TITLE
fix: deprecate the block-level render props on `PortableTextEditable`

### DIFF
--- a/.changeset/deprecate-legacy-render-props.md
+++ b/.changeset/deprecate-legacy-render-props.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: deprecate the block-level render props on `<PortableTextEditable>`
+
+`renderBlock`, `renderChild`, `renderStyle`, and `renderListItem` are deprecated, along with their function types. They keep working, but node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan` mounted through `NodePlugin`) are the supported way to render nodes, and list numbering comes from `@portabletext/plugin-list-index`. The migration guide walks through each prop: https://www.portabletext.org/editor/guides/migrate-render-props/
+
+The span-level props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`) and `rangeDecorations` are not deprecated.

--- a/apps/docs/src/content/docs/editor/getting-started.mdx
+++ b/apps/docs/src/content/docs/editor/getting-started.mdx
@@ -174,6 +174,10 @@ Include the `App` component in your application and run it. You should see an ou
 
 ## Create render functions for schema elements
 
+:::caution[Deprecated]
+The block-level render props used below (`renderStyle`, `renderBlock`, `renderListItem`) are deprecated and will be removed in future major versions in favor of node registrations. The [migration guide](/editor/guides/migrate-render-props/) shows the replacement for each prop.
+:::
+
 At this point the PTE only has a schema, but it doesn't know how to render anything. Fix that by creating render functions for each property in the schema.
 
 Start by creating a render function for styles.

--- a/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
+++ b/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
@@ -13,6 +13,10 @@ The Portable Text Editor handles text blocks (paragraphs, headings, lists) by de
 This guide covers `@portabletext/editor` **v7.x** and `@portabletext/toolbar` **v8.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.7+. You should be familiar with the [getting started guide](/editor/getting-started/) and [custom rendering](/editor/guides/custom-rendering/).
 :::
 
+:::caution[Deprecated]
+The `renderBlock` and `renderChild` props used in this guide are deprecated and will be removed in future major versions in favor of node registrations (`defineBlockObject`, `defineInlineObject`). The [migration guide](/editor/guides/migrate-render-props/) shows the replacement for each prop.
+:::
+
 ## How custom blocks work
 
 There are two kinds of custom content in Portable Text:

--- a/apps/docs/src/content/docs/editor/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/editor/guides/custom-rendering.md
@@ -11,18 +11,18 @@ The Portable Text Editor gives you control of how it renders each schema type el
 This guide covers `@portabletext/editor` **v7.x** ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.7+.
 :::
 
-:::note[Two rendering systems]
-The render props on this page are the editor's original rendering API, and they keep working. The editor also has node registrations (`defineTextBlock`, `defineBlockObject`, and friends), a newer pipeline that powers [containers](/editor/concepts/containers/) and owns the wrapper entirely where registered. To move an editor from these render props onto registrations, follow the [migration guide](/editor/guides/migrate-render-props/).
+:::caution[Deprecated]
+The block-level render props (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`) are deprecated and will be removed in future major versions. Node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`) replace them; the [migration guide](/editor/guides/migrate-render-props/) walks through each prop. The span-level props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`) are not deprecated.
 :::
 
 The following props can be passed to the `PortableTextEditable` component:
 
 - `renderAnnotation`: For annotations (e.g., hyperlinks).
-- `renderBlock`: For block objects (e.g., images, embeds).
-- `renderChild`: For inline objects (e.g., custom emoji, stock symbols).
+- `renderBlock`: For block objects (e.g., images, embeds). (deprecated)
+- `renderChild`: For inline objects (e.g., custom emoji, stock symbols). (deprecated)
 - `renderDecorator`: For decorators (e.g., strong, italic, emphasis text).
-- `renderStyle`: For core text block types (e.g., normal, h1, h2, h3, blockquote).
-- `renderListItem`: For list item styling (e.g., bullet, numbered lists).
+- `renderStyle`: For core text block types (e.g., normal, h1, h2, h3, blockquote). (deprecated)
+- `renderListItem`: For list item styling (e.g., bullet, numbered lists). (deprecated)
 - `renderPlaceholder`: For custom placeholder text when the editor is empty.
 - `rangeDecorations`: For highlighting specific ranges of text (e.g., search results, comments).
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -18,7 +18,7 @@ Then open the local URL Vite prints (defaults to `http://localhost:5173`).
 ## What it demonstrates
 
 - Defining a schema with `defineSchema` (decorators, annotations, styles, lists, block and inline objects)
-- Render functions: `renderDecorator`, `renderAnnotation`, `renderStyle`, `renderBlock`, `renderChild`
+- Render functions: `renderDecorator`, `renderAnnotation`, `renderStyle`, `renderBlock`, `renderChild`, `renderListItem` (the block-level ones are deprecated; see the [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/))
 - A toolbar that toggles marks, styles, and lists using `useEditor` and `useEditorSelector` with selectors from `@portabletext/editor/selectors`
 - Reading the editor value through `EventListenerPlugin` and rendering it as JSON
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -156,6 +156,9 @@ Include the `App` component in your application and run it. You should see an ou
 
 ### Create render functions for schema elements
 
+> [!WARNING]
+> The block-level render props (`renderStyle`, `renderBlock`, `renderListItem`, `renderChild`) are deprecated and will be removed in future major versions in favor of node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`). See the [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/). The span-level props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`) are not deprecated.
+
 At this point the PTE only has a schema, but it doesn't know how to render anything. Fix that by creating render functions for each property in the schema.
 
 Start by creating a render function for styles.

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -68,11 +68,34 @@ export type PortableTextEditableProps = Omit<
   onCopy?: OnCopyFn
   rangeDecorations?: RangeDecoration[]
   renderAnnotation?: RenderAnnotationFunction
+  /**
+   * @deprecated Register your block objects and text blocks with
+   * `defineBlockObject` / `defineTextBlock` mounted through `NodePlugin`
+   * instead. See the migration guide:
+   * https://www.portabletext.org/editor/guides/migrate-render-props/
+   */
   renderBlock?: RenderBlockFunction
+  /**
+   * @deprecated Register your inline objects and spans with
+   * `defineInlineObject` / `defineSpan` mounted through `NodePlugin`
+   * instead. See the migration guide:
+   * https://www.portabletext.org/editor/guides/migrate-render-props/
+   */
   renderChild?: RenderChildFunction
   renderDecorator?: RenderDecoratorFunction
+  /**
+   * @deprecated Render list items with `defineTextBlock` mounted through
+   * `NodePlugin`, with list numbering from
+   * `@portabletext/plugin-list-index`. See the migration guide:
+   * https://www.portabletext.org/editor/guides/migrate-render-props/
+   */
   renderListItem?: RenderListItemFunction
   renderPlaceholder?: RenderPlaceholderFunction
+  /**
+   * @deprecated Render text-block styles with `defineTextBlock` mounted
+   * through `NodePlugin` instead. See the migration guide:
+   * https://www.portabletext.org/editor/guides/migrate-render-props/
+   */
   renderStyle?: RenderStyleFunction
   scrollSelectionIntoView?: ScrollSelectionIntoViewFunction
   selection?: EditorSelection

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -230,10 +230,23 @@ export interface BlockListItemRenderProps {
   value: string
 }
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated The `renderBlock` render prop is deprecated. Register your
+ * block objects and text blocks with `defineBlockObject` /
+ * `defineTextBlock` mounted through `NodePlugin` instead. See the
+ * migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export type RenderBlockFunction = (props: BlockRenderProps) => JSX.Element
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated The `renderChild` render prop is deprecated. Register your
+ * inline objects and spans with `defineInlineObject` / `defineSpan`
+ * mounted through `NodePlugin` instead. See the migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export type RenderChildFunction = (props: BlockChildRenderProps) => JSX.Element
 
 /** @beta */
@@ -249,7 +262,13 @@ export type RenderAnnotationFunction = (
 /** @beta */
 export type RenderPlaceholderFunction = () => React.ReactNode
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated The `renderStyle` render prop is deprecated. Render
+ * text-block styles with `defineTextBlock` mounted through `NodePlugin`
+ * instead. See the migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export type RenderStyleFunction = (props: BlockStyleRenderProps) => JSX.Element
 
 /** @beta */
@@ -264,7 +283,14 @@ export interface BlockStyleRenderProps {
   value: string
 }
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated The `renderListItem` render prop is deprecated. Render list
+ * items with `defineTextBlock` mounted through `NodePlugin`, with list
+ * numbering from `@portabletext/plugin-list-index`. See the migration
+ * guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export type RenderListItemFunction = (
   props: BlockListItemRenderProps,
 ) => JSX.Element


### PR DESCRIPTION
The block-level render props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`) each have a registration equivalent (`defineBlockObject`, `defineTextBlock`, `defineInlineObject`, `defineSpan` mounted through `NodePlugin`), and registrations own node rendering wherever both exist: the render props do not compose with them. This PR marks the four props and their function types `@deprecated`, pointing at the equivalents and the [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/). List numbering, which `renderListItem` consumers get from the `data-list-index` attribute today, points at `@portabletext/plugin-list-index`.

The docs carry the same signal, since the site deploys from `main` and taught the props as the current API with no hint: `:::caution[Deprecated]` asides on the custom-rendering, getting-started, and custom-blocks guides, `(deprecated)` markers in the prop list, and warnings in the editor and basic-example READMEs. Tutorial prose is intentionally untouched; the registration rewrite of those tutorials ships with the next major, and rewriting them here would only conflict with it.

No behavior changes: the props keep working, and the span-level props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`) and `rangeDecorations` are not deprecated. The point is to give v7 consumers the strikethrough and the migration path before the next major removes the props whose replacements have fully shipped (`renderStyle`, `renderListItem` in #3072).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8b2c8f9029b1bde7be8b7e98b7366a5836416a16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->