### PR TITLE
refactor: route default type renderer refusal through a `guarded` classifier

### DIFF
--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -5,7 +5,10 @@ import {
   escapeImageAndLinkTitle,
   escapeTableCell,
 } from '../../escape'
-import type {PortableTextTypeRenderer} from '../types'
+import type {
+  PortableTextTypeRenderer,
+  PortableTextTypeRendererOptions,
+} from '../types'
 
 /**
  * @public
@@ -54,9 +57,7 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
  * there: `rows` an array of typed objects with a `cells` array, every cell
  * a typed object whose `value` array holds typed objects (`renderNode`'s
  * input contract). The predicate narrows to exactly what `renderTable`
- * consumes, so the renderer needs no casts. A malformed `table` value
- * (e.g. a consumer's differently-shaped `table` type) falls back to the
- * fenced-JSON path instead of throwing.
+ * consumes, so the renderer needs no casts.
  */
 function isTableShaped(value: unknown): value is TableShaped {
   const rows = (value as {rows?: unknown} | null)?.rows
@@ -110,14 +111,29 @@ export const DefaultTableRenderer: PortableTextTypeRenderer<{
       value: Array<PortableTextBlock>
     }>
   }>
-}> = (options) => {
-  const {value, renderNode} = options
+}> = guarded(isTableShaped, ({value, renderNode}) =>
+  renderTable(value, renderNode),
+)
 
-  if (!isTableShaped(value)) {
-    return DefaultUnknownTypeRenderer(options)
+/**
+ * Wires the classify-then-render pattern used by `DefaultTableRenderer`:
+ * `isShaped` decides whether `options.value` matches what `render`
+ * dereferences, and an unshaped value falls back to
+ * `DefaultUnknownTypeRenderer`'s fenced-JSON output instead of throwing.
+ * `isShaped` must check exactly what `render` dereferences, no more and no
+ * less: the predicate is `render`'s input type, earned, not assumed by a
+ * cast.
+ */
+function guarded<V extends TypedObject, T>(
+  isShaped: (value: unknown) => value is T,
+  render: (options: PortableTextTypeRendererOptions<V & T>) => string,
+): PortableTextTypeRenderer<V> {
+  return (options) => {
+    if (!isShaped(options.value)) {
+      return DefaultUnknownTypeRenderer(options)
+    }
+    return render({...options, value: options.value})
   }
-
-  return renderTable(value, renderNode)
 }
 
 function renderTable(


### PR DESCRIPTION
The markdown serializer dispatches on the `_type` name alone, so a default type renderer receives arbitrary values whenever a consumer schema declares a same-named type of a different shape. The table default (the only default type renderer today) handles this with a classify-then-render pair: `isTableShaped` gates between the typed `renderTable` and the fenced-JSON `DefaultUnknownTypeRenderer` fallback. Before more default renderers ship and each improvises its own version, this PR extracts the wiring into one internal `guarded(isShaped, render)` combinator and makes the table renderer its first caller.

The combinator carries the pattern's one rule in its contract: the predicate must check exactly what the render function dereferences, no more and no less, so the narrowing is earned rather than asserted. `guarded<V, T>` returns `PortableTextTypeRenderer<V>` with the render callback typed against `V & T`; `V` infers from the annotation at the assignment site, which keeps the compiler link between `DefaultTableRenderer`'s public annotation and its implementation that the hand-wired version had. No cast, no `any` seam.

`guarded` stays internal. Making refusal consumer-visible (renderers returning `undefined` with the dispatcher owning the fallback) is a real API design with its own trade-offs and is deliberately not decided here.

Pure refactor: zero observable change on every dispatch path (shaped table → GFM, unshaped value → fenced JSON, empty `rows` → empty string), pinned by the existing suite. No changeset.

Stacked on #3073; retarget to `main` after it merges.