### PR TITLE
fix: scope `createFlattenTableRule`'s row and cell lookup to its own table

### DIFF
--- a/.changeset/scope-flatten-table-lookup.md
+++ b/.changeset/scope-flatten-table-lookup.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/html': patch
+---
+
+fix: scope `createFlattenTableRule`'s row and cell lookup to its own table
+
+A table containing another table in one of its cells was not flattened at all: its cells came through as separate blocks, as if the rule had not been passed. Rows and cells are now read from the table's own `rows` and `cells` collections, so a nested table stays inside the cell that holds it.

--- a/packages/html/src/deserializer/helpers.ts
+++ b/packages/html/src/deserializer/helpers.ts
@@ -140,3 +140,12 @@ export function hasPreservedWhitespaceStyle(el: Node): boolean {
 export function isElement(node: Node): node is Element {
   return node.nodeType === 1
 }
+
+/**
+ * Narrows to `HTMLTableElement` so the scoped `rows`, `cells`, `tHead`, and
+ * `tBodies` collections are available: unlike `querySelectorAll`, they stop
+ * at the table's own structure and never reach into a nested table.
+ */
+export function isTableElement(node: Node): node is HTMLTableElement {
+  return isElement(node) && tagName(node) === 'table'
+}

--- a/packages/html/src/rules/create-table.ts
+++ b/packages/html/src/rules/create-table.ts
@@ -1,6 +1,6 @@
 import type {Schema} from '@portabletext/schema'
 import {flattenNestedBlocks} from '../deserializer/flatten-nested-blocks'
-import {isElement, tagName} from '../deserializer/helpers'
+import {isTableElement, tagName} from '../deserializer/helpers'
 import {normalizeBlock} from '../deserializer/normalize-block'
 import {keyGenerator as defaultKeyGenerator} from '../deserializer/random-key'
 import type {
@@ -78,12 +78,11 @@ export function createTableRule({
 
   return {
     deserialize: (node, next, createBlock) => {
-      if (!isElement(node) || tagName(node) !== 'table') {
+      if (!isTableElement(node)) {
         return undefined
       }
 
-      const tableElement = node as HTMLTableElement
-      const rowElements = [...tableElement.rows]
+      const rowElements = [...node.rows]
 
       if (rowElements.length === 0) {
         return undefined

--- a/packages/html/src/rules/flatten-tables.ts
+++ b/packages/html/src/rules/flatten-tables.ts
@@ -102,7 +102,7 @@ export function createFlattenTableRule({
       const tbody = node.tBodies[0]
       const bodyRows = tbody ? [...tbody.rows] : []
 
-      if (!headerRows || !bodyRows) {
+      if (!headerRows) {
         return undefined
       }
 

--- a/packages/html/src/rules/flatten-tables.ts
+++ b/packages/html/src/rules/flatten-tables.ts
@@ -86,10 +86,7 @@ export function createFlattenTableRule({
         return undefined
       }
 
-      const columnCounts = [...node.querySelectorAll('tr')].map((row) => {
-        const cells = row.querySelectorAll('td, th')
-        return cells.length
-      })
+      const columnCounts = [...node.rows].map((row) => row.cells.length)
 
       const firstColumnCount = columnCounts[0]
 
@@ -101,10 +98,9 @@ export function createFlattenTableRule({
         return undefined
       }
 
-      const thead = node.querySelector('thead')
-      const headerRows = thead?.querySelectorAll('tr')
-      const tbody = node.querySelector('tbody')
-      const bodyRows = tbody ? [...tbody.querySelectorAll('tr')] : []
+      const headerRows = node.tHead?.rows
+      const tbody = node.tBodies[0]
+      const bodyRows = tbody ? [...tbody.rows] : []
 
       if (!headerRows || !bodyRows) {
         return undefined
@@ -116,7 +112,7 @@ export function createFlattenTableRule({
         return undefined
       }
 
-      const headerCells = headerRow.querySelectorAll('th, td')
+      const headerCells = headerRow.cells
       const headerResults = [...headerCells].map((headerCell) =>
         next(headerCell),
       )
@@ -125,7 +121,7 @@ export function createFlattenTableRule({
       const rows: TypedObject[] = []
 
       for (const row of bodyRows) {
-        const cells = row.querySelectorAll('td')
+        const cells = [...row.cells].filter((cell) => tagName(cell) === 'td')
 
         let cellIndex = 0
         for (const cell of cells) {

--- a/packages/html/src/rules/flatten-tables.ts
+++ b/packages/html/src/rules/flatten-tables.ts
@@ -5,7 +5,7 @@ import {
   type Schema,
 } from '@portabletext/schema'
 import {flattenNestedBlocks} from '../deserializer/flatten-nested-blocks'
-import {isElement, tagName} from '../deserializer/helpers'
+import {isTableElement, tagName} from '../deserializer/helpers'
 import type {
   ArbitraryTypedObject,
   DeserializerRule,
@@ -82,7 +82,7 @@ export function createFlattenTableRule({
 }): DeserializerRule {
   return {
     deserialize: (node, next) => {
-      if (!isElement(node) || tagName(node) !== 'table') {
+      if (!isTableElement(node)) {
         return undefined
       }
 

--- a/packages/html/src/tests/html-to-portable-text/flatten-tables.test.ts
+++ b/packages/html/src/tests/html-to-portable-text/flatten-tables.test.ts
@@ -405,6 +405,34 @@ describe(createFlattenTableRule.name, () => {
     ).toEqual(['Name', 'John Doe', 'Age', '18'])
   })
 
+  test('table with a nested table in a cell', () => {
+    const html = [
+      '<table>',
+      '<thead>',
+      '<tr>',
+      '<th>foo</th>',
+      '<th>bar</th>',
+      '</tr>',
+      '</thead>',
+      '<tbody>',
+      '<tr>',
+      '<td>baz</td>',
+      '<td><table><tr><td>fizz</td></tr></table></td>',
+      '</tr>',
+      '</tbody>',
+      '</table>',
+    ].join('')
+
+    expect(
+      getTersePt({
+        schema,
+        value: transform(html, {
+          rules: [flattenTableRule],
+        }),
+      }),
+    ).toEqual(['foo, ,baz', 'bar, ,fizz'])
+  })
+
   describe('table with images', () => {
     /**
      * | Name       | Photo                                                          |


### PR DESCRIPTION
Pasting a table that contains another table in one of its cells produced no flattening at all: every cell came through as its own block, exactly as if `createFlattenTableRule` had never been passed.

The rule collected rows with `node.querySelectorAll('tr')` and cells with `row.querySelectorAll('td, th')`. Neither is scoped to the table being deserialized, so a nested table contributed its rows and cells to the outer table's tally. For a two-column table whose second body cell held a one-cell table, the column counts came out `[2, 3, 1]`, the consistency check that guards the rule failed, and the rule declined the node, leaving it to the generic HTML rule. `querySelector('thead')` and `querySelector('tbody')` had the same reach and could resolve to a nested table's sections.

The structure now comes from the table's own collections, `rows`, `cells`, `tHead`, and `tBodies[0]`, which the DOM spec scopes to the element itself. Body cells keep their `td`-only selection by filtering `row.cells`, so a row carrying a leading `th` behaves as before. A test flattening a table whose cell holds a nested table pins the fix; it is red on the old lookup, where the phantom rows make the rule bail out. No existing expectation in the suite changed.

Two refactors bracket the fix, both behavior-neutral. The first makes the fix typable: both table rules opened with the same `isElement` plus `tagName` check, which narrows only to `Element`, so the scoped collections were out of reach and `createTableRule` carried an `as HTMLTableElement` cast to get at them; a shared `isTableElement` guard does the same check as a narrowing guard, and the cast goes. The last drops an unreachable arm the fix left exposed: `bodyRows` is always an array, so `!bodyRows` never held, and the absent-body case is already carried by an empty array producing no flattened rows.

One pre-existing quirk is left alone deliberately: rows in a second `<tbody>`, and `<tfoot>` rows, count toward the column-count check but are never emitted, because only `tBodies[0]` is read. Changing that changes output for tables shaped that way, so it wants its own decision rather than riding along here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ca6452e03a0608d881153463ce1b41505aef6d45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->