### PR TITLE
feat: render code, image, horizontal rule, HTML, and callout blocks to markdown by default

### DIFF
--- a/.changeset/serializer-default-renderers.md
+++ b/.changeset/serializer-default-renderers.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: render code, image, horizontal rule, HTML, and callout blocks to markdown by default
+
+`portableTextToMarkdown` now renders `code`, `image`, `horizontal-rule`, `html`, and `callout` block objects back to Markdown by default, instead of a fenced JSON block. This matches `table`, which already rendered as GFM by default.
+
+`code`, `image`, `html`, and `callout` fall back to the fenced JSON rendering when a value doesn't match the shape its renderer expects, for example a consumer's own differently-shaped `code` type reaching the renderer via the same `_type` name; `horizontal-rule` always renders `---`. A consumer-supplied `types` renderer still wins over any of the defaults.
+
+`@portabletext/editor`'s markdown clipboard picks this up via the automatic dependency bump: copying a code block, image, horizontal rule, HTML block, or callout out of the editor now produces real Markdown instead of a fenced JSON block.
+
+One narrow behavioral fix rides along: when a `callout` or `DefaultBlockquoteObjectRenderer` content entry falls back to fenced JSON, the JSON is the original value; previously it carried a `style: 'normal'` field injected by the renderer.

--- a/apps/docs/src/content/docs/rendering/markdown.mdx
+++ b/apps/docs/src/content/docs/rendering/markdown.mdx
@@ -29,7 +29,7 @@ const markdown = portableTextToMarkdown(blocks)
 
 ## Custom type renderers
 
-Custom block types (objects in the blocks array) are not rendered by default, with one exception: `table` renders as GFM Markdown out of the box. Register a renderer for other types you use.
+`callout`, `code`, `horizontal-rule`, `html`, `image`, and `table` block objects render as Markdown out of the box. `callout`, `code`, `html`, `image`, and `table` fall back to a fenced JSON block when a value doesn't match the shape its renderer expects (a consumer's own differently-shaped `code` type, say); `horizontal-rule` always renders `---`. Register a renderer for other custom types you use, or to override one of the defaults.
 
 ```ts
 portableTextToMarkdown(blocks, {
@@ -67,39 +67,35 @@ portableTextToMarkdown(blocks, {
 
 ## Built-in type renderers
 
-The package exports default renderers for common block types. Import and register the ones you need.
+`callout`, `code`, `horizontal-rule`, `html`, `image`, and `table` are registered by default. The package also exports `DefaultBlockquoteObjectRenderer` and `DefaultListRenderer` for the structural container shapes the parser produces when `types.blockquote`/`types.list` matchers are registered; those two stay opt-in since the parser only produces that shape when asked to.
 
 ```ts
 import {
-  DefaultCalloutRenderer,
-  DefaultCodeBlockRenderer,
-  DefaultHorizontalRuleRenderer,
-  DefaultHtmlRenderer,
-  DefaultImageRenderer,
+  DefaultBlockquoteObjectRenderer,
+  DefaultListRenderer,
   portableTextToMarkdown,
 } from '@portabletext/markdown'
 
 portableTextToMarkdown(blocks, {
   types: {
-    'callout': DefaultCalloutRenderer,
-    'code': DefaultCodeBlockRenderer,
-    'horizontal-rule': DefaultHorizontalRuleRenderer,
-    'html': DefaultHtmlRenderer,
-    'image': DefaultImageRenderer,
+    blockquote: DefaultBlockquoteObjectRenderer,
+    list: DefaultListRenderer,
   },
 })
 ```
 
-`table` uses `DefaultTableRenderer` automatically; supply your own `table` renderer to override how tables serialize.
+Supply your own `types.<name>` renderer to override any of the defaults.
 
-| Renderer                        | Expected fields         | Output                         |
-| ------------------------------- | ----------------------- | ------------------------------ |
-| `DefaultCalloutRenderer`        | `tone`, `content`       | `> [!TYPE]\n> content`         |
-| `DefaultCodeBlockRenderer`      | `code`, `language?`     | ` ```lang\ncode\n``` `         |
-| `DefaultHorizontalRuleRenderer` | (none required)         | `---`                          |
-| `DefaultHtmlRenderer`           | `html`                  | Raw HTML string                |
-| `DefaultImageRenderer`          | `src`, `alt?`, `title?` | `![alt](src "title")`          |
-| `DefaultTableRenderer`          | `rows`, `headerRows?`   | Markdown table (on by default) |
+| Renderer                          | Expected fields         | Output                 |
+| --------------------------------- | ----------------------- | ---------------------- |
+| `DefaultCalloutRenderer`          | `tone`, `content`       | `> [!TYPE]\n> content` |
+| `DefaultCodeBlockRenderer`        | `code`, `language?`     | ` ```lang\ncode\n``` ` |
+| `DefaultHorizontalRuleRenderer`   | (none required)         | `---`                  |
+| `DefaultHtmlRenderer`             | `html`                  | Raw HTML string        |
+| `DefaultImageRenderer`            | `src`, `alt?`, `title?` | `![alt](src "title")`  |
+| `DefaultTableRenderer`            | `rows`, `headerRows?`   | Markdown table         |
+| `DefaultBlockquoteObjectRenderer` | `content`               | `> content`            |
+| `DefaultListRenderer`             | `kind`, `items`         | Markdown list          |
 
 ## Renderer map keys
 
@@ -132,14 +128,12 @@ By default, unknown types render as JSON code blocks. Unknown marks, block style
 | Ordered lists    |       ✅       |
 | Unordered lists  |       ✅       |
 | Nested lists     |       ✅       |
-| Code blocks      |      ✅\*      |
-| Horizontal rules |      ✅\*      |
-| Images           |      ✅\*      |
+| Code blocks      |       ✅       |
+| Horizontal rules |       ✅       |
+| Images           |       ✅       |
 | Tables           |       ✅       |
-| HTML blocks      |      ✅\*      |
-| Callouts         |      ✅\*      |
-
-\* Requires registering the built-in renderer (see above). Tables render by default.
+| HTML blocks      |       ✅       |
+| Callouts         |       ✅       |
 
 :::note
 This package uses markdown-it as its Markdown parser. Remark and unified plugins are not compatible.

--- a/apps/playground/src/previews/markdown-options.ts
+++ b/apps/playground/src/previews/markdown-options.ts
@@ -1,5 +1,4 @@
 import {
-  DefaultCalloutRenderer,
   DefaultHorizontalRuleRenderer,
   type PortableTextRenderers,
   type PortableTextTypeRenderer,
@@ -39,8 +38,6 @@ export const markdownOptions: Partial<PortableTextRenderers> = {
         .join('\n')
       return `\`\`\`\n${code}\n\`\`\``
     },
-
-    'callout': DefaultCalloutRenderer,
 
     // No native markdown for fact-box. Render inner content as a
     // collapsible `<details>` block so the preview still surfaces the

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -72,14 +72,14 @@ const markdown = portableTextToMarkdown([
 | Unordered lists  | ✅                       | ✅                       |
 | Task lists       | ✅\*                     | ✅\*                     |
 | Nested lists     | ✅                       | ✅                       |
-| Code blocks      | ✅                       | ✅\*                     |
-| Horizontal rules | ✅                       | ✅\*                     |
-| Images           | ✅                       | ✅\*                     |
+| Code blocks      | ✅                       | ✅                       |
+| Horizontal rules | ✅                       | ✅                       |
+| Images           | ✅                       | ✅                       |
 | Tables           | ✅                       | ✅                       |
-| HTML blocks      | ✅                       | ✅\*                     |
-| Callouts         | ✅\*                     | ✅\*                     |
+| HTML blocks      | ✅                       | ✅                       |
+| Callouts         | ✅                       | ✅                       |
 
-\* Requires custom configuration (see usage below)
+\* Requires a schema that declares a `task` list; the default schema does not (see [GFM task lists](#configuring-matchers) below)
 
 ## Usage
 
@@ -162,14 +162,14 @@ Out of the box, the library includes sensible defaults for both. Customize them 
 
 The default schema includes the following definitions:
 
-| Type            | Values                                                                                                                                                                                                                                                                                                  |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `styles`        | `'normal'`, `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'`, `'blockquote'`                                                                                                                                                                                                                              |
-| `lists`         | `'number'`, `'bullet'`                                                                                                                                                                                                                                                                                  |
-| `decorators`    | `'strong'`, `'em'`, `'code'`, `'strike-through'`                                                                                                                                                                                                                                                        |
-| `annotations`   | `'link'` (fields: `'href'`, `'title'`)                                                                                                                                                                                                                                                                  |
-| `blockObjects`  | `'code'` (fields: `'language'`, `'code'`), `'image'` (fields: `'src'`, `'alt'`, `'title'`), `'horizontal-rule'`, `'html'` (fields: `'html'`), `'table'` (fields: `'headerRows'`, `'alignment'`, `'rows'` of `'row'` of `'cells'` of `'cell'` of `'value'`), `'callout'` (fields: `'tone'`, `'content'`) |
-| `inlineObjects` | `'image'` (fields: `'src'`, `'alt'`, `'title'`)                                                                                                                                                                                                                                                         |
+| Type            | Values                                                                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `styles`        | `'normal'`, `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'`, `'blockquote'`                                                                                                                                                                                                   |
+| `lists`         | `'number'`, `'bullet'`                                                                                                                                                                                                                                                       |
+| `decorators`    | `'strong'`, `'em'`, `'code'`, `'strike-through'`                                                                                                                                                                                                                             |
+| `annotations`   | `'link'` (fields: `'href'`, `'title'`)                                                                                                                                                                                                                                       |
+| `blockObjects`  | `'code'` (fields: `'language'`, `'code'`), `'image'` (fields: `'src'`, `'alt'`, `'title'`), `'horizontal-rule'`, `'html'` (fields: `'html'`), `'table'` (the canonical nested shape, see [Default behavior](#default-behavior)), `'callout'` (fields: `'tone'`, `'content'`) |
+| `inlineObjects` | `'image'` (fields: `'src'`, `'alt'`, `'title'`)                                                                                                                                                                                                                              |
 
 To use a custom Schema, import `compileSchema` and `defineSchema` from `@portabletext/schema`:
 
@@ -219,8 +219,37 @@ Matchers map Markdown concepts to Portable Text types defined in the Schema. Eac
 |            | `html`           | HTML blocks             | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.       | `'callout'`         |
 |            | `table`          | GFM pipe tables         | `'table'`           |
-|            | `blockquote`     | `>` blockquotes         | `'blockquote'`      |
-|            | `list`           | `- ` or `1. ` lists     | `'list'`            |
+|            | `blockquote`\*   | `>` blockquotes         | `'blockquote'`      |
+|            | `list`\*         | `- ` or `1. ` lists     | `'list'`            |
+
+\* Opt-in, not registered by default: `blockquote` and `list` map onto structural container shapes, and the parser only produces those shapes when you register the matcher (see [Configuring matchers](#configuring-matchers)). Without them, blockquotes and lists parse to flat text blocks, which is the standard Portable Text shape for both, not a degraded fallback.
+
+#### Default behavior
+
+**Tables** (GFM pipe tables) convert by default, in the canonical shape `@portabletext/plugin-table` expects: a `table` block object (`headerRows`, `rows`), each row a `row` object (`cells`), each cell a `cell` object (`value`, an array of Portable Text blocks; a cell holding a single image becomes a standalone block-level `image` object instead of a text block wrapping it). `alignment` is a `@portabletext/markdown` extension field; `@portabletext/plugin-table` ignores it. This needs no configuration when the schema declares a `table` block object with a `rows` field (see `blockObjects` above). A schema whose `table` doesn't declare `rows`, or that doesn't declare `table` at all, produces no table object at all: the table's cell content flattens into top-level blocks, in reading order, and the table structure is discarded.
+
+**Images** are handled based on context:
+
+- Standalone images (a paragraph containing only an image) become block-level `'image'` objects
+- Images mixed with text become inline `'image'` objects (if the schema includes `'image'` in `inlineObjects`)
+- If neither is supported, falls back to plain text: `![alt](src)`
+
+The default image matcher requires the schema type to have a `'src'` field. If your `'image'` type doesn't include this field, the matcher returns `undefined`.
+
+**Code** is handled based on the Markdown syntax:
+
+- Fenced code blocks (` ``` `) become `'code'` block objects with `language` and `code` fields
+- Inline code (`` ` ``) applies the `'code'` decorator to a span
+
+The default code block matcher requires the schema type to have a `'code'` field. If your `'code'` type doesn't include this field, the matcher returns `undefined`.
+
+**Links** support optional titles using `[text](url "title")` syntax. The title is captured in the `'title'` field of the `'link'` annotation.
+
+**Nested lists** are handled automatically. Each list item block includes a `level` property indicating its nesting depth (1 for top-level, 2 for nested, etc.).
+
+**HTML blocks** (like `<div>...</div>`) become `'html'` block objects with the raw HTML in the `'html'` field. Inline HTML is controlled by the `html.inline` option.
+
+**Callouts** use the `> [!TYPE]` syntax (GFM alerts) where `TYPE` is one of `NOTE`, `TIP`, `WARNING`, `CAUTION`, or `IMPORTANT`. They become `'callout'` block objects with a `'tone'` field (the lowercased type name) and a `'content'` field (an array of Portable Text blocks). When the schema doesn't include a `'callout'` block object, the content falls back to blockquote-styled blocks.
 
 #### Configuring matchers
 
@@ -247,9 +276,7 @@ markdownToPortableText(markdown, {
 
 > **Note:** Checking if the type exists in the schema isn't required, but it's good practice. Returning `undefined` gracefully skips unsupported types.
 
-**Table matcher:** GFM pipe tables convert by default, in the canonical shape `@portabletext/plugin-table` expects: a `table` block object (`headerRows`, `rows`), each row a `row` object (`cells`), each cell a `cell` object (`value`, an array of Portable Text blocks; a cell holding a single image becomes a standalone block-level `image` object instead of a text block wrapping it). `alignment` is a `@portabletext/markdown` extension field; `@portabletext/plugin-table` ignores it. This needs no configuration when the schema declares a `table` block object with a `rows` field (see `blockObjects` above). A schema whose `table` doesn't declare `rows`, or that doesn't declare `table` at all, keeps the pre-default behavior: the table's cell content flattens into top-level blocks, in reading order.
-
-Provide your own matcher to map onto a differently-shaped `table` type:
+**Table matcher:** GFM pipe tables convert by default (see [Default behavior](#default-behavior)). Provide your own matcher to map onto a differently-shaped `table` type:
 
 ```ts
 markdownToPortableText(markdown, {
@@ -351,31 +378,6 @@ Matchers receive:
 
 Return `undefined` to skip the element (e.g., if the type isn't in the schema).
 
-#### Default behavior for images and code
-
-**Images** are handled based on context:
-
-- Standalone images (a paragraph containing only an image) become block-level `'image'` objects
-- Images mixed with text become inline `'image'` objects (if the schema includes `'image'` in `inlineObjects`)
-- If neither is supported, falls back to plain text: `![alt](src)`
-
-The default image matcher requires the schema type to have a `'src'` field. If your `'image'` type doesn't include this field, the matcher returns `undefined`.
-
-**Code** is handled based on the Markdown syntax:
-
-- Fenced code blocks (` ``` `) become `'code'` block objects with `language` and `code` fields
-- Inline code (`` ` ``) applies the `'code'` decorator to a span
-
-The default code block matcher requires the schema type to have a `'code'` field. If your `'code'` type doesn't include this field, the matcher returns `undefined`.
-
-**Links** support optional titles using `[text](url "title")` syntax. The title is captured in the `'title'` field of the `'link'` annotation.
-
-**Nested lists** are handled automatically. Each list item block includes a `level` property indicating its nesting depth (1 for top-level, 2 for nested, etc.).
-
-**HTML blocks** (like `<div>...</div>`) become `'html'` block objects with the raw HTML in the `'html'` field. Inline HTML is controlled by the `html.inline` option.
-
-**Callouts** use the `> [!TYPE]` syntax (GFM alerts) where `TYPE` is one of `NOTE`, `TIP`, `WARNING`, `CAUTION`, or `IMPORTANT`. They become `'callout'` block objects with a `'tone'` field (the lowercased type name) and a `'content'` field (an array of Portable Text blocks). When the schema doesn't include a `'callout'` block object, the content falls back to blockquote-styled blocks.
-
 #### Other options
 
 ```ts
@@ -452,27 +454,34 @@ The conversion is driven by **Renderers**: functions that render Portable Text e
 
 #### Default renderers
 
-| Group               | Renderer         | Renders                           | Output                   |
-| ------------------- | ---------------- | --------------------------------- | ------------------------ |
-| `types`             | `table`          | `table` block objects             | Markdown table           |
-| `block`             | `normal`         | Paragraphs                        | `{children}`             |
-|                     | `h1`–`h6`        | Headings                          | `# `–`###### `           |
-|                     | `blockquote`     | Blockquotes                       | `> {children}`           |
-| `marks`             | `strong`         | Bold text                         | `**{children}**`         |
-|                     | `em`             | Italic text                       | `_{children}_`           |
-|                     | `code`           | Inline code                       | `` `{children}` ``       |
-|                     | `underline`      | Underlined text                   | `<u>{children}</u>`      |
-|                     | `strike-through` | Strikethrough                     | `~~{children}~~`         |
-|                     | `link`           | Links                             | `[{children}](url)`      |
-| `listItem`          |                  | List items (bullet, number, task) | `- `, `1. `, or `- [x] ` |
-| `hardBreak`         |                  | Line breaks within blocks         | `  \n` (two spaces)      |
-| `blockSpacing`      |                  | Spacing between blocks            | `\n\n`, `\n`, `\n>\n`    |
-| `unknownType`       |                  | Unknown block types               | JSON code block          |
-| `unknownBlockStyle` |                  | Unknown block styles              | `{children}`             |
-| `unknownListItem`   |                  | Unknown list item types           | `- {children}`           |
-| `unknownMark`       |                  | Unknown marks                     | `{children}`             |
+| Group               | Renderer          | Renders                           | Output                   |
+| ------------------- | ----------------- | --------------------------------- | ------------------------ |
+| `types`             | `callout`         | `callout` block objects           | `> [!TYPE]\n> content`   |
+|                     | `code`            | `code` block objects              | Fenced code block        |
+|                     | `horizontal-rule` | `horizontal-rule` block objects   | `---`                    |
+|                     | `html`            | `html` block objects              | Raw HTML                 |
+|                     | `image`           | `image` block/inline objects      | `![alt](src "title")`    |
+|                     | `table`           | `table` block objects             | Markdown table           |
+| `block`             | `normal`          | Paragraphs                        | `{children}`             |
+|                     | `h1`–`h6`         | Headings                          | `# `–`###### `           |
+|                     | `blockquote`      | Blockquotes                       | `> {children}`           |
+| `marks`             | `strong`          | Bold text                         | `**{children}**`         |
+|                     | `em`              | Italic text                       | `_{children}_`           |
+|                     | `code`            | Inline code                       | `` `{children}` ``       |
+|                     | `underline`       | Underlined text                   | `<u>{children}</u>`      |
+|                     | `strike-through`  | Strikethrough                     | `~~{children}~~`         |
+|                     | `link`            | Links                             | `[{children}](url)`      |
+| `listItem`          |                   | List items (bullet, number, task) | `- `, `1. `, or `- [x] ` |
+| `hardBreak`         |                   | Line breaks within blocks         | `  \n` (two spaces)      |
+| `blockSpacing`      |                   | Spacing between blocks            | `\n\n`, `\n`, `\n>\n`    |
+| `unknownType`       |                   | Unknown block types               | JSON code block          |
+| `unknownBlockStyle` |                   | Unknown block styles              | `{children}`             |
+| `unknownListItem`   |                   | Unknown list item types           | `- {children}`           |
+| `unknownMark`       |                   | Unknown marks                     | `{children}`             |
 
 Unknown types render as JSON code blocks by default; unknown styles, list items, and marks pass through their children.
+
+The default type renderers are collision-safe: because the serializer dispatches on the `_type` name alone, `code`, `html`, `image`, `callout`, and `table` fall back to the `unknownType` renderer (a JSON code block) when a value doesn't match the shape their renderer expects (say, your own differently-shaped `code` type); `horizontal-rule` has no shape to check and always renders `---`. Register your own `types.<name>` renderer to override how any of them serialize, or to handle a same-named type of a different shape.
 
 > **Note:** The `underline` renderer is included for Portable Text that uses it, but there's no standard Markdown syntax for underline, so it renders as HTML.
 
@@ -480,7 +489,7 @@ Unknown types render as JSON code blocks by default; unknown styles, list items,
 
 Provide custom renderers to control how Portable Text renders to Markdown.
 
-**Custom type renderers:** Render custom block types (objects in the blocks array):
+**Custom type renderers:** Render custom block types (objects in the blocks array). A custom renderer under a default's name (see [Default renderers](#default-renderers)) replaces that default:
 
 ```ts
 portableTextToMarkdown(blocks, {
@@ -490,11 +499,6 @@ portableTextToMarkdown(blocks, {
   },
 })
 ```
-
-`table` block objects render as GFM tables by default; a value that isn't
-table-shaped (no `rows` array of row-shaped objects) falls back to the JSON
-code block `unknownType` renders. Provide your own `types.table` renderer to
-override how tables serialize.
 
 **Custom block styles:** Override how block styles render:
 
@@ -509,31 +513,19 @@ portableTextToMarkdown(blocks, {
 })
 ```
 
-**Built-in type renderers:** The library exports default renderers for common block types:
+**Built-in type renderers:** the library exports every built-in type renderer, in case you want to compose one into a different renderer or reuse it under a different type name. Two of them are exported but not registered by default: `DefaultBlockquoteObjectRenderer` and `DefaultListRenderer` render the structural container shapes (`types.blockquote`/`types.list` on the parser side) and stay opt-in, since the parser only produces those shapes when a matcher is registered for them:
 
 ```ts
 import {
   DefaultBlockquoteObjectRenderer,
-  DefaultCalloutRenderer,
-  DefaultCodeBlockRenderer,
-  DefaultHorizontalRuleRenderer,
-  DefaultHtmlRenderer,
-  DefaultImageRenderer,
   DefaultListRenderer,
-  DefaultTableRenderer,
   portableTextToMarkdown,
 } from '@portabletext/markdown'
 
 portableTextToMarkdown(blocks, {
   types: {
-    'blockquote': DefaultBlockquoteObjectRenderer,
-    'callout': DefaultCalloutRenderer,
-    'code': DefaultCodeBlockRenderer,
-    'horizontal-rule': DefaultHorizontalRuleRenderer,
-    'html': DefaultHtmlRenderer,
-    'image': DefaultImageRenderer,
-    'list': DefaultListRenderer,
-    'table': DefaultTableRenderer,
+    blockquote: DefaultBlockquoteObjectRenderer,
+    list: DefaultListRenderer,
   },
 })
 ```

--- a/packages/markdown/src/example-document.advanced.test.ts
+++ b/packages/markdown/src/example-document.advanced.test.ts
@@ -1,16 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type {BlockObjectDefinition} from '@portabletext/schema'
 import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {defaultSchema} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
-import {
-  DefaultCodeBlockRenderer,
-  DefaultTableRenderer,
-} from './from-portable-text/renderers/type'
 import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
-import {buildObjectMatcher} from './to-portable-text/matchers'
 
 const exampleDocumentMarkdown = fs.readFileSync(
   path.resolve(__dirname, 'example-document.advanced.md'),
@@ -27,28 +21,11 @@ const exampleDocumentTersePt = JSON.parse(
   ),
 )
 
-const tableObjectDefinition = {
-  name: 'table',
-  fields: [
-    {name: 'headerRows', type: 'number'},
-    {name: 'rows', type: 'array'},
-  ],
-} as const satisfies BlockObjectDefinition
-
-const tableObjectMatcher = buildObjectMatcher(tableObjectDefinition)
-
 describe('example document (advanced)', () => {
   test('markdown to portable text', () => {
     const keyGenerator = createTestKeyGenerator()
     const blocks = markdownToPortableText(exampleDocumentMarkdown, {
       keyGenerator,
-      schema: {
-        ...defaultSchema,
-        blockObjects: [...defaultSchema.blockObjects, tableObjectDefinition],
-      },
-      types: {
-        table: tableObjectMatcher,
-      },
     })
     const tersePt = getTersePt({schema: defaultSchema, value: blocks})
 
@@ -59,26 +36,11 @@ describe('example document (advanced)', () => {
     const keyGenerator = createTestKeyGenerator()
     const blocks = markdownToPortableText(exampleDocumentMarkdown, {
       keyGenerator,
-      schema: {
-        ...defaultSchema,
-        blockObjects: [...defaultSchema.blockObjects, tableObjectDefinition],
-      },
-      types: {
-        table: tableObjectMatcher,
-      },
       html: {
         inline: 'text',
       },
     })
     const markdown = portableTextToMarkdown(blocks, {
-      types: {
-        'horizontal-rule': () => '---',
-        'table': DefaultTableRenderer,
-        'code': DefaultCodeBlockRenderer,
-        'html': ({value}) => value.html || '',
-        'image': ({value}) =>
-          `![${value.alt}](${value.src}${value.title ? ` "${value.title}"` : ''})`,
-      },
       hardBreak: () => '<br />\n',
     })
 

--- a/packages/markdown/src/example-document.test.ts
+++ b/packages/markdown/src/example-document.test.ts
@@ -1,16 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type {BlockObjectDefinition} from '@portabletext/schema'
 import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {defaultSchema} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
-import {
-  DefaultCodeBlockRenderer,
-  DefaultTableRenderer,
-} from './from-portable-text/renderers/type'
 import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
-import {buildObjectMatcher} from './to-portable-text/matchers'
 
 const exampleDocumentMarkdown = fs.readFileSync(
   path.resolve(__dirname, 'example-document.md'),
@@ -28,28 +22,11 @@ const exampleDocumentTersePt = JSON.parse(
   ),
 )
 
-const tableObjectDefinition = {
-  name: 'table',
-  fields: [
-    {name: 'headerRows', type: 'number'},
-    {name: 'rows', type: 'array'},
-  ],
-} as const satisfies BlockObjectDefinition
-
-const tableObjectMatcher = buildObjectMatcher(tableObjectDefinition)
-
 describe('example document', () => {
   test('markdown to portable text', () => {
     const keyGenerator = createTestKeyGenerator()
     const blocks = markdownToPortableText(exampleDocumentMarkdown, {
       keyGenerator,
-      schema: {
-        ...defaultSchema,
-        blockObjects: [...defaultSchema.blockObjects, tableObjectDefinition],
-      },
-      types: {
-        table: tableObjectMatcher,
-      },
     })
     const tersePt = getTersePt({schema: defaultSchema, value: blocks})
 
@@ -60,27 +37,24 @@ describe('example document', () => {
     const keyGenerator = createTestKeyGenerator()
     const blocks = markdownToPortableText(exampleDocumentMarkdown, {
       keyGenerator,
-      schema: {
-        ...defaultSchema,
-        blockObjects: [...defaultSchema.blockObjects, tableObjectDefinition],
-      },
-      types: {
-        table: tableObjectMatcher,
-      },
       html: {
         inline: 'text',
       },
     })
-    const markdown = portableTextToMarkdown(blocks, {
-      types: {
-        'horizontal-rule': () => '---',
-        'table': DefaultTableRenderer,
-        'code': DefaultCodeBlockRenderer,
-        'html': ({value}) => value.html || '',
-        'image': ({value}) =>
-          `![${value.alt}](${value.src}${value.title ? ` "${value.title}"` : ''})`,
+    const markdown = portableTextToMarkdown(blocks)
+
+    expect(`${markdown}\n`).toBe(exampleDocumentMarkdownOut)
+  })
+
+  test('round-trip closes: the normalized markdown is a fixpoint', () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blocks = markdownToPortableText(exampleDocumentMarkdownOut, {
+      keyGenerator,
+      html: {
+        inline: 'text',
       },
     })
+    const markdown = portableTextToMarkdown(blocks)
 
     expect(`${markdown}\n`).toBe(exampleDocumentMarkdownOut)
   })

--- a/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
+++ b/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
@@ -35,6 +35,11 @@ import {
   DefaultUnknownStyleRenderer,
 } from './renderers/style'
 import {
+  DefaultCalloutRenderer,
+  DefaultCodeBlockRenderer,
+  DefaultHorizontalRuleRenderer,
+  DefaultHtmlRenderer,
+  DefaultImageRenderer,
   DefaultTableRenderer,
   DefaultUnknownTypeRenderer,
 } from './renderers/type'
@@ -42,7 +47,12 @@ import type {PortableTextRenderers} from './types'
 
 const defaultRenderers: PortableTextRenderers = {
   types: {
-    table: DefaultTableRenderer,
+    'callout': DefaultCalloutRenderer,
+    'code': DefaultCodeBlockRenderer,
+    'horizontal-rule': DefaultHorizontalRuleRenderer,
+    'html': DefaultHtmlRenderer,
+    'image': DefaultImageRenderer,
+    'table': DefaultTableRenderer,
   },
 
   block: {

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -14,8 +14,29 @@ export const DefaultCodeBlockRenderer: PortableTextTypeRenderer<{
   _type: 'code'
   code: string
   language: string | undefined
-}> = ({value}) => {
-  return `\`\`\`${value.language ?? ''}\n${value.code}\n\`\`\``
+}> = (options) => {
+  if (!isCodeShaped(options.value)) {
+    return DefaultUnknownTypeRenderer(options)
+  }
+  return `\`\`\`${normalizeLanguage(options.value.language)}\n${options.value.code}\n\`\`\``
+}
+
+function isCodeShaped(value: unknown): value is {code: string} {
+  return typeof (value as {code?: unknown} | null)?.code === 'string'
+}
+
+/**
+ * A fence info string is everything after the opening fence on the same
+ * line, so a real `language` can never contain a newline, and the parser
+ * only ever produces a string. Junk in this optional field should not send
+ * an otherwise valid code block to the fenced-JSON path, so it is treated
+ * as absent instead of guarded.
+ */
+function normalizeLanguage(language: unknown): string {
+  if (typeof language !== 'string' || language.includes('\n')) {
+    return ''
+  }
+  return language
 }
 
 /**
@@ -31,8 +52,15 @@ export const DefaultHorizontalRuleRenderer: PortableTextTypeRenderer = () => {
 export const DefaultHtmlRenderer: PortableTextTypeRenderer<{
   _type: 'html'
   html: string
-}> = ({value}) => {
-  return value.html
+}> = (options) => {
+  if (!isHtmlShaped(options.value)) {
+    return DefaultUnknownTypeRenderer(options)
+  }
+  return options.value.html
+}
+
+function isHtmlShaped(value: unknown): value is {html: string} {
+  return typeof (value as {html?: unknown} | null)?.html === 'string'
 }
 
 /**
@@ -43,10 +71,30 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
   src: string
   alt: string | undefined
   title: string | undefined
-}> = ({value}) => {
-  const alt = escapeImageAndLinkText(value.alt ?? '')
-  const title = value.title ? ` "${escapeImageAndLinkTitle(value.title)}"` : ''
-  return `![${alt}](${value.src}${title})`
+}> = (options) => {
+  if (!isImageShaped(options.value)) {
+    return DefaultUnknownTypeRenderer(options)
+  }
+  const alt = escapeImageAndLinkText(options.value.alt ?? '')
+  const title = options.value.title
+    ? ` "${escapeImageAndLinkTitle(options.value.title)}"`
+    : ''
+  return `![${alt}](${options.value.src}${title})`
+}
+
+function isImageShaped(value: unknown): value is {
+  src: string
+  alt: string | null | undefined
+  title: string | null | undefined
+} {
+  const image = value as {src?: unknown; alt?: unknown; title?: unknown} | null
+  return (
+    typeof image?.src === 'string' &&
+    // CMS payloads commonly store cleared optional strings as `null`; the
+    // render body treats `null` like absent, so the guard must too
+    (image.alt == null || typeof image.alt === 'string') &&
+    (image.title == null || typeof image.title === 'string')
+  )
 }
 
 /**
@@ -227,11 +275,15 @@ export const DefaultCalloutRenderer: PortableTextTypeRenderer<{
   _type: 'callout'
   tone: string
   content: Array<PortableTextBlock>
-}> = ({value, renderNode}) => {
-  const renderedContent = value.content
+}> = (options) => {
+  if (!isCalloutShaped(options.value)) {
+    return DefaultUnknownTypeRenderer(options)
+  }
+  const {renderNode} = options
+  const renderedContent = options.value.content
     .map((block, index) =>
       renderNode({
-        node: {...block, style: 'normal'},
+        node: block._type === 'block' ? {...block, style: 'normal'} : block,
         index,
         isInline: false,
         renderNode,
@@ -244,7 +296,18 @@ export const DefaultCalloutRenderer: PortableTextTypeRenderer<{
     .map((line) => (line === '' ? '>' : `> ${line}`))
     .join('\n')
 
-  return `> [!${value.tone.toUpperCase()}]\n${prefixed}`
+  return `> [!${options.value.tone.toUpperCase()}]\n${prefixed}`
+}
+
+function isCalloutShaped(
+  value: unknown,
+): value is {tone: string; content: Array<TypedObject>} {
+  const callout = value as {tone?: unknown; content?: unknown} | null
+  return (
+    typeof callout?.tone === 'string' &&
+    Array.isArray(callout.content) &&
+    callout.content.every(isTypedObject)
+  )
 }
 
 /**
@@ -266,7 +329,7 @@ export const DefaultBlockquoteObjectRenderer: PortableTextTypeRenderer<{
   const renderedContent = value.content
     .map((block, index) =>
       renderNode({
-        node: {...block, style: 'normal'},
+        node: block._type === 'block' ? {...block, style: 'normal'} : block,
         index,
         isInline: false,
         renderNode,

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -14,9 +14,6 @@ import {portableTextToMarkdown} from './from-portable-text/portable-text-to-mark
 import {DefaultListItemRenderer} from './from-portable-text/renderers/list-item'
 import {
   DefaultBlockquoteObjectRenderer,
-  DefaultCalloutRenderer,
-  DefaultCodeBlockRenderer,
-  DefaultImageRenderer,
   DefaultListRenderer,
   DefaultTableRenderer,
 } from './from-portable-text/renderers/type'
@@ -905,7 +902,6 @@ describe(portableTextToMarkdown.name, () => {
         portableTextToMarkdown(portableText, {
           types: {
             list: DefaultListRenderer,
-            code: DefaultCodeBlockRenderer,
           },
         }),
       ).toBe(markdown)
@@ -1014,6 +1010,23 @@ describe(portableTextToMarkdown.name, () => {
       expect(portableTextToMarkdown(portableText, outOpts)).toBe(markdown)
     })
 
+    test('nested content that falls back to fenced JSON is not polluted with the injected `style`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const malformedCode = {_type: 'code', _key: keyGenerator(), code: 42}
+      const value = {
+        _type: 'blockquote',
+        _key: keyGenerator(),
+        content: [malformedCode],
+      }
+
+      const jsonLines = JSON.stringify(malformedCode, null, 2).split('\n')
+      expect(portableTextToMarkdown([value], outOpts)).toBe(
+        ['> ```json', ...jsonLines.map((line) => `> ${line}`), '> ```'].join(
+          '\n',
+        ),
+      )
+    })
+
     test('multi-paragraph blockquote', () => {
       const markdown = ['> one', '>', '> two'].join('\n')
       const keyGenerator = createTestKeyGenerator()
@@ -1051,7 +1064,6 @@ describe(portableTextToMarkdown.name, () => {
         portableTextToMarkdown(portableText, {
           types: {
             blockquote: DefaultBlockquoteObjectRenderer,
-            code: DefaultCodeBlockRenderer,
           },
         }),
       ).toBe(markdown)
@@ -1067,21 +1079,7 @@ describe(portableTextToMarkdown.name, () => {
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
       test('default renderer', () => {
-        const markdownOut = [
-          'foo',
-          '',
-          '```json',
-          '{',
-          '  "_key": "k3",',
-          '  "_type": "image",',
-          '  "src": "https://example.com/image.png",',
-          '  "alt": "alt text"',
-          '}',
-          '```',
-          '',
-          'bar',
-        ].join('\n')
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
+        expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
       })
 
       test('custom renderer', () => {
@@ -1111,13 +1109,9 @@ describe(portableTextToMarkdown.name, () => {
           alt: 'photo [1]',
         },
       ]
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe('![photo \\[1\\]](https://example.com/image.png)')
+      expect(portableTextToMarkdown(portableText)).toBe(
+        '![photo \\[1\\]](https://example.com/image.png)',
+      )
     })
 
     test('image with backslashes in alt text', () => {
@@ -1129,13 +1123,9 @@ describe(portableTextToMarkdown.name, () => {
           alt: 'path\\to\\file',
         },
       ]
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe('![path\\\\to\\\\file](https://example.com/image.png)')
+      expect(portableTextToMarkdown(portableText)).toBe(
+        '![path\\\\to\\\\file](https://example.com/image.png)',
+      )
     })
 
     test('image with backslash before bracket in alt text', () => {
@@ -1147,13 +1137,9 @@ describe(portableTextToMarkdown.name, () => {
           alt: 'a\\]b',
         },
       ]
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe('![a\\\\\\]b](https://example.com/image.png)')
+      expect(portableTextToMarkdown(portableText)).toBe(
+        '![a\\\\\\]b](https://example.com/image.png)',
+      )
     })
 
     test('image with backslash in title', () => {
@@ -1166,13 +1152,7 @@ describe(portableTextToMarkdown.name, () => {
           title: 'example\\image',
         },
       ]
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe(
+      expect(portableTextToMarkdown(portableText)).toBe(
         '![example image](https://example.com/image.png "example\\\\image")',
       )
     })
@@ -1181,37 +1161,56 @@ describe(portableTextToMarkdown.name, () => {
       const markdown =
         '![example image](https://example.com/image.png "example\\\\image")'
       const portableText = markdownToPortableText(markdown)
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe(markdown)
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
     })
 
     test('image with escaped bracket in alt text roundtrip', () => {
       const markdown = '![photo \\[1\\]](https://example.com/image.png)'
       const portableText = markdownToPortableText(markdown)
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe(markdown)
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
     })
 
     test('image with escaped backslash in alt text roundtrip', () => {
       const markdown = '![path\\\\to\\\\file](https://example.com/image.png)'
       const portableText = markdownToPortableText(markdown)
-      expect(
-        portableTextToMarkdown(portableText, {
-          types: {
-            image: DefaultImageRenderer,
-          },
-        }),
-      ).toBe(markdown)
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
+    })
+
+    test('malformed image value (no `src` field) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'image', _key: keyGenerator(), alt: 'foo'}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test.each([
+      ['`src` is not a string', {src: 42}],
+      ['`alt` is not a string', {src: 'foo.png', alt: 42}],
+      ['`title` is not a string', {src: 'foo.png', title: 42}],
+    ])('malformed image value (%s) falls back to fenced JSON', (_, image) => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'image', _key: keyGenerator(), ...image}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('`null` in the optional `alt`/`title` fields is treated as absent', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'https://example.com/image.png',
+        alt: null,
+        title: null,
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        '![](https://example.com/image.png)',
+      )
     })
   })
 
@@ -1223,19 +1222,7 @@ describe(portableTextToMarkdown.name, () => {
       const portableText = markdownToPortableText(markdown, {keyGenerator})
 
       test('default renderer', () => {
-        const markdownOut = [
-          'foo ',
-          '```json',
-          '{',
-          '  "_key": "k2",',
-          '  "_type": "image",',
-          '  "src": "https://example.com/image.png",',
-          '  "alt": "alt text"',
-          '}',
-          '```',
-          ' bar',
-        ].join('\n')
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
+        expect(portableTextToMarkdown(portableText)).toBe(markdown)
       })
 
       test('custom renderer', () => {
@@ -1314,17 +1301,7 @@ describe(portableTextToMarkdown.name, () => {
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
       test('default renderer', () => {
-        const markdownOut = [
-          '```json',
-          '{',
-          '  "_key": "k0",',
-          '  "_type": "code",',
-          '  "language": "js",',
-          '  "code": "const foo = \'bar\'"',
-          '}',
-          '```',
-        ].join('\n')
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
+        expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
       })
 
       test('custom renderer', () => {
@@ -1393,34 +1370,101 @@ describe(portableTextToMarkdown.name, () => {
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
       test('default renderer', () => {
-        const markdownOut = [
-          '```json',
-          '{',
-          '  "_key": "k0",',
-          '  "_type": "code",',
-          '  "language": "js",',
-          '  "code": "const foo = \'bar\'\\nconst bar = \'baz\'"',
-          '}',
-          '```',
-        ].join('\n')
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
+        expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
+      })
+    })
+
+    test('malformed code value (no `code` field) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'code', _key: keyGenerator(), language: 'js'}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('malformed code value (`code` is not a string) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'code', _key: keyGenerator(), code: 42}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('non-string `language` normalizes to a plain fence, code body intact', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'code',
+        _key: keyGenerator(),
+        code: "const foo = 'bar'",
+        language: {foo: 1},
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```', "const foo = 'bar'", '```'].join('\n'),
+      )
+    })
+
+    test('`language` containing newlines does not inject a line into the code body', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'code',
+        _key: keyGenerator(),
+        code: "const foo = 'bar'",
+        language: 'js\nalert(1)',
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```', "const foo = 'bar'", '```'].join('\n'),
+      )
+    })
+  })
+
+  describe('horizontal rule', () => {
+    test('renders as `---` by default', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [{_type: 'horizontal-rule', _key: keyGenerator()}]
+
+      expect(portableTextToMarkdown(portableText)).toBe('---')
+    })
+
+    test('MD -> PT -> MD round-trip is stable', () => {
+      const markdown = 'foo\n\n---\n\nbar'
+      const portableText = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
       })
 
-      test('pluggable default renderer', () => {
-        const markdownOut = [
-          '```js',
-          `const foo = 'bar'`,
-          `const bar = 'baz'`,
-          '```',
-        ].join('\n')
-        expect(
-          portableTextToMarkdown(portableText, {
-            types: {
-              code: DefaultCodeBlockRenderer,
-            },
-          }),
-        ).toBe(markdownOut)
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
+    })
+  })
+
+  describe('html', () => {
+    test('renders the raw HTML by default', () => {
+      const markdown = '<div class="note">hello</div>'
+      const portableText = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
       })
+
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
+    })
+
+    test('malformed html value (no `html` field) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'html', _key: keyGenerator()}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('malformed html value (`html` is not a string) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'html', _key: keyGenerator(), html: 42}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
     })
   })
 
@@ -2250,18 +2294,82 @@ describe(portableTextToMarkdown.name, () => {
       ]
 
       test('replaces newlines with <br> so the row stays intact', () => {
-        const result = portableTextToMarkdown(portableText, {
-          types: {
-            table: DefaultTableRenderer,
-            code: DefaultCodeBlockRenderer,
-          },
-        })
+        const result = portableTextToMarkdown(portableText)
 
         expect(result).toBe(
           [
             '| Header |',
             '| --- |',
             '| ```js<br>const x = 1<br>const y = 2<br>``` |',
+          ].join('\n'),
+        )
+      })
+    })
+
+    describe('table with an image in a cell', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const portableText = [
+        {
+          _type: 'table',
+          _key: keyGenerator(),
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'Header',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'row',
+              _key: keyGenerator(),
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: keyGenerator(),
+                  value: [
+                    {
+                      _type: 'image',
+                      _key: keyGenerator(),
+                      src: 'https://example.com/image.png',
+                      alt: 'alt text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      test('renders `![alt](src)` inline in the GFM cell', () => {
+        const result = portableTextToMarkdown(portableText)
+
+        expect(result).toBe(
+          [
+            '| Header |',
+            '| --- |',
+            '| ![alt text](https://example.com/image.png) |',
           ].join('\n'),
         )
       })
@@ -2673,23 +2781,7 @@ describe(portableTextToMarkdown.name, () => {
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
       test('default renderer', () => {
-        const markdownOut = [
-          '```json',
-          JSON.stringify(portableText.at(0), null, 2),
-          '```',
-        ].join('\n')
-
-        expect(portableTextToMarkdown(portableText)).toBe(markdownOut)
-      })
-
-      test('pluggable default renderer', () => {
-        expect(
-          portableTextToMarkdown(portableText, {
-            types: {
-              callout: DefaultCalloutRenderer,
-            },
-          }),
-        ).toBe(markdownIn)
+        expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
       })
     })
 
@@ -2698,14 +2790,10 @@ describe(portableTextToMarkdown.name, () => {
       const markdownIn = '> [!TIP]\n> This is **bold** and *italic*'
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
-      test('pluggable default renderer', () => {
-        expect(
-          portableTextToMarkdown(portableText, {
-            types: {
-              callout: DefaultCalloutRenderer,
-            },
-          }),
-        ).toBe('> [!TIP]\n> This is **bold** and _italic_')
+      test('default renderer', () => {
+        expect(portableTextToMarkdown(portableText)).toBe(
+          '> [!TIP]\n> This is **bold** and _italic_',
+        )
       })
     })
 
@@ -2715,14 +2803,8 @@ describe(portableTextToMarkdown.name, () => {
         '> [!IMPORTANT]\n> First paragraph\n>\n> Second paragraph'
       const portableText = markdownToPortableText(markdownIn, {keyGenerator})
 
-      test('pluggable default renderer', () => {
-        expect(
-          portableTextToMarkdown(portableText, {
-            types: {
-              callout: DefaultCalloutRenderer,
-            },
-          }),
-        ).toBe(markdownIn)
+      test('default renderer', () => {
+        expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
       })
     })
 
@@ -2737,15 +2819,85 @@ describe(portableTextToMarkdown.name, () => {
             keyGenerator,
           })
 
-          expect(
-            portableTextToMarkdown(portableText, {
-              types: {
-                callout: DefaultCalloutRenderer,
-              },
-            }),
-          ).toBe(markdownIn)
+          expect(portableTextToMarkdown(portableText)).toBe(markdownIn)
         })
       }
+    })
+
+    test('malformed callout value (no `tone`) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {_type: 'callout', _key: keyGenerator(), content: []}
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test.each([
+      ['`tone` is not a string', {tone: 42, content: []}],
+      ['no `content` array', {tone: 'note'}],
+      [
+        '`content` contains a non-typed-object',
+        {tone: 'note', content: [null]},
+      ],
+    ])(
+      'malformed callout value (%s) falls back to fenced JSON',
+      (_, callout) => {
+        const keyGenerator = createTestKeyGenerator()
+        const value = {_type: 'callout', _key: keyGenerator(), ...callout}
+
+        expect(portableTextToMarkdown([value])).toBe(
+          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        )
+      },
+    )
+
+    test('nested content that falls back to fenced JSON is not polluted with the injected `style`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const malformedCode = {_type: 'code', _key: keyGenerator(), code: 42}
+      const value = {
+        _type: 'callout',
+        _key: keyGenerator(),
+        tone: 'note',
+        content: [malformedCode],
+      }
+
+      const jsonLines = JSON.stringify(malformedCode, null, 2).split('\n')
+      expect(portableTextToMarkdown([value])).toBe(
+        [
+          '> [!NOTE]',
+          '> ```json',
+          ...jsonLines.map((line) => `> ${line}`),
+          '> ```',
+        ].join('\n'),
+      )
+    })
+  })
+
+  describe('zero-config round-trip', () => {
+    test('MD -> PT -> MD round-trip is stable for a document exercising code, image, horizontal rule, HTML, and a callout', () => {
+      const markdown = [
+        'Some text with `inline code`.',
+        '',
+        '```js',
+        "console.log('hi')",
+        '```',
+        '',
+        '![alt text](https://example.com/image.png)',
+        '',
+        '---',
+        '',
+        '<div class="note">Raw HTML</div>',
+        '',
+        '> [!NOTE]',
+        '> A callout',
+      ].join('\n')
+
+      const portableText = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+      })
+
+      expect(portableTextToMarkdown(portableText)).toBe(markdown)
     })
   })
 })


### PR DESCRIPTION
With tables converting by default, the serializer's remaining gap was the rest of the parser's default set: `markdownToPortableText` ships default matchers for `code`, `horizontal-rule`, `html`, `image`, and `callout`, but `portableTextToMarkdown` rendered all of them as fenced JSON unless the consumer registered the exported renderers manually. This PR registers them by default, so a zero-config round-trip now survives every block type the parser produces, and closes the ceiling named on the tables PR: an image inside a table cell renders as image markdown within the GFM cell (pipe-escaped) instead of fenced JSON.

The serializer dispatches on the `_type` name alone, so each default verifies what it dereferences and falls back to fenced JSON on a foreign shape, per the rule established on the tables work: `code` requires a string `code` field, `html` a string `html`, `image` a string `src` (plus `alt`/`title` string-or-absent, since the escape helpers call `.replace` on them), and `callout` a string `tone` plus a `content` array of typed objects. `horizontal-rule` dereferences nothing and renders `---` unconditionally. One asymmetry is deliberate: a foreign `language` on an otherwise valid code block is normalized away rather than failing the guard, because a fence info string is one line by construction, a non-string or newline-carrying `language` has no representation and would otherwise interpolate garbage (or an injected line) into the fence. Consumer-supplied `types` renderers win over every default, and a consumer's differently-named types (like the playground's `break` horizontal rule) still register manually, unaffected.

One narrow fix rides along, named in the changeset: `DefaultCalloutRenderer` and `DefaultBlockquoteObjectRenderer` injected `style: 'normal'` into every content entry before recursion, so nested entries falling back to fenced JSON rendered polluted JSON; the spread now applies only to text blocks and the fallback JSON is the original value.

The editor's markdown clipboard picks the defaults up via the automatic dependency bump: copying any of these five block types now puts real Markdown on the clipboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor semver bump but changes default serializer output for five block types; consumers depending on fenced JSON for those `_type`s will see different Markdown unless they opt out with custom renderers.
> 
> **Overview**
> **`portableTextToMarkdown`** now registers default **`types`** renderers for **`callout`**, **`code`**, **`horizontal-rule`**, **`html`**, and **`image`** (alongside **`table`**), so zero-config export produces real Markdown instead of fenced JSON for those blocks. Custom **`types.<name>`** renderers still override defaults.
> 
> Default renderers **validate shape** before rendering; mismatched values (e.g. a custom **`code`** type without a string **`code`**) fall back to **`unknownType`** fenced JSON. **`horizontal-rule`** always outputs **`---`**. **`DefaultCodeBlockRenderer`** strips invalid **`language`** (non-string or newlines) instead of failing the guard.
> 
> **`DefaultCalloutRenderer`** and **`DefaultBlockquoteObjectRenderer`** only apply **`style: 'normal'`** to **`block`** entries when recursing, so nested fallbacks serialize the **original** object without an injected **`style`**.
> 
> Docs, changeset, example tests, and playground markdown options are updated to match; editor markdown clipboard benefits via the dependency bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9e5253b4977cdcbfe2955c1c9abe6555680ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->