### PR TITLE
docs: document the legacy pipeline's affordance wrappers in the migration guide

### DIFF
--- a/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
+++ b/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
@@ -50,29 +50,27 @@ import {defineBlockObject} from '@portabletext/editor'
 
 const imageBlock = defineBlockObject({
   type: 'image',
-  render: ({attributes, children, node}) => (
+  render: ({attributes, children, node, readOnly}) => (
     <div {...attributes} style={{border: '1px solid #ccc', padding: '0.5em'}}>
-      <img
-        src={String(node.src)}
-        alt={String(node.alt ?? '')}
-        contentEditable={false}
-      />
+      <div contentEditable={false} draggable={!readOnly}>
+        <img src={String(node.src)} alt={String(node.alt ?? '')} />
+      </div>
       {children}
     </div>
   ),
 })
 ```
 
-Three contract differences from the legacy callback: spread `attributes` onto your outer element, render `children` even though the block is a void (the engine mounts its internals through them), and mark the visible content `contentEditable={false}` while keeping the outer element editable, the engine anchors the caret through it. This mirrors the engine's own default block-object render.
+Four contract differences from the legacy callback: spread `attributes` onto your outer element, render `children` even though the block is a void (the engine mounts its internals through them), mark the visible content `contentEditable={false}` while keeping the outer element editable (the engine anchors the caret through it), and put `draggable={!readOnly}` on that non-editable wrapper. The legacy pipeline added the `contentEditable` and `draggable` wrapper for you; a registration owns the whole node, so dropping `draggable` silently loses drag-to-move. This mirrors the engine's own default block-object render.
 
 If you render every block object the same way, a preview card, say, the catch-all `type: '*'` matches every block object type that has no more specific registration, which is the direct equivalent of the generic legacy callback:
 
 ```tsx
 const blockObjectFallback = defineBlockObject({
   type: '*',
-  render: ({attributes, children, node}) => (
+  render: ({attributes, children, node, readOnly}) => (
     <div {...attributes}>
-      <div contentEditable={false}>
+      <div contentEditable={false} draggable={!readOnly}>
         <BlockObjectPreview node={node} />
       </div>
       {children}
@@ -103,16 +101,18 @@ import {defineInlineObject} from '@portabletext/editor'
 
 const stockTicker = defineInlineObject({
   type: 'stock-ticker',
-  render: ({attributes, children, node}) => (
+  render: ({attributes, children, node, readOnly}) => (
     <span {...attributes} className="ticker">
-      {String(node.symbol)}
       {children}
+      <span draggable={!readOnly} style={{display: 'inline-block'}}>
+        {String(node.symbol)}
+      </span>
     </span>
   ),
 })
 ```
 
-Unlike block objects, inline objects need no `contentEditable={false}`: the engine's outer attributes already carry non-editability, and your content inherits it. The legacy default case (`return props.children`) disappears: spans keep rendering through the engine and the span-level render props, and only registered inline object types hit your render.
+Unlike block objects, inline objects need no `contentEditable={false}`: the engine's outer attributes already carry non-editability, and your content inherits it. They DO need the inner `draggable={!readOnly}` wrapper around the visible content: the legacy pipeline wrapped your `renderChild` output in a `draggable` inline-block span, which is what makes an inline object drag-movable and keeps its text unselectable (a draggable element starts a drag instead of a text selection). A registration that renders the content bare loses both behaviors, and nothing fails loudly. The legacy default case (`return props.children`) disappears: spans keep rendering through the engine and the span-level render props, and only registered inline object types hit your render.
 
 ## Step 3: spans, if you customized them
 


### PR DESCRIPTION
A migration written faithfully from the migrate-render-props guide ships two silent regressions on object nodes: they stop being draggable, and their text becomes selectable. The guide's examples render the object content bare, but the legacy pipeline wrapped every `renderBlock`/`renderChild` output in an affordance wrapper the registration must now recreate: `contentEditable={false}` + `draggable={!readOnly}` around block-object content, and a `draggable={!readOnly}` inline-block span around inline-object content. `draggable` is the load-bearing attribute: it enables drag-to-move and suppresses text selection, because a draggable element starts a drag instead of a selection. Both regressions shipped in a real migration (Studio's comment input) before being caught by hand.

The object examples now include the wrappers, the block-object contract list grows from three items to four, and the inline-object prose names both behaviors and states that nothing fails loudly when the wrapper is dropped. Docs only, no changeset. A follow-up adds full copy/paste legacy-parity snippets pinned by a DOM-parity test suite against the legacy pipeline; this PR only corrects the claims that are actively wrong today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 09dda4a3529d41b9a46d1e3e8a51b25ba3d3103f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->