### PR TITLE
feat: promote node registration from alpha to public

### DIFF
--- a/.changeset/promote-node-registration-public.md
+++ b/.changeset/promote-node-registration-public.md
@@ -1,0 +1,28 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote node registration from alpha to public
+
+`defineContainer`, `defineTextBlock`, `defineSpan`, `defineBlockObject`, `defineInlineObject`, `editor.registerNode`, and `NodePlugin` are no longer alpha. Their types are stable too: `Container`, `TextBlock`, `Span`, `BlockObject`, `InlineObject`, `RegistrableNode`, and the `ContainerRender`/`ContainerRenderProps`, `SpanRender`/`SpanRenderProps`, `BlockObjectRender`/`BlockObjectRenderProps`, `InlineObjectRender`/`InlineObjectRenderProps`, and `TextBlockRender`/`TextBlockRenderProps` pairs.
+
+This is the supported replacement for the deprecated `renderBlock`, `renderChild`, `renderStyle`, and `renderListItem` render props:
+
+```tsx
+import {defineTextBlock} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
+
+const textBlock = defineTextBlock({
+  type: 'block',
+  render: ({attributes, children}) => <div {...attributes}>{children}</div>,
+})
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <NodePlugin nodes={[textBlock]} />
+      <PortableTextEditable />
+    </EditorProvider>
+  )
+}
+```

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -67,7 +67,7 @@ export type Editor = {
    * `defineSpan`, `defineBlockObject`, `defineInlineObject`). Returns
    * a function that unregisters the node when called.
    *
-   * @alpha
+   * @public
    */
   registerNode: (config: {node: RegistrableNode}) => () => void
   send: (event: EditorEvent) => void

--- a/packages/editor/src/editor/render.container.tsx
+++ b/packages/editor/src/editor/render.container.tsx
@@ -27,7 +27,7 @@ export function RenderContainer(props: {
   const render = props.containerConfig.container.render
 
   // Container registrations forbid the `'block'` and `'span'` types
-  // at the factory level (see `ContainerNodeForType`), so a container
+  // at the factory level (`defineContainer` rejects them), so a container
   // node here is always a `PortableTextObject`. The runtime invariant
   // is enforced by registration; expressing it in the type graph
   // would require threading the `_type` literal through dispatch.

--- a/packages/editor/src/plugins/plugin.node.tsx
+++ b/packages/editor/src/plugins/plugin.node.tsx
@@ -3,7 +3,7 @@ import {useEditor} from '../editor/use-editor'
 import type {RegistrableNode} from '../renderers/renderer.types'
 
 /**
- * @alpha
+ * @public
  *
  * Plugin component that registers a list of nodes (containers, text
  * blocks, spans, block objects, inline objects) with the editor. Each

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -8,20 +8,7 @@ import type {Path} from '../engine/interfaces/path'
 import type {ChildArrayField} from '../schema/resolve-containers'
 
 /**
- * @alpha
- *
- * Narrow the container node type by the registered `_type`. Containers
- * always render portable text objects: `'span'` is always a leaf and
- * `'block'` is always a text block; both are excluded.
- */
-export type ContainerNodeForType<TType extends string> = TType extends
-  | 'span'
-  | 'block'
-  ? never
-  : PortableTextObject
-
-/**
- * @alpha
+ * @public
  *
  * A container's render function receives a node and renders an element
  * that wraps its editable children. The render is positional: it fires for
@@ -55,12 +42,12 @@ export type ContainerRenderProps = {
   renderDefault: (props: ContainerRenderProps) => ReactElement
 }
 /**
- * @alpha
+ * @public
  */
 export type ContainerRender = (props: ContainerRenderProps) => ReactElement
 
 /**
- * @alpha
+ * @public
  *
  * A span's render function. Receives a portable text span node and
  * wraps it. `children` carries the styled text already decorated by
@@ -81,12 +68,12 @@ export type SpanRenderProps = {
   renderDefault: (props: SpanRenderProps) => ReactElement
 }
 /**
- * @alpha
+ * @public
  */
 export type SpanRender = (props: SpanRenderProps) => ReactElement
 
 /**
- * @alpha
+ * @public
  *
  * A block object's render function. Receives a non-editable block-level
  * portable text object. `children` carries an engine-emitted void
@@ -109,12 +96,12 @@ export type BlockObjectRenderProps = {
   renderDefault: (props: BlockObjectRenderProps) => ReactElement
 }
 /**
- * @alpha
+ * @public
  */
 export type BlockObjectRender = (props: BlockObjectRenderProps) => ReactElement
 
 /**
- * @alpha
+ * @public
  *
  * An inline object's render function. Receives a non-editable inline
  * portable text object. `children` carries an engine-emitted void
@@ -137,14 +124,14 @@ export type InlineObjectRenderProps = {
   renderDefault: (props: InlineObjectRenderProps) => ReactElement
 }
 /**
- * @alpha
+ * @public
  */
 export type InlineObjectRender = (
   props: InlineObjectRenderProps,
 ) => ReactElement
 
 /**
- * @alpha
+ * @public
  *
  * A container registration. Identifies a block object `_type` whose value
  * holds editable children in `arrayField`. The optional `of` array carries
@@ -176,7 +163,7 @@ export type Container = {
 }
 
 /**
- * @alpha
+ * @public
  *
  * A text block registration. The text block `_type` is `'block'` at the
  * top level. Positional overrides nested in a container's `of` array can
@@ -213,7 +200,7 @@ export type TextBlock = {
 }
 
 /**
- * @alpha
+ * @public
  *
  * Text block render function. `children` carries the rendered spans -
  * `renderDecorator`, `renderAnnotation`, `renderPlaceholder`, and range
@@ -236,12 +223,12 @@ export type TextBlockRenderProps = {
   renderDefault: (props: TextBlockRenderProps) => ReactElement
 }
 /**
- * @alpha
+ * @public
  */
 export type TextBlockRender = (props: TextBlockRenderProps) => ReactElement
 
 /**
- * @alpha
+ * @public
  *
  * A span registration. The span `_type` is `'span'` at the top level.
  * Positional overrides nested in a container's `of` array can register
@@ -261,7 +248,7 @@ export type Span = {
 }
 
 /**
- * @alpha
+ * @public
  *
  * A non-editable block-level object registration. Identifies a `_type`
  * whose value renders as a block-level void node (image, embed, etc.).
@@ -279,7 +266,7 @@ export type BlockObject = {
 }
 
 /**
- * @alpha
+ * @public
  *
  * A non-editable inline object registration. Identifies a `_type` whose
  * value renders as an inline void node (mention, inline image, etc.).
@@ -297,7 +284,7 @@ export type InlineObject = {
 }
 
 /**
- * @alpha
+ * @public
  *
  * The discriminated union of every registration accepted by
  * `editor.registerNode` and the `<NodePlugin>` component.
@@ -310,7 +297,7 @@ export type RegistrableNode =
   | InlineObject
 
 /**
- * @alpha
+ * @public
  *
  * Define a container renderer. The returned registration is mounted via
  * the `<NodePlugin>` component at the top level, or nested inside
@@ -354,7 +341,7 @@ export function defineContainer<const TType extends string>(config: {
     attributes: Record<string, unknown>
     children: ReactElement
     focused: boolean
-    node: ContainerNodeForType<TType>
+    node: TType extends 'span' | 'block' ? never : PortableTextObject
     path: Path
     readOnly: boolean
     selected: boolean
@@ -366,7 +353,7 @@ export function defineContainer<const TType extends string>(config: {
 }
 
 /**
- * @alpha
+ * @public
  *
  * Define a span renderer. The returned registration is mounted via the
  * `<NodePlugin>` component at the top level, or nested inside a
@@ -397,7 +384,7 @@ export function defineSpan<const TType extends string>(config: {
 }
 
 /**
- * @alpha
+ * @public
  *
  * Define a non-editable block-level object renderer for a `_type`
  * declared in the schema's `blockObjects` array.
@@ -432,7 +419,7 @@ export function defineBlockObject<const TType extends string>(config: {
 }
 
 /**
- * @alpha
+ * @public
  *
  * Define a non-editable inline object renderer for a `_type` declared
  * in the schema's `inlineObjects` array.
@@ -467,7 +454,7 @@ export function defineInlineObject<const TType extends string>(config: {
 }
 
 /**
- * @alpha
+ * @public
  *
  * Define a text block renderer. The returned registration is mounted
  * via the `<NodePlugin>` component, or nested inside a container's

--- a/packages/editor/src/schema/build-public-containers.ts
+++ b/packages/editor/src/schema/build-public-containers.ts
@@ -65,8 +65,8 @@ function toRegisteredOfEntry(
   if ('inlineObject' in entry) {
     return {kind: 'inlineObject', type: entry.inlineObject.type}
   }
-  // Text-block configs are not exposed on the public Containers tree -
-  // they have their own `textBlocks` map on the editor context.
+  // Text-block configs are deliberately dropped: they live on an
+  // engine-internal `textBlocks` map, not on the public `Containers` tree.
   return undefined
 }
 

--- a/packages/editor/src/schema/container-types.ts
+++ b/packages/editor/src/schema/container-types.ts
@@ -24,8 +24,8 @@ export type ChildArrayField = FieldDefinition & {
  *   scoped to this parent.
  *
  * The full container registration (including the render callback)
- * lives on the editor's internal {@link ResolvedContainers} map and
- * is not exposed on the public context.
+ * lives on an engine-internal map and is not exposed on the public
+ * context.
  *
  * Two top-level entries with the same `_type` cannot coexist - the
  * register handler warns on duplicates. But the SAME `_type`
@@ -81,8 +81,7 @@ export type RegisteredInlineObject = {
 /**
  * Union of non-container positional registrations that may appear in
  * a {@link RegisteredContainer}'s `of` array. Text-block registrations
- * are NOT included here; they surface on `EditorContext.textBlocks`,
- * not on the containers tree.
+ * are NOT included here and do not appear on the containers tree.
  *
  * @alpha
  */


### PR DESCRIPTION
The block-level render props (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`) are deprecated, and their deprecation messages point consumers at node registration. That surface, however, was still `@alpha`: the `defineContainer`/`defineTextBlock`/`defineSpan`/`defineBlockObject`/`defineInlineObject` factories and their types, `editor.registerNode`, and `NodePlugin`. A consumer cannot migrate off a deprecation onto an API we reserve the right to break, so this PR flips the 23 `@alpha` tags on the registration surface to `@public`. The `ContainerNodeForType` helper, which `defineContainer`'s public signature referenced without the root exporting it, is inlined into the signature rather than exported: consumers get the same inference, and the package root grows no name for a type nobody writes out.

The read-side introspection of registrations deliberately stays `@alpha`: `snapshot.context.containers`, `resolveContainerAt`, `Containers`, and the `Registered*` types have no consumers anywhere yet, and their shape (in particular `resolveContainerAt`'s `value` parameter, which leaks the internal engine `Node` type) should be frozen by a real use, not ahead of one. Promoting the write side alone keeps the migration promise intact; the read side follows in its own PR when a consumer appears.

Two doc claims that named internals not reachable from the public surface are corrected alongside. Net behavior is unchanged: every change is a release tag or documentation, so no new tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9dc8650601769ee3a1b068f66d600ac22551dccc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->