### PR TITLE
feat: promote `RangeDecoration` and `RangeDecorationOnMovedDetails` to public API

### DIFF
--- a/.changeset/range-decorations-public.md
+++ b/.changeset/range-decorations-public.md
@@ -1,0 +1,24 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote `RangeDecoration` and `RangeDecorationOnMovedDetails` to public API
+
+`RangeDecoration` and `RangeDecorationOnMovedDetails` are no longer alpha. The `rangeDecorations` prop on `PortableTextEditable` was already public; the types it takes are now stable too:
+
+```tsx
+<PortableTextEditable
+  rangeDecorations={[
+    {
+      component: (props) => <SearchResultHighlight {...props} />,
+      selection: {
+        anchor: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
+      },
+      onMoved: (details) => {
+        rememberSelection(details.newSelection)
+      },
+    },
+  ]}
+/>
+```

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -307,25 +307,25 @@ export type ScrollSelectionIntoViewFunction = (
 ) => void
 
 /**
- * Parameters for the callback that will be called for a RangeDecoration's onMoved.
- * @alpha */
+ * Details passed to a `RangeDecoration`'s `onMoved` callback.
+ * @public */
 export interface RangeDecorationOnMovedDetails {
   rangeDecoration: RangeDecoration
   newSelection: EditorSelection
   origin: 'remote' | 'local'
 }
 /**
- * A range decoration is a UI affordance that wraps a given selection range in the editor
- * with a custom component. This can be used to highlight search results,
- * mark validation errors on specific words, draw user presence and similar.
- * @alpha */
+ * A UI affordance that wraps a selection range in the editor with a custom
+ * component, for example to highlight search results, mark validation
+ * errors on specific words, or draw user presence.
+ * @public */
 export interface RangeDecoration {
   /**
-   * A component for rendering the range decoration.
-   * The component will receive the children (text) of the range decoration as its children.
+   * The component that renders the range decoration. It receives the
+   * decorated text as its children.
    *
    * @example
-   * ```ts
+   * ```tsx
    * (rangeComponentProps: PropsWithChildren) => (
    *    <SearchResultHighlight>
    *      {rangeComponentProps.children}
@@ -335,15 +335,17 @@ export interface RangeDecoration {
    */
   component: (props: PropsWithChildren) => ReactElement<any>
   /**
-   * The editor content selection range
+   * The editor content selection range to decorate.
    */
   selection: EditorSelection
   /**
-   * A optional callback that will be called when the range decoration potentially moves according to user edits.
+   * Called when edits move the decorated range. The details carry the new
+   * selection (`null` when the range is lost) and whether the edit was
+   * `local` or `remote`.
    */
   onMoved?: (details: RangeDecorationOnMovedDetails) => void
   /**
-   * A custom payload that can be set on the range decoration
+   * A custom payload that can be set on the range decoration.
    */
   payload?: Record<string, unknown>
 }


### PR DESCRIPTION
`RangeDecoration` and `RangeDecorationOnMovedDetails` carried `@alpha`, an API we reserved the right to break, while Studio ships range decorations in production for presence, comments, and search highlights. We were never going to break them without warning, so the tag misstated the contract. This PR flips both tags to `@public`; the `rangeDecorations` prop on `PortableTextEditableProps` was already public, and these two types were the only alpha remnants of the surface.

The JSDoc becomes published consumer docs with the promotion, so it is tightened alongside: present-tense prose, and the `onMoved` doc now states when it fires and that `newSelection` is `null` when the decorated range is lost, matching what `range-decorations-machine.ts` actually emits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 581e368de8b1b2af79bc09c95475630ae6397df0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->