### PR TITLE
test: force a chromium gc after each browser test file

### DIFF
--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         resolve,
         test: {
           name: 'browser',
+          setupFiles: ['./vitest.setup.ts'],
           include: [
             'gherkin-tests/**/*.test.ts',
             'gherkin-tests/**/*.test.tsx',

--- a/packages/editor/vitest.setup.ts
+++ b/packages/editor/vitest.setup.ts
@@ -1,0 +1,13 @@
+import {afterAll} from 'vitest'
+import {cdp, server} from 'vitest/browser'
+
+afterAll(async () => {
+  if (server.browser === 'chromium') {
+    // Chromium leaks shared memory for every module request answered with
+    // `304 Not Modified` until a forced GC (vitest-dev/vitest#9437). On long
+    // CI runs the leak exhausts the runner disk and crashes the browser
+    // mid-run. Delete this hook once Vitest ships the built-in GC trigger
+    // (vitest-dev/vitest#10912).
+    await cdp().send('HeapProfiler.collectGarbage')
+  }
+})


### PR DESCRIPTION
The chromium browser-test job intermittently dies mid-suite with `[vitest] Browser connection was closed while running tests`, caused by `[birpc] rpc is closed, cannot call "createTesters"`, after every executed test passed (for example, 146 of the editor package's 196 files, then silence). The victim file roams and the failure never reproduces locally.

The mechanism is vitest-dev/vitest#9437: Chromium leaks a 2 MiB block of shared memory for every module request answered with `304 Not Modified`, and only a forced garbage collection releases the blocks. Vite serves modules with an etag, so every tester iframe revalidates the whole module graph; on a suite this size the leak fills the CI runner's disk in bursts, Chromium crashes, and the websocket close converts the pending `createTesters` call into the error above. Whether a given run passes depends only on whether the burst crests the disk, which is what the flakiness is made of.

The upstream fix (vitest-dev/vitest#10912, GC on low disk) is merged but unreleased and v5-only. Until it ships, a setup file on the editor package's browser project sends `HeapProfiler.collectGarbage` over CDP after each test file, chromium only (~5ms per file). The upstream thread confirms this exact hook takes a comparable suite from ~70% failure to 6 of 6 green runs. The hook carries its own removal condition in a comment. The plugin packages' suites (1-4 files each) are too short to hit the leak and get no hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ac66250f8f6991bc90f0536308a3cc159bf7a89c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->