### PR TITLE
feat: promote the `containers` introspection map from alpha to public

### DIFF
--- a/.changeset/promote-containers-map-public.md
+++ b/.changeset/promote-containers-map-public.md
@@ -1,0 +1,18 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the `containers` introspection map from alpha to public
+
+`snapshot.context.containers` is no longer alpha. Its types are stable too: `Containers`, `RegisteredContainer`, `RegisteredSpan`, `RegisteredBlockObject`, `RegisteredInlineObject`, and `RegisteredPositional`. `OfDefinition` is now re-exported from the package root; it appears in `RegisteredContainer['field']`, whose shape is named via indexed access rather than a dedicated export.
+
+The map is the read side of node registration: entries keyed by container `_type`, each carrying the array field that holds the container's editable children and any position-scoped child registrations.
+
+```tsx
+import {useEditorSelector} from '@portabletext/editor'
+
+const tableRegistration = useEditorSelector(
+  editor,
+  (snapshot) => snapshot.context.containers.get('table'),
+)
+```

--- a/packages/editor/src/editor/editor-snapshot.ts
+++ b/packages/editor/src/editor/editor-snapshot.ts
@@ -31,7 +31,7 @@ export type EditorContext = {
    * `resolveContainerAt(containers, value, path)` for position-aware
    * resolution that handles both top-level and positional entries.
    *
-   * @alpha
+   * @public
    */
   containers: Containers
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -32,6 +32,7 @@ export {
   type FieldDefinition,
   type InlineObjectDefinition,
   type ListDefinition,
+  type OfDefinition,
   type SchemaDefinition,
   type StyleDefinition,
 } from '@portabletext/schema'

--- a/packages/editor/src/schema/container-types.ts
+++ b/packages/editor/src/schema/container-types.ts
@@ -1,11 +1,6 @@
 import type {FieldDefinition, OfDefinition} from '@portabletext/schema'
 import type {ContainerConfig} from '../renderers/renderer.types'
 
-export type ChildArrayField = FieldDefinition & {
-  type: 'array'
-  of: ReadonlyArray<OfDefinition>
-}
-
 /**
  * Public view of a registered editable container, surfaced on
  * {@link EditorContext.containers}.
@@ -33,21 +28,26 @@ export type ChildArrayField = FieldDefinition & {
  * a feature; `resolveContainerAt` walks the positional tree using
  * the path to return the entry that applies at a given position.
  *
- * @alpha
+ * @public
  */
 export type RegisteredContainer = {
   kind: 'container'
   type: string
-  field: ChildArrayField
+  field: FieldDefinition & {
+    type: 'array'
+    of: ReadonlyArray<OfDefinition>
+  }
   of?: ReadonlyArray<RegisteredContainer | RegisteredPositional>
 }
+
+export type ChildArrayField = RegisteredContainer['field']
 
 /**
  * Public view of a registered span, surfaced inside a containing
  * {@link RegisteredContainer}'s `of` array as a positional
  * registration. The render function is engine-internal.
  *
- * @alpha
+ * @public
  */
 export type RegisteredSpan = {
   kind: 'span'
@@ -59,7 +59,7 @@ export type RegisteredSpan = {
  * containing {@link RegisteredContainer}'s `of` array as a positional
  * registration. The render function is engine-internal.
  *
- * @alpha
+ * @public
  */
 export type RegisteredBlockObject = {
   kind: 'blockObject'
@@ -71,7 +71,7 @@ export type RegisteredBlockObject = {
  * containing {@link RegisteredContainer}'s `of` array as a positional
  * registration. The render function is engine-internal.
  *
- * @alpha
+ * @public
  */
 export type RegisteredInlineObject = {
   kind: 'inlineObject'
@@ -83,7 +83,7 @@ export type RegisteredInlineObject = {
  * a {@link RegisteredContainer}'s `of` array. Text-block registrations
  * are NOT included here and do not appear on the containers tree.
  *
- * @alpha
+ * @public
  */
 export type RegisteredPositional =
   | RegisteredSpan
@@ -107,7 +107,7 @@ export type RegisteredPositional =
  * does not find a positional override, the resolver falls back to the
  * top-level entry for the type if one is registered.
  *
- * @alpha
+ * @public
  */
 export type Containers = ReadonlyMap<string, RegisteredContainer>
 


### PR DESCRIPTION
`snapshot.context.containers` is the read side of node registration: the map of registered editable containers the engine builds from `registerNode` calls, keyed by `_type`, each entry carrying the array field that holds the container's editable children plus any position-scoped child registrations. The registration write side went public in #3081; the map stayed `@alpha` while the positional resolver's shape was undecided. That question has since moved off the map: `resolveContainerAt` gets unexported in v8, and the map's own types reference nothing internal, so nothing about its shape is waiting on a decision.

Two things make alpha actively wrong here. `plugin-list-index`, a published package, types against the map and `RegisteredContainer`, so an alpha break to the map would break released plugin versions. And `getContainerChildren` (`@beta`) takes `Containers` in its signature: a beta function consuming an alpha type promises more stability than its inputs have.

This PR flips the 7 `@alpha` tags (`containers`, `Containers`, the five `Registered*` types) to `@public`. `RegisteredContainer.field`'s shape is inlined into the type rather than exposing the internal `ChildArrayField` name: consumers who need the name have it as `RegisteredContainer['field']`, and the internal alias now derives from the public site, so there is one definition. `OfDefinition`, which the inlined shape references, joins the root re-exports from `@portabletext/schema`. `getContainerChildren` deliberately stays `@beta`: its `node` parameter still leaks the internal engine `Node` type, and beta consuming public is a consistent ladder. Net behavior is unchanged: every change is a release tag, a type restatement, or an export, so no new tests.
