### PR TITLE
fix: keep the drag source when a drop fits no blocks

### DIFF
--- a/.changeset/fix-empty-fit-drop.md
+++ b/.changeset/fix-empty-fit-drop.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep the drag source when a drop fits no blocks
+
+Dropping blocks that the destination rejects entirely (a table cell whose schema accepts none of them, for example) deleted the drag source with nothing inserted. That drop is now a no-op.

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -341,16 +341,14 @@ export const coreDndBehaviors = [
           : undefined
 
       const draggedNodes = getFragment(dragSnapshot)
-      const fittedBlocks = fitBlocksToDestination(
-        {
-          ...snapshot,
-          context: {
-            ...snapshot.context,
-            selection: dropPosition,
-          },
+      const dropSnapshot = {
+        ...snapshot,
+        context: {
+          ...snapshot.context,
+          selection: dropPosition,
         },
-        event.data,
-      )
+      }
+      const fittedBlocks = fitBlocksToDestination(dropSnapshot, event.data)
 
       if (!droppingOnDragOrigin) {
         return {
@@ -379,6 +377,12 @@ export const coreDndBehaviors = [
           movedInlineObjectKey,
         },
       ) => {
+        // Nothing survives `fitBlocksToDestination`: leave the source where
+        // it is instead of deleting it with nothing to show for the drop.
+        if (fittedBlocks.length === 0) {
+          return []
+        }
+
         // The dropped object lives in the drop position's block, keyed by its
         // preserved `_key`. Re-selecting it keeps the moved inline object
         // selected, mirroring inserting an inline object, instead of leaving

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -1552,4 +1552,218 @@ describe('event.drag.drop', () => {
       ])
     })
   })
+  test('Scenario: Dragging a type the destination cell rejects leaves the source and destination untouched', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const videoKey = keyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const cellBlockKey = keyGenerator()
+    const cellSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'video', fields: [{name: 'src', type: 'string'}]},
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {_key: videoKey, _type: 'video', src: 'https://example.com/v.mp4'},
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: 'foobar',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'table',
+              arrayField: 'rows',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+              of: [
+                defineContainer({
+                  type: 'row',
+                  arrayField: 'cells',
+                  render: ({attributes, children}) => (
+                    <div {...attributes}>{children}</div>
+                  ),
+                  of: [
+                    defineContainer({
+                      type: 'cell',
+                      arrayField: 'content',
+                      render: ({attributes, children}) => (
+                        <div {...attributes}>{children}</div>
+                      ),
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const videoSelection = {
+      anchor: {path: [{_key: videoKey}], offset: 0},
+      focus: {path: [{_key: videoKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: videoSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const cellSpanPath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellKey},
+      'content',
+      {_key: cellBlockKey},
+      'children',
+      {_key: cellSpanKey},
+    ]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: videoSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: cellSpanPath, offset: 3},
+          focus: {path: cellSpanPath, offset: 3},
+        },
+      },
+    })
+
+    // The video block's type isn't accepted anywhere in the cell's
+    // sub-schema (which only accepts `block`), so the fitted payload is
+    // empty: neither the source nor the destination change. A no-op has
+    // no observable settle signal, so a real edit provides the anchor:
+    // once its text lands, any change the drop had caused would be
+    // visible too.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: cellSpanPath, offset: 6},
+        focus: {path: cellSpanPath, offset: 6},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {_key: videoKey, _type: 'video', src: 'https://example.com/v.mp4'},
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: 'foobar!',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Dragging a block into a destination whose schema rejects it entirely (a video into a table cell that accepts none of it, for example) deleted the dragged block with nothing inserted. The drop path removed the source before checking whether anything survived fitting to the destination. Such a drop is now a no-op: the source stays where it was.

The new test drops a rejected type into a table cell, then types one character (a no-op emits no signal of its own to wait for) and waits for the document to equal exactly the original plus that character. On the unguarded code it fails with the dragged block gone from the value.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f4b63998edb483be8cead217e218112e3430a185. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->