### PR TITLE
feat: promote the Behavior API from beta to public

### DIFF
--- a/.changeset/promote-behavior-api-public.md
+++ b/.changeset/promote-behavior-api-public.md
@@ -1,0 +1,22 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the Behavior API from beta to public
+
+The Behavior API is no longer beta. `defineBehavior`, the action creators (`execute`, `forward`, `raise`, `effect`), `editor.registerBehavior`, and `BehaviorPlugin` are stable. Their types are stable too: `Behavior`, `BehaviorAction`, `BehaviorActionSet`, `BehaviorEvent`, `SyntheticBehaviorEvent`, `NativeBehaviorEvent`, `CustomBehaviorEvent`, `BehaviorGuard`, and `InsertPlacement`.
+
+```tsx
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {getFocusTextBlock} from '@portabletext/editor/selectors'
+
+const noBreakInTitles = defineBehavior({
+  on: 'insert.break',
+  guard: ({snapshot}) =>
+    snapshot.context.selection !== null &&
+    getFocusTextBlock(snapshot)?.node.style === 'title',
+  actions: [() => [raise({type: 'insert.soft break'})]],
+})
+```
+
+The alpha primitive event forms stay alpha: `insert`, `remove.text`, `set`, `unset`, and the explicit `at`/`offset` form of `insert.text`.

--- a/packages/editor/src/behaviors/behavior.types.action.ts
+++ b/packages/editor/src/behaviors/behavior.types.action.ts
@@ -9,7 +9,7 @@ import type {
 } from './behavior.types.event'
 
 /**
- * @beta
+ * @public
  */
 export type BehaviorAction =
   | {
@@ -68,7 +68,7 @@ export type BehaviorAction =
  * })
  * ```
  *
- * @beta
+ * @public
  */
 export function execute(
   event: SyntheticBehaviorEvent,
@@ -111,7 +111,7 @@ export function execute(
  * })
  * ```
  *
- * @beta
+ * @public
  */
 export function forward(
   event: NativeBehaviorEvent | SyntheticBehaviorEvent | CustomBehaviorEvent,
@@ -150,7 +150,7 @@ export function forward(
  * })
  * ```
  *
- * @beta
+ * @public
  */
 export function raise(
   event: SyntheticBehaviorEvent | CustomBehaviorEvent,
@@ -198,7 +198,7 @@ export function raise(
  * })
  * ```
  *
- * @beta
+ * @public
  */
 export function effect(
   effect: PickFromUnion<BehaviorAction, 'type', 'effect'>['effect'],
@@ -207,7 +207,7 @@ export function effect(
 }
 
 /**
- * @beta
+ * @public
  */
 export type BehaviorActionSet<TBehaviorEvent, TGuardResponse> = (
   payload: {

--- a/packages/editor/src/behaviors/behavior.types.behavior.ts
+++ b/packages/editor/src/behaviors/behavior.types.behavior.ts
@@ -8,7 +8,7 @@ import type {
 import type {BehaviorGuard} from './behavior.types.guard'
 
 /**
- * @beta
+ * @public
  */
 export type Behavior<
   TBehaviorEventType extends
@@ -40,7 +40,7 @@ export type Behavior<
 }
 
 /**
- * @beta
+ * @public
  *
  * @example
  *

--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -15,7 +15,7 @@ import type {EditorSelection} from '../types/editor'
 import type {AnnotationPath, BlockPath, ChildPath, Path} from '../types/paths'
 
 /**
- * @beta
+ * @public
  */
 export type BehaviorEvent =
   | SyntheticBehaviorEvent
@@ -97,7 +97,7 @@ type SyntheticBehaviorEventNamespace =
   ExtractNamespace<SyntheticBehaviorEventType>
 
 /**
- * @beta
+ * @public
  */
 export type SyntheticBehaviorEvent =
   | {
@@ -326,7 +326,7 @@ export type SyntheticBehaviorEvent =
   | AbstractBehaviorEvent
 
 /**
- * @beta
+ * @public
  */
 export type InsertPlacement = 'auto' | 'after' | 'before'
 
@@ -631,7 +631,7 @@ export function isNativeBehaviorEvent(
 }
 
 /**
- * @beta
+ * @public
  */
 export type NativeBehaviorEvent =
   | ClipboardBehaviorEvent
@@ -766,7 +766,7 @@ type CustomBehaviorEventType<
 > = TType extends '' ? `${TNamespace}` : `${TNamespace}.${TType}`
 
 /**
- * @beta
+ * @public
  */
 export type CustomBehaviorEvent<
   TPayload extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/editor/src/behaviors/behavior.types.guard.ts
+++ b/packages/editor/src/behaviors/behavior.types.guard.ts
@@ -2,7 +2,7 @@ import type {EditorDom} from '../editor/editor-dom'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 
 /**
- * @beta
+ * @public
  */
 export type BehaviorGuard<TBehaviorEvent, TGuardResponse> = (payload: {
   snapshot: EditorSnapshot

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -58,7 +58,7 @@ export type Editor = {
   dom: EditorDom
   getSnapshot: () => EditorSnapshot
   /**
-   * @beta
+   * @public
    */
   registerBehavior: (config: {behavior: Behavior}) => () => void
   /**

--- a/packages/editor/src/plugins/plugin.behavior.tsx
+++ b/packages/editor/src/plugins/plugin.behavior.tsx
@@ -3,7 +3,7 @@ import type {Behavior} from '../behaviors/behavior.types.behavior'
 import {useEditor} from '../editor/use-editor'
 
 /**
- * @beta
+ * @public
  *
  * Plugin component that registers a list of `Behavior`s with the editor.
  *


### PR DESCRIPTION
The Behavior API is `@beta` on paper and frozen in practice: ten plugin packages and the toolbar type against `@portabletext/editor/behaviors`, and the docs teach it as the extension mechanism. A break there is already a coordinated major across the plugin ecosystem, which is exactly the commitment `@public` names. This PR flips the 16 `@beta` tags on the behavior surface (`defineBehavior`, the action creators, the event unions, `BehaviorGuard`, `editor.registerBehavior`, `BehaviorPlugin`) to `@public`; every change is a release tag.

The `@alpha` primitive event forms stay alpha: `insert`, `remove.text`, `set`, `unset`, and the explicit `at`/`offset` form of `insert.text`. Their shape leaks raw `Path` and the apply-layer `text` on `remove.text`, and freezing that before real collaborative-edit consumers exist would be premature, the same holdback the node-registration promotion made for its read-side introspection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bc8fadbf4e651f286cdef4fa0d19342773d05bd8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->