### PR TITLE
feat: promote the traversal utils from beta to public

### DIFF
--- a/.changeset/promote-traversal-public.md
+++ b/.changeset/promote-traversal-public.md
@@ -1,0 +1,16 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the traversal utils from beta to public
+
+The traversal utilities are no longer beta: `getNode`, `getChildren`, `getParent`, `getSibling`, `getAncestor`, `getAncestors`, `getContainer`, `getFirstChild`, `getLastChild`, `getLeaf`, `getSpan`, `getText`, `getTextBlock`, `getAnnotation`, `getEnclosingBlock`, `getPathSubSchema`, `getUnionSchema`, `getBlock`, `isBlock`, `isInline`, `isLeafObject`, `isObject`, `hasNode`, `comparePoints`, `pathContains`, and `rangeIntersects` are all `@public` now and follow the package's normal semver guarantees.
+
+```ts
+import {getEnclosingBlock, getNode} from '@portabletext/editor/traversal'
+
+const entry = getNode(snapshot, selection.anchor.path)
+const block = entry ? getEnclosingBlock(snapshot, entry.path) : undefined
+```
+
+`getContainerChildren` stays `@beta`.

--- a/packages/editor/src/traversal/compare-points.ts
+++ b/packages/editor/src/traversal/compare-points.ts
@@ -12,7 +12,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * Compares the two points by document order, resolved at any depth. When
  * the paths are equal, compares offsets.
  *
- * @beta
+ * @public
  */
 export function comparePoints(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-ancestor.ts
+++ b/packages/editor/src/traversal/get-ancestor.ts
@@ -12,7 +12,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  *
  * When `match` is a type predicate, the returned `node` narrows to that type.
  *
- * @beta
+ * @public
  */
 export function getAncestor<TMatch extends PortableTextBlock>(
   snapshot: TraversalSnapshot,
@@ -23,7 +23,7 @@ export function getAncestor<TMatch extends PortableTextBlock>(
   },
 ): {node: TMatch; path: Path} | undefined
 /**
- * @beta
+ * @public
  */
 export function getAncestor(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-ancestors.ts
+++ b/packages/editor/src/traversal/get-ancestors.ts
@@ -21,7 +21,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * Every ancestor is a `PortableTextBlock`: only text blocks and object
  * nodes can contain children.
  *
- * @beta
+ * @public
  */
 export function getAncestors(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-annotation.ts
+++ b/packages/editor/src/traversal/get-annotation.ts
@@ -13,7 +13,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * `[..., {_key: block}, 'markDefs', {_key: annotation}, ...]` to the
  * annotation node on the enclosing text block.
  *
- * @beta
+ * @public
  */
 export function getAnnotation(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-children.ts
+++ b/packages/editor/src/traversal/get-children.ts
@@ -15,7 +15,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the children of a node at a given path.
  *
- * @beta
+ * @public
  */
 export function getChildren(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-container.ts
+++ b/packages/editor/src/traversal/get-container.ts
@@ -7,7 +7,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the registered editable container at a given path.
  *
- * @beta
+ * @public
  */
 export function getContainer(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-enclosing-block.ts
+++ b/packages/editor/src/traversal/get-enclosing-block.ts
@@ -20,7 +20,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * ancestor that matches, falling back to the node at the path only if no
  * ancestor does.
  *
- * @beta
+ * @public
  */
 export function getEnclosingBlock<TMatch extends PortableTextBlock>(
   snapshot: TraversalSnapshot,
@@ -31,7 +31,7 @@ export function getEnclosingBlock<TMatch extends PortableTextBlock>(
   },
 ): {node: TMatch; path: Path} | undefined
 /**
- * @beta
+ * @public
  */
 export function getEnclosingBlock(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-first-child.ts
+++ b/packages/editor/src/traversal/get-first-child.ts
@@ -6,7 +6,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the first child of a node at a given path.
  *
- * @beta
+ * @public
  */
 export function getFirstChild(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-last-child.ts
+++ b/packages/editor/src/traversal/get-last-child.ts
@@ -6,7 +6,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the last child of a node at a given path.
  *
- * @beta
+ * @public
  */
 export function getLastChild(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-leaf.ts
+++ b/packages/editor/src/traversal/get-leaf.ts
@@ -9,7 +9,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * start or end edge. A leaf is any node that has no children according to the
  * traversal context.
  *
- * @beta
+ * @public
  */
 export function getLeaf(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -27,7 +27,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * it, so `getNode` resolves an annotation path to the enclosing text
  * block. Use `getAnnotation` to resolve the annotation itself.
  *
- * @beta
+ * @public
  */
 export function getNode(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-parent.ts
+++ b/packages/editor/src/traversal/get-parent.ts
@@ -13,7 +13,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * When `match` is provided and the parent does not satisfy it, returns
  * `undefined`.
  *
- * @beta
+ * @public
  */
 export function getParent<TMatch extends PortableTextBlock>(
   snapshot: TraversalSnapshot,
@@ -23,7 +23,7 @@ export function getParent<TMatch extends PortableTextBlock>(
   },
 ): {node: TMatch; path: Path} | undefined
 /**
- * @beta
+ * @public
  */
 export function getParent(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-path-sub-schema.ts
+++ b/packages/editor/src/traversal/get-path-sub-schema.ts
@@ -11,7 +11,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * container, walks ancestors to find the nearest container and returns the
  * sub-schema derived from its `of` declaration.
  *
- * @beta
+ * @public
  */
 export function getPathSubSchema(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-sibling.ts
+++ b/packages/editor/src/traversal/get-sibling.ts
@@ -14,7 +14,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  *
  * When `match` is a type predicate, the returned `node` narrows to that type.
  *
- * @beta
+ * @public
  */
 export function getSibling<TMatch extends Node>(
   snapshot: TraversalSnapshot,
@@ -25,7 +25,7 @@ export function getSibling<TMatch extends Node>(
   },
 ): {node: TMatch; path: Path} | undefined
 /**
- * @beta
+ * @public
  */
 export function getSibling(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-span.ts
+++ b/packages/editor/src/traversal/get-span.ts
@@ -6,7 +6,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the span node at a given path.
  *
- * @beta
+ * @public
  */
 export function getSpan(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-text-block.ts
+++ b/packages/editor/src/traversal/get-text-block.ts
@@ -6,7 +6,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the text block node at a given path.
  *
- * @beta
+ * @public
  */
 export function getTextBlock(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-text.ts
+++ b/packages/editor/src/traversal/get-text.ts
@@ -7,7 +7,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Get the concatenated text content of the node at a given path.
  *
- * @beta
+ * @public
  */
 export function getText(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/get-union-schema.ts
+++ b/packages/editor/src/traversal/get-union-schema.ts
@@ -23,7 +23,7 @@ import type {Containers} from '../schema/resolve-containers'
  * range) to determine which of the union's members are applicable at the
  * current selection.
  *
- * @beta
+ * @public
  */
 export function getUnionSchema(schema: Schema, containers: Containers): Schema {
   const decorators = mergeByName(schema.decorators, [])

--- a/packages/editor/src/traversal/has-node.ts
+++ b/packages/editor/src/traversal/has-node.ts
@@ -5,7 +5,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Check if a node exists at a given path.
  *
- * @beta
+ * @public
  */
 export function hasNode(snapshot: TraversalSnapshot, path: Path): boolean {
   return getNode(snapshot, path) !== undefined

--- a/packages/editor/src/traversal/is-block.ts
+++ b/packages/editor/src/traversal/is-block.ts
@@ -14,7 +14,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * (spans and inline objects) are not blocks. Children of containers are
  * blocks within that container.
  *
- * @beta
+ * @public
  */
 export function isBlock(snapshot: TraversalSnapshot, path: Path): boolean {
   const parent = getParent(snapshot, path)
@@ -32,7 +32,7 @@ export function isBlock(snapshot: TraversalSnapshot, path: Path): boolean {
  * Returns the node narrowed to PortableTextBlock, or undefined if the node
  * doesn't exist or is not a block.
  *
- * @beta
+ * @public
  */
 export function getBlock(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/is-inline.ts
+++ b/packages/editor/src/traversal/is-inline.ts
@@ -8,7 +8,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * A node is inline if its parent is a text block. This is the inverse of
  * `isBlock`. Top-level nodes are never inline.
  *
- * @beta
+ * @public
  */
 export function isInline(snapshot: TraversalSnapshot, path: Path): boolean {
   return !isBlock(snapshot, path)

--- a/packages/editor/src/traversal/is-leaf-object.ts
+++ b/packages/editor/src/traversal/is-leaf-object.ts
@@ -10,7 +10,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * Returns true for block objects and inline objects that don't have
  * registered editable content (containers).
  *
- * @beta
+ * @public
  */
 export function isLeafObject(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/is-object.ts
+++ b/packages/editor/src/traversal/is-object.ts
@@ -5,7 +5,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
 /**
  * Check if a node is an object node (not a text block or span).
  *
- * @beta
+ * @public
  */
 export function isObject(
   snapshot: TraversalSnapshot,

--- a/packages/editor/src/traversal/path-contains.ts
+++ b/packages/editor/src/traversal/path-contains.ts
@@ -5,7 +5,7 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
  * Returns true if `ancestor` is equal to `descendant`, or if `descendant`
  * lives anywhere inside `ancestor`'s subtree.
  *
- * @beta
+ * @public
  */
 export function pathContains(ancestor: Path, descendant: Path): boolean {
   if (ancestor.length > descendant.length) {

--- a/packages/editor/src/traversal/range-intersects.ts
+++ b/packages/editor/src/traversal/range-intersects.ts
@@ -25,7 +25,7 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  *
  * Returns `false` when either `range` or `target` is `null`.
  *
- * @beta
+ * @public
  */
 export function rangeIntersects(
   snapshot: TraversalSnapshot,


### PR DESCRIPTION
The `./traversal` subpath is `@beta` on paper and load-bearing in practice: plugin-table stands on it broadly, five plugins use `getPathSubSchema`, the toolbar uses `getUnionSchema`, and Studio now uses `getSpan` and `getEnclosingBlock` in production. Every type the signatures reference is public since the containers-map promotion (#3084), so this PR flips the 30 `@beta` tags (26 symbols; four functions tag both overload declarations) to `@public`; every change is a release tag.

`getContainerChildren` stays `@beta`: its positional, non-snapshot-shaped calling convention is younger than its snapshot-shaped siblings and has a single consumer, so it is not worth freezing yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 27c37b9ff26b18db677882de40ae0de4836f046f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->