### PR TITLE
feat: promote the applicable-schema and mark-state selectors from beta to public

### DIFF
--- a/.changeset/promote-selectors-public.md
+++ b/.changeset/promote-selectors-public.md
@@ -1,0 +1,18 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the applicable-schema and mark-state selectors from beta to public
+
+`ApplicableSchema`, `getApplicableSchema`, `compareApplicableSchema`, `MarkState`, and `getMarkState` are now stable, public API. Their behavior is unchanged; only the stability guarantee changes.
+
+```ts
+import {useEditorSelector} from '@portabletext/editor'
+import {getApplicableSchema, compareApplicableSchema} from '@portabletext/editor/selectors'
+
+const applicableSchema = useEditorSelector(
+  editor,
+  getApplicableSchema,
+  compareApplicableSchema,
+)
+```

--- a/packages/editor/src/selectors/selector.get-applicable-schema.ts
+++ b/packages/editor/src/selectors/selector.get-applicable-schema.ts
@@ -7,7 +7,7 @@ import {getSelectedTextBlocks} from './selector.get-selected-text-blocks'
  * The set of schema member names applicable at the current selection,
  * grouped by category.
  *
- * @beta
+ * @public
  */
 export type ApplicableSchema = {
   decorators: ReadonlySet<string>
@@ -51,7 +51,7 @@ export type ApplicableSchema = {
  * compare to avoid re-rendering on every editor tick. Use
  * {@link compareApplicableSchema} as the third argument.
  *
- * @beta
+ * @public
  */
 export const getApplicableSchema: EditorSelector<ApplicableSchema> = (
   snapshot,
@@ -106,7 +106,7 @@ export const getApplicableSchema: EditorSelector<ApplicableSchema> = (
  * Pass as the `compare` argument to `useEditorSelector` to keep React
  * subscriptions stable.
  *
- * @beta
+ * @public
  */
 export function compareApplicableSchema(
   a: ApplicableSchema,

--- a/packages/editor/src/selectors/selector.get-mark-state.ts
+++ b/packages/editor/src/selectors/selector.get-mark-state.ts
@@ -11,7 +11,7 @@ import {getPreviousSpan} from './selector.get-previous-span'
 import {getSelectedSpans} from './selector.get-selected-spans'
 
 /**
- * @beta
+ * @public
  */
 export type MarkState =
   | {
@@ -27,7 +27,7 @@ export type MarkState =
 /**
  * Given that text is inserted at the current position, what marks should
  * be applied?
- * @beta
+ * @public
  */
 export const getMarkState: EditorSelector<MarkState | undefined> = (
   snapshot,


### PR DESCRIPTION
The applicable-schema and mark-state selectors are `@beta` on paper and consumed everywhere in practice: the toolbar, plugin-emoji-picker, plugin-typeahead-picker, and plugin-input-rule type against them, and Studio uses `getApplicableSchema` with `compareApplicableSchema` in production. This PR flips the five tags (`getApplicableSchema`, `ApplicableSchema`, `compareApplicableSchema`, `getMarkState`, `MarkState`) to `@public`; every change is a release tag.

One boundary worth naming: `getMarkState` reads the still-beta `decoratorState` snapshot property internally. That stays behind the function; promoting the selector does not freeze the property.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f5c92d30273224fc6bfb8e233f8e1f868de2866. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->