### PR TITLE
feat: promote the config, offset, and editor-ref surface from beta to public

### DIFF
--- a/.changeset/promote-root-types-public.md
+++ b/.changeset/promote-root-types-public.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the config, offset, and editor-ref surface from beta to public
+
+`EditorConfig.keyGenerator`, `InvalidValueResolution`, `BlockOffset`, and `EditorRefPlugin` move from `@beta` to `@public`. Their shapes and behavior are unchanged; they now follow the package's normal semver guarantees.

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -11,9 +11,6 @@ import type {RegistrableNode} from './renderers/renderer.types'
  * @public
  */
 export type EditorConfig = {
-  /**
-   * @beta
-   */
   keyGenerator?: () => string
   readOnly?: boolean
   initialValue?: Array<PortableTextBlock>

--- a/packages/editor/src/plugins/plugin.editor-ref.tsx
+++ b/packages/editor/src/plugins/plugin.editor-ref.tsx
@@ -3,7 +3,7 @@ import type {Editor} from '../editor'
 import {useEditor} from '../editor/use-editor'
 
 /**
- * @beta
+ * @public
  */
 export const EditorRefPlugin = React.forwardRef<Editor | null>((_, ref) => {
   const editor = useEditor()

--- a/packages/editor/src/types/block-offset.ts
+++ b/packages/editor/src/types/block-offset.ts
@@ -1,7 +1,7 @@
 import type {BlockPath} from './paths'
 
 /**
- * @beta
+ * @public
  */
 export type BlockOffset = {
   path: BlockPath

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -114,7 +114,7 @@ export type EditorSelection = {
 
 /**
  * The editor has invalid data in the value that can be resolved by the user
- * @beta */
+ * @public */
 export type InvalidValueResolution = {
   autoResolve?: boolean
   patches: Patch[]


### PR DESCRIPTION
These root-exported types are `@beta` on paper and production surface in practice: Studio types against `EditorConfig.keyGenerator` and `InvalidValueResolution`, Canvas imports `BlockOffset` and `EditorRefPlugin`, and public util signatures like `blockOffsetToSpanSelectionPoint` already accept `BlockOffset`, so leaving that one beta while public functions take it was the fiction. `InvalidValueResolution`, `BlockOffset`, and `EditorRefPlugin` flip to `@public`; `keyGenerator` instead loses its member-level tag and inherits `@public` from the enclosing `EditorConfig`, like its untagged sibling properties. Every change is a release tag.

Two surfaces deliberately stay `@beta` because they are slated for removal, and removal never routes through a promotion: `HotkeyOptions`, and the clipboard override types (`OnPasteFn`, `OnCopyFn`, `OnPasteResult`, `OnPasteResultOrPromise`, `PasteData`). Both get deprecation notices instead, tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5ea10c30f3cd9744e00eef361b8d843f1369e71d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->