### PR TITLE
feat: promote the surviving render-prop types from beta to public

### DIFF
--- a/.changeset/promote-render-types-public.md
+++ b/.changeset/promote-render-types-public.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: promote the surviving render-prop types from beta to public
+
+`RenderPlaceholderFunction`, `RenderEditableFunction`, and `ScrollSelectionIntoViewFunction` are now `@public`: editor-chrome hooks with no replacement on the horizon.
+
+The content-rendering props stay `@beta`: `RenderAnnotationFunction`, `RenderDecoratorFunction`, and their prop types alongside the already-deprecated `RenderBlockFunction`, `RenderChildFunction`, `RenderStyleFunction`, and `RenderListItemFunction`.

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -249,7 +249,7 @@ export type RenderBlockFunction = (props: BlockRenderProps) => JSX.Element
  */
 export type RenderChildFunction = (props: BlockChildRenderProps) => JSX.Element
 
-/** @beta */
+/** @public */
 export type RenderEditableFunction = (
   props: PortableTextEditableProps,
 ) => JSX.Element
@@ -259,7 +259,7 @@ export type RenderAnnotationFunction = (
   props: BlockAnnotationRenderProps,
 ) => JSX.Element
 
-/** @beta */
+/** @public */
 export type RenderPlaceholderFunction = () => React.ReactNode
 
 /**
@@ -300,7 +300,7 @@ export type RenderDecoratorFunction = (
   props: BlockDecoratorRenderProps,
 ) => JSX.Element
 
-/** @beta */
+/** @public */
 export type ScrollSelectionIntoViewFunction = (
   editor: PortableTextEditor,
   domRange: globalThis.Range,


### PR DESCRIPTION
Three render-prop symbols are editor chrome, not content rendering: `RenderPlaceholderFunction`, `RenderEditableFunction`, and `ScrollSelectionIntoViewFunction`. Studio consumes them in production, they survive the v8 branch, and no replacement is on the horizon, so this PR flips their `@beta` tags to `@public`; every change is a release tag.

Every content-rendering prop stays `@beta`. The annotation and decorator pairs (`RenderAnnotationFunction`, `BlockAnnotationRenderProps`, `RenderDecoratorFunction`, `BlockDecoratorRenderProps`) are removal candidates once node registration covers annotations and decorators, and promoting a surface slated for removal would make the tag a promise we intend to break. The four already-deprecated render functions (`RenderBlockFunction`, `RenderChildFunction`, `RenderStyleFunction`, `RenderListItemFunction`) and their prop types are untouched: already deleted on v8, they stay `@beta` and `@deprecated` here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only API tagging with no runtime or behavior changes; low risk aside from consumers treating the types as formally stable.
> 
> **Overview**
> Promotes **`RenderPlaceholderFunction`**, **`RenderEditableFunction`**, and **`ScrollSelectionIntoViewFunction`** from `@beta` to **`@public`** in `packages/editor/src/types/editor.ts`, signaling stable editor-chrome hooks (placeholder, editable wrapper, scroll-into-view) rather than content render props.
> 
> **Content-rendering** symbols are unchanged: annotation/decorator render types and the deprecated block/child/style/list-item render functions and their prop interfaces remain **`@beta`** (and **`@deprecated`** where already marked). A **minor** changeset for `@portabletext/editor` documents the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9ac65348bc184c1fc7dc4488c2c9ac510247c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->