### PR TITLE
fix: deprecate `EditableAPIDeleteOptions` in favor of behavior events

### DIFF
--- a/.changeset/deprecate-editable-api-delete-options.md
+++ b/.changeset/deprecate-editable-api-delete-options.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: deprecate `EditableAPIDeleteOptions` in favor of behavior events
+
+`EditableAPIDeleteOptions` is deprecated together with the `PortableTextEditor.delete` static it serves. Send a `delete` behavior event (with an optional `unit`) or a `delete.block` event via `editor.send` instead.

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -24,7 +24,12 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {PortableTextEditor} from '../editor/PortableTextEditor'
 import type {BlockPath, Path} from './paths'
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated `EditableAPIDeleteOptions` is deprecated together with the
+ * `PortableTextEditor.delete` static. Send a `delete` behavior event (with
+ * an optional `unit`) or a `delete.block` event via `editor.send` instead.
+ */
 export interface EditableAPIDeleteOptions {
   mode?: 'blocks' | 'children' | 'selected'
 }
@@ -47,7 +52,7 @@ export type AddedAnnotationPaths = {
   spanPath: Path
 }
 
-/** @beta */
+/** @internal */
 export interface EditableAPI {
   activeAnnotations: () => PortableTextObject[]
   isAnnotationActive: (annotationType: PortableTextObject['_type']) => boolean


### PR DESCRIPTION
`EditableAPIDeleteOptions` exists only to serve the deprecated `PortableTextEditor.delete` static: it flows through that one call into `EditableAPI.delete`, and no other caller exists. It now carries `@deprecated` with the replacement spelled out: send a `delete` behavior event (with an optional `unit`) or a `delete.block` event via `editor.send`.

`EditableAPI` rides along: it is exported from no package entry point and the changelog already calls it internal, so its `@beta` becomes `@internal`. Net behavior unchanged; both changes are documentation tags, shipped as a patch so the deprecation notice reaches v7 consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e5a32d5483625fc3868aa29bc80961c28cee006d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->