### PR TITLE
fix: deprecate the legacy render-prop payload types

### DIFF
--- a/.changeset/deprecate-render-prop-types.md
+++ b/.changeset/deprecate-render-prop-types.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: deprecate the legacy render-prop payload types
+
+`BlockRenderProps`, `BlockChildRenderProps`, `BlockStyleRenderProps`, and `BlockListItemRenderProps` are deprecated together with the render props they serve (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`). Type against the node registration API instead: `BlockObjectRenderProps` / `TextBlockRenderProps` for blocks, `InlineObjectRenderProps` / `SpanRenderProps` for children, and `defineTextBlock` render props for styles and list items. See the migration guide: https://www.portabletext.org/editor/guides/migrate-render-props/

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -175,7 +175,14 @@ export type OnCopyFn = (
   event: ClipboardEvent<HTMLDivElement | HTMLSpanElement>,
 ) => undefined | unknown
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated `BlockRenderProps` is deprecated together with the
+ * `renderBlock` render prop it serves. Type against
+ * `BlockObjectRenderProps` / `TextBlockRenderProps` from the node
+ * registration API instead. See the migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export interface BlockRenderProps {
   children: ReactElement<any>
   editorElementRef: RefObject<HTMLElement | null>
@@ -189,7 +196,14 @@ export interface BlockRenderProps {
   value: PortableTextBlock
 }
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated `BlockChildRenderProps` is deprecated together with the
+ * `renderChild` render prop it serves. Type against
+ * `InlineObjectRenderProps` / `SpanRenderProps` from the node
+ * registration API instead. See the migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export interface BlockChildRenderProps {
   annotations: PortableTextObject[]
   children: ReactElement<any>
@@ -222,7 +236,14 @@ export interface BlockDecoratorRenderProps {
   selected: boolean
   value: string
 }
-/** @beta */
+/**
+ * @beta
+ * @deprecated `BlockListItemRenderProps` is deprecated together with the
+ * `renderListItem` render prop it serves. Render list items with
+ * `defineTextBlock` mounted through `NodePlugin` instead. See the
+ * migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export interface BlockListItemRenderProps {
   block: PortableTextTextBlock
   children: ReactElement<any>
@@ -276,7 +297,14 @@ export type RenderPlaceholderFunction = () => React.ReactNode
  */
 export type RenderStyleFunction = (props: BlockStyleRenderProps) => JSX.Element
 
-/** @beta */
+/**
+ * @beta
+ * @deprecated `BlockStyleRenderProps` is deprecated together with the
+ * `renderStyle` render prop it serves. Render text-block styles with
+ * `defineTextBlock` mounted through `NodePlugin` instead. See the
+ * migration guide:
+ * https://www.portabletext.org/editor/guides/migrate-render-props/
+ */
 export interface BlockStyleRenderProps {
   block: PortableTextTextBlock
   children: ReactElement<any>


### PR DESCRIPTION
The four deprecated render props (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`) warn their consumers, but their payload types never did: `BlockRenderProps`, `BlockChildRenderProps`, `BlockStyleRenderProps`, and `BlockListItemRenderProps` are plain `@beta` while Studio imports them directly in production, and the next major deletes them. They would vanish without any v7 release ever having said so.

This PR adds `@deprecated` to each type, pointing at the node-registration replacements (`BlockObjectRenderProps` / `TextBlockRenderProps` for blocks, `InlineObjectRenderProps` / `SpanRenderProps` for children, `defineTextBlock` for styles and list items) and the migration guide, matching the notices on their functions. Net behavior unchanged; shipped as a patch so the warning reaches v7 consumers before the major.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d5b475c57243205fece2cd9ec281b4457829f315. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->