### PR TITLE
docs: state the Portable Text <-> Markdown round-trip contract

### DIFF
--- a/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
@@ -5,6 +5,8 @@ description: Convert Markdown strings into Portable Text blocks using @portablet
 
 import {PackageManagers} from 'starlight-package-managers'
 
+{/* The schema, matcher, and supported-features tables and the round-trip section mirror packages/markdown/README.md. Keep the twins in sync: a claim corrected in one place is stale in the other. */}
+
 :::note[Prerequisites]
 This guide covers `@portabletext/markdown` **v1.x** ([changelog](https://github.com/portabletext/editor/releases)). No framework dependencies. Works in Node.js, Deno, edge runtimes, and browsers.
 :::
@@ -38,34 +40,13 @@ The default schema includes:
 | Type            | Values                                                         |
 | --------------- | -------------------------------------------------------------- |
 | `styles`        | `normal`, `h1`-`h6`, `blockquote`                              |
-| `lists`         | `bullet`, `number`                                             |
+| `lists`         | `bullet`, `number`, `task`                                     |
 | `decorators`    | `strong`, `em`, `code`, `strike-through`                       |
 | `annotations`   | `link` (fields: `href`, `title`)                               |
 | `blockObjects`  | `code`, `image`, `horizontal-rule`, `html`, `table`, `callout` |
 | `inlineObjects` | `image`                                                        |
 
-To use a custom schema, import `compileSchema` and `defineSchema` from `@portabletext/schema`:
-
-```ts
-import {compileSchema, defineSchema} from '@portabletext/schema'
-
-markdownToPortableText(markdown, {
-  schema: compileSchema(
-    defineSchema({
-      styles: [{name: 'normal'}, {name: 'heading 1'}],
-    }),
-  ),
-})
-```
-
-If you are using a Sanity schema, use `@portabletext/sanity-bridge` to convert it first:
-
-```ts
-import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
-
-const schema = sanitySchemaToPortableTextSchema(sanityBlockArraySchema)
-markdownToPortableText(markdown, {schema})
-```
+To use a custom schema, build one with `compileSchema` and `defineSchema` from `@portabletext/schema` and pass it as the `schema` option; a Sanity schema converts first through `@portabletext/sanity-bridge`. The [package README](https://github.com/portabletext/editor/tree/main/packages/markdown#schema-configuration) has the configuration recipes for both.
 
 ## Matchers
 
@@ -89,25 +70,7 @@ Matchers control how Markdown elements map to schema types. The library includes
 |            | `html`           | HTML blocks           | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.     | `'callout'`         |
 
-Override a matcher when your schema uses a different name for a type. For example, if your schema uses `'heading 1'` instead of `'h1'`:
-
-```ts
-markdownToPortableText(markdown, {
-  schema: compileSchema(
-    defineSchema({
-      /* your schema */
-    }),
-  ),
-  block: {
-    h1: ({context}) => {
-      const style = context.schema.styles.find((s) => s.name === 'heading 1')
-      return style?.name
-    },
-  },
-})
-```
-
-Returning `undefined` from a matcher skips the element gracefully. This is useful when a type may or may not exist in the schema depending on the content model.
+Override a matcher when your schema uses a different name for a type (say, `'heading 1'` instead of `'h1'`): pass your own function under the matcher's group and name, resolve the type against `context.schema`, and return its name, or `undefined` to skip the element gracefully. The [package README](https://github.com/portabletext/editor/tree/main/packages/markdown#configuring-matchers) has worked matcher recipes, including the structural `table`, `list`, and `blockquote` shapes.
 
 ## Supported features
 
@@ -123,19 +86,28 @@ Returning `undefined` from a matcher skips the element gracefully. This is usefu
 | Blockquotes      |       ✅       |
 | Ordered lists    |       ✅       |
 | Unordered lists  |       ✅       |
+| Task lists       |       ✅       |
 | Nested lists     |       ✅       |
 | Code blocks      |       ✅       |
 | Horizontal rules |       ✅       |
 | Images           |       ✅       |
-| Tables           |      ✅\*      |
+| Tables           |       ✅       |
 | HTML blocks      |       ✅       |
-| Callouts         |      ✅\*      |
-
-\* Requires custom schema configuration (see above).
+| Callouts         |       ✅       |
 
 :::note
 This package uses markdown-it as its Markdown parser. Remark and unified plugins are not compatible.
 :::
+
+## Round-trip behavior
+
+Converting Markdown to Portable Text and back isn't a lossless mirror. Five things to expect:
+
+- Translation normalizes rather than preserves: a first Markdown → Portable Text → Markdown pass rewrites Markdown to one canonical spelling. Autolinks and reference links become inline links, indented code becomes fenced code, and `<https://portabletext.org>` comes back as `[https://portabletext.org](https://portabletext.org)`.
+- The normalized form is a fixpoint for the constructs in the table above: parsing it and serializing again reproduces it byte-for-byte. The exception is plain text containing literal Markdown punctuation: serialization doesn't yet escape it, so `\*bar\*` comes back as `*bar*`, which a second parse reads as emphasis.
+- Unrecognized constructs degrade, they don't fail. A mark, list, or task checkbox whose type isn't in the schema keeps its text and drops the formatting: an undeclared `strong` decorator turns `**bar**` into a plain span reading `bar`.
+- Portable Text structures with no Markdown form degrade predictably going back out. GFM has one header row, so extra header rows flatten into the body; deep or level-skipping lists collapse to relative nesting; unknown object types render as a fenced JSON block.
+- Keys and span boundaries aren't identity: every parse regenerates block and span keys, and adjacent spans with identical marks merge.
 
 ## Other conversion paths
 

--- a/apps/docs/src/content/docs/rendering/index.mdx
+++ b/apps/docs/src/content/docs/rendering/index.mdx
@@ -17,7 +17,7 @@ But Portable Text isn't just rich text. The same array can contain **any type of
 
 Within text blocks, **marks** add meaning to inline text. **Decorators** (bold, italic, underline) work by default. **Annotations** (links, references, footnotes) carry structured data as mark definitions. A link annotation isn't just an `<a>` tag: it's a data object with href, target, tracking parameters, or whatever fields you define. You customize annotation rendering through the `marks` component map. Text blocks can also contain **inline objects**: structured data embedded in the text flow, like a stock ticker, a product reference, or a custom emoji. Inline objects are rendered through the same `types` component map as custom blocks.
 
-If a serializer encounters a type it doesn't recognize, it skips it. Nothing breaks.
+If a serializer encounters a type it doesn't recognize, it falls back to an unknown-type handler instead of throwing; what that fallback renders varies per serializer (the [Markdown serializer](/rendering/markdown/), for example, renders unrecognized types as a fenced JSON block).
 
 ## Get started
 
@@ -328,7 +328,7 @@ All serializers use the same component map structure (except Astro, which uses s
 | `listItem`  | List items                      | Custom list item rendering              |
 | `hardBreak` | Line breaks within text         | Custom line break handling              |
 
-Unknown types, marks, and styles are skipped by default. You can handle them with `unknownType`, `unknownMark`, `unknownBlockStyle`, `unknownList`, and `unknownListItem` components.
+Unknown types, marks, and styles go through an unknown-type fallback whose default varies per serializer (the React serializer renders a hidden warning, the Markdown serializer a fenced JSON block). You can take over with `unknownType`, `unknownMark`, `unknownBlockStyle`, `unknownList`, and `unknownListItem` components.
 
 ## Framework guides
 

--- a/apps/docs/src/content/docs/rendering/markdown.mdx
+++ b/apps/docs/src/content/docs/rendering/markdown.mdx
@@ -11,7 +11,7 @@ This guide covers `@portabletext/markdown` **v1.x** ([changelog](https://github.
 
 `@portabletext/markdown` renders Portable Text blocks as Markdown strings. Use it to generate Markdown for static site generators, README files, AI prompts, or any system that consumes Markdown.
 
-Looking to convert Markdown into Portable Text? See the [Markdown to Portable Text](/conversion/markdown-to-portable-text/) conversion guide.
+Looking to convert Markdown into Portable Text? See the [Markdown to Portable Text](/conversion/markdown-to-portable-text/) conversion guide, whose [Round-trip behavior](/conversion/markdown-to-portable-text/#round-trip-behavior) section covers what survives a Markdown → Portable Text → Markdown loop.
 
 ## Install
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -70,7 +70,7 @@ const markdown = portableTextToMarkdown([
 | Blockquotes      | ✅                       | ✅                       |
 | Ordered lists    | ✅                       | ✅                       |
 | Unordered lists  | ✅                       | ✅                       |
-| Task lists       | ✅\*                     | ✅\*                     |
+| Task lists       | ✅                       | ✅                       |
 | Nested lists     | ✅                       | ✅                       |
 | Code blocks      | ✅                       | ✅                       |
 | Horizontal rules | ✅                       | ✅                       |
@@ -79,9 +79,34 @@ const markdown = portableTextToMarkdown([
 | HTML blocks      | ✅                       | ✅                       |
 | Callouts         | ✅                       | ✅                       |
 
-\* Requires a schema that declares a `task` list; the default schema does not (see [GFM task lists](#configuring-matchers) below)
+## Round-trip behavior
+
+1. Translation preserves semantics, not source spelling. The first MD→PT→MD pass normalizes Markdown to one canonical spelling: autolinks and reference links become inline links, indented code becomes fenced code, and emphasis, headings, lists, and tables each get one canonical form.
+
+   ```
+   <https://portabletext.org>  ->  [https://portabletext.org](https://portabletext.org)
+   [ref link][id]              ->  [ref link](https://example.com "title")
+   ```
+
+2. The normalized Markdown is a fixpoint for the constructs in the [Supported features](#supported-features) table above: parsing it and serializing again reproduces it byte-for-byte, pinned by a full-document round-trip test. This doesn't yet extend to plain text that happens to contain literal Markdown punctuation: serialization doesn't escape it, so a second parse reads it back as markup instead of literal text.
+
+   ```
+   \*bar\*  ->  *bar*  (serialized unescaped; a second parse reads this as emphasis)
+   ```
+
+3. MD→PT survival is schema-driven. Constructs whose type the schema doesn't declare degrade predictably: they keep their content and drop the structure that named them. Marks drop formatting but keep the text (`**bar**` with no `strong` decorator in the schema becomes a plain span reading `bar`); tables flatten their cell content into top-level blocks; images fall back to their Markdown source as plain text; task-list checkboxes strip to plain list items.
+
+4. PT structures with no Markdown form degrade predictably on PT→MD. GFM tables have one header row, so header rows beyond the first flatten into the body. Deep or level-skipping lists collapse to relative nesting. A list's first item renders at the top level whatever its `level`, and each deeper jump between items indents one step, however many levels it skips. Multi-block table cells join their blocks with spaces. Unknown object types render as a fenced JSON block; unknown marks pass their text through unformatted.
+
+5. Identity does not round-trip. Keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
 
 ## Usage
+
+<!-- The schema table, matcher table, supported-features table, and
+     round-trip section have condensed twins on the docs site
+     (apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx).
+     Keep them in sync: a claim corrected in one place is stale in the
+     other. -->
 
 ### `markdownToPortableText`
 
@@ -165,7 +190,7 @@ The default schema includes the following definitions:
 | Type            | Values                                                                                                                                                                                                                                                                       |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `styles`        | `'normal'`, `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'`, `'blockquote'`                                                                                                                                                                                                   |
-| `lists`         | `'number'`, `'bullet'`                                                                                                                                                                                                                                                       |
+| `lists`         | `'number'`, `'bullet'`, `'task'`                                                                                                                                                                                                                                             |
 | `decorators`    | `'strong'`, `'em'`, `'code'`, `'strike-through'`                                                                                                                                                                                                                             |
 | `annotations`   | `'link'` (fields: `'href'`, `'title'`)                                                                                                                                                                                                                                       |
 | `blockObjects`  | `'code'` (fields: `'language'`, `'code'`), `'image'` (fields: `'src'`, `'alt'`, `'title'`), `'horizontal-rule'`, `'html'` (fields: `'html'`), `'table'` (the canonical nested shape, see [Default behavior](#default-behavior)), `'callout'` (fields: `'tone'`, `'content'`) |
@@ -318,7 +343,7 @@ The matcher receives `value.items` already assembled. Each item's `content` arra
 
 Without `types.list`, the existing flat-block path runs unchanged.
 
-**GFM task lists** (`- [ ]` / `- [x]`): Task lists are recognized when the schema declares a `task` list item. Without a `task` definition, the checkbox markers are stripped from the text and the items render as their surrounding list type (bullet or number). With a `task` definition, items carrying a checkbox become text blocks with `listItem: 'task'` and a `checked: boolean` field; items without a checkbox keep their surrounding list type.
+**GFM task lists** (`- [ ]` / `- [x]`): Task lists are recognized when the schema declares a `task` list item; the default schema does, so task lists parse zero-config. Without a `task` definition (a custom schema that omits it), the checkbox markers are stripped from the text and the items render as their surrounding list type (bullet or number). With a `task` definition, items carrying a checkbox become text blocks with `listItem: 'task'` and a `checked: boolean` field; items without a checkbox keep their surrounding list type.
 
 ```ts
 markdownToPortableText('- [x] done\n- [ ] todo', {


### PR DESCRIPTION
A developer evaluating `@portabletext/markdown` for a markdown-based pipeline needs to know what happens to content in a Markdown → Portable Text → Markdown loop. The docs explain the machinery well (matchers, renderers, schema gating, both directions) but never answer that question: no page says what survives a round trip, what normalizes, or what degrades.

The behavior itself is already pinned by tests, so this PR states it rather than promising anything new. A "Round-trip behavior" section in the package README and on the conversion page (with a cross-link from the rendering page) covers five points: translation preserves semantics, not source spelling; the normalized markdown is a fixpoint, pinned by the example-document round-trip test, except plain text containing literal markdown punctuation, which serialization does not yet escape (tracked separately); schema-driven degradation on the way in; predictable degradation for structures markdown can't express on the way out; keys regenerate and same-mark spans merge.

Three stale claims are fixed along the way: tables, callouts, and `task` lists are all in the default schema now, and the rendering overview said unknown types are "skipped" where the markdown serializer renders fenced JSON.

The conversion page and the README mirror each other in their tables, and that duplication is where the stale claims lived, so both twins now carry a keep-in-sync pointer and the page's duplicated configuration recipes collapse to one-sentence summaries linking the README's anchors.
