### PR TITLE
chore: drop the undeclared `browserslist` config from `@portabletext/test`

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -60,7 +60,6 @@
     "vite": "catalog:tooling",
     "vitest": "catalog:tooling"
   },
-  "browserslist": "extends @sanity/browserslist-config",
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
   }


### PR DESCRIPTION
Cold builds of `@portabletext/test` fail everywhere: its `package.json` declares `"browserslist": "extends @sanity/browserslist-config"`, but no package in the monorepo depends on `@sanity/browserslist-config`, so the module is never installed and `pkg-utils build` dies with `Cannot find module`. Warm turbo caches mask it, which is why CI and long-lived checkouts pass while any fresh worktree fails on every chain that includes the package (for example `pnpm --filter docs... build`).

The field arrived with the package's original build setup as template boilerplate. No other package in the repo carries a `browserslist` field; all of them build on `pkg-utils` defaults. This PR deletes the field, aligning `@portabletext/test` with its 22 siblings, rather than adding the missing dependency for a config only this package would use.

Verified in a cold worktree: `pnpm --filter @portabletext/test build` and the previously blocked `docs...` chain both pass with no `BROWSERSLIST` env override; the package's 12 unit tests and all root checks green. No changeset: build metadata only, nothing consumer-observable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 207f81647efa62f591a1e411cafc2b10a3cf7e98. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->