### PR TITLE
feat: accept `Decorator` and `Annotation` entries in `defineTextBlock`'s `of`

### DIFF
--- a/.changeset/positional-mark-overrides.md
+++ b/.changeset/positional-mark-overrides.md
@@ -1,0 +1,36 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: accept `Decorator` and `Annotation` entries in `defineTextBlock`'s `of`
+
+`defineTextBlock`'s `of` array, previously `Span | InlineObject` only,
+now also takes `Decorator` and `Annotation` entries, giving decorators
+and annotations the same positional scoping spans and inline objects
+already had:
+
+```ts
+defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+
+defineTextBlock({
+  type: 'block',
+  of: [
+    defineDecorator({
+      type: 'strong',
+      render: ({children}) => <mark>{children}</mark>,
+    }),
+  ],
+})
+```
+
+With both registered, `strong` renders as `<mark>` inside these text
+blocks and as `<strong>` everywhere else. Remove the positional
+entry's `render` and `strong` renders as `<strong>` everywhere: an
+entry without a `render` defers to the global registration instead of
+silencing it. `'*'` entries work at both levels and lose to an exact
+`type` match at the same level. The legacy `renderDecorator`/
+`renderAnnotation` render props fire only for types with no
+registration at all.

--- a/apps/docs/src/content/docs/editor/concepts/containers.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/containers.mdx
@@ -198,7 +198,33 @@ const nodes = [
 
 The `of` entry scopes its registration to the callout's immediate children, where it beats the global registration for the same type: paragraphs render through the first `defineTextBlock` everywhere else and through the tighter one inside the callout.
 
-Inline objects and spans sit inside a text block's line, so the DOM around them belongs to whoever renders that text block: register the text block too when you want to own it. The span-level render props (`renderDecorator`, `renderAnnotation`, `renderPlaceholder`) and range decorations keep composing on the spans inside `children`, no matter who renders the block.
+A text block's own `of` goes one level deeper, into `defineDecorator` and `defineAnnotation` entries. Register the same decorator globally and positionally to see the scoping:
+
+```tsx
+defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+
+defineTextBlock({
+  type: 'block',
+  render: ({attributes, children}) => (
+    <p {...attributes} style={{margin: 0, fontSize: '0.875em'}}>
+      {children}
+    </p>
+  ),
+  of: [
+    defineDecorator({
+      type: 'strong',
+      render: ({children}) => <mark>{children}</mark>,
+    }),
+  ],
+})
+```
+
+With both registered, `strong` renders as `<mark>` inside these text blocks and as `<strong>` everywhere else. Remove the positional entry's `render` and `strong` renders as `<strong>` everywhere: an entry without a `render` defers to the global registration instead of silencing it, the same fall-through rule every positional `of` entry on this page follows. `'*'` entries work at both levels and lose to an exact `type` match at the same level.
+
+Inline objects and spans sit inside a text block's line, so the DOM around them belongs to whoever renders that text block: register the text block too when you want to own it. Decorator and annotation rendering on the spans inside `children` happens through `defineDecorator`/`defineAnnotation` registrations, global or positional, or the deprecated `renderDecorator`/`renderAnnotation` render props, no matter who renders the block; `renderPlaceholder` and range decorations keep composing the same way regardless.
 
 Two rendering concerns ship as plugins:
 
@@ -347,6 +373,8 @@ function App() {
 An `image` block at the document root renders through the global registration, full width. The same `_type: 'image'` inside the callout's `content` hits the positional override first and renders compact. The text block registration needs no positional counterpart: `type: 'block'` already covers both scopes.
 
 Positional overrides only need to carry what they change: an `of` entry that omits `render` falls through to the global registration's render, so a positional registration never has to re-implement what the global one already does. Calling `renderDefault` is different: it renders the engine default at any position, never the global registration's render.
+
+Decorators and annotations scope the same way, one level deeper: a `defineDecorator` or `defineAnnotation` entry inside the callout's text block `of` (as shown under [Registrations own their rendering subtree](#registrations-own-their-rendering-subtree)) makes an annotation like `link` render differently only inside the callout, and the text block entry needs no `render` of its own to carry it.
 
 ## Read the registered containers
 

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -1,4 +1,9 @@
-import {defineContainer, defineTextBlock} from '@portabletext/editor'
+import {
+  defineAnnotation,
+  defineContainer,
+  defineDecorator,
+  defineTextBlock,
+} from '@portabletext/editor'
 import {defineTable} from '@portabletext/plugin-table'
 import {referenceContainers, TableCell} from '@portabletext/plugin-table/ui'
 import {ListItemBlock} from './list-item-block'
@@ -29,6 +34,29 @@ export const table = defineTable({
             ) : (
               <div {...attributes}>{children}</div>
             ),
+          // Positional override demo: inside table cells only, the
+          // `strong` decorator renders with a highlight and the `link`
+          // annotation as a green dotted underline, while the top-level
+          // `'*'` decorator and annotation registrations (a plain
+          // `<strong>` and a blue underline) still apply everywhere else.
+          of: [
+            defineDecorator({
+              type: 'strong',
+              render: ({children}) => (
+                <strong className="bg-yellow-200 dark:bg-yellow-900/60 rounded px-0.5">
+                  {children}
+                </strong>
+              ),
+            }),
+            defineAnnotation({
+              type: 'link',
+              render: ({children}) => (
+                <span className="text-emerald-700 dark:text-emerald-400 underline decoration-dotted">
+                  {children}
+                </span>
+              ),
+            }),
+          ],
         }),
         cellImageLeaf,
         calloutContainer,

--- a/packages/editor/src/editor/find-positional-override.ts
+++ b/packages/editor/src/editor/find-positional-override.ts
@@ -1,6 +1,8 @@
 import type {
+  AnnotationConfig,
   BlockObjectConfig,
   ContainerConfig,
+  DecoratorConfig,
   InlineObjectConfig,
   SpanConfig,
   TextBlockConfig,
@@ -54,19 +56,82 @@ export function findInlinePositionalOverride(
   if (!parentTextBlock?.of) {
     return undefined
   }
-  const specific = parentTextBlock.of.find((entry) => {
-    if ('span' in entry) {
-      return entry.span.type === type
-    }
-    return entry.inlineObject.type === type
-  })
+  const specific = parentTextBlock.of.find((entry) =>
+    isMatchingSpanOrInlineObject(entry, type),
+  )
   if (specific) {
     return specific
   }
-  return parentTextBlock.of.find((entry) => {
-    if ('span' in entry) {
-      return entry.span.type === '*'
-    }
-    return entry.inlineObject.type === '*'
-  })
+  return parentTextBlock.of.find((entry) =>
+    isMatchingSpanOrInlineObject(entry, '*'),
+  )
+}
+
+function isMatchingSpanOrInlineObject(
+  entry: SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig,
+  type: string,
+): entry is SpanConfig | InlineObjectConfig {
+  if ('span' in entry) {
+    return entry.span.type === type
+  }
+  if ('inlineObject' in entry) {
+    return entry.inlineObject.type === type
+  }
+  return false
+}
+
+/**
+ * Decorator positional override lookup. Walks the immediate parent
+ * text block's `of` array (decorator kind) for a matching decorator
+ * name: exact first, then a `'*'` entry.
+ */
+export function findPositionalDecoratorOverride(
+  parentTextBlock: TextBlockConfig | undefined,
+  decorator: string,
+): DecoratorConfig | undefined {
+  if (!parentTextBlock?.of) {
+    return undefined
+  }
+  const specific = parentTextBlock.of.find((entry) =>
+    isMatchingDecorator(entry, decorator),
+  )
+  if (specific) {
+    return specific
+  }
+  return parentTextBlock.of.find((entry) => isMatchingDecorator(entry, '*'))
+}
+
+function isMatchingDecorator(
+  entry: SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig,
+  decorator: string,
+): entry is DecoratorConfig {
+  return 'decorator' in entry && entry.decorator.type === decorator
+}
+
+/**
+ * Annotation positional override lookup. Walks the immediate parent
+ * text block's `of` array (annotation kind) for a matching annotation
+ * `_type`: exact first, then a `'*'` entry.
+ */
+export function findPositionalAnnotationOverride(
+  parentTextBlock: TextBlockConfig | undefined,
+  type: string,
+): AnnotationConfig | undefined {
+  if (!parentTextBlock?.of) {
+    return undefined
+  }
+  const specific = parentTextBlock.of.find((entry) =>
+    isMatchingAnnotation(entry, type),
+  )
+  if (specific) {
+    return specific
+  }
+  return parentTextBlock.of.find((entry) => isMatchingAnnotation(entry, '*'))
+}
+
+function isMatchingAnnotation(
+  entry: SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig,
+  type: string,
+): entry is AnnotationConfig {
+  return 'annotation' in entry && entry.annotation.type === type
 }

--- a/packages/editor/src/editor/parent-text-block-context.ts
+++ b/packages/editor/src/editor/parent-text-block-context.ts
@@ -5,8 +5,9 @@ import type {TextBlockConfig} from '../renderers/renderer.types'
  * The active text block's resolved config at this render position.
  * Provided by the text-block render branch in `render.element.tsx`;
  * consumed by inline-level dispatch (`useSpanConfig` + the
- * inline-object branch of `render.element.tsx`) for positional
- * override lookup.
+ * inline-object branch of `render.element.tsx`) for positional span/
+ * inline-object override lookup, and directly by `RenderSpan` for
+ * positional decorator/annotation override lookup.
  *
  * Separate from `ParentContainerContext` so inline subscribers only
  * re-render on text-block `of` changes, and block subscribers only

--- a/packages/editor/src/editor/render.leaf-config.tsx
+++ b/packages/editor/src/editor/render.leaf-config.tsx
@@ -52,23 +52,29 @@ export function useSpanConfig(
 }
 
 /**
- * Hook: the engine's registered decorator map.
+ * Hook: the engine's registered GLOBAL decorator map. Positional
+ * (in-parent) decorator overrides are a separate layer: the caller
+ * resolves them from `ParentTextBlockContext` via
+ * `findPositionalDecoratorOverride` and combines that result with
+ * this map's.
  *
- * Global-only: decorators have no positional (in-parent) override
- * layer, unlike containers/spans/inline-objects. The per-mark
- * exact-then-`'*'` lookup happens as a plain `Map` read against this
- * snapshot rather than as one hook call per mark: a span carries a
- * variable number of decorator marks, and hooks cannot be called a
- * variable number of times.
+ * The per-mark exact-then-`'*'` lookup against this map happens as a
+ * plain `Map` read rather than as one hook call per mark: a span
+ * carries a variable number of decorator marks, and hooks cannot be
+ * called a variable number of times.
  */
 export function useDecoratorConfigs(): ReadonlyMap<string, DecoratorConfig> {
   return useRegistrationsSelector((engine) => engine.decorators)
 }
 
 /**
- * Hook: the engine's registered annotation map.
+ * Hook: the engine's registered GLOBAL annotation map. Positional
+ * (in-parent) annotation overrides are a separate layer: the caller
+ * resolves them from `ParentTextBlockContext` via
+ * `findPositionalAnnotationOverride` and combines that result with
+ * this map's.
  *
- * Global-only, for the same reason as {@link useDecoratorConfigs}: a
+ * Same plain-`Map`-read reasoning as {@link useDecoratorConfigs}: a
  * span's marks resolve to a variable number of annotation `markDef`s
  * per render.
  */

--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -20,7 +20,12 @@ import type {
   RenderDecoratorFunction,
 } from '../types/editor'
 import type {EditorSchema} from './editor-schema'
+import {
+  findPositionalAnnotationOverride,
+  findPositionalDecoratorOverride,
+} from './find-positional-override'
 import {NewPipelineContext} from './new-pipeline-context'
+import {ParentTextBlockContext} from './parent-text-block-context'
 import {
   renderDefaultAnnotation,
   renderDefaultDecorator,
@@ -63,6 +68,7 @@ export function RenderSpan(props: RenderSpanProps) {
   const spanConfig = useSpanConfig(child ?? props.leaf, props.path)
   const decoratorConfigs = useDecoratorConfigs()
   const annotationConfigs = useAnnotationConfigs()
+  const parentTextBlock = useContext(ParentTextBlockContext)
 
   const isInNewPipeline = useContext(NewPipelineContext)
   const serializedPath = serializePath(props.path)
@@ -111,8 +117,19 @@ export function RenderSpan(props: RenderSpanProps) {
       continue
     }
 
-    const decoratorConfig =
+    const globalDecoratorConfig =
       decoratorConfigs.get(mark) ?? decoratorConfigs.get('*')
+    const positionalDecorator = findPositionalDecoratorOverride(
+      parentTextBlock,
+      mark,
+    )
+    // Positional present: undefined render falls through to global;
+    // function render is used at this position.
+    const decoratorConfig = positionalDecorator
+      ? positionalDecorator.decorator.render === undefined
+        ? globalDecoratorConfig
+        : positionalDecorator
+      : globalDecoratorConfig
 
     if (decoratorConfig) {
       const render = decoratorConfig.decorator.render
@@ -159,9 +176,20 @@ export function RenderSpan(props: RenderSpanProps) {
       (t) => t.name === annotationMarkDef._type,
     )
     if (annotationSchemaType) {
-      const annotationConfig =
+      const globalAnnotationConfig =
         annotationConfigs.get(annotationMarkDef._type) ??
         annotationConfigs.get('*')
+      const positionalAnnotation = findPositionalAnnotationOverride(
+        parentTextBlock,
+        annotationMarkDef._type,
+      )
+      // Positional present: undefined render falls through to global;
+      // function render is used at this position.
+      const annotationConfig = positionalAnnotation
+        ? positionalAnnotation.annotation.render === undefined
+          ? globalAnnotationConfig
+          : positionalAnnotation
+        : globalAnnotationConfig
 
       if (annotationConfig) {
         const render = annotationConfig.annotation.render

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -277,8 +277,13 @@ export type TextBlock = {
    * Inline-content positional overrides. A `Span` or `InlineObject`
    * placed here scopes the inline render to this text block (or any
    * text block of this `type` if registered at the top level).
+   * `Decorator` and `Annotation` entries scope those renders the
+   * same way: the decorator or annotation renders through this entry
+   * inside the text block, and through the global registration (or
+   * the legacy `renderDecorator`/`renderAnnotation` prop) everywhere
+   * else.
    */
-  of?: ReadonlyArray<Span | InlineObject>
+  of?: ReadonlyArray<Span | InlineObject | Decorator | Annotation>
 }
 
 /**
@@ -340,7 +345,8 @@ export type Decorator = {
   type: string
   /**
    * Outer render. Two modes:
-   * - omitted: no wrapper is applied (identity)
+   * - omitted: fall through to global registered render (or identity,
+   *   the engine default, if no global registration exists)
    * - function: use this render. The function receives a `renderDefault`
    *   prop that returns identity when called.
    */
@@ -359,7 +365,8 @@ export type Annotation = {
   type: string
   /**
    * Outer render. Two modes:
-   * - omitted: no wrapper is applied (identity)
+   * - omitted: fall through to global registered render (or identity,
+   *   the engine default, if no global registration exists)
    * - function: use this render. The function receives a `renderDefault`
    *   prop that returns identity when called.
    */
@@ -657,7 +664,7 @@ export function defineTextBlock<const TType extends string>(config: {
     ? "Error: defineTextBlock({type: 'span'}) is forbidden -- 'span' is always a span, use defineSpan"
     : TType
   render?: TextBlockRender
-  of?: ReadonlyArray<Span | InlineObject>
+  of?: ReadonlyArray<Span | InlineObject | Decorator | Annotation>
 }): TextBlock {
   return {kind: 'textBlock', ...config} as unknown as TextBlock
 }
@@ -724,10 +731,13 @@ export type ContainerConfig = {
  * @internal
  *
  * Resolved text block config. The optional `of` carries resolved
- * inline-content positional overrides (spans, inline-objects) for
- * children rendered inside this text block.
+ * inline-content positional overrides (spans, inline-objects, and
+ * per-decorator and per-annotation overrides) for children rendered
+ * inside this text block.
  */
 export type TextBlockConfig = {
   textBlock: TextBlock
-  of?: ReadonlyArray<SpanConfig | InlineObjectConfig>
+  of?: ReadonlyArray<
+    SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig
+  >
 }

--- a/packages/editor/src/schema/resolve-containers-batch.ts
+++ b/packages/editor/src/schema/resolve-containers-batch.ts
@@ -1,8 +1,10 @@
 import type {OfDefinition} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {
+  AnnotationConfig,
   BlockObjectConfig,
   ContainerConfig,
+  DecoratorConfig,
   InlineObjectConfig,
   Container as PublicContainer,
   SpanConfig,
@@ -140,14 +142,25 @@ function describeContainerFailure(
  * (if present) for inline-content positional overrides.
  */
 export function resolveTextBlockConfig(textBlock: TextBlock): TextBlockConfig {
-  const resolvedOf: ReadonlyArray<SpanConfig | InlineObjectConfig> | undefined =
-    textBlock.of
-      ? textBlock.of.flatMap<SpanConfig | InlineObjectConfig>((entry) => {
-          if (entry.kind === 'span') {
-            return [{span: entry}]
-          }
+  const resolvedOf:
+    | ReadonlyArray<
+        SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig
+      >
+    | undefined = textBlock.of
+    ? textBlock.of.flatMap<
+        SpanConfig | InlineObjectConfig | DecoratorConfig | AnnotationConfig
+      >((entry) => {
+        if (entry.kind === 'span') {
+          return [{span: entry}]
+        }
+        if (entry.kind === 'inlineObject') {
           return [{inlineObject: entry}]
-        })
-      : undefined
+        }
+        if (entry.kind === 'decorator') {
+          return [{decorator: entry}]
+        }
+        return [{annotation: entry}]
+      })
+    : undefined
   return {textBlock, ...(resolvedOf ? {of: resolvedOf} : {})}
 }

--- a/packages/editor/tests/positional-override-decorator-annotation.test.tsx
+++ b/packages/editor/tests/positional-override-decorator-annotation.test.tsx
@@ -1,0 +1,613 @@
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import type {BlockDecoratorRenderProps, PortableTextObject} from '../src'
+import {NodePlugin} from '../src/plugins/plugin.node'
+import {
+  defineAnnotation,
+  defineContainer,
+  defineDecorator,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
+import {createTestEditor} from '../src/test/vitest'
+
+/**
+ * Positional decorator/annotation override composition.
+ *
+ * `defineTextBlock.of` accepts `Decorator | Annotation` entries, the
+ * same precedence ladder as inline/block-level positional overrides:
+ *
+ *   1. Positional exact (`type` matches the mark) beats everything.
+ *   2. Positional `'*'` beats a global exact registration.
+ *   3. Global exact beats a global `'*'`.
+ *   4. Global `'*'` beats the legacy `renderDecorator`/
+ *      `renderAnnotation` render props.
+ *   5. A positional entry with no `render` falls through to the
+ *      global layer for that mark, ignoring a sibling positional
+ *      `'*'`; it does not silence it for other marks.
+ */
+
+const calloutDecoratorSchema = defineSchema({
+  decorators: [{name: 'strong'}],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+const calloutAnnotationSchema = defineSchema({
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
+
+describe('positional overrides', () => {
+  test('positional decorator override wins over global inside the parent; global still fires outside', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const outsideBlockKey = keyGenerator()
+    const outsideSpanKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+
+    const globalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <strong data-testid="global-strong">{children}</strong>
+      ),
+    })
+    const positionalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <mark data-testid="positional-strong">{children}</mark>
+      ),
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalStrong],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutDecoratorSchema,
+      initialValue: [
+        markedBlock(outsideBlockKey, outsideSpanKey, 'foo', 'strong'),
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            markedBlock(insideBlockKey, insideSpanKey, 'bar', 'strong'),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalStrong]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-strong"]')
+          ?.textContent,
+      ).toEqual('bar')
+      expect(calloutEl!.querySelector('[data-testid="global-strong"]')).toEqual(
+        null,
+      )
+    })
+
+    expect(
+      document.querySelector('[data-testid="global-strong"]')?.textContent,
+    ).toEqual('foo')
+  })
+
+  test('positional decorator with render: undefined falls through to the global render', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+
+    const globalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <strong data-testid="global-strong">{children}</strong>
+      ),
+    })
+    const positionalStrong = defineDecorator({type: 'strong'})
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalStrong],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutDecoratorSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            markedBlock(insideBlockKey, insideSpanKey, 'bar', 'strong'),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalStrong]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="global-strong"]')?.textContent,
+      ).toEqual('bar')
+    })
+  })
+
+  test("positional '*' decorator beats global exact", async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+
+    const globalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <strong data-testid="global-strong">{children}</strong>
+      ),
+    })
+    const positionalWildcard = defineDecorator({
+      type: '*',
+      render: ({children}) => (
+        <mark data-testid="positional-wildcard">{children}</mark>
+      ),
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalWildcard],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutDecoratorSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            markedBlock(insideBlockKey, insideSpanKey, 'bar', 'strong'),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalStrong]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-wildcard"]')
+          ?.textContent,
+      ).toEqual('bar')
+      expect(calloutEl!.querySelector('[data-testid="global-strong"]')).toEqual(
+        null,
+      )
+    })
+  })
+
+  test('positional annotation override wins inside the parent, receives the markDef as `annotation`', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const outsideBlockKey = keyGenerator()
+    const outsideSpanKey = keyGenerator()
+    const outsideLinkKey = keyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+    const insideLinkKey = keyGenerator()
+
+    let receivedNode: PortableTextObject | undefined
+
+    const globalLink = defineAnnotation({
+      type: 'link',
+      render: ({annotation, children}) => (
+        <a
+          data-testid="global-link"
+          href={(annotation as {href?: string}).href}
+        >
+          {children}
+        </a>
+      ),
+    })
+    const positionalLink = defineAnnotation({
+      type: 'link',
+      render: ({annotation, children}) => {
+        receivedNode = annotation
+        return (
+          <a
+            data-testid="positional-link"
+            href={(annotation as {href?: string}).href}
+          >
+            {children}
+          </a>
+        )
+      },
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalLink],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutAnnotationSchema,
+      initialValue: [
+        linkedBlock(
+          outsideBlockKey,
+          outsideSpanKey,
+          'foo',
+          outsideLinkKey,
+          'https://example.com/outside',
+        ),
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            linkedBlock(
+              insideBlockKey,
+              insideSpanKey,
+              'bar',
+              insideLinkKey,
+              'https://example.com/inside',
+            ),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalLink]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-link"]')
+          ?.textContent,
+      ).toEqual('bar')
+      expect(calloutEl!.querySelector('[data-testid="global-link"]')).toEqual(
+        null,
+      )
+    })
+
+    expect(
+      document.querySelector('[data-testid="global-link"]')?.textContent,
+    ).toEqual('foo')
+    expect(receivedNode).toEqual({
+      _key: insideLinkKey,
+      _type: 'link',
+      href: 'https://example.com/inside',
+    })
+  })
+
+  test('positional annotation with render: undefined falls through to the global render', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+    const insideLinkKey = keyGenerator()
+
+    const globalLink = defineAnnotation({
+      type: 'link',
+      render: ({annotation, children}) => (
+        <a
+          data-testid="global-link"
+          href={(annotation as {href?: string}).href}
+        >
+          {children}
+        </a>
+      ),
+    })
+    const positionalLink = defineAnnotation({type: 'link'})
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalLink],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutAnnotationSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            linkedBlock(
+              insideBlockKey,
+              insideSpanKey,
+              'bar',
+              insideLinkKey,
+              'https://example.com/inside',
+            ),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalLink]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="global-link"]')?.textContent,
+      ).toEqual('bar')
+    })
+  })
+
+  test("positional '*' annotation beats global exact", async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+    const insideLinkKey = keyGenerator()
+
+    const globalLink = defineAnnotation({
+      type: 'link',
+      render: ({annotation, children}) => (
+        <a
+          data-testid="global-link"
+          href={(annotation as {href?: string}).href}
+        >
+          {children}
+        </a>
+      ),
+    })
+    const positionalWildcard = defineAnnotation({
+      type: '*',
+      render: ({children}) => (
+        <mark data-testid="positional-wildcard">{children}</mark>
+      ),
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalWildcard],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutAnnotationSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            linkedBlock(
+              insideBlockKey,
+              insideSpanKey,
+              'bar',
+              insideLinkKey,
+              'https://example.com/inside',
+            ),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalLink]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-wildcard"]')
+          ?.textContent,
+      ).toEqual('bar')
+      expect(calloutEl!.querySelector('[data-testid="global-link"]')).toEqual(
+        null,
+      )
+    })
+  })
+
+  test('positional exact decorator with render: undefined falls through to global, ignoring a sibling positional wildcard', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+
+    const globalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <strong data-testid="global-strong">{children}</strong>
+      ),
+    })
+    const positionalStrong = defineDecorator({type: 'strong'})
+    const positionalWildcard = defineDecorator({
+      type: '*',
+      render: ({children}) => (
+        <mark data-testid="positional-wildcard">{children}</mark>
+      ),
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalStrong, positionalWildcard],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutDecoratorSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            markedBlock(insideBlockKey, insideSpanKey, 'bar', 'strong'),
+          ],
+        },
+      ],
+      children: <NodePlugin nodes={[callout, globalStrong]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="global-strong"]')?.textContent,
+      ).toEqual('bar')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-wildcard"]'),
+      ).toEqual(null)
+    })
+  })
+
+  test('positional decorator beats renderDecorator prop when no global registration exists', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const calloutKey = keyGenerator()
+    const insideBlockKey = keyGenerator()
+    const insideSpanKey = keyGenerator()
+
+    const positionalStrong = defineDecorator({
+      type: 'strong',
+      render: ({children}) => (
+        <mark data-testid="positional-strong">{children}</mark>
+      ),
+    })
+    const calloutBlock = defineTextBlock({
+      type: 'block',
+      of: [positionalStrong],
+    })
+    const callout = defineContainer({
+      type: 'callout',
+      arrayField: 'content',
+      render: ({attributes, children}) => (
+        <aside data-testid="callout" {...attributes}>
+          {children}
+        </aside>
+      ),
+      of: [calloutBlock],
+    })
+
+    const renderDecorator = vi.fn((props: BlockDecoratorRenderProps) => (
+      <span data-testid="legacy-strong">{props.children}</span>
+    ))
+
+    await createTestEditor({
+      keyGenerator,
+      schemaDefinition: calloutDecoratorSchema,
+      initialValue: [
+        {
+          _key: calloutKey,
+          _type: 'callout',
+          content: [
+            markedBlock(insideBlockKey, insideSpanKey, 'bar', 'strong'),
+          ],
+        },
+      ],
+      editableProps: {renderDecorator},
+      children: <NodePlugin nodes={[callout]} />,
+    })
+
+    await vi.waitFor(() => {
+      const calloutEl = document.querySelector('[data-testid="callout"]')
+      expect(
+        calloutEl!.querySelector('[data-testid="positional-strong"]')
+          ?.textContent,
+      ).toEqual('bar')
+    })
+
+    expect(renderDecorator).not.toHaveBeenCalled()
+  })
+})
+
+function markedBlock(
+  blockKey: string,
+  spanKey: string,
+  text: string,
+  mark: string,
+) {
+  return {
+    _key: blockKey,
+    _type: 'block' as const,
+    children: [{_key: spanKey, _type: 'span' as const, text, marks: [mark]}],
+    markDefs: [],
+    style: 'normal',
+  }
+}
+
+function linkedBlock(
+  blockKey: string,
+  spanKey: string,
+  text: string,
+  linkKey: string,
+  href: string,
+) {
+  return {
+    _key: blockKey,
+    _type: 'block' as const,
+    children: [{_key: spanKey, _type: 'span' as const, text, marks: [linkKey]}],
+    markDefs: [{_key: linkKey, _type: 'link' as const, href}],
+    style: 'normal',
+  }
+}


### PR DESCRIPTION
## What

Registered decorators and annotations (#3097) were global: one render per type, everywhere. This PR gives them the positional layer spans and inline objects already have: a `defineTextBlock` registration's `of` array accepts `Decorator | Annotation` entries, so the same decorator or annotation renders one way at the top level and another way inside that text block type:

```tsx
defineTextBlock({
  type: 'block',
  of: [
    defineDecorator({
      type: 'strong',
      render: ({children}) => <mark>{children}</mark>,
    }),
    defineAnnotation({
      type: 'link',
      render: ({children}) => <span className="cell-link">{children}</span>,
    }),
  ],
})
```

The playground shows both kinds: inside table cells, `strong` renders highlighted and `link` as a green dotted underline; outside, both render through the top-level `'*'` registrations. Run `pnpm dev:playground`, add a table, and toggle bold or add a link inside and outside a cell.

## Design notes

The feature reuses the existing positional machinery rather than adding a parallel one: `resolveTextBlockConfig` resolves the new entries into `TextBlockConfig.of`, and `RenderSpan`'s decorator and annotation loops consult the parent config from `ParentTextBlockContext` before the global maps. Resolution per decorator or annotation is positional exact, positional `'*'`, global exact, global `'*'`, legacy prop, and the fall-through rule is `useSpanConfig`'s: a positional entry without `render` falls through to the global layer (skipping a positional `'*'` sibling), it does not silence it. Every rung is pinned by a browser test in `tests/positional-override-decorator-annotation.test.tsx`, including positional-beats-legacy-prop and the exact-without-render-skips-sibling-wildcard edge.

One latent misfire is fixed by the widening: `findInlinePositionalOverride` treated every non-span `of` entry as an inline object, so a decorator entry would have hijacked inline-object positional lookup; the kind checks now discriminate all four entry kinds. With no positional decorator or annotation entries the dispatch is value-equivalent to before, and the pre-existing positional-override suites pass unchanged. These entries deliberately do not surface in `snapshot.context.containers`, which exposes only span/block-object/inline-object positional entries.

The containers guide teaches the new entries next to the existing positional-override examples, and the changeset covers the widened `of` union.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches leaf-level render dispatch for every decorator and annotation mark, but behavior is unchanged when no positional entries exist; precedence is covered by extensive browser tests.
> 
> **Overview**
> **`defineTextBlock`'s `of` array now accepts `defineDecorator` and `defineAnnotation` entries**, so decorator and annotation renders can differ inside a scoped text block (e.g. table cells) while global registrations still apply elsewhere—the same positional model spans and inline objects already use.
> 
> Resolution flows through **`resolveTextBlockConfig`** into **`TextBlockConfig.of`**, and **`RenderSpan`** picks configs via **`ParentTextBlockContext`**: positional exact, then positional `'*'`, then global maps, with **omitted `render` on a positional entry falling through to global** (not silencing). **`findInlinePositionalOverride`** is tightened so decorator/annotation `of` entries no longer match inline-object lookup.
> 
> Docs (**containers** guide), a **playground table-cell demo**, a **changeset**, and **`positional-override-decorator-annotation.test.tsx`** cover precedence, wildcards, legacy `renderDecorator`/`renderAnnotation`, and the exact-without-render vs sibling-wildcard edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6289d01f33a16054ac59924dae761c58d2800de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->