### PR TITLE
docs: link the clipboard page and section overviews from the sidebar

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -110,14 +110,17 @@ export default defineConfig({
             {
               label: 'Concepts',
               items: [
+                {slug: 'editor/concepts', label: 'Overview'},
                 {slug: 'editor/concepts/portabletext'},
                 {slug: 'editor/concepts/behavior'},
                 {slug: 'editor/concepts/containers'},
+                {slug: 'editor/concepts/clipboard'},
               ],
             },
             {
               label: 'Guides',
               items: [
+                {slug: 'editor/guides', label: 'Overview'},
                 {slug: 'editor/guides/custom-rendering'},
                 {slug: 'editor/guides/migrate-render-props'},
                 {slug: 'editor/guides/customize-toolbar'},

--- a/apps/docs/src/content/docs/editor/concepts/index.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/index.mdx
@@ -16,3 +16,7 @@ Nest editable block content inside custom structures like callouts, code blocks,
 ### [Behaviors](/editor/concepts/behavior/)
 
 How behaviors work in the editor. Events, guards, and actions: the pattern that lets you customize how users interact with the editor.
+
+### [Clipboard](/editor/concepts/clipboard/)
+
+How copy and paste run through behaviors: the events in each direction and how several behaviors compose around the same clipboard.


### PR DESCRIPTION
The clipboard concepts page (`/editor/concepts/clipboard/`) was unreachable from the docs menu: the sidebar is hand-maintained in `astro.config.mjs`, and the page landed without an entry. The concepts landing page skipped it too.

This PR adds the sidebar entry after Containers, a card for the page on the concepts landing page, and Overview entries for the Concepts and Guides groups. Starlight group labels are not links, so those two landing pages were reachable only by direct URL. Verified with the docs build, whose links validator checks the new slugs and link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only sidebar and landing-page link changes with no runtime or product behavior impact.
> 
> **Overview**
> Fixes discoverability for editor docs that already existed but were missing from hand-maintained navigation.
> 
> The Starlight sidebar in `astro.config.mjs` now includes **Overview** links for the **Concepts** and **Guides** groups (group labels are not clickable), adds **`editor/concepts/clipboard`** after Containers, and the **Concepts** landing page (`editor/concepts/index.mdx`) gets a card linking to the clipboard concepts page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8623858b7935842fceddb996f3604ad9103763fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->