### PR TITLE
test: run the mark Gherkin suites through registered decorator and annotation renders

### DIFF
--- a/packages/editor/gherkin-tests/registered-decorator-annotation-renders.test.tsx
+++ b/packages/editor/gherkin-tests/registered-decorator-annotation-renders.test.tsx
@@ -1,0 +1,137 @@
+import {Given} from 'racejar'
+import {Feature} from 'racejar/vitest'
+import annotationsAcrossBlocksFeature from '../gherkin-spec/annotations-across-blocks.feature?raw'
+import annotationsCollaborationFeature from '../gherkin-spec/annotations-collaboration.feature?raw'
+import annotationsEdgeCasesFeature from '../gherkin-spec/annotations-edge-cases.feature?raw'
+import annotationsOverlappingDecoratorsFeature from '../gherkin-spec/annotations-overlapping-decorators.feature?raw'
+import annotationsOverlappingFeature from '../gherkin-spec/annotations-overlapping.feature?raw'
+import annotationsFeature from '../gherkin-spec/annotations.feature?raw'
+import decoratorsOverlappingFeature from '../gherkin-spec/decorators-overlapping.feature?raw'
+import decoratorsFeature from '../gherkin-spec/decorators.feature?raw'
+import {defineAnnotation, defineDecorator} from '../src'
+import {NodePlugin} from '../src/plugins'
+import {parameterTypes} from '../src/test'
+import {
+  createTestEditor,
+  createTestEditors,
+  gherkinSchemaDefinition,
+  stepDefinitions,
+} from '../src/test/vitest'
+import type {Context} from '../src/test/vitest/step-context'
+
+// Pins that editing through custom decorator/annotation DOM (typing,
+// splitting, toggling, caret movement) behaves the same as through the
+// engine's default markup. No other suite edits through registered
+// wrappers, so a regression there would otherwise only surface as a
+// rendering bug, not an editing one.
+const registeredRenderNodes = [
+  defineDecorator({
+    type: '*',
+    render: ({decorator, children}) =>
+      decorator === 'strong' ? (
+        <strong>{children}</strong>
+      ) : (
+        <em>{children}</em>
+      ),
+  }),
+  defineAnnotation({
+    type: '*',
+    render: ({annotation, children}) => (
+      <span data-annotation={annotation._type}>{children}</span>
+    ),
+  }),
+]
+
+const oneEditorWithRegisteredRenders = Given(
+  'one editor',
+  async (context: Context) => {
+    const {editor, locator} = await createTestEditor({
+      schemaDefinition: gherkinSchemaDefinition,
+      children: <NodePlugin nodes={registeredRenderNodes} />,
+    })
+
+    context.locator = locator
+    context.editor = editor
+  },
+)
+const twoEditorsWithRegisteredRenders = Given(
+  'two editors',
+  async (context: Context) => {
+    const {editor, locator, editorB, locatorB} = await createTestEditors({
+      schemaDefinition: gherkinSchemaDefinition,
+      children: <NodePlugin nodes={registeredRenderNodes} />,
+    })
+
+    context.locator = locator
+    context.editor = editor
+    context.locatorB = locatorB
+    context.editorB = editorB
+  },
+)
+
+const stepDefinitionsWithoutEditorMounts = stepDefinitions.filter(
+  (stepDefinition) =>
+    stepDefinition.text !== 'one editor' &&
+    stepDefinition.text !== 'two editors',
+)
+if (stepDefinitionsWithoutEditorMounts.length !== stepDefinitions.length - 2) {
+  // A silent filter no-op would run every scenario without the wrappers
+  // and stay green; fail loudly instead.
+  throw new Error(
+    'Expected to replace the `one editor` and `two editors` step definitions',
+  )
+}
+
+const registeredRenderStepDefinitions = [
+  ...stepDefinitionsWithoutEditorMounts,
+  oneEditorWithRegisteredRenders,
+  twoEditorsWithRegisteredRenders,
+]
+
+Feature({
+  featureText: decoratorsFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: decoratorsOverlappingFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsOverlappingFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsOverlappingDecoratorsFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsAcrossBlocksFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsEdgeCasesFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})
+
+Feature({
+  featureText: annotationsCollaborationFeature,
+  stepDefinitions: registeredRenderStepDefinitions,
+  parameterTypes,
+})

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -32,7 +32,10 @@ import {reverseSelection} from '../../utils/util.reverse-selection'
 import type {Parameter} from '../gherkin-parameter-types'
 import type {Context} from './step-context'
 
-const schemaDefinition = defineSchema({
+/**
+ * @internal
+ */
+export const gherkinSchemaDefinition = defineSchema({
   annotations: [{name: 'comment'}, {name: 'link'}],
   decorators: [{name: 'em'}, {name: 'strong'}],
   blockObjects: [{name: 'image'}, {name: 'break'}],
@@ -207,7 +210,7 @@ async function selectionFromInput(context: Context, textspec: string) {
 export const stepDefinitions = [
   Given('one editor', async (context: Context) => {
     const {editor, locator} = await createTestEditor({
-      schemaDefinition,
+      schemaDefinition: gherkinSchemaDefinition,
     })
 
     context.locator = locator
@@ -215,7 +218,7 @@ export const stepDefinitions = [
   }),
   Given('two editors', async (context: Context) => {
     const {editor, locator, editorB, locatorB} = await createTestEditors({
-      schemaDefinition,
+      schemaDefinition: gherkinSchemaDefinition,
     })
 
     context.locator = locator


### PR DESCRIPTION
No test edited through a registered decorator or annotation wrapper: the registration suites render custom wrappers but never type, the Gherkin behavior suites type but mount a bare editor, and the legacy render-prop tests that do use keyboard input render `props.children` without a wrapper. Custom decorator/annotation DOM changes what the engine maps selections against, so typing, splitting, toggling, and caret movement through it were unpinned.

This PR re-runs the eight mark-related feature files verbatim against an editor mounting `'*'` `defineDecorator`/`defineAnnotation` registrations with real wrappers (`<strong>`/`<em>` per decorator, an attribute-carrying `<span>` per annotation). No feature file changes: the features' own `Given one editor`/`Given two editors` steps mount the editor, so the variant swaps exactly those two step definitions for versions that add a `NodePlugin`, and a guard throws if the swap ever stops matching, since a silent no-op would run every scenario without wrappers and stay green. The collaboration feature needs no special handling: the two-editor harness mounts the same `children` in both editors. The only source change is exporting the previously private default Gherkin schema (`gherkinSchemaDefinition`, internal test module) so the swapped steps pass what the originals pass.

151 scenarios, matching the combined count of the three original runners, all green on chromium. The wrappers are proven load-bearing: dropping `children` from the decorator wrapper fails 68 of 151 while the original runners stay green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cf6968b05fe1b9147b1f0af37df595051eaaecdf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->