### PR TITLE
docs: say why `renderPlaceholder` stays unmigrated in the render-props guide

### DIFF
--- a/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
+++ b/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
@@ -355,4 +355,4 @@ function App() {
 }
 ```
 
-`renderPlaceholder` is the only render prop left unmigrated: it has no registration equivalent, so it stays as is. `rangeDecorations` is a separate data prop, not a render prop: it carries a component that wraps a span's rendered output from the outside, after the span (registered or not) has already rendered, so it is untouched by this migration too.
+`renderPlaceholder` is the only render prop left unmigrated: registrations render nodes identified by a schema type, and the placeholder is empty-editor chrome with no type to register under, so it stays as is. `rangeDecorations` is a separate data prop, not a render prop: it carries a component that wraps a span's rendered output from the outside, after the span (registered or not) has already rendered, so it is untouched by this migration too.


### PR DESCRIPTION
The migration guide says `renderPlaceholder` stays unmigrated, but not why, so the question comes back every time someone sweeps the remaining render props. Now it gives the reason: registrations render nodes identified by a schema type, and the placeholder is empty-editor chrome with no type to register under.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 117ca0012d160844611ceef9906ef015ff4bb6c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->