### PR TITLE
docs: teach mark registrations as the recommended rendering path

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -113,6 +113,7 @@ export default defineConfig({
                 {slug: 'editor/concepts', label: 'Overview'},
                 {slug: 'editor/concepts/portabletext'},
                 {slug: 'editor/concepts/behavior'},
+                {slug: 'editor/concepts/rendering'},
                 {slug: 'editor/concepts/containers'},
                 {slug: 'editor/concepts/clipboard'},
               ],

--- a/apps/docs/src/components/editor/portable-text-editor.tsx
+++ b/apps/docs/src/components/editor/portable-text-editor.tsx
@@ -1,5 +1,7 @@
 import './editor.css'
 import {
+  defineAnnotation,
+  defineDecorator,
   EditorProvider,
   PortableTextEditable,
   type BlockRenderProps,
@@ -7,7 +9,7 @@ import {
   type PortableTextBlock,
   type SchemaDefinition,
 } from '@portabletext/editor'
-import {EventListenerPlugin} from '@portabletext/editor/plugins'
+import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {TypographyPlugin} from '@portabletext/plugin-typography'
 import {PortableText} from '@portabletext/react'
@@ -22,6 +24,43 @@ import {
 import {defaultSchema} from './defaultSchema'
 import {initialValue as defaultInitialValue} from './initial-value'
 import {PortableTextToolbar} from './toolbar/portable-text-toolbar'
+
+// Module scope: a new array identity re-registers the nodes on every render.
+const nodes = [
+  defineDecorator({
+    type: 'strong',
+    render: ({children}) => <strong>{children}</strong>,
+  }),
+  defineDecorator({
+    type: 'em',
+    render: ({children}) => <em>{children}</em>,
+  }),
+  defineDecorator({
+    type: 'underline',
+    render: ({children}) => <span className="underline">{children}</span>,
+  }),
+  defineAnnotation({
+    type: 'link',
+    render: ({annotation, children}) => {
+      const href =
+        typeof annotation.href === 'string' ? annotation.href : undefined
+      return (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-blue-700 dark:text-blue-400 underline">
+                {children}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="text-xs">{href || 'No URL'}</span>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )
+    },
+  }),
+]
 
 type PortableTextEditorProps = {
   customSchema?: SchemaDefinition
@@ -81,6 +120,7 @@ export function PortableTextEditor({customSchema}: PortableTextEditorProps) {
           }}
         />
         <TypographyPlugin />
+        <NodePlugin nodes={nodes} />
         <div className="w-full mb-4">
           <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
             <div className="bg-gray-50 dark:bg-gray-800 px-2 py-1 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-4">
@@ -175,38 +215,6 @@ export function PortableTextEditor({customSchema}: PortableTextEditorProps) {
                   )
                 }
                 return <p className="mb-1 relative">{props.children}</p>
-              }}
-              renderDecorator={(props) => {
-                if (props.value === 'strong') {
-                  return <strong>{props.children}</strong>
-                }
-                if (props.value === 'em') {
-                  return <em>{props.children}</em>
-                }
-                if (props.value === 'underline') {
-                  return <span className="underline">{props.children}</span>
-                }
-                return props.children
-              }}
-              renderAnnotation={(props) => {
-                if (props.schemaType.name === 'link') {
-                  const href = (props.value as {href?: string}).href
-                  return (
-                    <TooltipProvider delayDuration={300}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="text-blue-700 dark:text-blue-400 underline">
-                            {props.children}
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <span className="text-xs">{href || 'No URL'}</span>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )
-                }
-                return props.children
               }}
               renderPlaceholder={() => (
                 <span className="text-gray-400 dark:text-gray-500">

--- a/apps/docs/src/content/docs/editor/concepts/clipboard.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/clipboard.mdx
@@ -2,7 +2,7 @@
 title: Clipboard
 description: How the editor turns a selection into clipboard data and clipboard data back into content, and how behaviors compose when several of them care about the same clipboard.
 sidebar:
-  order: 3
+  order: 4
 ---
 
 import {LinkCard} from '@astrojs/starlight/components'

--- a/apps/docs/src/content/docs/editor/concepts/containers.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/containers.mdx
@@ -2,7 +2,7 @@
 title: Containers
 description: Nest editable block content inside custom structures like callouts, code blocks, and tables, while the value stays plain Portable Text.
 sidebar:
-  order: 2
+  order: 3
 ---
 
 A container is a block object that holds editable block content: one of its fields is an array whose members include text blocks (or further containers). Containers are how callouts carry editable paragraphs, code blocks carry editable lines, and tables carry editable cells, without leaving Portable Text.
@@ -107,6 +107,8 @@ The render contract:
 - Spread `attributes` onto your outer element so the engine can track the node.
 - Render `children` where the editable content goes; the engine fills it with the container's blocks.
 - Mark any chrome that is not editable content (icons, buttons, drag handles) with `contentEditable={false}`.
+- `selected` is `true` when the container is the current selection; use it for selection styling, as `data-selected` above does.
+- `readOnly` is `true` when the editor is read-only; check it before making chrome interactive, for example `draggable={!readOnly}` on a drag handle.
 - `renderDefault` renders the engine's minimal wrapper; call it to fall back or wrap the default.
 
 Omitting `render` falls through to the engine default, so a registration can exist purely to mark the field as editable.
@@ -115,11 +117,13 @@ Registering a container also normalizes the value: existing blocks of the regist
 
 A container registration that doesn't match the schema is skipped with a `console.warn` naming the actual mismatch: an unknown type, a missing field, a field that isn't an array, or an array of primitives only. The editor keeps working; the type renders as an ordinary block object until the registration and schema agree.
 
+Containers only exist as registrations, there's no legacy render prop to migrate from. If the rest of your editor still renders through the deprecated props, the [migration guide](/editor/guides/migrate-render-props/) covers moving those to registrations too.
+
 ## Editing follows the sub-schema
 
 Inside a container, the editor resolves the schema at the caret, not the top-level schema. A code block whose sub-schema declares no decorators won't accept bold, whether from the keyboard, the toolbar, or a paste.
 
-Schema-aware plugins get the same gating for free, because their callbacks receive the sub-schema at the caret as `context.schema`. Take a schema whose code block forbids decorators, and a Markdown shortcut configured by schema lookup:
+Schema-aware plugins get the same gating for free: `MarkdownShortcutsPlugin` passes each callback a `context` object carrying the schema at the caret as `context.schema`. Take a schema whose code block forbids decorators, and a Markdown shortcut configured by schema lookup:
 
 ```tsx
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
@@ -155,11 +159,11 @@ The callback runs against the schema at the caret. In a regular paragraph the lo
 
 Your own code can resolve the schema at any position with `getPathSubSchema` from `@portabletext/editor/traversal`.
 
-## Registrations own their rendering subtree
+## Narrow rendering with `of`
 
-A registered node's markup is yours: the engine hands your `render` the `attributes` you spread on your outer element and the `children` you render inside it, and adds nothing else. The callout render above already shows the whole interface.
+A registration's markup ownership, and how the engine dispatches between global and positional renders, is one model shared by every kind of registration. [Rendering](/editor/concepts/rendering/) covers that model; this page covers the part specific to containers: an `of` array scopes registrations to positions inside one.
 
-That ownership covers everything inside the node, a rendering subtree. Unregistered node types inside it render through the engine defaults: a registered callout holding an unregistered text block renders your `<aside>` with default paragraphs inside. Register both to own both:
+A container's `of` entry beats the global registration for the same type, one level down, in its immediate children. A code block can render its lines without paragraph spacing, or a callout can render its paragraphs tighter than the rest of the document:
 
 ```tsx
 import {defineContainer, defineTextBlock} from '@portabletext/editor'
@@ -196,9 +200,9 @@ const nodes = [
 ]
 ```
 
-The `of` entry scopes its registration to the callout's immediate children, where it beats the global registration for the same type: paragraphs render through the first `defineTextBlock` everywhere else and through the tighter one inside the callout.
+Paragraphs render through the first `defineTextBlock` everywhere else and through the tighter one inside the callout.
 
-A text block's own `of` goes one level deeper, into `defineDecorator` and `defineAnnotation` entries. Register the same decorator globally and positionally to see the scoping:
+Any text block's `of` can scope marks one level deeper, into `defineDecorator` and `defineAnnotation` entries, whether or not that text block sits inside a container; it lives on this page because `of` scoping is this page's subject. Register the same decorator globally and positionally to see the scoping:
 
 ```tsx
 defineDecorator({
@@ -222,20 +226,7 @@ defineTextBlock({
 })
 ```
 
-With both registered, `strong` renders as `<mark>` inside these text blocks and as `<strong>` everywhere else. Remove the positional entry's `render` and `strong` renders as `<strong>` everywhere: an entry without a `render` defers to the global registration instead of silencing it, the same fall-through rule every positional `of` entry on this page follows. `'*'` entries work at both levels and lose to an exact `type` match at the same level.
-
-Inline objects and spans sit inside a text block's line, so the DOM around them belongs to whoever renders that text block: register the text block too when you want to own it. Decorator and annotation rendering on the spans inside `children` happens through `defineDecorator`/`defineAnnotation` registrations, global or positional, or the deprecated `renderDecorator`/`renderAnnotation` render props, no matter who renders the block; `renderPlaceholder` and range decorations keep composing the same way regardless.
-
-Two rendering concerns ship as plugins:
-
-- List numbering: your text-block render reads `node.listItem` and `node.level` for list markup, and [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, correct across nesting, remote edits, and non-list blocks interrupting a list.
-- Drop indicators: pointer-driven UI rendered by you. [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's public `drag.*` events.
-
-Both plugins follow the same pattern: a provider inside `EditorProvider`, and a hook read from a component your `render` returns, not inline in the `render` callback, since hooks can't run there. Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
-
-:::note[Migrating from the render props?]
-If your editor still renders through the deprecated render props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`), each has a registration equivalent, and the engine dispatches per `_type`, so you can migrate one kind at a time. The [migration guide](/editor/guides/migrate-render-props/) walks through it.
-:::
+With both registered, `strong` renders as `<mark>` inside these text blocks and as `<strong>` everywhere else. A global `defineDecorator` or `defineAnnotation` renders inside every text block; a positional entry, registered through a text block's `of`, only renders inside that scope, everywhere else the global registration still applies. Remove the positional entry's `render` and `strong` renders as `<strong>` everywhere: an `of` entry without its own `render` defers to the global registration, or, absent one, whatever would have rendered anyway. That is a different fall-through than a top-level registration: a top-level registration without `render` falls to the engine default, while an `of` entry without `render` falls to the global registration first. See [Dispatch precedence](/editor/concepts/rendering/#dispatch-precedence) for how positional, global, and the `'*'` catch-all rank against each other.
 
 ## Nest containers
 
@@ -372,9 +363,9 @@ function App() {
 
 An `image` block at the document root renders through the global registration, full width. The same `_type: 'image'` inside the callout's `content` hits the positional override first and renders compact. The text block registration needs no positional counterpart: `type: 'block'` already covers both scopes.
 
-Positional overrides only need to carry what they change: an `of` entry that omits `render` falls through to the global registration's render, so a positional registration never has to re-implement what the global one already does. Calling `renderDefault` is different: it renders the engine default at any position, never the global registration's render.
+Both registrations call `renderDefault` when `node.src` isn't a string; see [`renderDefault`](/editor/concepts/rendering/#renderdefault) on the Rendering page for what that falls back to.
 
-Decorators and annotations scope the same way, one level deeper: a `defineDecorator` or `defineAnnotation` entry inside the callout's text block `of` (as shown under [Registrations own their rendering subtree](#registrations-own-their-rendering-subtree)) makes an annotation like `link` render differently only inside the callout, and the text block entry needs no `render` of its own to carry it.
+Decorators and annotations scope the same way, one level deeper: a `defineDecorator` or `defineAnnotation` entry inside the callout's text block `of` (as shown under [Narrow rendering with `of`](#narrow-rendering-with-of)) makes an annotation like `link` render differently only inside the callout, and the text block entry needs no `render` of its own to carry it.
 
 ## Read the registered containers
 

--- a/apps/docs/src/content/docs/editor/concepts/index.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/index.mdx
@@ -9,6 +9,10 @@ Learn about the building blocks of Portable Text and how the editor works.
 
 The parts that make up the Portable Text Editor: schema, styles, decorators, annotations, lists, block objects, inline objects, and how they connect. Includes a glossary of common terms.
 
+### [Rendering](/editor/concepts/rendering/)
+
+How node registrations own the editor's markup, and how the engine dispatches between global, positional, and legacy renders.
+
 ### [Containers](/editor/concepts/containers/)
 
 Nest editable block content inside custom structures like callouts, code blocks, and tables, while the value stays plain Portable Text.

--- a/apps/docs/src/content/docs/editor/concepts/rendering.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/rendering.mdx
@@ -1,0 +1,119 @@
+---
+title: Rendering
+description: How node registrations own the editor's markup, and how the engine dispatches between global, positional, and legacy renders.
+sidebar:
+  order: 2
+---
+
+The editor renders every kind of Portable Text node, text blocks, spans, decorators, annotations, block objects, and inline objects, through the same mechanism: a node registration. This page covers the model that every registration shares. [Containers](/editor/concepts/containers/) covers the container-specific factory and how `of` scopes a registration to positions inside one.
+
+## Markup ownership
+
+Every registration owns its markup: your `render` gets `children` to render where the editable content goes, and the engine adds nothing around what you return (with one exception: annotations compose inside an engine-owned anchor span). Every kind except decorators and annotations also receives `attributes` to spread on the outer element, so the engine can track the node; decorators and annotations wrap inline content rather than owning an element the engine tracks, so their `render` receives no `attributes`.
+
+```tsx
+import {defineTextBlock} from '@portabletext/editor'
+
+const paragraph = defineTextBlock({
+  type: 'block',
+  render: ({attributes, children, node}) => (
+    <p {...attributes} data-style={node.style}>
+      {children}
+    </p>
+  ),
+})
+```
+
+Spread `attributes` onto your outer element when your registration receives one, and render `children` where the editable content goes. That's the whole interface: no hidden classes, no wrapper the engine adds behind your back.
+
+## Register a node
+
+The schema declares what the editor allows; a registration only renders what the schema already permits. `defineDecorator({type: 'strong'})` and `defineAnnotation({type: 'link'})` below render because the schema declares a `strong` decorator and a `link` annotation:
+
+```tsx
+import {defineSchema} from '@portabletext/editor'
+
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}],
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+})
+```
+
+Each node kind has a factory: `defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`, `defineDecorator`, `defineAnnotation`, and `defineContainer` (see [Containers](/editor/concepts/containers/) for that one). Every factory returns a plain registration object; mount them together through one `NodePlugin`:
+
+```tsx
+import {
+  defineAnnotation,
+  defineDecorator,
+  defineTextBlock,
+  EditorProvider,
+  PortableTextEditable,
+} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
+
+// Module scope: a new array identity re-registers the nodes on every render.
+const nodes = [
+  defineTextBlock({
+    type: 'block',
+    render: ({attributes, children}) => <p {...attributes}>{children}</p>,
+  }),
+  defineDecorator({
+    type: 'strong',
+    render: ({children}) => <strong>{children}</strong>,
+  }),
+  defineAnnotation({
+    type: 'link',
+    render: ({annotation, children}) => (
+      <a href={String((annotation as {href?: string}).href ?? '')}>
+        {children}
+      </a>
+    ),
+  }),
+]
+
+function App() {
+  return (
+    <EditorProvider initialConfig={{schemaDefinition}}>
+      <NodePlugin nodes={nodes} />
+      <PortableTextEditable />
+    </EditorProvider>
+  )
+}
+```
+
+`annotation` is the markDef object from the block's `markDefs`: `{_key, _type, ...fields}`, cast here from its `unknown` index signature to read `href`. Each render callback is a plain function call, not a component: when a render needs hooks, return a component instead, `render: (props) => <MyAnnotation {...props} />`.
+
+Keep `nodes` at module scope, as above: a fresh array identity on every render makes `NodePlugin` unregister and re-register every keystroke.
+
+## Subtree ownership
+
+A block-level registration (a text block, block object, or container) owns everything rendered inside it, its rendering subtree. Unregistered node types inside it fall back to the engine defaults: a registered text block holding an unregistered inline object still renders that inline object through the engine's default wrapper, not through markup you control. Register a node type when you need to own its markup, wherever it appears.
+
+## Dispatch precedence
+
+At a given position, a positional registration (one scoped through a container or text block's own `of`, see [Containers](/editor/concepts/containers/)) beats a global registration, which beats the deprecated `renderDecorator`/`renderAnnotation` render props on `<PortableTextEditable>`. Within a level, an exact `type` match beats a `'*'` catch-all.
+
+[Narrow rendering with `of`](/editor/concepts/containers/#narrow-rendering-with-of) covers how far a positional entry's scope reaches and what it falls back to when it omits `render`.
+
+## `renderDefault`
+
+Every render receives `renderDefault`, a function that renders the engine's minimal wrapper for that position. Call it to fall back, or to wrap the default instead of replacing it:
+
+```tsx
+render: (props) => props.renderDefault(props)
+```
+
+`renderDefault` is the engine default at any position: it never chains back to a global registration's render, even from inside a positional one. PTE has one user layer plus positional overrides, and the engine default is the canonical fallback everywhere. For block-level, span, and inline-object registrations the default is a minimal wrapper; for decorators the default is identity, the engine applies no decorator markup of its own. For annotations the default is identity too, but every known annotation renders inside an engine-owned anchor span the engine adds regardless of which render fires.
+
+## Plugins for lists and drag-and-drop
+
+Two rendering concerns ship as plugins instead of registration props:
+
+- List numbering: your text-block render reads `node.listItem` and `node.level` for list markup, and [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, correct across nesting, remote edits, and non-list blocks interrupting a list.
+- Drop indicators: pointer-driven UI rendered by you. [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's public `drag.*` events.
+
+Both plugins follow the same pattern: a provider inside `EditorProvider`, and a hook read from a component your `render` returns, not inline in the `render` callback, since hooks can't run there. Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
+
+:::note[Migrating from the render props?]
+If your editor still renders through the deprecated render props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`), each has a registration equivalent, and the engine dispatches per `_type`, so you can migrate one kind at a time. The [migration guide](/editor/guides/migrate-render-props/) walks through it.
+:::

--- a/apps/docs/src/content/docs/editor/concepts/rendering.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/rendering.mdx
@@ -88,11 +88,51 @@ Keep `nodes` at module scope, as above: a fresh array identity on every render m
 
 ## Subtree ownership
 
-A block-level registration (a text block, block object, or container) owns everything rendered inside it, its rendering subtree. Unregistered node types inside it fall back to the engine defaults: a registered text block holding an unregistered inline object still renders that inline object through the engine's default wrapper, not through markup you control. Register a node type when you need to own its markup, wherever it appears.
+A block-level registration (a text block, block object, or container) owns everything rendered inside it, its rendering subtree. Unregistered node types inside it fall back to the engine defaults: a registered text block holding an unregistered inline object still renders that inline object through the engine's default wrapper, not through markup you control. Register a node type when you need to own its markup, wherever it appears:
+
+```tsx
+const nodes = [
+  defineTextBlock({
+    type: 'block',
+    render: ({attributes, children}) => <p {...attributes}>{children}</p>,
+  }),
+  defineInlineObject({
+    type: 'stock-ticker',
+    render: (props) =>
+      typeof props.node.symbol === 'string' ? (
+        <span {...props.attributes}>
+          {props.children}
+          <span draggable={!props.readOnly} style={{display: 'inline-block'}}>
+            {props.node.symbol}
+          </span>
+        </span>
+      ) : (
+        props.renderDefault(props)
+      ),
+  }),
+]
+```
 
 ## Dispatch precedence
 
-At a given position, a positional registration (one scoped through a container or text block's own `of`, see [Containers](/editor/concepts/containers/)) beats a global registration, which beats the deprecated `renderDecorator`/`renderAnnotation` render props on `<PortableTextEditable>`. Within a level, an exact `type` match beats a `'*'` catch-all.
+At a given position, a positional registration (one scoped through a container or text block's own `of`, see [Containers](/editor/concepts/containers/)) beats a global registration, which beats the deprecated `renderDecorator`/`renderAnnotation` render props on `<PortableTextEditable>`. Within a level, an exact `type` match beats a `'*'` catch-all:
+
+```tsx
+const nodes = [
+  // `strong` hits the exact match...
+  defineDecorator({
+    type: 'strong',
+    render: ({children}) => <strong>{children}</strong>,
+  }),
+  // ...every other decorator hits the catch-all.
+  defineDecorator({
+    type: '*',
+    render: ({decorator, children}) => (
+      <span data-decorator={decorator}>{children}</span>
+    ),
+  }),
+]
+```
 
 [Narrow rendering with `of`](/editor/concepts/containers/#narrow-rendering-with-of) covers how far a positional entry's scope reaches and what it falls back to when it omits `render`.
 
@@ -104,6 +144,27 @@ Every render receives `renderDefault`, a function that renders the engine's mini
 render: (props) => props.renderDefault(props)
 ```
 
+Its most common use is the fallback branch of a field-presence check: a document can carry a partially filled value, and the engine default beats rendering nothing:
+
+```tsx
+defineBlockObject({
+  type: 'image',
+  render: (props) =>
+    typeof props.node.src === 'string' ? (
+      <figure {...props.attributes}>
+        <div contentEditable={false} draggable={!props.readOnly}>
+          <img src={props.node.src} alt="" />
+        </div>
+        {props.children}
+      </figure>
+    ) : (
+      props.renderDefault(props)
+    ),
+})
+```
+
+The `contentEditable={false}`/`draggable` wrapper is the block-object render contract; the [custom blocks guide](/editor/guides/custom-blocks/) covers it in full.
+
 `renderDefault` is the engine default at any position: it never chains back to a global registration's render, even from inside a positional one. PTE has one user layer plus positional overrides, and the engine default is the canonical fallback everywhere. For block-level, span, and inline-object registrations the default is a minimal wrapper; for decorators the default is identity, the engine applies no decorator markup of its own. For annotations the default is identity too, but every known annotation renders inside an engine-owned anchor span the engine adds regardless of which render fires.
 
 ## Plugins for lists and drag-and-drop
@@ -113,7 +174,34 @@ Two rendering concerns ship as plugins instead of registration props:
 - List numbering: your text-block render reads `node.listItem` and `node.level` for list markup, and [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, correct across nesting, remote edits, and non-list blocks interrupting a list.
 - Drop indicators: pointer-driven UI rendered by you. [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's public `drag.*` events.
 
-Both plugins follow the same pattern: a provider inside `EditorProvider`, and a hook read from a component your `render` returns, not inline in the `render` callback, since hooks can't run there. Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
+Both plugins follow the same pattern: a provider inside `EditorProvider`, and a hook read from a component your `render` returns, not inline in the `render` callback, since hooks can't run there:
+
+```tsx
+import type {TextBlockRenderProps} from '@portabletext/editor'
+import {useListIndex} from '@portabletext/plugin-list-index'
+
+const nodes = [
+  defineTextBlock({
+    type: 'block',
+    render: (props) => <TextBlock {...props} />,
+  }),
+]
+
+function TextBlock(props: TextBlockRenderProps) {
+  const listIndex = useListIndex(props.path)
+
+  return (
+    <p {...props.attributes}>
+      {listIndex !== undefined ? (
+        <span contentEditable={false}>{listIndex}. </span>
+      ) : null}
+      {props.children}
+    </p>
+  )
+}
+```
+
+`useListIndex` reads from `ListIndexProvider`, mounted inside `EditorProvider`. Each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
 
 :::note[Migrating from the render props?]
 If your editor still renders through the deprecated render props on `<PortableTextEditable>` (`renderBlock`, `renderChild`, `renderStyle`, `renderListItem`), each has a registration equivalent, and the engine dispatches per `_type`, so you can migrate one kind at a time. The [migration guide](/editor/guides/migrate-render-props/) walks through it.

--- a/apps/docs/src/content/docs/editor/concepts/rendering.mdx
+++ b/apps/docs/src/content/docs/editor/concepts/rendering.mdx
@@ -63,11 +63,12 @@ const nodes = [
   }),
   defineAnnotation({
     type: 'link',
-    render: ({annotation, children}) => (
-      <a href={String((annotation as {href?: string}).href ?? '')}>
-        {children}
-      </a>
-    ),
+    render: ({annotation, children}) =>
+      typeof annotation.href === 'string' ? (
+        <a href={annotation.href}>{children}</a>
+      ) : (
+        children
+      ),
   }),
 ]
 
@@ -81,7 +82,7 @@ function App() {
 }
 ```
 
-`annotation` is the markDef object from the block's `markDefs`: `{_key, _type, ...fields}`, cast here from its `unknown` index signature to read `href`. Each render callback is a plain function call, not a component: when a render needs hooks, return a component instead, `render: (props) => <MyAnnotation {...props} />`.
+`annotation` is the markDef object from the block's `markDefs`: `{_key, _type, ...fields}`. Its fields type as `unknown` because they depend on the schema, so narrow with `typeof` before use; the fallback renders `children` untouched, matching the engine default. Each render callback is a plain function call, not a component: when a render needs hooks, return a component instead, `render: (props) => <MyAnnotation {...props} />`.
 
 Keep `nodes` at module scope, as above: a fresh array identity on every render makes `NodePlugin` unregister and re-register every keystroke.
 

--- a/apps/docs/src/content/docs/editor/getting-started.mdx
+++ b/apps/docs/src/content/docs/editor/getting-started.mdx
@@ -20,10 +20,6 @@ This guide walks you through installing and configuring the Portable Text Editor
 If you already have Portable Text content and want to display it, see [Render Portable Text](/rendering/) instead.
 :::
 
-:::note[Prerequisites]
-This guide covers `@portabletext/editor`, `@portabletext/toolbar`, and `@portabletext/keyboard-shortcuts`. Requires React 19.2.8 or later. Check the [editor changelog](https://github.com/portabletext/editor/releases) for breaking changes.
-:::
-
 You'll need to:
 
 - Create a schema that defines your content elements.
@@ -44,7 +40,7 @@ Before starting, it helps to understand the components that make up the editor.
 
 ## Add the library to your project
 
-Start by installing the editor:
+Start by installing the editor (it requires React 19.2.8 or later):
 
 <PackageManagers pkg="@portabletext/editor" />
 

--- a/apps/docs/src/content/docs/editor/getting-started.mdx
+++ b/apps/docs/src/content/docs/editor/getting-started.mdx
@@ -26,7 +26,7 @@ This guide covers `@portabletext/editor`, `@portabletext/toolbar`, and `@portabl
 
 You'll need to:
 
-- Create a schema that defines the rich text and block content elements.
+- Create a schema that defines your content elements.
 - Create a toolbar to toggle and insert these elements.
 - Set up rendering for your text blocks and inline formatting, like bold and italic.
 - Render the editor.
@@ -38,8 +38,9 @@ Before starting, it helps to understand the components that make up the editor.
 - **Schema:** Describes the type of content the editor accepts. Think of this as the foundation for configuring the editor.
 - **`EditorProvider`:** Supplies the schema and initial state to the editor.
 - **`EventListenerPlugin`:** Listens to events emitted by the editor. Commonly used to update application state.
+- **Node registrations:** Own how each content element renders, mounted through `NodePlugin`. [Rendering](/editor/concepts/rendering/) covers the model.
 - **Toolbars:** UI elements that interact with the editor.
-- **`PortableTextEditable`:** The core editor component. Handles text rendering and manages behavior.
+- **`PortableTextEditable`:** The core editor component. Hosts the editable surface and manages behavior.
 
 ## Add the library to your project
 
@@ -52,15 +53,13 @@ Next, import the components and types you'll need:
 ```tsx
 // App.tsx
 import {
+  defineDecorator,
   defineSchema,
   defineTextBlock,
   EditorProvider,
   PortableTextEditable,
 } from '@portabletext/editor'
-import type {
-  PortableTextBlock,
-  RenderDecoratorFunction,
-} from '@portabletext/editor'
+import type {PortableTextBlock} from '@portabletext/editor'
 import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
 ```
 
@@ -70,7 +69,7 @@ You won't need all of these right away, but you can add them now.
 
 Before you can render the editor, you need a schema. The editor schema configures the types of content rendered by the editor.
 
-Start with a schema that includes some common rich text elements.
+Start with a schema that includes some common formatting elements.
 
 :::note
 This guide includes a limited set of schema types to get you started. See the [rendering guide](/editor/guides/custom-rendering/) for mark examples, and the [custom blocks guide](/editor/guides/custom-blocks/) for block and inline objects.
@@ -123,15 +122,13 @@ Add `react` and `useState`, then scaffold out a basic application component:
 ```tsx
 // app.tsx
 import {
+  defineDecorator,
   defineSchema,
   defineTextBlock,
   EditorProvider,
   PortableTextEditable,
 } from '@portabletext/editor'
-import type {
-  PortableTextBlock,
-  RenderDecoratorFunction,
-} from '@portabletext/editor'
+import type {PortableTextBlock} from '@portabletext/editor'
 import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {useState} from 'react'
 
@@ -176,9 +173,9 @@ Include the `App` component in your application and run it. You should see an ou
 
 ## Set up rendering for schema elements
 
-At this point the editor renders every text block as plain text, whatever its style. Fix that by registering a render for text blocks and creating render functions for the marks.
+At this point the editor renders every text block as plain text, whatever its style. Fix that by registering a `defineTextBlock` node for the text blocks and `defineDecorator` nodes for the marks. The [Rendering](/editor/concepts/rendering/) page covers the model these registrations share.
 
-If you're maintaining an editor that still renders through the deprecated `renderStyle`, `renderBlock`, and `renderListItem` props, see the [migration guide](/editor/guides/migrate-render-props/) to move to node registrations instead of following this section from scratch.
+If you're maintaining an editor that still renders through the deprecated `renderStyle`, `renderBlock`, `renderListItem`, `renderDecorator`, and `renderAnnotation` props, see the [migration guide](/editor/guides/migrate-render-props/) to move to node registrations instead of following this section from scratch.
 
 Start by registering the text block render with `defineTextBlock`. The editor dispatches every text block to this callback. Your callback owns the block's wrapper element, so spread `props.attributes` on the outermost element you return, and use the block's `style` to pick the element.
 
@@ -201,48 +198,45 @@ const textBlock = defineTextBlock({
     return <div {...props.attributes}>{props.children}</div>
   },
 })
-
-const nodes = [textBlock]
 ```
 
-Marks (decorators and annotations) use render functions instead. Render functions all follow the same format:
+Marks (decorators and annotations) join the same `nodes` array. Registrations all follow the same shape:
 
 - They take in props and return JSX elements.
-- They use the schema to make decisions.
-- They return JSX and pass `children` as a fallback.
+- They decide what to render from the registration's `type` and the node itself.
+- They return JSX that renders `children` somewhere inside it, the editable content the registration wraps.
 
 With this in mind, continue for the remaining schema types.
 
-Create a render function for decorators:
+Register a decorator with `defineDecorator`, one per decorator name:
 
 ```tsx
-const renderDecorator: RenderDecoratorFunction = (props) => {
-  if (props.value === 'strong') {
-    return <strong>{props.children}</strong>
-  }
-  if (props.value === 'em') {
-    return <em>{props.children}</em>
-  }
-  if (props.value === 'underline') {
-    return <u>{props.children}</u>
-  }
-  return <>{props.children}</>
-}
+const strong = defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+const em = defineDecorator({
+  type: 'em',
+  render: ({children}) => <em>{children}</em>,
+})
+const underline = defineDecorator({
+  type: 'underline',
+  render: ({children}) => <u>{children}</u>,
+})
+
+const nodes = [textBlock, strong, em, underline]
 ```
 
 :::note
-By default, text is rendered as an inline `span` element in the editor. While mark render functions return a fragment (`<>`) as the fallback, the registered text block render must return a block-level element, like a `<div>`.
+By default, text is rendered as an inline `span` element in the editor. A decorator's render can pass `children` through unwrapped, but the registered text block render must return a block-level element, like a `<div>`.
 :::
 
-Mount the registration with `NodePlugin` and pass the render functions to `PortableTextEditable`. Both belong inside the `EditorProvider`. Keep the `nodes` array itself at module scope, as above: a fresh array on every render would make `NodePlugin` unregister and re-register on every keystroke.
+Mount every registration through one `NodePlugin`, inside the `EditorProvider`. Keep the `nodes` array itself at module scope, as above: a fresh array on every render would make `NodePlugin` unregister and re-register on every keystroke.
 
 ```tsx
 <>
   <NodePlugin nodes={nodes} />
-  <PortableTextEditable
-    style={{border: '1px solid black', padding: '0.5em'}}
-    renderDecorator={renderDecorator}
-  />
+  <PortableTextEditable style={{border: '1px solid black', padding: '0.5em'}} />
 </>
 ```
 
@@ -378,7 +372,7 @@ In the next step, you'll add the toolbar to the editor.
 
 ## Bring it all together
 
-With render functions created and a toolbar in place, you can fully render the editor. Add the `Toolbar` inside the `EditorProvider`.
+With the registrations created and a toolbar in place, you can fully render the editor. Add the `Toolbar` inside the `EditorProvider`.
 
 ```tsx
 // App.tsx
@@ -407,7 +401,6 @@ function App() {
         <Toolbar />
         <PortableTextEditable
           style={{border: '1px solid black', padding: '0.5em'}}
-          renderDecorator={renderDecorator}
         />
       </EditorProvider>
     </>
@@ -456,8 +449,8 @@ Learn more about [behaviors](/editor/concepts/behavior/) and how to [create your
     href="/editor/guides/custom-rendering/"
   />
   <LinkCard
-    title="Nest rich text with containers"
-    description="Callouts, code blocks, and tables that carry editable Portable Text."
+    title="Nest block content with containers"
+    description="Callouts, code blocks, and tables that carry editable block content."
     href="/editor/concepts/containers/"
   />
   <LinkCard

--- a/apps/docs/src/content/docs/editor/guides/behavior-cheat-sheet.mdx
+++ b/apps/docs/src/content/docs/editor/guides/behavior-cheat-sheet.mdx
@@ -10,10 +10,6 @@ import {PackageManagers} from 'starlight-package-managers'
 
 Below are some common behavior examples. You can also find a list of core behaviors [on GitHub](https://github.com/portabletext/editor/tree/main/packages/editor/src/behaviors).
 
-:::note[Prerequisites]
-These recipes are written for `@portabletext/editor` ([changelog](https://github.com/portabletext/editor/releases)).
-:::
-
 To add these to your editor, first import `defineBehavior` as well as the `BehaviorPlugin`.
 
 ```tsx

--- a/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
+++ b/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
@@ -7,10 +7,6 @@ import {LinkCard} from '@astrojs/starlight/components'
 
 Behaviors add functionality to the Portable Text Editor (PTE) in a declarative way.
 
-:::note[Prerequisites]
-This guide covers `@portabletext/editor` ([changelog](https://github.com/portabletext/editor/releases)). Requires React 19.2.8 or later.
-:::
-
 For a deep dive into behaviors and how they work, check out [Behaviors](/editor/concepts/behavior/).
 
 ## Import the behavior helper

--- a/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
+++ b/apps/docs/src/content/docs/editor/guides/custom-blocks.mdx
@@ -9,9 +9,7 @@ import {LinkCard} from '@astrojs/starlight/components'
 
 The Portable Text Editor handles text blocks (paragraphs, headings, lists) by default. To add structured content like images, code blocks, or calls to action, you define custom block types in your schema and tell the editor how to render and insert them. If your editor still renders block objects and inline objects through the deprecated `renderBlock`/`renderChild` props, see the [migration guide](/editor/guides/migrate-render-props/) to move to node registrations.
 
-:::note[Prerequisites]
-This guide covers `@portabletext/editor` and `@portabletext/toolbar`. Requires React 19.2.8 or later. You should be familiar with the [getting started guide](/editor/getting-started/) and [custom rendering](/editor/guides/custom-rendering/).
-:::
+You should be familiar with the [getting started guide](/editor/getting-started/) and [custom rendering](/editor/guides/custom-rendering/) first.
 
 ## How custom blocks work
 

--- a/apps/docs/src/content/docs/editor/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/editor/guides/custom-rendering.md
@@ -9,10 +9,6 @@ Marks (decorators and annotations) render through node registrations: `defineDec
 
 `renderPlaceholder` and `rangeDecorations`, the remaining rendering props without a registration equivalent, stay on `<PortableTextEditable>`; this guide documents them below.
 
-:::note[Prerequisites]
-This guide covers `@portabletext/editor`. Requires React 19.2.8 or later. Check the [editor changelog](https://github.com/portabletext/editor/releases) for breaking changes.
-:::
-
 If your editor still renders through the deprecated `renderDecorator`, `renderAnnotation`, `renderBlock`, `renderChild`, `renderStyle`, or `renderListItem` props, the [migration guide](/editor/guides/migrate-render-props/) walks through moving to registrations. None of these choices affect the Portable Text output: they only change how the editor itself renders content.
 
 ## Decorators

--- a/apps/docs/src/content/docs/editor/guides/custom-rendering.md
+++ b/apps/docs/src/content/docs/editor/guides/custom-rendering.md
@@ -5,65 +5,111 @@ sidebar:
   order: 1
 ---
 
-This page covers the span-level render props: `renderAnnotation`, `renderDecorator`, `renderPlaceholder`, and `rangeDecorations`, passed directly to `PortableTextEditable`. Block-level rendering, for text blocks, block objects, inline objects, and containers, goes through node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineSpan`) mounted with `NodePlugin` instead; see [Containers](/editor/concepts/containers/) for that model. `renderAnnotation` and `renderDecorator` fire on the spans inside a block no matter who renders that block, registered or not; `renderPlaceholder` fires on the empty editor instead of a span, and `rangeDecorations` is a prop carrying decoration configs, not a render callback.
+Marks (decorators and annotations) render through node registrations: `defineDecorator` and `defineAnnotation`, mounted with `NodePlugin` alongside the editor's other registrations. [Rendering](/editor/concepts/rendering/) covers the model every registration shares: markup ownership, dispatch precedence, and `renderDefault`. [Containers](/editor/concepts/containers/) covers positional overrides, rendering a mark differently only inside one part of the document.
 
-If your editor still renders through the deprecated `renderBlock`, `renderChild`, `renderStyle`, or `renderListItem` props, the [migration guide](/editor/guides/migrate-render-props/) walks through moving to registrations. None of these choices affect the Portable Text output: they only change how the editor itself renders content.
+`renderPlaceholder` and `rangeDecorations`, the remaining rendering props without a registration equivalent, stay on `<PortableTextEditable>`; this guide documents them below.
 
 :::note[Prerequisites]
 This guide covers `@portabletext/editor`. Requires React 19.2.8 or later. Check the [editor changelog](https://github.com/portabletext/editor/releases) for breaking changes.
 :::
 
-:::caution[Deprecated]
-`renderDecorator` and `renderAnnotation` are deprecated and will be removed in a future major version. Node registrations (`defineDecorator`, `defineAnnotation`) replace them; the [migration guide](/editor/guides/migrate-render-props/) walks through both props. `renderPlaceholder` is not deprecated.
-:::
+If your editor still renders through the deprecated `renderDecorator`, `renderAnnotation`, `renderBlock`, `renderChild`, `renderStyle`, or `renderListItem` props, the [migration guide](/editor/guides/migrate-render-props/) walks through moving to registrations. None of these choices affect the Portable Text output: they only change how the editor itself renders content.
 
-The following props can be passed to the `PortableTextEditable` component:
+## Decorators
 
-- `renderAnnotation`: For annotations (e.g., hyperlinks). (deprecated)
-- `renderDecorator`: For decorators (e.g., strong, italic, emphasis text). (deprecated)
-- `renderPlaceholder`: For custom placeholder text when the editor is empty.
-- `rangeDecorations`: For highlighting specific ranges of text (e.g., search results, comments).
-
-All the different render functions passed to `PortableTextEditable` can be defined as stand-alone React components.
-
-Most follow the same pattern of reading `props` and conditionally rendering elements based on schema data.
-
-Lists are a bit unique. A list in Portable Text is flat: a run of sibling text blocks carrying `listItem` and `level`, with no wrapper node. ([Containers](/editor/concepts/containers/) nest blocks through object fields, but lists stay flat.) Visual nesting comes from CSS, and list numbering comes from [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index). We suggest [including this example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) or similar to manage list rendering.
-
-Here are basic implementations of some core types:
+Register one `defineDecorator` per decorator name. `render` receives the styled `children` to wrap:
 
 ```tsx
-import type {
-  RenderAnnotationFunction,
-  RenderDecoratorFunction,
-} from '@portabletext/editor'
+import {defineDecorator} from '@portabletext/editor'
 
-const renderDecorator: RenderDecoratorFunction = (props) => {
-  if (props.value === 'strong') {
-    return <strong>{props.children}</strong>
-  }
-  if (props.value === 'em') {
-    return <em>{props.children}</em>
-  }
-  if (props.value === 'underline') {
-    return <u>{props.children}</u>
-  }
-  return <>{props.children}</>
-}
-
-// Annotations
-const renderAnnotation: RenderAnnotationFunction = (props) => {
-  if (props.schemaType.name === 'link') {
-    return <span style={{textDecoration: 'underline'}}>{props.children}</span>
-  }
-
-  return <>{props.children}</>
-}
+const strong = defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+const em = defineDecorator({
+  type: 'em',
+  render: ({children}) => <em>{children}</em>,
+})
+const underline = defineDecorator({
+  type: 'underline',
+  render: ({children}) => <u>{children}</u>,
+})
 ```
 
-:::note
-List items in Portable Text don't nest like HTML lists. Visual nesting is achieved through CSS. See the [example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) for list styling patterns.
-:::
+Or keep one switching function with `type: '*'`, which matches any decorator that has no more specific registration; see [dispatch precedence](/editor/concepts/rendering/#dispatch-precedence) for how it ranks against an exact `type` match:
+
+```tsx
+const decorator = defineDecorator({
+  type: '*',
+  render: ({children, decorator}) => {
+    if (decorator === 'strong') {
+      return <strong>{children}</strong>
+    }
+    if (decorator === 'em') {
+      return <em>{children}</em>
+    }
+    if (decorator === 'underline') {
+      return <u>{children}</u>
+    }
+    return <>{children}</>
+  },
+})
+```
+
+## Annotations
+
+Register `defineAnnotation` for a markDef `_type`. `render` receives the markDef object as `annotation`:
+
+```tsx
+import {defineAnnotation} from '@portabletext/editor'
+
+const link = defineAnnotation({
+  type: 'link',
+  render: ({annotation, children}) =>
+    typeof annotation.href === 'string' ? (
+      <a href={annotation.href}>{children}</a>
+    ) : (
+      children
+    ),
+})
+```
+
+`render` is a plain function call, not a component, so hooks inside it violate the Rules of Hooks. When a render needs hooks, for example to open a tooltip on the annotation, return a component instead:
+
+```tsx
+import {useState} from 'react'
+import type {AnnotationRenderProps} from '@portabletext/editor'
+
+function LinkSpan(props: AnnotationRenderProps) {
+  const [hovered, setHovered] = useState(false)
+  const href =
+    typeof props.annotation.href === 'string' ? props.annotation.href : ''
+
+  return (
+    <span
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{textDecoration: 'underline'}}
+    >
+      {props.children}
+      {hovered ? <span className="tooltip">{href}</span> : null}
+    </span>
+  )
+}
+
+const link = defineAnnotation({
+  type: 'link',
+  render: (props) => <LinkSpan {...props} />,
+})
+```
+
+## Mount the registrations
+
+Marks join the same `nodes` array as your other registrations, mounted through one `NodePlugin`: see [Register a node](/editor/concepts/rendering/#register-a-node) on the Rendering page for the full example.
+
+## Lists
+
+Lists are a bit unique. A list in Portable Text is flat: a run of sibling text blocks carrying `listItem` and `level`, with no wrapper node. ([Containers](/editor/concepts/containers/) nest blocks through object fields, but lists stay flat.) Visual nesting comes from CSS, and list numbering comes from [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index). We suggest [including this example CSS](https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css) or similar to manage list rendering.
 
 ## Placeholder text
 

--- a/apps/docs/src/content/docs/editor/guides/customize-toolbar.mdx
+++ b/apps/docs/src/content/docs/editor/guides/customize-toolbar.mdx
@@ -7,10 +7,6 @@ import {PackageManagers} from 'starlight-package-managers'
 
 The [getting started guide](/editor/getting-started/) introduces the basics of setting up toolbar components. This guide provides some extra context, best practices, and patterns to get you started.
 
-:::note[Prerequisites]
-This guide covers `@portabletext/toolbar` and `@portabletext/keyboard-shortcuts` ([changelog](https://github.com/portabletext/editor/releases)). Requires `@portabletext/editor` and React 19.2.8 or later.
-:::
-
 ## Render the toolbar inside the provider
 
 You must render any toolbars within `EditorProvider`, as any toolbar actions require access to the instance of the editor. There are two ways to do this:

--- a/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
+++ b/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
@@ -125,7 +125,7 @@ const stockTicker = defineInlineObject({
 })
 ```
 
-Unlike block objects, inline objects need no `contentEditable={false}`: the engine's outer attributes already carry non-editability, and your content inherits it. They DO need the inner `draggable={!readOnly}` wrapper around the visible content: the legacy pipeline wrapped your `renderChild` output in a `draggable` inline-block span, which is what makes an inline object drag-movable and keeps its text unselectable (a draggable element starts a drag instead of a text selection). A registration that renders the content bare loses both behaviors, and nothing fails loudly. The legacy default case (`return props.children`) disappears: spans keep rendering through the engine and the span-level render props, and only registered inline object types hit your render.
+Unlike block objects, inline objects need no `contentEditable={false}`: the engine's outer attributes already carry non-editability, and your content inherits it. They DO need the inner `draggable={!readOnly}` wrapper around the visible content: the legacy pipeline wrapped your `renderChild` output in a `draggable` inline-block span, which is what makes an inline object drag-movable and keeps its text unselectable (a draggable element starts a drag instead of a text selection). A registration that renders the content bare loses both behaviors, and nothing fails loudly. The legacy default case (`return props.children`) disappears: spans keep rendering through the engine, with decorator and annotation renders, registered or legacy, still composing inside them exactly as before, and only registered inline object types hit your render.
 
 ## Step 3: spans, if you customized them
 
@@ -313,13 +313,17 @@ const annotationFallback = defineAnnotation({
 
 `annotation` is the full `markDef` object (`{_key, _type, ...fields}`) with an `unknown` index signature, so a field the legacy callback read off a separately-typed `value` (a `link` annotation's `href`, say) needs a cast: `String(annotation.href)`. It is named `annotation`, not `node`, because `path` addresses the span carrying the annotation, not the markDef.
 
+:::note[Legacy fields with no registration equivalent]
+`renderDecorator` and `renderAnnotation` both carried `editorElementRef`, a ref to the engine-owned leaf DOM anchor. No registration exposes it; consumers relying on it keep the render prop. Both also carried `schemaType` (`renderAnnotation` carried `block` too), which a registration's `render` doesn't receive, but you can derive them yourself from a `path`: `getPathSubSchema` and `getEnclosingBlock`, both from `@portabletext/editor/traversal`, read the sub-schema and enclosing text block inside a selector.
+:::
+
 :::caution[Registration renders are plain function calls, not components]
 This holds for every `define*` render, and it matters most here: the legacy `renderDecorator`/`renderAnnotation` callbacks each ran inside their own wrapper component, so hooks in them happened to work. A registration's `render` runs as a plain call inside the engine's render, where hooks violate the Rules of Hooks and crash as decorators toggle. If a migrated callback uses hooks, move them into a component and return it: `render: (props) => <MyDecorator {...props} />`.
 :::
 
 ## Step 7: reclaim the engine's chrome
 
-Under the legacy pipeline the engine wrapped list items and numbered ordered lists for you, and drew a drop indicator during block drags. Under registrations both are yours. [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, and [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's `drag.*` events. Both follow the same pattern, a provider inside `EditorProvider` and a hook read from a component your render returns; the [containers page](/editor/concepts/containers/#registrations-opt-into-the-new-render-pipeline) has the worked example and each plugin's README carries the full recipe.
+Under the legacy pipeline the engine wrapped list items and numbered ordered lists for you, and drew a drop indicator during block drags. Under registrations both are yours. [`@portabletext/plugin-list-index`](https://github.com/portabletext/editor/tree/main/packages/plugin-list-index) computes the 1-based list index at any path, and [`@portabletext/plugin-dnd`](https://github.com/portabletext/editor/tree/main/packages/plugin-dnd) tracks the drop position from the editor's `drag.*` events. Both follow the same pattern, a provider inside `EditorProvider` and a hook read from a component your render returns; the [Rendering page](/editor/concepts/rendering/#plugins-for-lists-and-drag-and-drop) covers the pattern, and each plugin's README carries the full recipe, including a reference `DropIndicator` implementation.
 
 ## Step 8: mount and clean up
 

--- a/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
+++ b/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
@@ -12,10 +12,6 @@ The Portable Text Editor ships with testing infrastructure you can use for your 
 
 Both approaches use Vitest Browser Mode with Playwright, running tests against a real browser.
 
-:::note[Prerequisites]
-This guide covers `@portabletext/editor` and `racejar` ([changelog](https://github.com/portabletext/editor/releases)). Requires Vitest with Browser Mode and Playwright.
-:::
-
 ## Setup
 
 Install the testing dependencies:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -18,7 +18,7 @@ Then open the local URL Vite prints (defaults to `http://localhost:5173`).
 ## What it demonstrates
 
 - Defining a schema with `defineSchema` (decorators, annotations, styles, lists, block and inline objects)
-- Node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`) mounted with `NodePlugin`, and span-level render functions (`renderDecorator`, `renderAnnotation`)
+- Node registrations (`defineTextBlock`, `defineBlockObject`, `defineInlineObject`, `defineDecorator`, `defineAnnotation`) mounted with `NodePlugin`
 - List numbering with [`@portabletext/plugin-list-index`](../../packages/plugin-list-index/)
 - A toolbar that toggles marks, styles, and lists using `useEditor` and `useEditorSelector` with selectors from `@portabletext/editor/selectors`
 - Reading the editor value through `EventListenerPlugin` and rendering it as JSON

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,6 +1,8 @@
 import './editor.css'
 import {
+  defineAnnotation,
   defineBlockObject,
+  defineDecorator,
   defineInlineObject,
   defineSchema,
   defineTextBlock,
@@ -8,8 +10,6 @@ import {
   keyGenerator,
   PortableTextBlock,
   PortableTextEditable,
-  RenderAnnotationFunction,
-  RenderDecoratorFunction,
   TextBlockRenderProps,
   useEditor,
   useEditorSelector,
@@ -84,7 +84,7 @@ function App() {
             }
           }}
         />
-        {/* Register how text blocks (styles and lists), inline objects, and block objects are rendered */}
+        {/* Register how text blocks (styles and lists), decorators, annotations, inline objects, and block objects are rendered */}
         <NodePlugin nodes={nodes} />
         {/* Toolbar needs to be rendered inside the `EditorProvider` component */}
         <Toolbar />
@@ -93,10 +93,6 @@ function App() {
           {/* Component that controls the actual rendering of the editor */}
           <PortableTextEditable
             style={{border: '1px solid black', padding: '0.5em'}}
-            // Control how decorators are rendered
-            renderDecorator={renderDecorator}
-            // Control how annotations are rendered
-            renderAnnotation={renderAnnotation}
           />
         </ListIndexProvider>
       </EditorProvider>
@@ -107,26 +103,29 @@ function App() {
   )
 }
 
-const renderDecorator: RenderDecoratorFunction = (props) => {
-  if (props.value === 'strong') {
-    return <strong>{props.children}</strong>
-  }
-  if (props.value === 'em') {
-    return <em>{props.children}</em>
-  }
-  if (props.value === 'underline') {
-    return <u>{props.children}</u>
-  }
-  return <>{props.children}</>
-}
+// Decorators render through a registered node: one entry per decorator
+// name, or `type: '*'` for a single switching function.
+const strongDecorator = defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+const emDecorator = defineDecorator({
+  type: 'em',
+  render: ({children}) => <em>{children}</em>,
+})
+const underlineDecorator = defineDecorator({
+  type: 'underline',
+  render: ({children}) => <u>{children}</u>,
+})
 
-const renderAnnotation: RenderAnnotationFunction = (props) => {
-  if (props.schemaType.name === 'link') {
-    return <span style={{textDecoration: 'underline'}}>{props.children}</span>
-  }
-
-  return <>{props.children}</>
-}
+// Annotations render through a registered node as well. `annotation` is
+// the markDef object: `{_key, _type, ...fields}`.
+const linkAnnotation = defineAnnotation({
+  type: 'link',
+  render: ({children}) => (
+    <span style={{textDecoration: 'underline'}}>{children}</span>
+  ),
+})
 
 // Text blocks render through a registered node: the `render` callback owns
 // the block's wrapper element and receives the block itself, so styles and
@@ -223,7 +222,15 @@ const imageBlock = defineBlockObject({
 
 // A stable module-level reference: a fresh array on every render would
 // make `NodePlugin` unregister and re-register on every keystroke.
-const nodes = [textBlock, stockTicker, imageBlock]
+const nodes = [
+  textBlock,
+  strongDecorator,
+  emDecorator,
+  underlineDecorator,
+  linkAnnotation,
+  stockTicker,
+  imageBlock,
+]
 
 function Toolbar() {
   // Obtain the editor instance

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -41,15 +41,13 @@ Next, in your app or the component you're building, import `EditorProvider`, `Po
 ```tsx
 // App.tsx
 import {
+  defineDecorator,
   defineSchema,
   defineTextBlock,
   EditorProvider,
   PortableTextEditable,
 } from '@portabletext/editor'
-import type {
-  PortableTextBlock,
-  RenderDecoratorFunction,
-} from '@portabletext/editor'
+import type {PortableTextBlock} from '@portabletext/editor'
 import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
 ```
 
@@ -103,15 +101,13 @@ Add `useState` from React, then scaffold out a basic application component. For 
 ```tsx
 // app.tsx
 import {
+  defineDecorator,
   defineSchema,
   defineTextBlock,
   EditorProvider,
   PortableTextEditable,
 } from '@portabletext/editor'
-import type {
-  PortableTextBlock,
-  RenderDecoratorFunction,
-} from '@portabletext/editor'
+import type {PortableTextBlock} from '@portabletext/editor'
 import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {useState} from 'react'
 
@@ -156,7 +152,7 @@ Include the `App` component in your application and run it. You should see an ou
 
 ### Set up rendering for schema elements
 
-At this point the editor renders every text block as plain text, whatever its style. Fix that by registering a render for text blocks and creating render functions for the marks. If your editor still renders through the deprecated `renderStyle`, `renderBlock`, `renderListItem`, and `renderChild` props, see the [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/) to move to node registrations instead.
+At this point the editor renders every text block as plain text, whatever its style. Fix that by registering a `defineTextBlock` node for the text blocks and `defineDecorator`/`defineAnnotation` nodes for the marks. If your editor still renders through the deprecated `renderStyle`, `renderBlock`, `renderListItem`, `renderChild`, `renderDecorator`, and `renderAnnotation` props, see the [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/) to move to node registrations instead.
 
 Start by registering the text block render with `defineTextBlock`. The editor dispatches every text block to this callback. Your callback owns the block's wrapper element, so spread `props.attributes` on the outermost element you return, and use the block's `style` to pick the element.
 
@@ -179,47 +175,44 @@ const textBlock = defineTextBlock({
     return <div {...props.attributes}>{props.children}</div>
   },
 })
-
-const nodes = [textBlock]
 ```
 
-Marks (decorators and annotations) use render functions instead. Render functions all follow the same format.
+Marks (decorators and annotations) join the same `nodes` array. Registrations all follow the same shape.
 
 - They take in props and return JSX elements.
-- They use the schema to make decisions.
-- They return JSX and pass `children` as a fallback.
+- They decide what to render from the registration's `type` and the node itself, not a separate schema-type argument.
+- They return JSX that renders `children` somewhere inside it, the editable content the registration wraps.
 
 With this in mind, continue for the remaining schema types.
 
-Create a render function for decorators.
+Register a decorator with `defineDecorator`, one per decorator name.
 
 ```tsx
-const renderDecorator: RenderDecoratorFunction = (props) => {
-  if (props.value === 'strong') {
-    return <strong>{props.children}</strong>
-  }
-  if (props.value === 'em') {
-    return <em>{props.children}</em>
-  }
-  if (props.value === 'underline') {
-    return <u>{props.children}</u>
-  }
-  return <>{props.children}</>
-}
+const strong = defineDecorator({
+  type: 'strong',
+  render: ({children}) => <strong>{children}</strong>,
+})
+const em = defineDecorator({
+  type: 'em',
+  render: ({children}) => <em>{children}</em>,
+})
+const underline = defineDecorator({
+  type: 'underline',
+  render: ({children}) => <u>{children}</u>,
+})
+
+const nodes = [textBlock, strong, em, underline]
 ```
 
 > [!NOTE]
-> By default, text is rendered as an inline `span` element in the editor. While mark render functions return a fragment (`<>`) as the fallback, the registered text block render must return a block-level element, like a `<div>`.
+> By default, text is rendered as an inline `span` element in the editor. A decorator's render can pass `children` through unwrapped, but the registered text block render must return a block-level element, like a `<div>`.
 
-Mount the registration with `NodePlugin` and pass the render functions to `PortableTextEditable`. Both belong inside the `EditorProvider`. Keep the `nodes` array itself at module scope, as above: a fresh array on every render would make `NodePlugin` unregister and re-register on every keystroke. You can learn more about [customizing the rendering](https://www.portabletext.org/editor/guides/custom-rendering/) in the documentation.
+Mount every registration through one `NodePlugin`, inside the `EditorProvider`. Keep the `nodes` array itself at module scope, as above: a fresh array on every render would make `NodePlugin` unregister and re-register on every keystroke. You can learn more about [customizing the rendering](https://www.portabletext.org/editor/guides/custom-rendering/) in the documentation.
 
 ```tsx
 <>
   <NodePlugin nodes={nodes} />
-  <PortableTextEditable
-    style={{border: '1px solid black', padding: '0.5em'}}
-    renderDecorator={renderDecorator}
-  />
+  <PortableTextEditable style={{border: '1px solid black', padding: '0.5em'}} />
 </>
 ```
 
@@ -296,7 +289,7 @@ The `useEditor` hook gives you access to the active editor. `send` lets you send
 
 ### Bring it all together
 
-With render functions created and a toolbar in place, you can fully render the editor. Add the `Toolbar` inside the `EditorProvider`.
+With the registrations created and a toolbar in place, you can fully render the editor. Add the `Toolbar` inside the `EditorProvider`.
 
 ```tsx
 // App.tsx
@@ -325,7 +318,6 @@ function App() {
         <NodePlugin nodes={nodes} />
         <PortableTextEditable
           style={{border: '1px solid black', padding: '0.5em'}}
-          renderDecorator={renderDecorator}
         />
       </EditorProvider>
     </>

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -61,8 +61,9 @@ export type Editor = {
   /**
    * Register a node renderer. The `node` argument is the result of one
    * of the `defineX` factories (`defineContainer`, `defineTextBlock`,
-   * `defineSpan`, `defineBlockObject`, `defineInlineObject`). Returns
-   * a function that unregisters the node when called.
+   * `defineSpan`, `defineBlockObject`, `defineInlineObject`,
+   * `defineDecorator`, `defineAnnotation`). Returns a function that
+   * unregisters the node when called.
    *
    * @public
    */

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -31,7 +31,7 @@ export type ContainerRenderProps = {
    * inside a custom render to fall back to or wrap the default:
    *
    * ```ts
-   * render: ({renderDefault, ...rest}) => renderDefault(rest)
+   * render: (props) => props.renderDefault(props)
    * ```
    *
    * The default is the engine's minimal wrapper. It does not chain


### PR DESCRIPTION
With `defineDecorator` and `defineAnnotation` covering marks globally and positionally, the docs were the last surfaces teaching the deprecated `renderDecorator`/`renderAnnotation` props as the primary path: getting-started, the custom-rendering guide, the editor README, the basic example, and the docs site's own editor component. They now teach registrations, marks join the same module-level `nodes` array as every other kind, and renders needing hooks return a component.

The flip surfaced an information-architecture problem first: the containers page had become the home for all registration teaching, which is why its lead section never sat right. The first commit extracts the model into a new `concepts/rendering.mdx` (markup ownership, the factories, dispatch precedence, `renderDefault`), with a boundary rule the pages now state: Containers owns everything scoped by `of`, Rendering owns everything global.

Payload parity is stated honestly where it matters: the migration guide names `editorElementRef` as the one field with no registration equivalent (consumers relying on it keep the render prop), notes `schemaType` and `block` are derivable via `@portabletext/editor/traversal` helpers, and the dispatch prose respects the verified semantics: global registrations render in every text block, positional ones only inside their matching `defineTextBlock` scope, and a registration beats the prop for the same type.

Two source JSDoc corrections ride the last commit: `registerNode`'s factory list stopped at five, and the `ContainerRenderProps` exemplar did not typecheck under strict TS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, examples, and comment-only API doc tweaks; no production editor runtime or security-sensitive logic changes.
> 
> **Overview**
> **Mark rendering** is documented and demonstrated through **`defineDecorator` / `defineAnnotation` + `NodePlugin`** instead of deprecated **`renderDecorator` / `renderAnnotation`** on **`PortableTextEditable`**. That path is updated in getting-started, custom-rendering, the package README, the basic example, and the docs site editor component.
> 
> A new **[Rendering](/editor/concepts/rendering/)** concept page holds the shared registration model (markup ownership, factories, dispatch precedence, **`renderDefault`**, list/DnD plugins). The **Containers** page is trimmed to **`of`** scoping and links out for global behavior. Concepts nav/sidebar order is adjusted accordingly.
> 
> The **migrate-render-props** guide notes **`editorElementRef`** has no registration equivalent and points list/DnD setup at Rendering. Minor **`registerNode`** / **`renderDefault`** JSDoc fixes in **`@portabletext/editor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3995d1de00acceb138f4c3aa055672c0061213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->