### PR TITLE
feat!: remove the `data-slate-*` DOM attribute aliases

### DIFF
--- a/.changeset/remove-data-slate-attributes.md
+++ b/.changeset/remove-data-slate-attributes.md
@@ -1,0 +1,18 @@
+---
+'@portabletext/editor': major
+---
+
+feat!: remove the `data-slate-*` DOM attribute aliases
+
+The editor DOM no longer carries the Slate-era `data-slate-*` attributes; it speaks `data-pt-*` only. CSS selectors and DOM queries keyed on the old attributes must migrate:
+
+- `data-slate-editor` → `data-pt-editor`
+- `data-slate-node="element"` → `data-pt-path` (every rendered node carries it; blocks also carry `data-pt-block`)
+- `data-slate-node="text"` → `data-pt-inline="span"`
+- `data-slate-leaf` → `data-pt-marks`
+- `data-slate-string` → `data-pt-text`
+- `data-slate-zero-width` → `data-pt-zero-width` (line-break variant: `data-pt-line-break`)
+- `data-slate-void` → `data-pt-block="object"` / `data-pt-inline="object"`
+- `data-slate-spacer` → `data-pt-spacer`
+
+One behavioral consequence rides along: a node registered via `registerNode` (for example `defineInlineObject` or `defineSpan`) now receives the same clean `data-pt-*` attributes whether its parent text block renders through the legacy pipeline or the new one; previously the legacy pipeline mixed `data-slate-*` into the attributes passed to the registered render.

--- a/packages/editor/src/editor/new-pipeline-context.ts
+++ b/packages/editor/src/editor/new-pipeline-context.ts
@@ -4,10 +4,9 @@ import {createContext} from 'react'
  * True when the current render position is inside a new-pipeline
  * subtree (any element rendered via `registerNode` and its descendants).
  *
- * Read by the legacy DOM-attribute emission sites in `element.tsx`,
- * `object-node.tsx`, `text.tsx`, `leaf.tsx`, and `string.tsx` to skip
- * `data-slate-*` attributes inside new-pipeline subtrees while still
- * emitting them in the legacy pipeline.
+ * Governs whether the dispatch sites in `render.element.tsx` /
+ * `render.text.tsx` emit the legacy DOM shape (`data-child-*`
+ * attributes, legacy default renderers) or the new-pipeline shape.
  *
  * Provided by `useChildren` (wrapping each new-pipeline child) and by
  * the dispatch sites in `render.element.tsx` / `render.span.tsx`.

--- a/packages/editor/src/editor/parent-container-context.ts
+++ b/packages/editor/src/editor/parent-container-context.ts
@@ -12,7 +12,7 @@ import type {ContainerConfig} from '../renderers/renderer.types'
  *
  * Not a pipeline gate. Whether the current render position emits the
  * new-pipeline DOM shape (clean `data-pt-*`) or the legacy shape
- * (`data-slate-*` + `data-child-*`) is governed by `NewPipelineContext`.
+ * (`data-child-*`) is governed by `NewPipelineContext`.
  * A top-level catch-all `defineTextBlock` puts a render position inside
  * the new pipeline without any parent container — reading this
  * context's truthiness as a pipeline gate produces a stale answer for

--- a/packages/editor/src/editor/render.block-object.tsx
+++ b/packages/editor/src/editor/render.block-object.tsx
@@ -50,11 +50,7 @@ export function RenderBlockObject(props: {
   }
 
   if (props.blockObjectConfig) {
-    const {
-      'data-slate-node': _slateNode,
-      'data-slate-void': _slateVoid,
-      ...ptAttributes
-    } = props.attributes
+    const ptAttributes = props.attributes
     const render = props.blockObjectConfig.blockObject.render
     const renderProps: BlockObjectRenderProps = {
       attributes: {

--- a/packages/editor/src/editor/render.element.tsx
+++ b/packages/editor/src/editor/render.element.tsx
@@ -197,12 +197,11 @@ export function RenderElement(props: {
   }
 
   if (isTextBlock({schema}, props.element)) {
-    const {'data-slate-node': _sn, ...rest} = props.attributes
     let rendered: ReactElement | null
     if (renderableTextBlockConfig?.textBlock.render) {
       rendered = (
         <RenderTextBlockConfig
-          attributes={{...rest, 'data-pt-block': 'text'}}
+          attributes={{...props.attributes, 'data-pt-block': 'text'}}
           render={renderableTextBlockConfig.textBlock.render}
           node={props.element}
           path={props.path}
@@ -216,7 +215,7 @@ export function RenderElement(props: {
       // subtree. Same shape as `renderDefault` returns when a
       // registered text-block omits `render`.
       rendered = renderDefaultTextBlock({
-        attributes: {...rest, 'data-pt-block': 'text'},
+        attributes: {...props.attributes, 'data-pt-block': 'text'},
         children: props.children,
       })
     } else {
@@ -250,13 +249,8 @@ export function RenderElement(props: {
 
   if (isInline(engineStatic.snapshot, props.path)) {
     if (isInNewPipeline && !inlineObjectConfig) {
-      const {
-        'data-slate-node': _sn,
-        'data-slate-void': _sv,
-        ...rest
-      } = props.attributes
       return (
-        <span {...rest} data-pt-inline="object">
+        <span {...props.attributes} data-pt-inline="object">
           {props.children}
           <span contentEditable={false}>
             [{props.element._type}: {props.element._key}]
@@ -280,13 +274,8 @@ export function RenderElement(props: {
   }
 
   if (isInNewPipeline && !blockObjectConfig) {
-    const {
-      'data-slate-node': _sn,
-      'data-slate-void': _sv,
-      ...rest
-    } = props.attributes
     return (
-      <div {...rest} data-pt-block="object">
+      <div {...props.attributes} data-pt-block="object">
         {props.children}
         <div contentEditable={false}>
           [{props.element._type}: {props.element._key}]

--- a/packages/editor/src/editor/render.inline-object.tsx
+++ b/packages/editor/src/editor/render.inline-object.tsx
@@ -46,11 +46,6 @@ export function RenderInlineObject(props: {
   const inlineObject = props.element as unknown as PortableTextChild
 
   if (props.inlineObjectConfig) {
-    // `props.attributes` is already shaped by `object-node.tsx`'s
-    // `NewPipelineContext` read: clean `data-pt-*` when inside a new-
-    // pipeline subtree, legacy + PT when the parent text block is
-    // legacy. The registered render runs in both modes; only the
-    // attribute shape inherits.
     const render = props.inlineObjectConfig.inlineObject.render
     const renderProps: InlineObjectRenderProps = {
       attributes: {

--- a/packages/editor/src/editor/render.text.tsx
+++ b/packages/editor/src/editor/render.text.tsx
@@ -10,12 +10,8 @@ export function RenderText(props: RenderTextProps) {
   const isInNewPipeline = useContext(NewPipelineContext)
 
   if (isInNewPipeline) {
-    const {'data-slate-node': _sn, ...rest} =
-      props.attributes as typeof props.attributes & {
-        'data-slate-node'?: string
-      }
     return (
-      <span {...rest} data-pt-inline="span">
+      <span {...props.attributes} data-pt-inline="span">
         {props.children}
       </span>
     )

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -96,9 +96,7 @@ export interface RenderElementProps {
   element: PortableTextTextBlock | PortableTextObject
   path: Path
   attributes: {
-    'data-slate-node'?: 'element'
     'data-pt-block'?: 'container'
-    'data-slate-void'?: true
     'data-pt-path': string
     'contentEditable'?: false
     'dir'?: 'rtl'
@@ -119,7 +117,6 @@ export interface RenderLeafProps {
   text: PortableTextSpan
   path: Path
   attributes: {
-    'data-slate-leaf'?: true
     'data-pt-marks': true
   }
   /**
@@ -135,7 +132,6 @@ export interface RenderTextProps {
   text: PortableTextSpan
   children: any
   attributes: {
-    'data-slate-node'?: 'text'
     'data-pt-path': string
   }
 }
@@ -1091,9 +1087,7 @@ export const Editable = forwardRef(
                   ? attributes.autoCapitalize
                   : 'false'
               }
-              data-slate-editor
               data-pt-editor
-              data-slate-node="value"
               data-pt-path=""
               // explicitly set this
               contentEditable={!readOnly}

--- a/packages/editor/src/engine/react/components/element.tsx
+++ b/packages/editor/src/engine/react/components/element.tsx
@@ -2,8 +2,7 @@ import type {
   PortableTextObject,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {useContext, type JSX} from 'react'
-import {NewPipelineContext} from '../../../editor/new-pipeline-context'
+import React, {type JSX} from 'react'
 import {serializePath} from '../../../paths/serialize-path'
 import {getText} from '../../../traversal/get-text'
 import {isInline as isInlinePath} from '../../../traversal/is-inline'
@@ -27,16 +26,10 @@ import type {
  * or an editable container) and threads decorations + children through the
  * `renderElement` callback.
  *
- * Two pipeline-aware signals:
- * - `isContainer` (prop): this element resolves as an editable container at
- *   this position. Governs the `data-pt-block="container"` literal.
- *   Resolved by `useChildren` at dispatch time (avoids a second
- *   `isEditableContainer` walk).
- * - `NewPipelineContext` (context): this element renders inside a
- *   `registerNode`-shaped subtree. Governs the `data-slate-node="element"`
- *   strip on the outer attributes. Provided by `useChildren` (wrapping
- *   each new-pipeline child) and by `render.element.tsx` /
- *   `render.span.tsx` (around dispatch sites).
+ * `isContainer` (prop): this element resolves as an editable container at
+ * this position. Governs the `data-pt-block="container"` literal.
+ * Resolved by `useChildren` at dispatch time (avoids a second
+ * `isEditableContainer` walk).
  */
 const Element = (props: {
   decorations: DecoratedRange[]
@@ -58,7 +51,6 @@ const Element = (props: {
   const dataPath = serializePath(props.path)
   const editor = useEngineStatic()
   const isInline = isInlinePath(editor.snapshot, props.path)
-  const isInNewPipeline = useContext(NewPipelineContext)
   const decorations = useDecorations(element, props.path, parentDecorations)
   const children = useChildren({
     decorations,
@@ -71,25 +63,14 @@ const Element = (props: {
 
   // Attributes that the developer must mix into the element in their
   // custom node renderer component.
-  //
-  // `isContainer` keeps the structural `data-pt-block="container"`
-  // literal. `isInNewPipeline` governs the `data-slate-node` strip:
-  // when true, the outer is part of a registerNode subtree and emits
-  // only `data-pt-*` attrs; when false, the legacy pipeline emits
-  // `data-slate-node="element"` for backwards compatibility.
   const attributes: RenderElementProps['attributes'] = isContainer
     ? {
         'data-pt-block': 'container',
         'data-pt-path': dataPath,
       }
-    : isInNewPipeline
-      ? {
-          'data-pt-path': dataPath,
-        }
-      : {
-          'data-slate-node': 'element',
-          'data-pt-path': dataPath,
-        }
+    : {
+        'data-pt-path': dataPath,
+      }
 
   // If it's a block node with inline children, add the proper `dir` attribute
   // for text direction.

--- a/packages/editor/src/engine/react/components/leaf.tsx
+++ b/packages/editor/src/engine/react/components/leaf.tsx
@@ -3,8 +3,7 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {useContext, type JSX} from 'react'
-import {NewPipelineContext} from '../../../editor/new-pipeline-context'
+import React, {type JSX} from 'react'
 import type {Path} from '../../interfaces/path'
 import type {LeafPosition} from '../../interfaces/text'
 import {textEquals} from '../../text/text-equals'
@@ -35,8 +34,6 @@ const Leaf = (props: {
     leafPosition,
   } = props
 
-  const isInNewPipeline = useContext(NewPipelineContext)
-
   const children = (
     <EngineString
       isLast={isLast}
@@ -51,16 +48,10 @@ const Leaf = (props: {
   // in certain misbehaving browsers they aren't weirdly cloned/destroyed by
   // contenteditable behaviors. (2019/05/08)
   const attributes: {
-    'data-slate-leaf'?: true
     'data-pt-marks': true
-  } = isInNewPipeline
-    ? {
-        'data-pt-marks': true,
-      }
-    : {
-        'data-slate-leaf': true,
-        'data-pt-marks': true,
-      }
+  } = {
+    'data-pt-marks': true,
+  }
 
   return renderLeaf({
     attributes,

--- a/packages/editor/src/engine/react/components/object-node.tsx
+++ b/packages/editor/src/engine/react/components/object-node.tsx
@@ -1,6 +1,5 @@
 import type {PortableTextObject} from '@portabletext/schema'
-import React, {useContext, type JSX} from 'react'
-import {NewPipelineContext} from '../../../editor/new-pipeline-context'
+import React, {type JSX} from 'react'
 import {serializePath} from '../../../paths/serialize-path'
 import {isElementDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -13,12 +12,6 @@ import type {RenderElementProps} from './editable'
  * Wrapper for block or inline object nodes that have no children in the engine
  * model. The DOM still needs a hidden zero-width text node for caret
  * anchoring, which is the spacer below.
- *
- * Reads `NewPipelineContext` to decide between the new-pipeline shape
- * (`data-pt-*` only) and the legacy shape (`data-slate-*` mixed in for
- * backwards compatibility). The context is provided by `useChildren`
- * (wrapping each new-pipeline child) and by the dispatch sites in
- * `render.element.tsx` / `render.span.tsx`.
  */
 const ObjectNodeComponent = (props: {
   decorations: DecoratedRange[]
@@ -30,17 +23,10 @@ const ObjectNodeComponent = (props: {
   const {isInline, objectNode, path, renderElement} = props
   const dataPath = serializePath(path)
   const readOnly = useReadOnly()
-  const isInNewPipeline = useContext(NewPipelineContext)
 
-  const attributes: RenderElementProps['attributes'] = isInNewPipeline
-    ? {
-        'data-pt-path': dataPath,
-      }
-    : {
-        'data-slate-node': 'element',
-        'data-slate-void': true,
-        'data-pt-path': dataPath,
-      }
+  const attributes: RenderElementProps['attributes'] = {
+    'data-pt-path': dataPath,
+  }
 
   if (isInline && !readOnly) {
     attributes.contentEditable = false
@@ -48,7 +34,7 @@ const ObjectNodeComponent = (props: {
 
   const Tag = isInline ? 'span' : 'div'
 
-  const children = isInNewPipeline ? (
+  const children = (
     <Tag
       data-pt-spacer
       style={{
@@ -61,25 +47,6 @@ const ObjectNodeComponent = (props: {
       <span>
         <span data-pt-marks>
           <span data-pt-zero-width>{'\uFEFF'}</span>
-        </span>
-      </span>
-    </Tag>
-  ) : (
-    <Tag
-      data-slate-spacer
-      data-pt-spacer
-      style={{
-        height: '0',
-        color: 'transparent',
-        outline: 'none',
-        position: 'absolute',
-      }}
-    >
-      <span data-slate-node="text">
-        <span data-slate-leaf data-pt-marks>
-          <span data-slate-zero-width="z" data-pt-zero-width>
-            {'\uFEFF'}
-          </span>
         </span>
       </span>
     </Tag>

--- a/packages/editor/src/engine/react/components/string.tsx
+++ b/packages/editor/src/engine/react/components/string.tsx
@@ -5,8 +5,7 @@ import {
   type PortableTextSpan,
   type PortableTextTextBlock,
 } from '@portabletext/schema'
-import {forwardRef, memo, useContext, useRef, useState} from 'react'
-import {NewPipelineContext} from '../../../editor/new-pipeline-context'
+import {forwardRef, memo, useRef, useState} from 'react'
 import {getNodes} from '../../../traversal/get-nodes'
 import {IS_ANDROID} from '../../dom/utils/environment'
 import {end as editorEnd} from '../../editor/end'
@@ -108,7 +107,6 @@ const TextString = (props: {text: string; isTrailing?: boolean}) => {
   // of which build (lib, tests, playground) sets the react-compiler boundary.
   'use no memo'
   const {text, isTrailing = false} = props
-  const isInNewPipeline = useContext(NewPipelineContext)
   const ref = useRef<HTMLSpanElement>(null)
   const getTextContent = () => {
     return `${text ?? ''}${isTrailing ? '\n' : ''}`
@@ -138,30 +136,17 @@ const TextString = (props: {text: string; isTrailing?: boolean}) => {
 
   // We intentionally render a memoized <span> that only receives the initial text content when the component is mounted.
   // We defer to the layout effect above to update the `textContent` of the span element when needed.
-  return (
-    <MemoizedText ref={ref} isInNewPipeline={isInNewPipeline}>
-      {initialText}
-    </MemoizedText>
-  )
+  return <MemoizedText ref={ref}>{initialText}</MemoizedText>
 }
 
 const MemoizedText = memo(
-  forwardRef<HTMLSpanElement, {children: string; isInNewPipeline: boolean}>(
-    (props, ref) => {
-      if (props.isInNewPipeline) {
-        return (
-          <span data-pt-text ref={ref}>
-            {props.children}
-          </span>
-        )
-      }
-      return (
-        <span data-slate-string data-pt-text ref={ref}>
-          {props.children}
-        </span>
-      )
-    },
-  ),
+  forwardRef<HTMLSpanElement, {children: string}>((props, ref) => {
+    return (
+      <span data-pt-text ref={ref}>
+        {props.children}
+      </span>
+    )
+  }),
 )
 
 /**
@@ -170,23 +155,14 @@ const MemoizedText = memo(
 
 const ZeroWidthString = (props: {isLineBreak?: boolean}) => {
   const {isLineBreak = false} = props
-  const isInNewPipeline = useContext(NewPipelineContext)
 
-  const engineValue = isLineBreak ? 'n' : 'z'
   const attributes: {
-    'data-slate-zero-width'?: string
     'data-pt-zero-width': true
     'data-pt-line-break'?: true
-  } = isInNewPipeline
-    ? {
-        'data-pt-zero-width': true,
-        ...(isLineBreak ? {'data-pt-line-break': true as const} : {}),
-      }
-    : {
-        'data-slate-zero-width': engineValue,
-        'data-pt-zero-width': true,
-        ...(isLineBreak ? {'data-pt-line-break': true as const} : {}),
-      }
+  } = {
+    'data-pt-zero-width': true,
+    ...(isLineBreak ? {'data-pt-line-break': true as const} : {}),
+  }
 
   // FIXME: Inserting the \uFEFF on iOS breaks capitalization at the start of an
   // empty editor (https://github.com/ianstormtaylor/engine/issues/5199).

--- a/packages/editor/src/engine/react/components/text.tsx
+++ b/packages/editor/src/engine/react/components/text.tsx
@@ -2,8 +2,7 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
-import React, {useContext, type JSX} from 'react'
-import {NewPipelineContext} from '../../../editor/new-pipeline-context'
+import React, {type JSX} from 'react'
 import {serializePath} from '../../../paths/serialize-path'
 import {isTextDecorationsEqual} from '../../dom/utils/range-list'
 import type {Path} from '../../interfaces/path'
@@ -61,19 +60,12 @@ const Text = (props: {
   }
 
   const dataPath = serializePath(path)
-  const isInNewPipeline = useContext(NewPipelineContext)
 
   const attributes: {
-    'data-slate-node'?: 'text'
     'data-pt-path': string
-  } = isInNewPipeline
-    ? {
-        'data-pt-path': dataPath,
-      }
-    : {
-        'data-slate-node': 'text',
-        'data-pt-path': dataPath,
-      }
+  } = {
+    'data-pt-path': dataPath,
+  }
 
   return renderText({
     text,

--- a/packages/editor/tests/container-rendering.test.tsx
+++ b/packages/editor/tests/container-rendering.test.tsx
@@ -84,13 +84,12 @@ describe('container rendering', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       expect(editorElement!.innerHTML).toEqual(
         [
           '<div',
-          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;k0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="k0"',
@@ -100,14 +99,13 @@ describe('container rendering', () => {
           ' data-style="normal">',
           '<div>',
           '<span',
-          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;k0&quot;].children[_key==&quot;k1&quot;]"',
           ' data-child-key="k1"',
           ' data-child-name="span"',
           ' data-child-type="span"',
           ' data-pt-inline="span">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-string="true" data-pt-text="true">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
           'hello',
           '</span>',
           '</span>',
@@ -316,7 +314,7 @@ describe('table with nested rows and cells', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       expect(editorElement!.innerHTML).toEqual(
@@ -419,7 +417,7 @@ describe('container with non-editable fields', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       expect(editorElement!.innerHTML).toEqual(
@@ -524,7 +522,7 @@ describe('positional block-leaf override', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       // The text block inside the callout picks up the positional override
@@ -597,7 +595,7 @@ describe('container and renderer independence', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       expect(editorElement!.innerHTML).toEqual(
@@ -655,7 +653,7 @@ describe('container and renderer independence', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
 
       // The callout renders as a void block object, not using the custom renderer
@@ -749,7 +747,7 @@ describe('code block container', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       expect(editorElement!.innerHTML).toEqual(
         [
@@ -844,7 +842,7 @@ describe('gallery with void block objects', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       expect(normalizeInnerHTML(editorElement!.innerHTML)).toEqual(
         [
@@ -1032,7 +1030,7 @@ describe('cell with mixed content', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       expect(normalizeInnerHTML(editorElement!.innerHTML)).toEqual(
         [

--- a/packages/editor/tests/container-resolution-rules.test.tsx
+++ b/packages/editor/tests/container-resolution-rules.test.tsx
@@ -171,7 +171,7 @@ describe('Rule 1: registration is type-keyed, activation is position-gated', () 
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       const list = editorElement!.querySelector('[data-testid="list"]')
       expect(list).not.toEqual(null)
@@ -231,7 +231,7 @@ describe('Registration silent-skip behavior', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       const callout = editorElement!.querySelector('[data-testid="callout"]')
       expect(callout).not.toEqual(null)
@@ -302,7 +302,7 @@ describe('Registration silent-skip behavior', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       const callout = editorElement!.querySelector('[data-testid="callout"]')
       expect(callout).not.toEqual(null)
@@ -363,7 +363,7 @@ describe('Registration silent-skip behavior', () => {
     })
 
     await vi.waitFor(() => {
-      const editorElement = document.querySelector('[data-slate-editor]')
+      const editorElement = document.querySelector('[data-pt-editor]')
       expect(editorElement).not.toEqual(null)
       // Custom render did NOT apply (registration dropped); engine
       // default renders the callout block-object.

--- a/packages/editor/tests/define-textblock.test.tsx
+++ b/packages/editor/tests/define-textblock.test.tsx
@@ -53,7 +53,7 @@ test('TextBlockPlugin renders custom wrapper', async () => {
   })
 
   await vi.waitFor(() => {
-    const editorElement = document.querySelector('[data-slate-editor]')
+    const editorElement = document.querySelector('[data-pt-editor]')
     expect(editorElement).not.toEqual(null)
     const customBlock = editorElement!.querySelector(
       '[data-testid="custom-block"]',
@@ -83,7 +83,7 @@ test('Without TextBlockPlugin, engine default renders', async () => {
   })
 
   await vi.waitFor(() => {
-    const editorElement = document.querySelector('[data-slate-editor]')
+    const editorElement = document.querySelector('[data-pt-editor]')
     expect(editorElement).not.toEqual(null)
     const customBlock = editorElement!.querySelector(
       '[data-testid="custom-block"]',

--- a/packages/editor/tests/dom-structure.test.tsx
+++ b/packages/editor/tests/dom-structure.test.tsx
@@ -29,12 +29,11 @@ describe('DOM structure', () => {
       ],
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
           '<div',
-          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
@@ -44,14 +43,13 @@ describe('DOM structure', () => {
           ' data-style="normal">',
           '<div>',
           '<span',
-          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
           ' data-child-type="span"',
           ' data-pt-inline="span">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-zero-width="n" data-pt-zero-width="true" data-pt-line-break="true">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-zero-width="true" data-pt-line-break="true">',
           '﻿',
           '<br>',
           '</span>',
@@ -84,12 +82,11 @@ describe('DOM structure', () => {
       ],
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
           '<div',
-          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
@@ -99,21 +96,18 @@ describe('DOM structure', () => {
           ' data-style="normal">',
           '<div>',
           '<span',
-          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
           ' data-child-type="span"',
           ' data-pt-inline="span">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-string="true" data-pt-text="true">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
           'hello ',
           '</span>',
           '</span>',
           '</span>',
           '<span',
-          ' data-slate-node="element"',
-          ' data-slate-void="true"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;i0&quot;]"',
           ' contenteditable="false"',
           ' class="pt-inline-object"',
@@ -122,12 +116,11 @@ describe('DOM structure', () => {
           ' data-child-type="object"',
           ' data-pt-inline="object">',
           '<span',
-          ' data-slate-spacer="true"',
           ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-zero-width="z" data-pt-zero-width="true">',
+          '<span>',
+          '<span data-pt-marks="true">',
+          '<span data-pt-zero-width="true">',
           '﻿',
           '</span>',
           '</span>',
@@ -140,14 +133,13 @@ describe('DOM structure', () => {
           '</span>',
           '</span>',
           '<span',
-          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s1&quot;]"',
           ' data-child-key="s1"',
           ' data-child-name="span"',
           ' data-child-type="span"',
           ' data-pt-inline="span">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-string="true" data-pt-text="true">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
           ' world',
           '</span>',
           '</span>',
@@ -176,12 +168,11 @@ describe('DOM structure', () => {
       ],
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
           '<div',
-          ' data-slate-node="element"',
           ' data-pt-path="[_key==&quot;b0&quot;]"',
           ' class="pt-block pt-text-block pt-text-block-style-normal"',
           ' data-block-key="b0"',
@@ -191,14 +182,13 @@ describe('DOM structure', () => {
           ' data-style="normal">',
           '<div>',
           '<span',
-          ' data-slate-node="text"',
           ' data-pt-path="[_key==&quot;b0&quot;].children[_key==&quot;s0&quot;]"',
           ' data-child-key="s0"',
           ' data-child-name="span"',
           ' data-child-type="span"',
           ' data-pt-inline="span">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-string="true" data-pt-text="true">',
+          '<span data-pt-marks="true">',
+          '<span data-pt-text="true">',
           'hello',
           '</span>',
           '</span>',
@@ -206,8 +196,6 @@ describe('DOM structure', () => {
           '</div>',
           '</div>',
           '<div',
-          ' data-slate-node="element"',
-          ' data-slate-void="true"',
           ' data-pt-path="[_key==&quot;img0&quot;]"',
           ' class="pt-block pt-object-block"',
           ' data-block-key="img0"',
@@ -215,12 +203,11 @@ describe('DOM structure', () => {
           ' data-block-type="object"',
           ' data-pt-block="object">',
           '<div',
-          ' data-slate-spacer="true"',
           ' data-pt-spacer="true"',
           ' style="height: 0px; color: transparent; outline: none; position: absolute;">',
-          '<span data-slate-node="text">',
-          '<span data-slate-leaf="true" data-pt-marks="true">',
-          '<span data-slate-zero-width="z" data-pt-zero-width="true">',
+          '<span>',
+          '<span data-pt-marks="true">',
+          '<span data-pt-zero-width="true">',
           '﻿',
           '</span>',
           '</span>',
@@ -271,7 +258,7 @@ describe('DOM structure', () => {
       children: <NodePlugin nodes={[galleryContainer]} />,
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
@@ -417,7 +404,7 @@ describe('DOM structure', () => {
       ),
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
@@ -526,7 +513,7 @@ describe('DOM structure', () => {
       children: <NodePlugin nodes={[codeContainer]} />,
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [
@@ -736,7 +723,7 @@ describe('DOM structure', () => {
       ),
     })
     await vi.waitFor(() => {
-      const el = document.querySelector('[data-slate-editor]')
+      const el = document.querySelector('[data-pt-editor]')
       expect(el).not.toEqual(null)
       expect(normalizeInnerHTML(el!.innerHTML)).toEqual(
         [

--- a/packages/editor/tests/event.focus.test.tsx
+++ b/packages/editor/tests/event.focus.test.tsx
@@ -170,7 +170,7 @@ async function performDomSelection(
   text: string,
 ) {
   const editorEl = context.locator.element() as HTMLElement
-  const textNode = editorEl.querySelector('[data-slate-string]')?.childNodes[0]
+  const textNode = editorEl.querySelector('[data-pt-text]')?.childNodes[0]
 
   if (!textNode) {
     throw new Error('Could not find text node in editor')

--- a/packages/editor/tests/inline-object-contenteditable.test.tsx
+++ b/packages/editor/tests/inline-object-contenteditable.test.tsx
@@ -49,9 +49,6 @@ describe('inline-object void wrapper contenteditable', () => {
         '[data-testid="stock-ticker"]',
       )
       expect(consumerSpan).not.toEqual(null)
-      // The legacy pipeline is in play (no `ContainerPlugin`); confirm
-      // by checking that `object-node.tsx` emitted the `data-slate-spacer`
-      // variant of the inline-void spacer.
       expect(consumerSpan!.querySelector('[data-pt-spacer]')).not.toEqual(null)
       expect(consumerSpan!.getAttribute('contenteditable')).toEqual('false')
     })

--- a/packages/editor/tests/inline-pipeline-mode-inheritance.test.tsx
+++ b/packages/editor/tests/inline-pipeline-mode-inheritance.test.tsx
@@ -16,11 +16,16 @@ import {createTestEditor} from '../src/test/vitest'
  * children, producing inconsistent DOM (legacy attrs on the outer
  * block, clean `data-pt-*` only on the inline subtree).
  *
+ * A registered inline node's own wrapper receives the same clean
+ * `data-pt-*` attributes in both modes; the mode signal lives on the
+ * legacy pipeline's surrounding DOM (`data-child-*` on span text
+ * wrappers, `pt-*` classes on the block).
+ *
  * The four tests below pin both directions of the contract:
  *
  *   - Tests 1 & 2: a registered inline node inside an UNregistered
- *     text block keeps legacy attributes on its wrapper (inherits
- *     legacy from the parent text block).
+ *     text block gets a clean wrapper while the surrounding legacy
+ *     DOM keeps its legacy attributes.
  *   - Tests 3 & 4: the same inline node inside a REGISTERED text
  *     block emits clean `data-pt-*` attributes (inherits new pipeline
  *     from the parent text block).
@@ -46,7 +51,7 @@ function getInlineWrapperAttrs(testid: string): string {
 }
 
 describe('inline pipeline mode inherits from text block', () => {
-  test('registered inline-object inside LEGACY text block keeps data-slate-* attributes on its wrapper', async () => {
+  test('registered inline-object inside LEGACY text block gets a clean wrapper inside legacy surroundings', async () => {
     const schema = defineSchema({
       inlineObjects: [{name: 'mention', fields: []}],
     })
@@ -81,17 +86,21 @@ describe('inline pipeline mode inherits from text block', () => {
 
     await vi.waitFor(() => {
       const editorHTML = getEditorHTML()
-      // Sanity: the text block is legacy (data-slate-node="element" on it).
-      expect(editorHTML).toMatch(/data-slate-node="element"/)
+      // Sanity: the text block is legacy (`pt-*` classes and
+      // `data-child-*` wrappers around it).
+      expect(editorHTML).toMatch(/data-block-key="b0"/)
+      expect(editorHTML).toMatch(/data-child-key="s0"/)
       // The mention is rendered.
       expect(editorHTML).toContain('@alice')
-      // The mention wrapper's own attributes include legacy data-slate-*.
+      // The mention wrapper's own attributes are the clean `data-pt-*`
+      // shape, identical to what a registered text block would produce.
       const attrs = getInlineWrapperAttrs('mention-wrapper')
-      expect(attrs).toMatch(/data-slate-/)
+      expect(attrs).toMatch(/data-pt-inline="object"/)
+      expect(attrs).not.toMatch(/data-child-/)
     })
   })
 
-  test('registered span inside LEGACY text block keeps data-slate-* attributes on its wrapper', async () => {
+  test('registered span inside LEGACY text block gets a clean wrapper inside legacy surroundings', async () => {
     const schema = defineSchema({})
     const span = defineSpan({
       type: 'span',
@@ -119,13 +128,16 @@ describe('inline pipeline mode inherits from text block', () => {
 
     await vi.waitFor(() => {
       const editorHTML = getEditorHTML()
-      // Sanity: the text block is legacy.
-      expect(editorHTML).toMatch(/data-slate-node="element"/)
+      // Sanity: the text block is legacy (`data-child-*` on the span's
+      // text wrapper).
+      expect(editorHTML).toMatch(/data-child-key="s0"/)
       // The span is rendered.
       expect(editorHTML).toContain('hello')
-      // The span wrapper's own attributes include legacy data-slate-*.
+      // The span wrapper's own attributes are the clean `data-pt-*`
+      // shape, identical to what a registered text block would produce.
       const attrs = getInlineWrapperAttrs('span-wrapper')
-      expect(attrs).toMatch(/data-slate-/)
+      expect(attrs).toMatch(/data-pt-marks/)
+      expect(attrs).not.toMatch(/data-child-/)
     })
   })
 

--- a/packages/editor/tests/positional-override-cross-scope.test.tsx
+++ b/packages/editor/tests/positional-override-cross-scope.test.tsx
@@ -126,7 +126,7 @@ describe('Cross-scope positional override', () => {
         calloutEl!.querySelector('[data-testid="mention-in-callout"]'),
       ).not.toEqual(null)
       // The top-level mention is rendered by the GLOBAL render.
-      const editor = document.querySelector('[data-slate-editor]')
+      const editor = document.querySelector('[data-pt-editor]')
       const globals = editor!.querySelectorAll('[data-testid="mention-global"]')
       // The top-level block has one mention via global render.
       expect(globals.length).toEqual(1)

--- a/packages/editor/tests/register-node-clean-dom.test.tsx
+++ b/packages/editor/tests/register-node-clean-dom.test.tsx
@@ -11,17 +11,6 @@ import {
 } from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 
-/**
- * The load-bearing TDD contract for PR #2681: any subtree rendered
- * through `registerNode` (the new pipeline) must emit ZERO
- * `data-slate-*` attributes. The engine's legacy pipeline still emits
- * `data-slate-*` for backwards compatibility with consumers that walk
- * engine-shaped legacy DOM; the new pipeline strictly emits `data-pt-*` only.
- *
- * One assertion per kind. If any of these fail, a registration
- * mechanism is leaking legacy attrs into the new pipeline.
- */
-
 function getSubtreeHTML(testid: string): string {
   const root = document.querySelector(`[data-testid="${testid}"]`)
   if (!root) {

--- a/packages/editor/tests/to-engine-range.test.tsx
+++ b/packages/editor/tests/to-engine-range.test.tsx
@@ -205,5 +205,5 @@ function findTextNode(
   if (!spanEl) {
     return undefined
   }
-  return spanEl.querySelector('[data-slate-string="true"]')?.childNodes[0]
+  return spanEl.querySelector('[data-pt-text="true"]')?.childNodes[0]
 }


### PR DESCRIPTION
The editor's DOM carried `data-slate-node`, `data-slate-leaf`, `data-slate-string`, and their siblings as aliases of the engine's own `data-pt-*` attributes, kept while consumers migrated selectors off the Slate names. This PR removes the aliases: the engine emits only its own attribute vocabulary, and the DOM-structure tests pin the resulting markup.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3cb2de89bc99ec38e4d32ce95ef0edad8ddcbd54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->