### PR TITLE
feat!: remove the `loading`, `done loading`, and `error` editor events

### DIFF
--- a/.changeset/remove-loading-relay-events.md
+++ b/.changeset/remove-loading-relay-events.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': major
+---
+
+feat!: remove the `loading`, `done loading`, and `error` editor events
+
+The deprecated `loading`, `done loading`, and `error` members are removed from `EditorEmittedEvent`. The `error` event was never emitted; `loading` and `done loading` fired only around an async `onPaste` resolution and no longer do. Exhaustive switches over `event.type` lose three cases; listeners for these events can be deleted.

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -82,7 +82,6 @@ import {Button} from './primitives/button'
 import {Container} from './primitives/container'
 import {ErrorBoundary} from './primitives/error-boundary'
 import {ErrorScreen} from './primitives/error-screen'
-import {Spinner} from './primitives/spinner'
 import {ToggleButton} from './primitives/toggle-button'
 import {Tooltip} from './primitives/tooltip'
 import {RangeDecorationButton} from './range-decoration-button'
@@ -98,7 +97,6 @@ export function Editor(props: {
     props.editorRef,
     (s) => s.context.keyGenerator,
   )
-  const [loading, setLoading] = useState(false)
   const [readOnly, setReadOnly] = useState(false)
   const playgroundFeatureFlags = useContext(PlaygroundFeatureFlagsContext)
   const featureFlags = useSelector(
@@ -128,12 +126,6 @@ export function Editor(props: {
               on={(event) => {
                 if (event.type === 'mutation') {
                   props.editorRef.send(event)
-                }
-                if (event.type === 'loading') {
-                  setLoading(true)
-                }
-                if (event.type === 'done loading') {
-                  setLoading(false)
                 }
                 if (event.type === 'editable') {
                   setReadOnly(false)
@@ -208,7 +200,6 @@ export function Editor(props: {
                 <FullscreenAwareEditable
                   rangeDecorations={props.rangeDecorations}
                   featureFlags={featureFlags}
-                  loading={loading}
                 />
                 <EditorFooter editorRef={props.editorRef} readOnly={readOnly} />
               </FullscreenAwareContainer>
@@ -223,7 +214,6 @@ export function Editor(props: {
 function FullscreenAwareEditable(props: {
   rangeDecorations: RangeDecoration[]
   featureFlags: EditorFeatureFlags
-  loading: boolean
 }) {
   const {isFullscreen} = useFullscreen()
   const wrapperClasses = isFullscreen
@@ -251,7 +241,6 @@ function FullscreenAwareEditable(props: {
           />
         </EditorFeatureFlagsContext.Provider>
       </ErrorBoundary>
-      {props.loading ? <Spinner /> : null}
     </div>
   )
 }

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -424,8 +424,6 @@ export const PortableTextEditable = forwardRef<
         event.preventDefault()
 
         // Resolve it as promise (can be either async promise or sync return value)
-        relay.send({type: 'loading'})
-
         Promise.resolve(onPasteResult)
           .then((result) => {
             debug.behaviors(
@@ -489,9 +487,6 @@ export const PortableTextEditable = forwardRef<
 
             return error
           })
-          .finally(() => {
-            relay.send({type: 'done loading'})
-          })
       } else if (event.nativeEvent.clipboardData) {
         // Prevent the engine from handling the event
         event.preventDefault()
@@ -521,7 +516,7 @@ export const PortableTextEditable = forwardRef<
 
       debug.behaviors('No result from custom paste handler, pasting normally')
     },
-    [editorActor, onPaste, portableTextEditor, relay, editorEngine],
+    [editorActor, onPaste, portableTextEditor, editorEngine],
   )
 
   const handleOnFocus: FocusEventHandler<HTMLDivElement> = useCallback(

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -142,11 +142,9 @@ export function createInternalEditor(config: EditorConfig): {
       return relay.on(type, (event) => {
         switch (event.type) {
           case 'blurred':
-          case 'done loading':
           case 'editable':
           case 'focused':
           case 'invalid value':
-          case 'loading':
           case 'mutation':
           case 'operation':
           case 'patch':

--- a/packages/editor/src/editor/relay.ts
+++ b/packages/editor/src/editor/relay.ts
@@ -13,15 +13,8 @@ export type EditorEmittedEvent =
       event: FocusEvent<HTMLDivElement, Element>
     }
   | {
-      /**
-       * @deprecated Will be removed in the next major version
-       */
-      type: 'done loading'
-    }
-  | {
       type: 'editable'
     }
-  | ErrorEvent
   | {
       type: 'focused'
       event: FocusEvent<HTMLDivElement, Element>
@@ -30,12 +23,6 @@ export type EditorEmittedEvent =
       type: 'invalid value'
       resolution: InvalidValueResolution | null
       value: Array<PortableTextBlock> | undefined
-    }
-  | {
-      /**
-       * @deprecated Will be removed in the next major version
-       */
-      type: 'loading'
     }
   | MutationEvent
   | {
@@ -76,16 +63,6 @@ export type EditorEmittedEvent =
       type: 'value changed'
       value: Array<PortableTextBlock> | undefined
     }
-
-/**
- * @deprecated The event is no longer emitted
- */
-type ErrorEvent = {
-  type: 'error'
-  name: string
-  description: string
-  data: unknown
-}
 
 /**
  * @public

--- a/packages/editor/src/plugins/plugin.event-listener.tsx
+++ b/packages/editor/src/plugins/plugin.event-listener.tsx
@@ -6,12 +6,9 @@ import {useEditor} from '../editor/use-editor'
  * @public
  * Listen for events emitted by the editor. Must be used inside `EditorProvider`. Events available include:
  *  - 'blurred'
- *  - 'done loading'
  *  - 'editable'
- *  - 'error'
  *  - 'focused'
  *  - 'invalid value'
- *  - 'loading'
  *  - 'mutation'
  *  - 'patch'
  *  - 'read only'


### PR DESCRIPTION
The relayed `loading` and `done loading` events fired around value normalization long after the editor stopped doing async setup, and the relayed `error` event had no emitter left at all: subscribers could listen forever without a single event arriving. This PR removes all three from the event listener surface and their types.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5725a04a00b7fde13f6457bb03210811ed65b0ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->