### PR TITLE
feat!: drop the legacy `main` and `module` fields

### DIFF
--- a/.changeset/drop-legacy-entry-fields.md
+++ b/.changeset/drop-legacy-entry-fields.md
@@ -1,0 +1,29 @@
+---
+'@portabletext/block-tools': major
+'@portabletext/editor': major
+'@portabletext/html': major
+'@portabletext/keyboard-shortcuts': major
+'@portabletext/markdown': major
+'@portabletext/patches': major
+'@portabletext/plugin-character-pair-decorator': major
+'@portabletext/plugin-dnd': major
+'@portabletext/plugin-emoji-picker': major
+'@portabletext/plugin-input-rule': major
+'@portabletext/plugin-list-index': major
+'@portabletext/plugin-markdown-shortcuts': major
+'@portabletext/plugin-one-line': major
+'@portabletext/plugin-paste-link': major
+'@portabletext/plugin-sdk-value': major
+'@portabletext/plugin-table': major
+'@portabletext/plugin-typeahead-picker': major
+'@portabletext/plugin-typography': major
+'@portabletext/sanity-bridge': major
+'@portabletext/schema': major
+'@portabletext/test': major
+'@portabletext/toolbar': major
+'racejar': major
+---
+
+feat!: drop the legacy `main` and `module` fields
+
+Every package now declares its entry points through the `exports` map only. Node, all maintained bundlers, and TypeScript (`moduleResolution: 'bundler'`, 'node16', or 'nodenext') resolve through `exports`; only tooling that predates `exports` support read `main` or `module` and can no longer resolve these packages.

--- a/packages/block-tools/package.json
+++ b/packages/block-tools/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -29,8 +29,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./lib/index.js",
-  "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/patches/package.json
+++ b/packages/patches/package.json
@@ -23,8 +23,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-character-pair-decorator/package.json
+++ b/packages/plugin-character-pair-decorator/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-dnd/package.json
+++ b/packages/plugin-dnd/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-emoji-picker/package.json
+++ b/packages/plugin-emoji-picker/package.json
@@ -23,8 +23,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-input-rule/package.json
+++ b/packages/plugin-input-rule/package.json
@@ -23,8 +23,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-list-index/package.json
+++ b/packages/plugin-list-index/package.json
@@ -24,8 +24,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-markdown-shortcuts/package.json
+++ b/packages/plugin-markdown-shortcuts/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-one-line/package.json
+++ b/packages/plugin-one-line/package.json
@@ -24,8 +24,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-paste-link/package.json
+++ b/packages/plugin-paste-link/package.json
@@ -26,8 +26,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -27,8 +27,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -25,8 +25,6 @@
   "sideEffects": [
     "*.css"
   ],
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-typeahead-picker/package.json
+++ b/packages/plugin-typeahead-picker/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/plugin-typography/package.json
+++ b/packages/plugin-typography/package.json
@@ -23,8 +23,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/racejar/package.json
+++ b/packages/racejar/package.json
@@ -25,8 +25,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/sanity-bridge/package.json
+++ b/packages/sanity-bridge/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -23,8 +23,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -22,8 +22,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Every package published from this repo carried legacy `main` and `module` fields alongside the `exports` map that has been the real resolution surface since Node 12 and every bundler of the last five years. This PR drops the legacy fields: resolution goes through `exports` alone, and tooling old enough to ignore `exports` is older than the packages' Node floor.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ba654c28444ebc483a77587254ffda832e5169e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->