### PR TITLE
ci: install only the matrix browser in browser-test jobs

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -49,13 +49,13 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-${{ matrix.browser }}-playwright-browsers
 
       - name: Install Playwright Browsers
         # TODO: Fix webkit caching when downloading from cache
         # for some reason it doesn't work without installing again
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' || matrix.browser == 'webkit'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Test
         id: test


### PR DESCRIPTION
The browser-test matrix ran `npx playwright install --with-deps` with no browser argument, so every job installed all three browsers and their full apt dependency lists. Scoping the install to `matrix.browser` cuts each job's download and apt surface to a third. Today's stalls made the cost visible: the runners' Azure apt mirror degraded, and the webkit job (which always reinstalls, per the existing cache workaround) sat in apt retries for the full hour-long timeout while fetching dependencies for browsers it never runs.

The cache key gains a `matrix.browser` dimension to match: with per-browser installs, a shared key would let the first finishing job save a single-browser cache that the other two jobs treat as a hit, skip install on, and fail against (caught by Bugbot on the first revision).

The webkit cache workaround itself is untouched; a plausible follow-up is replacing it with `playwright install-deps webkit` on cache hits, if the original cache failure was missing system dependencies rather than a broken cached binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with no application runtime impact; slightly different cache partitioning per browser.
> 
> **Overview**
> **Browser CI jobs now install and cache only the browser they run**, instead of pulling all three Playwright browsers and their full apt dependency set on every matrix leg.
> 
> The Playwright browser cache key includes **`matrix.browser`**, so chromium, firefox, and webkit jobs no longer share one cache entry. The install step runs `npx playwright install --with-deps ${{ matrix.browser }}` rather than an unscoped install. The existing webkit cache workaround (reinstall when cache hits) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606e81d6640c4258784cb51e1b2b3b8874c08e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

