### PR TITLE
feat!: remove the `renderStyle` render prop

### DIFF
--- a/.changeset/remove-render-style.md
+++ b/.changeset/remove-render-style.md
@@ -1,0 +1,26 @@
+---
+'@portabletext/editor': major
+---
+
+feat!: remove the `renderStyle` render prop
+
+The `renderStyle` render prop on `<PortableTextEditable>` is removed, along with the `RenderStyleFunction` type. Text-block styles render through a `defineTextBlock` registration instead: the registered `render` callback receives the block as `props.node` and owns the wrapper element.
+
+```tsx
+import {defineTextBlock} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
+
+const textBlock = defineTextBlock({
+  type: 'block',
+  render: (props) =>
+    props.node.style === 'h1' ? (
+      <h1 {...props.attributes}>{props.children}</h1>
+    ) : (
+      <div {...props.attributes}>{props.children}</div>
+    ),
+})
+
+// Inside `EditorProvider`:
+// <NodePlugin nodes={[textBlock]} />
+```
+

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,7 @@
     "@astrojs/starlight-tailwind": "^5.0.0",
     "@portabletext/editor": "workspace:*",
     "@portabletext/keyboard-shortcuts": "workspace:*",
+    "@portabletext/plugin-list-index": "workspace:*",
     "@portabletext/plugin-markdown-shortcuts": "workspace:*",
     "@portabletext/plugin-typography": "workspace:*",
     "@portabletext/react": "catalog:tooling",

--- a/apps/docs/src/components/editor/portable-text-editor.tsx
+++ b/apps/docs/src/components/editor/portable-text-editor.tsx
@@ -1,15 +1,18 @@
 import './editor.css'
 import {
+  defineInlineObject,
+  defineTextBlock,
   defineAnnotation,
   defineDecorator,
   EditorProvider,
   PortableTextEditable,
   type BlockRenderProps,
-  type ChildRenderProps,
   type PortableTextBlock,
   type SchemaDefinition,
+  type TextBlockRenderProps,
 } from '@portabletext/editor'
 import {EventListenerPlugin, NodePlugin} from '@portabletext/editor/plugins'
+import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {TypographyPlugin} from '@portabletext/plugin-typography'
 import {PortableText} from '@portabletext/react'
@@ -25,8 +28,81 @@ import {defaultSchema} from './defaultSchema'
 import {initialValue as defaultInitialValue} from './initial-value'
 import {PortableTextToolbar} from './toolbar/portable-text-toolbar'
 
+type PortableTextEditorProps = {
+  customSchema?: SchemaDefinition
+}
+
+const textBlock = defineTextBlock({
+  type: 'block',
+  render: (props) => <DocsTextBlock {...props} />,
+})
+
+function DocsTextBlock(props: TextBlockRenderProps) {
+  const listIndex = useListIndex(props.path)
+
+  let children = props.children
+  if (props.node.style === 'h1') {
+    children = <h1 className="mb-1 font-bold text-3xl relative">{children}</h1>
+  } else if (props.node.style === 'h2') {
+    children = <h2 className="mb-1 font-bold text-2xl relative">{children}</h2>
+  } else if (props.node.style === 'h3') {
+    children = <h3 className="mb-1 font-bold text-xl relative">{children}</h3>
+  } else if (props.node.style === 'blockquote') {
+    children = (
+      <blockquote className="mb-1 pl-2 py-1 border-gray-200 dark:border-gray-600 border-l-4 relative">
+        {children}
+      </blockquote>
+    )
+  } else {
+    children = <p className="mb-1 relative">{children}</p>
+  }
+
+  return (
+    <div
+      {...props.attributes}
+      data-style={props.node.style}
+      data-list-item={props.node.listItem}
+      data-level={props.node.level}
+      data-list-index={listIndex}
+    >
+      {children}
+    </div>
+  )
+}
+
+const stockTicker = defineInlineObject({
+  type: 'stock-ticker',
+  render: (props) => {
+    const value = props.node as {symbol?: string}
+    return (
+      <span
+        {...props.attributes}
+        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-xs font-mono ${
+          props.selected
+            ? 'border-blue-400 dark:border-blue-500'
+            : 'border-gray-300 dark:border-gray-600'
+        } ${props.focused ? 'bg-blue-50 dark:bg-blue-950' : 'bg-gray-50 dark:bg-gray-800'}`}
+      >
+        {props.children}
+        {/* `draggable` makes the object movable and keeps its text
+            unselectable: a draggable element starts a drag instead of a
+            text selection */}
+        <span
+          draggable={!props.readOnly}
+          className="inline-flex items-center gap-1"
+        >
+          <ActivityIcon className="size-3" />
+          {value.symbol || 'TICKER'}
+        </span>
+      </span>
+    )
+  },
+})
+
 // Module scope: a new array identity re-registers the nodes on every render.
 const nodes = [
+  textBlock,
+  stockTicker,
   defineDecorator({
     type: 'strong',
     render: ({children}) => <strong>{children}</strong>,
@@ -61,10 +137,6 @@ const nodes = [
     },
   }),
 ]
-
-type PortableTextEditorProps = {
-  customSchema?: SchemaDefinition
-}
 
 export function PortableTextEditor({customSchema}: PortableTextEditorProps) {
   const [value, setValue] = useState<Array<PortableTextBlock> | undefined>(
@@ -129,98 +201,51 @@ export function PortableTextEditor({customSchema}: PortableTextEditorProps) {
                 @portabletext/editor
               </span>
             </div>
-            <PortableTextEditable
-              className="min-h-[200px] p-4 outline-none"
-              renderBlock={(props: BlockRenderProps) => {
-                if (props.schemaType.name === 'image') {
-                  const value = props.value as {src?: string; alt?: string}
-                  return (
-                    <div
-                      className={`my-2 p-2 border-2 rounded flex items-start gap-3 ${
-                        props.selected
-                          ? 'border-blue-400 dark:border-blue-500'
-                          : 'border-gray-200 dark:border-gray-700'
-                      } ${props.focused ? 'bg-blue-50 dark:bg-blue-950' : ''}`}
-                    >
-                      <div className="bg-gray-100 dark:bg-gray-800 size-16 flex items-center justify-center rounded overflow-hidden shrink-0">
-                        {value.src ? (
-                          <img
-                            src={value.src}
-                            alt={value.alt ?? ''}
-                            className="object-cover max-w-full max-h-full"
-                          />
-                        ) : (
-                          <ImageIcon className="size-6 text-gray-400 dark:text-gray-500" />
-                        )}
+            <ListIndexProvider>
+              <PortableTextEditable
+                className="min-h-[200px] p-4 outline-none"
+                renderBlock={(props: BlockRenderProps) => {
+                  if (props.schemaType.name === 'image') {
+                    const value = props.value as {src?: string; alt?: string}
+                    return (
+                      <div
+                        className={`my-2 p-2 border-2 rounded flex items-start gap-3 ${
+                          props.selected
+                            ? 'border-blue-400 dark:border-blue-500'
+                            : 'border-gray-200 dark:border-gray-700'
+                        } ${props.focused ? 'bg-blue-50 dark:bg-blue-950' : ''}`}
+                      >
+                        <div className="bg-gray-100 dark:bg-gray-800 size-16 flex items-center justify-center rounded overflow-hidden shrink-0">
+                          {value.src ? (
+                            <img
+                              src={value.src}
+                              alt={value.alt ?? ''}
+                              className="object-cover max-w-full max-h-full"
+                            />
+                          ) : (
+                            <ImageIcon className="size-6 text-gray-400 dark:text-gray-500" />
+                          )}
+                        </div>
+                        <div className="flex flex-col gap-1 min-w-0 text-sm">
+                          <span className="truncate text-gray-600 dark:text-gray-300">
+                            {value.src || 'No source'}
+                          </span>
+                          <span className="truncate text-gray-400 dark:text-gray-500 text-xs">
+                            {value.alt || 'No alt text'}
+                          </span>
+                        </div>
                       </div>
-                      <div className="flex flex-col gap-1 min-w-0 text-sm">
-                        <span className="truncate text-gray-600 dark:text-gray-300">
-                          {value.src || 'No source'}
-                        </span>
-                        <span className="truncate text-gray-400 dark:text-gray-500 text-xs">
-                          {value.alt || 'No alt text'}
-                        </span>
-                      </div>
-                    </div>
-                  )
-                }
-                return props.children
-              }}
-              renderChild={(props: ChildRenderProps) => {
-                if (props.schemaType.name === 'stock-ticker') {
-                  const value = props.value as {symbol?: string}
-                  return (
-                    <span
-                      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-xs font-mono ${
-                        props.selected
-                          ? 'border-blue-400 dark:border-blue-500'
-                          : 'border-gray-300 dark:border-gray-600'
-                      } ${props.focused ? 'bg-blue-50 dark:bg-blue-950' : 'bg-gray-50 dark:bg-gray-800'}`}
-                    >
-                      <ActivityIcon className="size-3" />
-                      {value.symbol || 'TICKER'}
-                    </span>
-                  )
-                }
-                return props.children
-              }}
-              renderStyle={(props) => {
-                if (props.value === 'h1') {
-                  return (
-                    <h1 className="mb-1 font-bold text-3xl relative">
-                      {props.children}
-                    </h1>
-                  )
-                }
-                if (props.value === 'h2') {
-                  return (
-                    <h2 className="mb-1 font-bold text-2xl relative">
-                      {props.children}
-                    </h2>
-                  )
-                }
-                if (props.value === 'h3') {
-                  return (
-                    <h3 className="mb-1 font-bold text-xl relative">
-                      {props.children}
-                    </h3>
-                  )
-                }
-                if (props.value === 'blockquote') {
-                  return (
-                    <blockquote className="mb-1 pl-2 py-1 border-gray-200 dark:border-gray-600 border-l-4 relative">
-                      {props.children}
-                    </blockquote>
-                  )
-                }
-                return <p className="mb-1 relative">{props.children}</p>
-              }}
-              renderPlaceholder={() => (
-                <span className="text-gray-400 dark:text-gray-500">
-                  Type something
-                </span>
-              )}
-            />
+                    )
+                  }
+                  return props.children
+                }}
+                renderPlaceholder={() => (
+                  <span className="text-gray-400 dark:text-gray-500">
+                    Type something
+                  </span>
+                )}
+              />
+            </ListIndexProvider>
           </div>
         </div>
       </EditorProvider>

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -35,7 +35,6 @@ import type {
   RenderChildFunction,
   RenderDecoratorFunction,
   RenderPlaceholderFunction,
-  RenderStyleFunction,
   ScrollSelectionIntoViewFunction,
 } from '../types/editor'
 import type {HotkeyOptions} from '../types/options'
@@ -93,12 +92,6 @@ export type PortableTextEditableProps = Omit<
    */
   renderDecorator?: RenderDecoratorFunction
   renderPlaceholder?: RenderPlaceholderFunction
-  /**
-   * @deprecated Render text-block styles with `defineTextBlock` mounted
-   * through `NodePlugin` instead. See the migration guide:
-   * https://www.portabletext.org/editor/guides/migrate-render-props/
-   */
-  renderStyle?: RenderStyleFunction
   scrollSelectionIntoView?: ScrollSelectionIntoViewFunction
   selection?: EditorSelection
   spellCheck?: boolean
@@ -150,7 +143,6 @@ export const PortableTextEditable = forwardRef<
     renderChild,
     renderDecorator,
     renderPlaceholder,
-    renderStyle,
     selection: propsSelection,
     scrollSelectionIntoView,
     ...restProps
@@ -203,9 +195,8 @@ export const PortableTextEditable = forwardRef<
     () => ({
       renderBlock,
       renderChild,
-      renderStyle,
     }),
-    [renderBlock, renderChild, renderStyle],
+    [renderBlock, renderChild],
   )
 
   const renderElement = useCallback(

--- a/packages/editor/src/editor/legacy-render-hooks.ts
+++ b/packages/editor/src/editor/legacy-render-hooks.ts
@@ -1,8 +1,4 @@
-import type {
-  RenderBlockFunction,
-  RenderChildFunction,
-  RenderStyleFunction,
-} from '../types/editor'
+import type {RenderBlockFunction, RenderChildFunction} from '../types/editor'
 
 /**
  * The legacy v6 render-callback bundle that the engine forwards to the
@@ -16,5 +12,4 @@ import type {
 export type LegacyRenderHooks = {
   renderBlock?: RenderBlockFunction
   renderChild?: RenderChildFunction
-  renderStyle?: RenderStyleFunction
 }

--- a/packages/editor/src/editor/render.text-block.tsx
+++ b/packages/editor/src/editor/render.text-block.tsx
@@ -6,12 +6,7 @@ import {useRef, type ReactElement} from 'react'
 import type {Path} from '../engine/interfaces/path'
 import type {RenderElementProps} from '../engine/react/components/editable'
 import {serializePath} from '../paths/serialize-path'
-import type {
-  BlockRenderProps,
-  BlockStyleRenderProps,
-  RenderBlockFunction,
-  RenderStyleFunction,
-} from '../types/editor'
+import type {BlockRenderProps, RenderBlockFunction} from '../types/editor'
 import {useElementDropPosition} from './drop-position-state-context'
 import type {EditorSchema} from './editor-schema'
 import type {LegacyRenderHooks} from './legacy-render-hooks'
@@ -20,7 +15,6 @@ import {
   useIsFocusedContainer,
   useIsSelectedContainer,
 } from './selection-state-context'
-import {useBlockSubSchema} from './use-block-sub-schema'
 
 export function RenderTextBlock(props: {
   attributes: RenderElementProps['attributes']
@@ -41,39 +35,8 @@ export function RenderTextBlock(props: {
   const selected = useIsSelectedContainer(serializedPath)
   const focused = useIsFocusedContainer(serializedPath)
   const dropPosition = useElementDropPosition(props.path)
-  const subSchema = useBlockSubSchema(props.path)
 
-  let children = props.children
-
-  if (props.legacy.renderStyle && props.textBlock.style) {
-    const styleSchemaType =
-      props.textBlock.style !== undefined
-        ? subSchema.styles.find(
-            (style) => style.value === props.textBlock.style,
-          )
-        : undefined
-
-    if (styleSchemaType) {
-      children = (
-        <RenderStyle
-          renderStyle={props.legacy.renderStyle}
-          block={props.textBlock}
-          editorElementRef={blockRef}
-          focused={focused}
-          path={[{_key: props.textBlock._key}]}
-          schemaType={styleSchemaType}
-          selected={selected}
-          value={props.textBlock.style}
-        >
-          {children}
-        </RenderStyle>
-      )
-    } else {
-      console.error(
-        `Unable to find Schema type for text block style ${props.textBlock.style}`,
-      )
-    }
-  }
+  const children = props.children
 
   return (
     <div
@@ -163,31 +126,6 @@ function RenderBlock({
     selected,
     style,
     schemaType,
-    value,
-  })
-}
-
-function RenderStyle({
-  renderStyle,
-  block,
-  children,
-  editorElementRef,
-  focused,
-  path,
-  schemaType,
-  selected,
-  value,
-}: {
-  renderStyle: RenderStyleFunction
-} & BlockStyleRenderProps) {
-  return renderStyle({
-    block,
-    children,
-    editorElementRef,
-    focused,
-    path,
-    schemaType,
-    selected,
     value,
   })
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -110,7 +110,6 @@ export type {
   RenderDecoratorFunction,
   RenderEditableFunction,
   RenderPlaceholderFunction,
-  RenderStyleFunction,
   ScrollSelectionIntoViewFunction,
 } from './types/editor'
 export type {HotkeyOptions} from './types/options'

--- a/packages/editor/src/renderers/renderer.types.ts
+++ b/packages/editor/src/renderers/renderer.types.ts
@@ -255,7 +255,7 @@ export type Container = {
  * The consumer's `render` callback owns the outer wrapper entirely:
  * the engine emits `data-pt-*` attributes only - no `pt-*` CSS classes,
  * no legacy `data-block-*` attributes - and the block-level
- * `renderStyle`/`renderBlock` props on
+ * `renderBlock` prop on
  * `<PortableTextEditable>` do not compose under this registration.
  *
  * Span-level render props - `renderDecorator`, `renderAnnotation`,

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -309,21 +309,11 @@ export type RenderPlaceholderFunction = () => React.ReactNode
 
 /**
  * @beta
- * @deprecated The `renderStyle` render prop is deprecated. Render
- * text-block styles with `defineTextBlock` mounted through `NodePlugin`
- * instead. See the migration guide:
- * https://www.portabletext.org/editor/guides/migrate-render-props/
+ * @deprecated The `renderStyle` render prop is removed; render text-block
+ * styles with `defineTextBlock` instead. This props shape will be removed
+ * in the next major version.
  */
-export type RenderStyleFunction = (props: BlockStyleRenderProps) => JSX.Element
 
-/**
- * @beta
- * @deprecated `BlockStyleRenderProps` is deprecated together with the
- * `renderStyle` render prop it serves. Render text-block styles with
- * `defineTextBlock` mounted through `NodePlugin` instead. See the
- * migration guide:
- * https://www.portabletext.org/editor/guides/migrate-render-props/
- */
 export interface BlockStyleRenderProps {
   block: PortableTextTextBlock
   children: ReactElement<any>

--- a/packages/editor/tests/legacy-suppression.test.tsx
+++ b/packages/editor/tests/legacy-suppression.test.tsx
@@ -14,8 +14,8 @@ import {createTestEditor} from '../src/test/vitest'
  * Legacy-suppression contract for the new render pipeline.
  *
  * Once a position is inside a `registerNode`-shaped subtree, the four
- * block-level legacy `renderX` hooks (renderBlock, renderListItem,
- * renderStyle, renderChild) are suppressed. The four span/leaf-level
+ * block-level legacy `renderX` hooks (renderBlock, renderChild) are
+ * suppressed. The four span/leaf-level
  * hooks (renderDecorator, renderAnnotation, renderPlaceholder, range
  * decorations) keep firing because they operate at the leaf level on
  * span text - they wrap runs of text and don't emit pipeline-shaped

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@portabletext/keyboard-shortcuts':
         specifier: workspace:*
         version: link:../../packages/keyboard-shortcuts
+      '@portabletext/plugin-list-index':
+        specifier: workspace:*
+        version: link:../../packages/plugin-list-index
       '@portabletext/plugin-markdown-shortcuts':
         specifier: workspace:*
         version: link:../../packages/plugin-markdown-shortcuts


### PR DESCRIPTION
The `renderStyle` render prop on `<PortableTextEditable>` is removed along with its `RenderStyleFunction` type: text-block styles render through the `defineTextBlock` registration, whose `render` receives the block as `props.node` and owns the wrapper element. `BlockStyleRenderProps` survives this PR as a deprecated tombstone and falls in the stack's types-removal PR.

The docs site's own editor component migrates to a registered text block (with `useListIndex` for numbering) and a registered inline object in the same motion, folding its previous mark registrations into one module-level `nodes` array with a single `NodePlugin` mount.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major breaking API removal affects every consumer still styling blocks via `renderStyle`; incorrect `defineTextBlock` migrations can change DOM structure and list numbering.
> 
> **Overview**
> **Breaking change:** `@portabletext/editor` drops the `renderStyle` prop on `PortableTextEditable` and stops exporting `RenderStyleFunction`. The default text-block path no longer wraps content through a legacy style callback; headings, lists, and block wrappers belong in a **`defineTextBlock`** `render` registered via **`NodePlugin`**.
> 
> Engine wiring removes `renderStyle` from legacy hooks and deletes the internal **`RenderStyle`** helper in `render.text-block.tsx`. Docs and types now describe **`defineTextBlock`** as the only supported style surface; **`BlockStyleRenderProps`** remains only as a deprecated type stub for a later cleanup.
> 
> The docs demo migrates off **`renderStyle`** / **`renderChild`**: a module-level **`defineTextBlock`** (`DocsTextBlock` with **`useListIndex`** from **`@portabletext/plugin-list-index`**) and **`defineInlineObject`** for stock tickers, wrapped in **`ListIndexProvider`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb1eeee57994a76c1941ce4488c32fce97bf06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->