### PR TITLE
test: pin registered-node render-callback counts under typing

### DIFF
--- a/packages/editor/tests/render-count-regression.test.tsx
+++ b/packages/editor/tests/render-count-regression.test.tsx
@@ -1,8 +1,27 @@
+import type {PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import React, {Profiler} from 'react'
 import {describe, expect, test, vi} from 'vitest'
-import {defineSchema} from '../src'
+import {render} from 'vitest-browser-react'
+import {page, userEvent} from 'vitest/browser'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+  type RegistrableNode,
+} from '../src'
+import {safeStringify} from '../src/internal-utils/safe-json'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
 import {NodePlugin} from '../src/plugins/plugin.node'
-import {defineContainer} from '../src/renderers/renderer.types'
+import {
+  defineContainer,
+  defineDecorator,
+  defineSpan,
+  defineTextBlock,
+} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
+import {getSelectionAfterText} from '../test-utils/text-selection'
 
 /**
  * Render-count regression suite for the consumer-facing render
@@ -325,4 +344,253 @@ describe('Render count regression', () => {
       errorSpy.mockRestore()
     }
   }, 60_000)
+})
+
+const SIBLING_BLOCKS = 50
+const KEYSTROKES = 20
+const RENDER_COUNT_TOLERANCE = 5
+
+function buildSiblingBlock(key: string): PortableTextBlock {
+  return {
+    _type: 'block',
+    _key: key,
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: `${key}-span`, text: key, marks: []}],
+  }
+}
+
+function buildDocument(
+  targetBlockKey: string,
+  spanKeys: [string, string, string],
+): Array<PortableTextBlock> {
+  const before = Array.from({length: SIBLING_BLOCKS / 2}, (_, i) =>
+    buildSiblingBlock(`sibling-before-${i}`),
+  )
+  const after = Array.from({length: SIBLING_BLOCKS / 2}, (_, i) =>
+    buildSiblingBlock(`sibling-after-${i}`),
+  )
+  const targetBlock: PortableTextBlock = {
+    _type: 'block',
+    _key: targetBlockKey,
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {_type: 'span', _key: spanKeys[0], text: 'foo', marks: []},
+      {_type: 'span', _key: spanKeys[1], text: 'bar', marks: ['strong']},
+      {_type: 'span', _key: spanKeys[2], text: 'baz', marks: []},
+    ],
+  }
+  return [...before, targetBlock, ...after]
+}
+
+function median(values: Array<number>): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+    : (sorted[middle] ?? 0)
+}
+
+type TypingScenarioResult = {
+  editedBlockRenders: number
+  siblingBlockRenders: Array<[string, number]>
+  editedSpanRenders: number
+  decoratorRenders: Array<[string, number]>
+  withinBlockSiblingSpanKeys: [string, string]
+  withinBlockSiblingSpanRenders: Array<[string, number]>
+  siblingBlockSpanRenders: Array<[string, number]>
+  medianCommitDuration: number
+  commitCount: number
+}
+
+/**
+ * The `Profiler` wraps `PortableTextEditable` only, so recorded commit
+ * durations exclude `EditorProvider`/`NodePlugin` registration effects.
+ */
+async function runTypingScenario(options: {
+  nodes: Array<RegistrableNode>
+  blockRenders: Map<string, number>
+  spanRenders: Map<string, number>
+  decoratorRenders: Map<string, number>
+}): Promise<TypingScenarioResult> {
+  const keyGenerator = createTestKeyGenerator()
+  const targetBlockKey = keyGenerator()
+  const spanKeys: [string, string, string] = [
+    keyGenerator(),
+    keyGenerator(),
+    keyGenerator(),
+  ]
+  const initialValue = buildDocument(targetBlockKey, spanKeys)
+  const editorRef = React.createRef<Editor>()
+  const commitDurations: Array<number> = []
+
+  render(
+    <EditorProvider
+      initialConfig={{
+        keyGenerator,
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+        initialValue,
+      }}
+    >
+      <EditorRefPlugin ref={editorRef} />
+      <NodePlugin nodes={options.nodes} />
+      <Profiler
+        id="registered-render-count-probe"
+        onRender={(_id, _phase, actualDuration) => {
+          commitDurations.push(actualDuration)
+        }}
+      >
+        <PortableTextEditable />
+      </Profiler>
+    </EditorProvider>,
+  )
+
+  const locator = page.getByRole('textbox')
+  await vi.waitFor(() => expect.element(locator).toBeInTheDocument(), {
+    timeout: 10_000,
+  })
+  await vi.waitFor(() => expect(locator.getByText('bar')).toBeInTheDocument(), {
+    timeout: 10_000,
+  })
+
+  const editor = editorRef.current!
+
+  // If all three spans carried equal marks, normalize would merge them
+  // into one span and silently break the per-span instrumentation below.
+  const mountedTargetBlock = editor
+    .getSnapshot()
+    .context.value.find((block) => block._key === targetBlockKey)
+  expect(mountedTargetBlock).toEqual({
+    _type: 'block',
+    _key: targetBlockKey,
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {_type: 'span', _key: spanKeys[0], text: 'foo', marks: []},
+      {_type: 'span', _key: spanKeys[1], text: 'bar', marks: ['strong']},
+      {_type: 'span', _key: spanKeys[2], text: 'baz', marks: []},
+    ],
+  })
+
+  await userEvent.click(locator.getByText('bar'))
+  const selection = getSelectionAfterText(editor.getSnapshot().context, 'bar')
+  editor.send({type: 'select', at: selection})
+  await vi.waitFor(
+    () => expect(editor.getSnapshot().context.selection).toEqual(selection),
+    {timeout: 10_000},
+  )
+
+  // Settle: let any pending renders from the click and `select`
+  // finish before resetting counters.
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  options.blockRenders.clear()
+  options.spanRenders.clear()
+  options.decoratorRenders.clear()
+  commitDurations.length = 0
+
+  await userEvent.type(locator, 'x'.repeat(KEYSTROKES))
+
+  await vi.waitFor(
+    () =>
+      expect(
+        locator.getByText(`bar${'x'.repeat(KEYSTROKES)}`),
+      ).toBeInTheDocument(),
+    {timeout: 10_000},
+  )
+
+  const withinBlockSiblingSpanKeys: ReadonlySet<string> = new Set([
+    spanKeys[0],
+    spanKeys[2],
+  ])
+
+  return {
+    editedBlockRenders: options.blockRenders.get(targetBlockKey) ?? 0,
+    siblingBlockRenders: Array.from(options.blockRenders.entries()).filter(
+      ([key]) => key !== targetBlockKey,
+    ),
+    editedSpanRenders: options.spanRenders.get(spanKeys[1]) ?? 0,
+    decoratorRenders: Array.from(options.decoratorRenders.entries()),
+    withinBlockSiblingSpanKeys: [spanKeys[0], spanKeys[2]],
+    withinBlockSiblingSpanRenders: Array.from(
+      options.spanRenders.entries(),
+    ).filter(([key]) => withinBlockSiblingSpanKeys.has(key)),
+    siblingBlockSpanRenders: Array.from(options.spanRenders.entries()).filter(
+      ([key]) => key !== spanKeys[1] && !withinBlockSiblingSpanKeys.has(key),
+    ),
+    medianCommitDuration: median(commitDurations),
+    commitCount: commitDurations.length,
+  }
+}
+
+describe('Registered nodes: typing render counts', () => {
+  test('Typing produces zero cross-block render callbacks, re-renders same-block sibling spans on every keystroke, fires the decorator callback once per edited-span render, and keeps edited-block and edited-span callbacks bounded', async () => {
+    const blockRenders = new Map<string, number>()
+    const spanRenders = new Map<string, number>()
+    const decoratorRenders = new Map<string, number>()
+    const textBlock = defineTextBlock({
+      type: 'block',
+      render: (props) => {
+        blockRenders.set(
+          props.node._key,
+          (blockRenders.get(props.node._key) ?? 0) + 1,
+        )
+        return props.renderDefault(props)
+      },
+    })
+    const span = defineSpan({
+      type: 'span',
+      render: (props) => {
+        spanRenders.set(
+          props.node._key,
+          (spanRenders.get(props.node._key) ?? 0) + 1,
+        )
+        return props.renderDefault(props)
+      },
+    })
+    const decorator = defineDecorator({
+      type: 'strong',
+      render: (props) => {
+        decoratorRenders.set(
+          props.decorator,
+          (decoratorRenders.get(props.decorator) ?? 0) + 1,
+        )
+        return props.renderDefault(props)
+      },
+    })
+
+    const registered = await runTypingScenario({
+      nodes: [textBlock, span, decorator],
+      blockRenders,
+      spanRenders,
+      decoratorRenders,
+    })
+
+    expect(registered.siblingBlockRenders).toEqual([])
+    expect(registered.siblingBlockSpanRenders).toEqual([])
+    expect(registered.withinBlockSiblingSpanRenders).toEqual([
+      [registered.withinBlockSiblingSpanKeys[0], KEYSTROKES],
+      [registered.withinBlockSiblingSpanKeys[1], KEYSTROKES],
+    ])
+    expect(registered.decoratorRenders).toEqual([
+      ['strong', registered.editedSpanRenders],
+    ])
+    expect(registered.editedBlockRenders).toBeLessThanOrEqual(
+      KEYSTROKES + RENDER_COUNT_TOLERANCE,
+    )
+    expect(registered.editedSpanRenders).toBeLessThanOrEqual(
+      KEYSTROKES + RENDER_COUNT_TOLERANCE,
+    )
+
+    console.warn(
+      `[registered] edited-block renders: ${registered.editedBlockRenders}, ` +
+        `sibling-block renders: ${registered.siblingBlockRenders.length}, ` +
+        `edited-span renders: ${registered.editedSpanRenders}, ` +
+        `decorator renders: ${safeStringify(registered.decoratorRenders)}, ` +
+        `within-block sibling-span renders: ${safeStringify(registered.withinBlockSiblingSpanRenders)}, ` +
+        `sibling-block span renders: ${registered.siblingBlockSpanRenders.length}, ` +
+        `median commit: ${registered.medianCommitDuration.toFixed(3)}ms across ${registered.commitCount} commits`,
+    )
+  }, 120_000)
 })


### PR DESCRIPTION
The typing render-count probe on `editor-v7.x` (#3113) pins parity between the legacy render props and registered nodes, so it cannot move to main: its legacy half stops compiling as the render props are removed. This PR adds the half that survives v8 to the render-count regression suite, which until now covered containers only.

The probe mounts a 51-block document with `defineTextBlock`/`defineSpan`/`defineDecorator` via `NodePlugin`, types 20 keystrokes into a three-span block, and pins the callback counts: zero for untouched sibling blocks and their spans, one per keystroke for the untouched same-block sibling spans, and the decorator callback firing once per edited-span render. Commit durations are reported, not asserted. The zero-sibling pins are scale-independent (one stray callback fails at any sibling count), so the document is deliberately small: the v7 probe's 501-block scale existed only to make the A/B duration medians visible, and on starved CI runners that mount blew the 10s first-paint wait.

One instrument detail worth flagging: the target block's middle span carries a `strong` mark, since normalize merges adjacent equal-mark spans and would collapse the fixture to one span; a full-value assertion pins the mounted shape so that failure mode stays loud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 48b478705064e74f596c2db19ad65de7c3048445. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->