### PR TITLE
test: settle pending renders before resetting the probe's counters

### DIFF
--- a/packages/editor/tests/render-count-regression.test.tsx
+++ b/packages/editor/tests/render-count-regression.test.tsx
@@ -350,7 +350,7 @@ describe('Render count regression', () => {
   }, 60_000)
 })
 
-const SIBLING_BLOCKS = 500
+const SIBLING_BLOCKS = 50
 const KEYSTROKES = 20
 const RENDER_COUNT_TOLERANCE = 5
 

--- a/packages/editor/tests/render-count-regression.test.tsx
+++ b/packages/editor/tests/render-count-regression.test.tsx
@@ -486,6 +486,10 @@ async function runTypingScenario(options: {
     {timeout: 10_000},
   )
 
+  // Settle: let any pending renders from the click and `select`
+  // finish before resetting counters.
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
   options.blockRenders.clear()
   options.spanRenders.clear()
   options.decoratorRenders.clear()


### PR DESCRIPTION
The parity probe added in #3113 has two flake modes on starved CI runners. Its callback counters are cleared right off the selection wait, which asserts model state rather than React commits, so a straggler commit from the click and `select` can land after the clear and break the exact per-keystroke equality; the suite's standard 100ms settle before the reset fixes that. And its 501-block mount, which existed only to make the A/B duration medians visible, blows the 10s first-paint wait on slow runners; the asserted contract is scale-independent (one stray sibling callback fails at any count), so the document shrinks to 50 sibling blocks. Same fixes as #3115 on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and fixture size changes; no production behavior.
> 
> **Overview**
> Stabilizes the **render path parity** probe in `render-count-regression.test.tsx` against two CI flake modes.
> 
> Before counting keystroke render callbacks, the scenario now **waits 100ms** after the selection assertion so any React commits from the click/`select` finish before counters are cleared—matching the settle pattern already used elsewhere in this file.
> 
> The synthetic document shrinks from **500 to 50** sibling blocks so slow runners can pass the first-paint wait without changing what the test asserts (cross-block callbacks must stay at zero at any scale).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa047a724acd68768ae5131c951cb161b71f60f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->