### PR TITLE
fix: accept `className` on toolbar schema `icon` components

### DIFF
--- a/.changeset/toolbar-icon-classname.md
+++ b/.changeset/toolbar-icon-classname.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/toolbar': patch
+---
+
+fix: accept `className` on toolbar schema `icon` components
+
+The `icon` fields on the toolbar schema types were typed as a bare `React.ComponentType`, rejecting icon components that take a `className` prop, which is every common icon library. The type now accepts `React.ComponentType<{className?: string}>`; existing icons without props remain assignable.

--- a/packages/toolbar/src/use-toolbar-schema.ts
+++ b/packages/toolbar/src/use-toolbar-schema.ts
@@ -122,7 +122,7 @@ export type ToolbarSchema = {
  * @beta
  */
 export type ToolbarDecoratorSchemaType = DecoratorSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
   shortcut?: KeyboardShortcut
   mutuallyExclusive?: ReadonlyArray<DecoratorDefinition['name']>
 }
@@ -131,7 +131,7 @@ export type ToolbarDecoratorSchemaType = DecoratorSchemaType & {
  * @beta
  */
 export type ToolbarAnnotationSchemaType = AnnotationSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
   defaultValues?: Record<string, unknown>
   shortcut?: KeyboardShortcut
   /**
@@ -153,14 +153,14 @@ export type ToolbarAnnotationSchemaType = AnnotationSchemaType & {
  * @beta
  */
 export type ToolbarListSchemaType = ListSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
 }
 
 /**
  * @beta
  */
 export type ToolbarBlockObjectSchemaType = BlockObjectSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
   defaultValues?: Record<string, unknown>
   shortcut?: KeyboardShortcut
 }
@@ -169,7 +169,7 @@ export type ToolbarBlockObjectSchemaType = BlockObjectSchemaType & {
  * @beta
  */
 export type ToolbarInlineObjectSchemaType = InlineObjectSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
   defaultValues?: Record<string, unknown>
   shortcut?: KeyboardShortcut
 }
@@ -178,7 +178,7 @@ export type ToolbarInlineObjectSchemaType = InlineObjectSchemaType & {
  * @beta
  */
 export type ToolbarStyleSchemaType = StyleSchemaType & {
-  icon?: React.ComponentType
+  icon?: React.ComponentType<{className?: string}>
   shortcut?: KeyboardShortcut
 }
 


### PR DESCRIPTION
Backport of the fix merged to `main` in #3118: the `icon` fields on the six toolbar schema types were typed as bare `React.ComponentType`, rejecting icon components that take a `className` prop, which is every common icon library. Widened to `ComponentType<{className?: string}>`; existing prop-less icons remain assignable by contravariance.

On `main` this patch only ships inside the toolbar's next major, so the v7 line carries it separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f3a4772df953d69255782d86c23a91663a374175. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->