### PR TITLE
feat!: remove `markDefPath` and `spanPath` from `AddedAnnotationPaths`

### DIFF
--- a/.changeset/remove-added-annotation-paths-fields.md
+++ b/.changeset/remove-added-annotation-paths-fields.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': major
+---
+
+feat!: remove `markDefPath` and `spanPath` from `AddedAnnotationPaths`
+
+`PortableTextEditor.addAnnotation` now returns only `markDefPaths` (document order). `markDefPath` was the focus-span's markDef and `spanPath` was documented as not meaningful. Consumers pick from `markDefPaths`: the first entry matches the old `markDefPath` whenever the annotation covers one block.

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -364,9 +364,7 @@ export function createEditableAPI(
 
       if (focusBlockAfter && spanPath && markDef) {
         return {
-          markDefPath: markDef.path,
           markDefPaths: markDefs.map((markDef) => markDef.path),
-          spanPath,
         }
       }
 

--- a/packages/editor/src/editor/create-editable-api.ts
+++ b/packages/editor/src/editor/create-editable-api.ts
@@ -355,14 +355,13 @@ export function createEditableAPI(
             (markDefBefore) => markDefBefore._key === markDef.markDef._key,
           ),
       )
-      const spanPath = focusSpanAfter?.path
-      const markDef = markDefs.find((markDef) =>
+      const focusSpanGainedMarkDef = markDefs.some((markDef) =>
         newMarkDefKeysOnFocusSpan?.some(
           (mark) => mark === markDef.markDef._key,
         ),
       )
 
-      if (focusBlockAfter && spanPath && markDef) {
+      if (focusBlockAfter && focusSpanAfter && focusSpanGainedMarkDef) {
         return {
           markDefPaths: markDefs.map((markDef) => markDef.path),
         }

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -34,18 +34,7 @@ export interface EditableAPIDeleteOptions {
  * @public
  */
 export type AddedAnnotationPaths = {
-  /**
-   * @deprecated An annotation may be applied to multiple blocks, resulting
-   * in multiple `markDef`'s being created. Use `markDefPaths` instead.
-   */
-  markDefPath: Path
   markDefPaths: Array<Path>
-  /**
-   * @deprecated Does not return anything meaningful since an annotation
-   * can span multiple blocks and spans. If references the span closest
-   * to the focus point of the selection.
-   */
-  spanPath: Path
 }
 
 /** @internal */

--- a/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
+++ b/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
@@ -120,12 +120,10 @@ describe(PortableTextEditor.addAnnotation.name, () => {
 
     await vi.waitFor(() => {
       expect(paths).toEqual({
-        markDefPath: [{_key: blockBKey}, 'markDefs', {_key: 'k12'}],
         markDefPaths: [
           [{_key: blockAKey}, 'markDefs', {_key: 'k9'}],
           [{_key: blockBKey}, 'markDefs', {_key: 'k12'}],
         ],
-        spanPath: [{_key: blockBKey}, 'children', {_key: bazSpanKey}],
       })
     })
   })


### PR DESCRIPTION
`annotation.add` reported three paths; `markDefPaths` (one per selected block, in selection order) is the canonical one, and Studio's annotation flows read `markDefPaths[0]`. The single-block `markDefPath` and the never-consumed `spanPath` are removed.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major semver break for consumers still reading markDefPath or spanPath; runtime addAnnotation behavior is slightly stricter about when paths are returned.
> 
> **Overview**
> **Breaking:** `PortableTextEditor.addAnnotation` / `EditableAPI.addAnnotation` now return only **`markDefPaths`** on `AddedAnnotationPaths`; deprecated **`markDefPath`** and **`spanPath`** are removed.
> 
> The editable implementation no longer picks a single focus-span `markDef` for `markDefPath`. It still returns paths when the focus block/span exists and the focus span gained at least one of the newly created mark defs, with **`markDefPaths`** listing every new mark def in document order (for multi-block selections, use **`markDefPaths[0]`** where the old single-block `markDefPath` applied). A major changeset is included for `@portabletext/editor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a8448c4edbadd6674d175a522d049986fdd185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->