### PR TITLE
feat!: remove the `BlockStyleRenderProps` and `BlockListItemRenderProps` types

### DIFF
--- a/.changeset/remove-render-list-item.md
+++ b/.changeset/remove-render-list-item.md
@@ -4,6 +4,6 @@
 
 feat!: remove `renderListItem` and the core list-index machinery
 
-The `renderListItem` render prop on `<PortableTextEditable>` is removed, along with the `RenderListItemFunction` type and the `data-list-index` attribute on legacy-rendered text blocks. Core no longer computes list-item indices at all. The `BlockListItemRenderProps` type remains exported but is deprecated.
+The `renderListItem` render prop on `<PortableTextEditable>` is removed, along with its `RenderListItemFunction` and `BlockListItemRenderProps` types and the `data-list-index` attribute on legacy-rendered text blocks. Core no longer computes list-item indices at all.
 
 List rendering migrates to a `defineTextBlock` registration (see the migrate-render-props guide), and list numbering comes from `@portabletext/plugin-list-index`: wrap the editor in `ListIndexProvider` and read `useListIndex(path)` inside the registered render to re-emit `data-list-index` (or use the index directly).

--- a/.changeset/remove-render-style.md
+++ b/.changeset/remove-render-style.md
@@ -4,7 +4,7 @@
 
 feat!: remove the `renderStyle` render prop
 
-The `renderStyle` render prop on `<PortableTextEditable>` is removed, along with the `RenderStyleFunction` type. Text-block styles render through a `defineTextBlock` registration instead: the registered `render` callback receives the block as `props.node` and owns the wrapper element.
+The `renderStyle` render prop on `<PortableTextEditable>` is removed, along with its `RenderStyleFunction` and `BlockStyleRenderProps` types. Text-block styles render through a `defineTextBlock` registration instead: the registered `render` callback receives the block as `props.node` and owns the wrapper element.
 
 ```tsx
 import {defineTextBlock} from '@portabletext/editor'
@@ -23,4 +23,3 @@ const textBlock = defineTextBlock({
 // Inside `EditorProvider`:
 // <NodePlugin nodes={[textBlock]} />
 ```
-

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -87,8 +87,6 @@ export type {
 export type {AddedAnnotationPaths} from './types/editor'
 export type {BlockOffset} from './types/block-offset'
 export type {
-  BlockListItemRenderProps,
-  BlockStyleRenderProps,
   EditableAPIDeleteOptions,
   EditorSelection,
   EditorSelectionPoint,

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -1,20 +1,11 @@
 import type {Patch} from '@portabletext/patches'
 import type {
-  ListSchemaType,
   PortableTextBlock,
   PortableTextChild,
   PortableTextObject,
-  PortableTextTextBlock,
-  StyleSchemaType,
   TypedObject,
 } from '@portabletext/schema'
-import type {
-  ClipboardEvent,
-  JSX,
-  PropsWithChildren,
-  ReactElement,
-  RefObject,
-} from 'react'
+import type {ClipboardEvent, JSX, PropsWithChildren, ReactElement} from 'react'
 import type {PortableTextEditableProps} from '../editor/Editable'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {PortableTextEditor} from '../editor/PortableTextEditor'
@@ -171,25 +162,6 @@ export type OnCopyFn = (
   event: ClipboardEvent<HTMLDivElement | HTMLSpanElement>,
 ) => undefined | unknown
 
-/**
- * @beta
- * @deprecated The `renderListItem` render prop is removed; render list
- * items with `defineTextBlock` and `@portabletext/plugin-list-index`
- * instead. See the migration guide:
- * https://www.portabletext.org/editor/guides/migrate-render-props/
- */
-export interface BlockListItemRenderProps {
-  block: PortableTextTextBlock
-  children: ReactElement<any>
-  editorElementRef: RefObject<HTMLElement | null>
-  focused: boolean
-  level: number
-  path: Path
-  schemaType: ListSchemaType
-  selected: boolean
-  value: string
-}
-
 /** @public */
 export type RenderEditableFunction = (
   props: PortableTextEditableProps,
@@ -197,24 +169,6 @@ export type RenderEditableFunction = (
 
 /** @public */
 export type RenderPlaceholderFunction = () => React.ReactNode
-
-/**
- * @beta
- * @deprecated The `renderStyle` render prop is removed; render text-block
- * styles with `defineTextBlock` instead. This props shape will be removed
- * in the next major version.
- */
-
-export interface BlockStyleRenderProps {
-  block: PortableTextTextBlock
-  children: ReactElement<any>
-  editorElementRef: RefObject<HTMLElement | null>
-  focused: boolean
-  path: Path
-  selected: boolean
-  schemaType: StyleSchemaType
-  value: string
-}
 
 /** @public */
 export type ScrollSelectionIntoViewFunction = (


### PR DESCRIPTION
The two remaining legacy props-shape types are removed; they served the `renderStyle` and `renderListItem` props that earlier stack PRs deleted, surviving as deprecated tombstones for consumers still naming the shapes. Type against `TextBlockRenderProps` from the registration API.

One rider: the `remove-render-list-item` changeset on main loses its "remains exported but is deprecated" sentence, which this PR turns false within the same release.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1c7b01a10d811705e6fc3efd5663d4e97eefc462. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
