### PR TITLE
refactor: collapse the annotation markDef lookup

### DIFF
--- a/packages/editor/src/editor/render.span.tsx
+++ b/packages/editor/src/editor/render.span.tsx
@@ -72,13 +72,10 @@ export function RenderSpan(props: RenderSpanProps) {
         return []
       }
 
-      const markDef = block?.markDefs?.find((markDef) => markDef._key === mark)
-
-      if (markDef) {
-        return [markDef]
-      }
-
-      return []
+      const markDef = block?.markDefs?.find(
+        (candidate) => candidate._key === mark,
+      )
+      return markDef ? [markDef] : []
     },
   )
 


### PR DESCRIPTION
The four-line find-check-return dance in `render.span.tsx`'s markDef collection fed both dispatch paths before the legacy mark props were removed, and its `find` callback parameter shadowed the `markDef` it assigned. It collapses to a single expression with the shadow renamed. The `flatMap` over `leaf.marks` stays as is: mark order drives composition order.