### PR TITLE
feat!: unexport `resolveContainerAt`

### DIFF
--- a/.changeset/unexport-resolve-container-at.md
+++ b/.changeset/unexport-resolve-container-at.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': major
+---
+
+feat!: unexport `resolveContainerAt`
+
+The positional container resolver is no longer part of the public API. It shipped as `@alpha` with the container redesign and found no consumers. `getContainerChildren` from `@portabletext/editor/traversal` stays and covers per-node descent; code that needs the full path walk can build it from that primitive.

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -75,7 +75,6 @@ export {
   type TextBlockRender,
   type TextBlockRenderProps,
 } from './renderers/renderer.types'
-export {resolveContainerAt} from './schema/resolve-containers'
 export type {
   Containers,
   RegisteredBlockObject,

--- a/packages/editor/src/schema/resolve-containers.ts
+++ b/packages/editor/src/schema/resolve-containers.ts
@@ -18,7 +18,6 @@ export type {
   ResolvedContainers,
 } from './container-types'
 export {descendToParent} from './descend-to-parent'
-export {resolveContainerAt} from './resolve-container-at'
 export {resolveContainerByPath} from './resolve-container-by-path'
 export {resolveContainerField} from './resolve-container-field'
 export {


### PR DESCRIPTION
`resolveContainerAt` walked the positional registration tree for a path. It shipped `@alpha` with the container redesign and found no consumers, and keeping it public freezes the positional tree's internal shape. The helper goes internal; `getContainerChildren` from `@portabletext/editor/traversal` stays and covers per-node descent, and the full path walk can be built from that primitive.

Part of the v8 stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API change (major) for `@portabletext/editor`. Risk is limited because the helper was `@alpha` and is reported to have no consumers; internals still use it.
> 
> **Overview**
> **Unexports** `resolveContainerAt` from `@portabletext/editor` (major). It remains an internal helper used by paste/drop fitting and engine mutation.
> 
> The function walked the positional registration tree for a path. It shipped `@alpha` with the container redesign and had no known consumers; keeping it public would freeze that tree’s shape.
> 
> `getContainerChildren` from `@portabletext/editor/traversal` stays as the public per-node descent primitive. Full path walks can be composed from it. Related container types (`Containers`, `RegisteredContainer`, etc.) remain exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d4dd601abcc871232b4ca0cf03e55b66892786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->