### PR TITLE
fix(playground): pass the absent active style as `null` to the style select

### DIFF
--- a/apps/playground/src/primitives/select.tsx
+++ b/apps/playground/src/primitives/select.tsx
@@ -64,7 +64,11 @@ export function Select<T extends object>({
       {label && <Label>{label}</Label>}
       <Button className={styles}>
         <SelectValue className="flex-1 text-xs placeholder-shown:italic">
-          {(props) => props.selectedText ?? props.defaultChildren}
+          {(props) =>
+            // `selectedText` is `''` (not `null`) in the placeholder state,
+            // and `defaultChildren` is what carries the `placeholder` text.
+            props.isPlaceholder ? props.defaultChildren : props.selectedText
+          }
         </SelectValue>
         <ChevronDown
           aria-hidden

--- a/apps/playground/src/toolbar/button.style.tsx
+++ b/apps/playground/src/toolbar/button.style.tsx
@@ -11,7 +11,6 @@ export function StyleButton(props: {
 }) {
   const styleSelector = useStyleSelector(props)
   const applicable = useApplicableSchema()
-  const activeStyle = styleSelector.snapshot.context.activeStyle ?? 'normal'
   const disabledKeys = props.schemaTypes
     .filter((schemaType) => !applicable.styles.has(schemaType.name))
     .map((schemaType) => schemaType.name)
@@ -23,7 +22,7 @@ export function StyleButton(props: {
         disabledKeys={disabledKeys}
         placeholder="Select style"
         aria-label="Style"
-        selectedKey={activeStyle}
+        selectedKey={styleSelector.snapshot.context.activeStyle ?? null}
         onSelectionChange={(style) => {
           if (typeof style === 'string') {
             styleSelector.send({type: 'toggle', style})

--- a/packages/editor/tests/event.style.toggle.test.tsx
+++ b/packages/editor/tests/event.style.toggle.test.tsx
@@ -60,3 +60,49 @@ test('Scenario: toggling a non-default style on a block missing `style` sets it'
     ])
   })
 })
+
+test('Scenario: toggling a style across a selection spanning blocks with different explicit styles sets both', async () => {
+  const blockH1 = {
+    _key: 'b0',
+    _type: 'block',
+    style: 'h1',
+    markDefs: [],
+    children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+  }
+  const blockH2 = {
+    _key: 'b1',
+    _type: 'block',
+    style: 'h2',
+    markDefs: [],
+    children: [{_key: 's1', _type: 'span', text: 'bar', marks: []}],
+  }
+  const {editor} = await createTestEditor({
+    schemaDefinition: defineSchema({
+      styles: [{name: 'normal'}, {name: 'h1'}, {name: 'h2'}],
+    }),
+    initialValue: [blockH1, blockH2],
+  })
+
+  const selection = {
+    anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 0},
+    focus: {path: [{_key: 'b1'}, 'children', {_key: 's1'}], offset: 3},
+  }
+  editor.send({type: 'select', at: selection})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection).toEqual({
+      ...selection,
+      backward: false,
+    })
+  })
+  expect(getActiveStyle(editor.getSnapshot())).toBeUndefined()
+
+  editor.send({type: 'style.toggle', style: 'normal'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {...blockH1, style: 'normal'},
+      {...blockH2, style: 'normal'},
+    ])
+  })
+})


### PR DESCRIPTION
Select across two text blocks with different styles (an `h1` and an `h2`) in the playground: the style select shows "Normal", and choosing "Normal" to reset both blocks does nothing.

Core is not the problem: `getActiveStyle` correctly returns `undefined` for the mixed selection, and `style.toggle` would route to `style.add` and set both blocks. The playground's style button coerced the absent active style to `'normal'` for the controlled select, and React Aria's `useSelectState` only fires `onSelectionChange` when the chosen key differs from the displayed one, so the choice was swallowed before any event reached the editor.

The fix passes `activeStyle ?? null` as `selectedKey`: mixed selections (and other no-active-style states, like an unfocused editor) now render the select's placeholder ("Select style") instead of a false "Normal", and every choice fires. Making the placeholder state reachable exposed a second bug in the shared select primitive: its `SelectValue` override rendered `selectedText ?? defaultChildren`, but react-aria's `selectedText` is the empty string (not `null`) when nothing is selected, so the trigger rendered empty. The override now branches on `isPlaceholder`, whose `defaultChildren` carries the placeholder text. The display change is the named delta: wherever "Normal" used to show without being active, "Select style" shows.

The playground has no test harness, so the wiring itself is unpinned; a new core test pins the contract the select relies on (`style.toggle 'normal'` across explicit `h1`+`h2` sets both blocks to `normal`), which no existing test covered. No changeset: playground app and test code only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground UI wiring plus a unit test; no editor core behavior change beyond pinning an existing toggle contract.
> 
> **Overview**
> Fixes the playground style dropdown swallowing “Normal” when a mixed-style selection has no active style.
> 
> `StyleButton` no longer coerces `activeStyle` to `'normal'`. It passes `null` so mixed (and unfocused) states show the **Select style** placeholder and `onSelectionChange` actually fires. The shared `Select` trigger now uses `isPlaceholder` so that placeholder text renders instead of an empty string.
> 
> Adds a core test that toggling `normal` across explicit `h1`+`h2` blocks sets both.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad7bf0cc6a85c70182b446b4937ed199a98b410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

