### PR TITLE
fix: warn at runtime when the deprecated `value` mirror or legacy callback params are read

### DIFF
--- a/.changeset/warn-deprecated-character-pair-decorator-callback-arg.md
+++ b/.changeset/warn-deprecated-character-pair-decorator-callback-arg.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/plugin-character-pair-decorator': patch
+---
+
+
+fix: warn once when reading the deprecated `schema` callback argument
+
+The `decorator` callback still receives the deprecated top-level `schema` argument, but reading it now logs a one-time console warning naming `context.schema` as the replacement. A callback that only reads `context.schema` sees no warning. The deprecated argument is removed in the next major.
+
+Any read of the deprecated fields counts, including spreading the callback argument. The warning fires once per process; the deprecated fields are removed in the next major.

--- a/.changeset/warn-deprecated-compiled-schema-value.md
+++ b/.changeset/warn-deprecated-compiled-schema-value.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/schema': patch
+---
+
+fix: warn once when reading the deprecated `value` on compiled schema types
+
+Reading `value` on a compiled style, list, or decorator now logs a one-time console warning naming `name` as the replacement. Any read counts, including spreading or serializing the object (`{...style}`, `JSON.stringify`, `toEqual` in a test), not only `style.value` directly. The value returned is unchanged, and assigning `value` still works. The warning fires once per process no matter how many objects or types are read, so it won't flood the console. `value` is removed in the next major.

--- a/.changeset/warn-deprecated-markdown-shortcuts-callback-args.md
+++ b/.changeset/warn-deprecated-markdown-shortcuts-callback-args.md
@@ -1,0 +1,10 @@
+---
+'@portabletext/plugin-markdown-shortcuts': patch
+---
+
+
+fix: warn once when reading the deprecated `schema`/`level` callback arguments
+
+`defaultStyle`, `blockquoteStyle`, `headingStyle`, `orderedList`, and `unorderedList` callbacks still receive the deprecated top-level `schema` argument (and `headingStyle` still receives the deprecated top-level `level`), but reading either now logs a one-time console warning naming `context.schema` or `props.level` as the replacement. Callbacks that only read `context.schema` and `props.level` see no warning. Both deprecated arguments are removed in the next major.
+
+Any read of the deprecated fields counts, including spreading the callback argument. The warning fires once per process; the deprecated fields are removed in the next major.

--- a/packages/plugin-character-pair-decorator/src/deprecated-callback-args.test.ts
+++ b/packages/plugin-character-pair-decorator/src/deprecated-callback-args.test.ts
@@ -1,0 +1,51 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import type {withDeprecatedSchema as WithDeprecatedSchema} from './deprecated-callback-args'
+
+// The warn-once flag lives at module scope, so each test needs its own
+// fresh module instance to observe a first read in isolation.
+async function importFresh() {
+  vi.resetModules()
+  return (await import('./deprecated-callback-args')) as {
+    withDeprecatedSchema: typeof WithDeprecatedSchema
+  }
+}
+
+describe('withDeprecatedSchema', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reading `schema` warns once and returns `context.schema`', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const arg = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(arg.schema).toBe('the-schema')
+    expect(arg.schema).toBe('the-schema')
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      '[@portabletext/plugin-character-pair-decorator] Reading the deprecated `schema` callback argument; read `context.schema` instead. It will be removed in the next major.',
+    )
+  })
+
+  test('reading only `context.schema` triggers no warning', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const {context} = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(context.schema).toBe('the-schema')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  test('destructuring `schema` off the argument warns and works', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const {schema} = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(schema).toBe('the-schema')
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/plugin-character-pair-decorator/src/deprecated-callback-args.ts
+++ b/packages/plugin-character-pair-decorator/src/deprecated-callback-args.ts
@@ -1,0 +1,34 @@
+let hasWarned = false
+
+/**
+ * Fires the deprecation warning only when a caller actually reads the
+ * legacy `schema` callback field, so removal in the next major can point
+ * at a runtime warning actually observed by consumers, not only the
+ * `@deprecated` JSDoc tag.
+ */
+function warnDeprecatedSchema(): void {
+  if (hasWarned) {
+    return
+  }
+  hasWarned = true
+  console.warn(
+    '[@portabletext/plugin-character-pair-decorator] Reading the deprecated `schema` callback argument; read `context.schema` instead. It will be removed in the next major.',
+  )
+}
+
+/**
+ * Replaces the eager top-level `schema` field on a callback argument with
+ * a getter that mirrors `context.schema`.
+ */
+export function withDeprecatedSchema<T extends {context: {schema: unknown}}>(
+  arg: T,
+): T & {schema: T['context']['schema']} {
+  return Object.defineProperty(arg, 'schema', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      warnDeprecatedSchema()
+      return arg.context.schema
+    },
+  }) as T & {schema: T['context']['schema']}
+}

--- a/packages/plugin-character-pair-decorator/src/rule.character-pair.ts
+++ b/packages/plugin-character-pair-decorator/src/rule.character-pair.ts
@@ -2,6 +2,7 @@ import type {EditorContext} from '@portabletext/editor'
 import {raise} from '@portabletext/editor/behaviors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {withDeprecatedSchema} from './deprecated-callback-args'
 import {createCharacterPairRegex} from './regex.character-pair'
 
 /**
@@ -51,10 +52,9 @@ export function createCharacterPairRule(config: {
       }
 
       const subSchema = getPathSubSchema(snapshot, event.focusBlock.path)
-      const decorator = config.decorator({
-        context: {schema: subSchema},
-        schema: subSchema,
-      })
+      const decorator = config.decorator(
+        withDeprecatedSchema({context: {schema: subSchema}}),
+      )
 
       if (decorator === undefined) {
         return false

--- a/packages/plugin-markdown-shortcuts/package.json
+++ b/packages/plugin-markdown-shortcuts/package.json
@@ -51,7 +51,9 @@
     "test:browser:firefox": "vitest run --project \"browser (firefox)\"",
     "test:browser:firefox:watch": "vitest watch --project \"browser (firefox)\"",
     "test:browser:webkit": "vitest run --project \"browser (webkit)\"",
-    "test:browser:webkit:watch": "vitest watch --project \"browser (webkit)\""
+    "test:browser:webkit:watch": "vitest watch --project \"browser (webkit)\"",
+    "test:unit": "vitest run --project unit",
+    "test:unit:watch": "vitest watch --project unit"
   },
   "dependencies": {
     "@portabletext/plugin-character-pair-decorator": "workspace:^",

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
@@ -2,6 +2,7 @@ import type {EditorContext} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import * as selectors from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
+import {withDeprecatedSchema} from './deprecated-callback-args'
 
 export type ObjectWithOptionalKey = {
   _type: string
@@ -116,10 +117,9 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
       }
 
       const subSchema = getPathSubSchema(snapshot, focusTextBlock.path)
-      const defaultStyle = config.defaultStyle?.({
-        context: {schema: subSchema},
-        schema: subSchema,
-      })
+      const defaultStyle = config.defaultStyle?.(
+        withDeprecatedSchema({context: {schema: subSchema}}),
+      )
 
       if (defaultStyle && focusTextBlock.node.style !== defaultStyle) {
         return {defaultStyle, focusTextBlock}

--- a/packages/plugin-markdown-shortcuts/src/deprecated-callback-args.test.ts
+++ b/packages/plugin-markdown-shortcuts/src/deprecated-callback-args.test.ts
@@ -1,0 +1,87 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import type {
+  withDeprecatedLevel as WithDeprecatedLevel,
+  withDeprecatedSchema as WithDeprecatedSchema,
+} from './deprecated-callback-args'
+
+// The warn-once flag lives at module scope, so each test needs its own
+// fresh module instance to observe a first read in isolation.
+async function importFresh() {
+  vi.resetModules()
+  return (await import('./deprecated-callback-args')) as {
+    withDeprecatedSchema: typeof WithDeprecatedSchema
+    withDeprecatedLevel: typeof WithDeprecatedLevel
+  }
+}
+
+describe('withDeprecatedSchema', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reading `schema` warns once and returns `context.schema`', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const arg = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(arg.schema).toBe('the-schema')
+    expect(arg.schema).toBe('the-schema')
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      '[@portabletext/plugin-markdown-shortcuts] Reading the deprecated `schema` callback argument; read `context.schema` instead. It will be removed in the next major.',
+    )
+  })
+
+  test('reading only `context.schema` triggers no warning', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const {context} = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(context.schema).toBe('the-schema')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  test('destructuring `schema` off the argument warns and works', async () => {
+    const {withDeprecatedSchema} = await importFresh()
+    const {schema} = withDeprecatedSchema({context: {schema: 'the-schema'}})
+
+    expect(schema).toBe('the-schema')
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('withDeprecatedLevel', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reading `level` warns once and returns `props.level`', async () => {
+    const {withDeprecatedLevel} = await importFresh()
+    const arg = withDeprecatedLevel({props: {level: 2}})
+
+    expect(arg.level).toBe(2)
+    expect(arg.level).toBe(2)
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      '[@portabletext/plugin-markdown-shortcuts] Reading the deprecated `level` callback argument; read `props.level` instead. It will be removed in the next major.',
+    )
+  })
+
+  test('reading only `props.level` triggers no warning', async () => {
+    const {withDeprecatedLevel} = await importFresh()
+    const {props} = withDeprecatedLevel({props: {level: 2}})
+
+    expect(props.level).toBe(2)
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/plugin-markdown-shortcuts/src/deprecated-callback-args.ts
+++ b/packages/plugin-markdown-shortcuts/src/deprecated-callback-args.ts
@@ -1,0 +1,51 @@
+const warned = new Set<string>()
+
+/**
+ * Fires the deprecation warning only when a caller actually reads the
+ * legacy callback field, so removal in the next major can point at a
+ * runtime warning actually observed by consumers, not only the
+ * `@deprecated` JSDoc tag.
+ */
+function warnDeprecatedCallbackArg(field: string, replacement: string): void {
+  if (warned.has(field)) {
+    return
+  }
+  warned.add(field)
+  console.warn(
+    `[@portabletext/plugin-markdown-shortcuts] Reading the deprecated \`${field}\` callback argument; read \`${replacement}\` instead. It will be removed in the next major.`,
+  )
+}
+
+/**
+ * Replaces the eager top-level `schema` field on a callback argument with
+ * a getter that mirrors `context.schema`.
+ */
+export function withDeprecatedSchema<T extends {context: {schema: unknown}}>(
+  arg: T,
+): T & {schema: T['context']['schema']} {
+  return Object.defineProperty(arg, 'schema', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      warnDeprecatedCallbackArg('schema', 'context.schema')
+      return arg.context.schema
+    },
+  }) as T & {schema: T['context']['schema']}
+}
+
+/**
+ * Replaces the eager top-level `level` field on a callback argument with
+ * a getter that mirrors `props.level`.
+ */
+export function withDeprecatedLevel<T extends {props: {level: number}}>(
+  arg: T,
+): T & {level: number} {
+  return Object.defineProperty(arg, 'level', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      warnDeprecatedCallbackArg('level', 'props.level')
+      return arg.props.level
+    },
+  }) as T & {level: number}
+}

--- a/packages/plugin-markdown-shortcuts/src/rule.blockquote.ts
+++ b/packages/plugin-markdown-shortcuts/src/rule.blockquote.ts
@@ -3,6 +3,7 @@ import {raise} from '@portabletext/editor/behaviors'
 import {getPreviousInlineObject} from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {withDeprecatedSchema} from './deprecated-callback-args'
 
 export function createBlockquoteRule(config: {
   blockquoteStyle: ({
@@ -20,10 +21,9 @@ export function createBlockquoteRule(config: {
     on: /^> /,
     guard: ({snapshot, event}) => {
       const subSchema = getPathSubSchema(snapshot, event.focusBlock.path)
-      const style = config.blockquoteStyle({
-        context: {schema: subSchema},
-        schema: subSchema,
-      })
+      const style = config.blockquoteStyle(
+        withDeprecatedSchema({context: {schema: subSchema}}),
+      )
 
       if (!style) {
         return false

--- a/packages/plugin-markdown-shortcuts/src/rule.heading.ts
+++ b/packages/plugin-markdown-shortcuts/src/rule.heading.ts
@@ -3,6 +3,10 @@ import {raise} from '@portabletext/editor/behaviors'
 import {getPreviousInlineObject} from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {
+  withDeprecatedLevel,
+  withDeprecatedSchema,
+} from './deprecated-callback-args'
 
 export function createHeadingRule(config: {
   headingStyle: ({
@@ -41,12 +45,14 @@ export function createHeadingRule(config: {
       const level = match.text.length - 1
 
       const subSchema = getPathSubSchema(snapshot, event.focusBlock.path)
-      const style = config.headingStyle({
-        context: {schema: subSchema},
-        schema: subSchema,
-        props: {level},
-        level,
-      })
+      const style = config.headingStyle(
+        withDeprecatedLevel(
+          withDeprecatedSchema({
+            context: {schema: subSchema},
+            props: {level},
+          }),
+        ),
+      )
 
       if (!style) {
         return false

--- a/packages/plugin-markdown-shortcuts/src/rule.ordered-list.ts
+++ b/packages/plugin-markdown-shortcuts/src/rule.ordered-list.ts
@@ -3,6 +3,7 @@ import {raise} from '@portabletext/editor/behaviors'
 import {getPreviousInlineObject} from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {withDeprecatedSchema} from './deprecated-callback-args'
 
 export function createOrderedListRule(config: {
   orderedList: ({
@@ -20,10 +21,9 @@ export function createOrderedListRule(config: {
     on: /^1\. /,
     guard: ({snapshot, event}) => {
       const subSchema = getPathSubSchema(snapshot, event.focusBlock.path)
-      const orderedList = config.orderedList({
-        context: {schema: subSchema},
-        schema: subSchema,
-      })
+      const orderedList = config.orderedList(
+        withDeprecatedSchema({context: {schema: subSchema}}),
+      )
 
       if (!orderedList) {
         return false

--- a/packages/plugin-markdown-shortcuts/src/rule.unordered-list.ts
+++ b/packages/plugin-markdown-shortcuts/src/rule.unordered-list.ts
@@ -3,6 +3,7 @@ import {raise} from '@portabletext/editor/behaviors'
 import {getPreviousInlineObject} from '@portabletext/editor/selectors'
 import {getPathSubSchema} from '@portabletext/editor/traversal'
 import {defineInputRule} from '@portabletext/plugin-input-rule'
+import {withDeprecatedSchema} from './deprecated-callback-args'
 
 export function createUnorderedListRule(config: {
   unorderedList: ({
@@ -20,10 +21,9 @@ export function createUnorderedListRule(config: {
     on: /^(-|\*) /,
     guard: ({snapshot, event}) => {
       const subSchema = getPathSubSchema(snapshot, event.focusBlock.path)
-      const unorderedList = config.unorderedList({
-        context: {schema: subSchema},
-        schema: subSchema,
-      })
+      const unorderedList = config.unorderedList(
+        withDeprecatedSchema({context: {schema: subSchema}}),
+      )
 
       if (!unorderedList) {
         return false

--- a/packages/plugin-markdown-shortcuts/vitest.config.ts
+++ b/packages/plugin-markdown-shortcuts/vitest.config.ts
@@ -6,12 +6,19 @@ export default defineConfig({
   test: {
     projects: [
       {
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+      {
         // Resolves the monorepo-only `@portabletext/editor/test*` specifiers
         // through this package's tsconfig `paths`.
         resolve: {tsconfigPaths: true},
         plugins: [react({compiler: {target: '19'}})],
         test: {
           name: 'browser',
+          include: ['src/**/*.test.tsx'],
           browser: {
             enabled: true,
             headless: true,

--- a/packages/schema/src/compile-schema.ts
+++ b/packages/schema/src/compile-schema.ts
@@ -1,4 +1,5 @@
 import type {SchemaDefinition} from './define-schema'
+import {withDeprecatedValue} from './deprecated-value'
 import type {
   AnnotationSchemaType,
   BaseDefinition,
@@ -65,13 +66,10 @@ function resolveBlockInheritance(
 ): BlockInheritance {
   return {
     styles: member.styles
-      ? member.styles.map((style) => ({...style, value: style.name}))
+      ? member.styles.map((style) => withDeprecatedValue(style))
       : inheritance.styles,
     decorators: member.decorators
-      ? member.decorators.map((decorator) => ({
-          ...decorator,
-          value: decorator.name,
-        }))
+      ? member.decorators.map((decorator) => withDeprecatedValue(decorator))
       : inheritance.decorators,
     annotations: member.annotations
       ? member.annotations.map((annotation) => ({
@@ -83,7 +81,7 @@ function resolveBlockInheritance(
         }))
       : inheritance.annotations,
     lists: member.lists
-      ? member.lists.map((list) => ({...list, value: list.name}))
+      ? member.lists.map((list) => withDeprecatedValue(list))
       : inheritance.lists,
     inlineObjects: member.inlineObjects
       ? member.inlineObjects.map((inlineObject) => ({
@@ -145,7 +143,7 @@ function compileField(
 function compileBaseDefinitionWithValue<T extends BaseDefinition>(
   definition: T,
 ): T & {value: string} {
-  return {...definition, value: definition.name}
+  return withDeprecatedValue(definition)
 }
 
 /**
@@ -155,11 +153,8 @@ export function compileSchema(definition: SchemaDefinition): Schema {
   const userStyles = (definition.styles ?? []).map(
     compileBaseDefinitionWithValue,
   )
-  const styles = !userStyles.some((style) => style.value === 'normal')
-    ? [
-        {value: 'normal', name: 'normal', title: 'Normal'} as StyleSchemaType,
-        ...userStyles,
-      ]
+  const styles = !userStyles.some((style) => style.name === 'normal')
+    ? [withDeprecatedValue({name: 'normal', title: 'Normal'}), ...userStyles]
     : userStyles
 
   const lists = (definition.lists ?? []).map(compileBaseDefinitionWithValue)

--- a/packages/schema/src/deprecated-value.test.ts
+++ b/packages/schema/src/deprecated-value.test.ts
@@ -1,0 +1,138 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import type {compileSchema as CompileSchema} from './compile-schema'
+import type {defineSchema as DefineSchema} from './define-schema'
+import type {withDeprecatedValue as WithDeprecatedValue} from './deprecated-value'
+import type {getSubSchema as GetSubSchema} from './get-sub-schema'
+
+// The warn-once flag lives at module scope, so each test needs its own
+// fresh module instance to observe a first read in isolation.
+async function importFresh() {
+  vi.resetModules()
+  return (await import('./deprecated-value')) as {
+    withDeprecatedValue: typeof WithDeprecatedValue
+  }
+}
+
+async function importFreshProductionPath() {
+  vi.resetModules()
+  const [{compileSchema}, {defineSchema}, {getSubSchema}] = await Promise.all([
+    import('./compile-schema'),
+    import('./define-schema'),
+    import('./get-sub-schema'),
+  ])
+  return {
+    compileSchema: compileSchema as typeof CompileSchema,
+    defineSchema: defineSchema as typeof DefineSchema,
+    getSubSchema: getSubSchema as typeof GetSubSchema,
+  }
+}
+
+describe('withDeprecatedValue', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reading `value` warns once and returns `name`', async () => {
+    const {withDeprecatedValue} = await importFresh()
+    const style = withDeprecatedValue({name: 'h1', title: 'Heading 1'})
+
+    expect(style.value).toBe('h1')
+    expect(style.value).toBe('h1')
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      '[@portabletext/schema] Reading the deprecated `value` on compiled schema types; read `name` instead. `value` will be removed in the next major.',
+    )
+  })
+
+  test('reading only `name` triggers no warning', async () => {
+    const {withDeprecatedValue} = await importFresh()
+    const style = withDeprecatedValue({name: 'h1', title: 'Heading 1'})
+
+    expect(style.name).toBe('h1')
+
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  test('spread and `toEqual` still see `value`', async () => {
+    const {withDeprecatedValue} = await importFresh()
+    const style = withDeprecatedValue({name: 'h1', title: 'Heading 1'})
+
+    expect({...style}).toEqual({name: 'h1', title: 'Heading 1', value: 'h1'})
+    expect(style).toEqual({name: 'h1', title: 'Heading 1', value: 'h1'})
+  })
+
+  test('re-wrapping an already-wrapped definition does not warn and returns it unchanged', async () => {
+    const {withDeprecatedValue} = await importFresh()
+    const style = withDeprecatedValue({name: 'h1', title: 'Heading 1'})
+
+    const rewrapped = withDeprecatedValue(style)
+
+    expect(console.warn).not.toHaveBeenCalled()
+    expect(rewrapped).toBe(style)
+  })
+
+  test('assigning `value` replaces the getter and reads back without warning or throwing', async () => {
+    const {withDeprecatedValue} = await importFresh()
+    const style = withDeprecatedValue({name: 'h1', title: 'Heading 1'})
+
+    expect(() => {
+      style.value = 'custom'
+    }).not.toThrow()
+
+    expect(style.value).toBe('custom')
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  test('production path: resolving a nested block sub-schema warns zero times until a consumer reads `value`', async () => {
+    const {compileSchema, defineSchema, getSubSchema} =
+      await importFreshProductionPath()
+
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'tableCell',
+            fields: [
+              {
+                name: 'content',
+                type: 'array',
+                of: [
+                  {
+                    type: 'block',
+                    styles: [{name: 'h1'}],
+                    decorators: [{name: 'strong'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(console.warn).not.toHaveBeenCalled()
+
+    const tableCell = schema.blockObjects[0]
+    const of = tableCell?.fields?.[0]
+    if (of?.type !== 'array' || !of.of) {
+      throw new Error('expected a compiled array field with `of`')
+    }
+
+    const subSchema = getSubSchema(schema, of.of)
+    const style = subSchema.styles[0]
+    if (!style) {
+      throw new Error('expected a resolved style')
+    }
+
+    expect(console.warn).not.toHaveBeenCalled()
+
+    expect(style.value).toBe('h1')
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/schema/src/deprecated-value.ts
+++ b/packages/schema/src/deprecated-value.ts
@@ -1,0 +1,59 @@
+import type {BaseDefinition} from './schema'
+
+let hasWarned = false
+
+function warnDeprecatedValue(): void {
+  if (hasWarned) {
+    return
+  }
+  hasWarned = true
+  console.warn(
+    '[@portabletext/schema] Reading the deprecated `value` on compiled schema types; read `name` instead. `value` will be removed in the next major.',
+  )
+}
+
+/**
+ * Replaces the eager `value: definition.name` mirror with a getter so the
+ * removal of `value` in the next major can point at a runtime warning
+ * actually observed by consumers, not only the `@deprecated` JSDoc tag.
+ */
+export function withDeprecatedValue<T extends BaseDefinition>(
+  definition: T,
+): T & {value: string} {
+  // `definition` may already be the output of a previous `withDeprecatedValue`
+  // call (nested block schemas get re-resolved by `getSubSchema`). Spreading
+  // it here would read `value` through its getter and warn on the library's
+  // own re-wrap rather than on a consumer read, so an already-wrapped input
+  // is returned unchanged.
+  if (Object.getOwnPropertyDescriptor(definition, 'value')?.get) {
+    return definition as T & {value: string}
+  }
+
+  const copy = Object.defineProperties(
+    {},
+    Object.getOwnPropertyDescriptors(definition),
+  ) as T & {value: string}
+
+  Object.defineProperty(copy, 'value', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      warnDeprecatedValue()
+      return definition.name
+    },
+    set(newValue: string) {
+      // Matches the old eager `value` field's writable contract: assigning
+      // replaces the deprecation getter with a plain data property instead
+      // of throwing (strict-mode assignment to a getter-only property
+      // throws).
+      Object.defineProperty(copy, 'value', {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: newValue,
+      })
+    },
+  })
+
+  return copy
+}

--- a/packages/schema/src/get-sub-schema.ts
+++ b/packages/schema/src/get-sub-schema.ts
@@ -1,3 +1,4 @@
+import {withDeprecatedValue} from './deprecated-value'
 import type {
   AnnotationSchemaType,
   BaseDefinition,
@@ -30,7 +31,7 @@ function asNamedTypes<
   if (!resolved) {
     return undefined
   }
-  return resolved.map((entry) => ({...entry, value: entry.name}) as T)
+  return resolved.map((entry) => withDeprecatedValue(entry) as T)
 }
 
 function asFieldedTypes<


### PR DESCRIPTION
v8 keeps two deprecated compat surfaces by decision: the `value` mirror on compiled schema entries and the top-level `schema`/`level` params on the shortcut plugins' callbacks. Their JSDoc deprecation reaches only consumers who typecheck; the configs that would break on a future removal are untyped and would fail silently. This PR makes reading either surface log a one-time `console.warn` naming the replacement (`name`, `context.schema`, `props.level`) and the next-major removal horizon, so the v9 removal lands on consumers who were warned at runtime.

The `value` mirror becomes an enumerable accessor with the old contract intact: spread, serialization, and deep equality see it unchanged, and assignment still works (the setter redefines it as plain data). Wrapping copies property descriptors instead of spreading, so the library's own internal re-wrapping neither warns to itself nor burns the once-flag before a consumer's first read; a production-path test pins zero warnings through `compileSchema` and `getSubSchema` until a consumer actually reads `value`. The callback params become getters on the argument object; destructuring counts as a read and keeps working.

One commit per package, each with a patch changeset. Part of the v8 stack; the removals these warnings precede are next-major scope.
