### PR TITLE
feat: split text blocks when a block is dropped inside them

### DIFF
--- a/.changeset/plugin-dnd-mid-block-indicator.md
+++ b/.changeset/plugin-dnd-mid-block-indicator.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-dnd': patch
+---
+
+fix: hide the edge indicator while hovering inside a text block
+
+The native drop caret is the affordance there; edge lines only show for boundary, void, and unresolved positions.

--- a/.changeset/split-on-block-drop.md
+++ b/.changeset/split-on-block-drop.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: split text blocks when a block is dropped inside them
+
+Dropping a block object mid-paragraph now splits the paragraph at the caret, matching what paste and external drops already did. Drops at block edges, on voids, and with unresolved caret positions keep snapping before/after.

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -6,10 +6,15 @@ import {rangeEdges} from '../engine/range/range-edges'
 import {getCompoundClientRect} from '../internal-utils/compound-client-rect'
 import {getDragSelection} from '../selectors/drag-selection'
 import {getFocusInlineObject} from '../selectors/selector.get-focus-inline-object'
+import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {getFragment} from '../selectors/selector.get-fragment'
 import {isOverlappingSelection} from '../selectors/selector.is-overlapping-selection'
 import {isSelectingEntireBlocks} from '../selectors/selector.is-selecting-entire-blocks'
 import type {EditorSelection} from '../types/editor'
+import {getBlockEndPoint} from '../utils/util.get-block-end-point'
+import {getBlockStartPoint} from '../utils/util.get-block-start-point'
+import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
+import {isEqualSelectionPoints} from '../utils/util.is-equal-selection-points'
 import {effect, forward, raise} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 import {fitBlocksToDestination} from './fit-blocks-to-destination'
@@ -350,6 +355,29 @@ export const coreDndBehaviors = [
       }
       const fittedBlocks = fitBlocksToDestination(dropSnapshot, event.data)
 
+      // A collapsed drop strictly inside a non-empty text block's own
+      // characters (not on an inline object leaf, which snaps like a void)
+      // resolves 'auto' placement to `split-insert` instead of snapping the
+      // dragged block before or after the hovered block.
+      const focusTextBlock = getFocusTextBlock(dropSnapshot)
+      const droppedInsideTextBlock =
+        isCollapsedRange(dropPosition) &&
+        focusTextBlock !== undefined &&
+        !isEmptyTextBlock(snapshot.context, focusTextBlock.node) &&
+        getFocusInlineObject(dropSnapshot) === undefined &&
+        !isEqualSelectionPoints(
+          dropPosition.focus,
+          getBlockStartPoint({
+            context: snapshot.context,
+            block: focusTextBlock,
+          }),
+        ) &&
+        !isEqualSelectionPoints(
+          dropPosition.focus,
+          getBlockEndPoint({context: snapshot.context, block: focusTextBlock}),
+        ) &&
+        fittedBlocks.length > 0
+
       if (!droppingOnDragOrigin) {
         return {
           dropPosition,
@@ -359,6 +387,7 @@ export const coreDndBehaviors = [
           originEvent: event.originEvent,
           fittedBlocks,
           movedInlineObjectKey,
+          droppedInsideTextBlock,
         }
       }
 
@@ -375,6 +404,7 @@ export const coreDndBehaviors = [
           originEvent,
           fittedBlocks,
           movedInlineObjectKey,
+          droppedInsideTextBlock,
         },
       ) => {
         // Nothing survives `fitBlocksToDestination`: leave the source where
@@ -426,11 +456,11 @@ export const coreDndBehaviors = [
             type: 'insert.blocks',
             blocks: fittedBlocks,
             placement: draggingEntireBlocks
-              ? originEvent.position.block === 'start'
-                ? 'before'
-                : originEvent.position.block === 'end'
-                  ? 'after'
-                  : 'auto'
+              ? droppedInsideTextBlock
+                ? 'auto'
+                : originEvent.position.block === 'start'
+                  ? 'before'
+                  : 'after'
               : 'auto',
             select: movedInlineObjectSelection ? 'none' : undefined,
           }),

--- a/packages/editor/tests/event.drag.drop.self-drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.self-drop.test.tsx
@@ -401,6 +401,82 @@ describe('event.drag.drop self-drop semantics', () => {
     })
   })
 
+  test('Scenario: collapsed drop mid-text of an entire-block drag origin is suppressed', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const {locator, editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    // The full text of the block, so `isSelectingEntireBlocks` treats this
+    // as an entire-blocks drag, same as dragging a block-object.
+    const dragSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 0,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 6},
+    }
+    const dropSelection = {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 3,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 3},
+    }
+
+    await userEvent.click(locator)
+    editor.send({type: 'select', at: dragSelection})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        ...dragSelection,
+        backward: false,
+      })
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: dropSelection,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(editor.getSnapshot().context.value).toEqual(initialValue)
+  })
+
   test('Scenario: chrome drop inside the dragged container is suppressed', async () => {
     const keyGenerator = createTestKeyGenerator()
     const codeBlockKey = keyGenerator()

--- a/packages/editor/tests/event.drag.drop.test.tsx
+++ b/packages/editor/tests/event.drag.drop.test.tsx
@@ -1766,4 +1766,832 @@ describe('event.drag.drop', () => {
       ])
     })
   })
+  test('Scenario: Dropping an entire block-object mid-text splits the paragraph at the drop point', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const dropPath = [{_key: blockKey}, 'children', {_key: spanKey}]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: dropPath, offset: 3},
+          focus: {path: dropPath, offset: 3},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: 'k6',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: 'k5', _type: 'span', text: 'bar', marks: []}],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Dropping at the very start of a non-empty text block snaps before it without splitting', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const dropPath = [{_key: blockKey}, 'children', {_key: spanKey}]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: dropPath, offset: 0},
+          focus: {path: dropPath, offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Dropping at the very end of a non-empty text block snaps after it without splitting', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const dropPath = [{_key: blockKey}, 'children', {_key: spanKey}]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: dropPath, offset: 6},
+          focus: {path: dropPath, offset: 6},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Dropping onto a void block snaps before or after it without splitting', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const imageAKey = keyGenerator()
+    const imageBKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: imageAKey,
+          _type: 'image',
+          src: 'https://example.com/a.jpg',
+        },
+        {
+          _key: imageBKey,
+          _type: 'image',
+          src: 'https://example.com/b.jpg',
+        },
+      ],
+    })
+
+    const dragSelection = {
+      anchor: {path: [{_key: imageAKey}], offset: 0},
+      focus: {path: [{_key: imageAKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: dragSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'end',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: [{_key: imageBKey}], offset: 0},
+          focus: {path: [{_key: imageBKey}], offset: 0},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: imageBKey,
+          _type: 'image',
+          src: 'https://example.com/b.jpg',
+        },
+        {
+          _key: imageAKey,
+          _type: 'image',
+          src: 'https://example.com/a.jpg',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Dropping with an expanded whole-block fallback position snaps without touching the hovered block', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    // Mirrors the whole-block fallback `getEventPosition` builds when it
+    // can't resolve a caret from the DOM event: an expanded range spanning
+    // the hovered block's start to end, not a collapsed point.
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 6,
+          },
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Undoing a splitting drop restores the pre-drop value in one step', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: blockKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: spanKey, _type: 'span', text: 'foobar', marks: []}],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+      ],
+    })
+
+    const initialValue = editor.getSnapshot().context.value
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const dropPath = [{_key: blockKey}, 'children', {_key: spanKey}]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: dropPath, offset: 3},
+          focus: {path: dropPath, offset: 3},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).not.toEqual(initialValue)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: Dragging an image into a table cell mid-line splits the cell text line', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const tableKey = keyGenerator()
+    const rowKey = keyGenerator()
+    const cellKey = keyGenerator()
+    const cellBlockKey = keyGenerator()
+    const cellSpanKey = keyGenerator()
+    const imageKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+          {
+            name: 'table',
+            fields: [
+              {
+                name: 'rows',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      {
+                        name: 'cells',
+                        type: 'array',
+                        of: [
+                          {
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              {
+                                name: 'content',
+                                type: 'array',
+                                of: [{type: 'block'}, {type: 'image'}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+      initialValue: [
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: 'foobar',
+                          marks: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      children: (
+        <NodePlugin
+          nodes={[
+            defineContainer({
+              type: 'table',
+              arrayField: 'rows',
+              render: ({attributes, children}) => (
+                <div {...attributes}>{children}</div>
+              ),
+              of: [
+                defineContainer({
+                  type: 'row',
+                  arrayField: 'cells',
+                  render: ({attributes, children}) => (
+                    <div {...attributes}>{children}</div>
+                  ),
+                  of: [
+                    defineContainer({
+                      type: 'cell',
+                      arrayField: 'content',
+                      render: ({attributes, children}) => (
+                        <div {...attributes}>{children}</div>
+                      ),
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const imageSelection = {
+      anchor: {path: [{_key: imageKey}], offset: 0},
+      focus: {path: [{_key: imageKey}], offset: 0},
+    }
+    editor.send({type: 'select', at: imageSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const cellSpanPath = [
+      {_key: tableKey},
+      'rows',
+      {_key: rowKey},
+      'cells',
+      {_key: cellKey},
+      'content',
+      {_key: cellBlockKey},
+      'children',
+      {_key: cellSpanKey},
+    ]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: imageSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: cellSpanPath, offset: 3},
+          focus: {path: cellSpanPath, offset: 3},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: tableKey,
+          _type: 'table',
+          rows: [
+            {
+              _key: rowKey,
+              _type: 'row',
+              cells: [
+                {
+                  _key: cellKey,
+                  _type: 'cell',
+                  content: [
+                    {
+                      _key: cellBlockKey,
+                      _type: 'block',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _key: cellSpanKey,
+                          _type: 'span',
+                          text: 'foo',
+                          marks: [],
+                        },
+                      ],
+                    },
+                    {
+                      _key: imageKey,
+                      _type: 'image',
+                      src: 'https://example.com/image.jpg',
+                    },
+                    {
+                      _key: 'k9',
+                      _type: 'block',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_key: 'k8', _type: 'span', text: 'bar', marks: []},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Dragging a multi-block selection (text, image, text) dropped mid-paragraph splits like a paste would', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const textAKey = keyGenerator()
+    const textASpanKey = keyGenerator()
+    const imageKey = keyGenerator()
+    const textBKey = keyGenerator()
+    const textBSpanKey = keyGenerator()
+    const destKey = keyGenerator()
+    const destSpanKey = keyGenerator()
+
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({
+        blockObjects: [
+          {name: 'image', fields: [{name: 'src', type: 'string'}]},
+        ],
+      }),
+      initialValue: [
+        {
+          _key: textAKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: textASpanKey, _type: 'span', text: 'foo', marks: []},
+          ],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: textBKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: textBSpanKey, _type: 'span', text: 'bar', marks: []},
+          ],
+        },
+        {
+          _key: destKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: destSpanKey, _type: 'span', text: 'hello world', marks: []},
+          ],
+        },
+      ],
+    })
+
+    // `isSelectingEntireBlocks` treats a selection spanning a text block's
+    // full text, an entire block object, and another text block's full text
+    // as an entire-blocks drag, same as selecting all three with the mouse.
+    const dragSelection = {
+      anchor: {
+        path: [{_key: textAKey}, 'children', {_key: textASpanKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: textBKey}, 'children', {_key: textBSpanKey}],
+        offset: 3,
+      },
+    }
+    editor.send({type: 'select', at: dragSelection})
+
+    const json = converterPortableText.serialize({
+      snapshot: editor.getSnapshot(),
+      event: {type: 'serialize', originEvent: 'drag.dragstart'},
+    })
+    if (json.type === 'serialization.failure') {
+      assert.fail(json.reason)
+    }
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData(json.mimeType, json.data)
+
+    const dropPath = [{_key: destKey}, 'children', {_key: destSpanKey}]
+
+    editor.send({
+      type: 'drag.drop',
+      originEvent: {dataTransfer},
+      dragOrigin: {selection: dragSelection},
+      position: {
+        block: 'start',
+        isEditor: false,
+        isContainer: false,
+        selection: {
+          anchor: {path: dropPath, offset: 5},
+          focus: {path: dropPath, offset: 5},
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      // The split reuses the same merge machinery as a multi-block paste at
+      // this position: the text before the caret ("hello") keeps the
+      // destination block's own keys and absorbs the first dragged text
+      // block's content, the block object keeps its own key in the middle,
+      // and the text after the caret (" world") is absorbed into the last
+      // dragged text block, which keeps its own key.
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: destKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: destSpanKey, _type: 'span', text: 'hellofoo', marks: []},
+          ],
+        },
+        {
+          _key: imageKey,
+          _type: 'image',
+          src: 'https://example.com/image.jpg',
+        },
+        {
+          _key: textBKey,
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_key: textBSpanKey, _type: 'span', text: 'bar world', marks: []},
+          ],
+        },
+      ])
+    })
+  })
 })

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -84,6 +84,34 @@ describe('DndProvider', () => {
     expect(renders).not.toContain('b0')
   })
 
+  test('Scenario: Dragging over the middle of a non-empty text block hides the indicator', async () => {
+    const {editor} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretMidText('b2'),
+        block: 'end',
+      }),
+    )
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+  })
+
+  test('Scenario: Dragging over the edge of a non-empty text block still shows the indicator', async () => {
+    const {editor} = await renderEditorWithProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'start',
+      }),
+    )
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'start'})
+  })
+
   test('Scenario: Ending the drag clears the drop position', async () => {
     const {editor} = await renderEditorWithProbes()
 
@@ -207,5 +235,12 @@ function caretIn(blockKey: string): NonNullable<EditorSelection> {
   return {
     anchor: {path: spanPath(blockKey), offset: 0},
     focus: {path: spanPath(blockKey), offset: 0},
+  }
+}
+
+function caretMidText(blockKey: string): NonNullable<EditorSelection> {
+  return {
+    anchor: {path: spanPath(blockKey), offset: 2},
+    focus: {path: spanPath(blockKey), offset: 2},
   }
 }

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -8,10 +8,19 @@ import {
 import {BehaviorPlugin} from '@portabletext/editor/plugins'
 import {
   getFocusBlock,
+  getFocusInlineObject,
+  getFocusTextBlock,
   getSelectedBlocks,
   isSelectingEntireBlocks,
 } from '@portabletext/editor/selectors'
-import {isKeyedSegment} from '@portabletext/editor/utils'
+import {
+  getBlockEndPoint,
+  getBlockStartPoint,
+  isEmptyTextBlock,
+  isEqualSelectionPoints,
+  isKeyedSegment,
+  isSelectionCollapsed,
+} from '@portabletext/editor/utils'
 import {
   createContext,
   useCallback,
@@ -181,15 +190,49 @@ function createDropPositionBehaviors(
           return false
         }
 
-        return {dropFocusBlock}
+        const dropSnapshot = {
+          ...snapshot,
+          context: {
+            ...snapshot.context,
+            selection: event.position.selection,
+          },
+        }
+        const focusTextBlock = getFocusTextBlock(dropSnapshot)
+        // A collapsed drop strictly inside a non-empty text block already
+        // shows the browser's own drop caret there.
+        const droppedInsideTextBlock =
+          isSelectionCollapsed(event.position.selection) &&
+          focusTextBlock !== undefined &&
+          !isEmptyTextBlock(snapshot.context, focusTextBlock.node) &&
+          getFocusInlineObject(dropSnapshot) === undefined &&
+          !isEqualSelectionPoints(
+            event.position.selection.focus,
+            getBlockStartPoint({
+              context: snapshot.context,
+              block: focusTextBlock,
+            }),
+          ) &&
+          !isEqualSelectionPoints(
+            event.position.selection.focus,
+            getBlockEndPoint({
+              context: snapshot.context,
+              block: focusTextBlock,
+            }),
+          )
+
+        return {dropFocusBlock, droppedInsideTextBlock}
       },
       actions: [
-        ({event}, {dropFocusBlock}) => [
+        ({event}, {dropFocusBlock, droppedInsideTextBlock}) => [
           effect(() => {
-            setDropPosition({
-              path: dropFocusBlock.path,
-              position: event.position.block,
-            })
+            setDropPosition(
+              droppedInsideTextBlock
+                ? undefined
+                : {
+                    path: dropFocusBlock.path,
+                    position: event.position.block,
+                  },
+            )
           }),
           forward(event),
         ],


### PR DESCRIPTION
Dropping a block object into the middle of a paragraph snapped it whole before or after the hovered block, contradicting the caret the browser shows during the hover, which points mid-text. The drop now splits the text block at that caret, the same treatment paste and external drops already give: a collapsed drop position strictly inside a non-empty text block's own characters resolves to a split-insert, while block edges, voids, inline-object leaves, expanded fallback positions, and drops whose payload fits nothing keep snapping (splitting there loses content, which is why the predicate is exact). Undo restores the pre-drop document in one step.

The feature is why the built-in drop indicator could go in the DOM unification: the caret is the drop affordance, and `@portabletext/plugin-dnd` supplies indicator chrome for designs that want it.

Part of the v8 stack, and the last piece of it that changes editor behavior; the drag-source data-loss guard this feature exposed shipped separately to v7 long since.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core drag-drop document mutation (split vs snap) and history grouping. Logic is tightly predicated and covered by tests, but incorrect placement would still rewrite block structure.
> 
> **Overview**
> Dropping an entire block (or multi-block selection) at a collapsed caret **inside** a non-empty text block now **splits** that paragraph at the caret, matching paste and external drops. Edges, voids, inline-object leaves, empty blocks, and unresolved/expanded fallback positions still snap before/after.
> 
> `insert.blocks` uses `placement: 'auto'` for those mid-text entire-block drops instead of always mapping hover `start`/`end` to `before`/`after`. Self-drops mid-origin stay suppressed. Undo restores the pre-drop document in one step.
> 
> `@portabletext/plugin-dnd` hides the edge indicator while hovering mid-text so the native drop caret is the only affordance; edge lines remain for boundaries and voids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d92d18f230f7c7e0fa864cf19edd9d360e3260c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->