### PR TITLE
test: pin the duplicated tail from concurrent same-spot splits

### DIFF
--- a/packages/editor/tests/collaborative-editing.test.tsx
+++ b/packages/editor/tests/collaborative-editing.test.tsx
@@ -1,6 +1,6 @@
 import {applyAll, diffMatchPatch, type Patch} from '@portabletext/patches'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent, type Locator} from 'vitest/browser'
 import type {Editor} from '../src'
@@ -1704,6 +1704,120 @@ describe('Collaborative editing', () => {
       })
 
       expect(emittedPatches).toEqual([])
+    })
+  })
+
+  describe('Concurrent same-spot split', () => {
+    test.fails('Scenario: Two editors split the same block at the same offset', async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const blockKey = keyGenerator()
+      const spanKey = keyGenerator()
+
+      const initialValue = [
+        {
+          _type: 'block',
+          _key: blockKey,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo bar baz', marks: []},
+          ],
+        },
+      ] satisfies Array<PortableTextBlock>
+
+      const localPatchesA: Array<Patch> = []
+      const localPatchesB: Array<Patch> = []
+
+      const {editor} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator('ea-'),
+        initialValue,
+        children: (
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch' && event.patch.origin === 'local') {
+                localPatchesA.push(event.patch)
+              }
+            }}
+          />
+        ),
+      })
+
+      const {editor: editorB} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator('eb-'),
+        initialValue,
+        children: (
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch' && event.patch.origin === 'local') {
+                localPatchesB.push(event.patch)
+              }
+            }}
+          />
+        ),
+      })
+
+      const selection = {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 4,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 4,
+        },
+        backward: false,
+      }
+
+      editor.send({type: 'select', at: selection})
+      editorB.send({type: 'select', at: selection})
+
+      await vi.waitFor(() => {
+        expect(editor.getSnapshot().context.selection).toEqual(selection)
+      })
+      await vi.waitFor(() => {
+        expect(editorB.getSnapshot().context.selection).toEqual(selection)
+      })
+
+      editor.send({type: 'insert.break'})
+      editorB.send({type: 'insert.break'})
+
+      await vi.waitFor(() => {
+        expect(getTersePt(editor.getSnapshot().context)).toEqual([
+          'foo ',
+          'bar baz',
+        ])
+      })
+      await vi.waitFor(() => {
+        expect(getTersePt(editorB.getSnapshot().context)).toEqual([
+          'foo ',
+          'bar baz',
+        ])
+      })
+
+      const valueFromA = editor.getSnapshot().context.value
+      const valueFromB = editorB.getSnapshot().context.value
+
+      editorB.send({
+        type: 'patches',
+        patches: localPatchesA.map((patch) => ({...patch, origin: 'remote'})),
+        snapshot: valueFromA,
+      })
+      editor.send({
+        type: 'patches',
+        patches: localPatchesB.map((patch) => ({...patch, origin: 'remote'})),
+        snapshot: valueFromB,
+      })
+
+      await vi.waitFor(() => {
+        expect(getTersePt(editor.getSnapshot().context)).toEqual(
+          getTersePt(editorB.getSnapshot().context),
+        )
+      })
+
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo ',
+        'bar baz',
+      ])
     })
   })
 })


### PR DESCRIPTION
When two editors split the same block at the same offset at the same time, both converge on a document with the tail duplicated. Each editor performs the split locally as a text shortening plus an insert of a new tail block, and each mints its own `_key` for that tail. The two inserts carry nothing that relates them, so when the patches cross, both apply on both sides: three blocks, the tail twice. The nearest existing coverage (the two-client collision suite's `block-split` scenario) splits at different offsets and asserts only convergence and validity, so this outcome was unpinned.

This PR adds the pin: two independent editors in the collaborative-editing suite, seeded identically, both performing `insert.break` at the same offset, exchanging their emitted patches through a lossless relay. The test asserts the sane outcome (two blocks, the tail once, both editors agreeing) as `test.fails`: it passes while the defect exists and starts failing the day concurrent same-spot splits stop duplicating, at which point it flips to a plain `test`. `test.fails` is new in this repo; the alternative was a red test parked on a branch, and a living pin in CI seemed strictly better.

The run surfaced a second, separate defect, which shapes how the test asserts. The two editors do not even agree on the order of the duplicated tails: each editor placed its own tail after the original block when it split, and the other's tail then arrives as "insert after" the same original block, landing in front of it, so editor A ends with Ben's tail first and editor B with Ann's first. Because of that, the test compares the sequence of block texts (via `getTersePt`) rather than raw blocks: raw comparison would fail on the ordering defect and leave this pin red for reasons unrelated to duplication. The ordering defect is tracked separately as a follow-up, and this test doubles as its repro (flip the final comparison to raw `toEqual`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pin of an existing collab bug; no production code changes.
> 
> **Overview**
> Pins a known collab defect: two editors that `insert.break` at the same offset currently duplicate the tail after patches cross.
> 
> Adds a `test.fails` scenario in `collaborative-editing.test.tsx` that relays local patches between two independent editors and asserts they converge on two blocks (`foo ` / `bar baz`) via `getTersePt`. It stays green while the duplication exists and will fail once the split is fixed, at which point it should become a regular `test`. Text-only comparison avoids a separate tail-ordering bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a335ea40c2bf6d7bce015d92a8542af7fbc3a58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->