### PR TITLE
test: capture the wire catalogue as deterministic scenario fixtures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ packages/html/src/tests/**/*.html
 .changeset/*.md
 packages/markdown/src/example-document.out.md
 packages/markdown/src/example-document.advanced.out.md
+packages/editor/tests/__fixtures__/wire-catalogue

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -86,7 +86,8 @@
     "test:browser:webkit:watch": "vitest --project \"browser (webkit)\"",
     "test:unit": "vitest --run --project unit",
     "test:unit:watch": "vitest --project unit",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "wire-catalogue:markdown": "node scripts/generate-wire-catalogue.ts"
   },
   "dependencies": {
     "@portabletext/html": "workspace:^",

--- a/packages/editor/scripts/generate-wire-catalogue.ts
+++ b/packages/editor/scripts/generate-wire-catalogue.ts
@@ -1,0 +1,118 @@
+/**
+ * Renders `__fixtures__/wire-catalogue/*.json` into a markdown catalogue.
+ *
+ * Usage: `node scripts/generate-wire-catalogue.ts [outputPath]`
+ * With no `outputPath`, the markdown goes to stdout: run through
+ * `pnpm --silent wire-catalogue:markdown` to keep pnpm's own script-name
+ * banner out of the output.
+ */
+import {execSync} from 'node:child_process'
+import {readdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+type Patch = {
+  type: string
+  path: Array<unknown>
+  [key: string]: unknown
+}
+
+type Capture = {
+  scenario: string
+  schema: Record<string, unknown>
+  seed: string
+  actions: Array<string>
+  patches: Array<Patch>
+  result: string
+  proof?: string
+}
+
+type LegacyCapture = {
+  scenario: string
+  schema: Record<string, unknown>
+  seed: Array<unknown>
+  seedTerse: Array<string>
+  actions: Array<string>
+  patches: Array<Patch>
+  resultTerse: Array<string>
+  proof?: string
+}
+
+function isTextspecCapture(
+  capture: Capture | LegacyCapture,
+): capture is Capture {
+  return typeof capture.seed === 'string'
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const fixturesDir = join(scriptDir, '../tests/__fixtures__/wire-catalogue')
+
+const commit = execSync('git describe --always --dirty', {
+  cwd: scriptDir,
+})
+  .toString()
+  .trim()
+
+const captures = readdirSync(fixturesDir)
+  .filter((file) => file.endsWith('.json'))
+  .sort()
+  .map((file) => {
+    // oxlint-disable-next-line no-restricted-globals -- standalone script outside the package's `safeStringify`/`safeParse` boundary, reading its own well-formed fixtures
+    return JSON.parse(readFileSync(join(fixturesDir, file), 'utf8')) as
+      | Capture
+      | LegacyCapture
+  })
+
+const lines: Array<string> = []
+
+lines.push('# Wire Catalogue')
+lines.push('')
+lines.push(`Generated from \`${commit}\`.`)
+lines.push('')
+
+for (const capture of captures) {
+  lines.push(`## ${capture.scenario}`)
+  lines.push('')
+  if (isTextspecCapture(capture)) {
+    lines.push('**Seed:**')
+    lines.push('')
+    lines.push('```text')
+    lines.push(capture.seed)
+    lines.push('```')
+    lines.push('')
+    lines.push('**Result:**')
+    lines.push('')
+    lines.push('```text')
+    lines.push(capture.result)
+    lines.push('```')
+  } else {
+    // oxlint-disable-next-line no-restricted-globals -- standalone script outside the package's `safeStringify`/`safeParse` boundary, rendering its own well-formed fixtures
+    lines.push(`**Seed:** \`${JSON.stringify(capture.seedTerse)}\``)
+    lines.push('')
+    // oxlint-disable-next-line no-restricted-globals -- standalone script outside the package's `safeStringify`/`safeParse` boundary, rendering its own well-formed fixtures
+    lines.push(`**Result:** \`${JSON.stringify(capture.resultTerse)}\``)
+  }
+  lines.push('')
+  lines.push('**Actions:**')
+  lines.push('')
+  for (const action of capture.actions) {
+    lines.push(`- ${action}`)
+  }
+  lines.push('')
+  lines.push(`**Patches** (${capture.patches.length}):`)
+  lines.push('')
+  lines.push('```json')
+  // oxlint-disable-next-line no-restricted-globals -- standalone script outside the package's `safeStringify`/`safeParse` boundary, rendering its own well-formed fixtures
+  lines.push(JSON.stringify(capture.patches, null, 2))
+  lines.push('```')
+  lines.push('')
+}
+
+const markdown = `${lines.join('\n')}\n`
+const outputPath = process.argv[2]
+
+if (outputPath) {
+  writeFileSync(outputPath, markdown)
+} else {
+  process.stdout.write(markdown)
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/annotation-add-mid-span.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/annotation-add-mid-span.json
@@ -1,0 +1,154 @@
+{
+  "scenario": "annotation-add-mid-span",
+  "schema": {
+    "annotations": [
+      {
+        "name": "link",
+        "fields": [
+          {
+            "name": "href",
+            "type": "string"
+          }
+        ]
+      }
+    ]
+  },
+  "seed": "B: foo ^bar| baz",
+  "actions": [
+    "select {offset 4..7 on the span}",
+    "send {type: 'annotation.add', annotation: {name: 'link', value: {href: 'https://example.com'}}}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "markDefs"
+      ],
+      "value": [
+        {
+          "_type": "link",
+          "_key": "k4",
+          "href": "https://example.com"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -4,8 +4,4 @@\n  bar\n- baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k5",
+          "_type": "span",
+          "marks": [],
+          "text": " baz"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,7 +1,4 @@\n foo \n-bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k6",
+          "_type": "span",
+          "marks": [],
+          "text": "bar"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k6"
+        },
+        "marks"
+      ],
+      "value": [
+        "k4"
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo [@link href=\"https://example.com\":^bar|] baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/annotation-remove.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/annotation-remove.json
@@ -1,0 +1,106 @@
+{
+  "scenario": "annotation-remove",
+  "schema": {
+    "annotations": [
+      {
+        "name": "link",
+        "fields": [
+          {
+            "name": "href",
+            "type": "string"
+          }
+        ]
+      }
+    ]
+  },
+  "seed": "B: foo [@link href=\"https://example.com\":^bar|] baz",
+  "actions": [
+    "select {offset 0..3 on the span}",
+    "send {type: 'annotation.remove', annotation: {name: 'link'}}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        },
+        "marks"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,7 @@\n foo \n+bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,7 +1,11 @@\n foo bar\n+ baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k4"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo ^bar| baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-backspace.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-backspace.json
@@ -1,0 +1,139 @@
+{
+  "scenario": "block-merge-backspace",
+  "schema": {},
+  "seed": "B: foo\nB: |bar",
+  "actions": [
+    "select {caret at start of block 2}",
+    "send {type: 'delete.backward', unit: 'character'}"
+  ],
+  "patches": [
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k6",
+          "_type": "span",
+          "marks": [],
+          "text": ""
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k3",
+          "text": "bar",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,3 +1,6 @@\n foo\n+bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k6"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo|bar"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-move.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-move.json
@@ -1,0 +1,46 @@
+{
+  "scenario": "block-move",
+  "schema": {},
+  "seed": "B: foo\nB: bar",
+  "actions": [
+    "send {type: 'move.block down', at: [{_key: block 1}]}"
+  ],
+  "patches": [
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k2"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "style": "normal",
+          "markDefs": [],
+          "_type": "block",
+          "_key": "k0",
+          "children": [
+            {
+              "_key": "k1",
+              "_type": "span",
+              "text": "foo",
+              "marks": []
+            }
+          ]
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: bar\nB: foo"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-split.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-split.json
@@ -1,0 +1,53 @@
+{
+  "scenario": "block-split",
+  "schema": {},
+  "seed": "B: foo |bar baz",
+  "actions": [
+    "select {caret at offset 4 on the span}",
+    "send {type: 'insert.break'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,11 +1,4 @@\n foo \n-bar baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "block",
+          "_key": "k4",
+          "children": [
+            {
+              "_type": "span",
+              "_key": "k1",
+              "text": "bar baz",
+              "marks": []
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo \nB: |bar baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/decorator-add-mid-span.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/decorator-add-mid-span.json
@@ -1,0 +1,131 @@
+{
+  "scenario": "decorator-add-mid-span",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": "B: foo ^bar| baz",
+  "actions": [
+    "select {offset 4..7 on the span}",
+    "send {type: 'decorator.add', decorator: 'strong'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -4,8 +4,4 @@\n  bar\n- baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k4",
+          "_type": "span",
+          "marks": [],
+          "text": " baz"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,7 +1,4 @@\n foo \n-bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k5",
+          "_type": "span",
+          "marks": [],
+          "text": "bar"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k5"
+        },
+        "marks"
+      ],
+      "value": [
+        "strong"
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo [strong:^bar|] baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/decorator-remove-sub-range.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/decorator-remove-sub-range.json
@@ -1,0 +1,133 @@
+{
+  "scenario": "decorator-remove-sub-range",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": "B: [strong:foo ^bar| baz]",
+  "actions": [
+    "select {offset 4..7 on the span}",
+    "send {type: 'decorator.remove', decorator: 'strong'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -4,8 +4,4 @@\n  bar\n- baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k4",
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": " baz"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,7 +1,4 @@\n foo \n-bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k5",
+          "_type": "span",
+          "marks": [
+            "strong"
+          ],
+          "text": "bar"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k5"
+        },
+        "marks"
+      ],
+      "value": [],
+      "origin": "local"
+    }
+  ],
+  "result": "B: [strong:foo ]^bar[strong:| baz]"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/decorator-remove-whole-span.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/decorator-remove-whole-span.json
@@ -1,0 +1,89 @@
+{
+  "scenario": "decorator-remove-whole-span",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": "B: foo [strong:^bar|] baz",
+  "actions": [
+    "select {offset 0..3 on the span}",
+    "send {type: 'decorator.remove', decorator: 'strong'}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k2"
+        },
+        "marks"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,7 @@\n foo \n+bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,7 +1,11 @@\n foo bar\n+ baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo ^bar| baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/delete-within-span.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/delete-within-span.json
@@ -1,0 +1,26 @@
+{
+  "scenario": "delete-within-span",
+  "schema": {},
+  "seed": "B: foo ^bar| baz",
+  "actions": [
+    "send {type: 'delete', at: {offset 4..7 on the span}}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,11 +1,8 @@\n foo \n-bar\n  baz\n",
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo  baz"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/insert-blocks-auto.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/insert-blocks-auto.json
@@ -1,0 +1,166 @@
+{
+  "scenario": "insert-blocks-auto",
+  "schema": {},
+  "seed": "B: foo|",
+  "actions": [
+    "select {caret at end of \"foo\"}",
+    "send {type: 'insert.blocks', placement: 'auto', blocks: [bar, baz]}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_key": "k8",
+          "_type": "span",
+          "marks": [],
+          "text": ""
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k5",
+          "text": "bar",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "block",
+          "_key": "k6",
+          "children": [
+            {
+              "_type": "span",
+              "_key": "k7",
+              "text": "baz",
+              "marks": []
+            }
+          ],
+          "style": "normal"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "k6"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,3 +1,6 @@\n foo\n+bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k5"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k8"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: foobar\nB: baz|"
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/span-merge-cosmetic.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/span-merge-cosmetic.json
@@ -1,0 +1,81 @@
+{
+  "scenario": "span-merge-cosmetic",
+  "schema": {},
+  "seed": [
+    {
+      "_type": "block",
+      "_key": "k0",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "k1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "k2",
+          "text": "bar",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ],
+  "seedTerse": [
+    "foo ,bar"
+  ],
+  "actions": [
+    "select {caret at end of the second span}",
+    "send {type: 'insert.text', text: '!'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k2"
+        },
+        "text"
+      ],
+      "value": "@@ -1,3 +1,4 @@\n bar\n+!\n",
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,8 @@\n foo \n+bar!\n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "resultTerse": [
+    "foo bar!"
+  ]
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/type-text.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/type-text.json
@@ -1,0 +1,27 @@
+{
+  "scenario": "type-text",
+  "schema": {},
+  "seed": "B: foo bar baz|",
+  "actions": [
+    "select {caret at end of the span}",
+    "send {type: 'insert.text', text: ' foo'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -4,8 +4,12 @@\n  bar baz\n+ foo\n",
+      "origin": "local"
+    }
+  ],
+  "result": "B: foo bar baz foo|"
+}

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -2317,6 +2317,95 @@ describe('event.update value: auto-resolved invalid blocks', () => {
     })
   })
 
+  test('Scenario: replacing a whole value with the same block/span keys emits no patches', async () => {
+    const patches: Array<Patch> = []
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'update value',
+      value: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo!', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo!', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    const patchesAtSettle = [...patches]
+    expect(patchesAtSettle).toEqual([])
+
+    // "No patches were emitted" can't be trusted on a silent listener, so
+    // prove the channel is live: a probe edit right after must still emit
+    // its own patch.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 4},
+        focus: {path: [{_key: 'b0'}, 'children', {_key: 's0'}], offset: 4},
+      },
+    })
+    editor.send({type: 'insert.text', text: ' foo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [{_key: 's0', _type: 'span', text: 'foo! foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('foo!', 'foo! foo'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
   test('Scenario: Clearing synced value with an empty array', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),

--- a/packages/editor/tests/wire-catalogue.test.tsx
+++ b/packages/editor/tests/wire-catalogue.test.tsx
@@ -1,0 +1,534 @@
+import type {Patch} from '@portabletext/patches'
+import {compileSchema, isTextBlock, type Schema} from '@portabletext/schema'
+import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {
+  defineSchema,
+  type Editor,
+  type PortableTextBlock,
+  type PortableTextSpan,
+  type PortableTextTextBlock,
+  type SchemaDefinition,
+} from '../src'
+import {safeStringify} from '../src/internal-utils/safe-json'
+import {EventListenerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+import {fromTextspec} from '../test-utils/from-textspec'
+import {toTextspec} from '../test-utils/to-textspec'
+
+/**
+ * The wire catalogue: one scenario per test, each producing a committed
+ * snapshot under `__fixtures__/wire-catalogue/`. The snapshot IS the
+ * fixture: `scripts/generate-wire-catalogue.ts` reads it back to render the
+ * markdown catalogue.
+ *
+ * `seed` and `result` are textspec notation strings (see
+ * `test-utils/from-textspec.ts`/`to-textspec.ts`): together with the
+ * `schema` field and the deterministic `createTestKeyGenerator`, `seed` is
+ * enough to replay the scenario. The one exception is
+ * `span-merge-cosmetic.json`, which pins two spans that carry identical
+ * (empty) marks — textspec has no notation for a span boundary that isn't
+ * a mark boundary, so that fixture keeps the pre-textspec shape (`seed` as
+ * full blocks, `seedTerse`/`resultTerse`).
+ */
+
+type Capture = {
+  scenario: string
+  schema: SchemaDefinition
+  seed: string
+  actions: Array<string>
+  patches: Array<Patch>
+  result: string
+  proof?: string
+}
+
+type LegacyCapture = {
+  scenario: string
+  schema: SchemaDefinition
+  seed: Array<PortableTextBlock>
+  seedTerse: Array<string>
+  actions: Array<string>
+  patches: Array<Patch>
+  resultTerse: Array<string>
+  proof?: string
+}
+
+async function writeCapture(capture: Capture | LegacyCapture) {
+  await expect(`${safeStringify(capture, 2)}\n`).toMatchFileSnapshot(
+    `__fixtures__/wire-catalogue/${capture.scenario}.json`,
+  )
+}
+
+function captureResult(schema: Schema, editor: Editor): string {
+  const {value, selection} = editor.getSnapshot().context
+  return toTextspec({schema, value, selection})
+}
+
+describe('wire catalogue', () => {
+  test('Scenario: typing text mid-span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo bar baz|'
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'insert.text', text: ' foo'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo bar baz foo',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'type-text',
+      schema,
+      seed,
+      actions: [
+        'select {caret at end of the span}',
+        "send {type: 'insert.text', text: ' foo'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: deleting a range within a span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo ^bar| baz'
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'delete', at: selection})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo  baz'])
+    })
+
+    await writeCapture({
+      scenario: 'delete-within-span',
+      schema,
+      seed,
+      actions: ["send {type: 'delete', at: {offset 4..7 on the span}}"],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: splitting a block with insert.break', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo |bar baz'
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'insert.break'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo ',
+        'bar baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'block-split',
+      schema,
+      seed,
+      actions: [
+        'select {caret at offset 4 on the span}',
+        "send {type: 'insert.break'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: merging two blocks with backspace at the boundary', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo\nB: |bar'
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foobar'])
+    })
+
+    await writeCapture({
+      scenario: 'block-merge-backspace',
+      schema,
+      seed,
+      actions: [
+        'select {caret at start of block 2}',
+        "send {type: 'delete.backward', unit: 'character'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: adding a decorator mid-span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo ^bar| baz'
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'decorator.add', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo ,bar, baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'decorator-add-mid-span',
+      schema,
+      seed,
+      actions: [
+        'select {offset 4..7 on the span}',
+        "send {type: 'decorator.add', decorator: 'strong'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: adding an annotation mid-span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo ^bar| baz'
+    const schemaDefinition = defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({
+      type: 'annotation.add',
+      annotation: {name: 'link', value: {href: 'https://example.com'}},
+    })
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo ,bar, baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'annotation-add-mid-span',
+      schema,
+      seed,
+      actions: [
+        'select {offset 4..7 on the span}',
+        "send {type: 'annotation.add', annotation: {name: 'link', value: {href: 'https://example.com'}}}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: removing a decorator from a whole span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo [strong:^bar|] baz'
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'decorator.remove', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+    })
+
+    await writeCapture({
+      scenario: 'decorator-remove-whole-span',
+      schema,
+      seed,
+      actions: [
+        'select {offset 0..3 on the span}',
+        "send {type: 'decorator.remove', decorator: 'strong'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: removing a decorator from a sub-range of a fully-marked span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: [strong:foo ^bar| baz]'
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'decorator.remove', decorator: 'strong'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foo ,bar, baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'decorator-remove-sub-range',
+      schema,
+      seed,
+      actions: [
+        'select {offset 4..7 on the span}',
+        "send {type: 'decorator.remove', decorator: 'strong'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: removing an annotation from a whole span', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo [@link href="https://example.com":^bar|] baz'
+    const schemaDefinition = defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({
+      type: 'annotation.remove',
+      annotation: {name: 'link'},
+    })
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar baz'])
+    })
+
+    await writeCapture({
+      scenario: 'annotation-remove',
+      schema,
+      seed,
+      actions: [
+        'select {offset 0..3 on the span}',
+        "send {type: 'annotation.remove', annotation: {name: 'link'}}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: typing across a cosmetic span boundary', async () => {
+    // Two spans with identical (empty) marks: textspec has no notation for
+    // a span boundary that isn't a mark boundary, so this seed can't be
+    // expressed as a spec string. Kept as hand-built blocks; see the file
+    // header.
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const span1Key = keyGenerator()
+    const span2Key = keyGenerator()
+    const seedBlock: PortableTextTextBlock<PortableTextSpan> = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {_type: 'span', _key: span1Key, text: 'foo ', marks: []},
+        {_type: 'span', _key: span2Key, text: 'bar', marks: []},
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    const {editor, patches, schema, seed, seedTerse} =
+      await setupLegacyScenario({
+        keyGenerator,
+        initialValue: [seedBlock],
+      })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: span2Key}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: span2Key}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['foo bar!'])
+    })
+
+    await writeCapture({
+      scenario: 'span-merge-cosmetic',
+      schema,
+      seed,
+      seedTerse,
+      actions: [
+        'select {caret at end of the second span}',
+        "send {type: 'insert.text', text: '!'}",
+      ],
+      patches,
+      resultTerse: getTersePt(editor.getSnapshot().context),
+    })
+  })
+
+  test('Scenario: moving a block down', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo\nB: bar'
+
+    const {editor, patches, schema, compiledSchema, blocks} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'move.block down', at: [{_key: blocks[0]!._key!}]})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual(['bar', 'foo'])
+    })
+
+    await writeCapture({
+      scenario: 'block-move',
+      schema,
+      seed,
+      actions: ["send {type: 'move.block down', at: [{_key: block 1}]}"],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
+  test('Scenario: inserting two blocks at the end of a block (paste-shaped)', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: foo|'
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({
+      type: 'insert.blocks',
+      placement: 'auto',
+      blocks: fromTextspec(
+        {schema: compiledSchema, keyGenerator},
+        'B: bar\nB: baz',
+      ).blocks,
+    })
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'foobar',
+        'baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'insert-blocks-auto',
+      schema,
+      seed,
+      actions: [
+        'select {caret at end of "foo"}',
+        "send {type: 'insert.blocks', placement: 'auto', blocks: [bar, baz]}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+})
+
+async function setupScenario(options: {
+  keyGenerator: () => string
+  seed: string
+  schemaDefinition?: SchemaDefinition
+}) {
+  const patches: Array<Patch> = []
+  const schema = options.schemaDefinition ?? {}
+  const compiledSchema = compileSchema(
+    options.schemaDefinition ?? defineSchema({}),
+  )
+  const {blocks: parsedBlocks, selection} = fromTextspec(
+    {schema: compiledSchema, keyGenerator: options.keyGenerator},
+    options.seed,
+  )
+  // The captures must contain only the scenario's own emission. Parsed
+  // seeds lack `markDefs`/`style`, and the first local edit would emit
+  // normalization's default-materialization patches on top of the
+  // scenario's, so the seeds are canonicalized up front.
+  const blocks = parsedBlocks.map((parsedBlock) =>
+    isTextBlock({schema: compiledSchema}, parsedBlock)
+      ? {
+          style: 'normal',
+          markDefs: [],
+          ...parsedBlock,
+        }
+      : parsedBlock,
+  )
+
+  if (!selection) {
+    throw new Error(
+      `Could not resolve selection from textspec: ${options.seed}`,
+    )
+  }
+
+  const {editor} = await createTestEditor({
+    keyGenerator: options.keyGenerator,
+    schemaDefinition: options.schemaDefinition,
+    initialValue: blocks,
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            patches.push(event.patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  return {editor, patches, schema, compiledSchema, blocks, selection}
+}
+
+async function setupLegacyScenario(options: {
+  keyGenerator: () => string
+  initialValue: Array<PortableTextBlock>
+  schemaDefinition?: SchemaDefinition
+}) {
+  const patches: Array<Patch> = []
+
+  const {editor} = await createTestEditor({
+    keyGenerator: options.keyGenerator,
+    schemaDefinition: options.schemaDefinition,
+    initialValue: options.initialValue,
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            patches.push(event.patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  return {
+    editor,
+    patches,
+    schema: options.schemaDefinition ?? {},
+    seed: options.initialValue,
+    seedTerse: getTersePt(editor.getSnapshot().context),
+  }
+}


### PR DESCRIPTION
The scenario catalogue for collaborative-editing work has been prose until now: statements like "a mid-span decorator add emits two diffs, two inserts, and a set" were read from source or inferred, and four of the eight known composite shapes had no test asserting their full wire sequence. Inferred shapes drift, and design work (composite recognition, point transformation, eventual canonical emission) is about to depend on knowing them exactly.

This PR captures the catalogue as fact. Twelve emission scenarios (formatting removal included: removing a decorator from a sub-range splits spans just like adding one, and removing an annotation emits the `markDefs` cleanup after the spans merge back) each run in a mounted test editor with deterministic keys, collecting every emitted `patch` event and snapshotting the whole capture to a committed fixture: scenario, schema, the seed as a textspec string (selection expressed in the notation: `B: foo ^bar| baz`), the actions, the patch sequence, and the result as textspec. From-scratch regenerations are byte-identical. A small script renders the fixtures as one markdown document with dirty-aware git provenance, so a human-readable catalogue can be generated at any commit without hand-writing a claim.

Textspec seeds are canonicalized (`style`, `markDefs` defaults added) before mounting; without that, the first local edit emits normalization's default-materialization patches into every capture, which is fallout, not the scenario's emission.

The captures corrected two shapes the research had inferred wrongly: `insert.blocks` with `placement: 'auto'` merges the first inserted block into the caret's span rather than inserting it whole (two blocks pasted after `foo` yield `foobar`, `baz`), and the backspace merge routes through a scratch empty span that is inserted and later unset. The related silence contract (replacing a whole value with unchanged keys emits no patches, proven by a probe edit) is pinned in the `update value` suite rather than the catalogue, since it produces no wire shape.

The fixtures directory is Prettier-ignored because the snapshots are generated output with a fixed JSON layout that formatting would fight on every regeneration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only: new snapshot fixtures, a generator script, and one extra update-value assertion. No production editor or patch-emission code changes.
> 
> **Overview**
> Records the exact **patch sequences** the editor emits for twelve collaborative-editing scenarios (type, delete, split/merge, move, paste-shaped insert, decorator/annotation add/remove, cosmetic span merge) as committed JSON fixtures.
> 
> Each scenario runs in a mounted test editor with deterministic keys, collects every `patch` event, and snapshots seed (textspec), actions, patches, and result. Seeds are canonicalized so normalization defaults do not leak into the captures. `pnpm wire-catalogue:markdown` renders those fixtures into a human-readable catalogue.
> 
> Also asserts that `update value` with the same block/span keys emits **no** patches (proven with a follow-up probe edit). Fixtures are Prettier-ignored so regeneration stays byte-stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d3315097c813f4030818ba4262a4effb8c202b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->