### PR TITLE
refactor: extract the point-transform rules into a pure step mapper

### DIFF
--- a/packages/editor/src/engine/point/step-mapper.test.ts
+++ b/packages/editor/src/engine/point/step-mapper.test.ts
@@ -1,0 +1,843 @@
+import {describe, expect, test} from 'vitest'
+import {
+  mapPointThroughStep,
+  mapPointThroughSteps,
+  type Step,
+} from './step-mapper'
+
+describe(mapPointThroughStep.name, () => {
+  test('a null point stays null for any step', () => {
+    const step: Step = {
+      type: 'insert.text',
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 0,
+      text: 'hello',
+    }
+    expect(mapPointThroughStep(step, null)).toEqual(null)
+  })
+
+  describe('insert.text', () => {
+    test('shifts the offset forward when the insertion is before it', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 8,
+      })
+    })
+
+    test('shifts the offset at the same position with forward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'forward'})).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 6,
+      })
+    })
+
+    test('leaves the offset untouched at the same position with backward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'backward'})).toBe(
+        point,
+      )
+    })
+
+    test('is a no-op when the insertion is after the offset', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 0,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('remove.text', () => {
+    test('shifts the offset backward', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+        text: 'ab',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      })
+    })
+
+    test('clamps to the removal offset when the point sits inside the removed text', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 1,
+        text: 'abcdef',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 1,
+      })
+    })
+
+    test('is a no-op when the removal starts after the offset', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 0,
+        text: 'ab',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('set.text', () => {
+    test('clamps the offset to the new text length', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        text: 'ab',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      })
+    })
+
+    test('leaves the offset untouched when it is within the new text length', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        text: 'abcdef',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('collapses to zero for an empty text value', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        text: '',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 0,
+      })
+    })
+
+    test('is a no-op on a different node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        text: 'ab',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('remove.node', () => {
+    test('invalidates a point at the removed node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('invalidates a point inside the removed node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b2'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('unset.text', () => {
+    test('collapses the offset to zero', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'unset.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 0,
+      })
+    })
+
+    test('is a no-op when the offset is already zero', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 0,
+      }
+      const step: Step = {
+        type: 'unset.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'unset.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('rekey', () => {
+    test('substitutes the old key with the new key wherever it appears in the path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {type: 'rekey', oldKey: 's1', newKey: 's2'}
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 3,
+      })
+    })
+
+    test('is a no-op when the old key is not in the path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {type: 'rekey', oldKey: 's9', newKey: 's2'}
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('replace.children', () => {
+    test('remaps a point through a text-preserving replacement', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foo', marks: []},
+          {_type: 'span', _key: 'n2', text: 'bar', marks: ['strong']},
+          {_type: 'span', _key: 'n3', text: 'baz', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n2'}],
+        offset: 2,
+      })
+    })
+
+    test('a boundary offset lands at the end of the earlier span', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foo', marks: []},
+          {_type: 'span', _key: 'n2', text: 'barbaz', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n1'}],
+        offset: 3,
+      })
+    })
+
+    test('inline objects occupy no text offset on either side', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 1,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foo', marks: []},
+          {_type: 'stock-ticker', _key: 'o1'},
+          {_type: 'span', _key: 's2', text: 'bar', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foo', marks: []},
+          {_type: 'stock-ticker', _key: 'n2'},
+          {_type: 'span', _key: 'n3', text: 'bar', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n3'}],
+        offset: 1,
+      })
+    })
+
+    test('a surviving span keeps its identity over offset mapping', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foo', marks: []},
+          {_type: 'span', _key: 'o2', text: 'bar', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'bar', marks: []},
+          {_type: 'span', _key: 's1', text: 'foo', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a text-changing replacement leaves the point untransformed', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [{_type: 'span', _key: 'n1', text: 'hello', marks: []}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a point in another block is untouched', () => {
+      const point = {
+        path: [{_key: 'b2'}, 'children', {_key: 's9'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foobarbaz', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('container blocks in a field named `children` are not offset-mapped', () => {
+      const point = {
+        path: [{_key: 'callout1'}, 'children', {_key: 'block1'}],
+        offset: 0,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'callout1'}, 'children'],
+        oldChildren: [
+          {
+            _type: 'block',
+            _key: 'block1',
+            children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          },
+        ],
+        newChildren: [
+          {
+            _type: 'block',
+            _key: 'newBlock1',
+            children: [{_type: 'span', _key: 'n1', text: 'foo', marks: []}],
+          },
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a point deeper inside replaced container blocks is untouched', () => {
+      const point = {
+        path: [
+          {_key: 'callout1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'callout1'}, 'children'],
+        oldChildren: [
+          {
+            _type: 'block',
+            _key: 'block1',
+            children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+          },
+        ],
+        newChildren: [
+          {
+            _type: 'block',
+            _key: 'newBlock1',
+            children: [{_type: 'span', _key: 'n1', text: 'foo', marks: []}],
+          },
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('remaps span points of a text block nested in a container', () => {
+      const point = {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'block1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 5,
+      }
+      const childrenPath = [
+        {_key: 'table1'},
+        'rows',
+        {_key: 'row1'},
+        'cells',
+        {_key: 'cell1'},
+        'content',
+        {_key: 'block1'},
+        'children',
+      ]
+      const step: Step = {
+        type: 'replace.children',
+        path: childrenPath,
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foo', marks: []},
+          {_type: 'span', _key: 'n2', text: 'bar', marks: ['strong']},
+          {_type: 'span', _key: 'n3', text: 'baz', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [...childrenPath, {_key: 'n2'}],
+        offset: 2,
+      })
+    })
+
+    test('a raw block-offset point is never offset-mapped', () => {
+      const point = {
+        path: [{_key: 'b1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [{_key: 'b1'}, 'children'],
+        oldChildren: [
+          {_type: 'span', _key: 's1', text: 'foobarbaz', marks: []},
+        ],
+        newChildren: [
+          {_type: 'span', _key: 'n1', text: 'foobarbaz', marks: []},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('nested paths', () => {
+    test('insert.text shifts the offset of a container-depth point', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 8,
+      })
+    })
+
+    test('insert.text at a different container-depth path is a no-op', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span2'},
+        ],
+        offset: 0,
+        text: 'abc',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('remove.text collapses a container-depth point to the removal start', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 1,
+        text: 'abcdef',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 1,
+      })
+    })
+
+    test('remove.node of the container root nullifies a point nested inside it', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'container1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('rekey rewrites a middle segment of a container-depth path', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {type: 'rekey', oldKey: 'cell1', newKey: 'cell2'}
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell2'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      })
+    })
+
+    test('replace.children on a container-depth array leaves a non-direct-child point untouched', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'replace.children',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+        ],
+        oldChildren: [
+          {
+            _type: 'block',
+            _key: 'block1',
+            children: [{_type: 'span', _key: 'span1', text: 'foo', marks: []}],
+          },
+        ],
+        newChildren: [
+          {
+            _type: 'block',
+            _key: 'newBlock1',
+            children: [{_type: 'span', _key: 'n1', text: 'foo', marks: []}],
+          },
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+})
+
+describe(mapPointThroughSteps.name, () => {
+  test('folds a batch of steps over the point in order', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    const steps: Step[] = [
+      {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        text: 'abc',
+      },
+      {type: 'rekey', oldKey: 's1', newKey: 's2'},
+    ]
+    expect(mapPointThroughSteps(steps, point)).toEqual({
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 8,
+    })
+  })
+
+  test('short-circuits once a step invalidates the point', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    const steps: Step[] = [
+      {type: 'remove.node', path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+      {type: 'rekey', oldKey: 's1', newKey: 's2'},
+    ]
+    expect(mapPointThroughSteps(steps, point)).toEqual(null)
+  })
+
+  test('an empty batch leaves the point untransformed', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    expect(mapPointThroughSteps([], point)).toBe(point)
+  })
+
+  test('a null point stays null through a batch', () => {
+    const steps: Step[] = [{type: 'rekey', oldKey: 's1', newKey: 's2'}]
+    expect(mapPointThroughSteps(steps, null)).toEqual(null)
+  })
+})

--- a/packages/editor/src/engine/point/step-mapper.ts
+++ b/packages/editor/src/engine/point/step-mapper.ts
@@ -1,0 +1,286 @@
+import {pathContains} from '../../traversal/path-contains'
+import {
+  childAtTextOffset,
+  textOffsetOfChild,
+} from '../../utils/util.child-text-offset'
+import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
+import type {Path} from '../interfaces/path'
+import type {Point, PointTransformOptions} from '../interfaces/point'
+import {pathEquals} from '../path/path-equals'
+
+export type InsertTextStep = {
+  type: 'insert.text'
+  path: Path
+  offset: number
+  text: string
+}
+
+export type RemoveTextStep = {
+  type: 'remove.text'
+  path: Path
+  offset: number
+  text: string
+}
+
+export type SetTextStep = {
+  type: 'set.text'
+  path: Path
+  text: string
+}
+
+export type RemoveNodeStep = {
+  type: 'remove.node'
+  path: Path
+}
+
+export type UnsetTextStep = {
+  type: 'unset.text'
+  path: Path
+}
+
+export type RekeyStep = {
+  type: 'rekey'
+  oldKey: string
+  newKey: string
+}
+
+export type ReplaceChildrenStep = {
+  type: 'replace.children'
+  path: Path
+  oldChildren: Array<unknown>
+  newChildren: Array<unknown>
+}
+
+export type Step =
+  | InsertTextStep
+  | RemoveTextStep
+  | SetTextStep
+  | RemoveNodeStep
+  | UnsetTextStep
+  | RekeyStep
+  | ReplaceChildrenStep
+
+/**
+ * Map a point through one step. Returns the same `point` reference when the
+ * step doesn't actually move the point, so callers can use referential
+ * equality to detect "nothing changed."
+ */
+export function mapPointThroughStep(
+  step: Step,
+  point: Point | null,
+  options: PointTransformOptions = {},
+): Point | null {
+  if (point === null) {
+    return null
+  }
+
+  const {affinity = 'forward'} = options
+
+  switch (step.type) {
+    case 'insert.text': {
+      if (
+        pathEquals(step.path, point.path) &&
+        (step.offset < point.offset ||
+          (step.offset === point.offset && affinity === 'forward'))
+      ) {
+        return {path: point.path, offset: point.offset + step.text.length}
+      }
+
+      return point
+    }
+
+    case 'remove.text': {
+      if (pathEquals(step.path, point.path) && step.offset <= point.offset) {
+        return {
+          path: point.path,
+          offset:
+            point.offset -
+            Math.min(point.offset - step.offset, step.text.length),
+        }
+      }
+
+      return point
+    }
+
+    case 'set.text': {
+      if (!pathEquals(step.path, point.path)) {
+        return point
+      }
+
+      const offset =
+        point.offset > step.text.length ? step.text.length : point.offset
+
+      if (offset === point.offset) {
+        return point
+      }
+
+      return {path: point.path, offset}
+    }
+
+    case 'rekey': {
+      let path: Path | undefined
+
+      for (let i = 0; i < point.path.length; i++) {
+        const segment = point.path[i]
+
+        if (isKeyedSegment(segment) && segment._key === step.oldKey) {
+          if (path === undefined) {
+            path = [...point.path]
+          }
+          path[i] = {_key: step.newKey}
+        }
+      }
+
+      return path === undefined ? point : {path, offset: point.offset}
+    }
+
+    case 'replace.children': {
+      const remapped = remapPointThroughChildrenReplacement(
+        point,
+        step.path,
+        step.newChildren,
+        step.oldChildren,
+      )
+
+      return remapped ?? point
+    }
+
+    case 'remove.node': {
+      if (pathContains(step.path, point.path)) {
+        return null
+      }
+
+      return point
+    }
+
+    case 'unset.text': {
+      if (pathEquals(step.path, point.path) && point.offset !== 0) {
+        return {path: point.path, offset: 0}
+      }
+
+      return point
+    }
+  }
+}
+
+/**
+ * Map a point through a batch of steps, in order. A step that invalidates
+ * the point (a node removal) short-circuits the remaining steps.
+ */
+export function mapPointThroughSteps(
+  steps: ReadonlyArray<Step>,
+  point: Point | null,
+  options: PointTransformOptions = {},
+): Point | null {
+  let current = point
+
+  for (const step of steps) {
+    if (current === null) {
+      return null
+    }
+    current = mapPointThroughStep(step, current, options)
+  }
+
+  return current
+}
+
+/**
+ * Map a point through a wholesale children replacement via its text
+ * offset within the node. Returns `undefined` (leave the point
+ * untransformed) unless every precondition holds: the point addresses
+ * a direct child of the node whose children were replaced, that
+ * child's key is gone from the new children (identity did not
+ * survive), and the old and new children carry identical concatenated
+ * span text, the condition that makes offset mapping lossless.
+ *
+ * Spans are detected structurally (`text` being a string) rather than
+ * through the schema: this mapper is deliberately schema-free, and
+ * text-carrying children are the only ones that occupy offsets.
+ *
+ * The offset arithmetic is shared with the snapshot-aware block-offset
+ * utils through `utils/util.child-text-offset.ts`, so the boundary
+ * convention (an offset landing exactly on a span boundary stays at
+ * the end of the earlier span) is the same by construction. Only the
+ * span detection differs: structural here, schema-based there.
+ *
+ * A container's array field may also be named `children` and hold
+ * blocks rather than spans. The text requirement makes that a no-op by
+ * construction: blocks carry no `text` of their own, so a point
+ * addressing a replaced block bails at the offset walk, and points
+ * deeper inside such blocks fail the direct-child path guard.
+ */
+function remapPointThroughChildrenReplacement(
+  point: Point,
+  childrenPath: Path,
+  newChildren: Array<unknown>,
+  oldChildren: Array<unknown>,
+): Point | undefined {
+  if (
+    point.path.length !== childrenPath.length + 1 ||
+    !pathEquals(point.path.slice(0, childrenPath.length), childrenPath)
+  ) {
+    return undefined
+  }
+
+  const pointSegment = point.path[point.path.length - 1]
+  if (!isKeyedSegment(pointSegment)) {
+    return undefined
+  }
+
+  if (newChildren.some((child) => childKey(child) === pointSegment._key)) {
+    // The point's span survived the replacement; identity wins over
+    // offset mapping.
+    return undefined
+  }
+
+  const nodeTextOffset = textOffsetOfChild(
+    oldChildren,
+    childText,
+    pointSegment._key,
+    point.offset,
+  )
+  if (nodeTextOffset === undefined) {
+    return undefined
+  }
+
+  if (concatenatedText(oldChildren) !== concatenatedText(newChildren)) {
+    return undefined
+  }
+
+  const placed = childAtTextOffset(newChildren, childText, nodeTextOffset)
+  if (placed === undefined) {
+    return undefined
+  }
+
+  return {
+    path: [...childrenPath, {_key: placed.key}],
+    offset: placed.offset,
+  }
+}
+
+function childText(child: unknown): string | undefined {
+  if (child !== null && typeof child === 'object' && 'text' in child) {
+    const text = (child as {text: unknown}).text
+    return typeof text === 'string' ? text : undefined
+  }
+  return undefined
+}
+
+function childKey(child: unknown): string | undefined {
+  if (child !== null && typeof child === 'object' && '_key' in child) {
+    const key = (child as {_key: unknown})._key
+    return typeof key === 'string' ? key : undefined
+  }
+  return undefined
+}
+
+function concatenatedText(children: Array<unknown>): string {
+  let text = ''
+  for (const child of children) {
+    const childTextValue = childText(child)
+    if (childTextValue !== undefined) {
+      text += childTextValue
+    }
+  }
+  return text
+}

--- a/packages/editor/src/engine/point/transform-point.test.ts
+++ b/packages/editor/src/engine/point/transform-point.test.ts
@@ -198,6 +198,66 @@ describe(transformPoint.name, () => {
     })
   })
 
+  test('set text: offset within new length is unchanged', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 3,
+    }
+    const op: EngineOperation = {
+      type: 'set',
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+      value: 'hello',
+      inverse: {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: 'hi',
+      },
+    }
+    expect(transformPoint(point, op)).toBe(point)
+  })
+
+  test('set text: offset beyond new length is clamped', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    const op: EngineOperation = {
+      type: 'set',
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+      value: 'ab',
+      inverse: {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: 'hello',
+      },
+    }
+    expect(transformPoint(point, op)).toEqual({
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 2,
+    })
+  })
+
+  test('set text: non-string value clamps offset to zero', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 4,
+    }
+    const op: EngineOperation = {
+      type: 'set',
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+      value: null,
+      inverse: {
+        type: 'set',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}, 'text'],
+        value: 'hello',
+      },
+    }
+    expect(transformPoint(point, op)).toEqual({
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 0,
+    })
+  })
+
   test('unset text collapses offset', () => {
     const point = {
       path: [{_key: 'b1'}, 'children', {_key: 's1'}],

--- a/packages/editor/src/engine/point/transform-point.ts
+++ b/packages/editor/src/engine/point/transform-point.ts
@@ -1,13 +1,7 @@
-import {pathContains} from '../../traversal/path-contains'
-import {
-  childAtTextOffset,
-  textOffsetOfChild,
-} from '../../utils/util.child-text-offset'
 import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import type {EngineOperation} from '../interfaces/operation'
-import type {Path} from '../interfaces/path'
 import type {Point, PointTransformOptions} from '../interfaces/point'
-import {pathEquals} from '../path/path-equals'
+import {mapPointThroughSteps, type Step} from './step-mapper'
 
 /**
  * Transform a point by an operation. Returns the same `point` reference when
@@ -28,243 +22,81 @@ export function transformPoint(
   op: EngineOperation,
   options: PointTransformOptions = {},
 ): Point | null {
-  if (point === null) {
-    return null
-  }
+  return mapPointThroughSteps(operationToSteps(op), point, options)
+}
 
-  const {affinity = 'forward'} = options
-
+function operationToSteps(op: EngineOperation): Step[] {
   switch (op.type) {
-    case 'insert.text': {
-      if (
-        pathEquals(op.path, point.path) &&
-        (op.offset < point.offset ||
-          (op.offset === point.offset && affinity === 'forward'))
-      ) {
-        return {path: point.path, offset: point.offset + op.text.length}
-      }
+    case 'insert.text':
+      return [
+        {type: 'insert.text', path: op.path, offset: op.offset, text: op.text},
+      ]
 
-      return point
-    }
-
-    case 'remove.text': {
-      if (pathEquals(op.path, point.path) && op.offset <= point.offset) {
-        return {
-          path: point.path,
-          offset:
-            point.offset - Math.min(point.offset - op.offset, op.text.length),
-        }
-      }
-
-      return point
-    }
+    case 'remove.text':
+      return [
+        {type: 'remove.text', path: op.path, offset: op.offset, text: op.text},
+      ]
 
     case 'set': {
       const propertyName = op.path[op.path.length - 1]
       const nodePath = op.path.slice(0, -1)
 
-      let path: Path = point.path
-      let offset: number = point.offset
-
-      // When _key is set to a new value, update any point referencing the old key
       if (propertyName === '_key' && typeof op.value === 'string') {
         const oldKey =
           op.inverse?.type === 'set' && typeof op.inverse.value === 'string'
             ? op.inverse.value
             : undefined
 
-        if (oldKey) {
-          let newPath: Path | undefined
-
-          for (let i = 0; i < path.length; i++) {
-            const segment = path[i]
-
-            if (isKeyedSegment(segment) && segment._key === oldKey) {
-              if (newPath === undefined) {
-                newPath = [...path]
-              }
-              newPath[i] = {_key: op.value}
-            }
-          }
-
-          if (newPath !== undefined) {
-            path = newPath
-          }
-        }
+        return oldKey ? [{type: 'rekey', oldKey, newKey: op.value}] : []
       }
 
-      // When text is set on a span, clamp offset to the new text length
-      if (propertyName === 'text' && pathEquals(nodePath, path)) {
-        if (op.value == null || typeof op.value !== 'string') {
-          offset = 0
-        } else if (offset > op.value.length) {
-          offset = op.value.length
-        }
+      if (propertyName === 'text') {
+        return [
+          {
+            type: 'set.text',
+            path: nodePath,
+            text: typeof op.value === 'string' ? op.value : '',
+          },
+        ]
       }
 
-      // When a node's children are replaced wholesale (the sync
-      // machine's fallback for re-keyed remote children), a point
-      // inside the old children references keys that no longer exist.
-      // When the replacement preserves the concatenated span text (a
-      // remote mark toggle: same characters, new span boundaries and
-      // keys), the point maps losslessly through its text offset
-      // within the node. Points whose span survived keep their
-      // identity, and text-changing replacements keep the
-      // untransformed point, offset mapping would be guesswork there.
       if (propertyName === 'children' && Array.isArray(op.value)) {
-        const remappedPoint = remapPointThroughChildrenReplacement(
-          point,
-          op.path,
-          op.value as Array<unknown>,
+        const oldChildren =
           op.inverse?.type === 'set' && Array.isArray(op.inverse.value)
             ? (op.inverse.value as Array<unknown>)
-            : undefined,
-        )
-        if (remappedPoint) {
-          path = remappedPoint.path
-          offset = remappedPoint.offset
-        }
+            : undefined
+
+        return oldChildren === undefined
+          ? []
+          : [
+              {
+                type: 'replace.children',
+                path: op.path,
+                oldChildren,
+                newChildren: op.value as Array<unknown>,
+              },
+            ]
       }
 
-      if (path === point.path && offset === point.offset) {
-        return point
-      }
-
-      return {path, offset}
+      return []
     }
 
     case 'unset': {
       const lastSegment = op.path[op.path.length - 1]
 
       if (isKeyedSegment(lastSegment)) {
-        if (pathContains(op.path, point.path)) {
-          return null
-        }
-        return point
+        return [{type: 'remove.node', path: op.path}]
       }
 
-      const propertyName = lastSegment
-      const nodePath = op.path.slice(0, -1)
-
-      if (
-        propertyName === 'text' &&
-        pathEquals(nodePath, point.path) &&
-        point.offset !== 0
-      ) {
-        return {path: point.path, offset: 0}
+      if (lastSegment === 'text') {
+        return [{type: 'unset.text', path: op.path.slice(0, -1)}]
       }
 
-      return point
+      return []
     }
 
-    // set.selection: no transform needed
+    // insert, set.selection: no transform needed
     default:
-      return point
+      return []
   }
-}
-
-/**
- * Map a point through a wholesale children replacement via its text
- * offset within the node. Returns `undefined` (leave the point
- * untransformed) unless every precondition holds: the point addresses
- * a direct child of the node whose children were replaced, that
- * child's key is gone from the new children (identity did not
- * survive), the old children are known (the op's inverse), and the
- * old and new children carry identical concatenated span text, the
- * condition that makes offset mapping lossless.
- *
- * Spans are detected structurally (`text` being a string) rather than
- * through the schema: `transformPoint` is deliberately schema-free,
- * and text-carrying children are the only ones that occupy offsets.
- *
- * The offset arithmetic is shared with the snapshot-aware block-offset
- * utils through `utils/util.child-text-offset.ts`, so the boundary
- * convention (an offset landing exactly on a span boundary stays at
- * the end of the earlier span) is the same by construction. Only the
- * span detection differs: structural here, schema-based there.
- *
- * A container's array field may also be named `children` and hold
- * blocks rather than spans. The text requirement makes that a no-op by
- * construction: blocks carry no `text` of their own, so a point
- * addressing a replaced block bails at the offset walk, and points
- * deeper inside such blocks fail the direct-child path guard.
- */
-function remapPointThroughChildrenReplacement(
-  point: Point,
-  childrenPath: Path,
-  newChildren: Array<unknown>,
-  oldChildren: Array<unknown> | undefined,
-): Point | undefined {
-  if (!oldChildren) {
-    return undefined
-  }
-
-  if (
-    point.path.length !== childrenPath.length + 1 ||
-    !pathEquals(point.path.slice(0, childrenPath.length), childrenPath)
-  ) {
-    return undefined
-  }
-
-  const pointSegment = point.path[point.path.length - 1]
-  if (!isKeyedSegment(pointSegment)) {
-    return undefined
-  }
-
-  if (newChildren.some((child) => childKey(child) === pointSegment._key)) {
-    // The point's span survived the replacement; identity wins over
-    // offset mapping.
-    return undefined
-  }
-
-  const nodeTextOffset = textOffsetOfChild(
-    oldChildren,
-    childText,
-    pointSegment._key,
-    point.offset,
-  )
-  if (nodeTextOffset === undefined) {
-    return undefined
-  }
-
-  if (concatenatedText(oldChildren) !== concatenatedText(newChildren)) {
-    return undefined
-  }
-
-  const placed = childAtTextOffset(newChildren, childText, nodeTextOffset)
-  if (placed === undefined) {
-    return undefined
-  }
-
-  return {
-    path: [...childrenPath, {_key: placed.key}],
-    offset: placed.offset,
-  }
-}
-
-function childText(child: unknown): string | undefined {
-  if (child !== null && typeof child === 'object' && 'text' in child) {
-    const text = (child as {text: unknown}).text
-    return typeof text === 'string' ? text : undefined
-  }
-  return undefined
-}
-
-function childKey(child: unknown): string | undefined {
-  if (child !== null && typeof child === 'object' && '_key' in child) {
-    const key = (child as {_key: unknown})._key
-    return typeof key === 'string' ? key : undefined
-  }
-  return undefined
-}
-
-function concatenatedText(children: Array<unknown>): string {
-  let text = ''
-  for (const child of children) {
-    const childTextValue = childText(child)
-    if (childTextValue !== undefined) {
-      text += childTextValue
-    }
-  }
-  return text
 }


### PR DESCRIPTION
`transformPoint` mixes two jobs: interpreting an `EngineOperation` (reading its paths, values, and inverse data) and the positional arithmetic that shifts a point through a change. Everything that needs the arithmetic (the caret, refs, range transforms, the decoration machine) has to arrive operation-shaped, and the transaction interpreter this work builds toward needs the same arithmetic against steps that never were operations, batches of them, derived from a transaction's patches.

This PR separates the jobs, behavior-preservingly. `step-mapper.ts` holds the rules as pure functions over a `Step` union that carries everything as plain values, including the inverse data the old code read from operations (the rekey's old key, the children replacement's old children). `transform-point.ts` becomes an `operationToSteps` adapter plus a mapper call; its exported signature and behavior do not change, down to referential equality on every no-op path. No call sites move: refs and decorations keep calling through `transformPoint`, and a batch of one operation is the degenerate case of the batch form the interpreter will consume.

Parity is pinned three ways: the existing point and selection suites are untouched and green, 42 new unit tests exercise the mapper at its own interface (every step kind, both affinities, the null-returning cases, batch short-circuiting, and a nested-paths suite pinning that the rules are depth-agnostic at container depth, plus the inherited direct-child-only limit of the children-replacement remap as the current contract), and three new `transformPoint` tests pin the one seam review found unprotected, the `set`-of-`text` branch (in-range offset unchanged by reference, out-of-range clamped, non-string value clamping to zero). The review also caught a truthiness delta on empty-string keys in the rekey guard, restored to match `main` exactly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caret/selection mapping is core editor behavior; the refactor is intended to be behavior-preserving but a mapping bug would misplace selections, refs, and decorations.
> 
> **Overview**
> Splits point transformation into two jobs: interpreting an `EngineOperation`, and applying positional arithmetic.
> 
> The arithmetic now lives in `mapPointThroughStep` / `mapPointThroughSteps` over a plain `Step` union (insert/remove/set text, node removal, rekey, children replacement). `transformPoint` becomes an `operationToSteps` adapter; its public signature, no-op referential equality, and call sites are unchanged.
> 
> This unblocks mapping points through transaction-derived step batches rather than only operation-shaped input. New mapper tests cover each step kind, affinity, nested paths, and batch short-circuiting; extra `transformPoint` tests pin `set` of `text` (in-range identity, clamp, non-string → 0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb871779374f6188859bcbcae7f12fe7d33dfa14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->