### PR TITLE
chore: add a zero-config vanilla example

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vanilla Portable Text Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example-vanilla",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check:types": "tsc",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@portabletext/editor": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:tooling",
+    "@types/react-dom": "catalog:tooling",
+    "@vitejs/plugin-react": "catalog:tooling",
+    "typescript": "catalog:tooling",
+    "vite": "catalog:tooling"
+  }
+}

--- a/examples/vanilla/src/main.tsx
+++ b/examples/vanilla/src/main.tsx
@@ -1,0 +1,62 @@
+import {
+  defineSchema,
+  EditorProvider,
+  keyGenerator,
+  PortableTextEditable,
+} from '@portabletext/editor'
+import {StrictMode} from 'react'
+import {createRoot} from 'react-dom/client'
+
+// The full content model, zero render config: no render props, no node
+// registrations, no plugins, no CSS. What you see is the editor's own
+// default rendering.
+const schemaDefinition = defineSchema({
+  decorators: [{name: 'strong'}, {name: 'em'}, {name: 'underline'}],
+  annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  styles: [{name: 'normal'}, {name: 'h1'}, {name: 'h2'}, {name: 'blockquote'}],
+  lists: [{name: 'bullet'}, {name: 'number'}],
+  inlineObjects: [
+    {name: 'mention', fields: [{name: 'userId', type: 'string'}]},
+  ],
+  blockObjects: [{name: 'image', fields: [{name: 'src', type: 'string'}]}],
+})
+
+const initialValue = [
+  {
+    _type: 'block',
+    _key: keyGenerator(),
+    children: [
+      {_type: 'span', _key: keyGenerator(), text: 'Hello '},
+      {_type: 'mention', _key: keyGenerator(), userId: 'u1'},
+      {_type: 'span', _key: keyGenerator(), text: ' world'},
+    ],
+  },
+  {_type: 'image', _key: keyGenerator(), src: 'https://example.com/cat.jpg'},
+  {
+    _type: 'block',
+    _key: keyGenerator(),
+    children: [{_type: 'span', _key: keyGenerator(), text: 'A list item'}],
+    listItem: 'bullet',
+    level: 1,
+  },
+]
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <main
+      style={{maxWidth: '40rem', margin: '2rem auto', fontFamily: 'sans-serif'}}
+    >
+      <h1>Vanilla PTE</h1>
+      <p>No render config. Editor defaults only.</p>
+      <EditorProvider initialConfig={{schemaDefinition, initialValue}}>
+        <PortableTextEditable
+          style={{
+            border: '1px solid #ccc',
+            padding: '0.5em',
+            minHeight: '10rem',
+          }}
+        />
+      </EditorProvider>
+    </main>
+  </StrictMode>,
+)

--- a/examples/vanilla/tsconfig.app.json
+++ b/examples/vanilla/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/examples/vanilla/tsconfig.json
+++ b/examples/vanilla/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/examples/vanilla/tsconfig.node.json
+++ b/examples/vanilla/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/vanilla/vite.config.ts
+++ b/examples/vanilla/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react'
+import {defineConfig} from 'vite'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,34 @@ importers:
         specifier: catalog:tooling
         version: 8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3)
 
+  examples/vanilla:
+    dependencies:
+      '@portabletext/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: catalog:tooling
+        version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.28.4)(rolldown@1.2.2)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3))
+      typescript:
+        specifier: catalog:tooling
+        version: 6.0.3
+      vite:
+        specifier: catalog:tooling
+        version: 8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.5)(yaml@2.8.3)
+
   packages/block-tools:
     dependencies:
       '@portabletext/html':


### PR DESCRIPTION
A full content model (styles, lists, decorators, a link annotation, an image block object, a mention inline object) with no render props, no registrations, no plugins, and no CSS: what the editor's own defaults render and what they don't (object previews as `[type: key]` tokens, lists with no visual treatment, no UI for anything the schema allows). `pnpm --filter example-vanilla dev` serves it.

The last piece of the v8 stack.