### PR TITLE
chore: render drop indicators in the playground via `plugin-dnd`

### DIFF
--- a/.changeset/dnd-nested-self-drop.md
+++ b/.changeset/dnd-nested-self-drop.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-dnd': patch
+---
+
+fix: suppress the drop indicator when dragging a nested block over itself
+
+Dragging a block nested inside a container (a callout's paragraph, a table cell's content) and hovering it over its own position no longer shows a drop indicator there. Indicators already rendered on the correct nested block for drops elsewhere in a container; only the self-drop suppression was still comparing at the container's root level and missed the nested case.

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -18,6 +18,7 @@
     "@portabletext/keyboard-shortcuts": "workspace:*",
     "@portabletext/markdown": "workspace:*",
     "@portabletext/patches": "workspace:*",
+    "@portabletext/plugin-dnd": "workspace:*",
     "@portabletext/plugin-emoji-picker": "workspace:*",
     "@portabletext/plugin-list-index": "workspace:*",
     "@portabletext/plugin-markdown-shortcuts": "workspace:*",

--- a/apps/playground/src/editor-settings-popover.tsx
+++ b/apps/playground/src/editor-settings-popover.tsx
@@ -35,6 +35,11 @@ export function EditorSettingsPopover(props: {editorRef: EditorActorRef}) {
               isSelected={featureFlags.dragHandles}
               onChange={() => toggleFlag('dragHandles')}
             />
+            <FeatureSwitch
+              label="Drop indicators (plugin-dnd)"
+              isSelected={featureFlags.dndPlugin}
+              onChange={() => toggleFlag('dndPlugin')}
+            />
           </Section>
 
           <Separator orientation="horizontal" />

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -633,7 +633,12 @@ function PlaygroundTextBlock(props: TextBlockRenderProps) {
     // rendering; this catch-all only mirrors the engine default so
     // containers without a positional text block (the code block's
     // lines) keep their plain shape.
-    return <div {...props.attributes}>{props.children}</div>
+    return (
+      <div {...props.attributes} className="relative">
+        {props.children}
+        {flags.dndPlugin ? <BlockDropIndicator path={props.path} /> : null}
+      </div>
+    )
   }
 
   const style = styleMap.get(props.node.style ?? 'normal')

--- a/apps/playground/src/editor.tsx
+++ b/apps/playground/src/editor.tsx
@@ -21,6 +21,7 @@ import {
 } from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import {portableTextToMarkdown} from '@portabletext/markdown'
+import {DndProvider} from '@portabletext/plugin-dnd'
 import {ListIndexProvider} from '@portabletext/plugin-list-index'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
@@ -46,7 +47,7 @@ import {
   TableIcon,
   XIcon,
 } from 'lucide-react'
-import {useContext, useEffect, useState, type JSX} from 'react'
+import {useContext, useEffect, useState, type JSX, type ReactNode} from 'react'
 import {TooltipTrigger} from 'react-aria-components'
 import {tv} from 'tailwind-variants'
 import {EditorSettingsPopover} from './editor-settings-popover'
@@ -65,6 +66,7 @@ import {
   LinkAnnotationSchema,
   playgroundSchemaDefinition,
 } from './playground-schema-definition'
+import {BlockDropIndicator} from './plugins/block-drop-indicator'
 import {ListItemBlock} from './plugins/list-item-block'
 import {CalloutPlugin} from './plugins/plugin.callout'
 import {CodeBlockPlugin} from './plugins/plugin.code-block'
@@ -156,54 +158,63 @@ export function Editor(props: {
               </FullscreenAwareToolbarWrapper>
             ) : null}
             <ListIndexProvider>
-              <FullscreenAwareContainer>
-                <NodePlugin nodes={playgroundNodes} />
-                {featureFlags.codeBlockPlugin ? <CodeBlockPlugin /> : null}
-                {featureFlags.calloutPlugin ? <CalloutPlugin /> : null}
-                {featureFlags.factBoxPlugin ? <FactBoxPlugin /> : null}
-                {featureFlags.tablePlugin ? <TablePlugin /> : null}
-                <InlineObjectsPlugin />
-                {featureFlags.emojiPickerPlugin ? <EmojiPickerPlugin /> : null}
-                {featureFlags.mentionPickerPlugin ? (
-                  <MentionPickerPlugin />
-                ) : null}
-                {featureFlags.slashCommandPlugin ? (
-                  <SlashCommandPickerPlugin />
-                ) : null}
-                {featureFlags.codeEditorPlugin ? <CodeEditorPlugin /> : null}
-                {featureFlags.linkPlugin ? <PasteLinkPlugin /> : null}
-                {featureFlags.imageDeserializerPlugin ? (
-                  <ImageDeserializerPlugin />
-                ) : null}
-                {featureFlags.htmlDeserializerPlugin ? (
-                  <HtmlDeserializerPlugin />
-                ) : null}
-                {featureFlags.textFileDeserializerPlugin ? (
-                  <TextFileDeserializerPlugin />
-                ) : null}
-                {featureFlags.markdownDeserializerPlugin ? (
-                  <MarkdownDeserializerPlugin />
-                ) : null}
-                {featureFlags.markdownPlugin ? (
-                  <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
-                ) : null}
-                {featureFlags.oneLinePlugin ? <OneLinePlugin /> : null}
-                {featureFlags.typographyPlugin ? (
-                  <TypographyPlugin
-                    guard={createDecoratorGuard({
-                      decorators: ({context}) =>
-                        context.schema.decorators.flatMap((decorator) =>
-                          decorator.name === 'code' ? [] : [decorator.name],
-                        ),
-                    })}
+              <MaybeDndProvider enabled={featureFlags.dndPlugin}>
+                <FullscreenAwareContainer>
+                  <NodePlugin nodes={playgroundNodes} />
+                  {featureFlags.codeBlockPlugin ? <CodeBlockPlugin /> : null}
+                  {featureFlags.calloutPlugin ? <CalloutPlugin /> : null}
+                  {featureFlags.factBoxPlugin ? <FactBoxPlugin /> : null}
+                  {featureFlags.tablePlugin ? <TablePlugin /> : null}
+                  <InlineObjectsPlugin />
+                  {featureFlags.emojiPickerPlugin ? (
+                    <EmojiPickerPlugin />
+                  ) : null}
+                  {featureFlags.mentionPickerPlugin ? (
+                    <MentionPickerPlugin />
+                  ) : null}
+                  {featureFlags.slashCommandPlugin ? (
+                    <SlashCommandPickerPlugin />
+                  ) : null}
+                  {featureFlags.codeEditorPlugin ? <CodeEditorPlugin /> : null}
+                  {featureFlags.linkPlugin ? <PasteLinkPlugin /> : null}
+                  {featureFlags.imageDeserializerPlugin ? (
+                    <ImageDeserializerPlugin />
+                  ) : null}
+                  {featureFlags.htmlDeserializerPlugin ? (
+                    <HtmlDeserializerPlugin />
+                  ) : null}
+                  {featureFlags.textFileDeserializerPlugin ? (
+                    <TextFileDeserializerPlugin />
+                  ) : null}
+                  {featureFlags.markdownDeserializerPlugin ? (
+                    <MarkdownDeserializerPlugin />
+                  ) : null}
+                  {featureFlags.markdownPlugin ? (
+                    <MarkdownShortcutsPlugin
+                      {...markdownShortcutsPluginProps}
+                    />
+                  ) : null}
+                  {featureFlags.oneLinePlugin ? <OneLinePlugin /> : null}
+                  {featureFlags.typographyPlugin ? (
+                    <TypographyPlugin
+                      guard={createDecoratorGuard({
+                        decorators: ({context}) =>
+                          context.schema.decorators.flatMap((decorator) =>
+                            decorator.name === 'code' ? [] : [decorator.name],
+                          ),
+                      })}
+                    />
+                  ) : null}
+                  <FullscreenAwareEditable
+                    rangeDecorations={props.rangeDecorations}
+                    featureFlags={featureFlags}
                   />
-                ) : null}
-                <FullscreenAwareEditable
-                  rangeDecorations={props.rangeDecorations}
-                  featureFlags={featureFlags}
-                />
-                <EditorFooter editorRef={props.editorRef} readOnly={readOnly} />
-              </FullscreenAwareContainer>
+                  <EditorFooter
+                    editorRef={props.editorRef}
+                    readOnly={readOnly}
+                  />
+                </FullscreenAwareContainer>
+              </MaybeDndProvider>
             </ListIndexProvider>
           </EditorProvider>
         </FullscreenProvider>
@@ -240,6 +251,14 @@ function FullscreenAwareEditable(props: {
         </EditorFeatureFlagsContext.Provider>
       </ErrorBoundary>
     </div>
+  )
+}
+
+function MaybeDndProvider(props: {enabled: boolean; children: ReactNode}) {
+  return props.enabled ? (
+    <DndProvider>{props.children}</DndProvider>
+  ) : (
+    props.children
   )
 }
 
@@ -457,7 +476,7 @@ function TaskListCheckbox(props: {block: PortableTextBlock; path: BlockPath}) {
 }
 
 const renderPlaceholder: RenderPlaceholderFunction = () => (
-  <span className="text-gray-400 dark:text-gray-500 px-2">Type something</span>
+  <span className="text-gray-400 dark:text-gray-500">Type something</span>
 )
 
 const playgroundBlockObjectFallback = defineBlockObject({
@@ -466,7 +485,8 @@ const playgroundBlockObjectFallback = defineBlockObject({
 })
 
 function PlaygroundBlockObject(props: BlockObjectRenderProps) {
-  const enableDragHandles = useContext(EditorFeatureFlagsContext).dragHandles
+  const flags = useContext(EditorFeatureFlagsContext)
+  const enableDragHandles = flags.dragHandles
 
   let content: JSX.Element
 
@@ -575,16 +595,19 @@ function PlaygroundBlockObject(props: BlockObjectRenderProps) {
     <div {...props.attributes}>
       {props.children}
       <div contentEditable={false} draggable={!props.readOnly}>
-        {enableDragHandles ? (
-          <div className="me-1 relative">
-            <div
-              contentEditable={false}
-              draggable={!props.readOnly}
-              className="absolute top-0 -left-3 bottom-0 w-1.5 bg-gray-300 dark:bg-gray-600 rounded cursor-grab"
-            >
-              <span />
-            </div>
+        {enableDragHandles || flags.dndPlugin ? (
+          <div className={enableDragHandles ? 'me-1 relative' : 'relative'}>
+            {enableDragHandles ? (
+              <div
+                contentEditable={false}
+                draggable={!props.readOnly}
+                className="absolute top-0 -left-3 bottom-0 w-1.5 bg-gray-300 dark:bg-gray-600 rounded cursor-grab"
+              >
+                <span />
+              </div>
+            ) : null}
             <div>{content}</div>
+            {flags.dndPlugin ? <BlockDropIndicator path={props.path} /> : null}
           </div>
         ) : (
           content
@@ -602,7 +625,8 @@ const playgroundTextBlock = defineTextBlock({
 const playgroundNodes = [playgroundTextBlock, playgroundBlockObjectFallback]
 
 function PlaygroundTextBlock(props: TextBlockRenderProps) {
-  const enableDragHandles = useContext(EditorFeatureFlagsContext).dragHandles
+  const flags = useContext(EditorFeatureFlagsContext)
+  const enableDragHandles = flags.dragHandles
 
   if (props.path.length > 1) {
     // Inside a container the positional `of` registrations own the rich
@@ -628,7 +652,7 @@ function PlaygroundTextBlock(props: TextBlockRenderProps) {
         </span>
       )
     }
-    return (
+    const listItem = (
       <ListItemBlock
         attributes={props.attributes}
         node={props.node}
@@ -637,11 +661,26 @@ function PlaygroundTextBlock(props: TextBlockRenderProps) {
         {children}
       </ListItemBlock>
     )
+
+    return flags.dndPlugin ? (
+      <div className="relative">
+        {listItem}
+        <BlockDropIndicator path={props.path} />
+      </div>
+    ) : (
+      listItem
+    )
   }
 
-  if (enableDragHandles) {
-    return (
-      <div {...props.attributes} className="me-1 relative">
+  // The wrapper is unconditional: the engine's placeholder anchors
+  // `absolute` to the nearest positioned ancestor, so the anchoring must
+  // not change with feature flags.
+  return (
+    <div
+      {...props.attributes}
+      className={enableDragHandles ? 'me-1 relative' : 'relative'}
+    >
+      {enableDragHandles ? (
         <div
           contentEditable={false}
           draggable={!props.readOnly}
@@ -649,17 +688,10 @@ function PlaygroundTextBlock(props: TextBlockRenderProps) {
         >
           <span />
         </div>
-        <div>{style ? style({children: props.children}) : props.children}</div>
-      </div>
-    )
-  }
-
-  return style ? (
-    style({attributes: props.attributes, children: props.children})
-  ) : (
-    <p {...props.attributes} className="my-1">
-      {props.children}
-    </p>
+      ) : null}
+      <div>{style ? style({children: props.children}) : props.children}</div>
+      {flags.dndPlugin ? <BlockDropIndicator path={props.path} /> : null}
+    </div>
   )
 }
 

--- a/apps/playground/src/feature-flags.ts
+++ b/apps/playground/src/feature-flags.ts
@@ -13,6 +13,7 @@ export const PlaygroundFeatureFlagsContext =
 
 export type EditorFeatureFlags = {
   dragHandles: boolean
+  dndPlugin: boolean
   imageDeserializerPlugin: boolean
   htmlDeserializerPlugin: boolean
   markdownDeserializerPlugin: boolean
@@ -33,6 +34,7 @@ export type EditorFeatureFlags = {
 
 export const defaultEditorFeatureFlags: EditorFeatureFlags = {
   dragHandles: false,
+  dndPlugin: true,
   imageDeserializerPlugin: false,
   htmlDeserializerPlugin: true,
   markdownDeserializerPlugin: true,
@@ -51,6 +53,7 @@ export const defaultEditorFeatureFlags: EditorFeatureFlags = {
   typographyPlugin: true,
 }
 
-export const EditorFeatureFlagsContext = createContext<EditorFeatureFlags>(
-  defaultEditorFeatureFlags,
-)
+export const EditorFeatureFlagsContext = createContext<EditorFeatureFlags>({
+  ...defaultEditorFeatureFlags,
+  dndPlugin: false,
+})

--- a/apps/playground/src/plugins/block-drop-indicator.tsx
+++ b/apps/playground/src/plugins/block-drop-indicator.tsx
@@ -1,6 +1,7 @@
 import type {Path} from '@portabletext/editor'
 import {useDropPosition} from '@portabletext/plugin-dnd'
-import type {JSX} from 'react'
+import {useContext, type JSX, type ReactNode} from 'react'
+import {EditorFeatureFlagsContext} from '../feature-flags'
 
 /**
  * `useDropPosition` throws below a missing `DndProvider`, so every caller
@@ -18,4 +19,23 @@ export function BlockDropIndicator(props: {path: Path}): JSX.Element | null {
       }`}
     />
   ) : null
+}
+
+/**
+ * Wraps a nested block render in the `relative` positioning context the
+ * indicator needs, or renders the children bare when the plugin is off.
+ */
+export function WithBlockDropIndicator(props: {
+  path: Path
+  children: ReactNode
+}): JSX.Element {
+  const flags = useContext(EditorFeatureFlagsContext)
+  return flags.dndPlugin ? (
+    <div className="relative">
+      {props.children}
+      <BlockDropIndicator path={props.path} />
+    </div>
+  ) : (
+    <>{props.children}</>
+  )
 }

--- a/apps/playground/src/plugins/block-drop-indicator.tsx
+++ b/apps/playground/src/plugins/block-drop-indicator.tsx
@@ -1,0 +1,21 @@
+import type {Path} from '@portabletext/editor'
+import {useDropPosition} from '@portabletext/plugin-dnd'
+import type {JSX} from 'react'
+
+/**
+ * `useDropPosition` throws below a missing `DndProvider`, so every caller
+ * must be gated behind `featureFlags.dndPlugin` before it renders, and must
+ * render inside a `position: relative` ancestor sized to the drop target so
+ * the line lands on it.
+ */
+export function BlockDropIndicator(props: {path: Path}): JSX.Element | null {
+  const dropPosition = useDropPosition(props.path)
+  return dropPosition ? (
+    <div
+      contentEditable={false}
+      className={`pointer-events-none absolute inset-x-0 h-0.5 bg-blue-500 dark:bg-blue-400 ${
+        dropPosition === 'start' ? 'top-0' : 'bottom-0'
+      }`}
+    />
+  ) : null
+}

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -2,6 +2,7 @@ import {
   defineBlockObject,
   defineContainer,
   defineTextBlock,
+  type ContainerRenderProps,
 } from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import {
@@ -12,6 +13,9 @@ import {
   TriangleAlertIcon,
 } from 'lucide-react'
 import type {JSX} from 'react'
+import {useContext} from 'react'
+import {EditorFeatureFlagsContext} from '../feature-flags'
+import {BlockDropIndicator} from './block-drop-indicator'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
 
@@ -73,29 +77,34 @@ const calloutImageLeaf = defineBlockObject({
   },
 })
 
+function CalloutContainer(props: ContainerRenderProps): JSX.Element {
+  const {attributes, children, node, path, readOnly, selected} = props
+  const flags = useContext(EditorFeatureFlagsContext)
+  const tone = typeof node.tone === 'string' ? node.tone : 'note'
+  const toneStyle = toneClassName[tone] ?? defaultToneClassName
+  return (
+    <aside
+      {...attributes}
+      data-selected={selected ? '' : undefined}
+      className={`group relative my-3 flex gap-2.5 rounded-md border-l-4 p-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
+    >
+      <span
+        contentEditable={false}
+        className="mt-[0.3rem] flex shrink-0 items-center justify-center"
+      >
+        <ToneIcon tone={tone} />
+      </span>
+      <div className="min-w-0 flex-1 cursor-text">{children}</div>
+      <DragHandle readOnly={readOnly} />
+      {flags.dndPlugin ? <BlockDropIndicator path={path} /> : null}
+    </aside>
+  )
+}
+
 export const calloutContainer = defineContainer({
   type: 'callout',
   arrayField: 'content',
-  render: ({attributes, children, node, readOnly, selected}) => {
-    const tone = typeof node.tone === 'string' ? node.tone : 'note'
-    const toneStyle = toneClassName[tone] ?? defaultToneClassName
-    return (
-      <aside
-        {...attributes}
-        data-selected={selected ? '' : undefined}
-        className={`group relative my-3 flex gap-2.5 rounded-md border-l-4 p-3 transition-shadow data-[selected]:shadow-md ${toneStyle}`}
-      >
-        <span
-          contentEditable={false}
-          className="mt-[0.3rem] flex shrink-0 items-center justify-center"
-        >
-          <ToneIcon tone={tone} />
-        </span>
-        <div className="min-w-0 flex-1 cursor-text">{children}</div>
-        <DragHandle readOnly={readOnly} />
-      </aside>
-    )
-  },
+  render: (props) => <CalloutContainer {...props} />,
   of: [
     defineTextBlock({
       type: 'block',

--- a/apps/playground/src/plugins/plugin.callout.tsx
+++ b/apps/playground/src/plugins/plugin.callout.tsx
@@ -3,6 +3,7 @@ import {
   defineContainer,
   defineTextBlock,
   type ContainerRenderProps,
+  type TextBlockRenderProps,
 } from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import {
@@ -15,7 +16,10 @@ import {
 import type {JSX} from 'react'
 import {useContext} from 'react'
 import {EditorFeatureFlagsContext} from '../feature-flags'
-import {BlockDropIndicator} from './block-drop-indicator'
+import {
+  BlockDropIndicator,
+  WithBlockDropIndicator,
+} from './block-drop-indicator'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
 
@@ -108,51 +112,11 @@ export const calloutContainer = defineContainer({
   of: [
     defineTextBlock({
       type: 'block',
-      render: ({attributes, children, node, path}) => {
-        if (node.listItem !== undefined) {
-          return (
-            <ListItemBlock attributes={attributes} node={node} path={path}>
-              {children}
-            </ListItemBlock>
-          )
-        }
-
-        switch (node.style) {
-          case 'h1':
-            return (
-              <h1 {...attributes} className="my-2 font-bold text-2xl">
-                {children}
-              </h1>
-            )
-          case 'h2':
-            return (
-              <h2 {...attributes} className="my-2 font-bold text-xl">
-                {children}
-              </h2>
-            )
-          case 'h3':
-            return (
-              <h3 {...attributes} className="my-2 font-bold text-lg">
-                {children}
-              </h3>
-            )
-          case 'blockquote':
-            return (
-              <blockquote
-                {...attributes}
-                className="my-1 border-l-2 border-amber-600 pl-2 italic dark:border-amber-300"
-              >
-                {children}
-              </blockquote>
-            )
-          default:
-            return (
-              <p {...attributes} className="my-1">
-                {children}
-              </p>
-            )
-        }
-      },
+      render: (props) => (
+        <WithBlockDropIndicator path={props.path}>
+          {renderCalloutTextBlock(props)}
+        </WithBlockDropIndicator>
+      ),
     }),
     calloutImageLeaf,
   ],
@@ -160,4 +124,55 @@ export const calloutContainer = defineContainer({
 
 export function CalloutPlugin(): JSX.Element {
   return <NodePlugin nodes={[calloutContainer]} />
+}
+
+function renderCalloutTextBlock({
+  attributes,
+  children,
+  node,
+  path,
+}: TextBlockRenderProps): JSX.Element {
+  if (node.listItem !== undefined) {
+    return (
+      <ListItemBlock attributes={attributes} node={node} path={path}>
+        {children}
+      </ListItemBlock>
+    )
+  }
+
+  switch (node.style) {
+    case 'h1':
+      return (
+        <h1 {...attributes} className="my-2 font-bold text-2xl">
+          {children}
+        </h1>
+      )
+    case 'h2':
+      return (
+        <h2 {...attributes} className="my-2 font-bold text-xl">
+          {children}
+        </h2>
+      )
+    case 'h3':
+      return (
+        <h3 {...attributes} className="my-2 font-bold text-lg">
+          {children}
+        </h3>
+      )
+    case 'blockquote':
+      return (
+        <blockquote
+          {...attributes}
+          className="my-1 border-l-2 border-amber-600 pl-2 italic dark:border-amber-300"
+        >
+          {children}
+        </blockquote>
+      )
+    default:
+      return (
+        <p {...attributes} className="my-1">
+          {children}
+        </p>
+      )
+  }
 }

--- a/apps/playground/src/plugins/plugin.code-block.tsx
+++ b/apps/playground/src/plugins/plugin.code-block.tsx
@@ -1,12 +1,15 @@
-import {defineContainer} from '@portabletext/editor'
+import {defineContainer, type ContainerRenderProps} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {useContext} from 'react'
+import {EditorFeatureFlagsContext} from '../feature-flags'
+import {BlockDropIndicator} from './block-drop-indicator'
 import {DragHandle} from './drag-handle'
 
-const codeBlockContainer = defineContainer({
-  type: 'code-block',
-  arrayField: 'lines',
-  render: ({attributes, children, readOnly, selected}) => (
+function CodeBlockContainer(props: ContainerRenderProps): JSX.Element {
+  const {attributes, children, path, readOnly, selected} = props
+  const flags = useContext(EditorFeatureFlagsContext)
+  return (
     <pre
       {...attributes}
       data-selected={selected ? '' : undefined}
@@ -14,8 +17,15 @@ const codeBlockContainer = defineContainer({
     >
       <code className="block min-w-0 cursor-text">{children}</code>
       <DragHandle readOnly={readOnly} />
+      {flags.dndPlugin ? <BlockDropIndicator path={path} /> : null}
     </pre>
-  ),
+  )
+}
+
+const codeBlockContainer = defineContainer({
+  type: 'code-block',
+  arrayField: 'lines',
+  render: (props) => <CodeBlockContainer {...props} />,
 })
 
 export function CodeBlockPlugin(): JSX.Element {

--- a/apps/playground/src/plugins/plugin.fact-box.tsx
+++ b/apps/playground/src/plugins/plugin.fact-box.tsx
@@ -1,13 +1,20 @@
-import {defineContainer, defineTextBlock} from '@portabletext/editor'
+import {
+  defineContainer,
+  defineTextBlock,
+  type ContainerRenderProps,
+} from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
+import {useContext} from 'react'
+import {EditorFeatureFlagsContext} from '../feature-flags'
+import {BlockDropIndicator} from './block-drop-indicator'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
 
-const factBoxContainer = defineContainer({
-  type: 'fact-box',
-  arrayField: 'content',
-  render: ({attributes, children, readOnly, selected}) => (
+function FactBoxContainer(props: ContainerRenderProps): JSX.Element {
+  const {attributes, children, path, readOnly, selected} = props
+  const flags = useContext(EditorFeatureFlagsContext)
+  return (
     <section
       {...attributes}
       data-selected={selected ? '' : undefined}
@@ -17,8 +24,15 @@ const factBoxContainer = defineContainer({
         {children}
       </div>
       <DragHandle readOnly={readOnly} />
+      {flags.dndPlugin ? <BlockDropIndicator path={path} /> : null}
     </section>
-  ),
+  )
+}
+
+const factBoxContainer = defineContainer({
+  type: 'fact-box',
+  arrayField: 'content',
+  render: (props) => <FactBoxContainer {...props} />,
   of: [
     defineTextBlock({
       type: 'block',

--- a/apps/playground/src/plugins/plugin.fact-box.tsx
+++ b/apps/playground/src/plugins/plugin.fact-box.tsx
@@ -1,13 +1,17 @@
 import {
   defineContainer,
   defineTextBlock,
+  type TextBlockRenderProps,
   type ContainerRenderProps,
 } from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import type {JSX} from 'react'
 import {useContext} from 'react'
 import {EditorFeatureFlagsContext} from '../feature-flags'
-import {BlockDropIndicator} from './block-drop-indicator'
+import {
+  BlockDropIndicator,
+  WithBlockDropIndicator,
+} from './block-drop-indicator'
 import {DragHandle} from './drag-handle'
 import {ListItemBlock} from './list-item-block'
 
@@ -36,73 +40,84 @@ const factBoxContainer = defineContainer({
   of: [
     defineTextBlock({
       type: 'block',
-      render: ({attributes, children, node, path}) => {
-        if (node.listItem !== undefined) {
-          return (
-            <ListItemBlock attributes={attributes} node={node} path={path}>
-              {children}
-            </ListItemBlock>
-          )
-        }
-
-        switch (node.style) {
-          case 'h1':
-            return (
-              <h1 {...attributes} className="my-2 font-bold text-2xl">
-                {children}
-              </h1>
-            )
-          case 'h2':
-            return (
-              <h2 {...attributes} className="my-2 font-bold text-xl">
-                {children}
-              </h2>
-            )
-          case 'h3':
-            return (
-              <h3 {...attributes} className="my-2 font-bold text-lg">
-                {children}
-              </h3>
-            )
-          case 'h4':
-            return (
-              <h4 {...attributes} className="my-2 font-bold">
-                {children}
-              </h4>
-            )
-          case 'h5':
-            return (
-              <h5 {...attributes} className="my-2 font-semibold">
-                {children}
-              </h5>
-            )
-          case 'h6':
-            return (
-              <h6 {...attributes} className="my-2 font-semibold">
-                {children}
-              </h6>
-            )
-          case 'blockquote':
-            return (
-              <blockquote
-                {...attributes}
-                className="my-1 border-l-2 border-stone-500 pl-2 italic dark:border-stone-300"
-              >
-                {children}
-              </blockquote>
-            )
-          default:
-            return (
-              <p {...attributes} className="my-1">
-                {children}
-              </p>
-            )
-        }
-      },
+      render: (props) => (
+        <WithBlockDropIndicator path={props.path}>
+          {renderFactBoxTextBlock(props)}
+        </WithBlockDropIndicator>
+      ),
     }),
   ],
 })
 
 export function FactBoxPlugin(): JSX.Element {
   return <NodePlugin nodes={[factBoxContainer]} />
+}
+
+function renderFactBoxTextBlock({
+  attributes,
+  children,
+  node,
+  path,
+}: TextBlockRenderProps): JSX.Element {
+  if (node.listItem !== undefined) {
+    return (
+      <ListItemBlock attributes={attributes} node={node} path={path}>
+        {children}
+      </ListItemBlock>
+    )
+  }
+
+  switch (node.style) {
+    case 'h1':
+      return (
+        <h1 {...attributes} className="my-2 font-bold text-2xl">
+          {children}
+        </h1>
+      )
+    case 'h2':
+      return (
+        <h2 {...attributes} className="my-2 font-bold text-xl">
+          {children}
+        </h2>
+      )
+    case 'h3':
+      return (
+        <h3 {...attributes} className="my-2 font-bold text-lg">
+          {children}
+        </h3>
+      )
+    case 'h4':
+      return (
+        <h4 {...attributes} className="my-2 font-bold">
+          {children}
+        </h4>
+      )
+    case 'h5':
+      return (
+        <h5 {...attributes} className="my-2 font-semibold">
+          {children}
+        </h5>
+      )
+    case 'h6':
+      return (
+        <h6 {...attributes} className="my-2 font-semibold">
+          {children}
+        </h6>
+      )
+    case 'blockquote':
+      return (
+        <blockquote
+          {...attributes}
+          className="my-1 border-l-2 border-stone-500 pl-2 italic dark:border-stone-300"
+        >
+          {children}
+        </blockquote>
+      )
+    default:
+      return (
+        <p {...attributes} className="my-1">
+          {children}
+        </p>
+      )
+  }
 }

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -3,19 +3,33 @@ import {
   defineContainer,
   defineDecorator,
   defineTextBlock,
+  type ContainerRenderProps,
 } from '@portabletext/editor'
 import {defineTable} from '@portabletext/plugin-table'
-import {referenceContainers, TableCell} from '@portabletext/plugin-table/ui'
+import {
+  referenceContainers,
+  Table,
+  TableCell,
+} from '@portabletext/plugin-table/ui'
+import {useContext, type JSX} from 'react'
+import {EditorFeatureFlagsContext} from '../feature-flags'
+import {BlockDropIndicator} from './block-drop-indicator'
 import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
 
-// The table/row renders come straight from the plugin's reference UI; the
-// cell definition is playground-owned so its `of` can carry the cell
-// *content* renders (list items, images, callouts).
+// The row's render comes straight from the plugin's reference UI; the table
+// render wraps the reference UI to add the drop indicator, and the cell
+// definition is playground-owned so its `of` can carry the cell *content*
+// renders (list items, images, callouts).
 export const table = defineTable({
   containers: {
     ...referenceContainers,
+    table: defineContainer({
+      type: 'table',
+      arrayField: 'rows',
+      render: (props) => <PlaygroundTable {...props} />,
+    }),
     cell: defineContainer({
       type: 'cell',
       arrayField: 'value',
@@ -61,5 +75,19 @@ export const table = defineTable({
     }),
   },
 })
+
+// The reference `Table` render positions its own chrome (handles, lanes,
+// menu) relative to an inner scroll wrapper, not its outermost element, so
+// the drop indicator gets its own `relative` wrapper around the whole thing
+// instead of reaching into that inner layout.
+function PlaygroundTable(props: ContainerRenderProps): JSX.Element {
+  const flags = useContext(EditorFeatureFlagsContext)
+  return (
+    <div className="relative">
+      <Table {...props} />
+      {flags.dndPlugin ? <BlockDropIndicator path={props.path} /> : null}
+    </div>
+  )
+}
 
 export const TablePlugin = table.Plugin

--- a/apps/playground/src/plugins/plugin.table.tsx
+++ b/apps/playground/src/plugins/plugin.table.tsx
@@ -13,7 +13,10 @@ import {
 } from '@portabletext/plugin-table/ui'
 import {useContext, type JSX} from 'react'
 import {EditorFeatureFlagsContext} from '../feature-flags'
-import {BlockDropIndicator} from './block-drop-indicator'
+import {
+  BlockDropIndicator,
+  WithBlockDropIndicator,
+} from './block-drop-indicator'
 import {ListItemBlock} from './list-item-block'
 import {calloutContainer} from './plugin.callout'
 import {cellImageLeaf} from './plugin.image'
@@ -37,14 +40,17 @@ export const table = defineTable({
       of: [
         defineTextBlock({
           type: 'block',
-          render: ({attributes, children, node, path}) =>
-            node.listItem !== undefined ? (
-              <ListItemBlock attributes={attributes} node={node} path={path}>
-                {children}
-              </ListItemBlock>
-            ) : (
-              <div {...attributes}>{children}</div>
-            ),
+          render: ({attributes, children, node, path}) => (
+            <WithBlockDropIndicator path={path}>
+              {node.listItem !== undefined ? (
+                <ListItemBlock attributes={attributes} node={node} path={path}>
+                  {children}
+                </ListItemBlock>
+              ) : (
+                <div {...attributes}>{children}</div>
+              )}
+            </WithBlockDropIndicator>
+          ),
           // Positional override demo: inside table cells only, the
           // `strong` decorator renders with a highlight and the `link`
           // annotation as a green dotted underline, while the top-level

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -1,4 +1,10 @@
-import type {Editor, EditorSelection, Path} from '@portabletext/editor'
+import {
+  defineContainer,
+  type Editor,
+  type EditorSelection,
+  type Path,
+} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
 import {describe, expect, test, vi} from 'vitest'
@@ -6,6 +12,20 @@ import {page} from 'vitest/browser'
 import {DndProvider, useDropPosition} from './plugin.dnd'
 
 const schemaDefinition = defineSchema({})
+
+const calloutContainer = defineContainer({
+  type: 'callout',
+  arrayField: 'content',
+})
+
+const containerSchemaDefinition = defineSchema({
+  blockObjects: [
+    {
+      name: 'callout',
+      fields: [{name: 'content', type: 'array', of: [{type: 'block'}]}],
+    },
+  ],
+})
 
 describe('DndProvider', () => {
   test('Scenario: Dragging an entire block over another block shows the drop position', async () => {
@@ -221,6 +241,53 @@ describe('DndProvider', () => {
   })
 })
 
+describe('DndProvider with a nested container', () => {
+  test('Scenario: Dragging a root block over a nested block shows the drop position on the nested block, not the container', async () => {
+    const {editor} = await renderEditorWithContainerProbes()
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: nestedCaretIn(),
+        block: 'end',
+      }),
+    )
+
+    await expectNestedDropPositions({container: 'none', nested: 'end'})
+  })
+
+  test('Scenario: Dragging a nested block over itself shows nothing', async () => {
+    const {editor} = await renderEditorWithContainerProbes()
+
+    // Seeds a real, non-'none' position at the nested block first: a
+    // suppressed dragover is a no-op, so starting from 'none' can't tell a
+    // genuine suppression from a guard that never ran and left 'none' alone.
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: nestedCaretIn(),
+        block: 'start',
+      }),
+    )
+    await expectNestedDropPositions({nested: 'start'})
+
+    editor.send(
+      dragover({
+        dragOrigin: nestedBlockSelection(),
+        over: nestedCaretIn(),
+        block: 'end',
+      }),
+    )
+
+    // A suppressed dragover is a no-op: nothing re-renders to confirm it
+    // ran, so there's no observable condition for `vi.waitFor` to poll on.
+    // Wait a tick for any (incorrect) update to land before reading.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(page.getByTestId('probe-nested').element().textContent).toBe('start')
+  })
+})
+
 function getEditorElement(editor: Editor): HTMLElement {
   const element = editor.dom.getEditorElement()
 
@@ -241,6 +308,87 @@ function DropPositionProbe(props: {
   return (
     <div data-testid={`probe-${props.blockKey}`}>{dropPosition ?? 'none'}</div>
   )
+}
+
+const containerKey = 'callout0'
+const nestedKey = 'n0'
+const nestedSpanKey = 'n0-span'
+const containerPath: Path = [{_key: containerKey}]
+const nestedPath: Path = [{_key: containerKey}, 'content', {_key: nestedKey}]
+
+function PathDropPositionProbe(props: {label: string; path: Path}) {
+  const dropPosition = useDropPosition(props.path)
+  return (
+    <div data-testid={`probe-${props.label}`}>{dropPosition ?? 'none'}</div>
+  )
+}
+
+async function renderEditorWithContainerProbes() {
+  const {editor} = await createTestEditor({
+    schemaDefinition: containerSchemaDefinition,
+    initialValue: [
+      block('b0', 'first'),
+      {
+        _type: 'callout',
+        _key: containerKey,
+        content: [
+          {
+            _type: 'block',
+            _key: nestedKey,
+            children: [
+              {_type: 'span', _key: nestedSpanKey, text: 'nested', marks: []},
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      } as unknown as PortableTextBlock,
+    ],
+    children: (
+      <>
+        <NodePlugin nodes={[calloutContainer]} />
+        <DndProvider>
+          <PathDropPositionProbe label="container" path={containerPath} />
+          <PathDropPositionProbe label="nested" path={nestedPath} />
+        </DndProvider>
+      </>
+    ),
+  })
+
+  await vi.waitFor(() => {
+    expect(page.getByTestId('probe-nested').element().textContent).toBe('none')
+  })
+
+  return {editor}
+}
+
+async function expectNestedDropPositions(
+  expected: Record<string, string>,
+): Promise<void> {
+  await vi.waitFor(() => {
+    for (const [label, dropPosition] of Object.entries(expected)) {
+      expect(
+        page.getByTestId(`probe-${label}`).element().textContent,
+        `drop position of ${label}`,
+      ).toBe(dropPosition)
+    }
+  })
+}
+
+function nestedCaretIn(): NonNullable<EditorSelection> {
+  const path = [...nestedPath, 'children', {_key: nestedSpanKey}]
+  return {
+    anchor: {path, offset: 0},
+    focus: {path, offset: 0},
+  }
+}
+
+function nestedBlockSelection(): NonNullable<EditorSelection> {
+  const path = [...nestedPath, 'children', {_key: nestedSpanKey}]
+  return {
+    anchor: {path, offset: 0},
+    focus: {path, offset: 'nested'.length},
+  }
 }
 
 async function renderEditorWithProbes() {

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -17,6 +17,7 @@ import {
   getBlockEndPoint,
   getBlockStartPoint,
   isEmptyTextBlock,
+  isEqualPaths,
   isEqualSelectionPoints,
   isKeyedSegment,
   isSelectionCollapsed,
@@ -181,20 +182,30 @@ function createDropPositionBehaviors(
           eventSelection: dragOrigin.selection,
           snapshot,
         })
-
-        const draggedBlocks = getSelectedBlocks({
+        const dragSnapshot = {
           ...snapshot,
           context: {
             ...snapshot.context,
             selection: dragSelection,
           },
-        })
+        }
+
+        const draggedBlocks = getSelectedBlocks(dragSnapshot)
+        // `getSelectedBlocks` only looks at root-level children, so a drag
+        // origin nested inside a container (a callout paragraph, a table
+        // cell) resolves to the container, not the nested block actually
+        // being dragged. `getFocusBlock` resolves the origin's own focus to
+        // the same depth `dropFocusBlock` was resolved to, so comparing the
+        // two catches a nested block dragged over itself too.
+        const draggedFocusBlock = getFocusBlock(dragSnapshot)
 
         if (
           draggedBlocks.some(
             (draggedBlock) =>
               draggedBlock.node._key === dropFocusBlock.node._key,
-          )
+          ) ||
+          (draggedFocusBlock &&
+            isEqualPaths(draggedFocusBlock.path, dropFocusBlock.path))
         ) {
           return false
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@portabletext/patches':
         specifier: workspace:*
         version: link:../../packages/patches
+      '@portabletext/plugin-dnd':
+        specifier: workspace:*
+        version: link:../../packages/plugin-dnd
       '@portabletext/plugin-emoji-picker':
         specifier: workspace:*
         version: link:../../packages/plugin-emoji-picker


### PR DESCRIPTION
The engine draws no drop chrome, and the playground never mounted `@portabletext/plugin-dnd`, which owns drop presentation, so edge-snap block drags in the playground had no affordance at all (mid-text drops show the native caret via split-on-drop). This PR makes the playground the runnable demonstration of the replacement the v8 story promises: a `dndPlugin` feature flag (default on) mounts `DndProvider`, and a shared `BlockDropIndicator` renders the plugin's edge line in every top-level block render, plain text blocks, list items, the block-object catch-all, and the callout, fact-box, code-block, and table containers. Toggling the flag off in the settings popover shows the editor bare.

Three mechanics worth knowing when reading: the block wrapper is unconditional even with the flag off, because the engine's placeholder anchors `position: absolute` to the nearest positioned ancestor and the anchoring must not change with feature flags (the playground placeholder's old `px-2` compensated for the previous outer anchor and is gone with it, probe-verified pixel-equal); `useDropPosition` throws without a provider, so every read is flag-gated and the flags context's built-in fallback fails closed; and the table's indicator gets its own `relative` wrapper because the reference `Table` positions its chrome against an inner scroll wrapper. Toggling the flag at runtime remounts the editable subtree (the provider swap changes the element type), which drops the DOM selection; document content lives in the editor actor and survives.

Playground only: no changeset, no public surface. Headless verification covers mount/toggle/typing with zero console errors in both flag states; the indicator's live-drag rendering rides the plugin's own browser suite (headless Chromium cannot synthesize real HTML5 drags).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches drag-over drop-position logic in plugin-dnd (self-drop vs nested paths) plus playground layout wrappers. Incorrect path comparison would show or hide drop chrome in nested containers, but this is presentation-only and covered by new nested-container tests.
> 
> **Overview**
> The playground now mounts `@portabletext/plugin-dnd` behind a **Drop indicators** flag (on by default) so edge-snap block drags show a blue line on text blocks, list items, block objects, and nested content in callouts, fact boxes, code blocks, and tables.
> 
> `plugin-dnd` no longer treats a nested drag origin as its parent container when deciding self-drops. Hovering a nested block over itself (callout paragraph, table cell, etc.) hides the indicator; drops onto nested blocks from elsewhere still land on the nested path.
> 
> Text-block wrappers stay `relative` even with the flag off so placeholder anchoring does not jump. `useDropPosition` is only rendered when the provider is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed937642ff6295be93769a33e165417a8971a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Two follow-up commits extend the coverage into containers. The plugin already resolves drop positions to the deepest block (`getFocusBlock` is `getEnclosingBlock` underneath), but its self-drop exclusion compared against the root-level `getSelectedBlocks`, so a nested block dragged over itself showed an indicator for a drop core suppresses; fixed with a patch changeset, red-proven. And the containers' own positional `defineTextBlock`s (callout, fact box, table cells) never reached the catch-all that renders the indicator, so a shared flag-gated `WithBlockDropIndicator` wrapper now covers them, plus the code block's lines through the catch-all's nested branch.
