### PR TITLE
fix: suppress the native drop caret while an edge indicator is shown

### DIFF
--- a/.changeset/dnd-suppress-drop-caret.md
+++ b/.changeset/dnd-suppress-drop-caret.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-dnd': patch
+---
+
+fix: suppress the native drop caret while an edge indicator is shown
+
+The browser's own drop caret used to keep rendering at the hovered text position even while an edge indicator was shown, suggesting a mid-text split that would never happen: the drop snaps to the block edge instead. The native caret now hides exactly while an edge position is active and returns as soon as the drag hovers mid-text, where it's the honest affordance again.

--- a/packages/plugin-dnd/README.md
+++ b/packages/plugin-dnd/README.md
@@ -44,6 +44,7 @@ function DropIndicator({edge}: {edge: 'start' | 'end'}) {
     <div
       contentEditable={false}
       style={{
+        pointerEvents: 'none',
         position: 'absolute',
         left: 0,
         right: 0,

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -1,4 +1,4 @@
-import type {EditorSelection, Path} from '@portabletext/editor'
+import type {Editor, EditorSelection, Path} from '@portabletext/editor'
 import {createTestEditor} from '@portabletext/editor/test/vitest'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
 import {describe, expect, test, vi} from 'vitest'
@@ -131,7 +131,105 @@ describe('DndProvider', () => {
 
     await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
   })
+
+  test('Scenario: An edge drop indicator hides the native drop caret', async () => {
+    const {editor} = await renderEditorWithProbes()
+    const editorElement = getEditorElement(editor)
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+
+    await expectDropPositions({b2: 'end'})
+    expect(editorElement.style.caretColor).toBe('transparent')
+  })
+
+  test('Scenario: Moving from an edge to a mid-block position restores the native drop caret', async () => {
+    const {editor} = await renderEditorWithProbes()
+    const editorElement = getEditorElement(editor)
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'end'})
+    expect(editorElement.style.caretColor).toBe('transparent')
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretMidText('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'none'})
+    expect(editorElement.style.caretColor).toBe('')
+  })
+
+  test('Scenario: Ending the drag restores the native drop caret', async () => {
+    const {editor} = await renderEditorWithProbes()
+    const editorElement = getEditorElement(editor)
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'end'})
+    expect(editorElement.style.caretColor).toBe('transparent')
+
+    editor.send({
+      type: 'drag.dragend',
+      originEvent: {dataTransfer: new DataTransfer()},
+    })
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+    expect(editorElement.style.caretColor).toBe('')
+  })
+
+  test('Scenario: A prior inline caret-color survives being hidden and restored', async () => {
+    const {editor} = await renderEditorWithProbes()
+    const editorElement = getEditorElement(editor)
+    editorElement.style.caretColor = 'red'
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'end'})
+    expect(editorElement.style.caretColor).toBe('transparent')
+
+    editor.send({
+      type: 'drag.dragend',
+      originEvent: {dataTransfer: new DataTransfer()},
+    })
+
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'none'})
+    expect(editorElement.style.caretColor).toBe('red')
+  })
 })
+
+function getEditorElement(editor: Editor): HTMLElement {
+  const element = editor.dom.getEditorElement()
+
+  if (!(element instanceof HTMLElement)) {
+    throw new Error('Expected the editor element to be an HTMLElement')
+  }
+
+  return element
+}
 
 function DropPositionProbe(props: {
   blockKey: string

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -1,4 +1,4 @@
-import type {Path} from '@portabletext/editor'
+import {useEditor, type Path} from '@portabletext/editor'
 import {
   defineBehavior,
   effect,
@@ -55,10 +55,13 @@ type DropPositionStore = {
   set: (next: DropPosition | undefined) => void
 }
 
-function createDropPositionStore(): DropPositionStore {
+function createDropPositionStore(
+  getEditorElement: () => HTMLElement | undefined,
+): DropPositionStore {
   let current:
     | {serializedPath: string; position: DropPosition['position']}
     | undefined
+  let restoreCaretColor: (() => void) | undefined
   const subscribers = new Map<string, Set<() => void>>()
 
   function notify(serializedPath: string | undefined) {
@@ -107,6 +110,24 @@ function createDropPositionStore(): DropPositionStore {
       current = next
         ? {serializedPath: serializePath(next.path), position: next.position}
         : undefined
+
+      const editorElement = getEditorElement()
+
+      if (editorElement) {
+        if (current && !restoreCaretColor) {
+          const previousCaretColor = editorElement.style.caretColor
+          restoreCaretColor = () => {
+            editorElement.style.caretColor = previousCaretColor
+          }
+          // The native drop caret renders at the hovered text position and
+          // promises a mid-text split, but an edge indicator means the drop
+          // will snap to the block edge instead.
+          editorElement.style.caretColor = 'transparent'
+        } else if (!current && restoreCaretColor) {
+          restoreCaretColor()
+          restoreCaretColor = undefined
+        }
+      }
 
       if (
         previous?.serializedPath === current?.serializedPath &&
@@ -274,7 +295,15 @@ const DndContext = createContext<DropPositionStore | undefined>(undefined)
  * @beta
  */
 export function DndProvider(props: {children?: ReactNode}) {
-  const store = useMemo(() => createDropPositionStore(), [])
+  const editor = useEditor()
+  const store = useMemo(
+    () =>
+      createDropPositionStore(() => {
+        const editorElement = editor.dom.getEditorElement()
+        return editorElement instanceof HTMLElement ? editorElement : undefined
+      }),
+    [editor],
+  )
   const behaviors = useMemo(
     () => createDropPositionBehaviors(store.set),
     [store],


### PR DESCRIPTION
During a block drag, the browser keeps drawing its native drop caret at the hovered text position. For mid-text hovers the caret is the honest affordance (the drop splits there); for edge positions it lies, the drop will snap to the block boundary the indicator marks, so two affordances promise two different outcomes. The drop-position store now sets `caret-color: transparent` on the editor element exactly while an edge position is active, restoring the prior inline value for mid-text hovers, on drop, dragend, and provider unmount (a pre-existing inline caret color survives the round trip, pinned by test).

v7 had this suppression: `behavior.core.drop-position` handled whole-block `dragover`s, and handled events `preventDefault`, which is what stops the browser painting its caret. The DOM unification deleted that behavior for its indicator job and the caret suppression rode out with it, uninventoried; split-on-drop then gave the returning caret real meaning mid-text, which disguised the regression. This fix restores the suppression as a pure observer (styling, not event-swallowing, so the plugin never eats `dragover` from later listeners) and selectively, edges only, since the mid-text caret is now the honest split affordance.

Fixed in the plugin so every consumer gets it. Red-proven: all four pinning tests fail against the unmodified plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only caret styling in the DnD plugin; no auth, data, or event-swallowing changes.
> 
> **Overview**
> While a block-edge drop indicator is active, the plugin now sets `caret-color: transparent` on the editor element so the native drop caret does not promise a mid-text split. The previous inline caret color is restored on mid-text hover, drag end, and provider unmount.
> 
> This is styling-only (no `preventDefault` on `dragover`), so later listeners still see the event. Tests cover hide/restore and a pre-existing inline caret color. The README sample indicator also gets `pointerEvents: 'none'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf73d282d22bf5006e69fbb19a6e83b40ac446e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->