### PR TITLE
fix: clear a stale drop indicator when a block is dragged over itself

### DIFF
--- a/.changeset/dnd-clear-stale-indicator.md
+++ b/.changeset/dnd-clear-stale-indicator.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-dnd': patch
+---
+
+fix: clear a stale drop indicator when a block is dragged over itself
+
+Hovering a dragged block over itself cancels the drop, but an indicator activated on a previous hover kept pointing at the block. The self-hover now clears the drop position, at the root and inside containers alike.

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -45,8 +45,19 @@ describe('DndProvider', () => {
     expect(renders).not.toContain('b1')
   })
 
-  test('Scenario: Dragging over the dragged block itself shows nothing', async () => {
+  test('Scenario: Dragging over the dragged block itself clears the indicator', async () => {
     const {editor} = await renderEditorWithProbes()
+
+    // Seeds a position on another block first, so the self-hover's clearing
+    // is observable rather than indistinguishable from a no-op.
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'end'})
 
     editor.send(
       dragover({
@@ -256,12 +267,12 @@ describe('DndProvider with a nested container', () => {
     await expectNestedDropPositions({container: 'none', nested: 'end'})
   })
 
-  test('Scenario: Dragging a nested block over itself shows nothing', async () => {
+  test('Scenario: Dragging a nested block over itself clears the indicator', async () => {
     const {editor} = await renderEditorWithContainerProbes()
 
-    // Seeds a real, non-'none' position at the nested block first: a
-    // suppressed dragover is a no-op, so starting from 'none' can't tell a
-    // genuine suppression from a guard that never ran and left 'none' alone.
+    // Seeds a real, non-'none' position at the nested block first, so the
+    // clearing is observable: core cancels a self-drop, and a position left
+    // over from the previous hover must not keep pointing at it.
     editor.send(
       dragover({
         dragOrigin: blockSelection('b0'),
@@ -279,12 +290,7 @@ describe('DndProvider with a nested container', () => {
       }),
     )
 
-    // A suppressed dragover is a no-op: nothing re-renders to confirm it
-    // ran, so there's no observable condition for `vi.waitFor` to poll on.
-    // Wait a tick for any (incorrect) update to land before reading.
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
-    expect(page.getByTestId('probe-nested').element().textContent).toBe('start')
+    await expectNestedDropPositions({nested: 'none'})
   })
 })
 

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -199,15 +199,18 @@ function createDropPositionBehaviors(
         // two catches a nested block dragged over itself too.
         const draggedFocusBlock = getFocusBlock(dragSnapshot)
 
-        if (
+        const selfDrop =
           draggedBlocks.some(
             (draggedBlock) =>
               draggedBlock.node._key === dropFocusBlock.node._key,
           ) ||
-          (draggedFocusBlock &&
+          (draggedFocusBlock !== undefined &&
             isEqualPaths(draggedFocusBlock.path, dropFocusBlock.path))
-        ) {
-          return false
+
+        if (selfDrop) {
+          // Core cancels the drop, so no position is valid here, including
+          // one left over from the previous hover.
+          return {dropFocusBlock, droppedInsideTextBlock: false, clear: true}
         }
 
         const draggingEntireBlocks = isSelectingEntireBlocks({
@@ -252,13 +255,13 @@ function createDropPositionBehaviors(
             }),
           )
 
-        return {dropFocusBlock, droppedInsideTextBlock}
+        return {dropFocusBlock, droppedInsideTextBlock, clear: false}
       },
       actions: [
-        ({event}, {dropFocusBlock, droppedInsideTextBlock}) => [
+        ({event}, {dropFocusBlock, droppedInsideTextBlock, clear}) => [
           effect(() => {
             setDropPosition(
-              droppedInsideTextBlock
+              clear || droppedInsideTextBlock
                 ? undefined
                 : {
                     path: dropFocusBlock.path,


### PR DESCRIPTION
Hovering a dragged block over itself cancels the drop, but the plugin's self-drop guard declined without touching its store, so an indicator activated on a previous hover kept pointing at the block. The guard now matches the self-hover and clears the position, root-level and nested alike; the pending changeset describing self-drop suppression becomes accurate rather than aspirational.

Seeding a position before the self-hover makes the clearing observable, so both tests anchor their wait on the transition instead of a fixed delay. Red-proven: with the source fix stashed and the tests kept, both fail showing the preserved stale position.

Should merge before the pending Version Packages release so its changelog entry is true.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized DnD UI state fix with targeted tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a bug where **dragging a block over itself** left the drop indicator stuck on a position from an earlier hover, even though the editor treats that as a cancelled self-drop.
> 
> The `drag.dragover` guard no longer bails out with `false` on self-drop. It now passes a **`clear: true`** flag into the action so **`setDropPosition(undefined)`** runs, matching root-level and nested blocks (via the existing focus-path comparison). Normal hovers still return **`clear: false`**.
> 
> Tests seed an indicator on another block first, then assert all probes go to **`none`** after self-hover—replacing a fixed timeout on the nested case. A patch changeset documents the fix for **`@portabletext/plugin-dnd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70038822cd3a26a69646dff687ebc505f81320e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->