### PR TITLE
fix: identify shadow roots by node type instead of a `host` property

### DIFF
--- a/.changeset/shadow-root-node-type-detection.md
+++ b/.changeset/shadow-root-node-type-detection.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: identify shadow roots by node type instead of a `host` property
+
+The shadow DOM-aware DOM traversals treated any parent node carrying a `host` property as a shadow root. A `<form>` exposes its own controls as named properties, so `'host' in form` is true for any form containing an element with `id="host"` or `name="host"` — the form was mistaken for a shadow root and the upward walk stepped from the form to that control and back forever, hanging the tab.
+
+This surfaced in editors rendered inside a form that has a field named `host`: moving the selection between two editors locked the browser, because rewriting the DOM selection runs one of these traversals from a layout effect. Shadow roots are document fragments, so the node type now separates them from a form.

--- a/packages/editor/src/engine/dom/utils/dom.ts
+++ b/packages/editor/src/engine/dom/utils/dom.ts
@@ -311,8 +311,8 @@ export const closestShadowAware = (
 
     if (current.parentElement) {
       current = current.parentElement
-    } else if (current.parentNode && 'host' in current.parentNode) {
-      current = (current.parentNode as ShadowRoot).host as DOMElement
+    } else if (isShadowRoot(current.parentNode)) {
+      current = current.parentNode.host as DOMElement
     } else {
       return null
     }
@@ -345,8 +345,8 @@ export const containsShadowAware = (
     }
 
     if (current.parentNode) {
-      if ('host' in current.parentNode) {
-        current = (current.parentNode as ShadowRoot).host
+      if (isShadowRoot(current.parentNode)) {
+        current = current.parentNode.host
       } else {
         current = current.parentNode
       }
@@ -356,4 +356,23 @@ export const containsShadowAware = (
   }
 
   return false
+}
+
+/**
+ * Check if a DOM node is a shadow root.
+ *
+ * A `host` property alone does not identify one: `HTMLFormElement` exposes its own controls as named
+ * properties, so `'host' in form` is `true` for any form containing an element with `id="host"` or
+ * `name="host"`. Shadow roots are document fragments, so the node type separates the two.
+ *
+ * The node type is checked instead of `instanceof ShadowRoot` to keep working across realms and where
+ * the global is undefined.
+ */
+
+const isShadowRoot = (value: any): value is ShadowRoot => {
+  return (
+    isDOMNode(value) &&
+    value.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
+    'host' in value
+  )
 }

--- a/packages/editor/tests/dom-shadow-aware.test.ts
+++ b/packages/editor/tests/dom-shadow-aware.test.ts
@@ -1,0 +1,90 @@
+import {afterEach, describe, expect, test} from 'vitest'
+import {
+  closestShadowAware,
+  containsShadowAware,
+} from '../src/engine/dom/utils/dom'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe(containsShadowAware.name, () => {
+  test('finds a descendant', () => {
+    document.body.innerHTML = '<div id="foo"><span id="bar"></span></div>'
+
+    expect(
+      containsShadowAware(
+        document.getElementById('foo'),
+        document.getElementById('bar'),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects an unrelated node', () => {
+    document.body.innerHTML = '<div id="foo"></div><span id="bar"></span>'
+
+    expect(
+      containsShadowAware(
+        document.getElementById('foo'),
+        document.getElementById('bar'),
+      ),
+    ).toBe(false)
+  })
+
+  test('crosses a shadow boundary', () => {
+    document.body.innerHTML = '<div id="foo"><div id="bar"></div></div>'
+    const shadowRoot = document
+      .getElementById('bar')!
+      .attachShadow({mode: 'open'})
+    const child = document.createElement('span')
+    shadowRoot.appendChild(child)
+
+    expect(containsShadowAware(document.getElementById('foo'), child)).toBe(
+      true,
+    )
+  })
+
+  test('rejects a node in a form owning a control named "host"', () => {
+    document.body.innerHTML =
+      '<form><input id="host" /><input id="foo" /></form>'
+
+    expect(
+      containsShadowAware(
+        document.createElement('span'),
+        document.getElementById('foo'),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe(closestShadowAware.name, () => {
+  test('finds a matching ancestor', () => {
+    document.body.innerHTML = '<div class="foo"><span id="bar"></span></div>'
+
+    expect(closestShadowAware(document.getElementById('bar'), '.foo')).toBe(
+      document.querySelector('.foo'),
+    )
+  })
+
+  test('crosses a shadow boundary', () => {
+    document.body.innerHTML = '<div class="foo"><div id="bar"></div></div>'
+    const shadowRoot = document
+      .getElementById('bar')!
+      .attachShadow({mode: 'open'})
+    const child = document.createElement('span')
+    shadowRoot.appendChild(child)
+
+    expect(closestShadowAware(child, '.foo')).toBe(
+      document.querySelector('.foo'),
+    )
+  })
+
+  test('returns null from a form owning a control named "host"', () => {
+    document.body.innerHTML =
+      '<form><input id="host" /><input id="foo" /></form>'
+
+    expect(closestShadowAware(document.getElementById('foo'), '.baz')).toBe(
+      null,
+    )
+  })
+})


### PR DESCRIPTION
Fixes #3155.

### The bug

`closestShadowAware` and `containsShadowAware` identified a shadow root with `'host' in current.parentNode`. `HTMLFormElement` exposes its own controls as named properties, so `'host' in form` is `true` for **any** form containing an element with `id="host"` or `name="host"`.

Such a form was then treated as a shadow root and the walk stepped `form` → `form.host` (the control) → back up to `form` → `form.host` → … . It never terminates: the main thread hangs, CPU pins at 100–190%, and the browser kills the tab.

Sanity Studio derives an input's DOM `id` from the field name, so a document type with a field named `host` (SMTP/server config — a very natural name) renders `<input id="host">` inside the document form. Clicking between two Portable Text fields on such a document locks the tab, because `setDomSelection` calls `containsShadowAware` from a layout effect:

```
#0 containsShadowAware
#1 setDomSelection
#2 (anonymous)                    <- useIsomorphicLayoutEffect
#3 react_stack_bottom_frame
#4 runWithFiberInDEV
#5 commitHookEffectListMount
#6 commitHookLayoutEffects
#7 commitLayoutEffectOnFiber
#8 recursivelyTraverseLayoutEffects
   ... (repeating)
```

### The fix

Identify shadow roots by node type. Shadow roots are document fragments; a form is an element, so the two no longer collide:

```ts
const isShadowRoot = (value: any): value is ShadowRoot => {
  return (
    isDOMNode(value) &&
    value.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
    'host' in value
  )
}
```

The node type is checked rather than `instanceof ShadowRoot` so the guard keeps working across realms (iframes) and in environments where the global is undefined. Both call sites now use it.

### Tests

`packages/editor/tests/dom-shadow-aware.test.ts` covers both helpers: ordinary containment, shadow-boundary crossing (still works), and the regression — a form owning a control named `host`.

The tests live in the browser project rather than the unit project on purpose: **jsdom does not implement form named-item access**, so `'host' in form` is `false` there and the bug cannot be reproduced under the unit runner. I confirmed that before moving them.

One caveat worth flagging: against the pre-fix code these tests do not fail, they **hang** — the loop is synchronous, so it blocks the very thread Vitest would use to time the test out. That is the nature of the bug rather than a property of the tests. If you would prefer a bounded-iteration guard so CI fails fast instead of stalling, I am happy to add one.

For a runner-independent demonstration, this reproduces the loop with the pre-fix logic in any Chromium browser:

```js
const walk = (parent, child, limit = 10_000) => {
  if (parent.contains(child)) return 'early-true'
  let current = child
  let steps = 0
  while (current && steps++ < limit) {
    if (current === parent) return 'true'
    if (current.parentNode) {
      current = 'host' in current.parentNode ? current.parentNode.host : current.parentNode
    } else {
      return `terminated cleanly after ${steps} steps`
    }
  }
  return '*** INFINITE LOOP ***'
}

const detached = document.createElement('span')

document.body.innerHTML = '<form><input id="host"><input id="other"></form>'
console.log(walk(detached, document.getElementById('other')))
// -> "*** INFINITE LOOP ***"

document.body.innerHTML = '<form><input id="smtpHost"><input id="other"></form>'
console.log(walk(detached, document.getElementById('other')))
// -> "terminated cleanly after 5 steps"
```

### Checks run

Per `AGENTS.md`: `pnpm check:format`, `pnpm check:lint`, `pnpm check:types`, `pnpm check:knip` (only pre-existing hints in unrelated packages), `pnpm --filter '@portabletext/editor' test:unit` (93 files, 1415 tests) and `test:browser:chromium` (195 files, 2006 tests) all pass.
