### PR TITLE
feat(plugin-sdk-value): add inline comment decorations and authoring

### DIFF
--- a/.changeset/sdk-inline-comments.md
+++ b/.changeset/sdk-inline-comments.md
@@ -1,0 +1,42 @@
+---
+'@portabletext/plugin-sdk-value': minor
+---
+
+feat: add inline comment decorations and authoring
+
+Two new hooks bring Sanity's inline comments to SDK apps that embed the editor. `useSDKCommentDecorations` returns `RangeDecoration[]` for the open comment threads anchored to text in the field; pass it to `SDKPortableTextEditable` (or a raw `PortableTextEditable`) through `rangeDecorations`:
+
+```tsx
+const decorations = useSDKCommentDecorations({
+  ...documentHandle,
+  path: 'content',
+  renderDecoration: (comment) => (props) => (
+    <span data-comment-id={comment.id} style={{background: '#fef3c7'}}>
+      {props.children}
+    </span>
+  ),
+})
+
+return (
+  <SDKPortableTextEditable
+    {...documentHandle}
+    path="content"
+    rangeDecorations={decorations}
+  />
+)
+```
+
+`useSDKCommentAuthoring` is the write side: `commentableSelection` is set when the current selection can take a comment, and `createInlineComment` starts a thread anchored to that selection:
+
+```tsx
+const {commentableSelection, createInlineComment} = useSDKCommentAuthoring({
+  ...documentHandle,
+  path: 'content',
+})
+// show the composer while `commentableSelection` is set, then:
+await createInlineComment({message})
+```
+
+The types their signatures reference (`UseSDKCommentDecorationsOptions`, `RenderCommentDecorationFunction`, `UseSDKCommentAuthoringOptions`, `SDKCommentAuthoring`) are exported alongside them.
+
+Highlights follow the text while the user types, and a highlight whose text is deleted or rewritten beyond recognition is dropped rather than drawn on the wrong words. Comments are written in the shape Sanity Studio stores, so threads round-trip between an SDK app and the Studio. The composer UI is the app's to render, the same split presence uses for carets. Requires `@sanity/sdk-react` 2.20.1 or later.

--- a/packages/plugin-sdk-value/README.md
+++ b/packages/plugin-sdk-value/README.md
@@ -3,8 +3,9 @@
 > Connect a Portable Text Editor with a Sanity document using the SDK
 
 Two-way synchronization between a Portable Text Editor and a field in a Sanity
-document, plus presence: other people's carets show up in the field, and the
-local user's caret shows up for them, including in the Studio.
+document, plus presence and inline comments: other people's carets show up in
+the field and the local user's caret shows up for them, and comment threads
+anchored to text draw as highlights, all interoperating with the Studio.
 
 ## Installation
 
@@ -18,6 +19,7 @@ npm install @portabletext/plugin-sdk-value
 - **Real-time updates**: Automatically handles patches from external sources (other users, mutations, etc.)
 - **Optimistic updates**: Provides smooth user experience with immediate local updates
 - **Presence**: Reports where the local user is editing, and draws other people's carets
+- **Inline comments**: Draws highlights for comment threads anchored to text, and starts new threads on the selection
 
 ## Usage
 
@@ -71,6 +73,55 @@ Your component receives the decorated text as `children` and should render it.
 Pass `renderCursor={null}` to draw no carets at all while still reporting the
 local user's presence, which is what you want if you only care about keeping the
 document in sync.
+
+### Inline comments
+
+Comment threads anchored to text in the field draw as highlights, and new
+threads can be started on the current selection. The composer UI stays with the
+app, the same split presence uses for carets. Comments are written in the shape
+Sanity Studio stores, so threads round-trip between an SDK app and the Studio.
+
+`useSDKCommentDecorations` returns `RangeDecoration[]` for the open threads on
+the field. Pass it through `rangeDecorations`, which `SDKPortableTextEditable`
+merges with the presence carets:
+
+```tsx
+const decorations = useSDKCommentDecorations({
+  ...documentHandle,
+  path: 'content',
+  renderDecoration: (comment) => (props) => (
+    <span data-comment-id={comment.id} style={{background: '#fef3c7'}}>
+      {props.children}
+    </span>
+  ),
+})
+
+return (
+  <SDKPortableTextEditable
+    {...documentHandle}
+    path="content"
+    rangeDecorations={decorations}
+  />
+)
+```
+
+`useSDKCommentAuthoring` is the write side: `commentableSelection` is set when
+the current selection can take a comment, and `createInlineComment` starts a
+thread anchored to it:
+
+```tsx
+const {commentableSelection, createInlineComment} = useSDKCommentAuthoring({
+  ...documentHandle,
+  path: 'content',
+})
+
+// Show the composer while `commentableSelection` is set, then:
+await createInlineComment({message})
+```
+
+Highlights follow the text while the user types, and a highlight whose text is
+deleted or rewritten beyond recognition is dropped rather than drawn on the
+wrong words. Resolved threads draw nothing, matching the Studio.
 
 ### Rendering the editable yourself
 
@@ -138,5 +189,5 @@ the Studio, whose field indicators compare the exact document id its form is on.
 
 This plugin requires:
 
-- `@sanity/sdk-react` 2.19 or newer, where the presence hooks were added
+- `@sanity/sdk-react` 2.20.1 or newer, where the comment hooks were added
 - The document must exist in the Sanity dataset

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@portabletext/patches": "workspace:^",
+    "@sanity/diff-match-patch": "catalog:",
     "@sanity/diff-patch": "^6.0.0",
     "@sanity/json-match": "^1.0.5",
     "@xstate/react": "catalog:",
@@ -71,7 +72,6 @@
     "@portabletext/editor": "workspace:^",
     "@portabletext/schema": "workspace:^",
     "@portabletext/test": "workspace:^",
-    "@sanity/diff-match-patch": "catalog:",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/sdk-react": "^3.0.0",
     "@sanity/tsconfig": "catalog:tooling",
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "@portabletext/editor": "workspace:^",
-    "@sanity/sdk-react": "^2.19.0 || ^3",
+    "@sanity/sdk-react": "^2.20.1 || ^3",
     "react": "^19.2",
     "react-dom": "^19.2"
   },

--- a/packages/plugin-sdk-value/src/comments-anchoring.test.ts
+++ b/packages/plugin-sdk-value/src/comments-anchoring.test.ts
@@ -1,0 +1,255 @@
+import {describe, expect, test} from 'vitest'
+import {
+  COMMENT_INDICATORS,
+  relativeCommentPath,
+  resolveCommentSelections,
+  type StoredTextSelection,
+} from './comments-anchoring'
+
+/**
+ * The scenarios are ported from the Studio's
+ * `buildRangeDecorationSelectionsFromComments` suite, fixtures included, so the
+ * two implementations can be diffed against the same cases. One known gap the
+ * Studio's suite also carries is pinned with `test.fails` below.
+ */
+
+function span(_key: string, text: string) {
+  return {_type: 'span', _key, marks: [], text}
+}
+
+function block(_key: string, children: ReturnType<typeof span>[]) {
+  return {_key, _type: 'block', style: 'normal', markDefs: [], children}
+}
+
+function stored(text: string, _key = '6222e4072b6e'): StoredTextSelection {
+  return {type: 'text', value: [{_key, text}]}
+}
+
+const MARKED = `Hello ${COMMENT_INDICATORS[0]}there${COMMENT_INDICATORS[1]} world`
+
+function resolve(value: unknown[], selection: StoredTextSelection) {
+  return resolveCommentSelections({
+    value,
+    comments: [{commentId: 'c1', relativePath: [], selection}],
+  }).map((anchored) => anchored.selection)
+}
+
+describe('resolveCommentSelections', () => {
+  test('exact match between the stored text and the block', () => {
+    const value = [
+      block('6222e4072b6e', [span('9d9c95878a6e0', 'Hello there world')]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 6,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+        focus: {
+          offset: 11,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+      },
+    ])
+  })
+
+  test('text before the range was bolded, splitting the span', () => {
+    const value = [
+      block('6222e4072b6e', [
+        span('9d9c95878a6e0', 'Hello'),
+        span('5d176cf77466', ' there world'),
+      ]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 1,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '5d176cf77466'}],
+        },
+        focus: {
+          offset: 6,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '5d176cf77466'}],
+        },
+      },
+    ])
+  })
+
+  test('text inside the range was bolded, splitting it across three spans', () => {
+    const value = [
+      block('6222e4072b6e', [
+        span('9d9c95878a6e0', 'Hello th'),
+        span('ea97036ed5c4', 'e'),
+        span('8daa33e86194', 're world'),
+      ]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 6,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+        focus: {
+          offset: 2,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '8daa33e86194'}],
+        },
+      },
+    ])
+  })
+
+  test('bolding spans both inside and outside the range', () => {
+    const value = [
+      block('6222e4072b6e', [
+        span('9d9c95878a6e0', 'Hel'),
+        span('897d8881c889', 'lo th'),
+        span('3b404dd88fc1', 'ere world'),
+      ]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 3,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '897d8881c889'}],
+        },
+        focus: {
+          offset: 3,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '3b404dd88fc1'}],
+        },
+      },
+    ])
+  })
+
+  test('an edit inside the commented word grows the range to cover it', () => {
+    const value = [
+      block('6222e4072b6e', [span('9d9c95878a6e0', 'Hello the123re world')]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 6,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+        focus: {
+          offset: 14,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+      },
+    ])
+  })
+
+  test('a similar word added before the range does not steal the anchor', () => {
+    const value = [
+      block('6222e4072b6e', [span('9d9c95878a6e0', 'Hello where there world')]),
+    ]
+
+    expect(resolve(value, stored(MARKED))).toEqual([
+      {
+        anchor: {
+          offset: 12,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+        focus: {
+          offset: 17,
+          path: [{_key: '6222e4072b6e'}, 'children', {_key: '9d9c95878a6e0'}],
+        },
+      },
+    ])
+  })
+
+  test('a comment whose block is gone resolves to nothing', () => {
+    const value = [block('another-block', [span('s1', 'Hello there world')])]
+
+    expect(resolve(value, stored(MARKED))).toEqual([])
+  })
+
+  // A known gap, carried by the Studio's own suite too: text typed
+  // immediately after the range is absorbed into it. Pinned with `fails` so
+  // this flips loudly if the algorithm ever gains the behaviour.
+  test.fails('an edit immediately after the range does not expand it', () => {
+    const value = [
+      block('6222e4072b6e', [span('9d9c95878a6e0', 'Hello there123 world')]),
+    ]
+    expect(resolve(value, stored(MARKED))).toEqual([])
+  })
+
+  test('a dramatically changed block drops the anchor', () => {
+    const value = [
+      block('6222e4072b6e', [span('9d9c95878a6e0', 'Something else entirely')]),
+    ]
+    expect(resolve(value, stored(MARKED))).toEqual([])
+  })
+
+  test('a nested block resolves through its container path', () => {
+    const value = [
+      {
+        _key: 'callout',
+        _type: 'callout',
+        content: [block('b1', [span('s1', 'Hello there world')])],
+      },
+    ]
+
+    const anchored = resolveCommentSelections({
+      value,
+      comments: [
+        {
+          commentId: 'c1',
+          relativePath: [{_key: 'callout'}, 'content'],
+          selection: stored(MARKED, 'b1'),
+        },
+      ],
+    })
+
+    expect(anchored.map((a) => a.selection)).toEqual([
+      {
+        anchor: {
+          offset: 6,
+          path: [
+            {_key: 'callout'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+        },
+        focus: {
+          offset: 11,
+          path: [
+            {_key: 'callout'},
+            'content',
+            {_key: 'b1'},
+            'children',
+            {_key: 's1'},
+          ],
+        },
+      },
+    ])
+  })
+})
+
+describe('relativeCommentPath', () => {
+  test('reduces a stored field path to a path inside the editor', () => {
+    expect(
+      relativeCommentPath(['body'], 'body[_key=="callout"].content'),
+    ).toEqual([{_key: 'callout'}, 'content'])
+  })
+
+  test('an exact match reduces to the empty path', () => {
+    expect(relativeCommentPath(['body'], 'body')).toEqual([])
+  })
+
+  test("a sibling editor's comment does not match", () => {
+    expect(relativeCommentPath(['body'], 'summary')).toBe(undefined)
+  })
+
+  test('an unparseable stored path is skipped rather than thrown on', () => {
+    expect(relativeCommentPath(['body'], '[[[')).toBe(undefined)
+  })
+
+  test('an empty stored path is skipped', () => {
+    expect(relativeCommentPath(['body'], '')).toBe(undefined)
+  })
+})

--- a/packages/plugin-sdk-value/src/comments-anchoring.ts
+++ b/packages/plugin-sdk-value/src/comments-anchoring.ts
@@ -1,0 +1,344 @@
+import type {EditorSelection} from '@portabletext/editor'
+import type {Path, PathSegment} from '@portabletext/patches'
+import {
+  applyPatches,
+  cleanupEfficiency,
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+  makeDiff,
+  makePatches,
+  type Diff,
+  type Patch,
+} from '@sanity/diff-match-patch'
+import {arrayifyPath} from './plugin.sdk-value'
+
+/**
+ * How the Studio stores an inline comment's anchor: per Portable Text block the
+ * selection touches, the block's entire plain text with these two private-use
+ * characters inserted where the selection starts and ends. Text rather than
+ * offsets, so the anchor can be re-found after the text around it changes.
+ */
+export const COMMENT_INDICATORS = ['\uF000', '\uF001'] as const
+
+const COMMENT_INDICATORS_REGEX = new RegExp(
+  `[${COMMENT_INDICATORS.join('')}]`,
+  'g',
+)
+
+/**
+ * Inserted between spans when diffing, so a plain-text offset can be mapped
+ * back to the span it belongs to afterwards.
+ */
+const CHILD_SYMBOL = '\uF0D0'
+
+/**
+ * Kept from the Studio implementation: high enough to avoid re-anchoring onto
+ * the wrong occurrence of a repeated word, low enough not to hurt.
+ */
+const DMP_MARGIN = 15
+
+/**
+ * The stored anchor of one inline comment, in the shape the SDK returns it.
+ * Structurally `CommentTextSelection` from `@sanity/sdk`, declared here so the
+ * pure modules in this package stay import-light.
+ */
+export interface StoredTextSelection {
+  type: 'text'
+  value: {_key: string; text: string}[]
+}
+
+export interface AnchoredComment {
+  /** The comment's id, echoed back so the caller can correlate. */
+  commentId: string
+  /** Where the comment's text sits in the current editor value. */
+  selection: NonNullable<EditorSelection>
+}
+
+interface ResolveOptions {
+  /** The editor's current value. */
+  value: unknown[]
+  /**
+   * Each comment's stored anchor, with its field path already reduced to the
+   * path *inside* the editor: `[]` for a block directly in the decorated
+   * field, or the keyed path of the containing array for a nested block.
+   */
+  comments: Array<{
+    commentId: string
+    relativePath: Path
+    selection: StoredTextSelection
+  }>
+}
+
+interface SpanLike {
+  _key: string
+  _type: string
+  text?: string
+}
+
+interface TextBlockLike {
+  _key: string
+  children: SpanLike[]
+}
+
+function isTextBlock(node: unknown): node is TextBlockLike {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    Array.isArray((node as TextBlockLike).children) &&
+    typeof (node as TextBlockLike)._key === 'string'
+  )
+}
+
+function isSpan(child: SpanLike): boolean {
+  return child._type === 'span' && typeof child.text === 'string'
+}
+
+function getValueAtPath(value: unknown, path: Path): unknown {
+  let current: unknown = value
+  for (const segment of path) {
+    if (current === null || typeof current !== 'object') {
+      return undefined
+    }
+    if (typeof segment === 'string') {
+      current = (current as Record<string, unknown>)[segment]
+    } else if (typeof segment === 'number') {
+      current = Array.isArray(current) ? current[segment] : undefined
+    } else if (isKeyedSegment(segment)) {
+      current = Array.isArray(current)
+        ? current.find(
+            (item) =>
+              typeof item === 'object' &&
+              item !== null &&
+              (item as {_key?: string})._key === segment._key,
+          )
+        : undefined
+    } else {
+      return undefined
+    }
+  }
+  return current
+}
+
+function isKeyedSegment(segment: PathSegment): segment is {_key: string} {
+  return typeof segment === 'object' && segment !== null && '_key' in segment
+}
+
+function toPlainTextWithChildSeparators(block: TextBlockLike): string {
+  return block.children
+    .map((child) =>
+      isSpan(child) ? (child.text ?? '').replaceAll(CHILD_SYMBOL, ' ') : '',
+    )
+    .join(CHILD_SYMBOL)
+}
+
+function diffText(
+  current: string,
+  next: string,
+): {patches: Patch[]; levenshtein: number} {
+  const diff = makeDiff(current, next)
+  const diffs = cleanupEfficiency(diff)
+  return {
+    patches: makePatches(current, diffs, {margin: DMP_MARGIN}),
+    levenshtein: diffsLevenshtein(diffs),
+  }
+}
+
+function diffApply(current: string, patches: Patch[]): string {
+  return applyPatches(patches, current, {
+    allowExceedingIndices: true,
+    margin: DMP_MARGIN,
+  })[0]
+}
+
+/**
+ * Finds each stored anchor in the current editor value.
+ *
+ * A direct port of the Studio's `buildRangeDecorationSelectionsFromComments`,
+ * minus its Studio-only inputs. The stored text is diffed against the block's
+ * current text, so an anchor survives edits around it and inside it up to a
+ * similarity threshold. An anchor whose text is gone, or changed beyond
+ * recognition, is dropped rather than drawn somewhere wrong.
+ *
+ * Live tracking while the user types is not this function's job: the editor's
+ * `RangeDecoration.onMoved` does that. This runs when comments load or change.
+ */
+export function resolveCommentSelections(
+  options: ResolveOptions,
+): AnchoredComment[] {
+  const {value, comments} = options
+  const anchored: AnchoredComment[] = []
+
+  for (const {commentId, relativePath, selection} of comments) {
+    for (const selectionMember of selection.value) {
+      const container =
+        relativePath.length > 0 ? getValueAtPath(value, relativePath) : value
+      const matchedBlock = Array.isArray(container)
+        ? container.find(
+            (block) =>
+              isTextBlock(block) && block._key === selectionMember._key,
+          )
+        : undefined
+      if (!matchedBlock || !isTextBlock(matchedBlock)) {
+        continue
+      }
+
+      const selectionText = selectionMember.text.replaceAll(
+        COMMENT_INDICATORS_REGEX,
+        '',
+      )
+      const textWithChildSeparators =
+        toPlainTextWithChildSeparators(matchedBlock)
+      const {patches} = diffText(selectionText, selectionMember.text)
+      const diffedText = diffApply(textWithChildSeparators, patches)
+      const startIndex = diffedText.indexOf(COMMENT_INDICATORS[0])
+      const endIndex = diffedText
+        .replaceAll(COMMENT_INDICATORS[0], '')
+        .indexOf(COMMENT_INDICATORS[1])
+      const textWithoutCommentTags = diffedText.replaceAll(
+        COMMENT_INDICATORS_REGEX,
+        '',
+      )
+
+      if (startIndex === -1 || endIndex === -1) {
+        continue
+      }
+
+      const oldCommentedText = selectionMember.text.slice(
+        selectionMember.text.indexOf(COMMENT_INDICATORS[0]) + 1,
+        selectionMember.text.indexOf(COMMENT_INDICATORS[1]),
+      )
+      const newCommentedText = textWithoutCommentTags.slice(
+        startIndex,
+        endIndex,
+      )
+      const {levenshtein} = diffText(newCommentedText, oldCommentedText)
+      // Kept from the Studio, oddity included: only the *old* length is halved.
+      const threshold = Math.round(
+        newCommentedText.length + oldCommentedText.length / 2,
+      )
+
+      // The anchor is lost when its text is gone or no longer recognisable.
+      // Better no highlight than a highlight on the wrong words.
+      if (
+        newCommentedText.length === 0 ||
+        levenshtein > threshold ||
+        startIndex + 1 === endIndex
+      ) {
+        continue
+      }
+
+      let childIndexAnchor = 0
+      let anchorOffset = 0
+      let childIndexFocus = 0
+      let focusOffset = 0
+      for (let i = 0; i < textWithoutCommentTags.length; i++) {
+        if (textWithoutCommentTags[i] === CHILD_SYMBOL) {
+          if (i <= startIndex) {
+            anchorOffset = -1
+            childIndexAnchor++
+          }
+          focusOffset = -1
+          childIndexFocus++
+        }
+        if (i < startIndex) {
+          anchorOffset++
+        }
+        if (i < startIndex + newCommentedText.length) {
+          focusOffset++
+        }
+        if (i === startIndex + newCommentedText.length) {
+          break
+        }
+      }
+
+      anchored.push({
+        commentId,
+        selection: {
+          anchor: {
+            path: [
+              ...relativePath,
+              {_key: matchedBlock._key},
+              'children',
+              {_key: matchedBlock.children[childIndexAnchor]._key},
+            ],
+            offset: anchorOffset,
+          },
+          focus: {
+            path: [
+              ...relativePath,
+              {_key: matchedBlock._key},
+              'children',
+              {_key: matchedBlock.children[childIndexFocus]._key},
+            ],
+            offset: focusOffset,
+          },
+        },
+      })
+    }
+  }
+
+  return anchored
+}
+
+function diffsLevenshtein(diffs: Diff[]): number {
+  let levenshtein = 0
+  let insertions = 0
+  let deletions = 0
+  for (const [op, data] of diffs) {
+    switch (op) {
+      case DIFF_INSERT:
+        insertions += data.length
+        break
+      case DIFF_DELETE:
+        deletions += data.length
+        break
+      case DIFF_EQUAL:
+        // A deletion and an insertion together count as one substitution.
+        levenshtein += Math.max(insertions, deletions)
+        insertions = 0
+        deletions = 0
+        break
+      default:
+        break
+    }
+  }
+  levenshtein += Math.max(insertions, deletions)
+  return levenshtein
+}
+
+/**
+ * Reduces a comment's stored field path to a path inside this editor.
+ *
+ * `undefined` means the comment belongs to some other editor: a different
+ * field, a sibling container, or a stored path that does not parse. Skipping
+ * those is what lets several editors on one document each decorate only their
+ * own comments.
+ */
+export function relativeCommentPath(
+  basePath: Path,
+  fieldPath: string,
+): Path | undefined {
+  let parsed: Path
+  try {
+    parsed = arrayifyPath(fieldPath)
+  } catch {
+    return undefined
+  }
+  if (parsed.length < basePath.length) {
+    return undefined
+  }
+  for (let i = 0; i < basePath.length; i++) {
+    if (!segmentsEqual(basePath[i], parsed[i])) {
+      return undefined
+    }
+  }
+  return parsed.slice(basePath.length)
+}
+
+function segmentsEqual(a: PathSegment, b: PathSegment): boolean {
+  if (isKeyedSegment(a) && isKeyedSegment(b)) {
+    return a._key === b._key
+  }
+  return a === b
+}

--- a/packages/plugin-sdk-value/src/comments-selection.test.ts
+++ b/packages/plugin-sdk-value/src/comments-selection.test.ts
@@ -1,0 +1,173 @@
+import {describe, expect, test} from 'vitest'
+import {
+  COMMENT_INDICATORS,
+  resolveCommentSelections,
+} from './comments-anchoring'
+import {buildStoredSelection} from './comments-selection'
+
+const [START, END] = COMMENT_INDICATORS
+
+function span(_key: string, text: string) {
+  return {_type: 'span', _key, marks: [], text}
+}
+
+function block(_key: string, children: ReturnType<typeof span>[]) {
+  return {_key, _type: 'block', style: 'normal', markDefs: [], children}
+}
+
+function point(blockKey: string, spanKey: string, offset: number) {
+  return {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset}
+}
+
+describe('buildStoredSelection', () => {
+  test('marks the selected run inside a single span', () => {
+    const foo = block('b1', [span('s1', 'foo bar baz')])
+
+    expect(
+      buildStoredSelection({
+        selection: {anchor: point('b1', 's1', 4), focus: point('b1', 's1', 7)},
+        selectedBlocks: [{node: foo, path: [{_key: 'b1'}]}],
+      }),
+    ).toEqual({
+      containerPath: [],
+      selection: {
+        type: 'text',
+        value: [{_key: 'b1', text: `foo ${START}bar${END} baz`}],
+      },
+    })
+  })
+
+  test('a backward selection marks the same run', () => {
+    const foo = block('b1', [span('s1', 'foo bar baz')])
+
+    expect(
+      buildStoredSelection({
+        selection: {
+          anchor: point('b1', 's1', 7),
+          focus: point('b1', 's1', 4),
+          backward: true,
+        },
+        selectedBlocks: [{node: foo, path: [{_key: 'b1'}]}],
+      }),
+    ).toEqual({
+      containerPath: [],
+      selection: {
+        type: 'text',
+        value: [{_key: 'b1', text: `foo ${START}bar${END} baz`}],
+      },
+    })
+  })
+
+  test('offsets count across earlier spans in the block', () => {
+    const foo = block('b1', [span('s1', 'foo '), span('s2', 'bar baz')])
+
+    expect(
+      buildStoredSelection({
+        selection: {anchor: point('b1', 's2', 0), focus: point('b1', 's2', 3)},
+        selectedBlocks: [{node: foo, path: [{_key: 'b1'}]}],
+      })?.selection.value,
+    ).toEqual([{_key: 'b1', text: `foo ${START}bar${END} baz`}])
+  })
+
+  test('a selection spanning blocks marks each block, middle blocks whole', () => {
+    const first = block('b1', [span('s1', 'foo bar')])
+    const middle = block('b2', [span('s2', 'baz')])
+    const last = block('b3', [span('s3', 'qux quux')])
+
+    expect(
+      buildStoredSelection({
+        selection: {anchor: point('b1', 's1', 4), focus: point('b3', 's3', 3)},
+        selectedBlocks: [
+          {node: first, path: [{_key: 'b1'}]},
+          {node: middle, path: [{_key: 'b2'}]},
+          {node: last, path: [{_key: 'b3'}]},
+        ],
+      })?.selection.value,
+    ).toEqual([
+      {_key: 'b1', text: `foo ${START}bar${END}`},
+      {_key: 'b2', text: `${START}baz${END}`},
+      {_key: 'b3', text: `${START}qux${END} quux`},
+    ])
+  })
+
+  test('nested blocks report their containing array', () => {
+    const nested = block('b1', [span('s1', 'foo bar')])
+    const path = [{_key: 'callout'}, 'content', {_key: 'b1'}]
+
+    expect(
+      buildStoredSelection({
+        selection: {
+          anchor: {
+            path: [...path.slice(0, 2), {_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 0,
+          },
+          focus: {
+            path: [...path.slice(0, 2), {_key: 'b1'}, 'children', {_key: 's1'}],
+            offset: 3,
+          },
+        },
+        selectedBlocks: [{node: nested, path}],
+      })?.containerPath,
+    ).toEqual([{_key: 'callout'}, 'content'])
+  })
+
+  test('blocks from different containers refuse to build', () => {
+    const topLevel = block('b1', [span('s1', 'foo')])
+    const nested = block('b2', [span('s2', 'bar')])
+
+    expect(
+      buildStoredSelection({
+        selection: {anchor: point('b1', 's1', 0), focus: point('b2', 's2', 3)},
+        selectedBlocks: [
+          {node: topLevel, path: [{_key: 'b1'}]},
+          {node: nested, path: [{_key: 'callout'}, 'content', {_key: 'b2'}]},
+        ],
+      }),
+    ).toBe(null)
+  })
+
+  test('a collapsed selection refuses to build', () => {
+    const foo = block('b1', [span('s1', 'foo bar')])
+
+    expect(
+      buildStoredSelection({
+        selection: {anchor: point('b1', 's1', 4), focus: point('b1', 's1', 4)},
+        selectedBlocks: [{node: foo, path: [{_key: 'b1'}]}],
+      }),
+    ).toBe(null)
+  })
+
+  test('a null selection refuses to build', () => {
+    expect(buildStoredSelection({selection: null, selectedBlocks: []})).toBe(
+      null,
+    )
+  })
+
+  test('what it writes, the reader finds again', () => {
+    // The round trip is the point of matching the Studio's format: written
+    // here, resolved by the same code path that resolves Studio comments.
+    const foo = block('b1', [span('s1', 'foo bar baz')])
+    const built = buildStoredSelection({
+      selection: {anchor: point('b1', 's1', 4), focus: point('b1', 's1', 7)},
+      selectedBlocks: [{node: foo, path: [{_key: 'b1'}]}],
+    })
+
+    const anchored = resolveCommentSelections({
+      value: [foo],
+      comments: [
+        {
+          commentId: 'c1',
+          relativePath: built!.containerPath,
+          selection: built!.selection,
+        },
+      ],
+    })
+
+    expect(anchored.map((a) => a.selection)).toEqual([
+      {
+        anchor: {offset: 4, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+        focus: {offset: 7, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+      },
+    ])
+  })
+})

--- a/packages/plugin-sdk-value/src/comments-selection.ts
+++ b/packages/plugin-sdk-value/src/comments-selection.ts
@@ -1,0 +1,153 @@
+import type {EditorSelection} from '@portabletext/editor'
+import type {Path, PathSegment} from '@portabletext/patches'
+import {
+  COMMENT_INDICATORS,
+  type StoredTextSelection,
+} from './comments-anchoring'
+
+interface SpanLike {
+  _key: string
+  _type: string
+  text?: string
+}
+
+interface TextBlockLike {
+  _key: string
+  children: SpanLike[]
+}
+
+export interface SelectedTextBlock {
+  node: TextBlockLike
+  path: Path
+}
+
+export interface BuiltSelection {
+  /**
+   * The path of the array holding the selected blocks, relative to the editor.
+   * Empty for blocks at the top level. Comments anchor on the containing array,
+   * matching what the Studio stores.
+   */
+  containerPath: Path
+  /** The anchor in the Studio's stored shape, ready to pass to `createComment`. */
+  selection: StoredTextSelection
+}
+
+/**
+ * Turns the current editor selection into the stored comment anchor.
+ *
+ * Per selected block, the block's entire plain text with the selection
+ * boundaries marked by the two indicator characters. The write-time mirror of
+ * `resolveCommentSelections`, and deliberately built the way the Studio builds
+ * it so a comment written here re-anchors there and back.
+ *
+ * Returns `null` when there is nothing commentable: a collapsed selection,
+ * no selected text, or a selection spanning blocks from different containing
+ * arrays, which a single stored path cannot describe.
+ */
+export function buildStoredSelection(options: {
+  selection: EditorSelection
+  selectedBlocks: SelectedTextBlock[]
+}): BuiltSelection | null {
+  const {selection, selectedBlocks} = options
+  if (!selection || selectedBlocks.length === 0) {
+    return null
+  }
+
+  const [start, end] = selection.backward
+    ? [selection.focus, selection.anchor]
+    : [selection.anchor, selection.focus]
+
+  const containerPath = selectedBlocks[0].path.slice(0, -1)
+  const sharedContainer = selectedBlocks.every((selected) =>
+    pathsEqual(selected.path.slice(0, -1), containerPath),
+  )
+  if (!sharedContainer) {
+    return null
+  }
+
+  let selectedCharacters = 0
+  const value = selectedBlocks.map((selected, index) => {
+    const isFirst = index === 0
+    const isLast = index === selectedBlocks.length - 1
+    const plain = plainText(selected.node)
+
+    const from = isFirst
+      ? plainOffset(selected.node, start.path, start.offset)
+      : 0
+    const to = isLast
+      ? plainOffset(selected.node, end.path, end.offset)
+      : plain.length
+
+    selectedCharacters += Math.max(0, to - from)
+
+    return {
+      _key: selected.node._key,
+      text: `${plain.slice(0, from)}${COMMENT_INDICATORS[0]}${plain.slice(from, to)}${COMMENT_INDICATORS[1]}${plain.slice(to)}`,
+    }
+  })
+
+  // A collapsed selection, or one that only touches empty text, anchors to
+  // nothing worth highlighting.
+  if (selectedCharacters === 0) {
+    return null
+  }
+
+  return {containerPath, selection: {type: 'text', value}}
+}
+
+function plainText(block: TextBlockLike): string {
+  return block.children
+    .map((child) => (isSpan(child) ? (child.text ?? '') : ''))
+    .join('')
+}
+
+/**
+ * Converts a selection point into an offset within the block's plain text: the
+ * text of every span before the point's child, plus the offset inside it. A
+ * point whose child is not in this block clamps to the block edge, which is
+ * where a cross-block selection boundary lands.
+ */
+function plainOffset(
+  block: TextBlockLike,
+  pointPath: Path,
+  offset: number,
+): number {
+  const childSegment = pointPath[pointPath.length - 1]
+  if (!isKeyedSegment(childSegment)) {
+    return offset
+  }
+
+  let total = 0
+  for (const child of block.children) {
+    if (child._key === childSegment._key) {
+      return total + (isSpan(child) ? offset : 0)
+    }
+    if (isSpan(child)) {
+      total += (child.text ?? '').length
+    }
+  }
+  return total
+}
+
+function isSpan(child: SpanLike): boolean {
+  return child._type === 'span' && typeof child.text === 'string'
+}
+
+function isKeyedSegment(
+  segment: PathSegment | undefined,
+): segment is {_key: string} {
+  return typeof segment === 'object' && segment !== null && '_key' in segment
+}
+
+function pathsEqual(a: Path, b: Path): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((segment, index) => {
+    const other = b[index]
+    if (isKeyedSegment(segment) && isKeyedSegment(other)) {
+      return segment._key === other._key
+    }
+    return segment === other
+  })
+}

--- a/packages/plugin-sdk-value/src/index.ts
+++ b/packages/plugin-sdk-value/src/index.ts
@@ -6,6 +6,14 @@ export {
   type SDKRemoteCursor,
   type UseSDKPresenceCursorsOptions,
 } from './plugin.sdk-presence'
+export {
+  useSDKCommentAuthoring,
+  useSDKCommentDecorations,
+  type RenderCommentDecorationFunction,
+  type SDKCommentAuthoring,
+  type UseSDKCommentAuthoringOptions,
+  type UseSDKCommentDecorationsOptions,
+} from './plugin.sdk-comments'
 export {SDKValuePlugin, ValueSyncPlugin} from './plugin.sdk-value'
 export {
   SDKPortableTextEditable,

--- a/packages/plugin-sdk-value/src/plugin.sdk-comments.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-comments.tsx
@@ -1,0 +1,317 @@
+import {
+  useEditor,
+  useEditorSelector,
+  type EditorSelection,
+  type RangeDecoration,
+} from '@portabletext/editor'
+import {
+  getSelectedTextBlocks,
+  getSelection,
+} from '@portabletext/editor/selectors'
+import {isEqualSelections} from '@portabletext/editor/utils'
+import {stringifyPath} from '@sanity/json-match'
+import {
+  useCommentActions,
+  useComments,
+  type Comment,
+  type CommentMessage,
+  type DocumentHandle,
+} from '@sanity/sdk-react'
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+  type ReactElement,
+} from 'react'
+import {
+  relativeCommentPath,
+  resolveCommentSelections,
+  type AnchoredComment,
+} from './comments-anchoring'
+import {
+  buildStoredSelection,
+  type SelectedTextBlock,
+} from './comments-selection'
+import {arrayifyPath} from './plugin.sdk-value'
+
+const NO_MOVES: Record<string, EditorSelection> = {}
+
+/**
+ * Anchors count as unchanged when every comment still sits at the same spot,
+ * so resolving on each editor emission only re-renders when a highlight
+ * actually needs to draw somewhere else.
+ */
+function sameAnchors(a: AnchoredComment[], b: AnchoredComment[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((anchor, index) => {
+    const other = b[index]
+    return (
+      anchor.commentId === other.commentId &&
+      samePoint(anchor.selection.anchor, other.selection.anchor) &&
+      samePoint(anchor.selection.focus, other.selection.focus)
+    )
+  })
+}
+
+function samePoint(
+  a: {path: unknown[]; offset: number},
+  b: {path: unknown[]; offset: number},
+): boolean {
+  if (a.offset !== b.offset || a.path.length !== b.path.length) {
+    return false
+  }
+  return a.path.every((segment, index) => {
+    const other = b.path[index]
+    if (
+      typeof segment === 'object' &&
+      segment !== null &&
+      typeof other === 'object' &&
+      other !== null
+    ) {
+      return (
+        (segment as {_key?: string})._key === (other as {_key?: string})._key
+      )
+    }
+    return segment === other
+  })
+}
+
+/**
+ * Draws one comment's highlight. The plugin has no opinion about how a
+ * highlight looks, so it is the caller's to provide, the same way presence
+ * takes `renderCursor`.
+ *
+ * @public
+ */
+export type RenderCommentDecorationFunction = (
+  comment: Comment,
+) => (props: PropsWithChildren) => ReactElement
+
+/**
+ * Options for {@link useSDKCommentDecorations}.
+ *
+ * @public
+ */
+export interface UseSDKCommentDecorationsOptions extends DocumentHandle {
+  /**
+   * The document path of the Portable Text field, for example `content`. The
+   * same form `SDKValuePlugin` takes.
+   */
+  path: string
+  renderDecoration: RenderCommentDecorationFunction
+}
+
+/**
+ * Inline comment highlights for a Portable Text field, as range decorations.
+ *
+ * Pass the result to `<PortableTextEditable rangeDecorations={...} />`. Each
+ * thread's first comment that carries a text anchor on this field gets one
+ * decoration. Highlights stay put while the local user types, and a highlight
+ * whose text has been deleted or rewritten beyond recognition is dropped
+ * rather than drawn on the wrong words.
+ *
+ * Suspends while the document's comments load, like every SDK read hook.
+ *
+ * Resolved threads draw nothing: this mirrors the Studio, where resolving a
+ * thread removes its highlight from the text.
+ *
+ * @public
+ */
+export function useSDKCommentDecorations(
+  options: UseSDKCommentDecorationsOptions,
+): RangeDecoration[] {
+  const {path, renderDecoration, ...handle} = options
+  const editor = useEditor()
+  const {comments} = useComments({...handle})
+
+  const inline = useMemo(() => {
+    const basePath = arrayifyPath(path)
+    return comments.flatMap((comment) => {
+      if (
+        comment.parentCommentId ||
+        !comment.selection ||
+        comment.status !== 'open'
+      ) {
+        return []
+      }
+      const relativePath = relativeCommentPath(basePath, comment.fieldPath)
+      if (relativePath === undefined) {
+        return []
+      }
+      return [{comment, relativePath, selection: comment.selection}]
+    })
+  }, [comments, path])
+
+  // Resolved inside the selector so every resolution reads the text as it is
+  // right now. Anything less fresh mis-anchors a comment written on text typed
+  // since the staler reading, and on first load finds nothing at all, since
+  // the field's value can arrive after the comments do. The anchor equality
+  // keeps re-renders to actual highlight changes, and positions the editor is
+  // already tracking through `onMoved` win over these resolutions anyway.
+  const resolveAnchors = useCallback(
+    (snapshot: {context: {value: unknown[]}}) =>
+      resolveCommentSelections({
+        value: snapshot.context.value,
+        comments: inline.map(({comment, relativePath, selection}) => ({
+          commentId: comment.id,
+          relativePath,
+          selection,
+        })),
+      }),
+    [inline],
+  )
+  const anchored = useEditorSelector(editor, resolveAnchors, sameAnchors)
+
+  // Moves are remembered against the comment list they were reported for, so a
+  // re-resolution wins over stale positions without a state reset.
+  const [moved, setMoved] = useState<{
+    forComments: typeof inline
+    selections: Record<string, EditorSelection>
+  }>({forComments: inline, selections: {}})
+  const movedSelections =
+    moved.forComments === inline ? moved.selections : NO_MOVES
+
+  return useMemo(() => {
+    const commentsById = new Map(
+      inline.map(({comment}) => [comment.id, comment]),
+    )
+
+    return anchored.flatMap((anchor) => {
+      const comment = commentsById.get(anchor.commentId)
+      if (!comment) {
+        return []
+      }
+
+      const movedSelection = movedSelections[anchor.commentId]
+      const selection =
+        movedSelection === undefined ? anchor.selection : movedSelection
+      if (selection === null) {
+        // The editor reported the range lost, for example its text was deleted.
+        return []
+      }
+
+      return [
+        {
+          component: renderDecoration(comment),
+          selection,
+          onMoved: ({newSelection}) => {
+            setMoved((previous) => ({
+              forComments: inline,
+              selections: {
+                ...(previous.forComments === inline ? previous.selections : {}),
+                [anchor.commentId]: newSelection,
+              },
+            }))
+          },
+          payload: {commentId: anchor.commentId},
+        } satisfies RangeDecoration,
+      ]
+    })
+  }, [anchored, inline, movedSelections, renderDecoration])
+}
+
+/**
+ * Options for {@link useSDKCommentAuthoring}.
+ *
+ * @public
+ */
+export interface UseSDKCommentAuthoringOptions extends DocumentHandle {
+  /**
+   * The document path of the Portable Text field, for example `content`.
+   */
+  path: string
+}
+
+/**
+ * What {@link useSDKCommentAuthoring} returns.
+ *
+ * @public
+ */
+export interface SDKCommentAuthoring {
+  /**
+   * The current selection when it can take a comment, `null` otherwise. Show
+   * the comment affordance when this is set, and position it off the
+   * selection. A selection can take a comment when it is expanded, contains
+   * text, and stays within one array of blocks.
+   */
+  commentableSelection: EditorSelection
+  /**
+   * Starts a comment thread anchored to the text selected right now.
+   *
+   * The anchor is captured from the live selection at call time, so call this
+   * from the affordance while the selection still stands. Rejects when nothing
+   * commentable is selected.
+   */
+  createInlineComment: (options: {
+    message: CommentMessage
+    /** Reuse the id of a failed comment to retry it. */
+    commentId?: string
+  }) => Promise<Comment>
+}
+
+/** Reports the selection when it can take a comment, `null` otherwise. */
+function getCommentableSelection(
+  snapshot: Parameters<typeof getSelection>[0],
+): EditorSelection {
+  const selection = getSelection(snapshot)
+  const built = buildStoredSelection({
+    selection,
+    selectedBlocks: getSelectedTextBlocks(snapshot) as SelectedTextBlock[],
+  })
+  return built ? selection : null
+}
+
+/**
+ * Lets the app author inline comments on a Portable Text field.
+ *
+ * The plugin captures the selection and writes the comment; the composer UI is
+ * the app's, the same split the Studio and Canvas use. Comments are written in
+ * the shape the Studio stores, so a thread started here shows up there.
+ *
+ * @public
+ */
+export function useSDKCommentAuthoring(
+  options: UseSDKCommentAuthoringOptions,
+): SDKCommentAuthoring {
+  const {path, ...handle} = options
+  const editor = useEditor()
+  const {createComment} = useCommentActions()
+
+  const commentableSelection = useEditorSelector(
+    editor,
+    getCommentableSelection,
+    isEqualSelections,
+  )
+
+  return {
+    commentableSelection,
+    createInlineComment: ({message, commentId}) => {
+      const snapshot = editor.getSnapshot()
+      const built = buildStoredSelection({
+        selection: getSelection(snapshot),
+        selectedBlocks: getSelectedTextBlocks(snapshot) as SelectedTextBlock[],
+      })
+      if (!built) {
+        return Promise.reject(
+          new Error(
+            'Nothing commentable is selected, so there is nothing to anchor the comment to.',
+          ),
+        )
+      }
+
+      return createComment({
+        ...handle,
+        fieldPath: stringifyPath([
+          ...arrayifyPath(path),
+          ...built.containerPath,
+        ]),
+        selection: built.selection,
+        message,
+        ...(commentId === undefined ? {} : {commentId}),
+      })
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1138,6 +1138,9 @@ importers:
       '@portabletext/patches':
         specifier: workspace:*
         version: link:../patches
+      '@sanity/diff-match-patch':
+        specifier: 'catalog:'
+        version: 3.2.0
       '@sanity/diff-patch':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1163,9 +1166,6 @@ importers:
       '@portabletext/test':
         specifier: workspace:^
         version: link:../test
-      '@sanity/diff-match-patch':
-        specifier: 'catalog:'
-        version: 3.2.0
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 12.3.0(@babel/runtime@7.28.4)(@tsdown/css@0.22.14)(@types/node@24.12.2)(@volar/typescript@2.4.28)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(oxc-transform-react@0.145.0)(typescript@7.0.2)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
@@ -17790,7 +17790,7 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@types/node@20.19.25)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
## Why

Sanity SDK 2.20.1 shipped comment hooks (`useComments`, `useCommentActions`), including inline text anchors on Portable Text fields. SDK apps that author content in the editor need both halves of that in the editor itself: highlights for existing comment threads, and a way to start a thread on the current selection. Today only Sanity Studio and Canvas can do this, and each hand-built the machinery privately.

This adds the machinery once, here, as two hooks. The composer UI stays with the app, the same split this package already uses for presence (`renderCursor`), and the same one Studio and Canvas chose.

## What

- `useSDKCommentDecorations({...handle, path, renderDecoration})` returns `RangeDecoration[]` for open comment threads anchored to text in this field. Anchors re-resolve when comments change; between resolutions the editor's own `onMoved` tracks edits, so there is no per-keystroke diffing. An anchor whose text is gone or rewritten beyond recognition is dropped rather than drawn on the wrong words.
- `useSDKCommentAuthoring({...handle, path})` exposes `commentableSelection` (set when the live selection can take a comment) and `createInlineComment({message})`, which captures the selection at call time and writes through `@sanity/sdk-react`.

Comments are written in the exact shape Sanity Studio stores (per selected block, the block's plain text with the selection boundaries marked by two private-use characters), so threads round-trip between an SDK app and the Studio. That format is deliberately internal to this package: the platform's comments storage is migrating, and keeping the anchor format out of the public API is what lets it change without a breaking release. The public surface is two hooks and the four types their signatures reference, mirroring the presence exports one for one.

## What to review

- `src/comments-anchoring.ts` is a direct port of Studio's `buildRangeDecorationSelectionsFromComments`, oddities preserved and annotated (the asymmetric similarity threshold, the child-separator offset walk). Its fixture suite is Studio's own, ported values and expectations.
- `src/comments-selection.ts` is the write side, new code: the editor's `getSelectedTextBlocks` already walks the selection, so this is a fraction of Studio's equivalent. Cross-container selections refuse to build rather than guessing an anchor.
- `src/plugin.sdk-comments.tsx` holds the hooks. The moved-highlight state is remembered against the comment list it was reported for, so a re-resolution wins over stale positions without an effect (the earlier draft used one; lint rightly objected).

## Testing

115 unit tests and 61 browser tests pass. The test that matters most is the round trip: what `buildStoredSelection` writes, `resolveCommentSelections` finds again at the same offsets, which is the interop contract with Studio expressed as a test. Not covered here: an end-to-end against a live dataset; the SDK side of that lives in sanity-io/sdk (see https://github.com/sanity-io/sdk/pull/1085 and https://github.com/sanity-io/sdk/pull/1087).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Comment anchoring is non-trivial and must stay aligned with Studio storage, but behavior is heavily unit-tested and scoped to optional hooks rather than core sync/presence paths.
> 
> **Overview**
> Adds **inline comment** support to `@portabletext/plugin-sdk-value` so SDK apps can show Studio-compatible text anchors and start new threads from the editor.
> 
> **`useSDKCommentDecorations`** loads open, anchored threads for a field via `@sanity/sdk-react`, maps stored anchors to `RangeDecoration[]` (custom `renderDecoration`), re-resolves on comment/value changes, and uses `onMoved` while typing; unrecognizable or resolved threads render no highlight.
> 
> **`useSDKCommentAuthoring`** exposes `commentableSelection` and **`createInlineComment`**, which snapshots the selection into Sanity’s stored text-anchor format and calls `createComment`.
> 
> New pure modules **`comments-anchoring`** (diff-match-patch re-anchoring, ported from Studio) and **`comments-selection`** (write path) back the hooks. Public exports include four related types. Peer dependency bumps to **`@sanity/sdk-react` ^2.20.1**; **`@sanity/diff-match-patch`** becomes a runtime dependency. README and changeset document usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e92fc063f87959abc7bcbdd26e7310eadad40c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->