### PR TITLE
docs: align two v8 changesets with the release they ship in

### DIFF
--- a/.changeset/remove-data-slate-attributes.md
+++ b/.changeset/remove-data-slate-attributes.md
@@ -15,4 +15,4 @@ The editor DOM no longer carries the Slate-era `data-slate-*` attributes; it spe
 - `data-slate-void` → `data-pt-block="object"` / `data-pt-inline="object"`
 - `data-slate-spacer` → `data-pt-spacer`
 
-One behavioral consequence rides along: a node registered via `registerNode` (for example `defineInlineObject` or `defineSpan`) now receives the same clean `data-pt-*` attributes whether its parent text block renders through the legacy pipeline or the new one; previously the legacy pipeline mixed `data-slate-*` into the attributes passed to the registered render.
+One behavioral consequence rides along: an inline object or span registered via `registerNode` (for example `defineInlineObject` or `defineSpan`) could receive `data-slate-*` attributes mixed into the `attributes` prop passed to its `render` function when its parent text block was not registered. Every registered inline render now receives the same clean `data-pt-*` attributes regardless of whether the parent text block is registered.

--- a/.changeset/remove-render-block-render-child.md
+++ b/.changeset/remove-render-block-render-child.md
@@ -6,4 +6,4 @@ feat!: remove the `renderBlock` and `renderChild` render props
 
 `renderBlock`, `renderChild`, and their `RenderBlockFunction`, `RenderChildFunction`, `BlockRenderProps`, and `BlockChildRenderProps` types are removed. Text blocks, block objects, inline objects, and spans render through node registrations instead: `defineTextBlock`, `defineBlockObject`, `defineInlineObject`, and `defineSpan`, mounted through `NodePlugin`. The [migration guide](https://www.portabletext.org/editor/guides/migrate-render-props/) walks through the replacement for each prop.
 
-`renderPlaceholder` and `rangeDecorations` are unaffected. Default rendering for a type with no matching registration is unchanged.
+`renderPlaceholder` and `rangeDecorations` are unaffected.


### PR DESCRIPTION
The v8 changesets were written one PR at a time but publish as one release, so each entry's claims have to be true of the release, not of the commit that added it. Read as one story, two entries had drifted.

`remove-render-block-render-child` still promised that default rendering for a type with no matching registration is unchanged; the one-default-DOM entry in the same release makes that false, so the sentence is gone. `remove-data-slate-attributes` explained its rides-along consequence through internal pipeline names and claimed it applied whenever the parent text block was unregistered, which is wider than the code: children of a registered container were already clean, and block objects were never affected. It now states the consumer-observable condition, scoped to inline objects and spans.

This PR merges before the Version Packages PR so the corrected prose is what the changelog publishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changeset edits with no runtime or API impact.
> 
> **Overview**
> Updates two **@portabletext/editor** v8 changesets so the published changelog matches what ships in the combined major release, not individual PRs.
> 
> In **`remove-render-block-render-child`**, drops the claim that default rendering for unregistered types is unchanged—that conflicts with **`unify-default-dom`** in the same release.
> 
> In **`remove-data-slate-attributes`**, rewrites the inline **`registerNode`** consequence: it now describes the consumer-visible case (mixed **`data-slate-*`** on **`attributes`** for inline objects/spans when the parent text block was unregistered) and states that registered inline renders always get clean **`data-pt-*`** attributes, without over-broad pipeline wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c443184d95c09f06a9af2e3989c4cf0ed28fd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->