### PR TITLE
fix: report `remote` origin in `onMoved` when remote operations move a range decoration

### DIFF
--- a/.changeset/range-decoration-remote-origin.md
+++ b/.changeset/range-decoration-remote-origin.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: report `remote` origin in `onMoved` when remote operations move a range decoration
+
+A range decoration's `onMoved` callback now reports `origin: 'remote'` when the edit that moved or removed the decoration came from a remote patch, matching the documented `RangeDecorationOnMovedDetails.origin` type. Previously `onMoved` always reported `'local'`, even for remote edits.

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -7,7 +7,10 @@ import {
   type AnyEventObject,
   type CallbackLogicFunction,
 } from 'xstate'
-import {subscribeToOperations} from '../engine/core/operation-channel'
+import {
+  subscribeToOperations,
+  type OperationOrigin,
+} from '../engine/core/operation-channel'
 import type {Node, NodeEntry} from '../engine/interfaces/node'
 import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Range} from '../engine/interfaces/range'
@@ -25,7 +28,11 @@ import type {EditorSchema} from './editor-schema'
 
 const engineOperationCallback: CallbackLogicFunction<
   AnyEventObject,
-  {type: 'engine operation'; operation: EngineOperation},
+  {
+    type: 'engine operation'
+    operation: EngineOperation
+    origin: OperationOrigin
+  },
   {editorEngine: PortableTextEditorEngine}
 > = ({input, sendBack}) => {
   return subscribeToOperations(
@@ -36,7 +43,11 @@ const engineOperationCallback: CallbackLogicFunction<
         // synchronously and needs the pre-apply tree (removed nodes must
         // still be present to resolve document order) — hence the
         // `before` phase.
-        sendBack({type: 'engine operation', operation: event.operation})
+        sendBack({
+          type: 'engine operation',
+          operation: event.operation,
+          origin: event.origin,
+        })
       }
     },
     {phase: 'before'},
@@ -73,6 +84,7 @@ export const rangeDecorationsMachine = setup({
       | {
           type: 'engine operation'
           operation: EngineOperation
+          origin: OperationOrigin
         }
       | {
           type: 'update read only'
@@ -150,7 +162,7 @@ export const rangeDecorationsMachine = setup({
           decoratedRange.rangeDecoration.onMoved?.({
             newSelection: null,
             rangeDecoration: decoratedRange.rangeDecoration,
-            origin: 'local',
+            origin: event.origin === 'remote' ? 'remote' : 'local',
           })
           continue
         }
@@ -168,7 +180,7 @@ export const rangeDecorationsMachine = setup({
           decoratedRange.rangeDecoration.onMoved?.({
             newSelection: newRange,
             rangeDecoration: decoratedRange.rangeDecoration,
-            origin: 'local',
+            origin: event.origin === 'remote' ? 'remote' : 'local',
           })
         }
 

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -1,3 +1,4 @@
+import {diffMatchPatch} from '@portabletext/patches'
 import {
   compileSchema,
   isSpan,
@@ -494,6 +495,193 @@ describe('RangeDecorations', () => {
         rangeDecorationIteration,
         'updated-with-different-payload',
       ]).toEqual([5, 'updated-with-different-payload'])
+    })
+  })
+
+  test('Scenario: A remote edit that moves a Range Decoration reports a remote origin', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+
+    const onMoved = vi.fn()
+
+    const rangeDecoration: RangeDecoration = {
+      component: (props) => (
+        <span data-testid="range-decoration">{props.children}</span>
+      ),
+      onMoved,
+      selection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      editableProps: {
+        rangeDecorations: [rangeDecoration],
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        diffMatchPatch('foo', 'barfoo', [
+          {_key: blockKey},
+          'children',
+          {_key: spanKey},
+          'text',
+        ]),
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(onMoved).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onMoved.mock.calls[0]?.[0]).toEqual({
+      newSelection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 4,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 6,
+        },
+      },
+      rangeDecoration,
+      origin: 'remote',
+    })
+  })
+
+  test('Scenario: Undoing a local edit that moves a Range Decoration reports a local origin', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+
+    const onMoved = vi.fn()
+
+    const rangeDecoration: RangeDecoration = {
+      component: (props) => (
+        <span data-testid="range-decoration">{props.children}</span>
+      ),
+      onMoved,
+      selection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      editableProps: {
+        rangeDecorations: [rangeDecoration],
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    editor.send({
+      type: 'select',
+      at: getSelectionBeforeText(editor.getSnapshot().context, 'foo'),
+    })
+
+    await userEvent.type(locator, 'x')
+
+    await vi.waitFor(() => {
+      expect(onMoved).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onMoved.mock.calls[0]?.[0]).toEqual({
+      newSelection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 2,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 4,
+        },
+      },
+      rangeDecoration,
+      origin: 'local',
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(onMoved).toHaveBeenCalledTimes(2)
+    })
+
+    expect(onMoved.mock.calls[1]?.[0]).toEqual({
+      newSelection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+      rangeDecoration: {
+        ...rangeDecoration,
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 2,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 4,
+          },
+        },
+      },
+      origin: 'local',
     })
   })
 


### PR DESCRIPTION
A range decoration's `onMoved` callback has an `origin` field typed `'remote' | 'local'`, but every call reported `'local'`. A consumer trying to tell a collaborator's edit moving its comment anchor apart from the user's own edit had nothing to go on.

The engine's operation channel already computes an origin for every operation (local, remote, undo, redo, normalization); the range-decorations machine's subscription dropped it and hardcoded `'local'` at both `onMoved` call sites. The subscription now forwards the origin and the call sites map it: `remote` reports `'remote'`, everything else reports `'local'`, since undo and redo replay local edits. The public type is unchanged.

Two browser tests pin the mapping: a remote patch that moves a decoration reports `origin: 'remote'` (fails on the old code), and an undone local edit reports `origin: 'local'` (fails on an inverted mapping). The `onMoved` calls in the prop-update path still report `'local'`; no operation is involved there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted behavior fix in range-decoration callbacks with no API changes; risk is mainly consumers now seeing `'remote'` where they previously always got `'local'`.
> 
> **Overview**
> Fixes **`RangeDecoration.onMoved`** so **`origin`** reflects whether the document edit came from collaboration, not always **`'local'`**.
> 
> The range-decorations state machine now forwards **`OperationOrigin`** from the engine operation subscription into **`move range decorations`**, and passes **`origin: 'remote'`** when that operation is remote; undo, redo, normalization, and other non-remote origins still surface as **`'local'`**. Prop-driven decoration updates are unchanged and keep reporting **`'local'`**.
> 
> Adds browser tests for a remote patch moving a decoration and for undo after a local edit, plus a patch changeset for **`@portabletext/editor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d172f18efd8eed052174713b56398a2e6147a787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->