### PR TITLE
fix: identify shadow roots by node type instead of a `host` property (v7)

### DIFF
--- a/.changeset/shadow-root-node-type-detection-v7.md
+++ b/.changeset/shadow-root-node-type-detection-v7.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: identify shadow roots by node type instead of a `host` property
+
+The shadow DOM-aware DOM traversals treated any parent node carrying a `host` property as a shadow root. A `<form>` exposes its own controls as named properties, so `'host' in form` is true for any form containing an element with `id="host"` or `name="host"` — the form was mistaken for a shadow root and the upward walk stepped from the form to that control and back forever, hanging the tab.
+
+This surfaced in editors rendered inside a form that has a field named `host`: moving the selection between two editors locked the browser, because rewriting the DOM selection runs one of these traversals from a layout effect. Shadow roots are document fragments, so the node type now separates them from a form.

--- a/packages/editor/src/engine/dom/utils/dom.ts
+++ b/packages/editor/src/engine/dom/utils/dom.ts
@@ -310,8 +310,8 @@ export const closestShadowAware = (
 
     if (current.parentElement) {
       current = current.parentElement
-    } else if (current.parentNode && 'host' in current.parentNode) {
-      current = (current.parentNode as ShadowRoot).host as DOMElement
+    } else if (isShadowRoot(current.parentNode)) {
+      current = current.parentNode.host as DOMElement
     } else {
       return null
     }
@@ -344,8 +344,8 @@ export const containsShadowAware = (
     }
 
     if (current.parentNode) {
-      if ('host' in current.parentNode) {
-        current = (current.parentNode as ShadowRoot).host
+      if (isShadowRoot(current.parentNode)) {
+        current = current.parentNode.host
       } else {
         current = current.parentNode
       }
@@ -355,4 +355,23 @@ export const containsShadowAware = (
   }
 
   return false
+}
+
+/**
+ * Check if a DOM node is a shadow root.
+ *
+ * A `host` property alone does not identify one: `HTMLFormElement` exposes its own controls as named
+ * properties, so `'host' in form` is `true` for any form containing an element with `id="host"` or
+ * `name="host"`. Shadow roots are document fragments, so the node type separates the two.
+ *
+ * The node type is checked instead of `instanceof ShadowRoot` to keep working across realms and where
+ * the global is undefined.
+ */
+
+const isShadowRoot = (value: any): value is ShadowRoot => {
+  return (
+    isDOMNode(value) &&
+    value.nodeType === Node.DOCUMENT_FRAGMENT_NODE &&
+    'host' in value
+  )
 }

--- a/packages/editor/tests/dom-shadow-aware.test.ts
+++ b/packages/editor/tests/dom-shadow-aware.test.ts
@@ -1,0 +1,90 @@
+import {afterEach, describe, expect, test} from 'vitest'
+import {
+  closestShadowAware,
+  containsShadowAware,
+} from '../src/engine/dom/utils/dom'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe(containsShadowAware.name, () => {
+  test('finds a descendant', () => {
+    document.body.innerHTML = '<div id="foo"><span id="bar"></span></div>'
+
+    expect(
+      containsShadowAware(
+        document.getElementById('foo'),
+        document.getElementById('bar'),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects an unrelated node', () => {
+    document.body.innerHTML = '<div id="foo"></div><span id="bar"></span>'
+
+    expect(
+      containsShadowAware(
+        document.getElementById('foo'),
+        document.getElementById('bar'),
+      ),
+    ).toBe(false)
+  })
+
+  test('crosses a shadow boundary', () => {
+    document.body.innerHTML = '<div id="foo"><div id="bar"></div></div>'
+    const shadowRoot = document
+      .getElementById('bar')!
+      .attachShadow({mode: 'open'})
+    const child = document.createElement('span')
+    shadowRoot.appendChild(child)
+
+    expect(containsShadowAware(document.getElementById('foo'), child)).toBe(
+      true,
+    )
+  })
+
+  test('rejects a node in a form owning a control named "host"', () => {
+    document.body.innerHTML =
+      '<form><input id="host" /><input id="foo" /></form>'
+
+    expect(
+      containsShadowAware(
+        document.createElement('span'),
+        document.getElementById('foo'),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe(closestShadowAware.name, () => {
+  test('finds a matching ancestor', () => {
+    document.body.innerHTML = '<div class="foo"><span id="bar"></span></div>'
+
+    expect(closestShadowAware(document.getElementById('bar'), '.foo')).toBe(
+      document.querySelector('.foo'),
+    )
+  })
+
+  test('crosses a shadow boundary', () => {
+    document.body.innerHTML = '<div class="foo"><div id="bar"></div></div>'
+    const shadowRoot = document
+      .getElementById('bar')!
+      .attachShadow({mode: 'open'})
+    const child = document.createElement('span')
+    shadowRoot.appendChild(child)
+
+    expect(closestShadowAware(child, '.foo')).toBe(
+      document.querySelector('.foo'),
+    )
+  })
+
+  test('returns null from a form owning a control named "host"', () => {
+    document.body.innerHTML =
+      '<form><input id="host" /><input id="foo" /></form>'
+
+    expect(closestShadowAware(document.getElementById('foo'), '.baz')).toBe(
+      null,
+    )
+  })
+})


### PR DESCRIPTION
Backport of #3157 to the `editor-v7.x` line.

`closestShadowAware` and `containsShadowAware` identified a shadow root by `'host' in parentNode`. A `<form>` exposes its own controls as named properties, so any form containing an element with `id="host"` or `name="host"` passed that test, and the upward walk stepped form → `form.host` → back to the form, forever, hanging the tab. In a Studio this is reachable with nothing more exotic than a document type that has a field named `host` next to a Portable Text field: moving the selection between editors never returns (#3155).

Shadow roots are document fragments, so the node type now distinguishes them from a form.

The v7 line carries the bug (the original report reproduced on 7.11.0). Cherry-picked from `34717cf5` with no adaptations, red-verified on this branch: with the unpatched `dom.ts`, the form-clobbering test hangs indefinitely instead of failing, which is the bug.
