### PR TITLE
fix: render every overlapping range decoration instead of only the last

### DIFF
--- a/.changeset/compose-overlapping-range-decorations.md
+++ b/.changeset/compose-overlapping-range-decorations.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: render every overlapping range decoration instead of only the last
+
+Overlapping range decorations now all render, nested in array order with the first outermost. Previously only the last decoration in the array rendered on the text where they overlapped.
+
+One consequence rides along: a decoration that overlaps others renders one wrapper per overlap segment, so its component can mount multiple times for one decoration. Components with per-mount side effects or seam-sensitive CSS (borders, rounded corners) should expect fragmentation.

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -168,7 +168,7 @@ export const PortableTextEditable = forwardRef<
       leafProps: RenderLeafProps & {
         leaf: PortableTextSpan & {
           placeholder?: boolean
-          rangeDecoration?: RangeDecoration
+          rangeDecorations?: Array<RangeDecoration>
         }
       },
     ) => (

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -1,4 +1,4 @@
-import {isTextBlock} from '@portabletext/schema'
+import {isTextBlock, type PortableTextSpan} from '@portabletext/schema'
 import {
   and,
   assign,
@@ -54,7 +54,18 @@ const engineOperationCallback: CallbackLogicFunction<
   )
 }
 
-export type DecoratedRange = Range & {rangeDecoration: RangeDecoration}
+export type DecoratedRange = Range & {
+  rangeDecoration: RangeDecoration
+  merge: (leaf: PortableTextSpan, decoration: object) => void
+}
+
+function mergeRangeDecoration(
+  leaf: PortableTextSpan & {rangeDecorations?: Array<RangeDecoration>},
+  decoration: object,
+) {
+  const {rangeDecoration} = decoration as {rangeDecoration: RangeDecoration}
+  leaf.rangeDecorations = [...(leaf.rangeDecorations ?? []), rangeDecoration]
+}
 
 export const rangeDecorationsMachine = setup({
   types: {
@@ -116,6 +127,7 @@ export const rangeDecorationsMachine = setup({
 
         rangeDecorationState.push({
           rangeDecoration,
+          merge: mergeRangeDecoration,
           ...rangeDecoration.selection,
         })
       }
@@ -141,6 +153,7 @@ export const rangeDecorationsMachine = setup({
 
         rangeDecorationState.push({
           rangeDecoration,
+          merge: mergeRangeDecoration,
           ...rangeDecoration.selection,
         })
       }
@@ -191,6 +204,7 @@ export const rangeDecorationsMachine = setup({
               ...decoratedRange.rangeDecoration,
               selection: newRange || currentSelection,
             },
+            merge: mergeRangeDecoration,
           })
         }
       }

--- a/packages/editor/src/editor/render.leaf.tsx
+++ b/packages/editor/src/editor/render.leaf.tsx
@@ -17,7 +17,7 @@ export function RenderLeaf(
   props: RenderLeafProps & {
     leaf: PortableTextSpan & {
       placeholder?: boolean
-      rangeDecoration?: RangeDecoration
+      rangeDecorations?: Array<RangeDecoration>
     }
     readOnly: boolean
     renderPlaceholder?: RenderPlaceholderFunction
@@ -47,10 +47,12 @@ export function RenderLeaf(
     )
   }
 
-  const rangeDecoration = props.leaf.rangeDecoration
+  const rangeDecorations = props.leaf.rangeDecorations
 
-  if (rangeDecoration) {
-    renderedSpan = rangeDecoration.component({children: renderedSpan})
+  if (rangeDecorations) {
+    for (const rangeDecoration of [...rangeDecorations].reverse()) {
+      renderedSpan = rangeDecoration.component({children: renderedSpan})
+    }
   }
 
   return renderedSpan

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -194,6 +194,12 @@ export interface RangeDecoration {
    * The component that renders the range decoration. It receives the
    * decorated text as its children.
    *
+   * The component can render more than once for one decoration: the range
+   * is split into segments at formatting boundaries and where it overlaps
+   * other decorations, and each segment gets its own wrapper. Where
+   * decorations overlap, their components nest, first in array order
+   * outermost.
+   *
    * @example
    * ```tsx
    * (rangeComponentProps: PropsWithChildren) => (

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -294,6 +294,142 @@ describe('RangeDecorations', () => {
     )
   })
 
+  test('Scenario: Overlapping Range Decorations render nested, outer decoration first', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const rangeDecorations: Array<RangeDecoration> = [
+      {
+        component: (props) => (
+          <span data-testid="decoration-a">{props.children}</span>
+        ),
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 0,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 2,
+          },
+        },
+      },
+      {
+        component: (props) => (
+          <span data-testid="decoration-b">{props.children}</span>
+        ),
+        selection: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 1,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: spanKey}],
+            offset: 3,
+          },
+        },
+      },
+    ]
+
+    await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations,
+      },
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-pt-editor]')
+      expect(editorElement).not.toEqual(null)
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          `<div data-pt-path="[_key==&quot;${blockKey}&quot;]" data-pt-block="text">`,
+          '<div>',
+          `<span data-pt-path="[_key==&quot;${blockKey}&quot;].children[_key==&quot;${spanKey}&quot;]" data-pt-inline="span">`,
+          '<span data-testid="decoration-a">',
+          '<span data-pt-marks="true"><span data-pt-text="true">f</span></span>',
+          '</span>',
+          '<span data-testid="decoration-a">',
+          '<span data-testid="decoration-b">',
+          '<span data-pt-marks="true"><span data-pt-text="true">o</span></span>',
+          '</span>',
+          '</span>',
+          '<span data-testid="decoration-b">',
+          '<span data-pt-marks="true"><span data-pt-text="true">o</span></span>',
+          '</span>',
+          '</span>',
+          '</div>',
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
+
+  test('Scenario: Three overlapping Range Decorations nest in array order', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const spanPath = [{_key: blockKey}, 'children', {_key: spanKey}]
+    const rangeDecorations: Array<RangeDecoration> = (
+      ['a', 'b', 'c'] as const
+    ).map((name) => ({
+      component: (props) => (
+        <span data-testid={`decoration-${name}`}>{props.children}</span>
+      ),
+      selection: {
+        anchor: {path: spanPath, offset: 0},
+        focus: {path: spanPath, offset: 3},
+      },
+    }))
+
+    await createTestEditor({
+      keyGenerator,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+        },
+      ],
+      editableProps: {
+        rangeDecorations,
+      },
+    })
+
+    await vi.waitFor(() => {
+      const editorElement = document.querySelector('[data-pt-editor]')
+      expect(editorElement).not.toEqual(null)
+      expect(editorElement!.innerHTML).toEqual(
+        [
+          `<div data-pt-path="[_key==&quot;${blockKey}&quot;]" data-pt-block="text">`,
+          '<div>',
+          `<span data-pt-path="[_key==&quot;${blockKey}&quot;].children[_key==&quot;${spanKey}&quot;]" data-pt-inline="span">`,
+          '<span data-testid="decoration-a">',
+          '<span data-testid="decoration-b">',
+          '<span data-testid="decoration-c">',
+          '<span data-pt-marks="true"><span data-pt-text="true">foo</span></span>',
+          '</span>',
+          '</span>',
+          '</span>',
+          '</span>',
+          '</div>',
+          '</div>',
+        ].join(''),
+      )
+    })
+  })
+
   it('only render range decorations as necessary', async () => {
     const editorRef: RefObject<PortableTextEditor | null> = createRef()
     const onChange = vi.fn()


### PR DESCRIPTION
Range decorations do not compose. `getTextDecorations` merges each decoration into the leaf with `Object.assign` onto a single `rangeDecoration` field, and the leaf renderer renders that lone survivor: when two decorations cover the same character, the last one in array order silently replaces the other on the overlap. A search highlight spanning a commented character either swallows the comment's chrome or gets a hole in it, depending on an ordering the consumer never chose.

The engine already has the extension point for this: a `DecoratedRange` accepts a private `merge` function. The range-decorations machine now attaches one that accumulates decorations into an ordered array on the leaf, and `RenderLeaf` wraps the span once per entry, first decoration in array order outermost, last innermost. That order is the only one the author directly controls, and it keeps continuity with the old behavior: the decoration that used to be the sole survivor is now the innermost wrapper, closest to the text. Single-decoration rendering is byte-identical, the public `RangeDecoration` type and the `rangeDecorations` prop are untouched, and leaf memoization survives because leaf equality already compares decorations structurally.

One consequence is disclosed in the changeset and in the `RangeDecoration.component` JSDoc: a decoration that overlaps others renders one wrapper per overlap segment, so its component can mount multiple times for one decoration, and seam-sensitive CSS (borders, rounded corners) shows the fragmentation.

Two browser tests pin the composition by asserting the editor's full rendered `innerHTML`: a partial overlap splits the span into three leaves with both wrappers correctly nested on the shared character (this one fails on the old scalar merge), and three co-extensive decorations nest in array order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes leaf rendering for overlapping decorations and can mount decoration components multiple times per logical range, which may affect side effects or border/rounding styling.
> 
> **Overview**
> **Overlapping range decorations now all render** instead of the last entry in the `rangeDecorations` array winning on shared text.
> 
> The range-decorations machine supplies a custom **`merge`** on each decorated range that **accumulates** decorations on the leaf as **`rangeDecorations`**, and **`RenderLeaf`** nests each wrapper in **reverse array order** (first decoration outermost, last innermost—matching the old “sole survivor” as the innermost layer). Public **`RangeDecoration`** / prop types are unchanged; docs note that a decoration’s component can **mount multiple times** when ranges split at overlaps or formatting boundaries.
> 
> New browser tests assert full **`innerHTML`** for partial and full overlaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e54808a16de7aec380745c9b993463ec77fc16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->