### PR TITLE
chore(renovate): group Changesets packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,6 +71,12 @@
       "groupName": "xstate"
     },
     {
+      "description": "Group Changesets packages, majors included: `@changesets/changelog-github` only works with the `@changesets/cli` generation it was built for, so the toolchain moves as one",
+      "matchPackageNames": ["@changesets/*"],
+      "groupName": "changesets",
+      "separateMajorMinor": false
+    },
+    {
       "description": "Group Cucumber packages",
       "matchPackageNames": ["@cucumber/*"],
       "groupName": "cucumber",


### PR DESCRIPTION
The dependency dashboard (#14) carries four separate pending branches for the changesets toolchain: `@changesets/cli` at 2.x and v3, and `@changesets/changelog-github` at 0.x and v1. The changelog plugin only works with the CLI generation it was built for, so bumping them separately invites a release pipeline where the two disagree.

One group with `separateMajorMinor: false`, the cucumber group's shape, moves the toolchain as a single PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/renovate.json` changes; no application or release-runtime behavior, just how dependency update PRs are grouped.
> 
> **Overview**
> Adds a Renovate **package rule** so all `@changesets/*` dependencies (notably `@changesets/cli` and `@changesets/changelog-github` in the root `package.json`) land in **one PR** named `changesets`.
> 
> The rule sets **`separateMajorMinor: false`**, matching the existing Cucumber group, so major bumps to the CLI and changelog plugin stay aligned—avoiding split dashboard branches where the changelog package and CLI generation could drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12512f0e51dfb825677402a0ead972dd4e24479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->