### PR TITLE
test: make the mutation-batching browser tests cadence-independent

### DIFF
--- a/packages/editor/src/editor/mutation-batcher.test.ts
+++ b/packages/editor/src/editor/mutation-batcher.test.ts
@@ -1,12 +1,18 @@
 import type {Patch} from '@portabletext/patches'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {
+  emitOperationEvent,
+  type OperationEvent,
+} from '../engine/core/operation-channel'
 import {createEditor} from '../engine/create-editor'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
 import {createMutationBatcher} from './mutation-batcher'
 import {createRelay} from './relay'
 
 const FLUSH_INTERVAL = 500
+const TYPE_DEBOUNCE = 250
 
 function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
   const editorEngine = createEditor() as PortableTextEditorEngine
@@ -77,11 +83,47 @@ function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
     setReadOnly: (value: boolean) => {
       isReadOnly = value
     },
+    sendOperation: (operation: EngineOperation) => {
+      emitOperationEvent(
+        editorEngine.operationListeners.before,
+        createOperationEvent(operation),
+      )
+    },
   }
 }
 
 function createPatch(path: string): Patch {
   return {type: 'set', path: [{_key: path}], value: path, origin: 'local'}
+}
+
+function createOperationEvent(operation: EngineOperation): OperationEvent {
+  return {
+    operation,
+    beforeValue: [],
+    beforeSelection: null,
+    operationsInProgress: false,
+    isNormalizingNode: false,
+    isPatching: false,
+    isProcessingRemoteChanges: false,
+    isUndoing: false,
+    isRedoing: false,
+    withHistory: false,
+    undoStepId: undefined,
+    origin: 'local',
+  }
+}
+
+function createInsertTextOperation(text: string): EngineOperation {
+  return {
+    type: 'insert.text',
+    path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+    offset: 0,
+    text,
+  }
+}
+
+function createSetOperation(): EngineOperation {
+  return {type: 'set', path: [{_key: 'b1'}, 'style'], value: 'h1'}
 }
 
 describe('mutation batcher', () => {
@@ -165,5 +207,44 @@ describe('mutation batcher', () => {
 
     expect(harness.mutationSends).toEqual([{patches: [createPatch('a')]}])
     expect(harness.editorEngine.isDeferringMutations).toBe(false)
+  })
+
+  test('merges a typing burst into one mutation and flushes at the last op plus the type debounce', () => {
+    const harness = createTestHarness()
+
+    harness.sendOperation(createInsertTextOperation('a'))
+    harness.sendPatch(createPatch('a'), 'op-1')
+
+    vi.advanceTimersByTime(100)
+
+    harness.sendOperation(createInsertTextOperation('b'))
+    harness.sendPatch(createPatch('b'), 'op-1')
+
+    // The first op's debounce would have fired here had the second op not
+    // reset it: still nothing flushed, so the burst didn't split per-op.
+    vi.advanceTimersByTime(TYPE_DEBOUNCE - 100)
+    expect(harness.mutationSends).toHaveLength(0)
+
+    // The second op's own debounce fires 250ms after it, not the interval
+    // (500ms, not yet reached).
+    vi.advanceTimersByTime(100)
+    expect(harness.mutationSends).toEqual([
+      {patches: [createPatch('a'), createPatch('b')]},
+    ])
+  })
+
+  test('a non-typing operation flushes eagerly, ending an in-progress typing session', () => {
+    const harness = createTestHarness()
+
+    harness.sendOperation(createInsertTextOperation('a'))
+    harness.sendPatch(createPatch('a'), 'op-1')
+
+    vi.advanceTimersByTime(50)
+
+    harness.sendOperation(createSetOperation())
+
+    // Flushed synchronously by the non-typing operation, well before the
+    // type debounce (250ms) or the flush interval (500ms) would fire.
+    expect(harness.mutationSends).toEqual([{patches: [createPatch('a')]}])
   })
 })

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -4,7 +4,7 @@ import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {useState} from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {page, userEvent} from 'vitest/browser'
+import {page, userEvent, type Locator} from 'vitest/browser'
 import {
   EditorProvider,
   PortableTextEditable,
@@ -109,15 +109,14 @@ describe('event.mutation', () => {
       ),
     })
 
-    // Each burst flushes into a single mutation: the keystrokes share one undo
-    // step (the key the batcher merges on) and a burst finishes well inside the
-    // batcher's `FLUSH_INTERVAL`, so the fixed flush cadence never fires
-    // mid-burst. Waiting on the settled count (rather than sleeping a fixed
-    // period) lets the first burst flush via its typing debounce before the
-    // second burst opens a fresh undo step.
-    await userEvent.type(locator, 'foo')
+    await userEvent.click(locator)
+
+    // Dispatched synchronously, back-to-back, one `insert.text` op per
+    // dispatched event: the burst can't straddle the batcher's flush
+    // cadence because nothing yields the event loop between the ops.
+    insertTextSync(locator, 'foo')
     await vi.waitFor(() => expect(mutations).toHaveLength(1))
-    await userEvent.type(locator, 'bar')
+    insertTextSync(locator, 'bar')
     await vi.waitFor(() => expect(mutations).toHaveLength(2))
 
     expect(mutations[0]!.value).toEqual([
@@ -264,3 +263,24 @@ describe('event.mutation', () => {
     })
   })
 })
+
+function insertTextSync(locator: Locator, text: string) {
+  const element = locator.element()
+  for (const character of text) {
+    element.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: character,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    // A real keystroke's native default action fires `input` synchronously;
+    // a script-dispatched `beforeinput` is untrusted and the browser skips
+    // that default action, so the editable's deferred native-path insert
+    // (gated on `insertText` with a collapsed selection, a single `[a-z ]`
+    // character, and a nonzero anchor offset, see the `native` fast path
+    // in `editable.tsx`) never flushes without this.
+    element.dispatchEvent(new InputEvent('input', {bubbles: true}))
+  }
+}

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -2473,14 +2473,25 @@ describe('event.update value: auto-resolved invalid blocks', () => {
     await userEvent.click(locator)
     await userEvent.type(locator, 'foo')
 
+    // On slow CI the typed burst can run slower than the flush interval
+    // and split across two mutations; wait for the latest one to carry
+    // the whole typed text before echoing it back.
     await vi.waitFor(() => {
-      expect(mutations.length).toBeGreaterThan(0)
+      expect(mutations.at(-1)?.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
     })
 
     // The controlled-host flow: the host receives the mutation and echoes
     // the value back down. After the echo the machine holds a non-empty
     // synced value, so a later `[]` is a genuine remote clear.
-    editor.send({type: 'update value', value: mutations[0]!.value})
+    editor.send({type: 'update value', value: mutations.at(-1)!.value})
 
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([


### PR DESCRIPTION
The v6 and v7 changesets PRs each failed a webkit browser test this week, different tests, one root. The mutation batcher flushes on a wall-clock interval (500ms in test env), and both tests assumed a `userEvent.type` burst of three keystrokes lands inside one tick. On slow CI webkit, keystrokes straddle the tick and the burst splits: "Batching typing mutations" counts three mutations instead of two, and the update-value echo scenario sends a partial `mutations[0].value` back as the host value. `main` carries the same assumption with wider headroom.

The bursts are now dispatched synchronously (one `beforeinput` + `input` pair per character, same operation pipeline as typing, verified against the editable's event handling), so the interval cannot fire mid-burst by construction, and every wait anchors on the flush result rather than a sleep. The echo scenario waits for a mutation carrying the complete text before echoing it.

One coverage move rides along: the synchronous bursts no longer exercise the typing debounce that real inter-key gaps hit, so that contract now lives in `mutation-batcher.test.ts` as fake-timer unit pins (red-verified by neutering the typing classification). Not verified on webkit locally (it does not connect in this environment); this PR's own CI is the webkit proof. Backport PRs for `editor-v7.x` and `editor-v6.x` follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production editor or batcher logic is modified.
> 
> **Overview**
> Fixes flaky WebKit CI failures where **`userEvent.type`** could stretch past the mutation batcher’s **500ms** flush window and split one typing burst into multiple mutations.
> 
> **Browser tests** now drive typing with synchronous **`beforeinput`/`input`** pairs via **`insertTextSync`**, so keystrokes cannot straddle the flush interval. The controlled-host echo scenario waits until the **latest** mutation contains the full typed text (**`mutations.at(-1)`**) before echoing it back.
> 
> **Unit coverage** moves typing-debounce behavior (**250ms** **`TYPE_DEBOUNCE`**, merge-on-burst, eager flush on non-typing ops) into **`mutation-batcher.test.ts`** with fake timers and a harness **`sendOperation`** hook, since synchronous browser bursts no longer exercise inter-key gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c22f98b2271da6cd92b89ec5a96500474fd528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->