### PR TITLE
test: make the mutation-batching browser tests cadence-independent (v7)

### DIFF
--- a/packages/editor/src/editor/mutation-batcher.test.ts
+++ b/packages/editor/src/editor/mutation-batcher.test.ts
@@ -1,12 +1,18 @@
 import type {Patch} from '@portabletext/patches'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {
+  emitOperationEvent,
+  type OperationEvent,
+} from '../engine/core/operation-channel'
 import {createEditor} from '../engine/create-editor'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
 import {createMutationBatcher} from './mutation-batcher'
 import {createRelay} from './relay'
 
 const FLUSH_INTERVAL = 500
+const TYPE_DEBOUNCE = 250
 
 function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
   const editorEngine = createEditor() as PortableTextEditorEngine
@@ -77,11 +83,47 @@ function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
     setReadOnly: (value: boolean) => {
       isReadOnly = value
     },
+    sendOperation: (operation: EngineOperation) => {
+      emitOperationEvent(
+        editorEngine.operationListeners.before,
+        createOperationEvent(operation),
+      )
+    },
   }
 }
 
 function createPatch(path: string): Patch {
   return {type: 'set', path: [{_key: path}], value: path, origin: 'local'}
+}
+
+function createOperationEvent(operation: EngineOperation): OperationEvent {
+  return {
+    operation,
+    beforeValue: [],
+    beforeSelection: null,
+    operationsInProgress: false,
+    isNormalizingNode: false,
+    isPatching: false,
+    isProcessingRemoteChanges: false,
+    isUndoing: false,
+    isRedoing: false,
+    withHistory: false,
+    undoStepId: undefined,
+    origin: 'local',
+  }
+}
+
+function createInsertTextOperation(text: string): EngineOperation {
+  return {
+    type: 'insert.text',
+    path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+    offset: 0,
+    text,
+  }
+}
+
+function createSetOperation(): EngineOperation {
+  return {type: 'set', path: [{_key: 'b1'}, 'style'], value: 'h1'}
 }
 
 describe('mutation batcher', () => {
@@ -165,5 +207,44 @@ describe('mutation batcher', () => {
 
     expect(harness.mutationSends).toEqual([{patches: [createPatch('a')]}])
     expect(harness.editorEngine.isDeferringMutations).toBe(false)
+  })
+
+  test('merges a typing burst into one mutation and flushes at the last op plus the type debounce', () => {
+    const harness = createTestHarness()
+
+    harness.sendOperation(createInsertTextOperation('a'))
+    harness.sendPatch(createPatch('a'), 'op-1')
+
+    vi.advanceTimersByTime(100)
+
+    harness.sendOperation(createInsertTextOperation('b'))
+    harness.sendPatch(createPatch('b'), 'op-1')
+
+    // The first op's debounce would have fired here had the second op not
+    // reset it: still nothing flushed, so the burst didn't split per-op.
+    vi.advanceTimersByTime(TYPE_DEBOUNCE - 100)
+    expect(harness.mutationSends).toHaveLength(0)
+
+    // The second op's own debounce fires 250ms after it, not the interval
+    // (500ms, not yet reached).
+    vi.advanceTimersByTime(100)
+    expect(harness.mutationSends).toEqual([
+      {patches: [createPatch('a'), createPatch('b')]},
+    ])
+  })
+
+  test('a non-typing operation flushes eagerly, ending an in-progress typing session', () => {
+    const harness = createTestHarness()
+
+    harness.sendOperation(createInsertTextOperation('a'))
+    harness.sendPatch(createPatch('a'), 'op-1')
+
+    vi.advanceTimersByTime(50)
+
+    harness.sendOperation(createSetOperation())
+
+    // Flushed synchronously by the non-typing operation, well before the
+    // type debounce (250ms) or the flush interval (500ms) would fire.
+    expect(harness.mutationSends).toEqual([{patches: [createPatch('a')]}])
   })
 })

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -4,7 +4,7 @@ import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {useState} from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {page, userEvent} from 'vitest/browser'
+import {page, userEvent, type Locator} from 'vitest/browser'
 import {
   EditorProvider,
   PortableTextEditable,
@@ -109,15 +109,14 @@ describe('event.mutation', () => {
       ),
     })
 
-    // Each burst flushes into a single mutation: the keystrokes share one undo
-    // step (the key the batcher merges on) and a burst finishes well inside the
-    // batcher's `FLUSH_INTERVAL`, so the fixed flush cadence never fires
-    // mid-burst. Waiting on the settled count (rather than sleeping a fixed
-    // period) lets the first burst flush via its typing debounce before the
-    // second burst opens a fresh undo step.
-    await userEvent.type(locator, 'foo')
+    await userEvent.click(locator)
+
+    // Dispatched synchronously, back-to-back, one `insert.text` op per
+    // dispatched event: the burst can't straddle the batcher's flush
+    // cadence because nothing yields the event loop between the ops.
+    insertTextSync(locator, 'foo')
     await vi.waitFor(() => expect(mutations).toHaveLength(1))
-    await userEvent.type(locator, 'bar')
+    insertTextSync(locator, 'bar')
     await vi.waitFor(() => expect(mutations).toHaveLength(2))
 
     expect(mutations[0]!.value).toEqual([
@@ -264,3 +263,24 @@ describe('event.mutation', () => {
     })
   })
 })
+
+function insertTextSync(locator: Locator, text: string) {
+  const element = locator.element()
+  for (const character of text) {
+    element.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: character,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    // A real keystroke's native default action fires `input` synchronously;
+    // a script-dispatched `beforeinput` is untrusted and the browser skips
+    // that default action, so the editable's deferred native-path insert
+    // (gated on `insertText` with a collapsed selection, a single `[a-z ]`
+    // character, and a nonzero anchor offset, see the `native` fast path
+    // in `editable.tsx`) never flushes without this.
+    element.dispatchEvent(new InputEvent('input', {bubbles: true}))
+  }
+}

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -2384,14 +2384,25 @@ describe('event.update value: auto-resolved invalid blocks', () => {
     await userEvent.click(locator)
     await userEvent.type(locator, 'foo')
 
+    // On slow CI the typed burst can run slower than the flush interval
+    // and split across two mutations; wait for the latest one to carry
+    // the whole typed text before echoing it back.
     await vi.waitFor(() => {
-      expect(mutations.length).toBeGreaterThan(0)
+      expect(mutations.at(-1)?.value).toEqual([
+        {
+          _key: 'k0',
+          _type: 'block',
+          children: [{_key: 'k1', _type: 'span', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
     })
 
     // The controlled-host flow: the host receives the mutation and echoes
     // the value back down. After the echo the machine holds a non-empty
     // synced value, so a later `[]` is a genuine remote clear.
-    editor.send({type: 'update value', value: mutations[0]!.value})
+    editor.send({type: 'update value', value: mutations.at(-1)!.value})
 
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.value).toEqual([


### PR DESCRIPTION
Backport of #3178 to the `editor-v7.x` line, which demonstrated the flake itself: this branch's webkit job failed the update-value echo scenario on the changesets-tooling PR. Cherry-picked with no adaptations (this branch's batcher, test files, and the `native` fast-path gate match `main`); the unit pins were red-verified on this branch by neutering the typing classification. Chromium runs 5x green per file; webkit does not connect locally, so this PR's CI is the webkit proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test files change; production mutation batcher behavior is unchanged.
> 
> **Overview**
> **Test-only** hardening so mutation-batching scenarios stop flaking when CI timing (especially WebKit) doesn’t match the batcher’s 500ms flush interval and 250ms typing debounce.
> 
> Unit coverage in `mutation-batcher.test.ts` now drives the batcher through `sendOperation` / operation-channel events and adds cases for **typing bursts** (debounce reset, single merged mutation) and **eager flush** when a non-typing op ends a typing session.
> 
> Browser tests no longer assume `userEvent.type` finishes inside one batch: `event.mutation.test.tsx` uses synchronous `beforeinput`/`input` per character via `insertTextSync` so a burst can’t straddle the flush cadence, and `event.update-value.test.tsx` waits for the **latest** mutation to contain the full typed text (`mutations.at(-1)`) before echoing it in the controlled-host flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8dc2d85c5b0b37dc67e868640c9502cdce24bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->