### PR TITLE
test: make the mutation-batching browser test cadence-independent (v6)

### DIFF
--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -4,7 +4,7 @@ import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {useState} from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
-import {page, userEvent} from 'vitest/browser'
+import {page, userEvent, type Locator} from 'vitest/browser'
 import {
   EditorProvider,
   PortableTextEditable,
@@ -107,12 +107,16 @@ describe('event.mutation', () => {
       ),
     })
 
-    await userEvent.type(locator, 'foo')
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    await userEvent.type(locator, 'bar')
-    await new Promise((resolve) => setTimeout(resolve, 250))
+    await userEvent.click(locator)
 
-    expect(mutations).toHaveLength(2)
+    // Dispatched synchronously, back-to-back, one `insert.text` op per
+    // dispatched event: the burst can't straddle the flush interval
+    // because nothing yields the event loop between the ops.
+    insertTextSync(locator, 'foo')
+    await vi.waitFor(() => expect(mutations).toHaveLength(1))
+    insertTextSync(locator, 'bar')
+    await vi.waitFor(() => expect(mutations).toHaveLength(2))
+
     expect(mutations[0]!.value).toEqual([
       {
         _type: 'block',
@@ -257,3 +261,25 @@ describe('event.mutation', () => {
     })
   })
 })
+
+function insertTextSync(locator: Locator, text: string) {
+  const element = locator.element()
+  for (const character of text) {
+    element.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: character,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    // A real keystroke's native default action fires `input` synchronously;
+    // a script-dispatched `beforeinput` is untrusted and the browser skips
+    // that default action, so the editable's deferred native-path insert
+    // (gated on `insertText` with a collapsed selection, a single `[a-z ]`
+    // character, and a nonzero anchor offset, see the `native` fast path
+    // in `src/slate/react/components/editable.tsx`) never flushes without
+    // this.
+    element.dispatchEvent(new InputEvent('input', {bubbles: true}))
+  }
+}


### PR DESCRIPTION
Backport of #3178 to the `editor-v6.x` line, which demonstrated the flake itself: this branch's webkit job failed "Batching typing mutations" (three mutations instead of two) on the changesets-tooling PR. Adaptations: the update-value echo scenario does not exist on this branch, so only the batching test ports, and this branch batches in `mutation-machine.ts` (no batcher harness), so the unit-level typing-debounce pins do not port; that contract stays unpinned here, acceptable for a maintenance branch that only receives backports. Chromium runs 5x green plus the full editor chromium suite; webkit does not connect locally, so this PR's CI is the webkit proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `event.mutation.test.tsx`; no production editor or batching logic is modified.
> 
> **Overview**
> **Stabilizes the "Batching typing mutations" browser test** so it no longer depends on `userEvent.type` plus fixed `setTimeout` gaps, which could flake (e.g. WebKit emitting three mutations instead of two when timing straddled the flush interval).
> 
> The test now focuses the field, injects text with a new **`insertTextSync`** helper that fires paired `beforeinput` / `input` events per character (mirroring the editable’s native fast path when scripted `beforeinput` is untrusted), and uses **`vi.waitFor`** to assert exactly one mutation after `foo` and a second after `bar`. Expectations on mutation payloads are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f089919e70bf7fec7d9adda5b47b30920ee1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->