### PR TITLE
fix: rename colliding keys before a text block merge deletes the merging block

### DIFF
--- a/.changeset/fix-key-rename-undo-inverse.md
+++ b/.changeset/fix-key-rename-undo-inverse.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: locate a renamed node by its new key when undoing a `_key` change
+
+Undoing an edit that renamed a node's own `_key` (a collision-avoiding rename ahead of a block merge, for example) left the node stuck under its new key instead of restoring the old one: the undo step tried to find the node by the key it had before the rename, which no longer resolved to anything once the rename had applied. Undoing now locates the node by its current key first, so a rename reverts cleanly along with everything else in the same undo step.

--- a/.changeset/rekey-point-transform-path-scoped.md
+++ b/.changeset/rekey-point-transform-path-scoped.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: re-point positions only at the renamed node's own path when a `_key` changes
+
+Renaming a node's `_key` no longer drags carets, selections, or tracked ranges sitting on an unrelated node that happens to carry the same key (keys are only unique among siblings, so twins across blocks are legal). Positions on the renamed node itself follow the rename as before; everything else stays put.

--- a/.changeset/rename-colliding-keys-before-merge.md
+++ b/.changeset/rename-colliding-keys-before-merge.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: rename colliding keys before a text block merge deletes the merging block
+
+Merging a text block into its neighbor (backspace at its start, or forward delete at the end of the block before it) could silently mint fresh `_key`s for any child span or annotation whose key collided with one already in the destination block. On the wire this read as those nodes being destroyed and re-created rather than moved, so a collaborator applying the same patches lost their caret through the merge instead of following it. The merge now renames the colliding keys first, so the emitted patches express the rename followed by the move instead of a destroy-and-create.

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -1,5 +1,11 @@
-import {isSpan, isTextBlock} from '@portabletext/schema'
-import {isTextBlockNode} from '../engine/node/is-text-block-node'
+import {
+  isSpan,
+  isTextBlock,
+  type PortableTextTextBlock,
+  type Schema,
+} from '@portabletext/schema'
+import type {Path} from '../engine/interfaces/path'
+import {isEqualMarks} from '../internal-utils/equality'
 import {getFocusChild} from '../selectors/selector.get-focus-child'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
@@ -9,7 +15,7 @@ import {getSibling} from '../traversal/get-sibling'
 import {getBlockEndPoint} from '../utils/util.get-block-end-point'
 import {getBlockStartPoint} from '../utils/util.get-block-start-point'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
-import {raise} from './behavior.types.action'
+import {raise, type BehaviorAction} from './behavior.types.action'
 import {defineBehavior} from './behavior.types.behavior'
 
 export const abstractDeleteBehaviors = [
@@ -83,10 +89,26 @@ export const abstractDeleteBehaviors = [
         block: previousBlock,
       })
 
-      return {previousBlockEndPoint, focusTextBlock}
+      const {renamedBlock, renameActions} = planMergeKeyRenames({
+        context: snapshot.context,
+        mergingBlockPath: focusTextBlock.path,
+        mergingBlock: focusTextBlock.node,
+        destinationBlock: previousBlock.node,
+      })
+
+      return {
+        previousBlockEndPoint,
+        focusTextBlock,
+        renamedBlock,
+        renameActions,
+      }
     },
     actions: [
-      (_, {previousBlockEndPoint, focusTextBlock}) => [
+      (
+        _,
+        {previousBlockEndPoint, focusTextBlock, renamedBlock, renameActions},
+      ) => [
+        ...renameActions,
         raise({
           type: 'delete.block',
           at: focusTextBlock.path,
@@ -100,7 +122,7 @@ export const abstractDeleteBehaviors = [
         }),
         raise({
           type: 'insert.block',
-          block: focusTextBlock.node,
+          block: renamedBlock,
           placement: 'auto',
           select: 'start',
         }),
@@ -231,21 +253,33 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
-      if (!isTextBlockNode(snapshot.context, nextSibling.node)) {
+      if (!isTextBlock(snapshot.context, nextSibling.node)) {
         return false
       }
 
-      return {nextBlock: {node: nextSibling.node, path: nextSibling.path}}
+      const {renamedBlock, renameActions} = planMergeKeyRenames({
+        context: snapshot.context,
+        mergingBlockPath: nextSibling.path,
+        mergingBlock: nextSibling.node,
+        destinationBlock: focusTextBlock.node,
+      })
+
+      return {
+        nextBlockPath: nextSibling.path,
+        renamedBlock,
+        renameActions,
+      }
     },
     actions: [
-      (_, {nextBlock}) => [
+      (_, {nextBlockPath, renamedBlock, renameActions}) => [
+        ...renameActions,
         raise({
           type: 'delete.block',
-          at: nextBlock.path,
+          at: nextBlockPath,
         }),
         raise({
           type: 'insert.block',
-          block: nextBlock.node,
+          block: renamedBlock,
           placement: 'auto',
           select: 'none',
         }),
@@ -332,3 +366,107 @@ export const abstractDeleteBehaviors = [
     actions: [({event}) => [raise({...event, type: 'delete'})]],
   }),
 ]
+
+/**
+ * A block merge folds `mergingBlock`'s children (and markDefs) into
+ * `destinationBlock` by key. Any key the merging block shares with the
+ * destination has to be renamed before the merge, or `insert.block`'s own
+ * collision handling mints a fresh key for it, which reads on the wire as
+ * that node being destroyed and a new one created instead of moved.
+ *
+ * Renames are raised as `set`/`child.set` events against the still-living
+ * `mergingBlock`, so they land on the wire before the merge's `unset`.
+ * `renamedBlock` mirrors the same renames applied to the value the caller
+ * already captured, since raising the rename events now doesn't change
+ * that captured value.
+ */
+function planMergeKeyRenames(args: {
+  context: {schema: Schema; keyGenerator: () => string}
+  mergingBlockPath: Path
+  mergingBlock: PortableTextTextBlock
+  destinationBlock: PortableTextTextBlock
+}): {
+  renamedBlock: PortableTextTextBlock
+  renameActions: Array<BehaviorAction>
+} {
+  const {context, mergingBlockPath, mergingBlock, destinationBlock} = args
+
+  const destinationChildKeys = new Set(
+    destinationBlock.children.map((child) => child._key),
+  )
+  const destinationMarkDefKeys = new Set(
+    (destinationBlock.markDefs ?? []).map((markDef) => markDef._key),
+  )
+
+  const markDefKeyMap = new Map<string, string>()
+  const renamedMarkDefs = mergingBlock.markDefs?.map((markDef) => {
+    if (!destinationMarkDefKeys.has(markDef._key)) {
+      return markDef
+    }
+
+    const newKey = context.keyGenerator()
+    markDefKeyMap.set(markDef._key, newKey)
+    return {...markDef, _key: newKey}
+  })
+
+  const renameActions: Array<BehaviorAction> = []
+
+  for (const markDef of mergingBlock.markDefs ?? []) {
+    const newKey = markDefKeyMap.get(markDef._key)
+
+    if (newKey) {
+      renameActions.push(
+        raise({
+          type: 'set',
+          at: [...mergingBlockPath, 'markDefs', {_key: markDef._key}, '_key'],
+          value: newKey,
+        }),
+      )
+    }
+  }
+
+  const renamedChildren = mergingBlock.children.map((child) => {
+    const currentMarks = isSpan(context, child) ? child.marks : undefined
+    const remappedMarks = currentMarks?.map(
+      (mark) => markDefKeyMap.get(mark) ?? mark,
+    )
+    const marksChanged = Boolean(
+      remappedMarks && !isEqualMarks(remappedMarks, currentMarks),
+    )
+
+    const newKey = destinationChildKeys.has(child._key)
+      ? context.keyGenerator()
+      : child._key
+
+    const props: Record<string, unknown> = {}
+    if (newKey !== child._key) {
+      props['_key'] = newKey
+    }
+    if (marksChanged) {
+      props['marks'] = remappedMarks
+    }
+
+    if (Object.keys(props).length > 0) {
+      renameActions.push(
+        raise({
+          type: 'child.set',
+          at: [...mergingBlockPath, 'children', {_key: child._key}],
+          props,
+        }),
+      )
+    }
+
+    return marksChanged
+      ? {...child, _key: newKey, marks: remappedMarks}
+      : {...child, _key: newKey}
+  })
+
+  return {
+    renamedBlock: {
+      ...mergingBlock,
+      children: renamedChildren,
+      ...(mergingBlock.markDefs ? {markDefs: renamedMarkDefs} : {}),
+    },
+    renameActions,
+  }
+}

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -169,10 +169,23 @@ export function applyOperation(editor: Editor, op: EngineOperation): void {
 
       if (!op.inverse && !editor.isProcessingRemoteChanges) {
         const previousValue = getValue(editor.snapshot.context.value, path)
+        const lastSegment = path[path.length - 1]
+
+        // Renaming a node's own `_key` moves how it resolves: from here on
+        // it's found by the new key, so the inverse (which runs after the
+        // rename) has to target that key too, or it can never find the
+        // node to restore.
+        const inversePath =
+          lastSegment === '_key' &&
+          typeof value === 'string' &&
+          isKeyedSegment(path[path.length - 2])
+            ? [...path.slice(0, -2), {_key: value}, '_key']
+            : path
+
         op.inverse =
           previousValue === undefined
-            ? {type: 'unset', path}
-            : {type: 'set', path, value: previousValue}
+            ? {type: 'unset', path: inversePath}
+            : {type: 'set', path: inversePath, value: previousValue}
       }
 
       // Root-level value replacement: set editor.snapshot.context.value directly

--- a/packages/editor/src/engine/point/step-mapper.test.ts
+++ b/packages/editor/src/engine/point/step-mapper.test.ts
@@ -300,25 +300,65 @@ describe(mapPointThroughStep.name, () => {
   })
 
   describe('rekey', () => {
-    test('substitutes the old key with the new key wherever it appears in the path', () => {
+    test('substitutes the old key with the new key at the segment directly under the step path', () => {
       const point = {
         path: [{_key: 'b1'}, 'children', {_key: 's1'}],
         offset: 3,
       }
-      const step: Step = {type: 'rekey', oldKey: 's1', newKey: 's2'}
+      const step: Step = {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's1',
+        newKey: 's2',
+      }
       expect(mapPointThroughStep(step, point)).toEqual({
         path: [{_key: 'b1'}, 'children', {_key: 's2'}],
         offset: 3,
       })
     })
 
-    test('is a no-op when the old key is not in the path', () => {
+    test('is a no-op when the old key is not the segment under the step path', () => {
       const point = {
         path: [{_key: 'b1'}, 'children', {_key: 's1'}],
         offset: 3,
       }
-      const step: Step = {type: 'rekey', oldKey: 's9', newKey: 's2'}
+      const step: Step = {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's9',
+        newKey: 's2',
+      }
       expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op when the key matches but at a different depth than the step path', () => {
+      const point = {
+        path: [
+          {_key: 'b1'},
+          'children',
+          {_key: 's1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's1',
+        newKey: 's2',
+      }
+
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'b1'},
+          'children',
+          {_key: 's2'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 3,
+      })
     })
   })
 
@@ -733,7 +773,12 @@ describe(mapPointThroughStep.name, () => {
         ],
         offset: 3,
       }
-      const step: Step = {type: 'rekey', oldKey: 'cell1', newKey: 'cell2'}
+      const step: Step = {
+        type: 'rekey',
+        path: [{_key: 'container1'}, 'rows', {_key: 'row1'}, 'cells'],
+        oldKey: 'cell1',
+        newKey: 'cell2',
+      }
       expect(mapPointThroughStep(step, point)).toEqual({
         path: [
           {_key: 'container1'},
@@ -808,7 +853,12 @@ describe(mapPointThroughSteps.name, () => {
         offset: 3,
         text: 'abc',
       },
-      {type: 'rekey', oldKey: 's1', newKey: 's2'},
+      {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's1',
+        newKey: 's2',
+      },
     ]
     expect(mapPointThroughSteps(steps, point)).toEqual({
       path: [{_key: 'b1'}, 'children', {_key: 's2'}],
@@ -823,7 +873,12 @@ describe(mapPointThroughSteps.name, () => {
     }
     const steps: Step[] = [
       {type: 'remove.node', path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
-      {type: 'rekey', oldKey: 's1', newKey: 's2'},
+      {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's1',
+        newKey: 's2',
+      },
     ]
     expect(mapPointThroughSteps(steps, point)).toEqual(null)
   })
@@ -837,7 +892,14 @@ describe(mapPointThroughSteps.name, () => {
   })
 
   test('a null point stays null through a batch', () => {
-    const steps: Step[] = [{type: 'rekey', oldKey: 's1', newKey: 's2'}]
+    const steps: Step[] = [
+      {
+        type: 'rekey',
+        path: [{_key: 'b1'}, 'children'],
+        oldKey: 's1',
+        newKey: 's2',
+      },
+    ]
     expect(mapPointThroughSteps(steps, null)).toEqual(null)
   })
 })

--- a/packages/editor/src/engine/point/step-mapper.ts
+++ b/packages/editor/src/engine/point/step-mapper.ts
@@ -38,8 +38,19 @@ export type UnsetTextStep = {
   path: Path
 }
 
+/**
+ * `path` is the array holding the renamed node (its parent path, one
+ * segment shallower than the node itself): the node's own segment,
+ * `oldKey`, is only rewritten at that exact depth under that exact
+ * parent, never wherever the key value happens to recur. A rename only
+ * ever touches one node; matching by key value alone would also rewrite
+ * an unrelated point that merely walks through a same-keyed node
+ * elsewhere in the tree (a duplicate-key merge's destination block, most
+ * notably, since it starts out sharing every key the donor block does).
+ */
 export type RekeyStep = {
   type: 'rekey'
+  path: Path
   oldKey: string
   newKey: string
 }
@@ -118,20 +129,26 @@ export function mapPointThroughStep(
     }
 
     case 'rekey': {
-      let path: Path | undefined
-
-      for (let i = 0; i < point.path.length; i++) {
-        const segment = point.path[i]
-
-        if (isKeyedSegment(segment) && segment._key === step.oldKey) {
-          if (path === undefined) {
-            path = [...point.path]
-          }
-          path[i] = {_key: step.newKey}
-        }
+      if (
+        point.path.length <= step.path.length ||
+        !pathEquals(point.path.slice(0, step.path.length), step.path)
+      ) {
+        return point
       }
 
-      return path === undefined ? point : {path, offset: point.offset}
+      const segment = point.path[step.path.length]
+      if (!isKeyedSegment(segment) || segment._key !== step.oldKey) {
+        return point
+      }
+
+      return {
+        path: [
+          ...step.path,
+          {_key: step.newKey},
+          ...point.path.slice(step.path.length + 1),
+        ],
+        offset: point.offset,
+      }
     }
 
     case 'replace.children': {

--- a/packages/editor/src/engine/point/transform-point.ts
+++ b/packages/editor/src/engine/point/transform-point.ts
@@ -47,7 +47,16 @@ function operationToSteps(op: EngineOperation): Step[] {
             ? op.inverse.value
             : undefined
 
-        return oldKey ? [{type: 'rekey', oldKey, newKey: op.value}] : []
+        return oldKey
+          ? [
+              {
+                type: 'rekey',
+                path: nodePath.slice(0, -1),
+                oldKey,
+                newKey: op.value,
+              },
+            ]
+          : []
       }
 
       if (propertyName === 'text') {

--- a/packages/editor/src/internal-utils/set-node-properties.ts
+++ b/packages/editor/src/internal-utils/set-node-properties.ts
@@ -42,23 +42,33 @@ export function setNodeProperties(
     if (propsRecord[key] !== nodeRecord[key]) {
       if (propsRecord[key] != null) {
         const hadProperty = nodeRecord.hasOwnProperty(key)
+        const lastSegment = currentPath[currentPath.length - 1]
+
+        // Renaming the node's own `_key` moves how it resolves: from here
+        // on it's found by the new key, so the inverse (which runs after
+        // the rename) has to target that key too, or it can never find
+        // the node to restore.
+        const renamedPath =
+          key === '_key' &&
+          typeof propsRecord[key] === 'string' &&
+          isKeyedSegment(lastSegment)
+            ? [...currentPath.slice(0, -1), {_key: propsRecord[key] as string}]
+            : undefined
+        const inversePath = renamedPath
+          ? [...renamedPath, key]
+          : [...currentPath, key]
+
         editor.apply({
           type: 'set',
           path: [...currentPath, key],
           value: propsRecord[key],
           inverse: hadProperty
-            ? {type: 'set', path: [...currentPath, key], value: nodeRecord[key]}
-            : {type: 'unset', path: [...currentPath, key]},
+            ? {type: 'set', path: inversePath, value: nodeRecord[key]}
+            : {type: 'unset', path: inversePath},
         })
-        // After _key changes, update the path for subsequent operations
-        if (key === '_key' && typeof propsRecord[key] === 'string') {
-          const lastSegment = currentPath[currentPath.length - 1]
-          if (isKeyedSegment(lastSegment)) {
-            currentPath = [
-              ...currentPath.slice(0, -1),
-              {_key: propsRecord[key] as string},
-            ]
-          }
+
+        if (renamedPath) {
+          currentPath = renamedPath
         }
       } else if (nodeRecord.hasOwnProperty(key)) {
         // Value is null/undefined and property exists on node: unset it

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys-forward.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys-forward.json
@@ -1,0 +1,321 @@
+{
+  "scenario": "block-merge-duplicate-keys-forward",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": [
+    {
+      "_type": "block",
+      "_key": "kA",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_type": "block",
+      "_key": "kB",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ],
+  "seedTerse": [
+    "foo ,bar, baz",
+    "foo ,bar, baz"
+  ],
+  "actions": [
+    "select {caret at end of block 1}",
+    "send {type: 'delete.forward', unit: 'character'}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s1"
+        },
+        "_key"
+      ],
+      "value": "k2",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s2"
+        },
+        "_key"
+      ],
+      "value": "k3",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "_key"
+      ],
+      "value": "k4",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kB"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k5",
+          "marks": [],
+          "text": ""
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k2",
+          "text": "foo ",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k3",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k4",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,8 @@\n  baz\n+foo \n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k5"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "resultTerse": [
+    "foo ,bar, bazfoo ,bar, baz"
+  ]
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys-markdefs.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys-markdefs.json
@@ -1,0 +1,391 @@
+{
+  "scenario": "block-merge-duplicate-keys-markdefs",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ],
+    "annotations": [
+      {
+        "name": "link",
+        "fields": [
+          {
+            "name": "href",
+            "type": "string"
+          }
+        ]
+      }
+    ]
+  },
+  "seed": [
+    {
+      "_type": "block",
+      "_key": "kA",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong",
+            "link1"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [
+        {
+          "_type": "link",
+          "_key": "link1",
+          "href": "https://a.example"
+        }
+      ],
+      "style": "normal"
+    },
+    {
+      "_type": "block",
+      "_key": "kB",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong",
+            "link1"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [
+        {
+          "_type": "link",
+          "_key": "link1",
+          "href": "https://b.example"
+        }
+      ],
+      "style": "normal"
+    }
+  ],
+  "seedTerse": [
+    "foo ,bar, baz",
+    "foo ,bar, baz"
+  ],
+  "actions": [
+    "select {caret at start of block 2}",
+    "send {type: 'delete.backward', unit: 'character'}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "markDefs",
+        {
+          "_key": "link1"
+        },
+        "_key"
+      ],
+      "value": "k2",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s1"
+        },
+        "_key"
+      ],
+      "value": "k3",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s2"
+        },
+        "_key"
+      ],
+      "value": "k4",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "k4"
+        },
+        "marks"
+      ],
+      "value": [
+        "strong",
+        "k2"
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "_key"
+      ],
+      "value": "k5",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kB"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "markDefs"
+      ],
+      "value": [
+        {
+          "_type": "link",
+          "_key": "link1",
+          "href": "https://a.example"
+        },
+        {
+          "_type": "link",
+          "_key": "k2",
+          "href": "https://b.example"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k6",
+          "marks": [],
+          "text": ""
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k3",
+          "text": "foo ",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k4",
+          "text": "bar",
+          "marks": [
+            "strong",
+            "k2"
+          ]
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k4"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k5",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,8 @@\n  baz\n+foo \n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k6"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "resultTerse": [
+    "foo ,bar, bazfoo ,bar, baz"
+  ]
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-merge-duplicate-keys.json
@@ -1,0 +1,321 @@
+{
+  "scenario": "block-merge-duplicate-keys",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": [
+    {
+      "_type": "block",
+      "_key": "kA",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_type": "block",
+      "_key": "kB",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "s1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "s2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        },
+        {
+          "_type": "span",
+          "_key": "s3",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ],
+  "seedTerse": [
+    "foo ,bar, baz",
+    "foo ,bar, baz"
+  ],
+  "actions": [
+    "select {caret at start of block 2}",
+    "send {type: 'delete.backward', unit: 'character'}"
+  ],
+  "patches": [
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s1"
+        },
+        "_key"
+      ],
+      "value": "k2",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s2"
+        },
+        "_key"
+      ],
+      "value": "k3",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "_key"
+      ],
+      "value": "k4",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kB"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "markDefs"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k5",
+          "marks": [],
+          "text": ""
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k2",
+          "text": "foo ",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k3",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k4",
+          "text": " baz",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "s3"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,8 @@\n  baz\n+foo \n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k5"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "resultTerse": [
+    "foo ,bar, bazfoo ,bar, baz"
+  ]
+}

--- a/packages/editor/tests/block-merge-duplicate-keys.test.tsx
+++ b/packages/editor/tests/block-merge-duplicate-keys.test.tsx
@@ -1,0 +1,404 @@
+import type {Patch} from '@portabletext/patches'
+import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {userEvent} from 'vitest/browser'
+import {EventListenerPlugin} from '../src/plugins'
+import {createTestEditor} from '../src/test/vitest'
+
+function duplicateKeyedChildren() {
+  return [
+    {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+    {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+    {_type: 'span', _key: 's3', text: ' baz', marks: []},
+  ]
+}
+
+function duplicateKeyedInitialValue(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'block',
+      _key: 'kA',
+      children: duplicateKeyedChildren(),
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'block',
+      _key: 'kB',
+      children: duplicateKeyedChildren(),
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+}
+
+function duplicateKeyedChildrenWithLink(linkMarkDefKey: string) {
+  return [
+    {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+    {_type: 'span', _key: 's2', text: 'bar', marks: ['strong', linkMarkDefKey]},
+    {_type: 'span', _key: 's3', text: ' baz', marks: []},
+  ]
+}
+
+function duplicateKeyedInitialValueWithLink(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'block',
+      _key: 'kA',
+      children: duplicateKeyedChildrenWithLink('link1'),
+      markDefs: [{_type: 'link', _key: 'link1', href: 'https://a.example'}],
+      style: 'normal',
+    },
+    {
+      _type: 'block',
+      _key: 'kB',
+      children: duplicateKeyedChildrenWithLink('link1'),
+      markDefs: [{_type: 'link', _key: 'link1', href: 'https://b.example'}],
+      style: 'normal',
+    },
+  ]
+}
+
+const duplicateKeyMergeSchema = defineSchema({decorators: [{name: 'strong'}]})
+
+/**
+ * Backspace-merge `kB` into `kA` in a fresh editor over
+ * `duplicateKeyedInitialValue`, capturing every patch it emits.
+ */
+async function mergeDuplicateKeyedBlocks() {
+  const patches: Array<Patch> = []
+
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition: duplicateKeyMergeSchema,
+    initialValue: duplicateKeyedInitialValue(),
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            patches.push(event.patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  await userEvent.click(locator)
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+    },
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      backward: false,
+    })
+  })
+
+  editor.send({type: 'delete.backward', unit: 'character'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value.length).toBe(1)
+  })
+
+  return {editor, patches}
+}
+
+describe('Feature: block merge renames colliding keys', () => {
+  test('Scenario: backspace-merging blocks whose children share keys renames instead of re-minting', async () => {
+    const {editor, patches} = await mergeDuplicateKeyedBlocks()
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+            {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: 's3', text: ' bazfoo ', marks: []},
+            {_type: 'span', _key: 'k3', text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: 'k4', text: ' baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // The three colliding children get renamed with keyed `set` patches on
+    // `_key` before the merging block is unset, so a receiver applying the
+    // patches in order never sees a duplicate key and can follow each
+    // renamed child by its new key instead of losing it to a destroy/create.
+    const keySetPatches = patches.filter(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === '_key',
+    )
+    const unsetKbIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'unset' &&
+        patch.path.length === 1 &&
+        typeof patch.path[0] === 'object' &&
+        patch.path[0] !== null &&
+        '_key' in patch.path[0] &&
+        patch.path[0]._key === 'kB',
+    )
+
+    expect(keySetPatches).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's1'}, '_key'],
+        value: 'k2',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's2'}, '_key'],
+        value: 'k3',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's3'}, '_key'],
+        value: 'k4',
+        origin: 'local',
+      },
+    ])
+    expect(unsetKbIndex).toBeGreaterThan(-1)
+    for (const keySetPatch of keySetPatches) {
+      expect(patches.indexOf(keySetPatch)).toBeLessThan(unsetKbIndex)
+    }
+
+    // Every child inserted back under `kA` carries a renamed key: none of
+    // the merging block's original `s1`/`s2`/`s3` keys reach the insert, so
+    // nothing collides with `kA`'s own children of the same name.
+    const insertedKeys = patches.flatMap((patch) =>
+      patch.type === 'insert'
+        ? patch.items.flatMap((item) =>
+            typeof item === 'object' && item !== null && '_key' in item
+              ? [item['_key']]
+              : [],
+          )
+        : [],
+    )
+    expect(insertedKeys).toEqual(['k5', 'k2', 'k3', 'k4'])
+  })
+
+  test('Scenario: forward-deleting at block end renames colliding keys the same way', async () => {
+    const patches: Array<Patch> = []
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: duplicateKeyMergeSchema,
+      initialValue: duplicateKeyedInitialValue(),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+        focus: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+        focus: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'delete.forward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    const keySetPatches = patches.filter(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === '_key',
+    )
+    const unsetKbIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'unset' &&
+        patch.path.length === 1 &&
+        typeof patch.path[0] === 'object' &&
+        patch.path[0] !== null &&
+        '_key' in patch.path[0] &&
+        patch.path[0]._key === 'kB',
+    )
+
+    expect(keySetPatches).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's1'}, '_key'],
+        value: 'k2',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's2'}, '_key'],
+        value: 'k3',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's3'}, '_key'],
+        value: 'k4',
+        origin: 'local',
+      },
+    ])
+    expect(patches.indexOf(keySetPatches[2] as Patch)).toBeLessThan(
+      unsetKbIndex,
+    )
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+            {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: 's3', text: ' bazfoo ', marks: []},
+            {_type: 'span', _key: 'k3', text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: 'k4', text: ' baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: a colliding markDef is renamed and every mark referencing it is rewritten before the merge', async () => {
+    const schemaDefinition = defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const patches: Array<Patch> = []
+
+    const {editor: editor1, locator: locator1} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: duplicateKeyedInitialValueWithLink(),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator1)
+
+    editor1.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor1.getSnapshot().context.selection).not.toBeNull()
+    })
+
+    editor1.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor1.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+            {
+              _type: 'span',
+              _key: 's2',
+              text: 'bar',
+              marks: ['strong', 'link1'],
+            },
+            {_type: 'span', _key: 's3', text: ' bazfoo ', marks: []},
+            {_type: 'span', _key: 'k4', text: 'bar', marks: ['strong', 'k2']},
+            {_type: 'span', _key: 'k5', text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_type: 'link', _key: 'link1', href: 'https://a.example'},
+            {_type: 'link', _key: 'k2', href: 'https://b.example'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+
+    // `kB`'s markDef collides with `kA`'s own `link1`, so it's renamed
+    // ahead of the merge, same as a colliding child key, before `kB` is
+    // unset.
+    const markDefKeySetPatch = patches.find(
+      (patch) =>
+        patch.type === 'set' &&
+        patch.path.at(-1) === '_key' &&
+        patch.path.at(-3) === 'markDefs',
+    )
+    expect(markDefKeySetPatch).toEqual({
+      type: 'set',
+      path: [{_key: 'kB'}, 'markDefs', {_key: 'link1'}, '_key'],
+      value: 'k2',
+      origin: 'local',
+    })
+
+    // `s2` carries the renamed markDef in its `marks`, so the rename
+    // rewrites that reference too, not just the markDef's own `_key`.
+    const marksRewritePatch = patches.find(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === 'marks',
+    )
+    expect(marksRewritePatch).toEqual({
+      type: 'set',
+      path: [{_key: 'kB'}, 'children', {_key: 'k4'}, 'marks'],
+      value: ['strong', 'k2'],
+      origin: 'local',
+    })
+
+    // Editor 2 starts from the same duplicate-markDef-keyed document and
+    // receives editor 1's patches as if they came over the wire.
+    const {editor: editor2} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: duplicateKeyedInitialValueWithLink(),
+    })
+
+    editor2.send({
+      type: 'patches',
+      patches: patches.map((patch) => ({...patch, origin: 'remote'})),
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor2.getSnapshot().context.value).toEqual(
+        editor1.getSnapshot().context.value,
+      )
+    })
+  })
+})

--- a/packages/editor/tests/block-merge-duplicate-keys.test.tsx
+++ b/packages/editor/tests/block-merge-duplicate-keys.test.tsx
@@ -288,6 +288,50 @@ describe('Feature: block merge renames colliding keys', () => {
     })
   })
 
+  test('Scenario: undoing the merge restores both original blocks, every `_key` included', async () => {
+    const {editor} = await mergeDuplicateKeyedBlocks()
+
+    const mergedValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [
+          {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+          {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+          {_type: 'span', _key: 's3', text: ' bazfoo ', marks: []},
+          {_type: 'span', _key: 'k3', text: 'bar', marks: ['strong']},
+          {_type: 'span', _key: 'k4', text: ' baz', marks: []},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    expect(editor.getSnapshot().context.value).toEqual(mergedValue)
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        duplicateKeyedInitialValue(),
+      )
+    })
+
+    editor.send({type: 'history.redo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(mergedValue)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        duplicateKeyedInitialValue(),
+      )
+    })
+  })
+
   test('Scenario: a colliding markDef is renamed and every mark referencing it is rewritten before the merge', async () => {
     const schemaDefinition = defineSchema({
       decorators: [{name: 'strong'}],

--- a/packages/editor/tests/wire-catalogue.test.tsx
+++ b/packages/editor/tests/wire-catalogue.test.tsx
@@ -174,6 +174,192 @@ describe('wire catalogue', () => {
     })
   })
 
+  test('Scenario: merging two blocks whose children share keys renames before the merge', async () => {
+    // Duplicate `_key`s across the two blocks: textspec mints keys itself
+    // and can't express a collision, so this seed is hand-built. See the
+    // file header.
+    const keyGenerator = createTestKeyGenerator()
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+    const duplicateKeyedChildren = (): Array<PortableTextSpan> => [
+      {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+      {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+      {_type: 'span', _key: 's3', text: ' baz', marks: []},
+    ]
+    const seed: Array<PortableTextTextBlock<PortableTextSpan>> = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: duplicateKeyedChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'kB',
+        children: duplicateKeyedChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, patches, schema, seedTerse} = await setupLegacyScenario({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: seed,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      },
+    })
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    await writeCapture({
+      scenario: 'block-merge-duplicate-keys',
+      schema,
+      seed,
+      seedTerse,
+      actions: [
+        'select {caret at start of block 2}',
+        "send {type: 'delete.backward', unit: 'character'}",
+      ],
+      patches,
+      resultTerse: getTersePt(editor.getSnapshot().context),
+    })
+  })
+
+  test('Scenario: merging blocks with duplicate keys with forward delete', async () => {
+    // Duplicate `_key`s across the two blocks: textspec mints keys itself
+    // and can't express a collision, so this seed is hand-built. See the
+    // file header.
+    const keyGenerator = createTestKeyGenerator()
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+    const duplicateKeyedChildren = (): Array<PortableTextSpan> => [
+      {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+      {_type: 'span', _key: 's2', text: 'bar', marks: ['strong']},
+      {_type: 'span', _key: 's3', text: ' baz', marks: []},
+    ]
+    const seed: Array<PortableTextTextBlock<PortableTextSpan>> = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: duplicateKeyedChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'kB',
+        children: duplicateKeyedChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, patches, schema, seedTerse} = await setupLegacyScenario({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: seed,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+        focus: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 4},
+      },
+    })
+    editor.send({type: 'delete.forward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    await writeCapture({
+      scenario: 'block-merge-duplicate-keys-forward',
+      schema,
+      seed,
+      seedTerse,
+      actions: [
+        'select {caret at end of block 1}',
+        "send {type: 'delete.forward', unit: 'character'}",
+      ],
+      patches,
+      resultTerse: getTersePt(editor.getSnapshot().context),
+    })
+  })
+
+  test('Scenario: merging blocks with duplicate keys and colliding markDefs', async () => {
+    // Duplicate `_key`s across the two blocks, including the `link1`
+    // markDef, so the merge must rename the annotation and rewrite the
+    // `marks` that reference it. Hand-built seed; see the file header.
+    const keyGenerator = createTestKeyGenerator()
+    const schemaDefinition = defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+    const duplicateKeyedLinkedChildren = (): Array<PortableTextSpan> => [
+      {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+      {_type: 'span', _key: 's2', text: 'bar', marks: ['strong', 'link1']},
+      {_type: 'span', _key: 's3', text: ' baz', marks: []},
+    ]
+    const seed: Array<PortableTextTextBlock<PortableTextSpan>> = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: duplicateKeyedLinkedChildren(),
+        markDefs: [{_type: 'link', _key: 'link1', href: 'https://a.example'}],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'kB',
+        children: duplicateKeyedLinkedChildren(),
+        markDefs: [{_type: 'link', _key: 'link1', href: 'https://b.example'}],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, patches, schema, seedTerse} = await setupLegacyScenario({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: seed,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      },
+    })
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    await writeCapture({
+      scenario: 'block-merge-duplicate-keys-markdefs',
+      schema,
+      seed,
+      seedTerse,
+      actions: [
+        'select {caret at start of block 2}',
+        "send {type: 'delete.backward', unit: 'character'}",
+      ],
+      patches,
+      resultTerse: getTersePt(editor.getSnapshot().context),
+    })
+  })
+
   test('Scenario: adding a decorator mid-span', async () => {
     const keyGenerator = createTestKeyGenerator()
     const seed = 'B: foo ^bar| baz'


### PR DESCRIPTION
Merging a text block into its neighbor (backspace at its start, or forward delete at the end of the block before it) re-keys any child span or annotation whose `_key` collides with one in the destination block. Today those fresh keys are minted silently before insertion, so the wire reads "block deleted, unrelated spans created": receivers can connect nothing through the merge, and anything tracking those nodes (carets, comments, decorations) loses them.

The fix makes both merge gestures say what they did. Before deleting the merging block, the merge behaviors rename the colliding keys in place, `set` patches on keyed `_key` paths, rewriting `marks` references when a markDef is renamed, and insert the children under their final keys. Rename-first matters: renaming after insertion would put twin keys among siblings. Non-colliding merges emit byte-identical patches to before.

Two engine fixes ride along in their own commits, both latent bugs this work surfaced and both reachable today without the merge change:

- The `rekey` point transform rewrote positions by key value alone, so renaming a node dragged carets and tracked ranges sitting on a same-keyed twin elsewhere in the document. It now rewrites only at the renamed node's own path.
- Undoing any `_key` rename silently dropped the rename: the auto-generated inverse addressed the node by a path that stopped resolving once the rename applied. Inverses now target the post-rename key, pinned by a merge-undo-redo-undo round-trip.

Receiver-side caret following through this new wire shape (the transaction interpreter recognizing renamed, reinserted children) lands separately once #3154 merges; this PR is emission and engine correctness only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core delete/merge behaviors, patch emission order, selection transformation, and undo inverses—high user impact for editing and collaboration, but changes are targeted with broad test and wire-catalogue coverage.
> 
> **Overview**
> **Block merges** (backspace at block start or forward delete at the prior block’s end) now **rename colliding `_key`s on the merging block before** it is removed and re-inserted. Collisions on child spans and `markDefs` are handled via explicit `set` / `child.set` actions (including remapping `marks` when an annotation key changes), so emitted patches describe **rename then move** instead of silent re-minting that looked like destroy-and-create on the wire. Non-colliding merges are unchanged.
> 
> **Selection and point mapping** for `_key` renames is **path-scoped**: `rekey` steps carry the parent path and only rewrite the renamed node’s segment at that depth, so carets on another node that shares the same key (legal across blocks) are not pulled along.
> 
> **Undo** of a `_key` rename now builds inverse `set`/`unset` paths against the **new** key, so reverting a merge (or any rename in the same undo batch) restores the original keys instead of leaving nodes stuck under renamed keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a16d76e817486156538d61c67014638b878f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->