### PR TITLE
chore(ci): fail PRs that carry autosquash commits

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,0 +1,29 @@
+name: check-commits
+
+on:
+  pull_request:
+    # `edited` covers base-branch retargets, which change the commit set
+    # without firing `synchronize`.
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check for unsquashed fixup/squash/amend commits
+        run: |
+          offenders=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --paginate \
+            --jq '.[] | select(.commit.message | split("\n")[0] | test("^(fixup|squash|amend)!")) | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"')
+
+          if [ -n "$offenders" ]; then
+            echo "Found unsquashed fixup/squash/amend commits:"
+            echo "$offenders"
+            echo "Squash them with 'git rebase -i --autosquash' before merge."
+            exit 1
+          fi


### PR DESCRIPTION
We use `fixup!` commits during review and autosquash before merge, so a merged autosquash commit is always a mistake, and nothing caught one. This PR adds a `check-commits` job that lists the PR's commits and fails when any subject starts with `fixup!`, `squash!`, or `amend!`, with the offenders and the autosquash remedy in the log.

To make it actually block, add the `check-commits` context to the `main` ruleset's `required_status_checks` after merging (same list as `check-format` et al.).

The check demonstrates itself below: a deliberate `fixup!` commit pushed to this PR turns it red, dropping the commit turns it green. Red on the fixup commit: https://github.com/portabletext/editor/actions/runs/33051531566/job/98447977960 — green after dropping it: https://github.com/portabletext/editor/actions/runs/33051637346/job/98448330364.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-only PR commit-message guard in CI with no application or runtime behavior changes.
> 
> **Overview**
> Adds a **`check-commits`** GitHub Actions workflow that runs on pull requests (`opened`, `synchronize`, `reopened`, and `edited` so retargets are covered).
> 
> The job uses the GitHub API to list commits on the PR and **fails the check** if any commit’s first-line subject matches `fixup!`, `squash!`, or `amend!`, printing the short SHAs and subjects plus a reminder to use `git rebase -i --autosquash`. It only needs `pull-requests: read` and does not check out the repo.
> 
> **Note:** Merging this workflow alone does not block merges until `check-commits` is added to the `main` branch ruleset’s required status checks (as described in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab571071edcb53d743a182251fe69941c78eb5aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->