### PR TITLE
fix: rename colliding keys before a range delete merges sibling blocks

### DIFF
--- a/.changeset/rename-before-range-delete-merge.md
+++ b/.changeset/rename-before-range-delete-merge.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: rename colliding keys before a range delete merges sibling blocks
+
+A range delete spanning two sibling text blocks with a colliding child `_key` or `markDefs` key could reorder the merged text, replace the start block's markDef with the end block's def of the same key, and re-mint colliding keys silently, so receivers applying the resulting patches saw those children destroyed and recreated instead of moved. Colliding keys are now renamed before the merge, with `set` patches on the wire ahead of the merge's `unset`, so both markDefs survive and the merged text keeps its original order.

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -5,7 +5,7 @@ import {
   type Schema,
 } from '@portabletext/schema'
 import type {Path} from '../engine/interfaces/path'
-import {isEqualMarks} from '../internal-utils/equality'
+import {planMergeKeyRenames} from '../internal-utils/plan-merge-key-renames'
 import {getFocusChild} from '../selectors/selector.get-focus-child'
 import {getFocusTextBlock} from '../selectors/selector.get-focus-text-block'
 import {isAtTheEndOfBlock} from '../selectors/selector.is-at-the-end-of-block'
@@ -89,7 +89,7 @@ export const abstractDeleteBehaviors = [
         block: previousBlock,
       })
 
-      const {renamedBlock, renameActions} = planMergeKeyRenames({
+      const {renamedBlock, renameActions} = planMergeKeyRenameActions({
         context: snapshot.context,
         mergingBlockPath: focusTextBlock.path,
         mergingBlock: focusTextBlock.node,
@@ -257,7 +257,7 @@ export const abstractDeleteBehaviors = [
         return false
       }
 
-      const {renamedBlock, renameActions} = planMergeKeyRenames({
+      const {renamedBlock, renameActions} = planMergeKeyRenameActions({
         context: snapshot.context,
         mergingBlockPath: nextSibling.path,
         mergingBlock: nextSibling.node,
@@ -368,19 +368,11 @@ export const abstractDeleteBehaviors = [
 ]
 
 /**
- * A block merge folds `mergingBlock`'s children (and markDefs) into
- * `destinationBlock` by key. Any key the merging block shares with the
- * destination has to be renamed before the merge, or `insert.block`'s own
- * collision handling mints a fresh key for it, which reads on the wire as
- * that node being destroyed and a new one created instead of moved.
- *
- * Renames are raised as `set`/`child.set` events against the still-living
- * `mergingBlock`, so they land on the wire before the merge's `unset`.
- * `renamedBlock` mirrors the same renames applied to the value the caller
- * already captured, since raising the rename events now doesn't change
- * that captured value.
+ * Raise the child/markDef renames `planMergeKeyRenames` computed as
+ * `set`/`child.set` events against the still-living `mergingBlock`, so
+ * they land on the wire before the merge's `unset`.
  */
-function planMergeKeyRenames(args: {
+function planMergeKeyRenameActions(args: {
   context: {schema: Schema; keyGenerator: () => string}
   mergingBlockPath: Path
   mergingBlock: PortableTextTextBlock
@@ -391,82 +383,33 @@ function planMergeKeyRenames(args: {
 } {
   const {context, mergingBlockPath, mergingBlock, destinationBlock} = args
 
-  const destinationChildKeys = new Set(
-    destinationBlock.children.map((child) => child._key),
-  )
-  const destinationMarkDefKeys = new Set(
-    (destinationBlock.markDefs ?? []).map((markDef) => markDef._key),
-  )
-
-  const markDefKeyMap = new Map<string, string>()
-  const renamedMarkDefs = mergingBlock.markDefs?.map((markDef) => {
-    if (!destinationMarkDefKeys.has(markDef._key)) {
-      return markDef
-    }
-
-    const newKey = context.keyGenerator()
-    markDefKeyMap.set(markDef._key, newKey)
-    return {...markDef, _key: newKey}
+  const {renamedBlock, childRenames, markDefRenames} = planMergeKeyRenames({
+    context,
+    mergingBlock,
+    destinationBlock,
   })
 
   const renameActions: Array<BehaviorAction> = []
 
-  for (const markDef of mergingBlock.markDefs ?? []) {
-    const newKey = markDefKeyMap.get(markDef._key)
-
-    if (newKey) {
-      renameActions.push(
-        raise({
-          type: 'set',
-          at: [...mergingBlockPath, 'markDefs', {_key: markDef._key}, '_key'],
-          value: newKey,
-        }),
-      )
-    }
+  for (const {markDefKey, newKey} of markDefRenames) {
+    renameActions.push(
+      raise({
+        type: 'set',
+        at: [...mergingBlockPath, 'markDefs', {_key: markDefKey}, '_key'],
+        value: newKey,
+      }),
+    )
   }
 
-  const renamedChildren = mergingBlock.children.map((child) => {
-    const currentMarks = isSpan(context, child) ? child.marks : undefined
-    const remappedMarks = currentMarks?.map(
-      (mark) => markDefKeyMap.get(mark) ?? mark,
+  for (const {childKey, props} of childRenames) {
+    renameActions.push(
+      raise({
+        type: 'child.set',
+        at: [...mergingBlockPath, 'children', {_key: childKey}],
+        props,
+      }),
     )
-    const marksChanged = Boolean(
-      remappedMarks && !isEqualMarks(remappedMarks, currentMarks),
-    )
-
-    const newKey = destinationChildKeys.has(child._key)
-      ? context.keyGenerator()
-      : child._key
-
-    const props: Record<string, unknown> = {}
-    if (newKey !== child._key) {
-      props['_key'] = newKey
-    }
-    if (marksChanged) {
-      props['marks'] = remappedMarks
-    }
-
-    if (Object.keys(props).length > 0) {
-      renameActions.push(
-        raise({
-          type: 'child.set',
-          at: [...mergingBlockPath, 'children', {_key: child._key}],
-          props,
-        }),
-      )
-    }
-
-    return marksChanged
-      ? {...child, _key: newKey, marks: remappedMarks}
-      : {...child, _key: newKey}
-  })
-
-  return {
-    renamedBlock: {
-      ...mergingBlock,
-      children: renamedChildren,
-      ...(mergingBlock.markDefs ? {markDefs: renamedMarkDefs} : {}),
-    },
-    renameActions,
   }
+
+  return {renamedBlock, renameActions}
 }

--- a/packages/editor/src/behaviors/behavior.abstract.delete.ts
+++ b/packages/editor/src/behaviors/behavior.abstract.delete.ts
@@ -387,6 +387,10 @@ function planMergeKeyRenameActions(args: {
     context,
     mergingBlock,
     destinationBlock,
+    // `renamedBlock` feeds `insert.block`, which parses the block
+    // standalone and strips any mark that doesn't resolve in its own
+    // `markDefs`, so a deduped def's spans would lose the annotation.
+    dedupeEqualMarkDefs: false,
   })
 
   const renameActions: Array<BehaviorAction> = []

--- a/packages/editor/src/internal-utils/apply-merge-node.ts
+++ b/packages/editor/src/internal-utils/apply-merge-node.ts
@@ -1,5 +1,6 @@
 import {isSpan, isTextBlock} from '@portabletext/schema'
 import {withoutNormalizing} from '../engine/editor/without-normalizing'
+import type {InsertOperation} from '../engine/interfaces/operation'
 import type {Path} from '../engine/interfaces/path'
 import type {Point} from '../engine/interfaces/point'
 import type {Range} from '../engine/interfaces/range'
@@ -224,22 +225,25 @@ export function applyMergeNode(
 
         for (let i = 0; i < node.children.length; i++) {
           const child = node.children[i]!
-          if (lastInsertedKey !== undefined) {
-            editor.apply({
-              type: 'insert',
-              path: [...prevPath, 'children', {_key: lastInsertedKey}],
-              node: child,
-              position: 'after',
-            })
-          } else {
-            editor.apply({
-              type: 'insert',
-              path: [...prevPath, 'children', 0],
-              node: child,
-              position: 'before',
-            })
-          }
-          lastInsertedKey = child._key
+          const operation: InsertOperation =
+            lastInsertedKey !== undefined
+              ? {
+                  type: 'insert',
+                  path: [...prevPath, 'children', {_key: lastInsertedKey}],
+                  node: child,
+                  position: 'after',
+                }
+              : {
+                  type: 'insert',
+                  path: [...prevPath, 'children', 0],
+                  node: child,
+                  position: 'before',
+                }
+          editor.apply(operation)
+          // The engine's collision backstop re-mints `operation.node._key`
+          // in place when it collides with an existing sibling, so the next
+          // anchor has to read the post-apply key, not `child._key`.
+          lastInsertedKey = operation.node._key
         }
         // Remove the now-empty element
         editor.apply({

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -22,6 +22,7 @@ import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {applyMergeNode} from './apply-merge-node'
 import {createPlaceholderBlock} from './create-placeholder-block'
 import {getFullyCoveredContainers} from './get-fully-covered-container'
+import {planMergeKeyRenames} from './plan-merge-key-renames'
 import {setNodeProperties} from './set-node-properties'
 
 /**
@@ -762,15 +763,42 @@ function mergeBlock(
     return
   }
 
-  const endMarkDefs = endBlock.node.markDefs
+  // The span holding the range's start point survives as an empty span
+  // until normalization runs, so it still occupies `startBlock`'s children
+  // and is a genuine collision source the plan must include.
+  const {renamedBlock, childRenames, markDefRenames} = planMergeKeyRenames({
+    context: editor.snapshot.context,
+    mergingBlock: endBlock.node,
+    destinationBlock: startBlock.node,
+    dedupeEqualMarkDefs: true,
+  })
+
+  for (const {markDefKey, newKey} of markDefRenames) {
+    // `getNode` can't resolve a keyed descent into `markDefs` (it's a
+    // sidecar field, not part of the child tree), so `setNodeProperties`
+    // would silently no-op here. Apply the rename directly.
+    editor.apply({
+      type: 'set',
+      path: [...endBlockPath, 'markDefs', {_key: markDefKey}, '_key'],
+      value: newKey,
+    })
+  }
+  for (const {childKey, props} of childRenames) {
+    setNodeProperties(editor, props, [
+      ...endBlockPath,
+      'children',
+      {_key: childKey},
+    ])
+  }
+
+  const endMarkDefs = renamedBlock.markDefs
   if (Array.isArray(endMarkDefs) && endMarkDefs.length > 0) {
     const oldDefs = startBlock.node.markDefs ?? []
-    const newMarkDefs = [
-      ...new Map(
-        [...oldDefs, ...endMarkDefs].map((def) => [def._key, def]),
-      ).values(),
-    ]
-    setNodeProperties(editor, {markDefs: newMarkDefs}, startBlockPath)
+    setNodeProperties(
+      editor,
+      {markDefs: [...oldDefs, ...endMarkDefs]},
+      startBlockPath,
+    )
   }
   applyMergeNode(editor, endBlockPath, startBlock.node.children.length)
 }

--- a/packages/editor/src/internal-utils/plan-merge-key-renames.ts
+++ b/packages/editor/src/internal-utils/plan-merge-key-renames.ts
@@ -3,7 +3,7 @@ import {
   type PortableTextTextBlock,
   type Schema,
 } from '@portabletext/schema'
-import {isEqualMarks} from './equality'
+import {isDeepEqual, isEqualMarks} from './equality'
 
 /**
  * A rename to apply to one of `mergingBlock`'s children before the merge.
@@ -24,10 +24,14 @@ export type MergeMarkDefRename = {
 
 /**
  * A block merge folds `mergingBlock`'s children (and markDefs) into
- * `destinationBlock` by key. Any key the merging block shares with the
- * destination has to be renamed before the merge, or the engine's own
+ * `destinationBlock` by key. Any child key the merging block shares with
+ * the destination has to be renamed before the merge, or the engine's own
  * collision handling mints a fresh key for it, which reads on the wire as
- * that node being destroyed and a new one created instead of moved.
+ * that node being destroyed and a new one created instead of moved. There
+ * is no such backstop for markDefs: an unrenamed collision either loses
+ * one of the two defs to last-wins replacement, or, on the `insert.block`
+ * path, gets silently re-minted by `adjustFragmentKeys` (see
+ * `dedupeEqualMarkDefs` below).
  *
  * Pure: computes the renames and the block they produce without touching
  * an editor. Callers raise or apply the renames themselves, ahead of the
@@ -37,29 +41,48 @@ export function planMergeKeyRenames(args: {
   context: {schema: Schema; keyGenerator: () => string}
   mergingBlock: PortableTextTextBlock
   destinationBlock: PortableTextTextBlock
+  /**
+   * When a merging markDef collides with a destination markDef that is
+   * deeply equal to it, drop the merging markDef (from `renamedBlock` and
+   * from the emitted renames) instead of renaming it, so the merge keeps
+   * a single copy under the original `_key` rather than duplicating
+   * identical content under two keys.
+   *
+   * Must be `false` when `renamedBlock` feeds `insert.block`: that path
+   * parses the block standalone, and `parseBlock`/`parseSpan` strip any
+   * mark that doesn't resolve in the block's own `markDefs`, so a span
+   * whose annotation was deduped away would arrive with the mark gone
+   * rather than re-keyed.
+   */
+  dedupeEqualMarkDefs: boolean
 }): {
   renamedBlock: PortableTextTextBlock
   childRenames: Array<MergeChildRename>
   markDefRenames: Array<MergeMarkDefRename>
 } {
-  const {context, mergingBlock, destinationBlock} = args
+  const {context, mergingBlock, destinationBlock, dedupeEqualMarkDefs} = args
 
   const destinationChildKeys = new Set(
     destinationBlock.children.map((child) => child._key),
   )
-  const destinationMarkDefKeys = new Set(
-    (destinationBlock.markDefs ?? []).map((markDef) => markDef._key),
+  const destinationMarkDefsByKey = new Map(
+    (destinationBlock.markDefs ?? []).map((markDef) => [markDef._key, markDef]),
   )
 
   const markDefKeyMap = new Map<string, string>()
-  const renamedMarkDefs = mergingBlock.markDefs?.map((markDef) => {
-    if (!destinationMarkDefKeys.has(markDef._key)) {
-      return markDef
+  const renamedMarkDefs = mergingBlock.markDefs?.flatMap((markDef) => {
+    const destinationMarkDef = destinationMarkDefsByKey.get(markDef._key)
+    if (!destinationMarkDef) {
+      return [markDef]
+    }
+
+    if (dedupeEqualMarkDefs && isDeepEqual(markDef, destinationMarkDef)) {
+      return []
     }
 
     const newKey = context.keyGenerator()
     markDefKeyMap.set(markDef._key, newKey)
-    return {...markDef, _key: newKey}
+    return [{...markDef, _key: newKey}]
   })
 
   const markDefRenames: Array<MergeMarkDefRename> = []

--- a/packages/editor/src/internal-utils/plan-merge-key-renames.ts
+++ b/packages/editor/src/internal-utils/plan-merge-key-renames.ts
@@ -1,0 +1,113 @@
+import {
+  isSpan,
+  type PortableTextTextBlock,
+  type Schema,
+} from '@portabletext/schema'
+import {isEqualMarks} from './equality'
+
+/**
+ * A rename to apply to one of `mergingBlock`'s children before the merge.
+ * `props` only carries the keys that actually change: `_key` when the
+ * child's key collides with the destination, `marks` when one of its
+ * marks referenced a markDef that got renamed.
+ */
+export type MergeChildRename = {
+  childKey: string
+  props: {_key?: string; marks?: Array<string>}
+}
+
+/** A rename to apply to one of `mergingBlock`'s markDefs before the merge. */
+export type MergeMarkDefRename = {
+  markDefKey: string
+  newKey: string
+}
+
+/**
+ * A block merge folds `mergingBlock`'s children (and markDefs) into
+ * `destinationBlock` by key. Any key the merging block shares with the
+ * destination has to be renamed before the merge, or the engine's own
+ * collision handling mints a fresh key for it, which reads on the wire as
+ * that node being destroyed and a new one created instead of moved.
+ *
+ * Pure: computes the renames and the block they produce without touching
+ * an editor. Callers raise or apply the renames themselves, ahead of the
+ * merge, against the still-living `mergingBlock`.
+ */
+export function planMergeKeyRenames(args: {
+  context: {schema: Schema; keyGenerator: () => string}
+  mergingBlock: PortableTextTextBlock
+  destinationBlock: PortableTextTextBlock
+}): {
+  renamedBlock: PortableTextTextBlock
+  childRenames: Array<MergeChildRename>
+  markDefRenames: Array<MergeMarkDefRename>
+} {
+  const {context, mergingBlock, destinationBlock} = args
+
+  const destinationChildKeys = new Set(
+    destinationBlock.children.map((child) => child._key),
+  )
+  const destinationMarkDefKeys = new Set(
+    (destinationBlock.markDefs ?? []).map((markDef) => markDef._key),
+  )
+
+  const markDefKeyMap = new Map<string, string>()
+  const renamedMarkDefs = mergingBlock.markDefs?.map((markDef) => {
+    if (!destinationMarkDefKeys.has(markDef._key)) {
+      return markDef
+    }
+
+    const newKey = context.keyGenerator()
+    markDefKeyMap.set(markDef._key, newKey)
+    return {...markDef, _key: newKey}
+  })
+
+  const markDefRenames: Array<MergeMarkDefRename> = []
+  for (const markDef of mergingBlock.markDefs ?? []) {
+    const newKey = markDefKeyMap.get(markDef._key)
+    if (newKey) {
+      markDefRenames.push({markDefKey: markDef._key, newKey})
+    }
+  }
+
+  const childRenames: Array<MergeChildRename> = []
+  const renamedChildren = mergingBlock.children.map((child) => {
+    const currentMarks = isSpan(context, child) ? child.marks : undefined
+    const remappedMarks = currentMarks?.map(
+      (mark) => markDefKeyMap.get(mark) ?? mark,
+    )
+    const marksChanged = Boolean(
+      remappedMarks && !isEqualMarks(remappedMarks, currentMarks),
+    )
+
+    const newKey = destinationChildKeys.has(child._key)
+      ? context.keyGenerator()
+      : child._key
+
+    const props: MergeChildRename['props'] = {}
+    if (newKey !== child._key) {
+      props['_key'] = newKey
+    }
+    if (marksChanged) {
+      props['marks'] = remappedMarks
+    }
+
+    if (Object.keys(props).length > 0) {
+      childRenames.push({childKey: child._key, props})
+    }
+
+    return marksChanged
+      ? {...child, _key: newKey, marks: remappedMarks}
+      : {...child, _key: newKey}
+  })
+
+  return {
+    renamedBlock: {
+      ...mergingBlock,
+      children: renamedChildren,
+      ...(mergingBlock.markDefs ? {markDefs: renamedMarkDefs} : {}),
+    },
+    childRenames,
+    markDefRenames,
+  }
+}

--- a/packages/editor/tests/__fixtures__/wire-catalogue/range-delete-duplicate-keys.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/range-delete-duplicate-keys.json
@@ -1,0 +1,247 @@
+{
+  "scenario": "range-delete-duplicate-keys",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": [
+    {
+      "_type": "block",
+      "_key": "kA",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "e0-k1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "e0-k2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_type": "block",
+      "_key": "kB",
+      "children": [
+        {
+          "_type": "span",
+          "_key": "e0-k1",
+          "text": "foo ",
+          "marks": []
+        },
+        {
+          "_type": "span",
+          "_key": "e0-k2",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    }
+  ],
+  "seedTerse": [
+    "foo ,bar",
+    "foo ,bar"
+  ],
+  "actions": [
+    "select {anchor at offset 0 on kA/e0-k2, focus at offset 3 on kB/e0-k1}",
+    "send {type: 'delete', direction: 'backward', unit: 'character'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "e0-k2"
+        },
+        "text"
+      ],
+      "value": "@@ -1,3 +0,0 @@\n-bar\n",
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "e0-k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1 @@\n-foo\n  \n",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "e0-k1"
+        },
+        "_key"
+      ],
+      "value": "k2",
+      "origin": "local"
+    },
+    {
+      "type": "set",
+      "path": [
+        {
+          "_key": "kB"
+        },
+        "children",
+        {
+          "_key": "e0-k2"
+        },
+        "_key"
+      ],
+      "value": "k3",
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "e0-k2"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k2",
+          "text": " ",
+          "marks": []
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "setIfMissing",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children"
+      ],
+      "value": [],
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "span",
+          "_key": "k3",
+          "text": "bar",
+          "marks": [
+            "strong"
+          ]
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kB"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "e0-k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "e0-k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,5 @@\n foo \n+ \n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "kA"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "resultTerse": [
+    "foo  ,bar"
+  ]
+}

--- a/packages/editor/tests/block-merge-duplicate-keys.test.tsx
+++ b/packages/editor/tests/block-merge-duplicate-keys.test.tsx
@@ -60,6 +60,25 @@ function duplicateKeyedInitialValueWithLink(): Array<PortableTextBlock> {
   ]
 }
 
+function duplicateKeyedInitialValueWithSameLink(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'block',
+      _key: 'kA',
+      children: duplicateKeyedChildrenWithLink('link1'),
+      markDefs: [{_type: 'link', _key: 'link1', href: 'https://a.example'}],
+      style: 'normal',
+    },
+    {
+      _type: 'block',
+      _key: 'kB',
+      children: duplicateKeyedChildrenWithLink('link1'),
+      markDefs: [{_type: 'link', _key: 'link1', href: 'https://a.example'}],
+      style: 'normal',
+    },
+  ]
+}
+
 const duplicateKeyMergeSchema = defineSchema({decorators: [{name: 'strong'}]})
 
 /**
@@ -175,9 +194,6 @@ describe('Feature: block merge renames colliding keys', () => {
       expect(patches.indexOf(keySetPatch)).toBeLessThan(unsetKbIndex)
     }
 
-    // Every child inserted back under `kA` carries a renamed key: none of
-    // the merging block's original `s1`/`s2`/`s3` keys reach the insert, so
-    // nothing collides with `kA`'s own children of the same name.
     const insertedKeys = patches.flatMap((patch) =>
       patch.type === 'insert'
         ? patch.items.flatMap((item) =>
@@ -397,9 +413,6 @@ describe('Feature: block merge renames colliding keys', () => {
       ])
     })
 
-    // `kB`'s markDef collides with `kA`'s own `link1`, so it's renamed
-    // ahead of the merge, same as a colliding child key, before `kB` is
-    // unset.
     const markDefKeySetPatch = patches.find(
       (patch) =>
         patch.type === 'set' &&
@@ -444,5 +457,659 @@ describe('Feature: block merge renames colliding keys', () => {
         editor1.getSnapshot().context.value,
       )
     })
+  })
+
+  test('Scenario: a byte-identical colliding markDef is still renamed on the collapsed merge path', async () => {
+    const schemaDefinition = defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: duplicateKeyedInitialValueWithSameLink(),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).not.toBeNull()
+    })
+
+    editor.send({type: 'delete.backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+            {
+              _type: 'span',
+              _key: 's2',
+              text: 'bar',
+              marks: ['strong', 'link1'],
+            },
+            {_type: 'span', _key: 's3', text: ' bazfoo ', marks: []},
+            {_type: 'span', _key: 'k4', text: 'bar', marks: ['strong', 'k2']},
+            {_type: 'span', _key: 'k5', text: ' baz', marks: []},
+          ],
+          markDefs: [
+            {_type: 'link', _key: 'link1', href: 'https://a.example'},
+            {_type: 'link', _key: 'k2', href: 'https://a.example'},
+          ],
+          style: 'normal',
+        },
+      ])
+    })
+  })
+})
+
+function reorderReproInitialValue(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'block',
+      _key: 'kA',
+      children: [
+        {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+        {_type: 'span', _key: 's2', text: 'bar', marks: []},
+      ],
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'block',
+      _key: 'kB',
+      children: [
+        {_type: 'span', _key: 's1', text: 'baz ', marks: []},
+        {_type: 'span', _key: 's2', text: 'bar', marks: []},
+      ],
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+}
+
+function rangeDeleteMergeSharedKeyChildren() {
+  return [
+    {_type: 'span', _key: 'e0-k1', text: 'foo ', marks: []},
+    {_type: 'span', _key: 'e0-k2', text: 'bar', marks: ['strong']},
+  ]
+}
+
+function rangeDeleteMergeSharedKeyInitialValue(): Array<PortableTextBlock> {
+  return [
+    {
+      _type: 'block',
+      _key: 'kA',
+      children: rangeDeleteMergeSharedKeyChildren(),
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'block',
+      _key: 'kB',
+      children: rangeDeleteMergeSharedKeyChildren(),
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+}
+
+/**
+ * Range-delete from `kA`'s second span into `kB`'s first span in a fresh
+ * editor over `rangeDeleteMergeSharedKeyInitialValue`, capturing every
+ * patch it emits. The two blocks share every child `_key`.
+ */
+async function rangeDeleteMergeSharedKeyBlocks() {
+  const patches: Array<Patch> = []
+
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition: duplicateKeyMergeSchema,
+    initialValue: rangeDeleteMergeSharedKeyInitialValue(),
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            patches.push(event.patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  await userEvent.click(locator)
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'kA'}, 'children', {_key: 'e0-k2'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 'e0-k1'}], offset: 3},
+    },
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {path: [{_key: 'kA'}, 'children', {_key: 'e0-k2'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 'e0-k1'}], offset: 3},
+      backward: false,
+    })
+  })
+
+  editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value.length).toBe(1)
+  })
+
+  return {editor, patches}
+}
+
+/**
+ * Range-delete from `kA`'s `s3` into `kB`'s `s2` in a fresh editor over
+ * `duplicateKeyedInitialValueWithLink`, capturing every patch it emits.
+ * The two blocks' markDefs share the `link1` key.
+ */
+async function rangeDeleteMergeMarkDefCollisionBlocks() {
+  const schemaDefinition = defineSchema({
+    decorators: [{name: 'strong'}],
+    annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+  })
+
+  const patches: Array<Patch> = []
+
+  const {editor, locator} = await createTestEditor({
+    keyGenerator: createTestKeyGenerator(),
+    schemaDefinition,
+    initialValue: duplicateKeyedInitialValueWithLink(),
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            patches.push(event.patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  await userEvent.click(locator)
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 's2'}], offset: 0},
+    },
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 0},
+      focus: {path: [{_key: 'kB'}, 'children', {_key: 's2'}], offset: 0},
+      backward: false,
+    })
+  })
+
+  editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value.length).toBe(1)
+  })
+
+  return {editor, patches}
+}
+
+describe('Feature: range delete renames colliding keys before merging sibling blocks', () => {
+  test('Scenario: a range delete spanning two sibling blocks with colliding child keys keeps children in order', async () => {
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: duplicateKeyMergeSchema,
+      initialValue: reorderReproInitialValue(),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 2},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's1'}], offset: 2},
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    // The renamed span and `kA`'s own children all carry the same (empty)
+    // marks, so normalization merges everything into a single span once
+    // the renamed key stops mattering; only the order of the merged text
+    // proves the reorder bug is gone.
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [{_type: 'span', _key: 's1', text: 'foz bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  test('Scenario: a colliding markDef is renamed and the migrated span keeps the a.example def resolvable', async () => {
+    const {editor, patches} = await rangeDeleteMergeMarkDefCollisionBlocks()
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [
+          {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+          {_type: 'span', _key: 's2', text: 'bar', marks: ['strong', 'link1']},
+          {_type: 'span', _key: 'k3', text: 'bar', marks: ['strong', 'k2']},
+          {_type: 'span', _key: 'k4', text: ' baz', marks: []},
+        ],
+        markDefs: [
+          {_type: 'link', _key: 'link1', href: 'https://a.example'},
+          {_type: 'link', _key: 'k2', href: 'https://b.example'},
+        ],
+        style: 'normal',
+      },
+    ])
+
+    // These land on the wire before `kB` is unset, checked below.
+    const keySetPatches = patches.filter(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === '_key',
+    )
+    expect(keySetPatches).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'markDefs', {_key: 'link1'}, '_key'],
+        value: 'k2',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's2'}, '_key'],
+        value: 'k3',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 's3'}, '_key'],
+        value: 'k4',
+        origin: 'local',
+      },
+    ])
+
+    // `s2` carries the renamed markDef in its `marks`, so the rename
+    // rewrites that reference too, not just the markDef's own `_key`.
+    const marksRewritePatch = patches.find(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === 'marks',
+    )
+    expect(marksRewritePatch).toEqual({
+      type: 'set',
+      path: [{_key: 'kB'}, 'children', {_key: 'k3'}, 'marks'],
+      value: ['strong', 'k2'],
+      origin: 'local',
+    })
+
+    const unsetKbIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'unset' &&
+        patch.path.length === 1 &&
+        typeof patch.path[0] === 'object' &&
+        patch.path[0] !== null &&
+        '_key' in patch.path[0] &&
+        patch.path[0]._key === 'kB',
+    )
+    expect(unsetKbIndex).toBeGreaterThan(-1)
+    for (const keySetPatch of keySetPatches) {
+      expect(patches.indexOf(keySetPatch)).toBeLessThan(unsetKbIndex)
+    }
+  })
+
+  test('Scenario: undoing a range delete with a colliding markDef restores both original blocks, every `_key` included', async () => {
+    const {editor} = await rangeDeleteMergeMarkDefCollisionBlocks()
+
+    const mergedValue = editor.getSnapshot().context.value
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        duplicateKeyedInitialValueWithLink(),
+      )
+    })
+
+    editor.send({type: 'history.redo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(mergedValue)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(
+        duplicateKeyedInitialValueWithLink(),
+      )
+    })
+  })
+
+  test('Scenario: a byte-identical colliding markDef is deduped instead of renamed', async () => {
+    const schemaDefinition = defineSchema({
+      decorators: [{name: 'strong'}],
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    })
+
+    const patches: Array<Patch> = []
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: duplicateKeyedInitialValueWithSameLink(),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's2'}], offset: 0},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 's2'}], offset: 0},
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [
+          {_type: 'span', _key: 's1', text: 'foo ', marks: []},
+          {
+            _type: 'span',
+            _key: 's2',
+            text: 'barbar',
+            marks: ['strong', 'link1'],
+          },
+          {_type: 'span', _key: 'k3', text: ' baz', marks: []},
+        ],
+        markDefs: [{_type: 'link', _key: 'link1', href: 'https://a.example'}],
+        style: 'normal',
+      },
+    ])
+
+    // Normalization merges the two adjacent `strong`+`link1` spans once
+    // deduping keeps them both pointing at the same markDef key; that
+    // merge is incidental to this scenario, not what it pins.
+    const markDefKeySetPatches = patches.filter(
+      (patch) =>
+        patch.type === 'set' &&
+        patch.path.at(-1) === '_key' &&
+        patch.path.at(-3) === 'markDefs',
+    )
+    expect(markDefKeySetPatches).toEqual([])
+  })
+
+  test('Scenario: the range start survives as a trimmed empty span and is itself a collision source', async () => {
+    const {editor} = await rangeDeleteMergeSharedKeyBlocks()
+
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [
+          {_type: 'span', _key: 'e0-k1', text: 'foo  ', marks: []},
+          {_type: 'span', _key: 'k3', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+
+    expect(editor.getSnapshot().context.selection).toEqual({
+      anchor: {path: [{_key: 'kA'}, 'children', {_key: 'e0-k1'}], offset: 4},
+      focus: {path: [{_key: 'kA'}, 'children', {_key: 'e0-k1'}], offset: 4},
+      backward: false,
+    })
+  })
+
+  test('Scenario: the rename patches land before the merge unsets and inserts on the wire', async () => {
+    const {patches} = await rangeDeleteMergeSharedKeyBlocks()
+
+    const keySetPatches = patches.filter(
+      (patch) => patch.type === 'set' && patch.path.at(-1) === '_key',
+    )
+    expect(keySetPatches).toEqual([
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 'e0-k1'}, '_key'],
+        value: 'k2',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: 'kB'}, 'children', {_key: 'e0-k2'}, '_key'],
+        value: 'k3',
+        origin: 'local',
+      },
+    ])
+
+    const unsetKbIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'unset' &&
+        patch.path.length === 1 &&
+        typeof patch.path[0] === 'object' &&
+        patch.path[0] !== null &&
+        '_key' in patch.path[0] &&
+        patch.path[0]._key === 'kB',
+    )
+    expect(unsetKbIndex).toBeGreaterThan(-1)
+    for (const keySetPatch of keySetPatches) {
+      expect(patches.indexOf(keySetPatch)).toBeLessThan(unsetKbIndex)
+    }
+
+    const insertedKeys = patches.flatMap((patch) =>
+      patch.type === 'insert'
+        ? patch.items.flatMap((item) =>
+            typeof item === 'object' && item !== null && '_key' in item
+              ? [item['_key']]
+              : [],
+          )
+        : [],
+    )
+    expect(insertedKeys).toEqual(['k2', 'k3'])
+  })
+
+  test('Scenario: undoing the range delete restores both original blocks, every `_key` included', async () => {
+    const {editor} = await rangeDeleteMergeSharedKeyBlocks()
+
+    const mergedValue = editor.getSnapshot().context.value
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: [
+          {_type: 'span', _key: 'e0-k1', text: 'foo ', marks: []},
+          {_type: 'span', _key: 'e0-k2', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'kB',
+        children: [
+          {_type: 'span', _key: 'e0-k1', text: 'foo ', marks: []},
+          {_type: 'span', _key: 'e0-k2', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+
+    editor.send({type: 'history.redo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(mergedValue)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+  })
+
+  test('Scenario: a range delete spanning two sibling blocks with a colliding inline-object key renames it and keeps its position', async () => {
+    const patches: Array<Patch> = []
+    const schemaDefinition = defineSchema({
+      decorators: [{name: 'strong'}],
+      inlineObjects: [{name: 'stock-ticker'}],
+    })
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: [
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [{_type: 'span', _key: 's1', text: 'foo ', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'kB',
+          children: [
+            {_type: 'span', _key: 'b1', text: 'baz ', marks: []},
+            {_type: 'stock-ticker', _key: 's1'},
+            {_type: 'span', _key: 'b2', text: 'qux', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 'b1'}], offset: 2},
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection).toEqual({
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 's1'}], offset: 2},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 'b1'}], offset: 2},
+        backward: false,
+      })
+    })
+
+    editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'kA',
+          children: [
+            {_type: 'span', _key: 's1', text: 'foz ', marks: []},
+            {_type: 'stock-ticker', _key: 'k2'},
+            {_type: 'span', _key: 'b2', text: 'qux', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    const keySetPatchIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'set' &&
+        patch.path.at(-1) === '_key' &&
+        patch.path.at(-2) &&
+        typeof patch.path.at(-2) === 'object' &&
+        (patch.path.at(-2) as {_key: string})._key === 's1',
+    )
+    const unsetKbIndex = patches.findIndex(
+      (patch) =>
+        patch.type === 'unset' &&
+        patch.path.length === 1 &&
+        typeof patch.path[0] === 'object' &&
+        patch.path[0] !== null &&
+        '_key' in patch.path[0] &&
+        patch.path[0]._key === 'kB',
+    )
+    expect(keySetPatchIndex).toBeGreaterThan(-1)
+    expect(unsetKbIndex).toBeGreaterThan(-1)
+    expect(keySetPatchIndex).toBeLessThan(unsetKbIndex)
   })
 })

--- a/packages/editor/tests/wire-catalogue.test.tsx
+++ b/packages/editor/tests/wire-catalogue.test.tsx
@@ -25,11 +25,10 @@ import {toTextspec} from '../test-utils/to-textspec'
  * `seed` and `result` are textspec notation strings (see
  * `test-utils/from-textspec.ts`/`to-textspec.ts`): together with the
  * `schema` field and the deterministic `createTestKeyGenerator`, `seed` is
- * enough to replay the scenario. The one exception is
- * `span-merge-cosmetic.json`, which pins two spans that carry identical
- * (empty) marks — textspec has no notation for a span boundary that isn't
- * a mark boundary, so that fixture keeps the pre-textspec shape (`seed` as
- * full blocks, `seedTerse`/`resultTerse`).
+ * enough to replay the scenario. Scenarios textspec can't express, such as
+ * a span boundary that isn't a mark boundary or a duplicate `_key` across
+ * sibling blocks, keep the pre-textspec shape instead (`seed` as full
+ * blocks, `seedTerse`/`resultTerse`).
  */
 
 type Capture = {
@@ -354,6 +353,68 @@ describe('wire catalogue', () => {
       actions: [
         'select {caret at start of block 2}',
         "send {type: 'delete.backward', unit: 'character'}",
+      ],
+      patches,
+      resultTerse: getTersePt(editor.getSnapshot().context),
+    })
+  })
+
+  test('Scenario: a range delete spanning two blocks with duplicate keys renames before the merge', async () => {
+    // Both blocks share every child `_key`: textspec can't express that
+    // collision, so this seed is hand-built (see the file header). The
+    // range starts inside `kA`'s second span, which survives the delete as
+    // a trimmed empty span and is itself a collision source alongside
+    // `kB`'s children.
+    const keyGenerator = createTestKeyGenerator()
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+    const rangeDeleteMergeSharedKeyChildren = (): Array<PortableTextSpan> => [
+      {_type: 'span', _key: 'e0-k1', text: 'foo ', marks: []},
+      {_type: 'span', _key: 'e0-k2', text: 'bar', marks: ['strong']},
+    ]
+    const seed: Array<PortableTextTextBlock<PortableTextSpan>> = [
+      {
+        _type: 'block',
+        _key: 'kA',
+        children: rangeDeleteMergeSharedKeyChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: 'kB',
+        children: rangeDeleteMergeSharedKeyChildren(),
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+
+    const {editor, patches, schema, seedTerse} = await setupLegacyScenario({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: seed,
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'kA'}, 'children', {_key: 'e0-k2'}], offset: 0},
+        focus: {path: [{_key: 'kB'}, 'children', {_key: 'e0-k1'}], offset: 3},
+      },
+    })
+    editor.send({type: 'delete', direction: 'backward', unit: 'character'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value.length).toBe(1)
+    })
+
+    await writeCapture({
+      scenario: 'range-delete-duplicate-keys',
+      schema,
+      seed,
+      seedTerse,
+      actions: [
+        'select {anchor at offset 0 on kA/e0-k2, focus at offset 3 on kB/e0-k1}',
+        "send {type: 'delete', direction: 'backward', unit: 'character'}",
       ],
       patches,
       resultTerse: getTersePt(editor.getSnapshot().context),


### PR DESCRIPTION
Deleting a range that spans two sibling text blocks merges the end block into the start block. When the blocks share a child `_key` (legal across blocks, and a shape real documents have), the merge comes out wrong twice over: the merged text is reordered, and a colliding `markDefs` key makes the end block's def replace the start block's, so the start block's surviving annotated spans point at the wrong annotation. Both corruptions are silent on the wire: the colliding keys are re-minted with no rename, so receivers read destroy-and-create for content that was merely merged, and carets, comments, and decorations tracking those spans lose them.

The fix mirrors what #3182 gave the collapsed backspace/forward-delete merges: `mergeBlock` plans `_key` renames before the merge and applies them to the still-living end block, so keyed `set` patches land on the wire ahead of the merge's `unset` and inserts. The plan is computed against the start block's mid-delete state, where the span holding the range's start point still exists as an empty span and is a genuine collision source. The rename planner is extracted from the delete behaviors into a shared helper in its own behavior-preserving commit. markDef renames apply as direct engine `set`s, since `setNodeProperties` cannot address keyed `markDefs` descents and would silently no-op (caught in review; the wire test now asserts the markDef rename patch explicitly). `applyMergeNode` also anchors each child insert on the post-apply key, since the engine's collision backstop re-mints keys in place; the stale pre-apply anchor was the reorder mechanism.

Byte-identical markDefs under the same `_key` dedupe instead of renaming: the merge keeps one def under the original key and the migrated spans resolve to it, preserving annotation identity the way the old merge did for identical defs. Only same-key-different-content defs rename. The dedupe is scoped to the range-delete path: the collapsed merges keep renaming, because their output feeds `insert.block`, where the block is parsed standalone and any mark that doesn't resolve in the block's own `markDefs` is stripped, so a deduped def's spans would lose the annotation entirely. A dedicated test pins that the collapsed path keeps renaming identical defs (it goes red if the dedupe flag is flipped there).

Pinned red-on-old: the reorder, the markDef overwrite, the markDef rename reaching the wire before the block `unset`, the identical-def dedupe (no rename patch on the wire), the empty-span collision (with the caret collapsing to the range start), an inline-object collision, and undo round-trips restoring every original `_key`. New wire-catalogue row: `range-delete-duplicate-keys`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core delete/merge and patch ordering for collaboration, but the change is scoped to duplicate-key merges with broad regression coverage.
> 
> **Overview**
> Fixes **range deletes** that merge two sibling blocks when those blocks reuse the same child `_key` or `markDefs` key—cases that could scramble merged text, overwrite annotations, and emit patches that look like destroy/create instead of moves.
> 
> **Range-delete merge** (`mergeBlock` in `delete-internal.ts`) now runs the same pre-merge rename plan as collapsed backspace/forward merges: colliding keys on the end block are updated with explicit `set` patches before unset/insert, using the start block’s mid-delete children (including the surviving empty span at the range anchor) as the collision set. Byte-identical colliding markDefs are **deduped** on this path; differing defs are renamed and span `marks` are rewritten.
> 
> Rename planning is **extracted** to `plan-merge-key-renames.ts`; delete behaviors keep a thin `planMergeKeyRenameActions` wrapper that raises behavior events (`dedupeEqualMarkDefs: false` for `insert.block`).
> 
> **`applyMergeNode`** chains child inserts using each insert operation’s **post-apply** `_key`, so engine collision re-minting no longer mis-orders siblings.
> 
> Tests cover wire order, markDef dedupe vs rename, inline-object collisions, undo/redo, and a new wire-catalogue scenario `range-delete-duplicate-keys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108c2d3d8d4dcc54a1dbe38261f1e57d0fc580ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->