### PR TITLE
fix: stop deduped `'selection'` events from falling through to the relay wildcard

### DIFF
--- a/.changeset/relay-selection-wildcard-fallthrough-v6.md
+++ b/.changeset/relay-selection-wildcard-fallthrough-v6.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: stop deduped `'selection'` events from falling through to the relay wildcard
+
+`'selection'` events no longer re-fire with an unchanged selection while the editor syncs an external value update. Installs resolving `xstate` 5.32.2 or later hit this regression regardless of editor version; in Sanity Studio v5 it closed the annotation-editing popover on the first keystroke in one of its fields.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -93,7 +93,7 @@
     "@xstate/react": "^6.1.0",
     "debug": "^4.4.3",
     "scroll-into-view-if-needed": "^3.1.0",
-    "xstate": "^5.30.0"
+    "xstate": "^5.32.5"
   },
   "devDependencies": {
     "@portabletext/test": "workspace:^",

--- a/packages/editor/src/editor/relay-machine.test.ts
+++ b/packages/editor/src/editor/relay-machine.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, test} from 'vitest'
+import {createActor} from 'xstate'
+import type {EditorSelection} from '../types/editor'
+import {relayMachine} from './relay-machine'
+
+const selection: EditorSelection = {
+  anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+  focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+  backward: false,
+}
+
+describe(relayMachine.id, () => {
+  test('a repeated selection is deduped instead of falling through to the wildcard', () => {
+    const relayActor = createActor(relayMachine).start()
+    const emitted: Array<EditorSelection> = []
+    relayActor.on('selection', (event) => {
+      emitted.push(event.selection)
+    })
+
+    relayActor.send({type: 'selection', selection})
+    relayActor.send({type: 'selection', selection})
+
+    expect(emitted).toEqual([selection])
+  })
+
+  test('a repeated selection is re-emitted right after a focused event', () => {
+    const relayActor = createActor(relayMachine).start()
+    const emitted: Array<EditorSelection> = []
+    relayActor.on('selection', (event) => {
+      emitted.push(event.selection)
+    })
+
+    relayActor.send({type: 'selection', selection})
+    relayActor.send({
+      type: 'focused',
+      event: {} as never,
+    })
+    relayActor.send({type: 'selection', selection})
+
+    expect(emitted).toEqual([selection, selection])
+  })
+
+  test('a repeated selection after a non-focus event stays deduped', () => {
+    const relayActor = createActor(relayMachine).start()
+    const emitted: Array<EditorSelection> = []
+    relayActor.on('selection', (event) => {
+      emitted.push(event.selection)
+    })
+
+    relayActor.send({type: 'selection', selection})
+    relayActor.send({type: 'ready'})
+    relayActor.send({type: 'selection', selection})
+
+    expect(emitted).toEqual([selection])
+  })
+})

--- a/packages/editor/src/editor/relay-machine.ts
+++ b/packages/editor/src/editor/relay-machine.ts
@@ -139,6 +139,16 @@ export const relayMachine = setup({
           }),
         ],
       },
+      {
+        // Without an unguarded fallback, a deduped `selection` event falls
+        // through to the `'*'` wildcard below and gets emitted anyway,
+        // defeating the dedupe above.
+        actions: [
+          assign({
+            lastEventWasFocused: false,
+          }),
+        ],
+      },
     ],
     '*': {
       actions: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,7 +425,7 @@ importers:
         version: 5.0.2
       '@xstate/react':
         specifier: ^6.1.0
-        version: 6.1.0(@types/react@19.2.14)(react@19.2.3)(xstate@5.30.0)
+        version: 6.1.0(@types/react@19.2.14)(react@19.2.3)(xstate@5.32.5)
       debug:
         specifier: ^4.4.3
         version: 4.4.3
@@ -433,8 +433,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       xstate:
-        specifier: ^5.30.0
-        version: 5.30.0
+        specifier: ^5.32.5
+        version: 5.32.5
     devDependencies:
       '@portabletext/test':
         specifier: workspace:^
@@ -8587,6 +8587,9 @@ packages:
   xstate@5.30.0:
     resolution: {integrity: sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw==}
 
+  xstate@5.32.5:
+    resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -12090,13 +12093,13 @@ snapshots:
     dependencies:
       rxjs: 7.8.2
       uuid: 11.1.0
-      xstate: 5.30.0
+      xstate: 5.32.5
 
   '@sanity/comlink@3.1.1':
     dependencies:
       rxjs: 7.8.2
       uuid: 11.1.0
-      xstate: 5.30.0
+      xstate: 5.32.5
 
   '@sanity/descriptors@1.3.0':
     dependencies:
@@ -13190,6 +13193,16 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.3)
     optionalDependencies:
       xstate: 5.30.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@xstate/react@6.1.0(@types/react@19.2.14)(react@19.2.3)(xstate@5.32.5)':
+    dependencies:
+      react: 19.2.3
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      xstate: 5.32.5
     transitivePeerDependencies:
       - '@types/react'
 
@@ -17399,6 +17412,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xstate@5.30.0: {}
+
+  xstate@5.32.5: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
Editing an annotation in Sanity Studio v5 closes the editing popover on the first keystroke in one of its fields. The popover survives a page reload (with the open path still in the URL) until it is closed and reopened, and no Studio or editor version bump introduced it: fresh installs of editor versions that used to work show the bug, existing lockfiles do not.

The trigger is xstate 5.32.2 (statelyai/xstate#5548), which changed transition selection so an event whose specific transitions are all disabled falls back to matching wildcard transitions. The relay machine's `'selection'` dedupe relied on the old behavior: when both guards failed (no preceding `focused` event, unchanged selection reference) the event was left unhandled and therefore swallowed. Under the new semantics it falls through to the relay's `'*'` passthrough and gets emitted anyway, so subscribers receive a `'selection'` event on every `editor.onChange()` cycle, including the ones triggered by syncing an external value update. Studio wires `'selection'` to its form focus path: the first keystroke in the popover loops the field patch back into the editor, the unchanged selection re-emits, the focus path moves off the annotation, and the popover closes.

The fix gives `'selection'` an unguarded final transition that consumes the deduped event without emitting, restoring the intended semantics under any xstate 5.x. Pinned by relay-machine unit tests; the dedupe tests are red on the unpatched machine. The editor package's xstate dependency moves to `^5.32.5` so CI runs against the semantics fresh installs resolve. Verified end to end against a Studio 5.31.2 sandbox: with editor 6.6.8 the popover closes on the first keypress, with this branch it stays open.

The v7 line (7.3.3 and later) and `main` replaced the relay machine with a plain emitter that dedupes with an early return, so only the v6 line carries the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor event relay semantics for `selection`, which Studio and other consumers use for focus; change is narrow and covered by new tests but affects observable editor behavior.
> 
> **Overview**
> Fixes a regression where **unchanged `selection` events were re-emitted** during external value sync (e.g. first keystroke in a Sanity Studio annotation popover closing the UI). **xstate 5.32.2+** now matches wildcard transitions when guarded `selection` handlers do not apply, so deduped selections used to fall through to the relay `'*'` handler and emit anyway.
> 
> The relay machine adds an **unguarded final `selection` transition** that consumes duplicate selections **without emitting**, preserving dedupe under current xstate semantics. **Unit tests** lock in dedupe after repeats, re-emission after `focused`, and dedupe after other events. **`xstate` is bumped to `^5.32.5`** so CI exercises the newer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c3614c68b0b43266a1e609dd4652a0d0a20b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->