### PR TITLE
fix: scroll the caret into view when a local edit moves content around an unchanged selection

### DIFF
--- a/.changeset/scroll-caret-on-local-change.md
+++ b/.changeset/scroll-caret-on-local-change.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: scroll the caret into view when a local edit moves content around an unchanged selection
+
+Pressing Enter at the start of a block inserts a new empty block above it without moving the caret's own selection points. Repeating this pushed the caret's block further and further below the fold without the editor ever scrolling it back into view. The caret's block now scrolls back into view whenever a local edit, undo, or redo moves content around a selection that stayed put.

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -27,6 +27,7 @@ import type {PortableTextEditorEngine} from '../../../types/editor-engine'
 import {collapse} from '../../core/collapse'
 import {deselect} from '../../core/deselect'
 import {move} from '../../core/move'
+import {subscribeToOperations} from '../../core/operation-channel'
 import {DOMEditor} from '../../dom/plugin/dom-editor'
 import {TRIPLE_CLICK} from '../../dom/utils/constants'
 import {
@@ -194,8 +195,25 @@ export const Editable = forwardRef(
       () => ({
         isUpdatingSelection: false,
         latestElement: null as DOMElement | null,
+        localContentChangePending: false,
       }),
       [],
+    )
+
+    // Consumed by the selection-sync layout effect below.
+    useEffect(
+      () =>
+        subscribeToOperations(editor, (event) => {
+          if (
+            event.operation.type !== 'set.selection' &&
+            (event.origin === 'local' ||
+              event.origin === 'undo' ||
+              event.origin === 'redo')
+          ) {
+            state.localContentChangePending = true
+          }
+        }),
+      [editor, state],
     )
 
     // The autoFocus TextareaHTMLAttribute doesn't do anything on a div, so it
@@ -369,6 +387,12 @@ export const Editable = forwardRef(
     })
 
     useIsomorphicLayoutEffect(() => {
+      // Consumed at most once per effect run: whichever render runs next
+      // after a local content change is the only one allowed to scroll
+      // for it, regardless of which early return below this point fires.
+      const hadPendingLocalContentChange = state.localContentChangePending
+      state.localContentChangePending = false
+
       // Update element-related editor maps with the DOM element ref.
       let window: Window | null = null
       if (ref.current && (window = getDefaultView(ref.current))) {
@@ -448,6 +472,20 @@ export const Editable = forwardRef(
           )
 
           if (editorSelection && rangeEquals(editorSelection, selection)) {
+            if (hadPendingLocalContentChange) {
+              // Content just moved around this selection without changing
+              // its points (inserting a block before the caret's own
+              // block, for example), so the DOM and model agree and
+              // nothing below rewrites the DOM selection or scrolls it
+              // into view; do that here instead.
+              try {
+                const domRange = DOMEditor.toDOMRange(editor, selection)
+                scrollSelectionIntoView(editor, domRange)
+              } catch (_e) {
+                // Ignore, dom and state might be out of sync
+              }
+            }
+
             return
           }
         }

--- a/packages/editor/tests/selection-scroll-into-view.test.tsx
+++ b/packages/editor/tests/selection-scroll-into-view.test.tsx
@@ -1,3 +1,4 @@
+import {insert} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
@@ -23,6 +24,14 @@ const paragraph = (index: number) => ({
   children: [
     {_type: 'span', _key: `s${index}`, text: `paragraph ${index}`, marks: []},
   ],
+})
+
+const fillerBlock = (key: string) => ({
+  _type: 'block',
+  _key: key,
+  style: 'normal',
+  markDefs: [],
+  children: [{_type: 'span', _key: `${key}s`, text: 'filler', marks: []}],
 })
 
 describe('Feature: Scrolling the Selection Into View', () => {
@@ -78,6 +87,100 @@ describe('Feature: Scrolling the Selection Into View', () => {
     await vi.waitFor(() => {
       expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
     })
+    expect(window.scrollY).toBe(0)
+  })
+
+  test('Scenario: pressing Enter at the start of a block scrolls it back into view as it moves below the fold', async () => {
+    const {editor} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition,
+      initialValue: Array.from({length: 3}, (_, index) => paragraph(index)),
+    })
+    editor.send({type: 'focus'})
+    window.scrollTo(0, 0)
+
+    // A caret at the very start of a block that starts on-screen.
+    const point = {path: [{_key: 'p2'}, 'children', {_key: 's2'}], offset: 0}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+    })
+
+    for (let index = 0; index < 60; index++) {
+      editor.send({type: 'insert.break'})
+    }
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[data-pt-block="text"]').length).toBe(
+        63,
+      )
+    })
+
+    await vi.waitFor(() => {
+      const block = document.querySelector(
+        `[data-pt-path="${CSS.escape('[_key=="p2"]')}"]`,
+      )
+      if (!block) {
+        throw new Error('block not rendered')
+      }
+      const rect = block.getBoundingClientRect()
+      expect(rect.top).toBeGreaterThanOrEqual(0)
+      expect(rect.top).toBeLessThan(window.innerHeight)
+    })
+  })
+
+  test('Scenario: a remote content change around an unchanged selection does not scroll', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition,
+      initialValue: Array.from({length: 3}, (_, index) => paragraph(index)),
+    })
+    editor.send({type: 'focus'})
+    window.scrollTo(0, 0)
+
+    const point = {path: [{_key: 'p2'}, 'children', {_key: 's2'}], offset: 0}
+    editor.send({type: 'select', at: {anchor: point, focus: point}})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.selection?.focus).toEqual(point)
+    })
+
+    const insertedKeys = Array.from({length: 60}, () => keyGenerator())
+    editor.send({
+      type: 'patches',
+      patches: [
+        insert(
+          insertedKeys.map((key) => fillerBlock(key)),
+          'before',
+          [{_key: 'p2'}],
+        ),
+      ],
+      snapshot: undefined,
+    })
+
+    const lastInsertedKey = insertedKeys[insertedKeys.length - 1]
+    await vi.waitFor(() => {
+      const block = document.querySelector(
+        `[data-pt-path="${CSS.escape(`[_key=="${lastInsertedKey}"]`)}"]`,
+      )
+      if (!block) {
+        throw new Error('block not rendered')
+      }
+    })
+
+    const block = document.querySelector(
+      `[data-pt-path="${CSS.escape('[_key=="p2"]')}"]`,
+    )
+    if (!block) {
+      throw new Error('block not rendered')
+    }
+    // Without this, a remote change that never affected the viewport would
+    // make the `scrollY` assertion below meaningless.
+    expect(block.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      window.innerHeight,
+    )
     expect(window.scrollY).toBe(0)
   })
 })


### PR DESCRIPTION
Holding Enter with the caret at the start of a block pushes the block further and further down the page while the viewport stays put; the caret disappears below the fold and the only way back is manual scrolling. Enter at the end of a block scrolls fine.

The two cases diverge in the selection-sync effect in `editable.tsx`. Enter at the end selects the start of the new block, the DOM selection disagrees with the model, and the rewrite path scrolls it into view. Enter at the start inserts the new block before the caret's block with `select: 'none'`; selection paths are keyed, so the model selection is untouched and the caret's DOM point never moves. The effect's in-sync early return fires before `scrollSelectionIntoView` is ever reached. Every `select: 'none'` insertion shares the gap.

The fix subscribes the component to the engine's operation channel and flags content-changing operations with origin `local`, `undo`, or `redo`. The sync effect consumes the flag once per run, and the in-sync branch scrolls the selection's DOM range into view when it was set. Remote and normalization operations never set the flag, so a remote edit landing above a parked caret does not move the viewport, pinned by a test inserting sixty remote blocks above an in-sync caret and asserting the page does not scroll. The Enter-at-start repro is pinned by a test that fails without the fix.

One broader delta: any local edit that leaves the DOM and model selection already in agreement now scrolls the caret into view if needed, where previously nothing did.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches selection-sync and scroll behavior in the core `Editable` path for all local/undo/redo content changes; wrong origin filtering could scroll on remote edits or miss local cases.
> 
> **Overview**
> Fixes a case where **Enter at the start of a block** inserts new blocks above the caret without changing selection paths, so DOM and model stay “in sync” and the selection-sync effect returned early—never calling **`scrollSelectionIntoView`** while the caret’s block drifted below the fold.
> 
> **`Editable`** now subscribes to the engine operation channel and sets **`localContentChangePending`** for non-`set.selection` operations from **`local`**, **`undo`**, or **`redo`**. On the next selection-sync layout pass, if model and DOM selection already match but that flag was set, it scrolls the caret’s DOM range into view. Remote/normalization edits do not set the flag, so collaborative inserts above a parked caret do not yank the viewport.
> 
> Adds regression tests: repeated **`insert.break`** at block start keeps the caret block visible, and a remote **`patches`** insert above the caret leaves **`scrollY`** at 0. Ships as a **`@portabletext/editor`** patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da867a51ecb6d7fcf9a86e12671e84f057b1afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->