### PR TITLE
refactor: throw from `setNodeProperties` when the path is structurally unreachable

### DIFF
--- a/packages/editor/src/internal-utils/set-node-properties.test.ts
+++ b/packages/editor/src/internal-utils/set-node-properties.test.ts
@@ -1,0 +1,168 @@
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {expect, test} from 'vitest'
+import type {EditorSchema} from '../editor/editor-schema'
+import {createEditor} from '../engine/create-editor'
+import type {Editor} from '../engine/interfaces/editor'
+import {defineContainer, type Container} from '../renderers/renderer.types'
+import {
+  resolveContainers,
+  resolveContainersRich,
+} from '../schema/resolve-containers-batch'
+import {buildIndexMaps} from './build-index-maps'
+import {setNodeProperties} from './set-node-properties'
+
+test('throws when the path is structurally unreachable', () => {
+  const keyGenerator = createTestKeyGenerator()
+  const blockKey = keyGenerator()
+  const spanKey = keyGenerator()
+  const markDefKey = keyGenerator()
+  const newKey = keyGenerator()
+
+  const schema = compileSchema(
+    defineSchema({
+      annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+    }),
+  )
+  const value: Array<PortableTextBlock> = [
+    {
+      _key: blockKey,
+      _type: 'block',
+      style: 'normal',
+      markDefs: [
+        {_key: markDefKey, _type: 'link', href: 'https://example.com/foo'},
+      ],
+      children: [
+        {_key: spanKey, _type: 'span', text: 'foo', marks: [markDefKey]},
+      ],
+    },
+  ]
+  const editor = createBareEditor(schema, [], value)
+
+  expect(() =>
+    setNodeProperties(editor, {_key: newKey}, [
+      {_key: blockKey},
+      'markDefs',
+      {_key: markDefKey},
+    ]),
+  ).toThrow('Unable to set properties at structurally unreachable path')
+})
+
+test('skips silently when the node is missing', () => {
+  const keyGenerator = createTestKeyGenerator()
+  const blockKey = keyGenerator()
+  const spanKey = keyGenerator()
+
+  const schema = compileSchema(defineSchema({}))
+  const value: Array<PortableTextBlock> = [
+    {
+      _key: blockKey,
+      _type: 'block',
+      style: 'normal',
+      markDefs: [],
+      children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+    },
+  ]
+  const editor = createBareEditor(schema, [], value)
+
+  expect(() =>
+    setNodeProperties(editor, {level: 1}, [{_key: 'nonexistent'}]),
+  ).not.toThrow()
+  expect(editor.snapshot.context.value).toEqual([
+    {
+      _key: blockKey,
+      _type: 'block',
+      style: 'normal',
+      markDefs: [],
+      children: [{_key: spanKey, _type: 'span', text: 'foo', marks: []}],
+    },
+  ])
+})
+
+test('applies the change through a container whose array field is named markDefs', () => {
+  const keyGenerator = createTestKeyGenerator()
+  const containerKey = keyGenerator()
+  const childKey = keyGenerator()
+
+  const schema = compileSchema(
+    defineSchema({
+      blockObjects: [
+        {
+          name: 'sidebar',
+          fields: [
+            {
+              name: 'markDefs',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'note',
+                  fields: [{name: 'title', type: 'string'}],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+  const publicContainers: Array<Container> = [
+    defineContainer({type: 'sidebar', arrayField: 'markDefs'}),
+  ]
+  const value: Array<PortableTextBlock> = [
+    {
+      _key: containerKey,
+      _type: 'sidebar',
+      markDefs: [{_key: childKey, _type: 'note', title: 'foo'}],
+    },
+  ]
+  const editor = createBareEditor(schema, publicContainers, value)
+
+  setNodeProperties(editor, {title: 'baz'}, [
+    {_key: containerKey},
+    'markDefs',
+    {_key: childKey},
+  ])
+
+  expect(editor.snapshot.context.value).toEqual([
+    {
+      _key: containerKey,
+      _type: 'sidebar',
+      markDefs: [{_key: childKey, _type: 'note', title: 'baz'}],
+    },
+  ])
+})
+
+function createBareEditor(
+  schema: EditorSchema,
+  publicContainers: Array<Container>,
+  value: Array<PortableTextBlock>,
+): Editor {
+  const editor = createEditor()
+  const containers = resolveContainers(schema, publicContainers)
+  const blockIndexMap = new Map<string, number>()
+  buildIndexMaps({schema, containers, value}, {blockIndexMap})
+
+  editor.containers = resolveContainersRich(schema, publicContainers)
+  editor.blockIndexMap = blockIndexMap
+  editor.verifiedUniqueChildGroups = new Set()
+  editor.snapshot = {
+    blockIndexMap,
+    context: {
+      containers,
+      converters: [],
+      keyGenerator: () => 'generated-key',
+      readOnly: false,
+      schema,
+      selection: null,
+      value,
+    },
+    decoratorState: {},
+  } as Editor['snapshot']
+
+  return editor
+}

--- a/packages/editor/src/internal-utils/set-node-properties.ts
+++ b/packages/editor/src/internal-utils/set-node-properties.ts
@@ -1,7 +1,8 @@
 import type {Path} from '../engine/interfaces/path'
-import {getNode} from '../traversal/get-node'
+import {resolveNode} from '../traversal/get-node'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
+import {safeStringify} from './safe-json'
 
 /**
  * Apply property changes at a known path using primitive `set` and `unset`
@@ -17,13 +18,19 @@ export function setNodeProperties(
   props: Record<string, unknown> | object,
   path: Path,
 ): void {
-  const nodeEntry = getNode(editor.snapshot, path)
+  const result = resolveNode(editor.snapshot, path)
 
-  if (!nodeEntry) {
+  if (result.status === 'unreachable') {
+    throw new Error(
+      `Unable to set properties at structurally unreachable path ${safeStringify(path)}`,
+    )
+  }
+
+  if (result.status === 'missing') {
     return
   }
 
-  const node = nodeEntry.node
+  const node = result.entry.node
   const nodeRecord = node as Record<string, unknown>
   const propsRecord = props as Record<string, unknown>
 

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -33,8 +33,32 @@ export function getNode(
   snapshot: TraversalSnapshot,
   path: Path,
 ): {node: Node; path: Path} | undefined {
+  const result = resolveNode(snapshot, path)
+  return result.status === 'found' ? result.entry : undefined
+}
+
+/**
+ * Result of walking a path against a snapshot.
+ *
+ * `unreachable` is the one outcome that means "structurally impossible
+ * by design": the path digs past a sidecar field (e.g. `markDefs` on
+ * a text block) into a keyed/indexed segment, which `getNode` can
+ * never resolve (use `getAnnotation` for annotations). Every other
+ * negative outcome is `missing`; on those branches a caller bug and a
+ * benign race (the node removed by a concurrent edit) produce the
+ * same state, so they cannot be told apart.
+ */
+export type ResolveNodeResult =
+  | {status: 'found'; entry: {node: Node; path: Path}}
+  | {status: 'missing'}
+  | {status: 'unreachable'}
+
+export function resolveNode(
+  snapshot: TraversalSnapshot,
+  path: Path,
+): ResolveNodeResult {
   if (path.length === 0) {
-    return undefined
+    return {status: 'missing'}
   }
 
   const {context, blockIndexMap} = snapshot
@@ -55,7 +79,7 @@ export function getNode(
       // block, a primitive field on an object). If the input keeps
       // digging past it with more keyed/numeric segments, the caller
       // wanted a node inside the sidecar and `getNode` can't reach it
-      // (use `getAnnotation` for annotations); return undefined.
+      // (use `getAnnotation` for annotations); report unreachable.
       // Otherwise the rest is just trailing field names — let the loop
       // exit and the post-loop strip remove them.
       if (currentFieldName !== undefined && segment === currentFieldName) {
@@ -65,7 +89,7 @@ export function getNode(
       for (let j = i + 1; j < path.length; j++) {
         const s = path[j]
         if (isKeyedSegment(s) || typeof s === 'number') {
-          return undefined
+          return {status: 'unreachable'}
         }
       }
       break
@@ -96,11 +120,11 @@ export function getNode(
         resolvedPath.push({_key: node._key})
       }
     } else {
-      return undefined
+      return {status: 'missing'}
     }
 
     if (!node) {
-      return undefined
+      return {status: 'missing'}
     }
 
     let hasMoreSegments = false
@@ -116,7 +140,7 @@ export function getNode(
       const next = getNodeChildren(context, node, currentParent)
 
       if (!next) {
-        return undefined
+        return {status: 'missing'}
       }
 
       currentChildren = next.children
@@ -128,7 +152,7 @@ export function getNode(
   }
 
   if (!node) {
-    return undefined
+    return {status: 'missing'}
   }
 
   // Strip trailing field-name segments. The walker may have pushed
@@ -143,5 +167,5 @@ export function getNode(
     resolvedPath.pop()
   }
 
-  return {node, path: resolvedPath}
+  return {status: 'found', entry: {node, path: resolvedPath}}
 }


### PR DESCRIPTION
`setNodeProperties` returned silently whenever `getNode` failed to resolve its path. That conflates two different failures: the node is genuinely gone (a legitimate race during value sync, where skipping is right), and a path shape `getNode` refuses by design, a keyed descent past a sidecar field like `markDefs` on a text block. The second is always a caller bug, and it hides well: the range-delete merge fix (#3187) originally applied markDef renames through this path, every value-asserting test stayed green because the merged value was rebuilt from computed defs, and only a wire assertion exposed that the rename patches never emitted.

The walker in `get-node.ts` now surfaces why it fails: `resolveNode` returns `found`, `missing`, or `unreachable`, with `unreachable` reserved for the sidecar-refusal branch, the only one where a caller bug is distinguishable from a race. `getNode` keeps its exact contract. `setNodeProperties` throws on `unreachable` and keeps the silent skip on `missing`. The throw keys on the shape mismatch, not the field name: a keyed descent through a registered container whose `arrayField` is named `markDefs` still applies, pinned by a test.

All 31 call sites pass block-level or child-level paths resolved against the same snapshot, so none can reach the throw, and the silent skip stays load-bearing for value-sync reconciliation. The new throw is pinned by a unit test that is red on the old silent no-op, alongside one pinning the missing-node skip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core path resolution and `setNodeProperties` error behavior; incorrect classification of `unreachable` vs `missing` could break sync callers or surface new throws in edge paths.
> 
> **Overview**
> Path walking in `get-node.ts` now exposes **`resolveNode`**, which returns **`found`**, **`missing`**, or **`unreachable`** instead of collapsing every failure into `undefined`. **`unreachable`** is reserved for paths that descend past a sidecar field (e.g. keyed segments under text-block `markDefs`) that **`getNode`** cannot target by design; **`getNode`**’s public behavior is unchanged via a thin wrapper.
> 
> **`setNodeProperties`** switches to **`resolveNode`**: it **throws** with a serialized path on **`unreachable`** (caller bugs that used to no-op silently) and still **returns without applying patches** when the node is **`missing`** (races / stale paths during value sync).
> 
> New **`set-node-properties`** tests lock in the throw, the missing-node skip, and that keyed descent through a **registered container** whose array field is named `markDefs` still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ffba4810e8a981c5576f7e6fc80349f1574264f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->