### PR TITLE
fix: only smart-undo on Backspace when no edit landed since the input rule applied

### DIFF
--- a/.changeset/smart-undo-stale-guard.md
+++ b/.changeset/smart-undo-stale-guard.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-input-rule': patch
+---
+
+fix: only smart-undo on Backspace when no edit landed since the input rule applied
+
+Pressing Backspace right after an input rule fires still undoes the rule, including when a collaborator's changes arrive in between. Once any other local edit lands, Backspace acts normally again.

--- a/packages/plugin-input-rule/src/edge-cases.feature
+++ b/packages/plugin-input-rule/src/edge-cases.feature
@@ -252,3 +252,23 @@ Feature: Edge Cases
       | state | inserted text | new state         |
       | "B: " | "judeee yeah" | "B: judeee!new\|" |
       | "B: " | "judeee"      | "B: judeeenew\|"  |
+
+  Scenario: Backspace does not smart-undo after a competing behavior mutated the block
+    Given the editor state is "B: "
+    When the editor is focused
+    And "qqq" is typed
+    Then the editor state is "B: Q|"
+    When "{Backspace}" is pressed
+    Then the editor state is "B style=\"consumed\": Q|"
+    When "{Backspace}" is pressed
+    Then the editor state is "B style=\"consumed\": |"
+
+  Scenario: Backspace after two consecutive rule applications only undoes the second
+    Given the editor state is "B: "
+    When the editor is focused
+    And "!hi!" is inserted
+    Then the editor state is "B: WHOLE|"
+    When "!yo!" is inserted
+    Then the editor state is "B: WHOLEWHOLE|"
+    When "{Backspace}" is pressed
+    Then the editor state is "B: WHOLE!yo!|"

--- a/packages/plugin-input-rule/src/edge-cases.test.tsx
+++ b/packages/plugin-input-rule/src/edge-cases.test.tsx
@@ -1,4 +1,9 @@
-import {getPreviousInlineObject} from '@portabletext/editor/selectors'
+import {useEditor} from '@portabletext/editor'
+import {defineBehavior, raise} from '@portabletext/editor/behaviors'
+import {
+  getFocusTextBlock,
+  getPreviousInlineObject,
+} from '@portabletext/editor/selectors'
 import {parameterTypes} from '@portabletext/editor/test'
 import {
   createTestEditor,
@@ -8,6 +13,7 @@ import {
 import {defineSchema} from '@portabletext/schema'
 import {Before} from 'racejar'
 import {Feature} from 'racejar/vitest'
+import {useEffect} from 'react'
 import edgeCasesFeature from './edge-cases.feature?raw'
 import {InputRulePlugin} from './plugin.input-rule'
 import {defineTextTransformRule} from './text-transform-rule'
@@ -75,6 +81,53 @@ const multiplicationRule = defineTextTransformRule({
   transform: {operator: () => '×'},
 })
 
+const competingRule = defineTextTransformRule({
+  on: /qqq/,
+  transform: () => 'Q',
+})
+
+// Guarded to the `competingRule`'s own output so it never fires for the
+// file's other scenarios.
+const competingBackspaceBehavior = defineBehavior({
+  on: 'delete.backward',
+  guard: ({snapshot}) => {
+    const focusTextBlock = getFocusTextBlock(snapshot)
+
+    if (!focusTextBlock || focusTextBlock.node.style === 'consumed') {
+      return false
+    }
+
+    const text = focusTextBlock.node.children
+      .map((child) => ('text' in child ? child.text : ''))
+      .join('')
+
+    if (text !== 'Q') {
+      return false
+    }
+
+    return {focusTextBlock}
+  },
+  actions: [
+    (_, {focusTextBlock}) => [
+      raise({
+        type: 'block.set',
+        props: {style: 'consumed'},
+        at: focusTextBlock.path,
+      }),
+    ],
+  ],
+})
+
+function CompetingBackspaceBehaviorPlugin() {
+  const editor = useEditor()
+
+  useEffect(() => {
+    return editor.registerBehavior({behavior: competingBackspaceBehavior})
+  }, [editor])
+
+  return null
+}
+
 Feature({
   hooks: [
     Before(async (context: Context) => {
@@ -92,12 +145,15 @@ Feature({
             <InputRulePlugin rules={[groupsWithoutReplaceRule]} />
             <InputRulePlugin rules={[optionalReplaceGroupRule]} />
             <InputRulePlugin rules={[multiplicationRule]} />
+            <InputRulePlugin rules={[competingRule]} />
+            <CompetingBackspaceBehaviorPlugin />
           </>
         ),
         schemaDefinition: defineSchema({
           decorators: [{name: 'strong'}],
           annotations: [{name: 'link'}],
           inlineObjects: [{name: 'stock-ticker'}],
+          styles: [{name: 'consumed'}],
         }),
       })
 

--- a/packages/plugin-input-rule/src/plugin.input-rule.remote-operation.test.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.remote-operation.test.tsx
@@ -1,0 +1,132 @@
+import {createTestEditor} from '@portabletext/editor/test/vitest'
+import {defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {expect, test, vi} from 'vitest'
+import {InputRulePlugin} from './plugin.input-rule'
+import {defineTextTransformRule} from './text-transform-rule'
+
+const arrowRule = defineTextTransformRule({
+  on: /->$/,
+  transform: () => '→',
+})
+
+test("Scenario: a remote collaborator's edit to another block does not disarm smart undo", async () => {
+  const keyGenerator = createTestKeyGenerator()
+  const ruleBlockKey = keyGenerator()
+  const ruleSpanKey = keyGenerator()
+  const otherBlockKey = keyGenerator()
+  const otherSpanKey = keyGenerator()
+
+  const {editor} = await createTestEditor({
+    keyGenerator,
+    schemaDefinition: defineSchema({}),
+    initialValue: [
+      {
+        _type: 'block',
+        _key: ruleBlockKey,
+        children: [{_type: 'span', _key: ruleSpanKey, text: '', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: otherBlockKey,
+        children: [{_type: 'span', _key: otherSpanKey, text: 'bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: <InputRulePlugin rules={[arrowRule]} />,
+  })
+
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {
+        path: [{_key: ruleBlockKey}, 'children', {_key: ruleSpanKey}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: ruleBlockKey}, 'children', {_key: ruleSpanKey}],
+        offset: 0,
+      },
+    },
+  })
+  // Typed as separate events, the way real typing arrives: the trigger
+  // character must already be in the document when the rule's own match
+  // fires.
+  editor.send({type: 'insert.text', text: '-'})
+  editor.send({type: 'insert.text', text: '>'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: ruleBlockKey,
+        children: [{_type: 'span', _key: ruleSpanKey, text: '→', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: otherBlockKey,
+        children: [{_type: 'span', _key: otherSpanKey, text: 'bar', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  editor.send({
+    type: 'patches',
+    patches: [
+      {
+        type: 'set',
+        path: [{_key: otherBlockKey}, 'children', {_key: otherSpanKey}, 'text'],
+        value: 'baz',
+        origin: 'remote',
+      },
+    ],
+    snapshot: undefined,
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: ruleBlockKey,
+        children: [{_type: 'span', _key: ruleSpanKey, text: '→', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: otherBlockKey,
+        children: [{_type: 'span', _key: otherSpanKey, text: 'baz', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+
+  editor.send({type: 'delete.backward', unit: 'character'})
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value).toEqual([
+      {
+        _type: 'block',
+        _key: ruleBlockKey,
+        children: [{_type: 'span', _key: ruleSpanKey, text: '->', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+      {
+        _type: 'block',
+        _key: otherBlockKey,
+        children: [{_type: 'span', _key: otherSpanKey, text: 'baz', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+})

--- a/packages/plugin-input-rule/src/plugin.input-rule.tsx
+++ b/packages/plugin-input-rule/src/plugin.input-rule.tsx
@@ -313,6 +313,7 @@ type InputRuleMachineEvent =
       blockOffsets: {start: BlockOffset; end: BlockOffset} | undefined
       selection: EditorSelection
     }
+  | {type: 'operation observed'}
 
 const inputRuleListenerCallback: CallbackLogicFunction<
   AnyEventObject,
@@ -354,6 +355,22 @@ const deleteBackwardListenerCallback: CallbackLogicFunction<
       ],
     }),
   })
+}
+
+const operationListenerCallback: CallbackLogicFunction<
+  AnyEventObject,
+  InputRuleMachineEvent,
+  {editor: Editor}
+> = ({input, sendBack}) => {
+  const subscription = input.editor.on('operation', (event) => {
+    if (event.origin === 'remote') {
+      return
+    }
+
+    sendBack({type: 'operation observed'})
+  })
+
+  return () => subscription.unsubscribe()
 }
 
 const selectionListenerCallback: CallbackLogicFunction<
@@ -400,6 +417,7 @@ const inputRuleSetup = setup({
   actors: {
     'delete.backward listener': fromCallback(deleteBackwardListenerCallback),
     'input rule listener': fromCallback(inputRuleListenerCallback),
+    'operation listener': fromCallback(operationListenerCallback),
     'selection listener': fromCallback(selectionListenerCallback),
   },
   guards: {
@@ -485,6 +503,10 @@ const inputRuleMachine = inputRuleSetup.createMachine({
           input: ({context}) => ({editor: context.editor}),
         },
         {
+          src: 'operation listener',
+          input: ({context}) => ({editor: context.editor}),
+        },
+        {
           src: 'selection listener',
           input: ({context}) => ({editor: context.editor}),
         },
@@ -495,6 +517,9 @@ const inputRuleMachine = inputRuleSetup.createMachine({
           guard: 'selection changed',
         },
         'history.undo raised': {
+          target: 'idle',
+        },
+        'operation observed': {
           target: 'idle',
         },
       },

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
@@ -99,6 +99,16 @@ Feature: Markdown Behaviors
       | "h5"  |
       | "h6"  |
 
+  Scenario: Backspace twice after an automatic heading does not resurface the heading
+    Given the editor state is "B: |"
+    When the editor is focused
+    And "# " is typed
+    Then the editor state is "B style=\"h1\": |"
+    When "{Backspace}" is pressed
+    Then the editor state is "B: |"
+    When "{Backspace}" is pressed
+    Then the editor state is "B: |"
+
   Scenario: Unordered list clear-on-enter works on second cycle
     Given the editor state is "B: -"
     When the editor is focused


### PR DESCRIPTION
Typing `# ` turns a block into a heading, and pressing Backspace clears the style back to a paragraph. Pressing Backspace again turned it back into a heading, and a third Backspace back into a paragraph again.

After an input rule applies, the input-rule plugin arms a Backspace-undoes-the-shortcut behavior and disarms it only when that undo fires or the selection moves. `clearStyleOnBackspace` in `plugin-markdown-shortcuts` consumes the first Backspace with a `block.set` that moves no selection, so the armed behavior survived it, and the second Backspace raised a `history.undo` that reverted the style clear instead of the rule application.

The armed state now also listens for `operation` events and disarms on any local document-changing operation, symmetric with the existing selection disarm. Smart undo thereby means Backspace with nothing in between. Operations with `origin: 'remote'` (#3197) are ignored: the undo stack is local-only and rebases against remote patches, so a collaborator's concurrent edit does not change what `history.undo` reverts and must not disarm. Arming happens after the rule's own operations, so the rule cannot disarm itself; the existing smart-undo suites across `plugin-input-rule`, `plugin-typography`, and `plugin-character-pair-decorator` pin that.

Pinned by a markdown-shortcuts scenario (`# `, Backspace twice, the block stays a paragraph), a machine-level scenario in `plugin-input-rule` with a competing Backspace behavior, one pinning that after two back-to-back rule applications Backspace undoes only the latest one, and one pinning that remote patches to another block leave smart undo armed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core input-rule undo timing and editor operation events; behavior change affects markdown shortcuts and all input-rule consumers, but scope is narrow and heavily tested.
> 
> **Overview**
> Fixes **Backspace smart-undo** for input rules so it only runs when nothing else has changed the document since the rule applied. Previously, armed undo could survive an intervening local change (e.g. markdown heading clear on first Backspace), so a second Backspace could `history.undo` the wrong step and flip heading/paragraph back and forth.
> 
> The input-rule state machine now **subscribes to local `operation` events** while in `input rule applied` and returns to idle on any non-remote document change, alongside existing disarm on selection move and after smart-undo. **Remote patches are ignored**, so collaborator edits elsewhere still allow undoing the rule with Backspace.
> 
> Coverage adds edge cases (competing Backspace behavior, two rules in a row), a remote-collaboration vitest, and a markdown-shortcuts scenario for double Backspace after `# `.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2eab9c7aa1b0f150d95524feaa508606d39aea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->