### PR TITLE
feat: report the origin on the `operation` event

### DIFF
--- a/.changeset/report-operation-origin.md
+++ b/.changeset/report-operation-origin.md
@@ -1,0 +1,17 @@
+---
+'@portabletext/editor': minor
+---
+
+feat: report the origin on the `operation` event
+
+Every `operation` event now carries an `origin` telling you where the change that produced it came from:
+
+```ts
+editor.on('operation', (event) => {
+  console.log(event.operation, event.origin)
+})
+```
+
+`origin` is `'local'` for changes made in this editor (edits, undo/redo) and `'remote'` for changes a collaborator applied through `patches` or `update value`. A normalization fix (a repaired key, a merged span) reports the origin of the change that triggered it: a local edit's fallout reports `'local'`, a remote patch's fallout reports `'remote'`.
+
+The field is required on the event object: code that constructs `operation` event values or asserts them wholesale (for example with `toEqual`) must add `origin` when upgrading.

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -260,7 +260,11 @@ function createActors(config: {
         return
       }
 
-      config.relay.send({type: 'operation', operation: event.operation})
+      config.relay.send({
+        type: 'operation',
+        operation: event.operation,
+        origin: event.origin === 'remote' ? 'remote' : 'local',
+      })
     })
   })
 

--- a/packages/editor/src/editor/on.test-d.ts
+++ b/packages/editor/src/editor/on.test-d.ts
@@ -54,4 +54,10 @@ describe('editor.on overloads', () => {
     // @ts-expect-error - unbatched delivery is a single event, not an array
     editor.on('operation', arrayListener)
   })
+
+  test('an operation event carries its origin', () => {
+    editor.on('operation', (event) => {
+      expectTypeOf(event.origin).toEqualTypeOf<'local' | 'remote'>()
+    })
+  })
 })

--- a/packages/editor/src/editor/relay.ts
+++ b/packages/editor/src/editor/relay.ts
@@ -47,6 +47,15 @@ export type EditorEmittedEvent =
        */
       type: 'operation'
       operation: Operation
+      /**
+       * Where the change that produced this operation came from:
+       * `'local'` for changes made in this editor (edits, undo/redo),
+       * `'remote'` for changes applied from the outside (`patches`,
+       * `update value`, and the initial value sync). A normalization fix
+       * (a repaired key, a merged span) reports the origin of the change
+       * that triggered it.
+       */
+      origin: 'local' | 'remote'
     }
   | PatchEvent
   | {

--- a/packages/editor/tests/event.operation.test.tsx
+++ b/packages/editor/tests/event.operation.test.tsx
@@ -3,6 +3,7 @@ import type {
   PortableTextSpan,
   PortableTextTextBlock,
 } from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import type {Editor, Operation} from '../src'
@@ -332,6 +333,178 @@ describe('event.operation', () => {
       ])
     })
   })
+
+  test('Scenario: A local edit reports origin `local`', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [block('b1', '')],
+    })
+    const origins = collectOperationOrigins(editor)
+
+    await userEvent.type(locator, 'fo')
+
+    await vi.waitFor(() => {
+      expect(origins).toEqual(['local', 'local'])
+    })
+  })
+
+  test('Scenario: A remote patch reports origin `remote`', async () => {
+    const {editor} = await createTestEditor({
+      initialValue: [block('b1', 'foo')],
+    })
+    const origins = collectOperationOrigins(editor)
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: 'b1'}, 'children', {_key: 'b1-span'}, 'text'],
+          value: 'bar',
+          origin: 'remote',
+        },
+      ],
+      snapshot: [block('b1', 'bar')],
+    })
+
+    await vi.waitFor(() => {
+      expect(firstSpanText(editor)).toBe('bar')
+      expect(origins).toEqual(['remote'])
+    })
+  })
+
+  test('Scenario: Undo and redo report origin `local`', async () => {
+    const {editor, locator} = await createTestEditor({
+      initialValue: [block('b1', 'foo')],
+    })
+    await userEvent.type(locator, 'bar')
+    await vi.waitFor(() => {
+      expect(firstSpanText(editor)).toBe('barfoo')
+    })
+
+    const origins = collectOperationOrigins(editor)
+
+    editor.send({type: 'history.undo'})
+    await vi.waitFor(() => {
+      expect(firstSpanText(editor)).toBe('foo')
+      expect(origins).toEqual(['local', 'local', 'local'])
+    })
+    origins.length = 0
+
+    editor.send({type: 'history.redo'})
+    await vi.waitFor(() => {
+      expect(firstSpanText(editor)).toBe('barfoo')
+      expect(origins).toEqual(['local', 'local', 'local'])
+    })
+  })
+
+  test('Scenario: Remote-fallout normalization reports origin `remote`', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const initialBlock = {
+      _type: 'block',
+      _key: blockKey,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+    }
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [initialBlock],
+    })
+    const origins = collectOperationOrigins(editor)
+
+    // A remote insert lands a second span with the same key as the first.
+    // The engine's duplicate-key fix, unlike the same-mark-merge fix, isn't
+    // gated off during remote processing, so it fires here and its `set`
+    // rides the same remote batch as the triggering `insert`.
+    const duplicateSpan = {
+      _type: 'span',
+      _key: spanKey,
+      text: 'bar',
+      marks: ['strong'],
+    }
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [duplicateSpan],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [
+        {...initialBlock, children: [...initialBlock.children, duplicateSpan]},
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...initialBlock,
+          children: [initialBlock.children[0], {...duplicateSpan, _key: 'k4'}],
+        },
+      ])
+      expect(origins).toEqual(['remote', 'remote'])
+    })
+  })
+
+  test('Scenario: Local-edit fallout normalization reports origin `local`', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanFooKey = keyGenerator()
+    const spanBarKey = keyGenerator()
+    const spanBazKey = keyGenerator()
+    const initialBlock = {
+      _type: 'block',
+      _key: blockKey,
+      children: [
+        {_type: 'span', _key: spanFooKey, text: 'foo', marks: ['strong']},
+        {_type: 'span', _key: spanBarKey, text: 'bar', marks: ['strong']},
+        {_type: 'span', _key: spanBazKey, text: 'baz', marks: []},
+      ],
+      markDefs: [],
+      style: 'normal',
+    }
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [initialBlock],
+    })
+    const origins = collectOperationOrigins(editor)
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanBazKey}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    // The `insert.text` and the same-mark-merge fix it triggers both run
+    // inside the local edit, unlike the initial value sync (which is
+    // wrapped as a remote change).
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          ...initialBlock,
+          children: [
+            {...initialBlock.children[0], text: 'foobar'},
+            {...initialBlock.children[2], text: 'baz!'},
+          ],
+        },
+      ])
+      expect(origins).toEqual(['local', 'local', 'local'])
+    })
+  })
 })
 
 /**
@@ -343,6 +516,17 @@ function collectOperations(editor: Editor): Array<Operation> {
     operations.push(event.operation)
   })
   return operations
+}
+
+/**
+ * Collect the `origin` of every public operation event from this point on.
+ */
+function collectOperationOrigins(editor: Editor): Array<'local' | 'remote'> {
+  const origins: Array<'local' | 'remote'> = []
+  editor.on('operation', (event) => {
+    origins.push(event.origin)
+  })
+  return origins
 }
 
 function block(key: string, text: string): PortableTextBlock {

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -560,6 +560,7 @@ describe('event.update value', () => {
         {
           type: 'operation',
           operation: {type: 'unset', path: [{_key: 'k0'}]},
+          origin: 'remote',
         },
         {
           type: 'operation',
@@ -573,6 +574,7 @@ describe('event.update value', () => {
               children: [{_type: 'span', _key: 'k3', text: 'foo', marks: []}],
             },
           },
+          origin: 'remote',
         },
         {
           type: 'invalid value',
@@ -639,6 +641,7 @@ describe('event.update value', () => {
             offset: 3,
             text: '!',
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -648,6 +651,7 @@ describe('event.update value', () => {
             value: [],
             inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -657,6 +661,7 @@ describe('event.update value', () => {
             value: 'normal',
             inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
           },
+          origin: 'local',
         },
         {
           type: 'patch',
@@ -957,6 +962,7 @@ describe('event.update value', () => {
       {
         type: 'operation',
         operation: {type: 'unset', path: [{_key: 'k1'}]},
+        origin: 'remote',
       },
       {
         type: 'operation',
@@ -970,6 +976,7 @@ describe('event.update value', () => {
             src: 'https://example.com/image.jpg',
           },
         },
+        origin: 'remote',
       },
       {
         type: 'value changed',

--- a/packages/editor/tests/setup.test.tsx
+++ b/packages/editor/tests/setup.test.tsx
@@ -69,6 +69,7 @@ describe('Setup', () => {
       {
         type: 'operation',
         operation: {type: 'unset', path: [{_key: 'k5'}]},
+        origin: 'remote',
       },
       {
         type: 'operation',
@@ -82,6 +83,7 @@ describe('Setup', () => {
             children: [{_type: 'span', _key: 'k1', text: 'foo'}],
           },
         },
+        origin: 'remote',
       },
       {
         type: 'invalid value',

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -76,6 +76,7 @@ describe('Value validation', () => {
         {
           type: 'operation',
           operation: {type: 'unset', path: [{_key: 'k3'}]},
+          origin: 'remote',
         },
         {
           type: 'operation',
@@ -89,6 +90,7 @@ describe('Value validation', () => {
               children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
             },
           },
+          origin: 'remote',
         },
         {
           type: 'invalid value',
@@ -152,6 +154,7 @@ describe('Value validation', () => {
             offset: 3,
             text: '!',
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -161,6 +164,7 @@ describe('Value validation', () => {
             value: [],
             inverse: {type: 'unset', path: [{_key: 'k0'}, 'markDefs']},
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -170,6 +174,7 @@ describe('Value validation', () => {
             value: 'normal',
             inverse: {type: 'unset', path: [{_key: 'k0'}, 'style']},
           },
+          origin: 'local',
         },
         {
           type: 'patch',
@@ -303,6 +308,7 @@ describe('Value validation', () => {
         {
           type: 'operation',
           operation: {type: 'unset', path: [{_key: 'k3'}]},
+          origin: 'remote',
         },
         {
           type: 'operation',
@@ -312,6 +318,7 @@ describe('Value validation', () => {
             position: 'before',
             node: syncedBlock,
           },
+          origin: 'remote',
         },
         {type: 'value changed', value: [syncedBlock]},
         {type: 'ready'},
@@ -425,6 +432,7 @@ describe('Value validation', () => {
             offset: 3,
             text: '!',
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -434,6 +442,7 @@ describe('Value validation', () => {
             value: [],
             inverse: {type: 'unset', path: [{_key: blockKey}, 'markDefs']},
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -443,6 +452,7 @@ describe('Value validation', () => {
             value: 'normal',
             inverse: {type: 'unset', path: [{_key: blockKey}, 'style']},
           },
+          origin: 'local',
         },
         {
           type: 'patch',
@@ -581,6 +591,7 @@ describe('Value validation', () => {
         {
           type: 'operation',
           operation: {type: 'unset', path: [{_key: 'k0'}]},
+          origin: 'remote',
         },
         {
           type: 'operation',
@@ -594,6 +605,7 @@ describe('Value validation', () => {
               children: [{_type: 'span', _key: 'k3', text: 'foo', marks: []}],
             },
           },
+          origin: 'remote',
         },
         {
           type: 'invalid value',
@@ -655,6 +667,7 @@ describe('Value validation', () => {
             offset: 3,
             text: '!',
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -664,6 +677,7 @@ describe('Value validation', () => {
             value: [],
             inverse: {type: 'unset', path: [{_key: 'k2'}, 'markDefs']},
           },
+          origin: 'local',
         },
         {
           type: 'operation',
@@ -673,6 +687,7 @@ describe('Value validation', () => {
             value: 'normal',
             inverse: {type: 'unset', path: [{_key: 'k2'}, 'style']},
           },
+          origin: 'local',
         },
         {
           type: 'patch',


### PR DESCRIPTION
Consumers of the `operation` event cannot tell a local edit from a collaborator's change: the engine computes an origin for every operation it applies, but the relay dropped it at the emission site. The first consumer waiting on the distinction is the input-rule plugin's smart undo, which currently disarms on any operation (#3196) and should stay armed across remote edits, since the undo stack is local-only and rebases against remote patches; that fix follows in a separate PR.

Every `operation` event now carries `origin: 'local' | 'remote'` as a sibling of `operation`. The public question the field answers is whether the change came from outside this editor, so everything except remote application collapses to `'local'`: undo and redo are locally initiated, and a normalization fix is fallout of whatever change triggered it, meaning a local edit's fallout reports `'local'` and a remote patch's fallout reports `'remote'` (the engine already stamps remote-triggered fixes as remote). Initial value sync and prop-driven value replacement run as remote changes and report `'remote'`. The internal channel knows finer values (`'undo'`, `'redo'`, `'normalization'`); widening the public union later is additive, while shipping values with no consumer is frozen surface.

Pinned by five scenarios in `tests/event.operation.test.tsx` (local edit, remote patches, undo/redo, and both normalization-fallout cases), all red without the forwarding, plus an exact payload type pin in `on.test-d.ts`. The field is required, so full-value assertions on `operation` events in three existing suites gain it; downstream code that constructs or wholesale-asserts these events will need the same one-line addition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor semver API change on a beta event surface: required `origin` breaks consumers that construct or deeply assert `operation` events without updating types/tests.
> 
> **Overview**
> **`operation` events now include a required `origin: 'local' | 'remote'`** so listeners can tell in-editor changes from externally applied ones.
> 
> The relay forwards the engine’s operation origin (previously dropped in `create-editor`): **`'remote'`** for `patches`, `update value`, and initial value sync; **`'local'`** for typing, undo/redo, and everything else. Normalization fixes inherit the triggering change’s origin.
> 
> `EditorEmittedEvent` and the changeset document the field. New integration tests cover local edits, remote patches, undo/redo, and normalization fallout; existing suites that assert full `operation` payloads were updated. **Upgraders** must add `origin` when constructing or `toEqual`-matching `operation` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0fae3af7fa9895adb75b42095347078c38c17f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->