### PR TITLE
docs: require a changeset on bare `fix` and `feat` commits

### DIFF
--- a/.agents/skills/commits/SKILL.md
+++ b/.agents/skills/commits/SKILL.md
@@ -19,6 +19,7 @@ description: How to write commit messages in the Portable Text Editor monorepo. 
 ## Type selection
 
 - A commit that ships a **changeset is `fix:` or `feat:`**, never `refactor:`/`chore:`. The changeset is the tell: releasable change ⇒ fix/feat.
+- The tell runs both ways for bare types: a bare `fix:`/`feat:` **must ship (or amend) a changeset**. No changeset means it is not a fix/feat; retype it (`refactor:` for code changes with no releasable behavior change, even ones that alter internal behavior, `chore:`/`test:`/`docs:` otherwise). The two exemptions are scoped commits to unpublished targets (`fix(playground):`) and `fix(deps):`, where the changeset bot ships the release.
 - `chore(deps):` for dependency/config work with no published-code change (no changeset).
 - Renovate-adjacent nuance: `fix(deps)` cuts a patch release via the changeset bot; don't hand it to tooling-only bumps.
 


### PR DESCRIPTION
The commits skill's type-selection tell ran one way only: a changeset forces `fix:`/`feat:`. Nothing forced the reverse, so a bare `fix:` with no changeset was expressible, and it reads as a releasable change that never releases. Derived twice in two days on real PRs before becoming a rule.

The tell now runs both ways for bare types: a bare `fix:`/`feat:` must ship or amend a changeset, and a commit with none retypes (`refactor:` for code without releasable behavior change, explicitly including internal behavior changes like new internal-only throws; `chore:`/`test:`/`docs:` otherwise). Scoped fixes to unpublished targets (`fix(playground):`) and `fix(deps):` are the stated exemptions.

Bare `fix:`/`feat:` ⇔ changeset also makes the convention mechanically lintable if we ever want CI to hold the line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to commit conventions in an agent skill file; no runtime or published package behavior.
> 
> **Overview**
> Updates the **commits** agent skill so the changeset rule is **bidirectional**: commits that ship a changeset stay `fix:`/`feat:`, and bare `fix:`/`feat:` must include (or amend) a changeset or be retyped (`refactor:` for non-releasable code changes, including internal-only behavior; `chore:`/`test:`/`docs:` otherwise).
> 
> Documents exemptions for scoped unpublished targets (`fix(playground):`) and `fix(deps):` (changeset bot handles release). The intent is to stop bare `fix:`/`feat:` from implying a releasable change with no release, and to make the convention **CI-lintable** later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb02411816695310a962eb3cbc9e39df4be24dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->