### PR TITLE
refactor: rename `setNodeProperties` to `applyNodeProperties`

### DIFF
--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -19,6 +19,7 @@ import {withoutPatching} from '../engine-plugins/engine-plugin.without-patching'
 import {start} from '../engine/editor/start'
 import {withoutNormalizing} from '../engine/editor/without-normalizing'
 import type {Node} from '../engine/interfaces/node'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {applyDeselect, applySelect} from '../internal-utils/apply-selection'
 import {debug} from '../internal-utils/debug'
 import {deleteRange} from '../internal-utils/delete-range'
@@ -28,7 +29,6 @@ import {
   isEqualValues,
 } from '../internal-utils/equality'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {validateValue} from '../internal-utils/validateValue'
 import {toEngineBlock} from '../internal-utils/values'
 import {hasNode} from '../traversal/has-node'
@@ -957,7 +957,7 @@ function updateBlock({
     unknown
   >
 
-  setNodeProperties(editorEngine, blockProps, [{_key: oldEngineBlock._key}])
+  applyNodeProperties(editorEngine, blockProps, [{_key: oldEngineBlock._key}])
 
   // Remove properties present on the old node but absent from the new block.
   // Skip children/text (structural, managed by dedicated operations).
@@ -976,7 +976,7 @@ function updateBlock({
   }
 
   if (Object.keys(removedProperties).length > 0) {
-    setNodeProperties(editorEngine, removedProperties, [
+    applyNodeProperties(editorEngine, removedProperties, [
       {_key: oldEngineBlock._key},
     ])
   }
@@ -1002,7 +1002,7 @@ function updateBlock({
 
     if (isPureReorder || (newKeys.length > 0 && !hasSharedKeys)) {
       debug.syncValue('Replacing children via set')
-      setNodeProperties(editorEngine, {children: engineBlock.children}, [
+      applyNodeProperties(editorEngine, {children: engineBlock.children}, [
         {_key: oldEngineBlock._key},
       ])
       editorEngine.onChange()
@@ -1084,7 +1084,7 @@ function updateBlock({
               delete childProps['text']
             }
 
-            setNodeProperties(editorEngine, childProps, path)
+            applyNodeProperties(editorEngine, childProps, path)
 
             if (isSpanNode && isTextChanged) {
               if (oldBlockChild.text.length > 0) {

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -6,10 +6,10 @@ import {isSpan, isTextBlock} from '@portabletext/schema'
 import {withoutPatching} from '../../engine-plugins/engine-plugin.without-patching'
 import {applyInsertNodeAtPath} from '../../internal-utils/apply-insert-node'
 import {applyMergeNode} from '../../internal-utils/apply-merge-node'
+import {applyNodeProperties} from '../../internal-utils/apply-node-properties'
 import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-block'
 import {debug} from '../../internal-utils/debug'
 import {isEqualMarkDefs} from '../../internal-utils/equality'
-import {setNodeProperties} from '../../internal-utils/set-node-properties'
 import {getChildFieldName} from '../../paths/get-child-field-name'
 import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
@@ -267,7 +267,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     !Array.isArray(node.markDefs)
   ) {
     debug.normalization('adding .markDefs to block node')
-    setNodeProperties(editor, {markDefs: []}, path)
+    applyNodeProperties(editor, {markDefs: []}, path)
     return
   }
 
@@ -284,7 +284,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     )?.name
     if (defaultStyle) {
       debug.normalization('adding .style to block node')
-      setNodeProperties(editor, {style: defaultStyle}, path)
+      applyNodeProperties(editor, {style: defaultStyle}, path)
       return
     }
   }
@@ -315,7 +315,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     !Array.isArray(node.marks)
   ) {
     debug.normalization('Adding .marks to span node')
-    setNodeProperties(editor, {marks: []}, path)
+    applyNodeProperties(editor, {marks: []}, path)
     return
   }
 
@@ -341,7 +341,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     if (node.text === '' && annotations && annotations.length > 0) {
       debug.normalization('removing annotations from empty span node')
-      setNodeProperties(
+      applyNodeProperties(
         editor,
         {marks: node.marks?.filter((mark) => !annotations.includes(mark))},
         path,
@@ -370,7 +370,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     if (markDefs.length !== newMarkDefs.length) {
       debug.normalization('removing duplicate markDefs')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
+      applyNodeProperties(editor, {markDefs: newMarkDefs}, path)
       return
     }
   }
@@ -394,7 +394,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     if (node.markDefs && !isEqualMarkDefs(newMarkDefs, node.markDefs)) {
       debug.normalization('removing markDef not in use')
-      setNodeProperties(editor, {markDefs: newMarkDefs}, path)
+      applyNodeProperties(editor, {markDefs: newMarkDefs}, path)
       return
     }
   }
@@ -467,12 +467,12 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
         if (needsField && childNode) {
           // Set the field with its initial child in a single operation
           // instead of two (set empty array + insert child).
-          setNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
+          applyNodeProperties(editor, {[arrayField.name]: [childNode]}, path)
           return
         }
 
         if (needsField) {
-          setNodeProperties(editor, {[arrayField.name]: []}, path)
+          applyNodeProperties(editor, {[arrayField.name]: []}, path)
           return
         }
 

--- a/packages/editor/src/internal-utils/apply-node-properties.test.ts
+++ b/packages/editor/src/internal-utils/apply-node-properties.test.ts
@@ -13,8 +13,8 @@ import {
   resolveContainers,
   resolveContainersRich,
 } from '../schema/resolve-containers-batch'
+import {applyNodeProperties} from './apply-node-properties'
 import {buildIndexMaps} from './build-index-maps'
-import {setNodeProperties} from './set-node-properties'
 
 test('throws when the path is structurally unreachable', () => {
   const keyGenerator = createTestKeyGenerator()
@@ -44,12 +44,12 @@ test('throws when the path is structurally unreachable', () => {
   const editor = createBareEditor(schema, [], value)
 
   expect(() =>
-    setNodeProperties(editor, {_key: newKey}, [
+    applyNodeProperties(editor, {_key: newKey}, [
       {_key: blockKey},
       'markDefs',
       {_key: markDefKey},
     ]),
-  ).toThrow('Unable to set properties at structurally unreachable path')
+  ).toThrow('Unable to apply properties at structurally unreachable path')
 })
 
 test('skips silently when the node is missing', () => {
@@ -70,7 +70,7 @@ test('skips silently when the node is missing', () => {
   const editor = createBareEditor(schema, [], value)
 
   expect(() =>
-    setNodeProperties(editor, {level: 1}, [{_key: 'nonexistent'}]),
+    applyNodeProperties(editor, {level: 1}, [{_key: 'nonexistent'}]),
   ).not.toThrow()
   expect(editor.snapshot.context.value).toEqual([
     {
@@ -122,7 +122,7 @@ test('applies the change through a container whose array field is named markDefs
   ]
   const editor = createBareEditor(schema, publicContainers, value)
 
-  setNodeProperties(editor, {title: 'baz'}, [
+  applyNodeProperties(editor, {title: 'baz'}, [
     {_key: containerKey},
     'markDefs',
     {_key: childKey},

--- a/packages/editor/src/internal-utils/apply-node-properties.ts
+++ b/packages/editor/src/internal-utils/apply-node-properties.ts
@@ -13,7 +13,7 @@ import {safeStringify} from './safe-json'
  * downstream patch consumers see the key change before any property
  * mutations that reference the new key.
  */
-export function setNodeProperties(
+export function applyNodeProperties(
   editor: PortableTextEditorEngine,
   props: Record<string, unknown> | object,
   path: Path,
@@ -22,7 +22,7 @@ export function setNodeProperties(
 
   if (result.status === 'unreachable') {
     throw new Error(
-      `Unable to set properties at structurally unreachable path ${safeStringify(path)}`,
+      `Unable to apply properties at structurally unreachable path ${safeStringify(path)}`,
     )
   }
 

--- a/packages/editor/src/internal-utils/delete-internal.ts
+++ b/packages/editor/src/internal-utils/delete-internal.ts
@@ -20,10 +20,10 @@ import {isLeafObject} from '../traversal/is-leaf-object'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {isEmptyTextBlock} from '../utils/util.is-empty-text-block'
 import {applyMergeNode} from './apply-merge-node'
+import {applyNodeProperties} from './apply-node-properties'
 import {createPlaceholderBlock} from './create-placeholder-block'
 import {getFullyCoveredContainers} from './get-fully-covered-container'
 import {planMergeKeyRenames} from './plan-merge-key-renames'
-import {setNodeProperties} from './set-node-properties'
 
 /**
  * What to do with the editor selection once the delete completes.
@@ -775,7 +775,7 @@ function mergeBlock(
 
   for (const {markDefKey, newKey} of markDefRenames) {
     // `getNode` can't resolve a keyed descent into `markDefs` (it's a
-    // sidecar field, not part of the child tree), so `setNodeProperties`
+    // sidecar field, not part of the child tree), so `applyNodeProperties`
     // would silently no-op here. Apply the rename directly.
     editor.apply({
       type: 'set',
@@ -784,7 +784,7 @@ function mergeBlock(
     })
   }
   for (const {childKey, props} of childRenames) {
-    setNodeProperties(editor, props, [
+    applyNodeProperties(editor, props, [
       ...endBlockPath,
       'children',
       {_key: childKey},
@@ -796,7 +796,7 @@ function mergeBlock(
   )
   if (Array.isArray(endMarkDefs) && endMarkDefs.length > 0) {
     const oldDefs = startBlock.node.markDefs ?? []
-    setNodeProperties(
+    applyNodeProperties(
       editor,
       {markDefs: [...oldDefs, ...endMarkDefs]},
       startBlockPath,

--- a/packages/editor/src/operations/operation.annotation.add.ts
+++ b/packages/editor/src/operations/operation.annotation.add.ts
@@ -10,10 +10,10 @@ import {isRange} from '../engine/range/is-range'
 import {rangeEdges} from '../engine/range/range-edges'
 import {rangeEnd} from '../engine/range/range-end'
 import {rangeStart} from '../engine/range/range-start'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getChildren} from '../traversal/get-children'
 import {getNode} from '../traversal/get-node'
 import {getNodes} from '../traversal/get-nodes'
@@ -109,7 +109,7 @@ export const addAnnotationOperationImplementation: OperationImplementation<
       )
 
       if (existingMarkDef === undefined) {
-        setNodeProperties(
+        applyNodeProperties(
           editor,
           {
             markDefs: [
@@ -178,7 +178,11 @@ export const addAnnotationOperationImplementation: OperationImplementation<
 
         const marks = span.marks ?? []
 
-        setNodeProperties(editor, {marks: [...marks, annotationKey]}, spanPath)
+        applyNodeProperties(
+          editor,
+          {marks: [...marks, annotationKey]},
+          spanPath,
+        )
       }
 
       blockIndex++

--- a/packages/editor/src/operations/operation.annotation.remove.ts
+++ b/packages/editor/src/operations/operation.annotation.remove.ts
@@ -13,9 +13,9 @@ import {isRange} from '../engine/range/is-range'
 import {rangeEdges} from '../engine/range/range-edges'
 import {rangeEnd} from '../engine/range/range-end'
 import {rangeStart} from '../engine/range/range-start'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getChildren} from '../traversal/get-children'
 import {getNode} from '../traversal/get-node'
 import {getNodes} from '../traversal/get-nodes'
@@ -135,7 +135,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
       [selectedChild, selectedChildPath] satisfies [PortableTextSpan, Path],
       ...nextSpansWithSameAnnotation,
     ]) {
-      setNodeProperties(
+      applyNodeProperties(
         editor,
         {
           marks: child.marks?.filter((mark) => mark !== annotationToRemove),
@@ -222,7 +222,7 @@ export const removeAnnotationOperationImplementation: OperationImplementation<
           })
 
           if (marksWithoutAnnotation.length !== marks.length) {
-            setNodeProperties(
+            applyNodeProperties(
               editor,
               {marks: marksWithoutAnnotation},
               childPath,

--- a/packages/editor/src/operations/operation.block.set.ts
+++ b/packages/editor/src/operations/operation.block.set.ts
@@ -1,7 +1,7 @@
 import {applyAll, set} from '@portabletext/patches'
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getBlockObjectSchema} from '../schema/get-block-object-schema'
 import {getNode} from '../traversal/get-node'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
@@ -77,7 +77,7 @@ export const blockSetOperationImplementation: OperationImplementation<
       }
     }
 
-    setNodeProperties(operation.editor, filteredProps, blockEntry.path)
+    applyNodeProperties(operation.editor, filteredProps, blockEntry.path)
   } else {
     const schemaDefinition = getBlockObjectSchema(
       snapshot,
@@ -107,6 +107,6 @@ export const blockSetOperationImplementation: OperationImplementation<
 
     const updatedEngineBlock = applyAll(engineBlock, patches)
 
-    setNodeProperties(operation.editor, updatedEngineBlock, blockEntry.path)
+    applyNodeProperties(operation.editor, updatedEngineBlock, blockEntry.path)
   }
 }

--- a/packages/editor/src/operations/operation.block.unset.ts
+++ b/packages/editor/src/operations/operation.block.unset.ts
@@ -1,6 +1,6 @@
 import {isTextBlockNode} from '../engine/node/is-text-block-node'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNode} from '../traversal/get-node'
 import type {OperationImplementation} from './operation.types'
 
@@ -25,10 +25,10 @@ export const blockUnsetOperationImplementation: OperationImplementation<
     for (const prop of propsToRemove) {
       unsetProps[prop] = null
     }
-    setNodeProperties(operation.editor, unsetProps, blockEntry.path)
+    applyNodeProperties(operation.editor, unsetProps, blockEntry.path)
 
     if (operation.props.includes('_key')) {
-      setNodeProperties(
+      applyNodeProperties(
         operation.editor,
         {_key: context.keyGenerator()},
         blockEntry.path,
@@ -49,5 +49,5 @@ export const blockUnsetOperationImplementation: OperationImplementation<
       unsetProps[key] = null
     }
   }
-  setNodeProperties(operation.editor, unsetProps, blockEntry.path)
+  applyNodeProperties(operation.editor, unsetProps, blockEntry.path)
 }

--- a/packages/editor/src/operations/operation.child.set.ts
+++ b/packages/editor/src/operations/operation.child.set.ts
@@ -1,8 +1,8 @@
 import {isSpan} from '@portabletext/schema'
 import {parentPath} from '../engine/path/parent-path'
 import {siblingPath} from '../engine/path/sibling-path'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNode} from '../traversal/get-node'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
 import {isObject} from '../traversal/is-object'
@@ -22,7 +22,7 @@ export const childSetOperationImplementation: OperationImplementation<
   if (isSpan({schema: operation.editor.snapshot.context.schema}, child)) {
     const {_type, text, ...rest} = operation.props
 
-    setNodeProperties(
+    applyNodeProperties(
       operation.editor,
       {
         ...child,
@@ -78,7 +78,7 @@ export const childSetOperationImplementation: OperationImplementation<
       }
     }
 
-    setNodeProperties(
+    applyNodeProperties(
       operation.editor,
       {
         ...child,

--- a/packages/editor/src/operations/operation.child.unset.ts
+++ b/packages/editor/src/operations/operation.child.unset.ts
@@ -1,6 +1,6 @@
 import {isSpan} from '@portabletext/schema'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {safeStringify} from '../internal-utils/safe-json'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNode} from '../traversal/get-node'
 import {isObject} from '../traversal/is-object'
 import type {OperationImplementation} from './operation.types'
@@ -35,7 +35,7 @@ export const childUnsetOperationImplementation: OperationImplementation<
       newNode[prop] = null
     }
 
-    setNodeProperties(operation.editor, newNode, childPath)
+    applyNodeProperties(operation.editor, newNode, childPath)
 
     return
   }
@@ -52,7 +52,7 @@ export const childUnsetOperationImplementation: OperationImplementation<
         unsetProps[prop] = null
       }
     }
-    setNodeProperties(operation.editor, unsetProps, childPath)
+    applyNodeProperties(operation.editor, unsetProps, childPath)
 
     return
   }

--- a/packages/editor/src/operations/operation.decorator.add.ts
+++ b/packages/editor/src/operations/operation.decorator.add.ts
@@ -9,9 +9,9 @@ import {isExpandedRange} from '../engine/range/is-expanded-range'
 import {rangeEdges} from '../engine/range/range-edges'
 import {rangeEnd} from '../engine/range/range-end'
 import {rangeStart} from '../engine/range/range-start'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNodes} from '../traversal/get-nodes'
 import {getParent} from '../traversal/get-parent'
 import {getPathSubSchema} from '../traversal/get-path-sub-schema'
@@ -99,7 +99,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
           ),
           mark,
         ]
-        setNodeProperties(editor, {marks}, spanPath)
+        applyNodeProperties(editor, {marks}, spanPath)
       }
     }) // end withoutNormalizing
   } else {
@@ -154,7 +154,7 @@ export const decoratorAddOperationImplementation: OperationImplementation<
             isSpan({schema: editor.snapshot.context.schema}, node),
         }),
       )) {
-        setNodeProperties(editor, {marks: newMarks}, spanPath)
+        applyNodeProperties(editor, {marks: newMarks}, spanPath)
       }
     } else {
       editor.snapshot.decoratorState[mark] = true

--- a/packages/editor/src/operations/operation.decorator.remove.ts
+++ b/packages/editor/src/operations/operation.decorator.remove.ts
@@ -10,9 +10,9 @@ import {isExpandedRange} from '../engine/range/is-expanded-range'
 import {rangeEdges} from '../engine/range/range-edges'
 import {rangeEnd} from '../engine/range/range-end'
 import {rangeStart} from '../engine/range/range-start'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {getNode} from '../traversal/get-node'
 import {getNodes} from '../traversal/get-nodes'
 import {getParent} from '../traversal/get-parent'
@@ -80,7 +80,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
             isTextBlock({schema: editor.snapshot.context.schema}, block) &&
             block.children.includes(node)
           ) {
-            setNodeProperties(
+            applyNodeProperties(
               editor,
               {
                 marks: (Array.isArray(node.marks) ? node.marks : []).filter(
@@ -123,7 +123,7 @@ export const decoratorRemoveOperationImplementation: OperationImplementation<
             isSpan({schema: editor.snapshot.context.schema}, node),
         }),
       )) {
-        setNodeProperties(
+        applyNodeProperties(
           editor,
           {marks: existingMarksWithoutDecorator},
           spanPath,

--- a/packages/editor/src/operations/operation.insert.block.ts
+++ b/packages/editor/src/operations/operation.insert.block.ts
@@ -17,6 +17,7 @@ import {rangeEdges} from '../engine/range/range-edges'
 import {rangeEnd} from '../engine/range/range-end'
 import {rangeStart} from '../engine/range/range-start'
 import {applyInsertNodeAtPath} from '../internal-utils/apply-insert-node'
+import {applyNodeProperties} from '../internal-utils/apply-node-properties'
 import {applySelect, resolveSelection} from '../internal-utils/apply-selection'
 import {applySplitNode} from '../internal-utils/apply-split-node'
 import {deleteRange} from '../internal-utils/delete-range'
@@ -25,7 +26,6 @@ import {
   isEqualChildren,
   isEqualMarks,
 } from '../internal-utils/equality'
-import {setNodeProperties} from '../internal-utils/set-node-properties'
 import {toEngineBlock} from '../internal-utils/values'
 import {getEnclosingBlock} from '../traversal/get-enclosing-block'
 import {getParent} from '../traversal/get-parent'
@@ -484,7 +484,7 @@ function mergeTextBlockFragment(args: {
     endBlock,
   })
 
-  setNodeProperties(
+  applyNodeProperties(
     editor,
     {
       markDefs: [...(endBlock.markDefs ?? []), ...(adjustedMarkDefs ?? [])],


### PR DESCRIPTION
`setNodeProperties` never just set: a `null` unsets, equal values emit nothing, and a `_key` among the props is ordered first with every later write re-addressed at the renamed key. The function's job is turning desired property values into a correctly ordered, correctly addressed op sequence, which is the contract of the `apply*` family it lives beside (`applyPatch`, `applySelect`, `applyMergeNode`, `applySplitNode`). It now joins the family as `applyNodeProperties`.

Mechanical: function, file, test file, all imports, and the unreachable-path error message. No behavior change, no public surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal naming and import churn with no logic or API changes; risk is limited to missed rename references, which the codebase no longer contains.
> 
> **Overview**
> Renames the internal helper **`setNodeProperties`** to **`applyNodeProperties`** and updates imports across the editor package (sync machine, normalization, delete/merge paths, and block/child/annotation/decorator/insert operations). The implementation file and tests follow the same name.
> 
> This is a **mechanical rename** only: behavior is unchanged and nothing public is exported under the old name. The unreachable-path error now says “Unable to **apply** properties…” instead of “set”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939e757c70c1bd05a3cdb3f56b7fbed12f95ebc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->