### PR TITLE
fix: only clear style on Backspace when nothing above the block can be removed

### DIFF
--- a/.changeset/clear-style-backspace-previous-sibling.md
+++ b/.changeset/clear-style-backspace-previous-sibling.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-markdown-shortcuts': patch
+---
+
+fix: only clear style on Backspace when nothing above the block can be removed
+
+Backspace at the start of a heading below an empty line now removes the empty line and keeps the heading's style. If the heading is also a list item, the first press clears the list instead, per the editor's existing list behavior, and the empty line above only goes on a second press. Below an image or other block object, it follows the editor's own object-removal handling instead. Below a block with content, and at the top of the document, it still clears the style as before.

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown-shortcuts.ts
@@ -1,7 +1,8 @@
 import type {EditorContext} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import * as selectors from '@portabletext/editor/selectors'
-import {getPathSubSchema} from '@portabletext/editor/traversal'
+import {getPathSubSchema, getSibling} from '@portabletext/editor/traversal'
+import {isEmptyTextBlock, isTextBlock} from '@portabletext/editor/utils'
 
 export type ObjectWithOptionalKey = {
   _type: string
@@ -112,6 +113,22 @@ export function createMarkdownBehaviors(config: MarkdownBehaviorsConfig) {
         // sub-schema and calling the consumer's `defaultStyle` callback on
         // every other backspace is wasted work with a consumer-visible
         // call frequency.
+        return false
+      }
+
+      const previousSibling = getSibling(snapshot, focusTextBlock.path, {
+        direction: 'previous',
+      })
+
+      const previousSiblingHasTextContent =
+        previousSibling !== undefined &&
+        isTextBlock(snapshot.context, previousSibling.node) &&
+        !isEmptyTextBlock(snapshot.context, previousSibling.node)
+
+      if (previousSibling && !previousSiblingHasTextContent) {
+        // An empty or object previous block takes priority over clearing
+        // the style: falling through lets core's own Backspace handling
+        // (list clearing, block removal) run on it first.
         return false
       }
 

--- a/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
+++ b/packages/plugin-markdown-shortcuts/src/behavior.markdown.feature
@@ -99,6 +99,50 @@ Feature: Markdown Behaviors
       | "h5"  |
       | "h6"  |
 
+  Scenario: Backspace removes an empty previous block instead of clearing style
+    Given the editor state is "B: ;;B style=\"h1\": foo"
+    When the editor is focused
+    And the selection is "B: ;;B style=\"h1\": |foo"
+    And "{Backspace}" is pressed
+    Then the editor state is "B style=\"h1\": |foo"
+
+  Scenario: Backspace removes an empty previous block instead of clearing style on an empty heading
+    Given the editor state is "B: ;;B style=\"h1\": "
+    When the editor is focused
+    And the selection is "B: ;;B style=\"h1\": |"
+    And "{Backspace}" is pressed
+    Then the editor state is "B style=\"h1\": |"
+
+  Scenario: Backspace removes an empty previous styled block instead of clearing style
+    Given the editor state is "B style=\"h2\": ;;B style=\"h1\": foo"
+    When the editor is focused
+    And the selection is "B style=\"h2\": ;;B style=\"h1\": |foo"
+    And "{Backspace}" is pressed
+    Then the editor state is "B style=\"h1\": |foo"
+
+  Scenario: Backspace removes a previous block object instead of clearing style
+    Given the editor state is "{IMAGE};;B style=\"h1\": foo"
+    When the editor is focused
+    And the selection is "{IMAGE};;B style=\"h1\": |foo"
+    And "{Backspace}" is pressed
+    Then the editor state is "B style=\"h1\": |foo"
+
+  Scenario: Clear style on Backspace still fires when the previous block has content
+    Given the editor state is "B: bar;;B style=\"h1\": foo"
+    When the editor is focused
+    And the selection is "B: bar;;B style=\"h1\": |foo"
+    And "{Backspace}" is pressed
+    Then the editor state is "B: bar;;B: |foo"
+
+  Scenario: Backspace on a styled list item clears the list before removing the empty previous block
+    Given the editor state is "B: ;;B style=\"h1\" listItem=\"bullet\": foo"
+    When the editor is focused
+    And the selection is "B: ;;B style=\"h1\" listItem=\"bullet\": |foo"
+    And "{Backspace}" is pressed
+    Then the editor state is "B: ;;B style=\"h1\": |foo"
+    When "{Backspace}" is pressed
+    Then the editor state is "B style=\"h1\": |foo"
+
   Scenario: Backspace twice after an automatic heading does not resurface the heading
     Given the editor state is "B: |"
     When the editor is focused


### PR DESCRIPTION
Backspace at the start of a heading always cleared the heading style, no matter what sat above the block. A user backspacing to remove the blank line above a heading (or aiming at the image above it) lost the formatting instead, and the thing they were aiming at survived.

`clearStyleOnBackspace` never inspected the previous sibling: its guard checked only that the caret sat at block start on a non-default style. The guard now resolves the previous sibling first and clears the style only when there is no previous block, or the previous block is a text block with content. Anything else falls through to core, which already does the right thing: it deletes an empty previous text block or a previous block object without touching the styled block (probed against core with the markdown behaviors out of the way before pinning). For a styled list item, core's existing at-block-start behavior wins the fall-through and clears the bullet first; the blank line above goes on the next press.

Pinned by five scenarios that fail on the old guard (empty block above, empty block above an empty heading, empty styled block above, image above, styled list item above an empty block), one pinning that a content-bearing block above still clears the style, and the existing single-block scenarios pinning that the top of the document still clears. The sibling checks run before the sub-schema and `defaultStyle` resolution, so the consumer callback's call frequency is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to markdown-shortcuts Backspace guard logic with feature tests; no auth, data, or broad editor API changes.
> 
> **Overview**
> **Backspace at block start** no longer always clears heading/block style via `clearStyleOnBackspace`. The guard now looks at the **previous sibling** first: if there is a previous block that is empty text, a non-text block object, or otherwise not “content-bearing text,” the behavior **returns false** so core **Backspace** handling runs (delete the empty line, remove an image/object, clear list formatting first).
> 
> Style clearing on Backspace is unchanged when there is **no** previous block, when the previous block has **text content**, or at the **top** of the document. Sibling checks run **before** sub-schema/`defaultStyle` work so consumer callback frequency stays the same.
> 
> Adds **Gherkin scenarios** for empty block above, styled empty block above, image above, content above, and styled list item + empty line (two presses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcdfb556c33397db2be56706f19d76149fa7fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->