### PR TITLE
test: gate wire-catalogue coverage against the behavior event union

### DIFF
--- a/packages/editor/src/behaviors/behavior.types.event.ts
+++ b/packages/editor/src/behaviors/behavior.types.event.ts
@@ -65,7 +65,7 @@ export type ExternalBehaviorEvent =
  * Synthetic events
  **************************************/
 
-const syntheticBehaviorEventTypes = [
+export const syntheticBehaviorEventTypes = [
   'annotation.add',
   'annotation.remove',
   'block.set',
@@ -348,7 +348,7 @@ export function isSyntheticBehaviorEvent(
  * Abstract events
  **************************************/
 
-const abstractBehaviorEventTypes = [
+export const abstractBehaviorEventTypes = [
   'annotation.set',
   'annotation.toggle',
   'decorator.toggle',

--- a/packages/editor/src/behaviors/wire-catalogue-coverage.test.ts
+++ b/packages/editor/src/behaviors/wire-catalogue-coverage.test.ts
@@ -1,0 +1,189 @@
+import {readdirSync, readFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {describe, expect, test} from 'vitest'
+import {safeParse} from '../internal-utils/safe-json'
+import {
+  abstractBehaviorEventTypes,
+  syntheticBehaviorEventTypes,
+} from './behavior.types.event'
+
+/**
+ * Every synthetic behavior event must either be exercised by a captured
+ * `tests/__fixtures__/wire-catalogue/*.json` scenario or be listed below
+ * with a reason. A new event fails until classified; an allowlisted event
+ * that a fixture now covers fails until the entry is removed.
+ */
+
+type SyntheticEventType =
+  | (typeof syntheticBehaviorEventTypes)[number]
+  | (typeof abstractBehaviorEventTypes)[number]
+
+const allSyntheticEventTypes: ReadonlyArray<SyntheticEventType> = [
+  ...syntheticBehaviorEventTypes,
+  ...abstractBehaviorEventTypes,
+]
+
+const excludedFromCoverage: Partial<Record<SyntheticEventType, string>> = {
+  'move.backward':
+    'non-emitting: `applyMove` calls `applySelect`, which only performs `set.selection` operations, no document patches',
+  'move.forward':
+    'non-emitting: `applyMove` calls `applySelect`, which only performs `set.selection` operations, no document patches',
+  'select':
+    'non-emitting: `selectOperationImplementation` only calls `applySelect`/`applyDeselect`, never `editor.apply`',
+  'select.block': 'non-emitting: resolves to `select`',
+  'select.previous block': 'non-emitting: resolves to `select.block`',
+  'select.next block': 'non-emitting: resolves to `select.block`',
+  'deserialize':
+    'non-emitting: pipeline stage, raises `deserialize.data`/`deserialization.failure`',
+  'deserialize.data':
+    "non-emitting: pipeline stage, raises the converter's output or `deserialization.success`/`.failure`",
+  'deserialization.success':
+    'non-emitting: raises `insert.blocks`, the mutation happens there',
+  'deserialization.failure':
+    'non-emitting: raises a follow-up `deserialize.data` attempt or logs a warning',
+  'serialize': 'non-emitting: fans out to `serialize.data` per mime type',
+  'serialize.data':
+    "non-emitting: raises the converter's output onto `serialization.success`/`.failure`",
+  'serialization.success':
+    'non-emitting: writes to `dataTransfer`, not the document',
+  'serialization.failure': 'non-emitting: logs a warning, no document mutation',
+  'block.set': 'uncaptured: emitting event without a captured fixture yet',
+  'block.unset': 'uncaptured: emitting event without a captured fixture yet',
+  'child.set': 'uncaptured: emitting event without a captured fixture yet',
+  'child.unset': 'uncaptured: emitting event without a captured fixture yet',
+  'history.redo': 'uncaptured: emitting event without a captured fixture yet',
+  'history.undo': 'uncaptured: emitting event without a captured fixture yet',
+  'insert': 'uncaptured: emitting event without a captured fixture yet',
+  'insert.block': 'uncaptured: emitting event without a captured fixture yet',
+  'insert.child': 'uncaptured: emitting event without a captured fixture yet',
+  'remove.text': 'uncaptured: emitting event without a captured fixture yet',
+  'set': 'uncaptured: emitting event without a captured fixture yet',
+  'unset': 'uncaptured: emitting event without a captured fixture yet',
+  'annotation.set': 'uncaptured: emitting event without a captured fixture yet',
+  'annotation.toggle':
+    'uncaptured: emitting event without a captured fixture yet',
+  'decorator.toggle':
+    'uncaptured: emitting event without a captured fixture yet',
+  'delete.block': 'uncaptured: emitting event without a captured fixture yet',
+  'delete.child': 'uncaptured: emitting event without a captured fixture yet',
+  'delete.text': 'uncaptured: emitting event without a captured fixture yet',
+  'insert.inline object':
+    'uncaptured: emitting event without a captured fixture yet',
+  'insert.soft break':
+    'uncaptured: emitting event without a captured fixture yet',
+  'insert.span': 'uncaptured: emitting event without a captured fixture yet',
+  'list item.add': 'uncaptured: emitting event without a captured fixture yet',
+  'list item.remove':
+    'uncaptured: emitting event without a captured fixture yet',
+  'list item.toggle':
+    'uncaptured: emitting event without a captured fixture yet',
+  'move.block': 'uncaptured: emitting event without a captured fixture yet',
+  'move.block up': 'uncaptured: emitting event without a captured fixture yet',
+  'split': 'uncaptured: emitting event without a captured fixture yet',
+  'style.add': 'uncaptured: emitting event without a captured fixture yet',
+  'style.remove': 'uncaptured: emitting event without a captured fixture yet',
+  'style.toggle': 'uncaptured: emitting event without a captured fixture yet',
+}
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../tests/__fixtures__/wire-catalogue',
+)
+
+function extractActionEventType(action: unknown): string | undefined {
+  if (typeof action === 'string') {
+    // Only `send {...}` actions execute; a `type:` inside a `select {...}`
+    // caret description (or any other prose) never reaches the machine, so
+    // it must not contribute to coverage.
+    if (!action.trimStart().startsWith('send')) {
+      return undefined
+    }
+
+    return action.match(/type\s*:\s*['"]([^'"]+)['"]/)?.[1]
+  }
+
+  if (typeof action === 'object' && action !== null && 'type' in action) {
+    return String((action as {type: unknown}).type)
+  }
+
+  return undefined
+}
+
+// Fixtures known to legitimately extract zero event types (e.g. a fixture
+// whose only action is a bare `select`). Empty today: every captured
+// fixture sends at least one event.
+const fixturesWithoutExtractedEventTypes: ReadonlyArray<string> = []
+
+const referencedEventTypes = new Set<string>()
+const fixtureFilesMissingEventTypes: Array<string> = []
+
+for (const file of readdirSync(fixturesDir)) {
+  if (!file.endsWith('.json')) {
+    continue
+  }
+
+  const fixture = safeParse(readFileSync(join(fixturesDir, file), 'utf8')) as {
+    actions: Array<unknown>
+  }
+
+  let extractedFromFixture = 0
+
+  for (const action of fixture.actions) {
+    const eventType = extractActionEventType(action)
+
+    if (eventType !== undefined) {
+      referencedEventTypes.add(eventType)
+      extractedFromFixture++
+    }
+  }
+
+  if (extractedFromFixture === 0) {
+    fixtureFilesMissingEventTypes.push(file)
+  }
+}
+
+// `select` only positions the caret; it never emits, so it does not count as
+// coverage for the `select` union member.
+const derivedCoveredEventTypes = new Set(
+  [...referencedEventTypes].filter((eventType) => eventType !== 'select'),
+)
+
+describe('wire catalogue coverage', () => {
+  test('every synthetic event is covered or classified', () => {
+    const unclassified = allSyntheticEventTypes
+      .filter(
+        (eventType) =>
+          !derivedCoveredEventTypes.has(eventType) &&
+          !(eventType in excludedFromCoverage),
+      )
+      .sort()
+
+    expect(unclassified).toEqual([])
+  })
+
+  test('no allowlisted event is covered by a fixture', () => {
+    const staleExclusions = Object.keys(excludedFromCoverage)
+      .filter((eventType) => derivedCoveredEventTypes.has(eventType))
+      .sort()
+
+    expect(staleExclusions).toEqual([])
+  })
+
+  test('every fixture yields at least one extracted event type', () => {
+    const unexpectedlyEmpty = fixtureFilesMissingEventTypes
+      .filter((file) => !fixturesWithoutExtractedEventTypes.includes(file))
+      .sort()
+
+    expect(unexpectedlyEmpty).toEqual([])
+  })
+
+  test('every event type referenced by a fixture exists in the union', () => {
+    const allEventTypes = new Set<string>(allSyntheticEventTypes)
+    const unknownReferencedTypes = [...referencedEventTypes]
+      .filter((eventType) => !allEventTypes.has(eventType))
+      .sort()
+
+    expect(unknownReferencedTypes).toEqual([])
+  })
+})


### PR DESCRIPTION
The wire catalogue only protects scenarios someone captured, and both of this quarter's field failures were uncaptured scenarios rather than wrong fixtures. Nothing noticed such gaps: a new emitting behavior event could ship with the catalogue and everything built on it blind to the event's wire shapes.

This adds the noticing as one unit test. Coverage is derived, not declared: the test parses every fixture's `actions` for the events it exercises (send prose in either quote style, structured objects; non-send prose deliberately contributes nothing) and reads the event union from the const arrays that define it, so neither side can drift from reality. Four assertions: every event is covered or allowlisted with a written reason; no allowlisted event is secretly covered, so stale exclusions fail; every event a fixture references exists in the union, so typos fail; every fixture yields at least one event, so a parse miss fails loudly instead of silently voiding a fixture's coverage.

The initial allowlist doubles as the census: 14 events verified non-emitting against their operation paths (reasons state the load-bearing claim: no document patches), and 30 emitting events awaiting capture, which is the burn-down list for the follow-up increment, container scenarios first. From this commit on, adding an emitting event without a capture or a deliberate exclusion is a red build instead of a memory.