### PR TITLE
docs: reword LLM-flavored phrasing in prose

### DIFF
--- a/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
@@ -70,7 +70,7 @@ Matchers control how Markdown elements map to schema types. The library includes
 |            | `html`           | HTML blocks           | `'html'`            |
 |            | `callout`        | `> [!NOTE]`, etc.     | `'callout'`         |
 
-Override a matcher when your schema uses a different name for a type (say, `'heading 1'` instead of `'h1'`): pass your own function under the matcher's group and name, resolve the type against `context.schema`, and return its name, or `undefined` to skip the element gracefully. The [package README](https://github.com/portabletext/editor/tree/main/packages/markdown#configuring-matchers) has worked matcher recipes, including the structural `table`, `list`, and `blockquote` shapes.
+Override a matcher when your schema uses a different name for a type (say, `'heading 1'` instead of `'h1'`): pass your own function under the matcher's group and name, resolve the type against `context.schema`, and return its name, or `undefined` to skip the element. The [package README](https://github.com/portabletext/editor/tree/main/packages/markdown#configuring-matchers) has worked matcher recipes, including the structural `table`, `list`, and `blockquote` shapes.
 
 ## Supported features
 

--- a/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
+++ b/apps/docs/src/content/docs/editor/guides/create-behavior.mdx
@@ -7,7 +7,7 @@ import {LinkCard} from '@astrojs/starlight/components'
 
 Behaviors add functionality to the Portable Text Editor (PTE) in a declarative way.
 
-For a deep dive into behaviors and how they work, check out [Behaviors](/editor/concepts/behavior/).
+To learn how behaviors work, read [Behaviors](/editor/concepts/behavior/).
 
 ## Import the behavior helper
 
@@ -49,7 +49,7 @@ Let's break it down:
 
 ## Register the behavior
 
-In order to use the behavior, add it to the `EditorProvider` using the `BehaviorPlugin`.
+To use the behavior, add it to the `EditorProvider` using the `BehaviorPlugin`.
 
 ```tsx
 import {defineBehavior} from '@portabletext/editor/behaviors'

--- a/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
+++ b/apps/docs/src/content/docs/editor/guides/migrate-render-props.mdx
@@ -151,7 +151,7 @@ A registered span owns the outer wrapper, and `children` arrive with the decorat
 Text blocks register as `type: 'block'`, which is the text block type at every nesting level, top level and inside containers alike. The registration's render owns the whole wrapper, so the three legacy callbacks fold into one function. Reproduce the engine's legacy composition order: style innermost, list item around it, block wrapper outermost.
 
 :::note[Why pass `type` at all?]
-If the text block is always `block` and the span is always `span`, the parameter looks redundant. It exists because registrations live in a type-keyed registry with two tiers: `'*'` is an optional catch-all, matching any type of that kind without a more specific registration, and positional overrides can register renamed types at that scope: block-level kinds through a container's `of`, inline kinds through a text block's `of`. `'block'` and `'span'` are simply those kinds' canonical names at the top level.
+If the text block is always `block` and the span is always `span`, the parameter looks redundant. It exists because registrations live in a type-keyed registry with two tiers: `'*'` is an optional catch-all, matching any type of that kind without a more specific registration, and positional overrides can register renamed types at that scope: block-level kinds through a container's `of`, inline kinds through a text block's `of`. `'block'` and `'span'` are those kinds' canonical names at the top level.
 :::
 
 Before:

--- a/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
+++ b/apps/docs/src/content/docs/editor/guides/testing-behaviors.mdx
@@ -98,7 +98,7 @@ describe('uppercase A behavior', () => {
 
 ## Gherkin approach with Racejar
 
-For comprehensive behavior specs, write Gherkin feature files and run them with Racejar. This is how every official plugin is tested.
+To spec a behavior end to end, write Gherkin feature files and run them with Racejar. This is how every official plugin is tested.
 
 ### Step 1: write a feature file
 

--- a/apps/docs/src/content/docs/editor/reference/selectors.mdx
+++ b/apps/docs/src/content/docs/editor/reference/selectors.mdx
@@ -144,7 +144,7 @@ Get information about active formatting and marks.
 - `getActiveAnnotations` - Get all active annotations in the selection
 - `getActiveListItem` - Get the active list item type
 - `getActiveStyle` - Get the active block style
-- `getMarkState` - Get comprehensive mark state information for the selection
+- `getMarkState` - Get the full mark state for the selection
 
 ## Text position selectors
 

--- a/apps/docs/src/content/docs/introduction.mdx
+++ b/apps/docs/src/content/docs/introduction.mdx
@@ -95,7 +95,7 @@ Because content is JSON, you can:
 
 - **Render anywhere.** Pass the same data to any serializer. Each renders what it can, ignores what it can't.
 - **Query the content.** "Find all blocks that contain a link to /pricing" is a JSON query, not a regex over HTML.
-- **Extend without breaking.** Add new block types, inline objects, or annotation types. Renderers that don't recognize them skip them gracefully.
+- **Extend without breaking.** Add new block types, inline objects, or annotation types. Renderers that don't recognize them skip them.
 - **Validate the structure.** The schema is explicit. You know exactly what types of content exist and what data they carry.
 
 [Learn why Portable Text over HTML, Markdown, or Gutenberg →](/why-portable-text/)

--- a/apps/docs/src/content/docs/specification.mdx
+++ b/apps/docs/src/content/docs/specification.mdx
@@ -29,7 +29,7 @@ A Portable Text document is a JSON array of **blocks**. Each block has a `_type`
 - **`text`**: the actual text content
 - **`marks`**: an array of mark keys (referencing `markDefs`) or decorator names (`"strong"`, `"em"`)
 
-**Custom blocks** can be any `_type` and carry any data. An image block, a code block, an embedded video, or a call-to-action are all custom blocks. Renderers that don't recognize a custom block type skip it gracefully.
+**Custom blocks** can be any `_type` and carry any data. An image block, a code block, an embedded video, or a call-to-action are all custom blocks. Renderers that don't recognize a custom block type skip it.
 
 ## Example
 

--- a/apps/docs/src/content/docs/why-portable-text.mdx
+++ b/apps/docs/src/content/docs/why-portable-text.mdx
@@ -95,7 +95,7 @@ More verbose? Yes. But now you can:
 
 - **Render anywhere.** Pass the same data to a React component, an HTML serializer, a PDF generator, or a Slack message formatter. Each renders what it can, ignores what it can't.
 - **Query the content.** "Find all blocks that contain a link to /docs" is a JSON query, not a regex over HTML.
-- **Extend without breaking.** Add a `callToAction` block type, a `footnote` annotation that carries citation data, or a `stockTicker` inline object with symbol and exchange fields inside a text paragraph. Renderers that don't know about them skip them gracefully. No parser changes needed.
+- **Extend without breaking.** Add a `callToAction` block type, a `footnote` annotation that carries citation data, or a `stockTicker` inline object with symbol and exchange fields inside a text paragraph. Renderers that don't know about them skip them. No parser changes needed.
 - **Validate the structure.** The schema is explicit. You know exactly what types of content exist, what data they carry, and where they can appear.
 
 ## What makes it portable

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -13,14 +13,14 @@
 
 This library provides you with the building blocks to create a completely custom editor experience built on top of Portable Text. We recommend [checking out the official documentation](https://www.portabletext.org/). The following guide includes the basics to get your started.
 
-In order to set up an editor you'll need to:
+To set up an editor you need to:
 
 - Create a schema that defines the rich text and block content elements.
 - Create a toolbar to toggle and insert these elements.
 - Set up rendering for each element type in the editor, including text blocks and inline formatting.
 - Render the editor.
 
-Check out the [Portable Text Playground](../../apps/playground/) for a comprehensive example of the editor in action.
+The [Portable Text Playground](../../apps/playground/) is a complete editor built with this library. Use it as a reference.
 
 ### Add the library to your project
 
@@ -361,7 +361,7 @@ Extend the editor with [official plugins](../../#editor-plugins).
 
 ## End-user experience
 
-In order to provide a robust and consistent end-user experience, the editor is backed by an elaborate E2E test suite generated from a [human-readable Gherkin spec](./gherkin-spec/).
+A large E2E test suite, generated from a [human-readable Gherkin spec](./gherkin-spec/), guards the end-user experience: how selection, editing, and formatting behave under real keyboard and pointer input.
 
 ## Development
 

--- a/packages/editor/src/behaviors/behavior.core.dnd.ts
+++ b/packages/editor/src/behaviors/behavior.core.dnd.ts
@@ -24,9 +24,9 @@ import {fitBlocksToDestination} from './fit-blocks-to-destination'
  * drag origin in a way that would make the drop a no-op.
  *
  * Two expanded selections that only touch at a single endpoint are not treated
- * as a self-drop — the drop position covers an adjacent block (typical when
+ * as a self-drop: the drop position covers an adjacent block (typical when
  * dragging a block-object onto the next block via the expanded fallback in
- * `getEventPosition`), and the user genuinely wants the drop to happen.
+ * `getEventPosition`), so the drop should go through.
  *
  * Chrome drags emit a collapsed selection pointing AT the dragged container.
  * A drop position whose path descends into that container is dropping the

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -391,7 +391,7 @@ function createDecorate(
     }
 
     return editorEngine.decoratedRanges.filter((decoratedRange) => {
-      // Special case in order to only return one decoration for collapsed ranges
+      // Special case so a collapsed range gets only one decoration
       if (isCollapsedRange(decoratedRange)) {
         // Collapsed ranges should only be decorated if they are on a block child level.
         const anchorBlock = getEnclosingBlock(

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -195,7 +195,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     // neither a scan nor a cache entry: re-checking it is already O(1). This
     // is the common shape for container fields (a row's single cell, a
     // cell's single content block) and single-span text blocks, so only
-    // genuinely multi-child groups ever cost a serialized id.
+    // groups with two or more children ever cost a serialized id.
     if (siblingNodes.length > 1) {
       // Identify the group by its serialized path (the root group is `''`).
       // The verdict survives edits elsewhere in the tree: it is dropped only

--- a/packages/editor/src/engine/point/step-mapper.ts
+++ b/packages/editor/src/engine/point/step-mapper.ts
@@ -44,7 +44,7 @@ export type UnsetTextStep = {
  * `oldKey`, is only rewritten at that exact depth under that exact
  * parent, never wherever the key value happens to recur. A rename only
  * ever touches one node; matching by key value alone would also rewrite
- * an unrelated point that merely walks through a same-keyed node
+ * an unrelated point that just walks through a same-keyed node
  * elsewhere in the tree (a duplicate-key merge's destination block, most
  * notably, since it starts out sharing every key the donor block does).
  */

--- a/packages/editor/src/engine/react/hooks/use-decorations-by-child.ts
+++ b/packages/editor/src/engine/react/hooks/use-decorations-by-child.ts
@@ -11,10 +11,10 @@ import type {DecoratedRange} from '../../interfaces/text'
 // Pure stabilization: returns previous when contents are per-index equal, else
 // builds a new outer array reusing previous per-index references where
 // unchanged. Outer-array identity is preserved when nothing changed; per-index
-// identity is preserved at every unchanged index. Both invariants are
-// load-bearing for the wrapper `React.memo` equalities on
-// `prev.decorations === next.decorations` and the per-index
-// `isElementDecorationsEqual` short-circuit downstream.
+// identity is preserved at every unchanged index. Downstream, the wrapper
+// `React.memo` equality on `prev.decorations === next.decorations` and the
+// per-index `isElementDecorationsEqual` short-circuit both rely on these
+// invariants.
 const stabilizeDecorationsByChild = (
   previous: DecoratedRange[][],
   next: DecoratedRange[][],

--- a/packages/editor/src/schema/resolve-container-by-path.ts
+++ b/packages/editor/src/schema/resolve-container-by-path.ts
@@ -182,7 +182,7 @@ function richDescentToParent(
  * 3. **Global fallback with position-validity.** Falls back to the
  *    top-level rich `containers` map keyed by `_type`. Activates only
  *    when schema-at-position permits the registered `arrayField`
- *    (for containers) or simply declares `_type` (for leaves).
+ *    (for containers) or declares `_type` (for leaves).
  *    Registration is type-keyed; activation is position-gated.
  */
 export function resolveContainerByPath(

--- a/packages/editor/src/traversal/get-sibling.test.ts
+++ b/packages/editor/src/traversal/get-sibling.test.ts
@@ -307,7 +307,7 @@ describe(getSibling.name, () => {
 
   test('resolves the anchor when `blockIndexMap` misses', () => {
     // An unmaintained map (e.g. a bare engine) must not hide siblings
-    // the tree plainly has; mirrors the `getNode`/`getChildren`
+    // that exist in the tree. Mirrors the `getNode`/`getChildren`
     // fallback.
     const snapshot = {
       context: testbed.snapshot.context,

--- a/packages/editor/src/traversal/node-traversal-testbed.ts
+++ b/packages/editor/src/traversal/node-traversal-testbed.ts
@@ -55,7 +55,7 @@ export function resolveTestbedContainers(
 }
 
 /**
- * A comprehensive test fixture for node traversal tests.
+ * A shared fixture for node traversal tests.
  *
  * Structure:
  *

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -194,7 +194,7 @@ describe('event.mutation', () => {
     await userEvent.type(locator, 'foo')
 
     await vi.waitFor(() => {
-      // Ignoring the two initial patches as they merely set the editor up
+      // Skip the two initial patches that set the editor up
       expect(patches.slice(2)).toEqual([
         {
           origin: 'local',

--- a/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
+++ b/packages/editor/tests/event.patches.sidecar-arrays.test.tsx
@@ -824,7 +824,7 @@ describe('event.patches sidecar arrays: multi-element and keyed tails', () => {
       children: <NodePlugin nodes={containers} />,
     })
 
-    // The mark insert rides along so the new markDef is referenced; an
+    // The mark insert is included so the new markDef is referenced. An
     // unreferenced markDef is orphaned data the editor strips (both the
     // unused-markDefs normalization rule and `validateValue`'s
     // auto-resolution remove it).

--- a/packages/editor/tests/positional-override-cross-scope.test.tsx
+++ b/packages/editor/tests/positional-override-cross-scope.test.tsx
@@ -10,8 +10,8 @@ import {
 import {createTestEditor} from '../src/test/vitest'
 
 /**
- * Cross-scope behavior — the load-bearing properties of inline scoping
- * via `defineTextBlock.of`.
+ * Cross-scope behavior: what inline scoping via `defineTextBlock.of`
+ * must guarantee.
  *
  *   - Two text blocks side-by-side in the same container can scope
  *     their inline content INDEPENDENTLY.

--- a/packages/editor/tests/select-all.test.tsx
+++ b/packages/editor/tests/select-all.test.tsx
@@ -60,7 +60,7 @@ const schemaDefinition = defineSchema({
 /**
  * Rendered with real `<table>` DOM plus a non-editable chrome sibling, the
  * shape of any real-world table render with selection chrome. The chrome
- * sibling is the load-bearing part: it puts a non-editable element at the
+ * sibling is the part that matters: it puts a non-editable element at the
  * document's content edge, which is what collapses chromium's native
  * select-all.
  */

--- a/packages/editor/tests/serialize-deserialize.test.tsx
+++ b/packages/editor/tests/serialize-deserialize.test.tsx
@@ -709,7 +709,7 @@ describe('Serialize/Deserialize', () => {
               actions: [({event}) => [forward(event)]],
             }),
             // This Behavior *will* receive the `deserialize.data` event
-            // since the Behavior above (with higher priority) merely
+            // since the Behavior above (with higher priority) only
             // forwards the `deserialize` event.
             defineBehavior({
               on: 'deserialize.data',

--- a/packages/html/src/deserializer/helpers.ts
+++ b/packages/html/src/deserializer/helpers.ts
@@ -126,7 +126,7 @@ export function hasMonospaceFontFamily(el: Node): boolean {
 /**
  * Returns true when the element's inline `style` declares a whitespace-
  * preserving `white-space`. Google Docs sets `white-space:pre-wrap` on its
- * spans; sources that merely use a monospace font without it (e.g. Word's
+ * spans. Sources that set a monospace font but no `white-space` (e.g. Word's
  * `font-family:"Roboto Mono"` spans) wrap their HTML source freely, so
  * their intra-span whitespace is formatting, not content.
  */

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -299,7 +299,7 @@ markdownToPortableText(markdown, {
 })
 ```
 
-> **Note:** Checking if the type exists in the schema isn't required, but it's good practice. Returning `undefined` gracefully skips unsupported types.
+> **Note:** Checking if the type exists in the schema isn't required, but it's good practice. Returning `undefined` skips unsupported types.
 
 **Table matcher:** GFM pipe tables convert by default (see [Default behavior](#default-behavior)). Provide your own matcher to map onto a differently-shaped `table` type:
 

--- a/packages/patches/README.md
+++ b/packages/patches/README.md
@@ -95,4 +95,4 @@ export function Editor() {
 }
 ```
 
-As the comment notes, this is redundant in a single app: the editor's `mutation` event already carries the finished `value`, so listen for that and use `event.value` instead. `applyAll` earns its place only when you have the patches but not the value, such as a server or secondary store replaying them onto its own copy.
+As the comment notes, this is redundant in a single app: the editor's `mutation` event already includes the finished `value`, so listen for that and use `event.value` instead. You only need `applyAll` when you have the patches but not the value, such as a server or secondary store replaying them onto its own copy.

--- a/packages/plugin-emoji-picker/README.md
+++ b/packages/plugin-emoji-picker/README.md
@@ -62,7 +62,7 @@ function EmojiPicker() {
 }
 ```
 
-**Tip:** For a comprehensive emoji library, you can install [`emojilib`](https://www.npmjs.com/package/emojilib) and use it directly:
+**Tip:** For a bigger emoji library, install [`emojilib`](https://www.npmjs.com/package/emojilib) and use it directly:
 
 ```tsx
 import emojilib from 'emojilib'

--- a/packages/plugin-sdk-value/src/sdk-editable.test.ts
+++ b/packages/plugin-sdk-value/src/sdk-editable.test.ts
@@ -116,7 +116,8 @@ describe('splitEditableProps', () => {
   it('forwards an explicitly undefined perspective, matching a direct hook call', () => {
     // Passing `perspective={maybeUndefined}` here has to behave exactly as
     // passing it straight to the SDK hook does: the key is present, so it wins
-    // over the context. Switching this to a value check would quietly diverge.
+    // over the context. A value check would let the wrapper drift from the
+    // direct hook call without this test noticing.
     const {handle} = splitEditableProps({
       documentId: 'doc-1',
       documentType: 'post',

--- a/packages/plugin-table/README.md
+++ b/packages/plugin-table/README.md
@@ -291,8 +291,8 @@ Who owns what:
   and, on the cell, its `of` (node definitions that only apply inside
   cells, like a compact image render).
 - The plugin owns the nesting. It grafts `table.of → row.of → cell`
-  itself, since the three-level shape is load-bearing for every behavior
-  and for the clipboard format. An `of` on the table or row definition
+  itself, since every behavior and the clipboard format depend on the
+  three-level shape. An `of` on the table or row definition
   logs a warning and is ignored.
 - Everything is optional. Omit a `render` and you get the bare built-in
   render for that role, omit a definition and you get the canonical one,
@@ -474,7 +474,7 @@ narrow to the `TableNode`, `RowNode`, and `CellNode` types.
 `<table>`/`<tr>`/`<td>` renders. Useful for tests and prototypes, or as
 the base for your own renders, with no `/ui` import and no stylesheet.
 
-If you need to own container registration outright, skip `table.Plugin`
+If you want to register the containers yourself, skip `table.Plugin`
 and mount `table.behaviors` in a `BehaviorPlugin` next to your own
 `NodePlugin` registration. Keeping that registration faithful to the
 nesting shape is then on you.

--- a/packages/plugin-table/src/define-table.tsx
+++ b/packages/plugin-table/src/define-table.tsx
@@ -89,8 +89,8 @@ export type TableDefinition = {
  * Builds a table definition over role-keyed container definitions. The
  * consumer owns each definition (type name, array field, render, and the
  * cell's `of`); the plugin owns the nesting, grafting `table.of → row.of →
- * cell` itself, because the three-level shape is load-bearing for every
- * behavior and the clipboard format. An `of` on the table or row
+ * cell` itself, because every behavior and the clipboard format depend
+ * on the three-level shape. An `of` on the table or row
  * definition draws a warning instead of being honored.
  *
  * No argument yields the canonical definition: `table`/`row`/`cell` type

--- a/packages/plugin-typeahead-picker/README.md
+++ b/packages/plugin-typeahead-picker/README.md
@@ -361,7 +361,7 @@ The error is cleared when the picker returns to idle (e.g., via Escape or cursor
 
 ## onDismiss
 
-The optional `onDismiss` callback runs when the picker is dismissed (Escape, Enter/Tab with no matches, or programmatically). Without `onDismiss`, dismissing simply closes the picker and leaves the typed text in place.
+The optional `onDismiss` callback runs when the picker is dismissed (Escape, Enter/Tab with no matches, or programmatically). Without `onDismiss`, dismissing closes the picker and leaves the typed text in place.
 
 For most pickers, you should **not** use `onDismiss` to delete text. If a user types `@` and dismisses, they likely wanted to type a literal `@`.
 

--- a/packages/sanity-bridge/src/get-sanity-sub-schema.ts
+++ b/packages/sanity-bridge/src/get-sanity-sub-schema.ts
@@ -180,7 +180,7 @@ function findChildArrayField(
  * Read the `of` array off a Sanity `SchemaType` if it carries one.
  * Mirrors the local helper in `sanity-schema-to-portable-text-schema.ts`.
  * Sanity schema getters can throw on partially-compiled types; the
- * try/catch keeps the walk robust at edges.
+ * try/catch lets the walk continue past a throwing getter.
  */
 function safeGetOf(
   schemaType: SchemaType,

--- a/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
+++ b/packages/sanity-bridge/src/mutually-embedding-types-performance.test.ts
@@ -68,7 +68,7 @@ describe('mutually-embedding block objects', () => {
     // unmemoized walk does not finish in any practical amount of time.
     expect(durationMs).toBeLessThan(2_000)
 
-    // The emitted definition must be small AS A TREE, not merely cheap to
+    // The emitted definition must be small AS A TREE, not just cheap to
     // build. The memoized walk builds shared `OfDefinition` objects (a
     // DAG) in linear time, but before root block objects referenced by
     // name at every position, each type's single expansion inlined the
@@ -235,7 +235,7 @@ describe('mutually-embedding block objects', () => {
     // heap-bounded. The absolute time stays generous because the
     // output of n mutually-embedding types is inherently O(n^2)
     // entries: each of the n embedding positions carries its own `of`
-    // list, and those lists genuinely differ per position (a type's
+    // list, and those lists really do differ per position (a type's
     // self-reference is ancestor-cut at its own position and
     // memo-shared at others).
     const objectCount = 1_600

--- a/packages/toolbar/README.md
+++ b/packages/toolbar/README.md
@@ -1,15 +1,15 @@
 # `@portabletext/toolbar`
 
-Powered by [Behaviors](https://www.portabletext.org/editor/concepts/behavior/) and [State Machines](https://stately.ai/docs/xstate), `@portabletext/toolbar` is a collection of robust React hooks for building toolbars and related UI components
+Powered by [Behaviors](https://www.portabletext.org/editor/concepts/behavior/) and [State Machines](https://stately.ai/docs/xstate), `@portabletext/toolbar` is a collection of React hooks for building toolbars and related UI components
 for the Portable Text editor.
 
-Refer to the toolbar in the [Portable Text Playground](../../apps/playground/) for a comprehensive example.
+Refer to the toolbar in the [Portable Text Playground](../../apps/playground/) for a full example.
 
 ## Features
 
 - **Schema Extension**: Extend the editor's schema with default values, icons, shortcuts and more. This makes it easier to use the schema to render toolbars, forms and other UI components.
 - **Hooks**: Headless React hooks to help building UI components for toggle buttons, popovers and insert dialogs.
-- **Keyboard Shortcuts**: Seamless integration with `@portabletext/keyboard-shortcuts` for platform-aware shortcuts.
+- **Keyboard Shortcuts**: Integrates with `@portabletext/keyboard-shortcuts` for platform-aware shortcuts.
 
 ## Installation
 


### PR DESCRIPTION
The repo's prose has accumulated machine mannerisms: "load-bearing" (five occurrences), "comprehensive", "robust", "seamless", "gracefully", "in order to", "merely", "genuinely", "rides along", "earns its place". Individually harmless, together they give READMEs, docs pages, and comments a recognizable generated flavor.

This is a wording-only pass over that vocabulary, split into a docs commit (READMEs and `apps/docs` pages) and a chore commit (source and test comments). Each rewording keeps the technical claim and drops the mannerism: "the three-level shape is load-bearing for every behavior" becomes "every behavior and the clipboard format depend on the three-level shape", and filler is deleted outright ("skip them gracefully" is "skip them"). Words that are precise in context stay: "silently" describing an actually silent failure, "carries" in ordinary use.

Deliberately untouched: test fixtures whose slop is the test data itself (`packages/html` from-the-wild HTML, the markdown example document), released changelogs, and the `.agents/skills` files, whose register is a separate conversation. Verified that no non-comment line changed in any `.ts`/`.tsx` file, so there is nothing to test; `check:format` and `check:types` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no executable code or configuration behavior changed.
> 
> **Overview**
> This PR is a **wording-only** cleanup across `apps/docs`, package READMEs, and inline comments in `packages/editor` and related packages. It does not change runtime behavior, APIs, or tests beyond comment text.
> 
> The edits target recurring “generated” mannerisms—**load-bearing**, **gracefully**, **comprehensive**, **robust**, **seamless**, **in order to**, **merely**, **genuinely**, **rides along**, **earns its place**—and replace or delete them while keeping the same technical meaning. Examples: unknown renderer types **skip them** instead of “skip them gracefully”; table plugin docs say behaviors **depend on** the three-level nesting shape instead of calling that shape “load-bearing”; editor README setup steps use direct “To set up…” phrasing instead of “In order to…”.
> 
> **Docs** (`introduction`, `specification`, `why-portable-text`, editor guides, selectors reference, markdown conversion page) and **READMEs** (editor, toolbar, markdown, patches, plugin-table, emoji-picker, typeahead-picker) are aligned with the same tone. **Source and test comments** (DnD self-drop, normalization, step-mapper, decorations hook, sanity-bridge, etc.) get the same pass. Deliberately excluded per the PR: wild HTML fixtures, changelogs, and `.agents/skills`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a6191fb2086c8c74fbbb28d7097843fcd0e00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->