### PR TITLE
fix: report `focus` honestly when something else holds the focus

### DIFF
--- a/.changeset/verify-dom-focus.md
+++ b/.changeset/verify-dom-focus.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: report `focus` honestly when something else holds the focus
+
+`editor.send({type: 'focus'})` now confirms the browser actually moved focus onto the editable before treating the request as done. When a focus trap or an `inert` container claims focus back, the editor no longer reports itself as focused while the DOM disagrees.
+
+A later `editor.send({type: 'focus'})` now works instead of being swallowed by that stale state, and a request that never lands gives up quietly instead of throwing.
+
+Sending `focus` to an already-focused editor no longer rewrites the DOM selection or emits a selection update.

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -374,10 +374,18 @@ export const editorMachine = setup({
 
       try {
         const currentSelection = editorEngine.snapshot.context.selection
+        const el = editorEngine.domElement
+        const alreadyFocused =
+          el !== null &&
+          DOMEditor.findDocumentOrShadowRoot(editorEngine).activeElement === el
 
         DOMEditor.focus(editorEngine)
 
-        if (currentSelection) {
+        // An editor that was already DOM-focused had nothing to move: the
+        // DOM selection may deliberately differ from the model (e.g. a
+        // native selection made for copying), and re-selecting here would
+        // overwrite it with the stale model selection.
+        if (currentSelection && !alreadyFocused) {
           editorEngine.select(currentSelection)
 
           // Tell the engine to use this selection for DOM sync

--- a/packages/editor/src/engine/dom/plugin/dom-editor.ts
+++ b/packages/editor/src/engine/dom/plugin/dom-editor.ts
@@ -1,5 +1,6 @@
 import {getDomNode} from '../../../dom-traversal/get-dom-node'
 import {getDomNodePath} from '../../../dom-traversal/get-dom-node-path'
+import {debug} from '../../../internal-utils/debug'
 import {safeStringify} from '../../../internal-utils/safe-json'
 import {getAncestor} from '../../../traversal/get-ancestor'
 import {getNode} from '../../../traversal/get-node'
@@ -68,6 +69,7 @@ export interface DOMEditor extends BaseEditor {
   pendingDiffs: TextDiff[]
   pendingAction: Action | null
   pendingSelection: Range | null
+  pendingFocusRetry: ReturnType<typeof setTimeout> | null
   forceRender: (() => void) | null
 }
 
@@ -82,7 +84,19 @@ interface DOMEditorInterface {
   findDocumentOrShadowRoot: (editor: Editor) => Document | ShadowRoot
 
   /**
-   * Focus the editor.
+   * Focus the editor. Makes one verified attempt: calls the DOM `focus()`
+   * and checks whether the browser actually moved focus onto the editable.
+   * Something else (a focus trap, an `inert` ancestor) can claim it back
+   * before or after that call; when it does, the request gives up quietly
+   * instead of fighting for it. The outcome reports through `editor.focused`;
+   * the `focused`/`blurred` events fire only when the DOM focus actually
+   * transitions, so a give-up against an `inert` ancestor (`el.focus()` is a
+   * no-op there) updates the flag without emitting either event. The
+   * function itself returns void.
+   *
+   * `options.retries` only bounds retries while the editor has pending
+   * operations, since the DOM (and its selection) is unstable until those
+   * settle; it is not a contest over who holds focus.
    */
   focus: (editor: Editor, options?: {retries: number}) => void
 
@@ -179,6 +193,11 @@ interface DOMEditorInterface {
 // eslint-disable-next-line no-redeclare
 export const DOMEditor: DOMEditorInterface = {
   blur: (editor) => {
+    if (editor.pendingFocusRetry !== null) {
+      clearTimeout(editor.pendingFocusRetry)
+      editor.pendingFocusRetry = null
+    }
+
     const el = getDomNode(editor, [])
     const root = DOMEditor.findDocumentOrShadowRoot(editor)
     editor.focused = false
@@ -205,29 +224,51 @@ export const DOMEditor: DOMEditorInterface = {
   },
 
   focus: (editor, options = {retries: 5}) => {
-    // Return if already focused
-    if (editor.focused) {
-      return
+    // A new focus request supersedes any retry chain still in flight;
+    // cancel it before any early return, or a stale timer could outlive
+    // this call and refocus the editor later.
+    if (editor.pendingFocusRetry !== null) {
+      clearTimeout(editor.pendingFocusRetry)
+      editor.pendingFocusRetry = null
     }
 
-    // Return if no dom node is associated with the editor, which means the editor is not yet mounted
-    // or has been unmounted. This can happen especially, while retrying to focus the editor.
+    // `findDocumentOrShadowRoot` throws once the editor is unmounted, so the
+    // mounted check has to run before resolving the root or DOM node.
     if (!editor.domElement) {
       return
     }
 
-    // Retry setting focus if the editor has pending operations.
-    // The DOM (selection) is unstable while changes are applied.
-    // Retry until retries are exhausted or editor is focused.
-    if (options.retries <= 0) {
-      throw new Error(
-        'Could not set focus, editor seems stuck with pending operations',
-      )
+    const giveUp = (reason: string) => {
+      editor.focused = false
+      debug.focus(reason)
     }
-    if (editor.operations.length > 0) {
-      setTimeout(() => {
-        DOMEditor.focus(editor, {retries: options.retries - 1})
+
+    if (options.retries <= 0) {
+      giveUp(
+        'Could not verify DOM focus after exhausting retries, giving up silently',
+      )
+      return
+    }
+
+    const retry = (remainingRetries: number) => {
+      editor.pendingFocusRetry = setTimeout(() => {
+        editor.pendingFocusRetry = null
+        try {
+          DOMEditor.focus(editor, {retries: remainingRetries})
+        } catch (error) {
+          giveUp(
+            `Focus retry raised before it could verify focus, giving up silently: ${error}`,
+          )
+        }
       }, 10)
+    }
+
+    // Retry setting focus if the editor has pending operations, before
+    // resolving the DOM node: while operations are in flight the node can be
+    // transiently unresolvable (renderer catching up), and that must retry,
+    // not throw.
+    if (editor.operations.length > 0) {
+      retry(options.retries - 1)
       return
     }
 
@@ -238,39 +279,52 @@ export const DOMEditor: DOMEditorInterface = {
     }
 
     const root = DOMEditor.findDocumentOrShadowRoot(editor)
-    if (root.activeElement !== el) {
-      // Ensure that the DOM selection state is set to the editor's selection
-      if (editor.snapshot.context.selection && root instanceof Document) {
-        const domSelection = getSelection(root)
-        const domRange = DOMEditor.toDOMRange(
-          editor,
-          editor.snapshot.context.selection,
-        )
-        domSelection?.removeAllRanges()
-        domSelection?.addRange(domRange)
-      }
-      // Create a new selection in the top of the document if missing
-      if (!editor.snapshot.context.selection) {
-        editor.select(editorStart(editor, []))
-      }
-      // IS_FOCUSED should be set before calling el.focus() to ensure that
-      // FocusedContext is updated to the correct value
-      editor.focused = true
-      el.focus({preventScroll: true})
 
-      // Re-apply the DOM selection after focus. Some browsers (notably WebKit)
-      // reset the selection when el.focus() is called, which can cause the
-      // selection to shift away from the intended position (e.g., away from
-      // an inline object to an adjacent empty span).
-      if (editor.snapshot.context.selection && root instanceof Document) {
-        const domSelection = getSelection(root)
-        const domRange = DOMEditor.toDOMRange(
-          editor,
-          editor.snapshot.context.selection,
-        )
-        domSelection?.removeAllRanges()
-        domSelection?.addRange(domRange)
-      }
+    if (root.activeElement === el) {
+      // The DOM selection may deliberately differ from the model (e.g. a
+      // native selection made for copying); only the flag needs healing.
+      editor.focused = true
+      return
+    }
+
+    // Ensure that the DOM selection state is set to the editor's selection
+    if (editor.snapshot.context.selection && root instanceof Document) {
+      const domSelection = getSelection(root)
+      const domRange = DOMEditor.toDOMRange(
+        editor,
+        editor.snapshot.context.selection,
+      )
+      domSelection?.removeAllRanges()
+      domSelection?.addRange(domRange)
+    }
+    // Create a new selection in the top of the document if missing
+    if (!editor.snapshot.context.selection) {
+      editor.select(editorStart(editor, []))
+    }
+    // IS_FOCUSED should be set before calling el.focus() to ensure that
+    // FocusedContext is updated to the correct value
+    editor.focused = true
+    el.focus({preventScroll: true})
+
+    if (root.activeElement !== el) {
+      // Something else (a focus trap, an `inert` ancestor) claimed focus
+      // back; report it honestly instead of fighting for it.
+      giveUp('Could not verify DOM focus: something else claimed it')
+      return
+    }
+
+    // Re-apply the DOM selection after focus. Some browsers (notably WebKit)
+    // reset the selection when el.focus() is called, which can cause the
+    // selection to shift away from the intended position (e.g., away from
+    // an inline object to an adjacent empty span).
+    if (editor.snapshot.context.selection && root instanceof Document) {
+      const domSelection = getSelection(root)
+      const domRange = DOMEditor.toDOMRange(
+        editor,
+        editor.snapshot.context.selection,
+      )
+      domSelection?.removeAllRanges()
+      domSelection?.addRange(domRange)
     }
   },
 

--- a/packages/editor/src/engine/dom/plugin/with-dom.ts
+++ b/packages/editor/src/engine/dom/plugin/with-dom.ts
@@ -31,6 +31,7 @@ export const withDOM = <T extends Editor>(editor: T): T & DOMEditor => {
   e.pendingDiffs = []
   e.pendingAction = null
   e.pendingSelection = null
+  e.pendingFocusRetry = null
   e.forceRender = null
 
   subscribeToOperations(

--- a/packages/editor/src/internal-utils/debug.ts
+++ b/packages/editor/src/internal-utils/debug.ts
@@ -12,6 +12,7 @@ function createDebugger(name: string): rawDebug.Debugger {
 
 export const debug = {
   behaviors: createDebugger('behaviors'),
+  focus: createDebugger('focus'),
   history: createDebugger('history'),
   mutation: createDebugger('mutation'),
   normalization: createDebugger('normalization'),

--- a/packages/editor/tests/focus.test.tsx
+++ b/packages/editor/tests/focus.test.tsx
@@ -1,7 +1,16 @@
 import {createTestKeyGenerator} from '@portabletext/test'
+import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
+import {render} from 'vitest-browser-react'
 import {page, userEvent} from 'vitest/browser'
-import type {EditorEmittedEvent} from '../src'
+import {
+  defineSchema,
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+  type EditorEmittedEvent,
+} from '../src'
+import {EditorRefPlugin} from '../src/plugins/plugin.editor-ref'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 
@@ -191,3 +200,273 @@ describe('focus', () => {
     },
   )
 })
+
+describe('focus trap recovery', () => {
+  test(
+    'Scenario: a focus trap steals focus back exactly once, and the editor reports itself honestly unfocused',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const onWindowError = vi.fn()
+      window.addEventListener('error', onWindowError)
+
+      try {
+        let steals = 0
+
+        const {editor, locator} = await createTestEditor({
+          keyGenerator: createTestKeyGenerator(),
+          children: <FocusTrap onSteal={() => steals++} />,
+        })
+
+        const trapLocator = page.getByTestId('trap')
+
+        await userEvent.click(trapLocator)
+        await vi.waitFor(() =>
+          expect(document.activeElement).toBe(trapLocator.element()),
+        )
+
+        editor.send({type: 'focus'})
+
+        await vi.waitFor(() => expect(steals).toBe(1))
+        expect(document.activeElement).toBe(trapLocator.element())
+        expect(document.activeElement).not.toBe(locator.element())
+        expect(onWindowError).not.toHaveBeenCalled()
+
+        // A regression that retries against the trap drives `steals` past
+        // 1 within this window.
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(steals).toBe(1)
+      } finally {
+        window.removeEventListener('error', onWindowError)
+      }
+    },
+  )
+
+  test(
+    'Scenario: a persistent focus trap gives up after one steal, and a later send recovers once the trap releases',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const onWindowError = vi.fn()
+      window.addEventListener('error', onWindowError)
+
+      try {
+        let steals = 0
+
+        const {editor, locator} = await createTestEditor({
+          keyGenerator: createTestKeyGenerator(),
+          children: <FocusTrap onSteal={() => steals++} />,
+        })
+
+        const trapLocator = page.getByTestId('trap')
+        const releaseTrapLocator = page.getByTestId('release-trap')
+
+        await userEvent.click(trapLocator)
+        await vi.waitFor(() =>
+          expect(document.activeElement).toBe(trapLocator.element()),
+        )
+
+        editor.send({type: 'focus'})
+
+        await vi.waitFor(() => expect(steals).toBe(1))
+        expect(document.activeElement).toBe(trapLocator.element())
+        expect(document.activeElement).not.toBe(locator.element())
+        expect(onWindowError).not.toHaveBeenCalled()
+
+        await userEvent.click(releaseTrapLocator)
+
+        editor.send({type: 'focus'})
+
+        await vi.waitFor(() => {
+          expect(document.activeElement).toBe(locator.element())
+        }, FOCUS_SETTLE)
+      } finally {
+        window.removeEventListener('error', onWindowError)
+      }
+    },
+  )
+
+  test(
+    'Scenario: an inert container blocks focus, and releasing it lets focus land',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const editorRef = React.createRef<Editor>()
+      const containerRef = React.createRef<HTMLDivElement>()
+      const focusEvents: Array<EditorEmittedEvent['type']> = []
+
+      const renderResult = await render(
+        <div ref={containerRef}>
+          <EditorProvider
+            initialConfig={{keyGenerator, schemaDefinition: defineSchema({})}}
+          >
+            <EditorRefPlugin ref={editorRef} />
+            <PortableTextEditable />
+            <EventListenerPlugin
+              on={(event) => {
+                if (event.type === 'focused' || event.type === 'blurred') {
+                  focusEvents.push(event.type)
+                }
+              }}
+            />
+          </EditorProvider>
+        </div>,
+      )
+
+      const locator = renderResult.locator.getByRole('textbox')
+      await vi.waitFor(() => expect.element(locator).toBeInTheDocument())
+
+      const editor = editorRef.current!
+      const container = containerRef.current!
+
+      container.inert = true
+
+      editor.send({type: 'focus'})
+
+      // An inert element suppresses focus/blur events entirely, so there is
+      // no event to await; this waits a fixed beat to observe that nothing
+      // ever fires.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(document.activeElement).not.toBe(locator.element())
+      expect(focusEvents).toEqual([])
+
+      container.inert = false
+
+      editor.send({type: 'focus'})
+
+      await vi.waitFor(() => {
+        expect(document.activeElement).toBe(locator.element())
+      }, FOCUS_SETTLE)
+    },
+  )
+})
+
+describe('focus and an already-good DOM selection', () => {
+  // `editor.focused` is a DOM-engine internal with no public accessor, so
+  // this pins the observable contract around it instead: once the editor is
+  // already the active element, a manually placed DOM selection that
+  // disagrees with the model selection has to survive a `focus` send
+  // untouched.
+  test(
+    'Scenario: focus does not rewrite an already-good DOM selection',
+    {timeout: TEST_TIMEOUT},
+    async () => {
+      const keyGenerator = createTestKeyGenerator()
+      const fooBlockKey = keyGenerator()
+      const fooSpanKey = keyGenerator()
+      const barBlockKey = keyGenerator()
+      const barSpanKey = keyGenerator()
+
+      const {editor, locator} = await createTestEditor({
+        keyGenerator,
+        initialValue: [
+          {
+            _type: 'block',
+            _key: fooBlockKey,
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {_type: 'span', _key: fooSpanKey, text: 'foo', marks: []},
+            ],
+          },
+          {
+            _type: 'block',
+            _key: barBlockKey,
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {_type: 'span', _key: barSpanKey, text: 'bar', marks: []},
+            ],
+          },
+        ],
+      })
+
+      await userEvent.click(locator.getByText('foo'))
+      await vi.waitFor(() =>
+        expect(document.activeElement).toBe(locator.element()),
+      )
+
+      const barTextNode = findTextNode('bar')
+      window.getSelection()?.setBaseAndExtent(barTextNode, 1, barTextNode, 2)
+
+      editor.send({type: 'focus'})
+
+      const domSelection = window.getSelection()
+      expect(domSelection?.anchorNode).toBe(barTextNode)
+      expect(domSelection?.anchorOffset).toBe(1)
+      expect(domSelection?.focusOffset).toBe(2)
+
+      // `focus`'s own selection-repair path (`select`/`pendingSelection`)
+      // runs through the machine layer asynchronously; give it a beat to
+      // land before re-checking that the DOM selection is still untouched.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const domSelectionAfterBeat = window.getSelection()
+      expect(domSelectionAfterBeat?.anchorNode).toBe(barTextNode)
+      expect(domSelectionAfterBeat?.anchorOffset).toBe(1)
+      expect(domSelectionAfterBeat?.focusOffset).toBe(2)
+    },
+  )
+})
+
+function findTextNode(text: string): Text {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  while (walker.nextNode()) {
+    if (walker.currentNode.textContent === text) {
+      return walker.currentNode as Text
+    }
+  }
+  throw new Error(`No text node with text "${text}"`)
+}
+
+// A capture-phase `focusin` listener refocuses the trap button whenever the
+// editable steals focus back. Scoped to the editable (rather than any
+// non-trap target) so it never fights the test's own controls (e.g. the
+// release button) for focus.
+function FocusTrap({onSteal}: {onSteal?: () => void} = {}) {
+  const [active, setActive] = React.useState(true)
+  const trapButtonRef = React.useRef<HTMLButtonElement | null>(null)
+
+  React.useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    const trapButton = trapButtonRef.current
+
+    if (!trapButton) {
+      return
+    }
+
+    const handler = (event: FocusEvent) => {
+      const editable = document.querySelector('[role="textbox"]')
+
+      if (event.target !== editable) {
+        return
+      }
+
+      trapButton.focus()
+      onSteal?.()
+    }
+
+    document.addEventListener('focusin', handler, true)
+
+    return () => {
+      document.removeEventListener('focusin', handler, true)
+    }
+  }, [active, onSteal])
+
+  return (
+    <>
+      <button type="button" data-testid="trap" ref={trapButtonRef}>
+        Trap
+      </button>
+      <button
+        type="button"
+        data-testid="release-trap"
+        onClick={() => setActive(false)}
+      >
+        Release trap
+      </button>
+    </>
+  )
+}


### PR DESCRIPTION
Sending `focus` to the editor misbehaved in two independent ways, one silent and one destructive.

The silent one: `DOMEditor.focus` set `editor.focused = true` before `el.focus()` and never verified the focus took. Under a focus-containing overlay (react-aria containment, or `inert` on surrounding content, where `el.focus()` is a complete no-op), the flag was left claiming focus the editor did not have, correctable only by incidental side effects (a real blur firing `onBlur`, a debounce-guarded `selectionchange` path nothing pins). The fix makes `focus` one honest, verified attempt: after `el.focus()`, check `root.activeElement === el`; a failed take resets the flag and gives up with a debug diagnostic. Deliberately no retry against a focus holder: none of the studied editors (Wordgard, CodeMirror, ProseMirror, Lexical, slate-react) competes with an external focus owner, and the DOM cannot distinguish a closing overlay's restore from a user's deliberate focus move. Recovery is an explicit re-request, which works because the flag is honest; an already-focused editor gets the flag healed without any DOM-selection work. The pre-existing retry that waits out the editor's own pending operations stays (renderer readiness, slate-react ancestry), now checked before `getDomNode` can throw, giving up silently instead of throwing inside a `setTimeout` callback where nothing could catch it; a pending retry is cancelled by a newer `focus` or a `blur`.

The destructive one, found by this PR's own strengthened pin: the machine's `handle focus` unconditionally re-selected and re-emitted after every send, even when the editor was already focused. The sequence: `select` with the stale model selection, `onChange`, an `update selection` re-render, and the layout effect overwriting a deliberately different live DOM selection with the stale model one. Deterministic on both browsers once pinned (Firefox immediately, Chromium 30/30 under the settled-boundary re-assert). The machine now skips that block when the editor was already DOM-focused before the send.

Honest pin accounting, since it was wrong in an earlier revision of this description: red-on-old are the `inert` recovery test (Firefox; Chromium's incidental self-heals cover it) and the already-good-DOM-selection pin (both browsers, deterministic). The remaining trap scenarios are contract pins, green pre-fix through the same incidental paths this change replaces with explicit resets; the steal-count assertion guards against a future retry-loop regression rather than documenting a pre-fix red. The blur-cancellation of a pending operations-retry is kept but unpinned: the window needs pending operations the public test surface cannot hold open. WebKit could not be launched in the verification environments; Chromium and Firefox are green, including `event.focus` on current `main`.

Dialog-close focus hand-off is the integration layer's job (Radix ships it as `onCloseAutoFocus`, Floating UI as `returnFocus`; react-aria lacks the seam, tracked in react-spectrum#9876) and lives with the dialog owner, not here.
