### PR TITLE
docs: drop `load-bearing` from the agent skills

### DIFF
--- a/.agents/skills/code-comments/SKILL.md
+++ b/.agents/skills/code-comments/SKILL.md
@@ -33,7 +33,7 @@ JSDoc on exported symbols (especially `@public`) is rendered by typedoc onto por
 - The why-only rule does not apply. Describe behavior at the surface the consumer sees, not internal mechanism.
 - Deleting or trimming it changes the published docs, so removal is an API-documentation decision, never comment cleanup. When it is wrong, improve it.
 - `@example` blocks are valuable; keep and fix them rather than remove.
-- `@deprecated` tags and their migration pointers are load-bearing API surface: consumers and tooling act on them. Keep them accurate.
+- `@deprecated` tags and their migration pointers are API surface: consumers and tooling act on them. Keep them accurate.
 
 ## Not comments: machine-read directives
 

--- a/.agents/skills/pr-descriptions/SKILL.md
+++ b/.agents/skills/pr-descriptions/SKILL.md
@@ -45,7 +45,7 @@ description: How to write pull request descriptions for the Portable Text Editor
 - **Lead with motivation**: the consumer pain that makes the change
   necessary, before the API or mechanism. The description stands on its own;
   explain the problem in terms of the code, not the PR graph, and reference
-  another PR only when load-bearing.
+  another PR only when the reader cannot follow the description without it.
 - **Prose over bullets.** Each design decision gets a paragraph carrying its
   own reasoning; bullets flatten the why out. A short bullet list is
   acceptable only for genuinely parallel items (e.g. "things I was careful
@@ -58,7 +58,7 @@ description: How to write pull request descriptions for the Portable Text Editor
   pins it.
 - Fenced code examples when introducing API.
 - Stacked or extracted PRs state why they are separate and what depends on
-  them, referencing the other PR only when load-bearing (#2777: "Extracted
+  them, referencing the other PR only when the reader needs it (#2777: "Extracted
   from #2772 because it changes behavior for all existing `editor.on`
   events ... #2772 stacks on this").
 - No generated-by footers, no emoji banners.


### PR DESCRIPTION
Follow-up to #3205, which removed LLM-flavored phrasing from READMEs, docs pages, and comments but deliberately skipped `.agents/skills`. GitHub code search still surfaces the term because three occurrences live there (and `rg` hides dot-directories by default, so the earlier verification missed them). This rewords those three lines: the two PR-reference rules now say when a reference is warranted instead of calling it load-bearing, and `@deprecated` JSDoc is described by what consumers and tooling do with it. Wording only; the skills' structure and rules are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to agent skill markdown with no runtime or API behavior impact.
> 
> **Overview**
> Continues the #3205 style cleanup by rephrasing three lines in `.agents/skills` that still used **load-bearing** (easy to miss because dot-directories don’t show up in a normal `rg` pass).
> 
> In **pr-descriptions**, rules for linking other PRs now say to reference them only when the reader **can’t follow without it** or **needs it**, instead of calling those links load-bearing. In **code-comments**, `@deprecated` JSDoc is described as **API surface** consumers and tooling rely on—same intent, without the metaphor. Skill structure and rules are unchanged; wording only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69bd908ff3cf8a52677796d0e0e2723a502a952e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->