### PR TITLE
feat(steps): add the step vocabulary, `mapPoint`/`mapRange`, and `interpretTransaction`

### DIFF
--- a/packages/editor/tests/__fixtures__/wire-catalogue/block-split-multi-span.json
+++ b/packages/editor/tests/__fixtures__/wire-catalogue/block-split-multi-span.json
@@ -1,0 +1,114 @@
+{
+  "scenario": "block-split-multi-span",
+  "schema": {
+    "decorators": [
+      {
+        "name": "strong"
+      }
+    ]
+  },
+  "seed": "B: fo|o [strong:bar] baz",
+  "actions": [
+    "select {caret at offset 2 on the first span}",
+    "send {type: 'insert.break'}"
+  ],
+  "patches": [
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k1"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +1,2 @@\n fo\n-o \n",
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k2"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "diffMatchPatch",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        },
+        "text"
+      ],
+      "value": "@@ -1,4 +0,0 @@\n- baz\n",
+      "origin": "local"
+    },
+    {
+      "type": "insert",
+      "path": [
+        {
+          "_key": "k0"
+        }
+      ],
+      "position": "after",
+      "items": [
+        {
+          "_type": "block",
+          "_key": "k6",
+          "children": [
+            {
+              "_type": "span",
+              "_key": "k1",
+              "text": "o ",
+              "marks": []
+            },
+            {
+              "_type": "span",
+              "_key": "k2",
+              "text": "bar",
+              "marks": [
+                "strong"
+              ]
+            },
+            {
+              "_type": "span",
+              "_key": "k3",
+              "text": " baz",
+              "marks": []
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ],
+      "origin": "local"
+    },
+    {
+      "type": "unset",
+      "path": [
+        {
+          "_key": "k0"
+        },
+        "children",
+        {
+          "_key": "k3"
+        }
+      ],
+      "origin": "local"
+    }
+  ],
+  "result": "B: fo\nB: |o [strong:bar] baz"
+}

--- a/packages/editor/tests/wire-catalogue.test.tsx
+++ b/packages/editor/tests/wire-catalogue.test.tsx
@@ -150,6 +150,37 @@ describe('wire catalogue', () => {
     })
   })
 
+  test('Scenario: splitting a block with multiple spans with insert.break', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const seed = 'B: fo|o [strong:bar] baz'
+    const schemaDefinition = defineSchema({decorators: [{name: 'strong'}]})
+
+    const {editor, patches, schema, compiledSchema, selection} =
+      await setupScenario({keyGenerator, seed, schemaDefinition})
+
+    editor.send({type: 'select', at: selection})
+    editor.send({type: 'insert.break'})
+
+    await vi.waitFor(() => {
+      expect(getTersePt(editor.getSnapshot().context)).toEqual([
+        'fo',
+        'o ,bar, baz',
+      ])
+    })
+
+    await writeCapture({
+      scenario: 'block-split-multi-span',
+      schema,
+      seed,
+      actions: [
+        'select {caret at offset 2 on the first span}',
+        "send {type: 'insert.break'}",
+      ],
+      patches,
+      result: captureResult(compiledSchema, editor),
+    })
+  })
+
   test('Scenario: merging two blocks with backspace at the boundary', async () => {
     const keyGenerator = createTestKeyGenerator()
     const seed = 'B: foo\nB: |bar'

--- a/packages/steps/README.md
+++ b/packages/steps/README.md
@@ -1,0 +1,52 @@
+# `@portabletext/steps`
+
+> Map a position across a transaction
+
+A transaction reshapes a Portable Text document: text is typed, a block splits, a span is folded into another. This package turns that reshaping into a small vocabulary of primitive steps (`insert.text`, `remove.text`, `move.text`, `remove.node`, `move.node`, `set.text`, `set.children`, `set.key`), derived from a transaction's Sanity patches, then maps a caret or a selection through them, so a position captured before the transaction still points at the right place after it.
+
+## You might not need this
+
+This is a low-level building block for collaborative and offline scenarios:
+
+- **Editing** with the Portable Text Editor directly? The editor already tracks its own selection through every local change; you don't need to map anything yourself.
+- **Applying Sanity patches** to a value without caring where a position ends up? Use [`@portabletext/patches`](https://www.npmjs.com/package/@portabletext/patches) instead.
+
+Reach for this package when you hold a position, your own or a remote collaborator's, that has to survive a transaction it didn't originate from: a server relaying another client's edits, or an offline client rebasing its own selection onto a transaction it received while disconnected.
+
+## Installation
+
+```bash
+npm install @portabletext/steps
+```
+
+## Usage
+
+`interpretTransaction(base, patches)` derives the steps for a transaction's patches, read against the document value they applied to. `mapPoint(steps, point, options?)` and `mapRange(steps, range)` map a `Point` (`{path, offset}`) or a `Range` (`{anchor, focus}`) through them:
+
+```ts
+import {interpretTransaction, mapPoint} from '@portabletext/steps'
+
+const steps = interpretTransaction(value, patches)
+
+const newPoint = mapPoint(steps, {
+  path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+  offset: 3,
+})
+```
+
+`mapPoint`'s `affinity` option (default `'forward'`) decides which side of an edit a point sitting exactly on the boundary lands on: forward moves it with an insertion made at that offset, backward leaves it behind. `mapRange` maps both ends with inward affinity, so text inserted exactly at a range's edge never gets swallowed into the range.
+
+## Step kinds
+
+| kind           | shape                                                |
+| -------------- | ---------------------------------------------------- |
+| `insert.text`  | `{path, offset, length}`                             |
+| `remove.text`  | `{path, offset, length}`                             |
+| `move.text`    | `{from: {path, offset, length}, to: {path, offset}}` |
+| `remove.node`  | `{path}`                                             |
+| `move.node`    | `{from, to}`                                         |
+| `set.text`     | `{path, length}`                                     |
+| `set.children` | `{path, field, oldChildren, newChildren}`            |
+| `set.key`      | `{path, newKey}`                                     |
+
+Every step's `path` (or `from`/`to`) ends at the `KeyedSegment` of the node it addresses, never at a numeric or tuple segment.

--- a/packages/steps/package.config.ts
+++ b/packages/steps/package.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  tsconfig: 'tsconfig.dist.json',
+  strictOptions: {
+    noImplicitBrowsersList: 'off',
+  },
+})

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@portabletext/steps",
+  "version": "1.0.0",
+  "description": "The step vocabulary: types, position mapping, and a wire-patch interpreter",
+  "keywords": [
+    "patches",
+    "portable-text",
+    "portable-text-editor"
+  ],
+  "homepage": "https://www.sanity.io/",
+  "bugs": {
+    "url": "https://github.com/portabletext/editor/issues"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/portabletext/editor.git",
+    "directory": "packages/steps"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    },
+    "access": "public"
+  },
+  "scripts": {
+    "build": "pkg-utils build --strict --check",
+    "check:types": "tsc --noEmit --pretty",
+    "check:types:watch": "tsc --noEmit --pretty --watch",
+    "clean": "del .turbo && del dist && del node_modules",
+    "dev": "pkg-utils watch",
+    "test": "vitest --run",
+    "test:unit": "vitest --run --project unit",
+    "test:unit:watch": "vitest --project unit",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@portabletext/patches": "workspace:^",
+    "@portabletext/schema": "workspace:^",
+    "@sanity/diff-match-patch": "catalog:"
+  },
+  "devDependencies": {
+    "@portabletext/test": "workspace:^",
+    "@sanity/pkg-utils": "catalog:tooling",
+    "@sanity/tsconfig": "catalog:tooling",
+    "typescript": "catalog:tooling",
+    "vite": "catalog:tooling",
+    "vitest": "catalog:tooling"
+  },
+  "engines": {
+    "node": ">=22.12"
+  }
+}

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -1,0 +1,15 @@
+export {interpretTransaction} from './interpret-transaction'
+export {mapPoint, mapRange} from './step-mapper'
+export type {
+  InsertTextStep,
+  MoveNodeStep,
+  MoveTextStep,
+  Point,
+  Range,
+  RemoveNodeStep,
+  RemoveTextStep,
+  SetChildrenStep,
+  SetKeyStep,
+  SetTextStep,
+  Step,
+} from './step-mapper'

--- a/packages/steps/src/interpret-transaction.test.ts
+++ b/packages/steps/src/interpret-transaction.test.ts
@@ -1,0 +1,2054 @@
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+import type {Patch, Path} from '@portabletext/patches'
+import {
+  compileSchema,
+  defineSchema,
+  isTextBlock,
+  type PortableTextBlock,
+} from '@portabletext/schema'
+import {fromTextspec, createTestKeyGenerator} from '@portabletext/test'
+import {makePatches, stringifyPatches} from '@sanity/diff-match-patch'
+import {describe, expect, test} from 'vitest'
+import {interpretTransaction} from './interpret-transaction'
+import {getValue} from './lib/get-value'
+import {isKeyedSegment} from './lib/is-keyed-segment'
+import {mapPoint, type Step, type StepPath} from './step-mapper'
+
+const wireCatalogueDir = join(
+  __dirname,
+  '../../editor/tests/__fixtures__/wire-catalogue',
+)
+
+function readFixture(scenario: string): {
+  seed: string | Array<PortableTextBlock>
+  patches: Array<Patch>
+} {
+  return JSON.parse(
+    readFileSync(join(wireCatalogueDir, `${scenario}.json`), 'utf-8'),
+  ) as {
+    seed: string | Array<PortableTextBlock>
+    patches: Array<Patch>
+  }
+}
+
+/**
+ * Parse a textspec seed the same way the wire catalogue captured it: a
+ * fresh key generator, canonicalized to carry `style`/`markDefs` so the
+ * seed matches what the recorded patches were derived against.
+ */
+function seedFromTextspec(
+  textspec: string,
+  schemaDefinition = defineSchema({}),
+): Array<PortableTextBlock> {
+  const compiledSchema = compileSchema(schemaDefinition)
+  const {blocks} = fromTextspec(
+    {schema: compiledSchema, keyGenerator: createTestKeyGenerator()},
+    textspec,
+  )
+  return blocks.map((block) =>
+    isTextBlock({schema: compiledSchema}, block)
+      ? {style: 'normal', markDefs: [], ...block}
+      : block,
+  )
+}
+
+describe(interpretTransaction.name, () => {
+  test('Scenario: block-split moves the tail into the new block', () => {
+    const fixture = readFixture('block-split')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {
+          path: [{_key: 'k4'}, 'children', {_key: 'k1'}],
+          offset: 0,
+        },
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: block-split-multi-span moves the two flanking spans by key, leaving the split span unpaired', () => {
+    const fixture = readFixture('block-split-multi-span')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({decorators: [{name: 'strong'}]}),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'remove.text',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+        offset: 2,
+        length: 2,
+      },
+      {
+        type: 'move.node',
+        from: [{_key: 'k0'}, 'children', {_key: 'k2'}],
+        to: [{_key: 'k6'}, 'children', {_key: 'k2'}],
+      },
+      {
+        type: 'move.node',
+        from: [{_key: 'k0'}, 'children', {_key: 'k3'}],
+        to: [{_key: 'k6'}, 'children', {_key: 'k3'}],
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: block-split-multi-span keeps a caret on the retained head span from being dragged into the reinserted duplicate key', () => {
+    const fixture = readFixture('block-split-multi-span')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({decorators: [{name: 'strong'}]}),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    for (let offset = 0; offset <= 2; offset++) {
+      expect(
+        mapPoint(steps, {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset,
+        }),
+      ).toEqual({path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset})
+    }
+  })
+
+  test('Scenario: decorator-add-mid-span carves the span in three by moving both flanks', () => {
+    const fixture = readFixture('decorator-add-mid-span')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({decorators: [{name: 'strong'}]}),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 7,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k4'}],
+          offset: 0,
+        },
+      },
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k5'}],
+          offset: 0,
+        },
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: type-text yields a single insert', () => {
+    const fixture = readFixture('type-text')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'insert.text',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+        offset: 11,
+        length: 4,
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: delete-within-span yields a single removal', () => {
+    const fixture = readFixture('delete-within-span')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'remove.text',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+        offset: 4,
+        length: 3,
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: span-merge-cosmetic folds the absorbed span in as one move, current text and all', () => {
+    // The fixture's own seed carries two spans with identical (empty)
+    // marks: textspec has no notation for a span boundary that isn't a
+    // mark boundary (see `packages/editor/tests/wire-catalogue.test.tsx`),
+    // so this fixture is read as full blocks rather than through
+    // `seedFromTextspec`.
+    const fixture = readFixture('span-merge-cosmetic')
+    const seed = fixture.seed as Array<PortableTextBlock>
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'insert.text',
+        path: [{_key: 'k0'}, 'children', {_key: 'k2'}],
+        offset: 3,
+        length: 1,
+      },
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k2'}],
+          offset: 0,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k2'}]},
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: block-merge-backspace chains two moves from the deleted block into the surviving span', () => {
+    const fixture = readFixture('block-merge-backspace')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k2'}, 'children', {_key: 'k3'}],
+          offset: 0,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k3'}],
+          offset: 0,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k2'}]},
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k3'}],
+          offset: 0,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 3,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k3'}]},
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k6'}]},
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: block-merge-duplicate-keys recognizes each renamed, reinserted child as its own move', () => {
+    // Unlike block-merge-backspace, kept as full blocks (not a textspec
+    // seed): a duplicate `_key` across two blocks has no textspec notation.
+    const fixture = readFixture('block-merge-duplicate-keys')
+    const seed = fixture.seed as Array<PortableTextBlock>
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'set.key',
+        path: [{_key: 'kB'}, 'children', {_key: 's1'}],
+        newKey: 'k2',
+      },
+      {
+        type: 'set.key',
+        path: [{_key: 'kB'}, 'children', {_key: 's2'}],
+        newKey: 'k3',
+      },
+      {
+        type: 'set.key',
+        path: [{_key: 'kB'}, 'children', {_key: 's3'}],
+        newKey: 'k4',
+      },
+      {
+        type: 'move.node',
+        from: [{_key: 'kB'}, 'children', {_key: 'k2'}],
+        to: [{_key: 'kA'}, 'children', {_key: 'k2'}],
+      },
+      {
+        type: 'move.node',
+        from: [{_key: 'kB'}, 'children', {_key: 'k3'}],
+        to: [{_key: 'kA'}, 'children', {_key: 'k3'}],
+      },
+      {
+        type: 'move.node',
+        from: [{_key: 'kB'}, 'children', {_key: 'k4'}],
+        to: [{_key: 'kA'}, 'children', {_key: 'k4'}],
+      },
+      {type: 'remove.node', path: [{_key: 'kB'}]},
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'kA'}, 'children', {_key: 'k2'}],
+          offset: 0,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'kA'}, 'children', {_key: 's3'}],
+          offset: 4,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'kA'}, 'children', {_key: 'k2'}]},
+      {type: 'remove.node', path: [{_key: 'kA'}, 'children', {_key: 'k5'}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: [{_key: 'kB'}, 'children', {_key: 's3'}],
+      offset: 3,
+    })
+
+    expect(mapped).toEqual({
+      path: [{_key: 'kA'}, 'children', {_key: 'k4'}],
+      offset: 3,
+    })
+
+    for (const untouchedCaret of [
+      {path: [{_key: 'kA'}, 'children', {_key: 's1'}], offset: 2},
+      {path: [{_key: 'kA'}, 'children', {_key: 's2'}], offset: 1},
+      {path: [{_key: 'kA'}, 'children', {_key: 's3'}], offset: 2},
+    ]) {
+      expect(mapPoint(steps, untouchedCaret)).toEqual(untouchedCaret)
+    }
+  })
+
+  test('Scenario: annotation-add-mid-span carves the span in three by moving both flanks', () => {
+    const fixture = readFixture('annotation-add-mid-span')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 7,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k5'}],
+          offset: 0,
+        },
+      },
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k6'}],
+          offset: 0,
+        },
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: annotation-remove chains two moves back into the surviving span', () => {
+    const fixture = readFixture('annotation-remove')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({
+        annotations: [{name: 'link', fields: [{name: 'href', type: 'string'}]}],
+      }),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k3'}],
+          offset: 0,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k3'}]},
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k4'}],
+          offset: 0,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 7,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k4'}]},
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: block-move recognizes the reinserted block as a moved node, not a removal', () => {
+    const fixture = readFixture('block-move')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {type: 'move.node', from: [{_key: 'k0'}], to: [{_key: 'k0'}]},
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: decorator-remove-sub-range carves the span in three by moving both flanks', () => {
+    const fixture = readFixture('decorator-remove-sub-range')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({decorators: [{name: 'strong'}]}),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 7,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k4'}],
+          offset: 0,
+        },
+      },
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k5'}],
+          offset: 0,
+        },
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: decorator-remove-whole-span chains two moves back into the surviving span', () => {
+    const fixture = readFixture('decorator-remove-whole-span')
+    const seed = seedFromTextspec(
+      fixture.seed as string,
+      defineSchema({decorators: [{name: 'strong'}]}),
+    )
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k2'}],
+          offset: 0,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 4,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k2'}]},
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k3'}],
+          offset: 0,
+          length: 4,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 7,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k3'}]},
+    ] satisfies Array<Step>)
+  })
+
+  test('Scenario: insert-blocks-auto folds the scratch span into the target and leaves the pasted block alone', () => {
+    const fixture = readFixture('insert-blocks-auto')
+    const seed = seedFromTextspec(fixture.seed as string)
+
+    const steps = interpretTransaction(seed, fixture.patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k5'}],
+          offset: 0,
+          length: 3,
+        },
+        to: {
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}],
+          offset: 3,
+        },
+      },
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k5'}]},
+      {type: 'remove.node', path: [{_key: 'k0'}, 'children', {_key: 'k8'}]},
+    ] satisfies Array<Step>)
+  })
+})
+
+function spanPath(blockKey: string, spanKey: string): StepPath {
+  return [{_key: blockKey}, 'children', {_key: spanKey}]
+}
+
+function makeBlock(blockKey: string, spanKey: string, text: string) {
+  return {
+    _type: 'block',
+    _key: blockKey,
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: spanKey, text, marks: []}],
+  } satisfies PortableTextBlock
+}
+
+describe('interpretTransaction oracle: character-identity across synthetic transactions', () => {
+  // Distinct characters (not foo/bar/baz) so every position in the seed is
+  // individually identifiable after the transaction reshuffles it: the
+  // oracle checks that a mapped point sits between the same two characters
+  // it did before, and that check is only unambiguous when no character
+  // repeats.
+  const seedText = 'abcdefghijkl'
+
+  function concatenatedSpanText(blocks: Array<PortableTextBlock>): string {
+    let text = ''
+    for (const block of blocks) {
+      if (!isTextBlock({schema: compileSchema(defineSchema({}))}, block)) {
+        continue
+      }
+      for (const child of block.children) {
+        if (typeof (child as {text?: unknown}).text === 'string') {
+          text += (child as {text: string}).text
+        }
+      }
+    }
+    return text
+  }
+
+  function globalOffsetOf(
+    blocks: Array<PortableTextBlock>,
+    path: Path,
+    offset: number,
+  ): number | undefined {
+    const blockSegment = path[0]
+    const spanSegment = path[2]
+    if (!isKeyedSegment(blockSegment) || !isKeyedSegment(spanSegment)) {
+      return undefined
+    }
+
+    let runningOffset = 0
+    for (const block of blocks) {
+      if (!isTextBlock({schema: compileSchema(defineSchema({}))}, block)) {
+        continue
+      }
+      for (const child of block.children) {
+        const childText = (child as {text?: unknown}).text
+        if (typeof childText !== 'string') {
+          continue
+        }
+        const isTargetSpan =
+          blockSegment._key === block._key &&
+          spanSegment._key === (child as {_key: string})._key
+        if (isTargetSpan) {
+          return runningOffset + offset
+        }
+        runningOffset += childText.length
+      }
+    }
+    return undefined
+  }
+
+  function assertCharacterIdentityPreserved(
+    resultBlocks: Array<PortableTextBlock>,
+    steps: Array<Step>,
+    caretPath: StepPath,
+    caretOffset: number,
+  ) {
+    expect(concatenatedSpanText(resultBlocks)).toBe(seedText)
+
+    const mapped = mapPoint(steps, {
+      path: caretPath,
+      offset: caretOffset,
+    })
+
+    expect(mapped).not.toBeNull()
+
+    const actualOffset = globalOffsetOf(
+      resultBlocks,
+      mapped!.path,
+      mapped!.offset,
+    )
+    expect(typeof actualOffset).toBe('number')
+
+    const expectedLeft = caretOffset > 0 ? seedText[caretOffset - 1] : null
+    const expectedRight =
+      caretOffset < seedText.length ? seedText[caretOffset] : null
+    const actualLeft = actualOffset! > 0 ? seedText[actualOffset! - 1] : null
+    const actualRight =
+      actualOffset! < seedText.length ? seedText[actualOffset!] : null
+
+    expect(actualLeft).toBe(expectedLeft)
+    expect(actualRight).toBe(expectedRight)
+  }
+
+  test('every split offset preserves character identity for every caret position', () => {
+    let cases = 0
+
+    // A tail shorter than two characters never pairs into a move (rule (a)
+    // distrusts single-character text), so it's excluded from this sweep:
+    // the point degrades to the split boundary instead, pinned separately
+    // by the interpreter's own negative tests.
+    for (
+      let splitOffset = 0;
+      splitOffset <= seedText.length - 2;
+      splitOffset++
+    ) {
+      const keyGenerator = createTestKeyGenerator()
+      const blockKey = keyGenerator()
+      const spanKey = keyGenerator()
+      const newBlockKey = keyGenerator()
+
+      const seed = [makeBlock(blockKey, spanKey, seedText)]
+
+      const keptText = seedText.slice(0, splitOffset)
+      const tailText = seedText.slice(splitOffset)
+
+      const patches: Array<Patch> = [
+        {
+          type: 'diffMatchPatch',
+          path: [...spanPath(blockKey, spanKey), 'text'],
+          value: dmpPatch(seedText, keptText),
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [{_key: blockKey}],
+          position: 'after',
+          items: [makeBlock(newBlockKey, spanKey, tailText)],
+          origin: 'local',
+        },
+      ]
+
+      const steps = interpretTransaction(seed, patches)
+      const resultBlocks = [
+        makeBlock(blockKey, spanKey, keptText),
+        makeBlock(newBlockKey, spanKey, tailText),
+      ]
+
+      for (let caretOffset = 0; caretOffset <= seedText.length; caretOffset++) {
+        assertCharacterIdentityPreserved(
+          resultBlocks,
+          steps,
+          spanPath(blockKey, spanKey),
+          caretOffset,
+        )
+        cases++
+      }
+    }
+
+    // Exhaustive over the small space, so the run is deterministic
+    // without a seeded RNG.
+    expect(cases).toBe(143)
+  })
+
+  test('every decorator-add range preserves character identity for every caret position', () => {
+    let cases = 0
+
+    // A moved range shorter than two characters never pairs (same rule as
+    // above), whether it's the decorated mid range or the trailing
+    // remainder, so both are excluded from this sweep.
+    for (let start = 0; start < seedText.length; start++) {
+      for (let end = start + 1; end <= seedText.length; end++) {
+        const midLength = end - start
+        const tailLength = seedText.length - end
+        if (midLength < 2 || (tailLength > 0 && tailLength < 2)) {
+          continue
+        }
+
+        const keyGenerator = createTestKeyGenerator()
+        const blockKey = keyGenerator()
+        const spanKey = keyGenerator()
+        const tailSpanKey = keyGenerator()
+        const midSpanKey = keyGenerator()
+
+        const seed = [makeBlock(blockKey, spanKey, seedText)]
+
+        const prefixText = seedText.slice(0, start)
+        const midText = seedText.slice(start, end)
+        const tailText = seedText.slice(end)
+
+        const patches: Array<Patch> = []
+        let afterTailRemovalText = seedText
+
+        if (tailText.length > 0) {
+          afterTailRemovalText = seedText.slice(0, end)
+          patches.push(
+            {
+              type: 'diffMatchPatch',
+              path: [...spanPath(blockKey, spanKey), 'text'],
+              value: dmpPatch(seedText, afterTailRemovalText),
+              origin: 'local',
+            },
+            {
+              type: 'setIfMissing',
+              path: [{_key: blockKey}, 'children'],
+              value: [],
+              origin: 'local',
+            },
+            {
+              type: 'insert',
+              path: spanPath(blockKey, spanKey),
+              position: 'after',
+              items: [
+                {_type: 'span', _key: tailSpanKey, text: tailText, marks: []},
+              ],
+              origin: 'local',
+            },
+          )
+        }
+
+        patches.push(
+          {
+            type: 'diffMatchPatch',
+            path: [...spanPath(blockKey, spanKey), 'text'],
+            value: dmpPatch(afterTailRemovalText, prefixText),
+            origin: 'local',
+          },
+          {
+            type: 'setIfMissing',
+            path: [{_key: blockKey}, 'children'],
+            value: [],
+            origin: 'local',
+          },
+          {
+            type: 'insert',
+            path: spanPath(blockKey, spanKey),
+            position: 'after',
+            items: [
+              {_type: 'span', _key: midSpanKey, text: midText, marks: []},
+            ],
+            origin: 'local',
+          },
+          {
+            type: 'set',
+            path: [{_key: blockKey}, 'children', {_key: midSpanKey}, 'marks'],
+            value: ['strong'],
+            origin: 'local',
+          },
+        )
+
+        const steps = interpretTransaction(seed, patches)
+
+        const resultChildren = [
+          {_type: 'span', _key: spanKey, text: prefixText, marks: []},
+          {_type: 'span', _key: midSpanKey, text: midText, marks: ['strong']},
+          ...(tailText.length > 0
+            ? [{_type: 'span', _key: tailSpanKey, text: tailText, marks: []}]
+            : []),
+        ]
+        const resultBlocks = [
+          {
+            _type: 'block',
+            _key: blockKey,
+            style: 'normal',
+            markDefs: [],
+            children: resultChildren,
+          } as PortableTextBlock,
+        ]
+
+        for (
+          let caretOffset = 0;
+          caretOffset <= seedText.length;
+          caretOffset++
+        ) {
+          assertCharacterIdentityPreserved(
+            resultBlocks,
+            steps,
+            spanPath(blockKey, spanKey),
+            caretOffset,
+          )
+          cases++
+        }
+      }
+    }
+
+    // Exhaustive over the small space, so the run is deterministic
+    // without a seeded RNG.
+    expect(cases).toBe(728)
+  })
+})
+
+describe('interpretTransaction oracle: multi-span block splits (key-reappearance)', () => {
+  type SpanSpec = {key: string; text: string; marks: Array<string>}
+
+  function concatenatedSpanText(blocks: Array<PortableTextBlock>): string {
+    let text = ''
+    for (const block of blocks) {
+      if (!isTextBlock({schema: compileSchema(defineSchema({}))}, block)) {
+        continue
+      }
+      for (const child of block.children) {
+        if (typeof (child as {text?: unknown}).text === 'string') {
+          text += (child as {text: string}).text
+        }
+      }
+    }
+    return text
+  }
+
+  function globalOffsetOf(
+    blocks: Array<PortableTextBlock>,
+    path: Path,
+    offset: number,
+  ): number | undefined {
+    const blockSegment = path[0]
+    const spanSegment = path[2]
+    if (!isKeyedSegment(blockSegment) || !isKeyedSegment(spanSegment)) {
+      return undefined
+    }
+
+    let runningOffset = 0
+    for (const block of blocks) {
+      if (!isTextBlock({schema: compileSchema(defineSchema({}))}, block)) {
+        continue
+      }
+      for (const child of block.children) {
+        const childText = (child as {text?: unknown}).text
+        if (typeof childText !== 'string') {
+          continue
+        }
+        const isTargetSpan =
+          blockSegment._key === block._key &&
+          spanSegment._key === (child as {_key: string})._key
+        if (isTargetSpan) {
+          return runningOffset + offset
+        }
+        runningOffset += childText.length
+      }
+    }
+    return undefined
+  }
+
+  function assertCharacterIdentityPreserved(
+    seedText: string,
+    resultBlocks: Array<PortableTextBlock>,
+    steps: Array<Step>,
+    caretPath: StepPath,
+    caretOffset: number,
+    globalCaretOffset: number,
+  ) {
+    expect(concatenatedSpanText(resultBlocks)).toBe(seedText)
+
+    const mapped = mapPoint(steps, {
+      path: caretPath,
+      offset: caretOffset,
+    })
+
+    expect(mapped).not.toBeNull()
+
+    const actualOffset = globalOffsetOf(
+      resultBlocks,
+      mapped!.path,
+      mapped!.offset,
+    )
+    expect(typeof actualOffset).toBe('number')
+
+    const expectedLeft =
+      globalCaretOffset > 0 ? seedText[globalCaretOffset - 1] : null
+    const expectedRight =
+      globalCaretOffset < seedText.length ? seedText[globalCaretOffset] : null
+    const actualLeft = actualOffset! > 0 ? seedText[actualOffset! - 1] : null
+    const actualRight =
+      actualOffset! < seedText.length ? seedText[actualOffset!] : null
+
+    expect(actualLeft).toBe(expectedLeft)
+    expect(actualRight).toBe(expectedRight)
+  }
+
+  /**
+   * Build the patches a real multi-span block split emits (see the
+   * `block-split-multi-span` wire capture): the split span is trimmed to
+   * its head portion in place, and every span after it (its own tail
+   * remainder included) reappears, key intact, as a child of a new tail
+   * block. Every span strictly after the split span is emptied by a
+   * `diffMatchPatch` and then unset, mirroring the capture's trickiest
+   * shape (the one `move.node`'s step-supersession exists for) rather than
+   * the simpler clean-unset shape a middle span can also take.
+   */
+  function buildMultiSpanSplit(
+    blockKey: string,
+    spans: ReadonlyArray<SpanSpec>,
+    splitSpanIndex: number,
+    localOffset: number,
+    newBlockKey: string,
+  ): {patches: Array<Patch>; resultBlocks: Array<PortableTextBlock>} {
+    const splitSpan = spans[splitSpanIndex]!
+    const trailingSpans = spans.slice(splitSpanIndex + 1)
+    const headRemainderText = splitSpan.text.slice(0, localOffset)
+    const tailRemainderText = splitSpan.text.slice(localOffset)
+
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(blockKey, splitSpan.key), 'text'],
+        value: dmpPatch(splitSpan.text, headRemainderText),
+        origin: 'local',
+      },
+    ]
+
+    for (const span of trailingSpans) {
+      patches.push({
+        type: 'diffMatchPatch',
+        path: [...spanPath(blockKey, span.key), 'text'],
+        value: dmpPatch(span.text, ''),
+        origin: 'local',
+      })
+    }
+
+    const tailChildren = [
+      {
+        _type: 'span',
+        _key: splitSpan.key,
+        text: tailRemainderText,
+        marks: splitSpan.marks,
+      },
+      ...trailingSpans.map((span) => ({
+        _type: 'span',
+        _key: span.key,
+        text: span.text,
+        marks: span.marks,
+      })),
+    ]
+
+    patches.push({
+      type: 'insert',
+      path: [{_key: blockKey}],
+      position: 'after',
+      items: [
+        {
+          _type: 'block',
+          _key: newBlockKey,
+          children: tailChildren,
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      origin: 'local',
+    })
+
+    for (const span of trailingSpans) {
+      patches.push({
+        type: 'unset',
+        path: [{_key: blockKey}, 'children', {_key: span.key}],
+        origin: 'local',
+      })
+    }
+
+    const headChildren = [
+      ...spans.slice(0, splitSpanIndex).map((span) => ({
+        _type: 'span',
+        _key: span.key,
+        text: span.text,
+        marks: span.marks,
+      })),
+      {
+        _type: 'span',
+        _key: splitSpan.key,
+        text: headRemainderText,
+        marks: splitSpan.marks,
+      },
+    ]
+
+    const resultBlocks: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal',
+        markDefs: [],
+        children: headChildren,
+      } as PortableTextBlock,
+      {
+        _type: 'block',
+        _key: newBlockKey,
+        style: 'normal',
+        markDefs: [],
+        children: tailChildren,
+      } as PortableTextBlock,
+    ]
+
+    return {patches, resultBlocks}
+  }
+
+  test('every split offset across every span, with carets at every position, preserves character identity', () => {
+    let cases = 0
+
+    // Two span layouts (2 and 3 spans) over the same 12-character alphabet
+    // as the single-span oracle, with a marked span in the middle of each:
+    // enough to exercise both an odd and an even span count while keeping
+    // the sweep small enough to stay exhaustive rather than sampled.
+    const layouts: Array<Array<{text: string; marks: Array<string>}>> = [
+      [
+        {text: 'abcdef', marks: []},
+        {text: 'ghijkl', marks: ['strong']},
+      ],
+      [
+        {text: 'abcd', marks: []},
+        {text: 'efgh', marks: ['strong']},
+        {text: 'ijkl', marks: []},
+      ],
+    ]
+
+    for (const layout of layouts) {
+      const seedText = layout.map((span) => span.text).join('')
+
+      // The split span must leave at least one whole span after it for the
+      // multi-span shape (a lone trailing remainder is the single-span
+      // `block-split` shape, already covered by its own oracle), and the
+      // split itself must land strictly inside the split span (offset 0
+      // would leave it wholly in the tail with nothing to carve, a shape
+      // this synthetic builder doesn't model since it always dmp-trims the
+      // split span in place).
+      for (
+        let splitSpanIndex = 0;
+        splitSpanIndex < layout.length - 1;
+        splitSpanIndex++
+      ) {
+        const splitSpanText = layout[splitSpanIndex]!.text
+
+        for (
+          let localOffset = 1;
+          localOffset <= splitSpanText.length;
+          localOffset++
+        ) {
+          const keyGenerator = createTestKeyGenerator()
+          const blockKey = keyGenerator()
+          const spans: Array<SpanSpec> = layout.map((span) => ({
+            key: keyGenerator(),
+            text: span.text,
+            marks: span.marks,
+          }))
+          const newBlockKey = keyGenerator()
+
+          const seed = [
+            {
+              _type: 'block',
+              _key: blockKey,
+              style: 'normal',
+              markDefs: [],
+              children: spans.map((span) => ({
+                _type: 'span',
+                _key: span.key,
+                text: span.text,
+                marks: span.marks,
+              })),
+            } as PortableTextBlock,
+          ]
+
+          const {patches, resultBlocks} = buildMultiSpanSplit(
+            blockKey,
+            spans,
+            splitSpanIndex,
+            localOffset,
+            newBlockKey,
+          )
+
+          const steps = interpretTransaction(seed, patches)
+
+          // Carets at every offset of every original span, not just the
+          // split span: spans strictly before it never move and are
+          // trivially exact; spans at or after it are asserted for full
+          // character identity. Each span's offset is local to that span,
+          // so it's converted to its global position in `seedText` before
+          // comparing: only the first span in a layout has local and
+          // global offsets coincide.
+          for (const [spanIndex, span] of spans.entries()) {
+            for (
+              let caretOffset = 0;
+              caretOffset <= span.text.length;
+              caretOffset++
+            ) {
+              const globalCaretOffset = globalOffsetOf(
+                seed,
+                spanPath(blockKey, span.key),
+                caretOffset,
+              )!
+
+              if (spanIndex === splitSpanIndex && caretOffset > localOffset) {
+                // The split span's key reappears in the tail (the new
+                // node holds its sliced-off remainder there), but it's
+                // never removed: the head keeps the same key, trimmed in
+                // place rather than unset. Identity-pairing only
+                // resolves removed keys, so this reappearance is never
+                // looked up, and the point degrades to the split
+                // boundary, the same accepted limit the single-span
+                // oracle documents for a short tail.
+                const mapped = mapPoint(steps, {
+                  path: spanPath(blockKey, span.key),
+                  offset: caretOffset,
+                })
+                expect(mapped).toEqual({
+                  path: spanPath(blockKey, span.key),
+                  offset: localOffset,
+                })
+                cases++
+                continue
+              }
+
+              assertCharacterIdentityPreserved(
+                seedText,
+                resultBlocks,
+                steps,
+                spanPath(blockKey, span.key),
+                caretOffset,
+                globalCaretOffset,
+              )
+              cases++
+            }
+          }
+        }
+      }
+    }
+
+    // Exhaustive over the small space, so the run is deterministic
+    // without a seeded RNG.
+    expect(cases).toBe(204)
+  })
+})
+
+describe('interpretTransaction: adversarial recognizer misfires', () => {
+  test('Probe rename-identity: a rename must never lend its lineage to an unrelated node that merely bears the same key value', () => {
+    const kP = 'kP'
+    const s1 = 's1'
+    const kQ = 'kQ'
+    const collidingKey = 'X'
+    const kR = 'kR'
+    const r1 = 'r1'
+    const seed = [
+      makeBlock(kP, s1, 'def'),
+      makeBlock(kQ, collidingKey, 'abc'),
+      makeBlock(kR, r1, 'zzz'),
+    ]
+
+    const patches: Array<Patch> = [
+      // Renames kP's own span to a key that happens to equal kQ's
+      // pre-existing, wholly unrelated span key.
+      {
+        type: 'set',
+        path: [{_key: kP}, 'children', {_key: s1}, '_key'],
+        value: collidingKey,
+        origin: 'local',
+      },
+      // Unrelated: kQ (holding its own, pre-existing 'X') is removed as a
+      // whole, nothing to do with kP's rename.
+      {type: 'unset', path: [{_key: kQ}], origin: 'local'},
+      // Unrelated: a brand-new span, coincidentally also keyed 'X',
+      // appears under kR.
+      {
+        type: 'insert',
+        path: [{_key: kR}, 'children', {_key: r1}],
+        position: 'after',
+        items: [{_type: 'span', _key: collidingKey, text: 'qqq', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'set.key',
+        path: [{_key: kP}, 'children', {_key: s1}],
+        newKey: collidingKey,
+      },
+      {type: 'remove.node', path: [{_key: kQ}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: spanPath(kQ, collidingKey),
+      offset: 1,
+    })
+
+    expect(mapped).toBeNull()
+  })
+
+  test('Probe partial-collision merge: a container remove.node survives descendant moves and still invalidates the sibling it does not cover', () => {
+    const kA = 'kA'
+    const kB = 'kB'
+    const collidingKey = 's1'
+    const renamedKey = 'k2'
+    const untouchedSibling = 's9'
+    const seed = [
+      makeBlock(kA, collidingKey, 'foo '),
+      {
+        _type: 'block',
+        _key: kB,
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: collidingKey, text: 'bar', marks: []},
+          {_type: 'span', _key: untouchedSibling, text: 'baz', marks: []},
+        ],
+      } satisfies PortableTextBlock,
+    ]
+
+    const patches: Array<Patch> = [
+      // Only `s1` collides with kA's own child, so only it is renamed;
+      // `s9` has no collision and keeps its key across the merge.
+      {
+        type: 'set',
+        path: [{_key: kB}, 'children', {_key: collidingKey}, '_key'],
+        value: renamedKey,
+        origin: 'local',
+      },
+      {type: 'unset', path: [{_key: kB}], origin: 'local'},
+      {
+        type: 'insert',
+        path: [{_key: kA}, 'children', {_key: collidingKey}],
+        position: 'after',
+        items: [{_type: 'span', _key: renamedKey, text: 'bar', marks: []}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: kA}, 'children', {_key: renamedKey}],
+        position: 'after',
+        items: [
+          {_type: 'span', _key: untouchedSibling, text: 'baz', marks: []},
+        ],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'set.key',
+        path: [{_key: kB}, 'children', {_key: collidingKey}],
+        newKey: renamedKey,
+      },
+      {
+        type: 'move.node',
+        from: spanPath(kB, renamedKey),
+        to: spanPath(kA, renamedKey),
+      },
+      {type: 'remove.node', path: [{_key: kB}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: spanPath(kB, untouchedSibling),
+      offset: 2,
+    })
+
+    expect(mapped).toBeNull()
+  })
+
+  test('Probe A: an unrelated identical delete and insert in different blocks never pairs', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const seed = [
+      makeBlock(b1, s1, 'hello cat world'),
+      makeBlock(b2, s2, 'goodbye '),
+    ]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b1, s1), 'text'],
+        value: dmpPatch('hello cat world', 'hello  world'),
+        origin: 'local',
+      },
+      // Unrelated: someone types "cat" into block 2's existing span.
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b2, s2), 'text'],
+        value: dmpPatch('goodbye ', 'goodbye cat'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.text', path: spanPath(b1, s1), offset: 6, length: 3},
+      {type: 'insert.text', path: spanPath(b2, s2), offset: 8, length: 3},
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe B: a one-character delete never pairs, even with matching typing elsewhere', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const seed = [makeBlock(b1, s1, 'cats')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b1, s1), 'text'],
+        value: dmpPatch('cats', 'cat'),
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: b1}],
+        position: 'after',
+        items: [makeBlock(b2, s2, 's')],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.text', path: spanPath(b1, s1), offset: 3, length: 1},
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe C: a node insertion preceding its matching removal never pairs', () => {
+    const b0 = 'b0'
+    const s0 = 's0'
+    const b1 = 'b1'
+    const s1 = 's1'
+    const seed = [makeBlock(b0, s0, 'wxyz')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'insert',
+        path: [{_key: b0}],
+        position: 'before',
+        items: [makeBlock(b1, s1, 'wxy')],
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b0, s0), 'text'],
+        value: dmpPatch('wxyz', 'z'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.text', path: spanPath(b0, s0), offset: 0, length: 3},
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe D: two identical splits in one batch resolve the ambiguity to no pairing', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const b3 = 'b3'
+    const s3 = 's3'
+    const b4 = 'b4'
+    const s4 = 's4'
+    const seed = [makeBlock(b1, s1, 'foo xyz'), makeBlock(b2, s2, 'bar xyz')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b1, s1), 'text'],
+        value: dmpPatch('foo xyz', 'foo '),
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b2, s2), 'text'],
+        value: dmpPatch('bar xyz', 'bar '),
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: b1}],
+        position: 'after',
+        items: [makeBlock(b3, s3, 'xyz')],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: b2}],
+        position: 'after',
+        items: [makeBlock(b4, s4, 'xyz')],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.text', path: spanPath(b1, s1), offset: 4, length: 3},
+      {type: 'remove.text', path: spanPath(b2, s2), offset: 4, length: 3},
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe E: a span emptied by diffMatchPatch and then unset never offers its pre-empty text as a removal', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const seed = [makeBlock(b1, s1, 'abc'), makeBlock(b2, s2, '')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b1, s1), 'text'],
+        value: dmpPatch('abc', ''),
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: b1}, 'children', {_key: s1}],
+        origin: 'local',
+      },
+      // Unrelated: someone types "abc" into block 2's existing span.
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b2, s2), 'text'],
+        value: dmpPatch('', 'abc'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.text', path: spanPath(b1, s1), offset: 0, length: 3},
+      {type: 'remove.node', path: spanPath(b1, s1)},
+      {
+        type: 'insert.text',
+        path: spanPath(b2, s2),
+        offset: 0,
+        length: 3,
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe R1: a whole-node removal matched by a node insertion and a fold at once pairs with neither', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b3 = 'b3'
+    const s3 = 's3'
+    const b4 = 'b4'
+    const s4 = 's4'
+    const seed = [makeBlock(b1, s1, 'bar'), makeBlock(b3, s3, 'foo')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: b1}, 'children', {_key: s1}],
+        origin: 'local',
+      },
+      // Unrelated: a brand-new node also carrying "bar".
+      {
+        type: 'insert',
+        path: [{_key: b3}],
+        position: 'after',
+        items: [makeBlock(b4, s4, 'bar')],
+        origin: 'local',
+      },
+      // Unrelated: someone types "bar" onto the end of block 3's span.
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b3, s3), 'text'],
+        value: dmpPatch('foo', 'foobar'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.node', path: spanPath(b1, s1)},
+      {
+        type: 'insert.text',
+        path: spanPath(b3, s3),
+        offset: 3,
+        length: 3,
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe R2: a one-character whole-node removal never folds, even into a span typed at its exact end', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const seed = [makeBlock(b1, s1, 'x'), makeBlock(b2, s2, 'foo')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: b1}, 'children', {_key: s1}],
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b2, s2), 'text'],
+        value: dmpPatch('foo', 'foox'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.node', path: spanPath(b1, s1)},
+      {
+        type: 'insert.text',
+        path: spanPath(b2, s2),
+        offset: 3,
+        length: 1,
+      },
+    ] satisfies Array<Step>)
+  })
+
+  test("Probe R3: a fold landing mid-span, not at the destination's end, never pairs", () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const s2 = 's2'
+    const seed = [makeBlock(b1, s1, 'bar'), makeBlock(b2, s2, 'fooXY')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: b1}, 'children', {_key: s1}],
+        origin: 'local',
+      },
+      // Typed "bar" between the existing "X" and "Y", not at the span's end.
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(b2, s2), 'text'],
+        value: dmpPatch('fooXY', 'fooXbarY'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.node', path: spanPath(b1, s1)},
+      {
+        type: 'insert.text',
+        path: spanPath(b2, s2),
+        offset: 4,
+        length: 3,
+      },
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: spanPath(b2, s2),
+      offset: 4,
+    })
+
+    expect(mapped).toEqual({path: spanPath(b2, s2), offset: 7})
+  })
+
+  test('Probe key-move duplicate: a removed key reappearing in more than one inserted node pairs with neither', () => {
+    const b1 = 'b1'
+    const s1 = 's1'
+    const b2 = 'b2'
+    const b3 = 'b3'
+    const seed = [makeBlock(b1, s1, 'foo')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: b1}, 'children', {_key: s1}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: b1}],
+        position: 'after',
+        items: [makeBlock(b2, s1, 'bar')],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: b2}],
+        position: 'after',
+        items: [makeBlock(b3, s1, 'baz')],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.node', path: spanPath(b1, s1)},
+    ] satisfies Array<Step>)
+  })
+
+  test('Probe key-move duplicate removal (case E): a key unset from two duplicate-keyed nodes, then reinserted once, pairs with neither', () => {
+    const bHead = 'bHead'
+    const bTail = 'bTail'
+    const k1 = 'k1'
+    const bNew = 'bNew'
+    // The base document already carries the duplicate key: the state a
+    // multi-span split leaves before its reused key gets resolved, here
+    // caught before that resolution happens.
+    const seed = [makeBlock(bHead, k1, 'foo'), makeBlock(bTail, k1, 'bar')]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: bHead}, 'children', {_key: k1}],
+        origin: 'local',
+      },
+      {
+        type: 'unset',
+        path: [{_key: bTail}, 'children', {_key: k1}],
+        origin: 'local',
+      },
+      {
+        type: 'insert',
+        path: [{_key: bTail}],
+        position: 'after',
+        items: [makeBlock(bNew, k1, 'qux')],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'remove.node', path: spanPath(bHead, k1)},
+      {type: 'remove.node', path: spanPath(bTail, k1)},
+    ] satisfies Array<Step>)
+  })
+
+  test("sweep blast radius: a block move plus a genuine child unset in the same transaction leaves the child's caret dangling, not recovered", () => {
+    const anchor = 'anchor'
+    const sAnchor = 'sAnchor'
+    const bA = 'bA'
+    const sX = 'sX'
+    const sChild = 'sChild'
+
+    const seed = [
+      makeBlock(anchor, sAnchor, 'anchor'),
+      {
+        _type: 'block',
+        _key: bA,
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: sX, text: 'foo', marks: []},
+          {_type: 'span', _key: sChild, text: 'bar', marks: []},
+        ],
+      } satisfies PortableTextBlock,
+    ]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'unset',
+        path: [{_key: bA}, 'children', {_key: sChild}],
+        origin: 'local',
+      },
+      {type: 'unset', path: [{_key: bA}], origin: 'local'},
+      {
+        type: 'insert',
+        path: [{_key: anchor}],
+        position: 'after',
+        items: [
+          {
+            _type: 'block',
+            _key: bA,
+            style: 'normal',
+            markDefs: [],
+            children: [{_type: 'span', _key: sX, text: 'foo', marks: []}],
+          },
+        ],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {type: 'move.node', from: [{_key: bA}], to: [{_key: bA}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: [{_key: bA}, 'children', {_key: sChild}],
+      offset: 1,
+    })
+    const resultBlocks = [
+      makeBlock(anchor, sAnchor, 'anchor'),
+      {
+        _type: 'block',
+        _key: bA,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: sX, text: 'foo', marks: []}],
+      } satisfies PortableTextBlock,
+    ]
+    expect(mapped).not.toBeNull()
+    expect(getValue(resultBlocks, mapped!.path)).toBeUndefined()
+  })
+
+  test('destination coordinates account for edits made to the destination between the move and its slot', () => {
+    // Source: a span holding "ab" is fully removed as a whole node.
+    const source = 'source'
+    const sourceSpan = 'sourceSpan'
+    // Destination: an existing span that first receives an unrelated "Z"
+    // at its start, then absorbs the moved "ab" right after it.
+    const destination = 'destination'
+    const destinationSpan = 'destinationSpan'
+
+    const seed = [
+      makeBlock(source, sourceSpan, 'ab'),
+      makeBlock(destination, destinationSpan, ''),
+    ]
+
+    const patches: Array<Patch> = [
+      {type: 'unset', path: [{_key: source}], origin: 'local'},
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(destination, destinationSpan), 'text'],
+        value: dmpPatch('', 'Z'),
+        origin: 'local',
+      },
+      {
+        type: 'diffMatchPatch',
+        path: [...spanPath(destination, destinationSpan), 'text'],
+        value: dmpPatch('Z', 'Zab'),
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    const mapped = mapPoint(steps, {
+      path: spanPath(source, sourceSpan),
+      offset: 1,
+    })
+
+    expect(mapped).toEqual({
+      path: spanPath(destination, destinationSpan),
+      offset: 2,
+    })
+  })
+
+  test('Probe chained rename: a descendant renamed twice in the same transaction still resolves its own move', () => {
+    const source = 'source'
+    const sibling = 'sibling'
+    const destination = 'destination'
+    const anchor = 'anchor'
+    const seed = [
+      {
+        _type: 'block',
+        _key: source,
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: 'A', text: 'foo', marks: []},
+          {_type: 'span', _key: sibling, text: 'zzz', marks: []},
+        ],
+      } satisfies PortableTextBlock,
+      makeBlock(destination, anchor, 'bar'),
+    ]
+
+    const patches: Array<Patch> = [
+      {
+        type: 'set',
+        path: [{_key: source}, 'children', {_key: 'A'}, '_key'],
+        value: 'B',
+        origin: 'local',
+      },
+      {
+        type: 'set',
+        path: [{_key: source}, 'children', {_key: 'B'}, '_key'],
+        value: 'C',
+        origin: 'local',
+      },
+      {type: 'unset', path: [{_key: source}], origin: 'local'},
+      {
+        type: 'insert',
+        path: [{_key: destination}, 'children', {_key: anchor}],
+        position: 'after',
+        items: [{_type: 'span', _key: 'C', text: 'foo', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'set.key',
+        path: [{_key: source}, 'children', {_key: 'A'}],
+        newKey: 'B',
+      },
+      {
+        type: 'set.key',
+        path: [{_key: source}, 'children', {_key: 'B'}],
+        newKey: 'C',
+      },
+      {
+        type: 'move.node',
+        from: [{_key: source}, 'children', {_key: 'C'}],
+        to: [{_key: destination}, 'children', {_key: 'C'}],
+      },
+      {type: 'remove.node', path: [{_key: source}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: [{_key: source}, 'children', {_key: 'A'}],
+      offset: 2,
+    })
+
+    expect(mapped).toEqual({
+      path: [{_key: destination}, 'children', {_key: 'C'}],
+      offset: 2,
+    })
+  })
+
+  test('Probe rename-then-container-hop: a rename recorded against a container identity that itself later changes pairs with nothing', () => {
+    const originalContainerKey = 'kB'
+    const renamedContainerKey = 'kC'
+    const seed = [makeBlock(originalContainerKey, 'A', 'foo')]
+
+    const patches: Array<Patch> = [
+      // The descendant is renamed while its container still answers to
+      // `kB`: the lineage this records lives at `kB/children/B`.
+      {
+        type: 'set',
+        path: [{_key: originalContainerKey}, 'children', {_key: 'A'}, '_key'],
+        value: 'B',
+        origin: 'local',
+      },
+      // The container itself is renamed next, the same shape a
+      // colliding-block rename ahead of a merge produces: the descendant's
+      // recorded lineage still reads `kB`, which the container no longer
+      // answers to.
+      {
+        type: 'set',
+        path: [{_key: originalContainerKey}, '_key'],
+        value: renamedContainerKey,
+        origin: 'local',
+      },
+      {type: 'unset', path: [{_key: renamedContainerKey}], origin: 'local'},
+    ]
+
+    const steps = interpretTransaction(seed, patches)
+
+    expect(steps).toEqual([
+      {
+        type: 'set.key',
+        path: [{_key: originalContainerKey}, 'children', {_key: 'A'}],
+        newKey: 'B',
+      },
+      {
+        type: 'set.key',
+        path: [{_key: originalContainerKey}],
+        newKey: renamedContainerKey,
+      },
+      {type: 'remove.node', path: [{_key: renamedContainerKey}]},
+    ] satisfies Array<Step>)
+
+    const mapped = mapPoint(steps, {
+      path: [{_key: originalContainerKey}, 'children', {_key: 'A'}],
+      offset: 2,
+    })
+
+    expect(mapped).toBeNull()
+  })
+})
+
+describe('interpretTransaction: node-anchoring assertion', () => {
+  test('a set.children step whose node path is not itself node-anchored throws outside production', () => {
+    // A `children` array written at the document root (no keyed node
+    // owns it) has nowhere to drop the trailing `children` segment down
+    // to: `nodePath` comes out empty, which the assertion catches before
+    // an unanchored step reaches a consumer.
+    const patches: Array<Patch> = [
+      {
+        type: 'set',
+        path: ['children'],
+        value: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    expect(() => interpretTransaction([], patches)).toThrow(/not node-anchored/)
+  })
+
+  test('a set.children step whose node path is not itself node-anchored does not throw in production, and the point parks', () => {
+    // Same malformed patch as the dev-side test above, but with the
+    // guard disabled: the interpreter still returns its (unanchored)
+    // steps instead of throwing, and a point that doesn't structurally
+    // match the malformed step just stays where it was.
+    const patches: Array<Patch> = [
+      {
+        type: 'set',
+        path: ['children'],
+        value: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+        origin: 'local',
+      },
+    ]
+
+    const originalNodeEnv = process.env['NODE_ENV']
+    process.env['NODE_ENV'] = 'production'
+
+    try {
+      const steps = interpretTransaction([], patches)
+
+      expect(steps).toEqual([
+        {
+          type: 'set.children',
+          path: [],
+          field: 'children',
+          oldChildren: [],
+          newChildren: [{_key: 's1', text: 'foo'}],
+        },
+      ] satisfies Array<Step>)
+
+      const point = {
+        path: [{_key: 'other'}, 'children', {_key: 's2'}],
+        offset: 5,
+      }
+      expect(mapPoint(steps, point)).toBe(point)
+    } finally {
+      process.env['NODE_ENV'] = originalNodeEnv
+    }
+  })
+})
+
+describe('interpretTransaction oracle: repeated text across two blocks', () => {
+  const repeatedWord = 'wolf'
+
+  function twoBlockSeed(keyGenerator: () => string): {
+    seed: Array<PortableTextBlock>
+    b1: string
+    s1: string
+    b2: string
+    s2: string
+  } {
+    const b1 = keyGenerator()
+    const s1 = keyGenerator()
+    const b2 = keyGenerator()
+    const s2 = keyGenerator()
+    return {
+      seed: [
+        makeBlock(b1, s1, `${repeatedWord} one`),
+        makeBlock(b2, s2, `${repeatedWord} two`),
+      ],
+      b1,
+      s1,
+      b2,
+      s2,
+    }
+  }
+
+  test('deleting the word from one block while typing it in the other keeps both blocks stable', () => {
+    let cases = 0
+
+    // Every caret position in both blocks, so the sweep is exhaustive over
+    // the small space rather than sampled.
+    for (const deleteFrom of ['first', 'second'] as const) {
+      const keyGenerator = createTestKeyGenerator()
+      const {seed, b1, s1, b2, s2} = twoBlockSeed(keyGenerator)
+
+      const [deletionBlock, deletionSpan, typingBlock, typingSpan] =
+        deleteFrom === 'first' ? [b1, s1, b2, s2] : [b2, s2, b1, s1]
+
+      const originalText =
+        deleteFrom === 'first' ? `${repeatedWord} one` : `${repeatedWord} two`
+      const typingOriginalText =
+        deleteFrom === 'first' ? `${repeatedWord} two` : `${repeatedWord} one`
+
+      const patches: Array<Patch> = [
+        {
+          type: 'diffMatchPatch',
+          path: [...spanPath(deletionBlock, deletionSpan), 'text'],
+          value: dmpPatch(
+            originalText,
+            originalText.slice(repeatedWord.length),
+          ),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [...spanPath(typingBlock, typingSpan), 'text'],
+          value: dmpPatch(
+            typingOriginalText,
+            `${repeatedWord} ${typingOriginalText}`,
+          ),
+          origin: 'local',
+        },
+      ]
+
+      const steps = interpretTransaction(seed, patches)
+
+      expect(steps.some((step) => step.type === 'move.text')).toBe(false)
+
+      for (const path of [
+        spanPath(deletionBlock, deletionSpan),
+        spanPath(typingBlock, typingSpan),
+      ]) {
+        for (let offset = 0; offset <= originalText.length; offset++) {
+          const mapped = mapPoint(steps, {path, offset})
+          expect(mapped).not.toBeNull()
+          expect(mapped!.path).toEqual(path)
+          cases++
+        }
+      }
+    }
+
+    // Exhaustive over the small space, so the run is deterministic
+    // without a seeded RNG.
+    expect(cases).toBe(36)
+  })
+})
+
+function dmpPatch(oldText: string, newText: string): string {
+  return stringifyPatches(makePatches(oldText, newText))
+}

--- a/packages/steps/src/interpret-transaction.ts
+++ b/packages/steps/src/interpret-transaction.ts
@@ -1,0 +1,1026 @@
+import type {InsertPatch, Patch, Path, PathSegment} from '@portabletext/patches'
+import type {PortableTextBlock} from '@portabletext/schema'
+import {
+  applyPatches as diffMatchPatchApplyPatches,
+  cleanupEfficiency,
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+  makeDiff,
+  parsePatch,
+} from '@sanity/diff-match-patch'
+import {getValue} from './lib/get-value'
+import {isKeyedSegment} from './lib/is-keyed-segment'
+import {pathContains} from './lib/path-contains'
+import {pathEquals} from './lib/path-equals'
+import {mapPoint, type Step, type StepPath} from './step-mapper'
+
+/*
+ * The recognition contract (internal design rationale, not consumer docs):
+ *
+ * Steps are derived by applying each patch to a working copy of the value
+ * as it goes: a
+ * `diffMatchPatch`'s offsets only mean anything against the span text they
+ * were computed from, which shifts patch by patch within the same
+ * transaction (a decorator applied mid-span, say, whose second
+ * `diffMatchPatch` targets the span text left behind by the first).
+ *
+ * Pairing a removal with an insertion is a claim that one node moved (a
+ * block split's tail, a decorator carving a span in three, a merge folding
+ * one span into another), which lets a point that sat inside the moved
+ * text follow it instead of collapsing to the removal boundary. A wrong
+ * pairing is worse than a missed one (it teleports a point to unrelated
+ * content instead of just degrading its precision), so pairing only fires
+ * for two shapes designed to make a coincidental, unrelated match rare,
+ * and backs off whenever more than one candidate would fit:
+ *
+ * - A brand-new node from an `insert` patch pairs with a removal whose
+ *   text matches it exactly and is at least 2 characters (a single
+ *   character is too common to trust). A whole-node removal (`unset` of
+ *   a keyed segment) can land in either patch order (a block merge's
+ *   `insert` can arrive before or after the `unset` it pairs with); a
+ *   removal that only carved text out of a still-living span must
+ *   precede the insertion, the shape a block split or a decorator carve
+ *   produces. A removal and insertion that land on the same path pair
+ *   with nothing: that's the same node reappearing at a new position in
+ *   its array (a block reorder), not content moving between nodes, and
+ *   `move.text` has nothing to add.
+ * - Text folded into an existing span (an `insert.text` step from a
+ *   `diffMatchPatch`) pairs only with a whole-node removal (`unset` of a
+ *   keyed segment) whose text, read from the working copy at the moment
+ *   of removal, matches the folded text exactly and is at least 2
+ *   characters, in either patch order (a span merge folds before it
+ *   unsets the absorbed span). The insert must also land at the
+ *   destination span's current end (its offset equals that span's text
+ *   length at fold time): appending is the only shape a real span merge
+ *   produces, so an insert landing mid-span or at the start is local
+ *   typing that happens to read the same as some unrelated removal, never
+ *   a merge.
+ *
+ * A removal whose text matches more than one still-available candidate,
+ * or an insertion matched by more than one still-available removal, pairs
+ * with neither. The two rules above are evaluated together for this: a
+ * removal claimed by one candidate of each kind (an unrelated node
+ * insertion and an unrelated fold that both happen to read the same text)
+ * backs off exactly like two candidates of the same kind would, and
+ * ambiguity resolves to leaving all sides as plain removal/insertion
+ * steps.
+ *
+ * These rules don't rule coincidence out entirely: two whole-node edits
+ * in the same batch that happen to carry identical text 2 characters or
+ * longer (an unrelated block deleted here, a different block bearing the
+ * same words inserted there) still read as one move. The design accepts
+ * that residual on purpose: every constraint these rules add only removes
+ * candidates, it never adds one, so tightening a rule can only turn a
+ * wrong pairing into a missed one (a caret degrading to a boundary),
+ * never the other way around.
+ *
+ * A known gap in the removal side: a whole-node removal's text is read
+ * from the working copy at the moment its `unset` patch is processed, so
+ * if that node's own span were edited again between an earlier fold that
+ * consumes it and its own later `unset`, the removal's captured text and
+ * range would reflect that intervening edit rather than what the fold
+ * actually carried. The real engine never emits that shape (a merge's own
+ * `unset` follows its fold with no further edit to the absorbed node in
+ * between), so this stays a documented limit rather than a fix.
+ *
+ * A paired whole-node removal keeps its `remove.node` step (a block or
+ * span can hold more than the single representative span the match was
+ * made on, so anything the move doesn't cover still needs to be
+ * invalidated), relocated to sit right after the `move.text` step so a
+ * point reaches the move before it can be nulled. A paired text removal
+ * needs no such step: the diff range it came from covers exactly the text
+ * that moved, nothing more.
+ *
+ * Every emitted step is node-anchored (its path, or its `from`/`to`
+ * path, ends at a `KeyedSegment`); see `assertStepPathsAreNodeAnchored`
+ * for why that invariant gets an explicit dev-mode guard.
+ */
+
+/**
+ * Derive the steps a transaction's wire patches produce, by replaying the
+ * patches against a working copy of `base` (a `diffMatchPatch` only
+ * decodes against the text it was computed from). Moved text and moved
+ * nodes are recognized conservatively so points can follow content;
+ * anything ambiguous degrades to plain insert/remove steps, so a point
+ * degrades to a boundary instead of relocating into unrelated content.
+ *
+ * The output is good enough to place a caret, never good enough to
+ * reconstruct content: steps carry lengths, offsets, paths, and keys,
+ * never text.
+ *
+ * @public
+ */
+export function interpretTransaction(
+  base: ReadonlyArray<PortableTextBlock>,
+  patches: ReadonlyArray<Patch>,
+): Step[] {
+  const workingCopy = structuredClone(base) as Array<PortableTextBlock>
+  const slots: Array<Step | null> = []
+  const removalCandidates: Array<RemovalCandidate> = []
+  const insertionCandidates: Array<InsertionCandidate> = []
+  const nodeRemovals: Array<NodeRemoval> = []
+  const nodeInsertions: Array<NodeInsertion> = []
+
+  // A scratch node born and discarded within the same transaction (typing
+  // composition's throwaway spans, say) can't be what a pre-existing point
+  // addresses, so its key reappearing elsewhere is never a move worth
+  // recognizing: only a removal of a key that predates the transaction
+  // qualifies.
+  const preExistingKeys = new Set(
+    base.flatMap((block) =>
+      collectKeyedNodes(block, []).map((keyedNode) => keyedNode.key),
+    ),
+  )
+
+  // A `set` on `_key` (a rename raised ahead of a merge to dodge a
+  // collision, say) gives a transaction-local key the same lineage back to
+  // a pre-existing node, but that lineage is only trusted for a
+  // container-walk match (see the `unset` case below) on the exact path
+  // the rename produced: the map records where the renamed node lives,
+  // not just the key value it now wears, so an unrelated pre-existing
+  // node that happens to bear the same key elsewhere is never mistaken
+  // for it.
+  const renamedKeyPaths = new Map<string, StepPath>()
+
+  const pushStep = (step: Step): number => slots.push(step) - 1
+  const pushSlot = (): number => slots.push(null) - 1
+
+  for (const patch of patches) {
+    switch (patch.type) {
+      case 'diffMatchPatch': {
+        const lastSegment = patch.path[patch.path.length - 1]
+
+        if (lastSegment !== 'text') {
+          // A diffMatchPatch on a non-text property (e.g. a markDef field):
+          // resolve, patch, and write back, mirroring a plain `set` on an
+          // arbitrary property, which needs no point-mapping step.
+          const currentValue = getValue(workingCopy, patch.path)
+          if (typeof currentValue === 'string') {
+            const [newValue] = diffMatchPatchApplyPatches(
+              parsePatch(patch.value),
+              currentValue,
+              {allowExceedingIndices: true},
+            )
+            writeAt(workingCopy, patch.path, newValue)
+          }
+          break
+        }
+
+        const spanPath = patch.path.slice(0, -1) as StepPath
+        const spanNode = getValue(workingCopy, spanPath)
+        const oldText = nodeText(spanNode)
+        if (oldText === undefined) {
+          break
+        }
+
+        const [newText] = diffMatchPatchApplyPatches(
+          parsePatch(patch.value),
+          oldText,
+          {allowExceedingIndices: true},
+        )
+        const diff = cleanupEfficiency(makeDiff(oldText, newText), 5)
+
+        const destinationLengthAtFoldTime = oldText.length
+
+        let offset = 0
+        for (const [op, text] of diff) {
+          if (op === DIFF_INSERT) {
+            const slotIndex = pushStep({
+              type: 'insert.text',
+              path: spanPath,
+              offset,
+              length: text.length,
+            })
+            if (offset === destinationLengthAtFoldTime) {
+              insertionCandidates.push({
+                kind: 'fold',
+                text,
+                path: spanPath,
+                offset,
+                slotIndex,
+                consumed: false,
+              })
+            }
+            offset += text.length
+          } else if (op === DIFF_DELETE) {
+            const slotIndex = pushStep({
+              type: 'remove.text',
+              path: spanPath,
+              offset,
+              length: text.length,
+            })
+            if (text.length > 0) {
+              removalCandidates.push({
+                text,
+                from: {path: spanPath, offset, length: text.length},
+                slotIndex,
+                isNodeRemoval: false,
+                consumed: false,
+              })
+            }
+          } else if (op === DIFF_EQUAL) {
+            offset += text.length
+          }
+        }
+
+        writeAt(workingCopy, patch.path, newText)
+        break
+      }
+
+      case 'set': {
+        const propertyName = patch.path[patch.path.length - 1]
+        const nodePath = patch.path.slice(0, -1) as StepPath
+
+        if (propertyName === '_key') {
+          const oldKey = getValue(workingCopy, patch.path)
+          if (typeof oldKey === 'string' && typeof patch.value === 'string') {
+            const containerPath = nodePath.slice(0, -1)
+            pushStep({
+              type: 'set.key',
+              path: [...containerPath, {_key: oldKey}],
+              newKey: patch.value,
+            })
+            renamedKeyPaths.set(patch.value, [
+              ...containerPath,
+              {_key: patch.value},
+            ])
+          }
+        } else if (propertyName === 'text') {
+          pushStep({
+            type: 'set.text',
+            path: nodePath,
+            length: typeof patch.value === 'string' ? patch.value.length : 0,
+          })
+        } else if (propertyName === 'children' && Array.isArray(patch.value)) {
+          const oldChildren = getValue(workingCopy, patch.path)
+          pushStep({
+            type: 'set.children',
+            path: nodePath,
+            field: propertyName,
+            oldChildren: asKeyedChildren(
+              Array.isArray(oldChildren) ? oldChildren : [],
+            ),
+            newChildren: asKeyedChildren(patch.value),
+          })
+        }
+
+        writeAt(workingCopy, patch.path, patch.value)
+        break
+      }
+
+      case 'setIfMissing': {
+        const exists =
+          patch.path.length === 0
+            ? workingCopy.length > 0
+            : getValue(workingCopy, patch.path) !== undefined
+
+        if (!exists) {
+          writeAt(workingCopy, patch.path, patch.value)
+        }
+        break
+      }
+
+      case 'unset': {
+        const lastSegment = patch.path[patch.path.length - 1]
+
+        if (isKeyedSegment(lastSegment)) {
+          const sourceNode = getValue(workingCopy, patch.path)
+          const representative = representativeSpan(
+            sourceNode,
+            patch.path as StepPath,
+          )
+
+          const slotIndex = pushStep({
+            type: 'remove.node',
+            path: patch.path as StepPath,
+          })
+
+          if (representative && representative.text.length > 0) {
+            removalCandidates.push({
+              text: representative.text,
+              from: {
+                path: representative.path,
+                offset: 0,
+                length: representative.text.length,
+              },
+              slotIndex,
+              isNodeRemoval: true,
+              consumed: false,
+            })
+          }
+
+          if (preExistingKeys.has(lastSegment._key)) {
+            nodeRemovals.push({
+              key: lastSegment._key,
+              path: patch.path as StepPath,
+              slotIndex,
+            })
+          }
+
+          // A renamed descendant is independently trackable even though
+          // the removal here targets its container, not the descendant
+          // itself (a block merge unsets the whole donor block after
+          // renaming every colliding child ahead of it, say): each one
+          // reappearing elsewhere is its own move, worth recognizing on
+          // top of whatever the container's own key does. An ordinary
+          // (never-renamed) descendant stays untracked here: nothing
+          // resolves its own move.
+          for (const keyedNode of collectKeyedNodes(
+            sourceNode,
+            patch.path as StepPath,
+          )) {
+            if (keyedNode.key === lastSegment._key) {
+              continue
+            }
+            const renamedPath = renamedKeyPaths.get(keyedNode.key)
+            if (renamedPath && pathEquals(renamedPath, keyedNode.path)) {
+              nodeRemovals.push({
+                key: keyedNode.key,
+                path: keyedNode.path,
+                slotIndex,
+              })
+            }
+          }
+        } else if (lastSegment === 'text') {
+          pushStep({
+            type: 'set.text',
+            path: patch.path.slice(0, -1) as StepPath,
+            length: 0,
+          })
+        }
+
+        removeAt(workingCopy, patch.path)
+        break
+      }
+
+      case 'insert': {
+        applyInsert(workingCopy, patch)
+
+        const parentPath = patch.path.slice(0, -1) as StepPath
+        for (const item of patch.items) {
+          const itemKey = nodeKey(item)
+          if (itemKey === undefined) {
+            continue
+          }
+          const itemPath: StepPath = [...parentPath, {_key: itemKey}]
+
+          const representative = representativeSpan(item, itemPath)
+          if (representative && representative.text.length > 0) {
+            insertionCandidates.push({
+              kind: 'node',
+              text: representative.text,
+              path: representative.path,
+              offset: 0,
+              slotIndex: pushSlot(),
+              consumed: false,
+            })
+          }
+
+          for (const keyedNode of collectKeyedNodes(item, itemPath)) {
+            nodeInsertions.push({
+              key: keyedNode.key,
+              path: keyedNode.path,
+              slotIndex: pushSlot(),
+            })
+          }
+        }
+        break
+      }
+
+      default:
+        break
+    }
+  }
+
+  const steps = assembleSteps(
+    slots,
+    removalCandidates,
+    insertionCandidates,
+    nodeRemovals,
+    nodeInsertions,
+  )
+
+  // @ts-expect-error - dot notation trips `noPropertyAccessFromIndexSignature`
+  // (`ProcessEnv` is index-signature-only), but bracket notation would break
+  // Vite's static replace of `process.env.NODE_ENV` at build time
+  if (process.env.NODE_ENV !== 'production') {
+    assertStepPathsAreNodeAnchored(steps)
+  }
+
+  return steps
+}
+
+type RemovalCandidate = {
+  text: string
+  from: {path: StepPath; offset: number; length: number}
+  slotIndex: number
+  isNodeRemoval: boolean
+  consumed: boolean
+}
+
+type InsertionCandidate = {
+  kind: 'node' | 'fold'
+  text: string
+  path: StepPath
+  offset: number
+  slotIndex: number
+  consumed: boolean
+}
+
+type Pairing = {removal: RemovalCandidate; insertion: InsertionCandidate}
+
+type NodeRemoval = {key: string; path: StepPath; slotIndex: number}
+type NodeInsertion = {key: string; path: StepPath; slotIndex: number}
+type NodeMove = {
+  from: StepPath
+  to: StepPath
+  removalSlotIndex: number
+  insertionSlotIndex: number
+}
+
+/**
+ * Resolve which removed node keys reappear, at any depth, inside a node
+ * inserted elsewhere in the same transaction: exact identity carries no
+ * coincidence risk the way text matching does, so unlike `pairMoves`,
+ * order between the removal and the insertion doesn't matter. A key
+ * appearing in more than one inserted node can't be resolved to a single
+ * destination, so it's left unrecognized (the malformed-input guard), and
+ * the same guard applies symmetrically to a key removed more than once
+ * (two duplicate-keyed nodes both unset in the same transaction): with two
+ * candidate origins for one reappearance, neither is the answer, so the
+ * key pairs with nothing.
+ */
+function resolveNodeMoves(
+  nodeRemovals: ReadonlyArray<NodeRemoval>,
+  nodeInsertions: ReadonlyArray<NodeInsertion>,
+): Array<NodeMove> {
+  const insertionsByKey = new Map<string, Array<NodeInsertion>>()
+  for (const insertion of nodeInsertions) {
+    const occurrences = insertionsByKey.get(insertion.key) ?? []
+    occurrences.push(insertion)
+    insertionsByKey.set(insertion.key, occurrences)
+  }
+
+  const removalsByKey = new Map<string, Array<NodeRemoval>>()
+  for (const removal of nodeRemovals) {
+    const occurrences = removalsByKey.get(removal.key) ?? []
+    occurrences.push(removal)
+    removalsByKey.set(removal.key, occurrences)
+  }
+
+  const moves: Array<NodeMove> = []
+  for (const removal of nodeRemovals) {
+    const [insertion, ...extraInsertions] =
+      insertionsByKey.get(removal.key) ?? []
+    if (insertion === undefined || extraInsertions.length > 0) {
+      continue
+    }
+    if ((removalsByKey.get(removal.key) ?? []).length !== 1) {
+      continue
+    }
+    moves.push({
+      from: removal.path,
+      to: insertion.path,
+      removalSlotIndex: removal.slotIndex,
+      insertionSlotIndex: insertion.slotIndex,
+    })
+  }
+  return moves
+}
+
+/**
+ * Resolve which removal/insertion candidates pair into moves, then replay
+ * `slots` in order, substituting each pairing's `move.text` step at its
+ * insertion's slot and dropping the removal's own slot (a whole-node
+ * removal's `remove.node` step is kept, relocated to right after the
+ * move; see the module doc comment for why).
+ *
+ * Text-pairing runs first and wins whenever it applies: a removal it
+ * already resolved into a `move.text` chain (a block merge's node hop
+ * followed by a span fold, say) is handled precisely by that chain, and
+ * racing an identity-based move against it would just strand the chain's
+ * own removal candidate. Key-reappearance only picks up removals and
+ * insertions text-pairing left untouched: an insertion it already claimed
+ * is off the table for key-pairing too, the same as its paired removal.
+ *
+ * A recognized `nodeMove` supersedes not just its own `remove.node` slot
+ * but every other step addressing that node's old path: the node didn't
+ * die and get edited independently, it moved, so whatever edits landed on
+ * its old path before the move was recognized (a diffMatchPatch emptying
+ * it ahead of its own cleanup unset, say) never happened from the moved
+ * point's perspective.
+ */
+function assembleSteps(
+  slots: ReadonlyArray<Step | null>,
+  removalCandidates: ReadonlyArray<RemovalCandidate>,
+  insertionCandidates: ReadonlyArray<InsertionCandidate>,
+  nodeRemovals: ReadonlyArray<NodeRemoval>,
+  nodeInsertions: ReadonlyArray<NodeInsertion>,
+): Array<Step> {
+  const pairings = pairMoves(removalCandidates, insertionCandidates)
+
+  const pairingsByInsertionSlot = new Map<number, Pairing>()
+  const nulledRemovalSlots = new Set<number>()
+  for (const pairing of pairings) {
+    pairingsByInsertionSlot.set(pairing.insertion.slotIndex, pairing)
+    nulledRemovalSlots.add(pairing.removal.slotIndex)
+  }
+
+  const nodeMoves = resolveNodeMoves(
+    nodeRemovals.filter(
+      (removal) => !nulledRemovalSlots.has(removal.slotIndex),
+    ),
+    nodeInsertions.filter(
+      (insertion) =>
+        !insertionCandidates.some(
+          (candidate) =>
+            candidate.consumed && pathEquals(candidate.path, insertion.path),
+        ),
+    ),
+  )
+
+  const supersededSlots = new Set<number>()
+  const nodeMoveByInsertionSlot = new Map<number, NodeMove>()
+
+  // A container's `remove.node` step can end up shared, as a removal
+  // slot, by more than one recognized move: a block merge unsets the
+  // whole donor block in one step, and every renamed child it carried
+  // resolves its own move against that same slot. When the move IS the
+  // container itself (its `from` is exactly the removed step's own path,
+  // the block-move shape), the step is fully accounted for and dropped.
+  // When the move is a strict descendant of it instead (the merge shape),
+  // the container can still hold more than what moved, so its step
+  // survives, relocated after the last such descendant move so a point
+  // reaches every move before it can be nulled.
+  const wholeNodeConsumedSlots = new Set<number>()
+  const relocatedRemovalBySlot = new Map<
+    number,
+    {step: Step; afterInsertionSlot: number}
+  >()
+
+  for (const move of nodeMoves) {
+    supersededSlots.add(move.removalSlotIndex)
+    nodeMoveByInsertionSlot.set(move.insertionSlotIndex, move)
+    for (let i = 0; i < slots.length; i++) {
+      const step = slots[i]
+      const path = step ? stepPath(step) : undefined
+      if (path && pathContains(move.from, path)) {
+        supersededSlots.add(i)
+      }
+    }
+
+    const removalStep = slots[move.removalSlotIndex]
+    if (removalStep?.type === 'remove.node') {
+      if (pathEquals(removalStep.path, move.from)) {
+        wholeNodeConsumedSlots.add(move.removalSlotIndex)
+      } else {
+        const existing = relocatedRemovalBySlot.get(move.removalSlotIndex)
+        if (
+          !existing ||
+          move.insertionSlotIndex > existing.afterInsertionSlot
+        ) {
+          relocatedRemovalBySlot.set(move.removalSlotIndex, {
+            step: removalStep,
+            afterInsertionSlot: move.insertionSlotIndex,
+          })
+        }
+      }
+    }
+  }
+  for (const slotIndex of wholeNodeConsumedSlots) {
+    relocatedRemovalBySlot.delete(slotIndex)
+  }
+
+  const steps: Array<Step> = []
+  const outputMarkAtRemoval = new Map<number, number>()
+
+  for (let slotIndex = 0; slotIndex < slots.length; slotIndex++) {
+    if (supersededSlots.has(slotIndex)) {
+      continue
+    }
+
+    if (nulledRemovalSlots.has(slotIndex)) {
+      outputMarkAtRemoval.set(slotIndex, steps.length)
+      continue
+    }
+
+    const nodeMove = nodeMoveByInsertionSlot.get(slotIndex)
+    if (nodeMove) {
+      steps.push({type: 'move.node', from: nodeMove.from, to: nodeMove.to})
+      const relocatedRemoval = relocatedRemovalBySlot.get(
+        nodeMove.removalSlotIndex,
+      )
+      if (relocatedRemoval?.afterInsertionSlot === slotIndex) {
+        steps.push(relocatedRemoval.step)
+      }
+      continue
+    }
+
+    const pairing = pairingsByInsertionSlot.get(slotIndex)
+    if (pairing) {
+      const {removal, insertion} = pairing
+      const isPlacedAfterRemoval = insertion.slotIndex > removal.slotIndex
+      const from = isPlacedAfterRemoval
+        ? mapRemovalForward(
+            steps.slice(outputMarkAtRemoval.get(removal.slotIndex) ?? 0),
+            removal.from,
+          )
+        : removal.from
+
+      steps.push({
+        type: 'move.text',
+        from,
+        to: {path: insertion.path, offset: insertion.offset},
+      })
+
+      if (removal.isNodeRemoval) {
+        const removalStep = slots[removal.slotIndex]
+        if (removalStep) {
+          steps.push(removalStep)
+        }
+      }
+      continue
+    }
+
+    const slot = slots[slotIndex]
+    if (slot) {
+      steps.push(slot)
+    }
+  }
+
+  return steps
+}
+
+function pairMoves(
+  removalCandidates: ReadonlyArray<RemovalCandidate>,
+  insertionCandidates: ReadonlyArray<InsertionCandidate>,
+): Array<Pairing> {
+  const pairings: Array<Pairing> = []
+
+  const tryPair = (insertion: InsertionCandidate): void => {
+    if (insertion.consumed) {
+      return
+    }
+
+    const eligibleRemovals = eligibleRemovalsFor(insertion, removalCandidates)
+    if (eligibleRemovals.length !== 1) {
+      return
+    }
+    const removal = eligibleRemovals[0]!
+
+    // The removal's own uniqueness check has to weigh both kinds
+    // together: an insertion only counts as a rival claim on `removal` if
+    // it is, in its own right, uniquely tied to `removal` too (its own
+    // eligible-removals set is exactly this one). An insertion that has
+    // some other removal available isn't a rival: it's slack that the
+    // chain below resolves once that other removal is settled, which is
+    // how a block merge's two chained moves (node move, then span fold)
+    // still both pair despite sharing a removal in their initial,
+    // unconsumed candidate pools.
+    const hasRivalClaim = insertionCandidates.some((other) => {
+      if (other === insertion || other.consumed) {
+        return false
+      }
+      const othersEligibleRemovals = eligibleRemovalsFor(
+        other,
+        removalCandidates,
+      )
+      return (
+        othersEligibleRemovals.length === 1 &&
+        othersEligibleRemovals[0] === removal
+      )
+    })
+    if (hasRivalClaim) {
+      return
+    }
+
+    removal.consumed = true
+    insertion.consumed = true
+    pairings.push({removal, insertion})
+  }
+
+  // Node insertions settle first, so a whole-node removal that's
+  // genuinely a two-hop chain (moved to a new node, then folded from
+  // there into a surviving span) claims its first hop before rule (b)
+  // below even looks at the second.
+  for (const insertion of insertionCandidates) {
+    if (insertion.kind === 'node') {
+      tryPair(insertion)
+    }
+  }
+
+  for (const insertion of insertionCandidates) {
+    if (insertion.kind === 'fold') {
+      tryPair(insertion)
+    }
+  }
+
+  return pairings
+}
+
+function eligibleRemovalsFor(
+  insertion: InsertionCandidate,
+  removalCandidates: ReadonlyArray<RemovalCandidate>,
+): Array<RemovalCandidate> {
+  return removalCandidates.filter(
+    (removal) =>
+      !removal.consumed &&
+      removal.text === insertion.text &&
+      removal.text.length >= 2 &&
+      !pathEquals(removal.from.path, insertion.path) &&
+      (insertion.kind === 'node'
+        ? removal.isNodeRemoval || removal.slotIndex < insertion.slotIndex
+        : removal.isNodeRemoval),
+  )
+}
+
+/**
+ * Re-read a captured `from` range against steps that landed between the
+ * removal and the slot its move ended up at, so a point in the moved
+ * range composes with edits made to the destination in between: when a
+ * whole-node removal's move is placed after its own slot (the paired
+ * insertion came later), other steps targeting the destination can sit
+ * ahead of the move in the output, and the move's `from` range has to be
+ * carried forward through those or it double-counts them (see the test
+ * pinning destination coordinates against edits made between the move
+ * and its slot for the failure this prevents).
+ */
+function mapRemovalForward(
+  interveningSteps: ReadonlyArray<Step>,
+  from: {path: StepPath; offset: number; length: number},
+): {path: StepPath; offset: number; length: number} {
+  const start = mapPoint(interveningSteps, {
+    path: from.path,
+    offset: from.offset,
+  })
+  const end = mapPoint(interveningSteps, {
+    path: from.path,
+    offset: from.offset + from.length,
+  })
+
+  if (start && end && pathEquals(start.path, end.path)) {
+    return {
+      path: start.path as StepPath,
+      offset: start.offset,
+      length: end.offset - start.offset,
+    }
+  }
+
+  return from
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nodeText(node: unknown): string | undefined {
+  if (!isPlainObject(node)) {
+    return undefined
+  }
+  const text = node['text']
+  return typeof text === 'string' ? text : undefined
+}
+
+function nodeKey(node: unknown): string | undefined {
+  if (!isPlainObject(node)) {
+    return undefined
+  }
+  const key = node['_key']
+  return typeof key === 'string' ? key : undefined
+}
+
+function nodeChildren(node: unknown): Array<unknown> | undefined {
+  if (!isPlainObject(node)) {
+    return undefined
+  }
+  const children = node['children']
+  return Array.isArray(children) ? children : undefined
+}
+
+function asKeyedChildren(
+  children: Array<unknown>,
+): Array<{_key: string; text?: string}> {
+  return children.flatMap((child) => {
+    const key = nodeKey(child)
+    if (key === undefined) {
+      return []
+    }
+    const text = nodeText(child)
+    return [text === undefined ? {_key: key} : {_key: key, text}]
+  })
+}
+
+function concatenatedSpanText(children: Array<unknown>): string {
+  let text = ''
+  for (const child of children) {
+    const childText = nodeText(child)
+    if (childText !== undefined) {
+      text += childText
+    }
+  }
+  return text
+}
+
+/**
+ * Resolve the span that represents a node for move recognition: the node
+ * itself if it's a span, or its first span child plus the block's
+ * concatenated span text if it's a text-bearing block. A block with no
+ * span children (an inline/void child only) has nothing to represent.
+ */
+function representativeSpan(
+  node: unknown,
+  path: StepPath,
+): {path: StepPath; text: string} | undefined {
+  const text = nodeText(node)
+  if (text !== undefined) {
+    return {path, text}
+  }
+
+  const children = nodeChildren(node)
+  if (children === undefined) {
+    return undefined
+  }
+
+  const firstSpan = children.find((child) => nodeText(child) !== undefined)
+  const firstSpanKey = nodeKey(firstSpan)
+  if (firstSpanKey === undefined) {
+    return undefined
+  }
+
+  return {
+    path: [...path, 'children', {_key: firstSpanKey}],
+    text: concatenatedSpanText(children),
+  }
+}
+
+/**
+ * Extract the path a step's own mapping is anchored on, for the steps
+ * that carry one. `move.text`, `move.node`, and `set.key` don't address a
+ * single fixed path (that's the whole point of a move, and a rename's
+ * own path already denotes the node under its old key rather than a
+ * subtree other steps could fall inside), so they're outside
+ * `assembleSteps`'s supersession sweep by construction.
+ */
+function stepPath(step: Step): StepPath | undefined {
+  switch (step.type) {
+    case 'insert.text':
+    case 'remove.text':
+    case 'set.text':
+    case 'remove.node':
+    case 'set.children':
+      return step.path
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Walk a freshly inserted node's own key and every keyed descendant's, at
+ * any depth: a block split reusing a span's key several levels down
+ * inside a new tail block is exactly the shape `resolveNodeMoves` needs
+ * to see. Traversal is structural (any array-valued property), not
+ * schema-based, matching the rest of this module.
+ */
+function collectKeyedNodes(
+  node: unknown,
+  path: StepPath,
+): Array<{key: string; path: StepPath}> {
+  if (!isPlainObject(node)) {
+    return []
+  }
+
+  const results: Array<{key: string; path: StepPath}> = []
+  const key = nodeKey(node)
+  if (key !== undefined) {
+    results.push({key, path})
+  }
+
+  for (const [propertyName, value] of Object.entries(node)) {
+    if (!Array.isArray(value)) {
+      continue
+    }
+    for (const child of value) {
+      const childKey = nodeKey(child)
+      if (childKey !== undefined) {
+        results.push(
+          ...collectKeyedNodes(child, [
+            ...path,
+            propertyName,
+            {_key: childKey},
+          ]),
+        )
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * `StepPath`'s type can't enforce node-anchoring: a producer could still
+ * slice a path one segment short. A misanchored path then fails downstream
+ * only silently, matching no point rather than raising where the mistake
+ * was actually made, so this is the loud guard, run outside production.
+ */
+function assertStepPathsAreNodeAnchored(steps: ReadonlyArray<Step>): void {
+  for (const step of steps) {
+    for (const path of nodeAnchoredPaths(step)) {
+      const lastSegment = path[path.length - 1]
+      if (!isKeyedSegment(lastSegment)) {
+        throw new Error(
+          `${step.type} step's path is not node-anchored: ${JSON.stringify(path)}`,
+        )
+      }
+    }
+  }
+}
+
+function nodeAnchoredPaths(step: Step): Array<StepPath> {
+  switch (step.type) {
+    case 'insert.text':
+    case 'remove.text':
+    case 'set.text':
+    case 'remove.node':
+    case 'set.children':
+      return [step.path]
+    case 'set.key':
+      return [step.path]
+    case 'move.text':
+      return [step.from.path, step.to.path]
+    case 'move.node':
+      return [step.from, step.to]
+  }
+}
+
+function findParent(
+  root: unknown,
+  path: Path,
+): {parent: unknown; key: PathSegment} | undefined {
+  if (path.length === 0) {
+    return undefined
+  }
+  return {
+    parent: getValue(root, path.slice(0, -1)),
+    key: path[path.length - 1]!,
+  }
+}
+
+function writeAt(root: unknown, path: Path, value: unknown): void {
+  const target = findParent(root, path)
+  if (!target) {
+    return
+  }
+  const {parent, key} = target
+
+  if (typeof key === 'number' && Array.isArray(parent)) {
+    parent[key] = value
+  } else if (typeof key === 'string' && isPlainObject(parent)) {
+    parent[key] = value
+  } else if (isKeyedSegment(key) && Array.isArray(parent)) {
+    const index = parent.findIndex((item) => nodeKey(item) === key._key)
+    if (index !== -1) {
+      parent[index] = value
+    }
+  }
+}
+
+function removeAt(root: unknown, path: Path): void {
+  const target = findParent(root, path)
+  if (!target) {
+    return
+  }
+  const {parent, key} = target
+
+  if (isKeyedSegment(key) && Array.isArray(parent)) {
+    const index = parent.findIndex((item) => nodeKey(item) === key._key)
+    if (index !== -1) {
+      parent.splice(index, 1)
+    }
+  } else if (typeof key === 'string' && isPlainObject(parent)) {
+    delete parent[key]
+  }
+}
+
+function applyInsert(root: unknown, patch: InsertPatch): void {
+  const anchorKey = patch.path[patch.path.length - 1]
+  if (!isKeyedSegment(anchorKey)) {
+    return
+  }
+
+  const parentArray = getValue(root, patch.path.slice(0, -1))
+  if (!Array.isArray(parentArray)) {
+    return
+  }
+
+  const index = parentArray.findIndex(
+    (item) => nodeKey(item) === anchorKey._key,
+  )
+  if (index === -1) {
+    return
+  }
+
+  const insertIndex = patch.position === 'after' ? index + 1 : index
+  const clonedItems = patch.items.map((item) => structuredClone(item))
+  parentArray.splice(insertIndex, 0, ...clonedItems)
+}

--- a/packages/steps/src/lib/child-text-offset.ts
+++ b/packages/steps/src/lib/child-text-offset.ts
@@ -1,0 +1,75 @@
+/**
+ * A copy of `packages/editor/src/utils/util.child-text-offset.ts`, kept in
+ * sync by hand.
+ */
+
+/**
+ * Pure text-offset arithmetic over a node's children array. Span-ness is
+ * the caller's concern, expressed as an accessor that returns the
+ * child's text when the child occupies text offsets and `undefined` when
+ * it does not (inline objects, blocks).
+ */
+
+/**
+ * The text offset of `(childKey, offsetInChild)` within `children`: the
+ * total text of the children before that child, plus the offset into it.
+ * `undefined` when the child is missing or carries no text.
+ */
+export function textOffsetOfChild(
+  children: ReadonlyArray<unknown>,
+  getSpanText: (child: unknown) => string | undefined,
+  childKey: string,
+  offsetInChild: number,
+): number | undefined {
+  let precedingTextLength = 0
+
+  for (const child of children) {
+    const text = getSpanText(child)
+    if (keyOf(child) === childKey) {
+      return text === undefined
+        ? undefined
+        : precedingTextLength + offsetInChild
+    }
+    if (text !== undefined) {
+      precedingTextLength += text.length
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * The child and child-local offset at `textOffset` within `children`.
+ * Forward-boundary convention: an offset landing exactly on a span
+ * boundary stays at the end of the earlier span. `undefined` when the
+ * offset lies beyond the children's total text.
+ */
+export function childAtTextOffset(
+  children: ReadonlyArray<unknown>,
+  getSpanText: (child: unknown) => string | undefined,
+  textOffset: number,
+): {key: string; offset: number} | undefined {
+  let remainingOffset = textOffset
+
+  for (const child of children) {
+    const text = getSpanText(child)
+    if (text === undefined) {
+      continue
+    }
+    if (remainingOffset <= text.length) {
+      const key = keyOf(child)
+      return key === undefined ? undefined : {key, offset: remainingOffset}
+    }
+    remainingOffset -= text.length
+  }
+
+  return undefined
+}
+
+function keyOf(child: unknown): string | undefined {
+  if (child !== null && typeof child === 'object' && '_key' in child) {
+    const key = (child as {_key: unknown})._key
+    return typeof key === 'string' ? key : undefined
+  }
+  return undefined
+}

--- a/packages/steps/src/lib/get-value.ts
+++ b/packages/steps/src/lib/get-value.ts
@@ -1,0 +1,46 @@
+import type {PathSegment} from '@portabletext/patches'
+
+import {isKeyedSegment} from './is-keyed-segment'
+
+/**
+ * A copy of `packages/editor/src/internal-utils/get-value.ts`, kept in
+ * sync by hand.
+ */
+
+/**
+ * Walk a path on a plain JS value (arrays and objects) and return
+ * whatever is found at the end. No schema awareness needed.
+ */
+export function getValue(
+  root: unknown,
+  path: ReadonlyArray<PathSegment>,
+): unknown {
+  let current: unknown = root
+
+  for (const segment of path) {
+    if (current === null || current === undefined) {
+      return current
+    }
+
+    if (isKeyedSegment(segment)) {
+      if (!Array.isArray(current)) {
+        return undefined
+      }
+      current = current.find(
+        (item: Record<string, unknown>) => item['_key'] === segment._key,
+      )
+    } else if (typeof segment === 'number') {
+      if (!Array.isArray(current)) {
+        return undefined
+      }
+      current = current[segment]
+    } else if (typeof segment === 'string') {
+      if (typeof current !== 'object' || current === null) {
+        return undefined
+      }
+      current = (current as Record<string, unknown>)[segment]
+    }
+  }
+
+  return current
+}

--- a/packages/steps/src/lib/is-keyed-segment.ts
+++ b/packages/steps/src/lib/is-keyed-segment.ts
@@ -1,0 +1,9 @@
+import type {KeyedSegment} from '@portabletext/patches'
+
+/**
+ * A copy of `packages/editor/src/utils/util.is-keyed-segment.ts`, kept in
+ * sync by hand.
+ */
+export function isKeyedSegment(segment: unknown): segment is KeyedSegment {
+  return typeof segment === 'object' && segment !== null && '_key' in segment
+}

--- a/packages/steps/src/lib/path-contains.ts
+++ b/packages/steps/src/lib/path-contains.ts
@@ -1,0 +1,33 @@
+import type {Path} from '@portabletext/patches'
+
+import {isKeyedSegment} from './is-keyed-segment'
+
+/**
+ * A copy of `packages/editor/src/traversal/path-contains.ts`, kept in sync
+ * by hand.
+ */
+
+/**
+ * Returns true if `ancestor` is equal to `descendant`, or if `descendant`
+ * lives anywhere inside `ancestor`'s subtree.
+ */
+export function pathContains(ancestor: Path, descendant: Path): boolean {
+  if (ancestor.length > descendant.length) {
+    return false
+  }
+
+  for (let i = 0; i < ancestor.length; i++) {
+    const segment = ancestor[i]
+    const otherSegment = descendant[i]
+
+    if (isKeyedSegment(segment) && isKeyedSegment(otherSegment)) {
+      if (segment._key !== otherSegment._key) {
+        return false
+      }
+    } else if (segment !== otherSegment) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/steps/src/lib/path-equals.ts
+++ b/packages/steps/src/lib/path-equals.ts
@@ -1,0 +1,28 @@
+import type {Path} from '@portabletext/patches'
+
+import {isKeyedSegment} from './is-keyed-segment'
+
+/**
+ * A copy of `packages/editor/src/engine/path/path-equals.ts`, kept in sync
+ * by hand.
+ */
+export function pathEquals(path: Path, another: Path): boolean {
+  if (path.length !== another.length) {
+    return false
+  }
+
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i]
+    const otherSegment = another[i]
+
+    if (isKeyedSegment(segment) && isKeyedSegment(otherSegment)) {
+      if (segment._key !== otherSegment._key) {
+        return false
+      }
+    } else if (segment !== otherSegment) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/steps/src/map-range.test.ts
+++ b/packages/steps/src/map-range.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, test} from 'vitest'
+import {mapRange, type Step} from './step-mapper'
+
+const spanA = [{_key: 'b1'}, 'children', {_key: 's1'}]
+const spanB = [{_key: 'b1'}, 'children', {_key: 's2'}]
+
+describe(mapRange.name, () => {
+  test('an insertion exactly at the range start rides the start past it, so the inserted text falls outside the range', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 8},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanA, offset: 4, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 7},
+      focus: {path: spanA, offset: 11},
+    })
+  })
+
+  test('an insertion exactly at the range end leaves the end behind it, so the inserted text falls outside the range', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 8},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanA, offset: 8, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 8},
+    })
+  })
+
+  test('an insertion strictly inside the range grows it', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 8},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanA, offset: 6, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 11},
+    })
+  })
+
+  test('a collapsed range at an insertion point stays collapsed, before the insertion', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 4},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanA, offset: 4, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 4},
+    })
+  })
+
+  test('a collapsed range strictly inside a later insertion still moves with it', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 4},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanA, offset: 2, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 7},
+      focus: {path: spanA, offset: 7},
+    })
+  })
+
+  test('a removal spanning the range end clamps the end to the removal start', () => {
+    const range = {
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanA, offset: 6},
+    }
+    const steps: Array<Step> = [
+      {type: 'remove.text', path: spanA, offset: 4, length: 10},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanA, offset: 4},
+    })
+  })
+
+  test('a removal spanning the range start clamps the start to the removal start', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 10},
+    }
+    const steps: Array<Step> = [
+      {type: 'remove.text', path: spanA, offset: 0, length: 6},
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanA, offset: 0},
+      focus: {path: spanA, offset: 4},
+    })
+  })
+
+  test('a remove.node containing the anchor invalidates the whole range', () => {
+    const range = {
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanB, offset: 2},
+    }
+    const steps: Array<Step> = [{type: 'remove.node', path: spanA}]
+
+    expect(mapRange(steps, range)).toBeNull()
+  })
+
+  test('a remove.node containing the focus invalidates the whole range', () => {
+    const range = {
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanB, offset: 2},
+    }
+    const steps: Array<Step> = [{type: 'remove.node', path: spanB}]
+
+    expect(mapRange(steps, range)).toBeNull()
+  })
+
+  test('a move.text carrying the whole range moves both ends together', () => {
+    const range = {
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanA, offset: 5},
+    }
+    const steps: Array<Step> = [
+      {
+        type: 'move.text',
+        from: {path: spanA, offset: 0, length: 7},
+        to: {path: spanB, offset: 0},
+      },
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanB, offset: 2},
+      focus: {path: spanB, offset: 5},
+    })
+  })
+
+  test('a move.text at the range boundaries carries the anchor along (forward) but leaves the focus behind (backward)', () => {
+    const range = {
+      anchor: {path: spanA, offset: 4},
+      focus: {path: spanA, offset: 8},
+    }
+    const steps: Array<Step> = [
+      {
+        type: 'move.text',
+        from: {path: spanA, offset: 4, length: 4},
+        to: {path: spanB, offset: 0},
+      },
+    ]
+
+    expect(mapRange(steps, range)).toEqual({
+      anchor: {path: spanB, offset: 0},
+      focus: {path: spanA, offset: 8},
+    })
+  })
+
+  test('an unrelated step on a different path leaves the range untransformed', () => {
+    const range = {
+      anchor: {path: spanA, offset: 2},
+      focus: {path: spanA, offset: 5},
+    }
+    const steps: Array<Step> = [
+      {type: 'insert.text', path: spanB, offset: 0, length: 3},
+    ]
+
+    expect(mapRange(steps, range)).toEqual(range)
+  })
+})

--- a/packages/steps/src/step-mapper.test.ts
+++ b/packages/steps/src/step-mapper.test.ts
@@ -1,0 +1,1082 @@
+import {describe, expect, test} from 'vitest'
+import {
+  mapPointThroughStep,
+  mapPoint,
+  type Point,
+  type Step,
+} from './step-mapper'
+
+describe(mapPointThroughStep.name, () => {
+  test('a null point stays null for any step', () => {
+    const step: Step = {
+      type: 'insert.text',
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 0,
+      length: 5,
+    }
+    expect(mapPointThroughStep(step, null)).toEqual(null)
+  })
+
+  describe('insert.text', () => {
+    test('shifts the offset forward when the insertion is before it', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 8,
+      })
+    })
+
+    test('shifts the offset at the same position with forward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'forward'})).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 6,
+      })
+    })
+
+    test('leaves the offset untouched at the same position with backward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'backward'})).toBe(
+        point,
+      )
+    })
+
+    test('is a no-op when the insertion is after the offset', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 0,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('remove.text', () => {
+    test('shifts the offset backward', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+        length: 2,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      })
+    })
+
+    test('clamps to the removal offset when the point sits inside the removed text', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 1,
+        length: 6,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 1,
+      })
+    })
+
+    test('is a no-op when the removal starts after the offset', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 0,
+        length: 2,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('set.text', () => {
+    test('clamps the offset to the new text length', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        length: 2,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      })
+    })
+
+    test('leaves the offset untouched when it is within the new text length', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        length: 6,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('collapses to zero for a length of zero, the shape a text removed outright takes', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        length: 0,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 0,
+      })
+    })
+
+    test('is a no-op when the offset is already zero and the length is zero', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 0,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        length: 0,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        length: 2,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('remove.node', () => {
+    test('invalidates a point at the removed node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('invalidates a point inside the removed node', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'b2'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('move.text', () => {
+    test('maps a point at the start of the moved range to the destination start with the default (forward) affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b2'}, 'children', {_key: 's2'}],
+        offset: 0,
+      })
+    })
+
+    test('maps a point at the end of the moved range to the destination end with the default (forward) affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 11,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b2'}, 'children', {_key: 's2'}],
+        offset: 7,
+      })
+    })
+
+    test('leaves a point at the start of the moved range behind with backward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 4,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'backward'})).toBe(
+        point,
+      )
+    })
+
+    test('leaves a point at the end of the moved range behind with backward affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 11,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'backward'})).toBe(
+        point,
+      )
+    })
+
+    test('a point strictly inside the moved range rides regardless of affinity', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 7,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point, {affinity: 'backward'})).toEqual({
+        path: [{_key: 'b2'}, 'children', {_key: 's2'}],
+        offset: 3,
+      })
+    })
+
+    test('is a no-op when the offset sits outside the moved range', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op on a different path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's9'}],
+        offset: 6,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 0},
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('offsets into the destination range by an offset target other than zero', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 6,
+      }
+      const step: Step = {
+        type: 'move.text',
+        from: {
+          path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+          offset: 4,
+          length: 7,
+        },
+        to: {path: [{_key: 'b2'}, 'children', {_key: 's2'}], offset: 5},
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b2'}, 'children', {_key: 's2'}],
+        offset: 7,
+      })
+    })
+  })
+
+  describe('set.key', () => {
+    test('substitutes the old key with the new key at the segment addressed by the step path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 3,
+      })
+    })
+
+    test('is a no-op when the old key is not the segment addressed by the step path', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's9'}],
+        newKey: 's2',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('is a no-op when the key matches but at a different depth than the step path', () => {
+      const point = {
+        path: [
+          {_key: 'b1'},
+          'children',
+          {_key: 's1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      }
+
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'b1'},
+          'children',
+          {_key: 's2'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 3,
+      })
+    })
+
+    test('a same-valued key elsewhere never matches: identity is by address, not by value', () => {
+      const point = {
+        path: [{_key: 'other'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('set.children', () => {
+    test('remaps a point through a text-preserving replacement', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [
+          {_key: 'n1', text: 'foo'},
+          {_key: 'n2', text: 'bar'},
+          {_key: 'n3', text: 'baz'},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n2'}],
+        offset: 2,
+      })
+    })
+
+    test('a vanished key among text-less children leaves the point alone', () => {
+      // Children without `text` (block-shaped members of a container
+      // array) cannot occupy offsets, so the offset walk bails and the
+      // point stays put rather than remapping through the replacement.
+      const point: Point = {
+        path: [{_key: 'container1'}, 'rows', {_key: 'row1'}],
+        offset: 0,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'container1'}],
+        field: 'rows',
+        oldChildren: [{_key: 'row1'}, {_key: 'row2'}],
+        newChildren: [{_key: 'row3'}, {_key: 'row2'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a boundary offset lands at the end of the earlier span', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [
+          {_key: 'n1', text: 'foo'},
+          {_key: 'n2', text: 'barbaz'},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n1'}],
+        offset: 3,
+      })
+    })
+
+    test('inline objects occupy no text offset on either side', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+        offset: 1,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [
+          {_key: 's1', text: 'foo'},
+          {_key: 'o1'},
+          {_key: 's2', text: 'bar'},
+        ],
+        newChildren: [
+          {_key: 'n1', text: 'foo'},
+          {_key: 'n2'},
+          {_key: 'n3', text: 'bar'},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 'n3'}],
+        offset: 1,
+      })
+    })
+
+    test('a surviving span keeps its identity over offset mapping', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [
+          {_key: 's1', text: 'foo'},
+          {_key: 'o2', text: 'bar'},
+        ],
+        newChildren: [
+          {_key: 'n1', text: 'bar'},
+          {_key: 's1', text: 'foo'},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a surviving key with shrunken text clamps the offset to the new length', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [{_key: 's1', text: 'foo'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+      })
+    })
+
+    test('a surviving key with the offset already within range keeps the same reference', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [{_key: 's1', text: 'foo'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a surviving key without text is left untouched', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 'o1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 'o1'}],
+        newChildren: [{_key: 'o1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a text-changing replacement leaves the point untransformed', () => {
+      const point = {
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [{_key: 'n1', text: 'hello'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a point in another block is untouched', () => {
+      const point = {
+        path: [{_key: 'b2'}, 'children', {_key: 's9'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [{_key: 'n1', text: 'foobarbaz'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a point in another array field of the same node is untouched', () => {
+      const point = {
+        path: [{_key: 'callout1'}, 'footnotes', {_key: 'f1'}],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'callout1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foo'}],
+        newChildren: [{_key: 'n1', text: 'foo'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('container blocks in a field named `children` are not offset-mapped', () => {
+      const point = {
+        path: [{_key: 'callout1'}, 'children', {_key: 'block1'}],
+        offset: 0,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'callout1'}],
+        field: 'children',
+        oldChildren: [{_key: 'block1'}],
+        newChildren: [{_key: 'newBlock1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('a point deeper inside replaced container blocks is untouched', () => {
+      const point = {
+        path: [
+          {_key: 'callout1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'callout1'}],
+        field: 'children',
+        oldChildren: [{_key: 'block1'}],
+        newChildren: [{_key: 'newBlock1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('remaps span points of a text block nested in a container', () => {
+      const point = {
+        path: [
+          {_key: 'table1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'content',
+          {_key: 'block1'},
+          'children',
+          {_key: 's1'},
+        ],
+        offset: 5,
+      }
+      const nodePath = [
+        {_key: 'table1'},
+        'rows',
+        {_key: 'row1'},
+        'cells',
+        {_key: 'cell1'},
+        'content',
+        {_key: 'block1'},
+      ]
+      const step: Step = {
+        type: 'set.children',
+        path: nodePath,
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [
+          {_key: 'n1', text: 'foo'},
+          {_key: 'n2', text: 'bar'},
+          {_key: 'n3', text: 'baz'},
+        ],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [...nodePath, 'children', {_key: 'n2'}],
+        offset: 2,
+      })
+    })
+
+    test('a raw block-offset point is never offset-mapped', () => {
+      const point = {
+        path: [{_key: 'b1'}],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [{_key: 'b1'}],
+        field: 'children',
+        oldChildren: [{_key: 's1', text: 'foobarbaz'}],
+        newChildren: [{_key: 'n1', text: 'foobarbaz'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+
+  describe('nested paths', () => {
+    test('insert.text shifts the offset of a container-depth point', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 8,
+      })
+    })
+
+    test('insert.text at a different container-depth path is a no-op', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'insert.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span2'},
+        ],
+        offset: 0,
+        length: 3,
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+
+    test('remove.text collapses a container-depth point to the removal start', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'remove.text',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 1,
+        length: 6,
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 1,
+      })
+    })
+
+    test('remove.node of the container root nullifies a point nested inside it', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 5,
+      }
+      const step: Step = {
+        type: 'remove.node',
+        path: [{_key: 'container1'}],
+      }
+      expect(mapPointThroughStep(step, point)).toEqual(null)
+    })
+
+    test('set.key rewrites a middle segment of a container-depth path', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      }
+      const step: Step = {
+        type: 'set.key',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+        ],
+        newKey: 'cell2',
+      }
+      expect(mapPointThroughStep(step, point)).toEqual({
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell2'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 3,
+      })
+    })
+
+    test('set.children on a container-depth array leaves a non-direct-child point untouched', () => {
+      const point = {
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+          'children',
+          {_key: 'block1'},
+          'children',
+          {_key: 'span1'},
+        ],
+        offset: 2,
+      }
+      const step: Step = {
+        type: 'set.children',
+        path: [
+          {_key: 'container1'},
+          'rows',
+          {_key: 'row1'},
+          'cells',
+          {_key: 'cell1'},
+        ],
+        field: 'children',
+        oldChildren: [{_key: 'block1', text: 'foo'}],
+        newChildren: [{_key: 'newBlock1', text: 'foo'}],
+      }
+      expect(mapPointThroughStep(step, point)).toBe(point)
+    })
+  })
+})
+
+describe(mapPoint.name, () => {
+  test('folds a batch of steps over the point in order', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    const steps: Step[] = [
+      {
+        type: 'insert.text',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        offset: 3,
+        length: 3,
+      },
+      {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      },
+    ]
+    expect(mapPoint(steps, point)).toEqual({
+      path: [{_key: 'b1'}, 'children', {_key: 's2'}],
+      offset: 8,
+    })
+  })
+
+  test('short-circuits once a step invalidates the point', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    const steps: Step[] = [
+      {type: 'remove.node', path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+      {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      },
+    ]
+    expect(mapPoint(steps, point)).toEqual(null)
+  })
+
+  test('an empty batch leaves the point untransformed', () => {
+    const point = {
+      path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+      offset: 5,
+    }
+    expect(mapPoint([], point)).toBe(point)
+  })
+
+  test('a null point stays null through a batch', () => {
+    const steps: Step[] = [
+      {
+        type: 'set.key',
+        path: [{_key: 'b1'}, 'children', {_key: 's1'}],
+        newKey: 's2',
+      },
+    ]
+    expect(mapPoint(steps, null)).toEqual(null)
+  })
+})

--- a/packages/steps/src/step-mapper.ts
+++ b/packages/steps/src/step-mapper.ts
@@ -1,0 +1,444 @@
+import type {KeyedSegment, Path} from '@portabletext/patches'
+import {childAtTextOffset, textOffsetOfChild} from './lib/child-text-offset'
+import {isKeyedSegment} from './lib/is-keyed-segment'
+import {pathContains} from './lib/path-contains'
+import {pathEquals} from './lib/path-equals'
+
+/**
+ * A step's own path never carries a numeric or tuple segment: a producer
+ * holding a numeric path resolves it to keys before emitting a step, so
+ * every step path compares by key identity, never by array position.
+ */
+export type StepPath = Array<string | KeyedSegment>
+
+/**
+ * A position in a Portable Text document: a path plus a UTF-16 offset.
+ * Point paths use the full `Path` union; the names-only restriction
+ * applies to step paths, not points.
+ * @public
+ */
+export type Point = {path: Path; offset: number}
+
+/**
+ * A span of a Portable Text document, marked by an `anchor` and a
+ * `focus` point.
+ * @public
+ */
+export type Range = {anchor: Point; focus: Point}
+
+/**
+ * Text was inserted into a span, `length` UTF-16 units of it starting at
+ * `offset`.
+ * @public
+ */
+export type InsertTextStep = {
+  type: 'insert.text'
+  path: StepPath
+  offset: number
+  length: number
+}
+
+/**
+ * Text was removed from a span, `length` UTF-16 units of it starting at
+ * `offset`.
+ * @public
+ */
+export type RemoveTextStep = {
+  type: 'remove.text'
+  path: StepPath
+  offset: number
+  length: number
+}
+
+/**
+ * A point strictly inside `from` always rides to `to` with its relative
+ * offset. A point exactly at either edge of `from` rides under
+ * `'forward'` affinity (the default) and stays under `'backward'`.
+ * @public
+ */
+export type MoveTextStep = {
+  type: 'move.text'
+  from: {path: StepPath; offset: number; length: number}
+  to: {path: StepPath; offset: number}
+}
+
+/**
+ * A node (a block, or a child within one) was removed.
+ * @public
+ */
+export type RemoveNodeStep = {
+  type: 'remove.node'
+  path: StepPath
+}
+
+/**
+ * A node moved from one array position to another, addressed by key
+ * rather than index on both ends.
+ * @public
+ */
+export type MoveNodeStep = {
+  type: 'move.node'
+  from: StepPath
+  to: StepPath
+}
+
+/**
+ * `length` is the new text's length, not its content: the mapper only
+ * ever reads `.length` (the offset clamps to zero, which is also how
+ * text removed outright maps).
+ * @public
+ */
+export type SetTextStep = {
+  type: 'set.text'
+  path: StepPath
+  length: number
+}
+
+/**
+ * `field` names the array property the replaced children belong to
+ * (`'children'` for a block's spans, or a container's own registered
+ * array field): `path` alone cannot name which of a node's arrays was
+ * swapped once a node holds more than one. Children are typed to
+ * exactly what the mapping reads: `_key` to follow identity, `text` to
+ * clamp an offset against a surviving span's new length.
+ * @public
+ */
+export type SetChildrenStep = {
+  type: 'set.children'
+  path: StepPath
+  field: string
+  oldChildren: Array<{_key: string; text?: string}>
+  newChildren: Array<{_key: string; text?: string}>
+}
+
+/**
+ * `path` ends at the renamed node itself, addressed by its OLD key: the
+ * node's own segment is only rewritten at that exact address, never
+ * wherever the key value happens to recur. A rename only ever touches one
+ * node; matching by key value alone would also rewrite an unrelated point
+ * that merely walks through a same-keyed node elsewhere in the tree (a
+ * duplicate-key merge's destination block, most notably, since it starts
+ * out sharing every key the donor block does).
+ * @public
+ */
+export type SetKeyStep = {
+  type: 'set.key'
+  path: StepPath
+  newKey: string
+}
+
+/**
+ * The union of every step kind a transaction can produce.
+ * @public
+ */
+export type Step =
+  | InsertTextStep
+  | RemoveTextStep
+  | MoveTextStep
+  | RemoveNodeStep
+  | MoveNodeStep
+  | SetTextStep
+  | SetChildrenStep
+  | SetKeyStep
+
+/**
+ * Map a point through one step. Returns the same `point` reference when the
+ * step doesn't actually move the point, so callers can use referential
+ * equality to detect "nothing changed."
+ */
+export function mapPointThroughStep(
+  step: Step,
+  point: Point | null,
+  options?: {affinity?: 'forward' | 'backward'},
+): Point | null {
+  if (point === null) {
+    return null
+  }
+
+  const {affinity = 'forward'} = options ?? {}
+
+  switch (step.type) {
+    case 'insert.text': {
+      if (
+        pathEquals(step.path, point.path) &&
+        (step.offset < point.offset ||
+          (step.offset === point.offset && affinity === 'forward'))
+      ) {
+        return {path: point.path, offset: point.offset + step.length}
+      }
+
+      return point
+    }
+
+    case 'remove.text': {
+      if (pathEquals(step.path, point.path) && step.offset <= point.offset) {
+        return {
+          path: point.path,
+          offset:
+            point.offset - Math.min(point.offset - step.offset, step.length),
+        }
+      }
+
+      return point
+    }
+
+    case 'set.text': {
+      if (!pathEquals(step.path, point.path)) {
+        return point
+      }
+
+      const offset = point.offset > step.length ? step.length : point.offset
+
+      if (offset === point.offset) {
+        return point
+      }
+
+      return {path: point.path, offset}
+    }
+
+    case 'set.key': {
+      if (
+        point.path.length < step.path.length ||
+        !pathEquals(point.path.slice(0, step.path.length), step.path)
+      ) {
+        return point
+      }
+
+      return {
+        path: [
+          ...step.path.slice(0, -1),
+          {_key: step.newKey},
+          ...point.path.slice(step.path.length),
+        ],
+        offset: point.offset,
+      }
+    }
+
+    case 'set.children': {
+      const remapped = remapPointThroughChildrenReplacement(
+        point,
+        step.path,
+        step.field,
+        step.newChildren,
+        step.oldChildren,
+      )
+
+      return remapped ?? point
+    }
+
+    case 'remove.node': {
+      if (pathContains(step.path, point.path)) {
+        return null
+      }
+
+      return point
+    }
+
+    case 'move.text': {
+      if (!pathEquals(step.from.path, point.path)) {
+        return point
+      }
+
+      const atStart = point.offset === step.from.offset
+      const atEnd = point.offset === step.from.offset + step.from.length
+      const insideRange =
+        step.from.offset < point.offset &&
+        point.offset < step.from.offset + step.from.length
+      const rides =
+        insideRange || ((atStart || atEnd) && affinity === 'forward')
+
+      if (!rides) {
+        return point
+      }
+
+      return {
+        path: step.to.path,
+        offset: step.to.offset + (point.offset - step.from.offset),
+      }
+    }
+
+    case 'move.node': {
+      if (pathContains(step.from, point.path)) {
+        return {
+          path: [...step.to, ...point.path.slice(step.from.length)],
+          offset: point.offset,
+        }
+      }
+
+      return point
+    }
+  }
+}
+
+/**
+ * Map a point through a batch of steps, in order. A step that invalidates
+ * the point (a node removal) short-circuits the remaining steps.
+ *
+ * `options.affinity` defaults to `'forward'`: say it loudly, a point
+ * exactly at an insertion offset moves with the insertion by default.
+ * Pass `'backward'` to have it stay instead.
+ * @public
+ */
+export function mapPoint(
+  steps: ReadonlyArray<Step>,
+  point: Point | null,
+  options?: {affinity?: 'forward' | 'backward'},
+): Point | null {
+  let current = point
+
+  for (const step of steps) {
+    if (current === null) {
+      return null
+    }
+    current = mapPointThroughStep(step, current, options)
+  }
+
+  return current
+}
+
+/**
+ * Map a range through a batch of steps with inward affinity: the anchor
+ * rides forward, the focus rides backward, so text inserted exactly at a
+ * range edge lands outside the range rather than being swallowed into it.
+ * This assumes a normalized forward range (anchor before focus);
+ * consumers normalize a backward range before calling.
+ *
+ * A collapsed range (anchor and focus at the same address) maps both ends
+ * with backward affinity instead, so it can never inflate into an
+ * inverted range at an insertion point.
+ *
+ * Returns `null` when either end is lost. Output for a backward range
+ * (anchor after focus) is unspecified.
+ * @public
+ */
+export function mapRange(
+  steps: ReadonlyArray<Step>,
+  range: Range,
+): Range | null {
+  const isCollapsed =
+    pathEquals(range.anchor.path, range.focus.path) &&
+    range.anchor.offset === range.focus.offset
+
+  if (isCollapsed) {
+    const point = mapPoint(steps, range.anchor, {
+      affinity: 'backward',
+    })
+    return point === null ? null : {anchor: point, focus: point}
+  }
+
+  const anchor = mapPoint(steps, range.anchor, {
+    affinity: 'forward',
+  })
+  const focus = mapPoint(steps, range.focus, {
+    affinity: 'backward',
+  })
+
+  if (anchor === null || focus === null) {
+    return null
+  }
+
+  return {anchor, focus}
+}
+
+/**
+ * Map a point through a wholesale children replacement via its text
+ * offset within the node. A surviving key (identity intact) only ever
+ * needs its offset clamped to the surviving child's new `text` length;
+ * beyond that, returns `undefined` (leave the point untransformed) unless
+ * every precondition for the vanished-key remap holds: the point
+ * addresses a direct child of the node's `field` array, that child's key
+ * is gone from the new children, and the old and new children carry
+ * identical concatenated span text, the condition that makes offset
+ * mapping lossless.
+ *
+ * Spans are detected structurally (`text` being a string) rather than
+ * through the schema: this mapper is deliberately schema-free, and
+ * text-carrying children are the only ones that occupy offsets.
+ *
+ * The offset arithmetic is a verbatim copy of the editor's own
+ * `util.child-text-offset.ts` (shared there with `util.block-offset.ts`);
+ * drift in the boundary convention (an offset landing exactly on a span
+ * boundary stays at the end of the earlier span) is caught by the pinned
+ * boundary tests. Only the span detection differs: structural here,
+ * schema-based elsewhere.
+ *
+ * A container's own array field may also hold blocks rather than spans.
+ * The text requirement makes that a no-op by construction: blocks carry
+ * no `text` of their own, so a point addressing a replaced block bails
+ * at the offset walk, and points deeper inside such blocks fail the
+ * direct-child path guard.
+ */
+function remapPointThroughChildrenReplacement(
+  point: Point,
+  nodePath: StepPath,
+  field: string,
+  newChildren: Array<{_key: string; text?: string}>,
+  oldChildren: Array<{_key: string; text?: string}>,
+): Point | undefined {
+  if (
+    point.path.length !== nodePath.length + 2 ||
+    !pathEquals(point.path.slice(0, nodePath.length), nodePath) ||
+    point.path[nodePath.length] !== field
+  ) {
+    return undefined
+  }
+
+  const pointSegment = point.path[point.path.length - 1]
+  if (!isKeyedSegment(pointSegment)) {
+    return undefined
+  }
+
+  const survivingChild = newChildren.find(
+    (child) => child._key === pointSegment._key,
+  )
+  if (survivingChild !== undefined) {
+    if (
+      typeof survivingChild.text === 'string' &&
+      point.offset > survivingChild.text.length
+    ) {
+      // The point's span survived the replacement, but shrank out from
+      // under the offset; clamp to the new length.
+      return {path: point.path, offset: survivingChild.text.length}
+    }
+
+    // The point's span survived the replacement; identity wins over
+    // offset mapping.
+    return undefined
+  }
+
+  const getSpanText = (child: unknown) => (child as {text?: string}).text
+
+  const nodeTextOffset = textOffsetOfChild(
+    oldChildren,
+    getSpanText,
+    pointSegment._key,
+    point.offset,
+  )
+  if (nodeTextOffset === undefined) {
+    return undefined
+  }
+
+  if (concatenatedText(oldChildren) !== concatenatedText(newChildren)) {
+    return undefined
+  }
+
+  const placed = childAtTextOffset(newChildren, getSpanText, nodeTextOffset)
+  if (placed === undefined) {
+    return undefined
+  }
+
+  return {
+    path: [...nodePath, field, {_key: placed.key}],
+    offset: placed.offset,
+  }
+}
+
+function concatenatedText(children: Array<{text?: string}>): string {
+  let text = ''
+  for (const child of children) {
+    if (child.text !== undefined) {
+      text += child.text
+    }
+  }
+  return text
+}

--- a/packages/steps/tsconfig.dist.json
+++ b/packages/steps/tsconfig.dist.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.settings",
+  "compilerOptions": {
+    "noCheck": true,
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/steps/tsconfig.json
+++ b/packages/steps/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "./node_modules"]
+}

--- a/packages/steps/tsconfig.settings.json
+++ b/packages/steps/tsconfig.settings.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sanity/tsconfig/strictest",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  }
+}

--- a/packages/steps/vitest.config.ts
+++ b/packages/steps/vitest.config.ts
@@ -1,0 +1,15 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        plugins: [],
+        test: {
+          name: 'unit',
+          environment: 'node',
+        },
+      },
+    ],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,6 +1460,37 @@ importers:
         specifier: catalog:tooling
         version: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
 
+  packages/steps:
+    dependencies:
+      '@portabletext/patches':
+        specifier: workspace:*
+        version: link:../patches
+      '@portabletext/schema':
+        specifier: workspace:^
+        version: link:../schema
+      '@sanity/diff-match-patch':
+        specifier: 'catalog:'
+        version: 3.2.0
+    devDependencies:
+      '@portabletext/test':
+        specifier: workspace:^
+        version: link:../test
+      '@sanity/pkg-utils':
+        specifier: catalog:tooling
+        version: 12.3.0(@babel/runtime@7.28.4)(@tsdown/css@0.22.14)(@types/node@24.12.2)(@volar/typescript@2.4.28)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(oxc-transform-react@0.145.0)(typescript@7.0.2)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+      '@sanity/tsconfig':
+        specifier: catalog:tooling
+        version: 2.1.0
+      typescript:
+        specifier: catalog:tooling
+        version: 7.0.2
+      vite:
+        specifier: catalog:tooling
+        version: 8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3)
+      vitest:
+        specifier: catalog:tooling
+        version: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+
   packages/test:
     dependencies:
       '@portabletext/schema':


### PR DESCRIPTION
The code that moves positions through edits has to exist once: a caret and a comment anchor on the same text must land in the same place after a remote edit. Today that code lives on a prototype branch inside the editor package, where behaviors cannot import it and a server re-anchoring stored positions cannot run it. This PR adds it as `@portabletext/steps`.

```ts
type Step = // eight kinds, verb.noun: insert.text, remove.text, move.text,
            // remove.node, move.node, set.text, set.children, set.key

mapPoint(steps, point, options?: {affinity?: 'forward' | 'backward'}): Point | null
mapRange(steps, range): Range | null
interpretTransaction(base, patches): Step[]
```

The mapper and interpreter are transcriptions of the prototypes on #3154, ported with their contract comments, probe suites, and character-identity oracles (expected outcomes are derived from character identity, never hand-written), and with the step spec's delta applied during transcription: `set.key` with a node-anchored path, `set.children` with typed children and a `field` property, `set.text {path, length}` absorbing `unset.text`, `length` instead of `text` on the text steps, names-only step paths with a dev-mode producer assertion, and affinity-gated `move.text` boundaries (default `'forward'` preserves the prototype behavior).

`mapRange` is new: the anchor maps with `'forward'` affinity and the focus with `'backward'`, so text inserted exactly at a range edge falls outside the range, and structurally equal ends both map `'backward'`, so a collapsed range stays collapsed instead of inflating around an insertion. The inward-affinity contract and null-when-lost are per the spec; the collapsed-range rule is a recorded design decision the spec's one-line definition is silent on. The contract assumes a normalized forward range; consumers normalize backward ranges first.

Conformance runs against the shared wire-catalogue fixtures in `packages/editor/tests`, read across packages, so the editor's internal copy and this package are held together by the same captures until the editor migrates to the package (a separate follow-up). The first commit adds the one capture the oracle suites need that the catalogue lacked; it is test-only and byte-identical to the capture on the source branch. The interpreter suite seeds documents from textspec notation via `fromTextspec`, which #3209 (merged) moved into `@portabletext/test`.

Version 1.0.0 of `@portabletext/steps` is hand-published from this branch before the merge. One further behavior goes beyond the prototypes, spec-mandated: a point on a `set.children` child whose key survives the replacement clamps its offset to the child's new `text` length. And one narrow delta rides on the typed children: children without a string `_key` are invisible to the interpreter's text-equality gate; valid Portable Text never produces them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New collaborative/offline selection mapping with intricate move-recognition rules; wrong pairing would misplace carets, though the design favors missed moves over false teleports and is heavily fixture- and oracle-tested.
> 
> **Overview**
> Introduces **`@portabletext/steps`**, a standalone package that turns Sanity wire patches into eight primitive step kinds and maps **`Point`** / **`Range`** through them via **`interpretTransaction`**, **`mapPoint`**, and **`mapRange`**. The interpreter replays patches on a working copy, conservatively pairs removals with insertions as **`move.text`** / **`move.node`** (including multi-span block splits and duplicate-key merges), and degrades ambiguous cases to plain insert/remove so carets don’t jump to unrelated content.
> 
> **`mapRange`** is new here: anchor maps forward and focus backward so edge insertions stay outside the selection; collapsed ranges use backward affinity on both ends.
> 
> Editor coverage adds a **`block-split-multi-span`** wire-catalogue capture and test for **`insert.break`** inside a multi-span block; **`packages/steps`** tests read those shared fixtures so interpreter behavior stays aligned with the editor until a later migration off in-editor prototypes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebddf040ae47d1e083848da865bafd736123af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->