### PR TITLE
feat: add `fromTextspec`, `toTextspec`, and `selectionFromTextspec`

### DIFF
--- a/.changeset/from-textspec-in-test-package.md
+++ b/.changeset/from-textspec-in-test-package.md
@@ -1,0 +1,20 @@
+---
+'@portabletext/test': minor
+---
+
+feat: add `fromTextspec`, `toTextspec`, and `selectionFromTextspec`
+
+Write test seeds and assertions as textspec notation instead of block literals. `fromTextspec` parses notation into Portable Text blocks and a selection, deterministic under the supplied key generator:
+
+```ts
+const {blocks, selection} = fromTextspec(
+  {schema: compiledSchema, keyGenerator: createTestKeyGenerator()},
+  'B: foo [strong:bar] b|az',
+)
+// blocks: one text block with spans 'foo ', 'bar' (strong), ' baz'
+// selection: collapsed after the 'b' in ' baz'
+```
+
+`toTextspec` is the inverse: it serializes blocks and a selection back to one notation string, so an editor state can be asserted in a single `toEqual`. `selectionFromTextspec` resolves a pattern's selection markers (`|` caret, `^...|` range) against an existing value, for placing a selection in an editor that already has content.
+
+Both directions take an optional `containers` map to resolve container schemas. The supporting types (`TextspecContainers`, `TextspecContainerRegistration`, `TextspecSelection`, `TextspecSelectionPoint`) are exported; the editor's own `Containers` and `EditorSelection` satisfy them structurally.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -107,7 +107,6 @@
     "@sanity/json-match": "catalog:",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
-    "@textspec/notation": "^1.0.2",
     "@types/debug": "catalog:",
     "@types/node": "catalog:tooling",
     "@types/react": "catalog:tooling",

--- a/packages/editor/src/editor/validate-selection-machine.test.ts
+++ b/packages/editor/src/editor/validate-selection-machine.test.ts
@@ -1,6 +1,6 @@
+import {toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import {toTextspec} from '../../test-utils/to-textspec'
 import {createTestEditor} from '../test/vitest'
 import {validateSelectionMachine} from './validate-selection-machine'
 

--- a/packages/editor/src/plugins/plugin.internal.auto-close-brackets.test.tsx
+++ b/packages/editor/src/plugins/plugin.internal.auto-close-brackets.test.tsx
@@ -1,6 +1,6 @@
+import {toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
-import {toTextspec} from '../../test-utils/to-textspec'
 import {createTestEditor} from '../test/vitest'
 import {AutoCloseBracketsPlugin} from './plugin.internal.auto-close-brackets'
 

--- a/packages/editor/src/test/index.ts
+++ b/packages/editor/src/test/index.ts
@@ -1,2 +1,2 @@
 export * from './gherkin-parameter-types'
-export {toTextspec} from '../../test-utils/to-textspec'
+export {toTextspec} from '@portabletext/test'

--- a/packages/editor/src/test/vitest/step-definitions.tsx
+++ b/packages/editor/src/test/vitest/step-definitions.tsx
@@ -1,14 +1,16 @@
 import {defineSchema} from '@portabletext/schema'
-import {getTersePt, parseTersePt} from '@portabletext/test'
+import {
+  fromTextspec,
+  getTersePt,
+  parseTersePt,
+  selectionFromTextspec,
+  toTextspec,
+} from '@portabletext/test'
 import {Given, Then, When} from 'racejar'
 import {assert, expect, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {boundaryEquivalentSelections} from '../../../test-utils/boundary-equivalent'
 import {getEditorSelection} from '../../../test-utils/editor-selection'
-import {
-  fromTextspec,
-  selectionFromTextspec,
-} from '../../../test-utils/from-textspec'
 import {getSelectionText} from '../../../test-utils/selection-text'
 import {getTextBlockKey} from '../../../test-utils/text-block-key'
 import {getTextMarks} from '../../../test-utils/text-marks'
@@ -17,7 +19,6 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../../../test-utils/text-selection'
-import {toTextspec} from '../../../test-utils/to-textspec'
 import {getValueAnnotations} from '../../../test-utils/value-annotations'
 import {createTestSnapshot} from '../../internal-utils/build-index-maps'
 import {IS_MAC} from '../../internal-utils/is-hotkey'

--- a/packages/editor/test-utils/from-textspec.test.ts
+++ b/packages/editor/test-utils/from-textspec.test.ts
@@ -1,12 +1,14 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {
+  createTestKeyGenerator,
+  fromTextspec,
+  toTextspec,
+} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {
   resolveContainers,
   type Containers,
 } from '../src/schema/resolve-containers'
-import {fromTextspec} from './from-textspec'
-import {toTextspec} from './to-textspec'
 
 const schemaDefinition = defineSchema({
   annotations: [{name: 'comment'}, {name: 'link'}],

--- a/packages/editor/test-utils/to-textspec.test.ts
+++ b/packages/editor/test-utils/to-textspec.test.ts
@@ -3,12 +3,12 @@ import type {
   PortableTextBlock,
   PortableTextTextBlock,
 } from '@portabletext/schema'
+import {toTextspec} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {
   resolveContainers,
   type Containers,
 } from '../src/schema/resolve-containers'
-import {toTextspec} from './to-textspec'
 
 const schemaDefinition = defineSchema({
   annotations: [{name: 'comment'}, {name: 'link'}],

--- a/packages/editor/tests/backspace-before-container.test.tsx
+++ b/packages/editor/tests/backspace-before-container.test.tsx
@@ -1,10 +1,9 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Backspace at the start of an empty text block that follows a container

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema, type EditorEmittedEvent} from '../src'
@@ -16,7 +16,6 @@ import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Behavior API', () => {
   test('Scenario: Suppressing raised events while executing', async () => {

--- a/packages/editor/tests/container-permutations.test.tsx
+++ b/packages/editor/tests/container-permutations.test.tsx
@@ -1,10 +1,9 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Container archetype permutations.

--- a/packages/editor/tests/cross-container-range-delete.test.tsx
+++ b/packages/editor/tests/cross-container-range-delete.test.tsx
@@ -1,12 +1,11 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {IS_MAC} from '../src/internal-utils/is-hotkey'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 const schemaDefinition = defineSchema({
   blockObjects: [

--- a/packages/editor/tests/delete-empty-container.test.tsx
+++ b/packages/editor/tests/delete-empty-container.test.tsx
@@ -1,10 +1,9 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer, defineTextBlock} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Pressing Backspace or Delete inside an empty callout should remove the

--- a/packages/editor/tests/event.annotation.test.tsx
+++ b/packages/editor/tests/event.annotation.test.tsx
@@ -1,4 +1,5 @@
 import {defineSchema, type PortableTextTextBlock} from '@portabletext/schema'
+import {toTextspec} from '@portabletext/test'
 import {describe, expect, test} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
@@ -7,7 +8,6 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.annotation', () => {
   test('.add/.remove', async () => {

--- a/packages/editor/tests/event.child.set.test.tsx
+++ b/packages/editor/tests/event.child.set.test.tsx
@@ -1,9 +1,8 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema, type Patch} from '../src'
 import {EventListenerPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.child.set', () => {
   test('Scenario: Setting properties on inline object', async () => {

--- a/packages/editor/tests/event.child.unset.test.tsx
+++ b/packages/editor/tests/event.child.unset.test.tsx
@@ -1,11 +1,10 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema, type Patch} from '../src'
 import {EventListenerPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.child.unset', () => {
   test('Scenario: Unsetting span marks', async () => {

--- a/packages/editor/tests/event.delete.backward.test.tsx
+++ b/packages/editor/tests/event.delete.backward.test.tsx
@@ -6,7 +6,7 @@ import {
   unset,
   type Patch,
 } from '@portabletext/patches'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -21,7 +21,6 @@ import {
   getSelectionBeforeText,
   getTextSelection,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.delete.backward', () => {
   test('Scenario: Deleting lonely block object', async () => {

--- a/packages/editor/tests/event.delete.matrix.test.tsx
+++ b/packages/editor/tests/event.delete.matrix.test.tsx
@@ -1,9 +1,8 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import type {EditorSelection} from '../src'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Scenarios that motivated the unification of `deleteText` into

--- a/packages/editor/tests/event.delete.test.tsx
+++ b/packages/editor/tests/event.delete.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -14,7 +14,6 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.delete', () => {
   test('Scenario: Deleting collapsed selection', async () => {

--- a/packages/editor/tests/event.focus.test.tsx
+++ b/packages/editor/tests/event.focus.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {page, userEvent, type Locator} from 'vitest/browser'
 import {useEditor, type Editor} from '../src'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.focus', () => {
   test('Scenario: Immediate focus after decorator toggle', async () => {

--- a/packages/editor/tests/event.history.redo.test.tsx
+++ b/packages/editor/tests/event.history.redo.test.tsx
@@ -1,9 +1,8 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.redo', () => {
   test('Scenario: Redo after remote patches', async () => {

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -13,7 +13,6 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {getFirstBlock, getFocusBlock} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
 import type {EditorSelection} from '../src/types/editor'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.history.undo', () => {
   test('Scenario: Undoing action sets', async () => {

--- a/packages/editor/tests/event.insert.block.test.tsx
+++ b/packages/editor/tests/event.insert.block.test.tsx
@@ -1,6 +1,6 @@
 import type {Patch} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {execute} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
@@ -11,7 +11,6 @@ import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {getFocusBlock} from '../src/selectors/selector.get-focus-block'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.block', () => {
   test('Scenario: Inserting block with custom _key', async () => {

--- a/packages/editor/tests/event.insert.blocks.test.tsx
+++ b/packages/editor/tests/event.insert.blocks.test.tsx
@@ -1,5 +1,5 @@
 import {isTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -7,7 +7,6 @@ import {defineBehavior, type InsertPlacement} from '../src/behaviors'
 import {BehaviorPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextBlockText} from '../src/utils'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.blocks', () => {
   test('Scenario: Inserting text block with lonely inline object', async () => {

--- a/packages/editor/tests/event.insert.child.test.tsx
+++ b/packages/editor/tests/event.insert.child.test.tsx
@@ -1,13 +1,12 @@
 import type {Patch} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineBehavior, raise} from '../src/behaviors'
 import {BehaviorPlugin, EventListenerPlugin} from '../src/plugins'
 import {getFocusSpan, getFocusTextBlock} from '../src/selectors'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.child', () => {
   test('Scenario: Carrying over an annotation', async () => {

--- a/packages/editor/tests/event.insert.inline-object.test.tsx
+++ b/packages/editor/tests/event.insert.inline-object.test.tsx
@@ -1,12 +1,11 @@
 import {defineSchema, type PortableTextTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {page, userEvent} from 'vitest/browser'
 import type {EditorEmittedEvent} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {isKeyedSegment} from '../src/utils'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.inline object', () => {
   test('Scenario: Inserting inline object without any initial fields', async () => {

--- a/packages/editor/tests/event.insert.span.test.tsx
+++ b/packages/editor/tests/event.insert.span.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {execute, forward} from '../src/behaviors/behavior.types.action'
 import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.span', () => {
   test('Scenario: Unknown decorators are filtered out', async () => {

--- a/packages/editor/tests/event.insert.text.test.tsx
+++ b/packages/editor/tests/event.insert.text.test.tsx
@@ -1,5 +1,5 @@
 import {isSpan} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
@@ -10,7 +10,6 @@ import {IS_MAC} from '../src/internal-utils/is-hotkey'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.insert.text', () => {
   test('Scenario: Consecutive `insert.text` events', async () => {

--- a/packages/editor/tests/event.keyboard.keydown.test.tsx
+++ b/packages/editor/tests/event.keyboard.keydown.test.tsx
@@ -1,3 +1,4 @@
+import {toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {execute, raise} from '../src/behaviors/behavior.types.action'
@@ -6,7 +7,6 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {getNextBlock} from '../src/selectors/selector.get-next-block'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionBeforeText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.keyboard.keydown', () => {
   const initialValue = [

--- a/packages/editor/tests/event.move.block.selection.test.tsx
+++ b/packages/editor/tests/event.move.block.selection.test.tsx
@@ -1,9 +1,8 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {whenTheCaretIsPutAfter} from '../test-utils/caret-placement'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.move.block regression', () => {
   test('Scenario: Moving a block down preserves selection on the moved block', async () => {

--- a/packages/editor/tests/event.mutation.test.tsx
+++ b/packages/editor/tests/event.mutation.test.tsx
@@ -1,5 +1,5 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {useState} from 'react'
 import {describe, expect, test, vi} from 'vitest'
@@ -14,7 +14,6 @@ import {
 } from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.mutation', () => {
   test('Scenario: Deferring mutation events when read-only', async () => {

--- a/packages/editor/tests/event.paste.test.tsx
+++ b/packages/editor/tests/event.paste.test.tsx
@@ -1,6 +1,6 @@
 import {htmlToPortableText, type ObjectMatcher} from '@portabletext/html'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {raise} from '../src/behaviors/behavior.types.action'
@@ -10,7 +10,6 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.clipboard.paste', () => {
   test('Scenario: Cut/paste block object', async () => {

--- a/packages/editor/tests/event.patch.test.tsx
+++ b/packages/editor/tests/event.patch.test.tsx
@@ -8,12 +8,11 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.patch', () => {
   test('Scenario: Deleting empty block above non-empty text block', async () => {

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -7,7 +7,7 @@ import {
   type Patch,
 } from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
@@ -16,7 +16,6 @@ import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor, createTestEditors} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.patches', () => {
   describe('Scenario: `set`ing the entire value', () => {

--- a/packages/editor/tests/event.select.test.tsx
+++ b/packages/editor/tests/event.select.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {
@@ -17,7 +17,6 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.select', () => {
   test('Scenario: Arrow navigation causes `select` event', async () => {

--- a/packages/editor/tests/event.split.test.tsx
+++ b/packages/editor/tests/event.split.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionText} from '../test-utils/selection-text'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.split', () => {
   test('Scenario: Splitting mid-block before inline object', async () => {

--- a/packages/editor/tests/event.update-value.container.test.tsx
+++ b/packages/editor/tests/event.update-value.container.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {safeParse, safeStringify} from '../src/internal-utils/safe-json'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 const schemaDefinition = defineSchema({
   blockObjects: [

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
@@ -10,7 +10,6 @@ import {
 } from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('event.update value', () => {
   test('Scenario: Clearing placeholder value', async () => {

--- a/packages/editor/tests/inline-objects.test.tsx
+++ b/packages/editor/tests/inline-objects.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineBehavior, raise} from '../src/behaviors'
 import {BehaviorPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Inline Objects', () => {
   test('Scenario: Deleting inline object with Backspace', async () => {

--- a/packages/editor/tests/insert-respects-sub-schema.test.tsx
+++ b/packages/editor/tests/insert-respects-sub-schema.test.tsx
@@ -1,10 +1,9 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 const schemaDefinition = defineSchema({
   decorators: [{name: 'strong'}, {name: 'em'}],

--- a/packages/editor/tests/overlapping-annotations.test.tsx
+++ b/packages/editor/tests/overlapping-annotations.test.tsx
@@ -1,5 +1,5 @@
 import {isTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema} from '../src'
 import {execute, raise} from '../src/behaviors/behavior.types.action'
@@ -9,7 +9,6 @@ import {isActiveAnnotation} from '../src/selectors/selector.is-active-annotation
 import {createTestEditor} from '../src/test/vitest'
 import {getTextMarks} from '../test-utils/text-marks'
 import {getTextSelection} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * By default, annotations of the same type cannot overlap.

--- a/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
+++ b/packages/editor/tests/portable-text-editor.add-annotation.test.tsx
@@ -1,11 +1,10 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema, PortableTextEditor} from '../src'
 import {InternalPortableTextEditorRefPlugin} from '../src/plugins/plugin.internal.portable-text-editor-ref'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe(PortableTextEditor.addAnnotation.name, () => {
   test('Scenario: Prevents overlapping annotations of the same type', async () => {

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -5,7 +5,7 @@ import {
   isTextBlock,
   type PortableTextBlock,
 } from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {createRef, useState, type ReactNode, type RefObject} from 'react'
 import {describe, expect, it, test, vi} from 'vitest'
 import {render} from 'vitest-browser-react'
@@ -33,7 +33,6 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 const helloBlock: PortableTextBlock = {
   _key: '123',

--- a/packages/editor/tests/recursive-schema.test.tsx
+++ b/packages/editor/tests/recursive-schema.test.tsx
@@ -1,6 +1,6 @@
 import {applyAll, type Patch} from '@portabletext/patches'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {safeParse, safeStringify} from '../src/internal-utils/safe-json'
@@ -8,7 +8,6 @@ import {EventListenerPlugin} from '../src/plugins'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Tests for self-referential / recursive schemas.

--- a/packages/editor/tests/selection-after-remote-patches.test.tsx
+++ b/packages/editor/tests/selection-after-remote-patches.test.tsx
@@ -1,12 +1,11 @@
 import {diffMatchPatch, insert, unset} from '@portabletext/patches'
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
 import {whenTheCaretIsPutAfter} from '../test-utils/caret-placement'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Selection adjustment after remote patches', () => {
   test('Scenario: Remote insert block before cursor', async () => {

--- a/packages/editor/tests/self-solving.test.tsx
+++ b/packages/editor/tests/self-solving.test.tsx
@@ -1,6 +1,6 @@
 import type {Patch} from '@portabletext/patches'
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
@@ -15,7 +15,6 @@ import {
   getSelectionAfterText,
   getTextSelection,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Feature: Self-solving', () => {
   test('Scenario: Missing .markDefs and .marks are added after the editor is made dirty', async () => {

--- a/packages/editor/tests/serialize-deserialize.test.tsx
+++ b/packages/editor/tests/serialize-deserialize.test.tsx
@@ -1,5 +1,5 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {execute, forward, raise} from '../src/behaviors/behavior.types.action'
@@ -9,7 +9,6 @@ import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {getSelectionText} from '../src/selectors/selector.get-selection-text'
 import {createTestEditor} from '../src/test/vitest'
 import {getTextSelection} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Serialize/Deserialize', () => {
   test('Scenario: Custom text/html deserializer', async () => {

--- a/packages/editor/tests/setup.test.tsx
+++ b/packages/editor/tests/setup.test.tsx
@@ -1,12 +1,11 @@
 import {compileSchema, defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import type {EditorEmittedEvent, MutationEvent} from '../src/editor/relay'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Setup', () => {
   test('Scenario: Unknown block object', async () => {

--- a/packages/editor/tests/string-reconcile-under-react-compiler.test.tsx
+++ b/packages/editor/tests/string-reconcile-under-react-compiler.test.tsx
@@ -1,10 +1,9 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema} from '../src'
 import {IS_MAC} from '../src/internal-utils/is-hotkey'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 // `TextString` reconciles the DOM text node against the model on every render
 // via a dependency-less layout effect. React Compiler compiles `string.tsx`

--- a/packages/editor/tests/test-editor.test.tsx
+++ b/packages/editor/tests/test-editor.test.tsx
@@ -1,7 +1,7 @@
+import {toTextspec} from '@portabletext/test'
 import {expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * Regression test for `createTestEditor`'s locator scoping.

--- a/packages/editor/tests/text-plain-paste.test.tsx
+++ b/packages/editor/tests/text-plain-paste.test.tsx
@@ -1,4 +1,4 @@
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {raise} from '../src/behaviors/behavior.types.action'
@@ -6,7 +6,6 @@ import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
 import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {createTestEditor} from '../src/test/vitest'
 import {getSelectionAfterText} from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('`text/plain` paste', () => {
   test('Scenario: Consumer behavior on `deserialize.data` can produce rich blocks from `text/plain`', async () => {

--- a/packages/editor/tests/undo-redo-collaboration.test.tsx
+++ b/packages/editor/tests/undo-redo-collaboration.test.tsx
@@ -1,5 +1,5 @@
 import type {PortableTextBlock} from '@portabletext/schema'
-import {getTersePt} from '@portabletext/test'
+import {getTersePt, toTextspec} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {createTestEditors} from '../src/test/vitest'
@@ -7,7 +7,6 @@ import {
   getSelectionAfterText,
   getSelectionBeforeText,
 } from '../test-utils/text-selection'
-import {toTextspec} from '../test-utils/to-textspec'
 
 function createInitialValue(text: string): Array<PortableTextBlock> {
   return [

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -1,11 +1,10 @@
 import {defineSchema} from '@portabletext/schema'
-import {createTestKeyGenerator} from '@portabletext/test'
+import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import type {EditorEmittedEvent} from '../src/editor/relay'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
-import {toTextspec} from '../test-utils/to-textspec'
 
 describe('Value validation', () => {
   test('Initial value with `null` child results in a validation error', async () => {

--- a/packages/editor/tests/wire-catalogue.test.tsx
+++ b/packages/editor/tests/wire-catalogue.test.tsx
@@ -1,6 +1,11 @@
 import type {Patch} from '@portabletext/patches'
 import {compileSchema, isTextBlock, type Schema} from '@portabletext/schema'
-import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {
+  createTestKeyGenerator,
+  fromTextspec,
+  getTersePt,
+  toTextspec,
+} from '@portabletext/test'
 import {describe, expect, test, vi} from 'vitest'
 import {
   defineSchema,
@@ -13,8 +18,6 @@ import {
 import {safeStringify} from '../src/internal-utils/safe-json'
 import {EventListenerPlugin} from '../src/plugins'
 import {createTestEditor} from '../src/test/vitest'
-import {fromTextspec} from '../test-utils/from-textspec'
-import {toTextspec} from '../test-utils/to-textspec'
 
 /**
  * The wire catalogue: one scenario per test, each producing a committed
@@ -23,12 +26,13 @@ import {toTextspec} from '../test-utils/to-textspec'
  * markdown catalogue.
  *
  * `seed` and `result` are textspec notation strings (see
- * `test-utils/from-textspec.ts`/`to-textspec.ts`): together with the
- * `schema` field and the deterministic `createTestKeyGenerator`, `seed` is
- * enough to replay the scenario. Scenarios textspec can't express, such as
- * a span boundary that isn't a mark boundary or a duplicate `_key` across
- * sibling blocks, keep the pre-textspec shape instead (`seed` as full
- * blocks, `seedTerse`/`resultTerse`).
+ * `@portabletext/test`'s `fromTextspec`/`toTextspec`):
+ * together with the `schema` field and the deterministic
+ * `createTestKeyGenerator`, `seed` is enough to replay the scenario.
+ * Scenarios textspec can't express, such as a span boundary that isn't a
+ * mark boundary or a duplicate `_key` across sibling blocks, keep the
+ * pre-textspec shape instead (`seed` as full blocks,
+ * `seedTerse`/`resultTerse`).
  */
 
 type Capture = {

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -72,6 +72,40 @@ const tersePt = getTersePt({
 // ['foo', 'bar']
 ```
 
+## Textspec
+
+[Textspec notation](https://github.com/textspec/textspec) is a richer sibling of Terse PT that also carries marks and selection markers (`|` caret, `^...|` range).
+
+### Parsing textspec notation
+
+```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator, fromTextspec} from '@portabletext/test'
+
+const {blocks, selection} = fromTextspec(
+  {
+    schema: compileSchema(defineSchema({decorators: [{name: 'strong'}]})),
+    keyGenerator: createTestKeyGenerator(),
+  },
+  'B: foo [strong:bar] b|az',
+)
+// blocks: one text block with spans 'foo ', 'bar' (strong), ' baz'
+// selection: caret between 'b' and 'az' in the last span
+```
+
+Pass an optional `containers` map (see `TextspecContainers`) to resolve container schemas. `selectionFromTextspec` resolves a pattern's selection markers against an existing Portable Text value, for placing a selection in an editor that already has content.
+
+### Producing textspec notation
+
+`toTextspec` is the inverse: serialize Portable Text blocks and a selection back into notation.
+
+```ts
+import {toTextspec} from '@portabletext/test'
+
+const notation = toTextspec({schema, value: blocks, selection})
+// 'B: foo [strong:bar] b|az'
+```
+
 ## Key generator
 
 Generate predictable keys for test fixtures:

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -48,8 +48,12 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest watch"
   },
-  "devDependencies": {
+  "dependencies": {
     "@portabletext/schema": "workspace:^",
+    "@textspec/notation": "^1.0.2"
+  },
+  "devDependencies": {
+    "@portabletext/patches": "workspace:^",
     "@sanity/pkg-utils": "catalog:tooling",
     "@sanity/tsconfig": "catalog:tooling",
     "typescript": "catalog:tooling",

--- a/packages/test/src/from-textspec.ts
+++ b/packages/test/src/from-textspec.ts
@@ -1,4 +1,7 @@
+import type {Path} from '@portabletext/patches'
 import type {
+  FieldDefinition,
+  OfDefinition,
   PortableTextBlock,
   PortableTextObject,
   PortableTextSpan,
@@ -14,22 +17,61 @@ import type {
   Block as TextspecBlock,
 } from '@textspec/notation'
 import {parse} from '@textspec/notation'
-import type {Containers} from '../src/schema/resolve-containers'
-import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
 
 /**
- * Parse a textspec notation string into PTE blocks and selection.
+ * A registered container: the schema-declared field holding its children,
+ * plus any positional child registrations that override the top-level
+ * registration when resolving a nested container.
+ * @public
+ */
+export type TextspecContainerRegistration = {
+  kind: 'container'
+  type: string
+  field: FieldDefinition & {type: 'array'; of: ReadonlyArray<OfDefinition>}
+  of?: ReadonlyArray<
+    | TextspecContainerRegistration
+    | {kind: 'span'; type: string}
+    | {kind: 'blockObject'; type: string}
+    | {kind: 'inlineObject'; type: string}
+  >
+}
+
+/**
+ * Map of registered containers, keyed by `_type`.
+ * @public
+ */
+export type TextspecContainers = ReadonlyMap<
+  string,
+  TextspecContainerRegistration
+>
+
+/** @public */
+export type TextspecSelectionPoint = {path: Path; offset: number}
+/** @public */
+export type TextspecSelection = {
+  anchor: TextspecSelectionPoint
+  focus: TextspecSelectionPoint
+  backward?: boolean
+} | null
+
+/**
+ * Parse textspec notation into Portable Text blocks and a selection,
+ * deterministic under the supplied key generator. Pass `containers` to
+ * resolve container schemas (block objects with array fields holding
+ * further blocks or container objects).
+ *
+ * @public
  */
 export function fromTextspec(
   context: {
     schema: Schema
     keyGenerator: () => string
-    containers?: Containers
+    containers?: TextspecContainers
   },
   textspec: string,
 ): {
   blocks: Array<PortableTextBlock>
-  selection: EditorSelection
+  selection: TextspecSelection
 } {
   // If no selection markers are present, add a cursor at the end
   // to satisfy the parser's requirement for a selection marker.
@@ -264,7 +306,7 @@ function flattenContainer(
  */
 function convertBlockToPTE(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   block: Block,
   keyGenerator: () => string,
   parentType: string | undefined,
@@ -367,7 +409,7 @@ function isListContainer(type: string): boolean {
  * container fallback path.
  */
 function resolveContainerType(
-  containers: Containers,
+  containers: TextspecContainers,
   parentType: string | undefined,
   textspecType: string,
 ): string | undefined {
@@ -399,7 +441,7 @@ function resolveContainerType(
 
 function convertContainerToPTE(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   container: ContainerBlock,
   keyGenerator: () => string,
   resolvedType: string,
@@ -440,14 +482,6 @@ function convertContainerToPTE(
  * the selection against an actual PTE value. Use this to apply a
  * textspec-defined selection to an editor that already has content.
  *
- * The pattern is a full textspec string (matching the editor's content)
- * with `|` marking caret position or `^...|` marking a range.
- */
-/**
- * Parse a textspec pattern (including its selection markers) and resolve
- * the selection against an actual PTE value. Use this to apply a
- * textspec-defined selection to an editor that already has content.
- *
  * The pattern must be a full textspec string matching the editor's content
  * (including blocks and marks), with `|` marking caret position or `^...|`
  * marking a range.
@@ -455,15 +489,17 @@ function convertContainerToPTE(
  * The pattern's mark structure may differ from the PTE value's flat spans.
  * We resolve by computing the character offset within each block from the
  * pattern, then walking the PTE value to find the span at that offset.
+ *
+ * @public
  */
 export function selectionFromTextspec(
   context: {
     schema: Schema
-    containers?: Containers
+    containers?: TextspecContainers
   },
   pattern: string,
   value: Array<PortableTextBlock>,
-): EditorSelection {
+): TextspecSelection {
   const state = parse(pattern)
 
   if (!state.selection) {
@@ -503,11 +539,11 @@ export function selectionFromTextspec(
  */
 function resolveIndexedPoint(
   schemaContext: {schema: Schema},
-  containers: Containers,
+  containers: TextspecContainers,
   patternBlocks: ReadonlyArray<TextspecBlock>,
   value: Array<PortableTextBlock>,
   point: {path: Array<number>; offset: number},
-): EditorSelectionPoint | undefined {
+): TextspecSelectionPoint | undefined {
   const [blockIndex, ...rest] = point.path
 
   if (typeof blockIndex !== 'number') {
@@ -644,7 +680,7 @@ function locateSpanAtOffset(
   blockKey: string,
   children: Array<Record<string, unknown>>,
   textOffset: number,
-): EditorSelectionPoint | undefined {
+): TextspecSelectionPoint | undefined {
   // Empty text block in PTE always has at least one placeholder span after
   // normalization. If there are no spans yet, the block is still being set
   // up — bail out so the caller can retry.
@@ -693,12 +729,12 @@ function locateSpanAtOffset(
  */
 function resolveContainerPoint(
   schemaContext: {schema: Schema},
-  containers: Containers,
+  containers: TextspecContainers,
   block: Record<string, unknown>,
   path: Array<number>,
   leafOffset: number,
-): EditorSelectionPoint | undefined {
-  const keyedPath: EditorSelectionPoint['path'] = []
+): TextspecSelectionPoint | undefined {
+  const keyedPath: TextspecSelectionPoint['path'] = []
   const blockKey = block['_key']
 
   if (typeof blockKey !== 'string') {
@@ -750,7 +786,7 @@ function resolveContainerPoint(
 
 function convertSelectionToPTE(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   blocks: Array<PortableTextBlock>,
   state: {
     selection: {
@@ -758,7 +794,7 @@ function convertSelectionToPTE(
       focus: {path: Array<number>; offset: number}
     } | null
   },
-): EditorSelection {
+): TextspecSelection {
   if (!state.selection) {
     return null
   }
@@ -796,10 +832,10 @@ function convertSelectionToPTE(
 
 function resolvePointToPTE(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   blocks: Array<PortableTextBlock>,
   point: {path: Array<number>; offset: number},
-): EditorSelectionPoint | undefined {
+): TextspecSelectionPoint | undefined {
   const keyedPath = indexedPathToKeyedPath(
     point.path,
     schema,
@@ -817,11 +853,11 @@ function resolvePointToPTE(
 function indexedPathToKeyedPath(
   indexedPath: Array<number>,
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   children: Array<Record<string, unknown>>,
-): EditorSelectionPoint['path'] | undefined {
+): TextspecSelectionPoint['path'] | undefined {
   const schemaContext = {schema}
-  const keyedPath: EditorSelectionPoint['path'] = []
+  const keyedPath: TextspecSelectionPoint['path'] = []
   let currentChildren = children
 
   for (const index of indexedPath) {

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,2 +1,4 @@
+export * from './from-textspec'
 export * from './terse-pt'
 export * from './test-key-generator'
+export * from './to-textspec'

--- a/packages/test/src/to-textspec.ts
+++ b/packages/test/src/to-textspec.ts
@@ -12,25 +12,27 @@ import type {
   EditorState,
   InlineNode,
   TextBlock,
-  Selection as TextspecSelection,
+  Selection as NotationSelection,
 } from '@textspec/notation'
 import type {
-  Containers,
-  RegisteredContainer,
-} from '../src/schema/resolve-containers'
-import type {EditorSelection, EditorSelectionPoint} from '../src/types/editor'
+  TextspecContainerRegistration,
+  TextspecContainers,
+  TextspecSelection,
+  TextspecSelectionPoint,
+} from './from-textspec'
 
 /**
- * Serialize PTE state to a textspec notation string.
+ * Serialize Portable Text blocks and a selection back to textspec
+ * notation, the inverse of {@link fromTextspec}.
  *
- * @internal
+ * @public
  */
 export function toTextspec(
   context: {
     schema: Schema
     value: Array<PortableTextBlock>
-    selection: EditorSelection
-    containers?: Containers
+    selection: TextspecSelection
+    containers?: TextspecContainers
     annotationKeys?: Map<string, string>
   },
   options?: {singleLine?: boolean; keys?: boolean | Set<string>},
@@ -260,7 +262,7 @@ function convertTextBlock(
 function resolveSelectionPoint(
   schema: Schema,
   blocks: Array<PortableTextBlock>,
-  point: EditorSelectionPoint,
+  point: TextspecSelectionPoint,
 ): {path: Array<number>; offset: number} | undefined {
   const indexedPath = keyedPathToIndexedPath(
     point.path,
@@ -316,7 +318,7 @@ function getMarkDepth(
 }
 
 function keyedPathToIndexedPath(
-  keyedPath: EditorSelectionPoint['path'],
+  keyedPath: TextspecSelectionPoint['path'],
   children: Array<Record<string, unknown>>,
 ): Array<number> | undefined {
   const indexedPath: Array<number> = []
@@ -353,10 +355,10 @@ function keyedPathToIndexedPath(
 
 function convertBlockToTextspec(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   annotationKeys: Map<string, string> | undefined,
   block: PortableTextBlock,
-  parent?: RegisteredContainer,
+  parent?: TextspecContainerRegistration,
 ): Block {
   if (isTextBlock({schema}, block)) {
     return convertTextBlock(schema, block, annotationKeys)
@@ -381,16 +383,16 @@ function convertBlockToTextspec(
 }
 
 /**
- * Resolve which {@link RegisteredContainer} applies to a child of type
- * `childType` under `parent`. Positional override (parent.of) wins;
+ * Resolve which {@link TextspecContainerRegistration} applies to a child
+ * of type `childType` under `parent`. Positional override (parent.of) wins;
  * otherwise fall back to the top-level `containers` map. Returns
  * undefined when the type is not registered at this position.
  */
 function resolveChildContainer(
-  containers: Containers,
-  parent: RegisteredContainer | undefined,
+  containers: TextspecContainers,
+  parent: TextspecContainerRegistration | undefined,
   childType: string,
-): RegisteredContainer | undefined {
+): TextspecContainerRegistration | undefined {
   if (parent?.of) {
     for (const entry of parent.of) {
       if (entry.type === childType && entry.kind === 'container') {
@@ -403,10 +405,10 @@ function resolveChildContainer(
 
 function convertContainerBlock(
   schema: Schema,
-  containers: Containers,
+  containers: TextspecContainers,
   annotationKeys: Map<string, string> | undefined,
   block: Record<string, unknown>,
-  parent: RegisteredContainer,
+  parent: TextspecContainerRegistration,
 ): ContainerBlock {
   const containerField = parent.field
 
@@ -463,8 +465,8 @@ function convertContainerBlock(
 function convertSelection(
   schema: Schema,
   blocks: Array<PortableTextBlock>,
-  selection: EditorSelection,
-): TextspecSelection | null {
+  selection: TextspecSelection,
+): NotationSelection | null {
   if (!selection) {
     return null
   }
@@ -527,7 +529,7 @@ function isEqualIndexedPaths(
  */
 function nodeAtKeyedPath(
   blocks: Array<PortableTextBlock>,
-  keyedPath: EditorSelectionPoint['path'],
+  keyedPath: TextspecSelectionPoint['path'],
 ):
   | {
       node: PortableTextBlock | PortableTextObject

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,9 +576,6 @@ importers:
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
-      '@textspec/notation':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@types/debug':
         specifier: 'catalog:'
         version: 4.1.13
@@ -1464,10 +1461,17 @@ importers:
         version: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
 
   packages/test:
-    devDependencies:
+    dependencies:
       '@portabletext/schema':
         specifier: workspace:^
         version: link:../schema
+      '@textspec/notation':
+        specifier: ^1.0.2
+        version: 1.0.2
+    devDependencies:
+      '@portabletext/patches':
+        specifier: workspace:*
+        version: link:../patches
       '@sanity/pkg-utils':
         specifier: catalog:tooling
         version: 12.3.0(@babel/runtime@7.28.4)(@tsdown/css@0.22.14)(@types/node@24.12.2)(@volar/typescript@2.4.28)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(oxc-transform-react@0.145.0)(typescript@7.0.2)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
@@ -5606,29 +5610,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-android-arm64@0.8.3':
-    resolution: {integrity: sha512-vySYRsMeul9ssvxeHdxgS9ZUIcq7gqljWNqgokjJE0uQWvVvOprihJ6hOsiifVqWsla0BMc3vAFBvNS9QqCw7g==}
-    cpu: [arm64]
-    os: [android]
-
   '@yuku-parser/binding-android-arm64@0.8.7':
     resolution: {integrity: sha512-eGKYiUDX7Y0V7tDTmg+JTVnXnjMqfXXsorZ+EDf5kxwchQ3Or1HS14MzI2fw+jFhHR85fCWt+mtX33Yao73hIQ==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-parser/binding-darwin-arm64@0.8.3':
-    resolution: {integrity: sha512-+wpB/wqhiZ685Y77I+lj6v9pHSAJ3Y+QMHJmvch0Q0ahIMbNwtKk3s54MhtjCMKO1qpjPbyN/PjuHDg2hbKaVQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@yuku-parser/binding-darwin-arm64@0.8.7':
     resolution: {integrity: sha512-Re0RHelKLnjEURulY2/KxW+Ngb8zuNA4BRZuMwgGQNzVumT6u4U2N2hc01oeYVNVof0i7GrXE4UCNBgbpRRnjQ==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@yuku-parser/binding-darwin-x64@0.8.3':
-    resolution: {integrity: sha512-jKqiWejj4zVy7pPtEGu4/Ty+pG1h7ooQOXIkm7shKZTSwTU9X8X+eoH11uIeKHZi2SQWV0GhNz0J56eerseysQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@yuku-parser/binding-darwin-x64@0.8.7':
@@ -5636,21 +5625,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.8.3':
-    resolution: {integrity: sha512-FC7zSwzFzd4z9bsId07CiHLR+Iw6yW/LzIQhL5AUtPUuVXLgEyx0rilgbRUYkl1CT3GJcLpkh63WuPZUSgCDzw==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@yuku-parser/binding-freebsd-x64@0.8.7':
     resolution: {integrity: sha512-bAP2OV8wRuzplX/jYxv9+vvqQT8JxyNphI8fLfXGL054Xs+4/J5u33cIm3y4rxY8rdoLmmdiJs2Tq7r7lrDRfA==}
     cpu: [x64]
     os: [freebsd]
-
-  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
-    resolution: {integrity: sha512-So61j88b9/ygDnUPlWCm1EUPw4HSxAyDjrNHKgud5N3aRDQ3kw94nW7TriXbo7GBXID9oBHCMNm1r1Fof/Df5Q==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-gnu@0.8.7':
     resolution: {integrity: sha512-kTYwJQQgmZeAWdDIWabiReIZMpmfLueIj1tCmjStUtFGhR1Z0qwxonKVfUC4N7h/VhGGzLZ//7O1kgt1QKqgCg==}
@@ -5658,23 +5636,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.3':
-    resolution: {integrity: sha512-Nmnn20yJvSSKL8ZdtqReBRSGCDkSMqR5jEk/Sk/cdIdZmqVD49Z6M7w2GbMjdrxMI1MBPbsWFMMWxa93cd5t5g==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-arm-musl@0.8.7':
     resolution: {integrity: sha512-uL4jE8HPT2BLlxAXyD10LqgPuXa9eDa0BKpCdSANmzIJghq/2eZo3/gQNtaxPZMupWoxjYzSad9IXrwu7aYPXQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
-
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
-    resolution: {integrity: sha512-Lfgw7AXJ0rxu6BMPGgfc8HLJWEIr8BHhCzcQp/75k+NM90uCLkHlBNqIg/K42KlSvBgAvu9euOvjdswib+4qJA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.8.7':
     resolution: {integrity: sha512-3gVN4pWSKZmXiNX7cU164dR9MPvesCHnlH6nPfpK+yQsCuYphjKKplcb4SnZBrhiqmXbgb2HR0c2TS0IZUPhgA==}
@@ -5682,23 +5648,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
-    resolution: {integrity: sha512-cfRyu87xsJ0tFkHNsnMC4Rq6+xsFJ6i2dc4VAH52d2qLvykEJU/Mdi3ul1O2PyOApX/LoLT3uQZ0fWs3D5XE4w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-arm64-musl@0.8.7':
     resolution: {integrity: sha512-S0mwfEjoLpxzXeZw802Wa4RaELsQiPtWqG6INcy8j4GtvNFtl4LCX3eGO1XLn9pyLAISLzTRyU3zUCBUPin8lg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
-    resolution: {integrity: sha512-GcQQCUuYxbm6P1n+io/A50rvWKDeWHutIp6rW0ycDOZuEQjOb8hDVgS88+NDyOnd9FfS0/Z6GXopcRFDyKpzOg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-gnu@0.8.7':
     resolution: {integrity: sha512-lnbWdPmerE5D1uH1G4IEZKnPzCrWCStRGrtgpSIe1RibAo5bZIjDbbbPYXmMHCEh4F+x/JaJpElh26a3r+BPbg==}
@@ -5706,40 +5660,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.3':
-    resolution: {integrity: sha512-rMkImBGZzg7GZlj8krYtdiezyjYI4igjKWMut5T65jHyNWFigMQrEpn9mDIBflloW9FKhGE3mN6yTZ/N+4HRwg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@yuku-parser/binding-linux-x64-musl@0.8.7':
     resolution: {integrity: sha512-769uwndMvMzUvATWbAcEvyLHKA+DzhHSCl/obBUrRdYfRo26yxui6S8y3z7uJ+Naup7UKrDxrpK7OnQkxkl9KQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.8.3':
-    resolution: {integrity: sha512-/2Pl2cAzCXWxah8FqJapEj/ikpt9cEutEZFCa0hnbfrshkn5+C+aBM3ZDq62d1jsgQjBMmqr5HVhJUA4OAG/Tg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@yuku-parser/binding-win32-arm64@0.8.7':
     resolution: {integrity: sha512-mEB/9PlaAkisJ6KWGz0zvywXoU6+80dTlR2LwS7s/jcXXoU6fm2+sitBZXtqu3+Q4DcDgPxM45uWMCzPs0TSRw==}
     cpu: [arm64]
-    os: [win32]
-
-  '@yuku-parser/binding-win32-x64@0.8.3':
-    resolution: {integrity: sha512-Ntnvjoan9jnfLhn7Kn3h8j/bhsbVdQSVmKUqFULKtmwImLCJVHOJbLL4qbEJyrOQ7r/FBL1/c/dRvx/AQWzzXg==}
-    cpu: [x64]
     os: [win32]
 
   '@yuku-parser/binding-win32-x64@0.8.7':
     resolution: {integrity: sha512-8vNB2DP0ou61nGb8tc/qfi41gfyDXz1MHr2zqL3nR+cJ6CEbiuWV/l/a/vv151gCgiZLLAyGkQGENpozdg716w==}
     cpu: [x64]
     os: [win32]
-
-  '@yuku-toolchain/types@0.8.3':
-    resolution: {integrity: sha512-9LN3HYs3A9qSPVFunsxlbfwBcUgexti3TmhOzIxB/UH8zFuaHQJXTRDcN17DW6cp1GsyZtiZA7f18uIra36Jag==}
 
   '@yuku-toolchain/types@0.8.7':
     resolution: {integrity: sha512-2Z53dNxAJL6UvFoIrDZvYf3zlO8s4VJK4O2hhaB4mXVwwpX/7ajtss3cmfqKvamlNLWyt9FSWs4eoYdlbxpnHA==}
@@ -9299,17 +9234,11 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  yuku-ast@0.8.3:
-    resolution: {integrity: sha512-8x34yU5uhHUnJXzy2Qvjvec/vE9BzS0/2khVT1MsLmSLO/P8Q1Wp8IxHv+IhD+HMYETk6kherOSvP4JPWw2joQ==}
-
   yuku-ast@0.8.7:
     resolution: {integrity: sha512-h6+4bDfyootiMB9vckk5uKo5r5j0GHrkr17FQTDNfEsFT3DWlN9uu1HJwQwc64pgmLCI945fWM3lbTIqxjT3GQ==}
 
   yuku-codegen@0.8.3:
     resolution: {integrity: sha512-okdo5bb+TfebQa4JOjz9QxeT34D6CcBxu8dxaPUdFEKRdLkp+D2Fah2OanepK+XTyPXdmAJzAo9iXvYvZ/5rmg==}
-
-  yuku-parser@0.8.3:
-    resolution: {integrity: sha512-KPQcpF9aj77ywlJBIkQWCQ9DObdxnCA8AJdUOmA5CZZx042Xt4+dvbQmPJfWxF3E+KG5dVAZ2fBKuDJ8VsKWgA==}
 
   yuku-parser@0.8.7:
     resolution: {integrity: sha512-vRD9nwt4L3aYpxNqeSC4WqLv58xrXef0Ong1Mc45CTXTIpvLafx7JO05sczmQZwdLEZvywrLOGdNC5+Rp5N1BQ==}
@@ -13653,7 +13582,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.4
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@20.19.25)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -13669,9 +13598,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@20.19.25)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.11(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))(vitest@4.1.11)
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -13818,79 +13747,41 @@ snapshots:
   '@yuku-codegen/binding-win32-x64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-android-arm64@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-android-arm64@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-darwin-arm64@0.8.3':
     optional: true
 
   '@yuku-parser/binding-darwin-arm64@0.8.7':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-darwin-x64@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-freebsd-x64@0.8.3':
     optional: true
 
   '@yuku-parser/binding-freebsd-x64@0.8.7':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-linux-arm-gnu@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-linux-arm-musl@0.8.3':
     optional: true
 
   '@yuku-parser/binding-linux-arm-musl@0.8.7':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-linux-arm64-gnu@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
     optional: true
 
   '@yuku-parser/binding-linux-arm64-musl@0.8.7':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-linux-x64-gnu@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-linux-x64-musl@0.8.3':
     optional: true
 
   '@yuku-parser/binding-linux-x64-musl@0.8.7':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.8.3':
-    optional: true
-
   '@yuku-parser/binding-win32-arm64@0.8.7':
-    optional: true
-
-  '@yuku-parser/binding-win32-x64@0.8.3':
     optional: true
 
   '@yuku-parser/binding-win32-x64@0.8.7':
     optional: true
-
-  '@yuku-toolchain/types@0.8.3': {}
 
   '@yuku-toolchain/types@0.8.7': {}
 
@@ -16935,15 +16826,15 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28)(oxc-resolver@11.19.1)(rolldown@1.2.2)(typescript@7.0.2):
+  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28)(oxc-resolver@11.19.1)(rolldown@1.2.5)(typescript@7.0.2):
     dependencies:
       dts-resolver: 3.0.0(oxc-resolver@11.19.1)
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
-      rolldown: 1.2.2
-      yuku-ast: 0.8.3
+      rolldown: 1.2.5
+      yuku-ast: 0.8.7
       yuku-codegen: 0.8.3
-      yuku-parser: 0.8.3
+      yuku-parser: 0.8.7
     optionalDependencies:
       '@volar/typescript': 2.4.28
       typescript: 7.0.2
@@ -17509,8 +17400,8 @@ snapshots:
       import-without-cache: 0.4.0
       obug: 2.1.4
       picomatch: 4.0.5
-      rolldown: 1.2.2
-      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28)(oxc-resolver@11.19.1)(rolldown@1.2.2)(typescript@7.0.2)
+      rolldown: 1.2.5
+      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28)(oxc-resolver@11.19.1)(rolldown@1.2.5)(typescript@7.0.2)
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -18119,17 +18010,13 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  yuku-ast@0.8.3:
-    dependencies:
-      '@yuku-toolchain/types': 0.8.3
-
   yuku-ast@0.8.7:
     dependencies:
       '@yuku-toolchain/types': 0.8.7
 
   yuku-codegen@0.8.3:
     dependencies:
-      '@yuku-toolchain/types': 0.8.3
+      '@yuku-toolchain/types': 0.8.7
     optionalDependencies:
       '@yuku-codegen/binding-android-arm64': 0.8.3
       '@yuku-codegen/binding-darwin-arm64': 0.8.3
@@ -18143,24 +18030,6 @@ snapshots:
       '@yuku-codegen/binding-linux-x64-musl': 0.8.3
       '@yuku-codegen/binding-win32-arm64': 0.8.3
       '@yuku-codegen/binding-win32-x64': 0.8.3
-
-  yuku-parser@0.8.3:
-    dependencies:
-      '@yuku-toolchain/types': 0.8.3
-      yuku-ast: 0.8.3
-    optionalDependencies:
-      '@yuku-parser/binding-android-arm64': 0.8.3
-      '@yuku-parser/binding-darwin-arm64': 0.8.3
-      '@yuku-parser/binding-darwin-x64': 0.8.3
-      '@yuku-parser/binding-freebsd-x64': 0.8.3
-      '@yuku-parser/binding-linux-arm-gnu': 0.8.3
-      '@yuku-parser/binding-linux-arm-musl': 0.8.3
-      '@yuku-parser/binding-linux-arm64-gnu': 0.8.3
-      '@yuku-parser/binding-linux-arm64-musl': 0.8.3
-      '@yuku-parser/binding-linux-x64-gnu': 0.8.3
-      '@yuku-parser/binding-linux-x64-musl': 0.8.3
-      '@yuku-parser/binding-win32-arm64': 0.8.3
-      '@yuku-parser/binding-win32-x64': 0.8.3
 
   yuku-parser@0.8.7:
     dependencies:


### PR DESCRIPTION
`@portabletext/test` gains the textspec parser and serializer, moved wholesale from the editor's internal `test-utils/`: `fromTextspec` turns notation like `'B: foo [strong:bar] b|az'` into Portable Text blocks and a selection, `toTextspec` turns blocks and a selection back into notation, and `selectionFromTextspec` resolves a pattern's selection markers against an existing value. All deterministic under the supplied key generator, so test seeds and assertions outside the editor package can be written as notation instead of block literals.

Nothing is duplicated: both editor files are deleted and every importer (about fifty, mostly test files) repoints to `@portabletext/test`. The editor-internal type imports become structural locals (`TextspecContainers`, `TextspecContainerRegistration`, `TextspecSelection`, `TextspecSelectionPoint`) built on `@portabletext/schema` and `@portabletext/patches` types, which the editor's own `Containers`, `RegisteredContainer`, and `EditorSelection` satisfy in both directions, so no call site needed a cast. With both directions moved, the editor drops its `@textspec/notation` devDependency. `@portabletext/schema` moves from devDependencies to dependencies of `@portabletext/test`: the parsers (and the pre-existing `terse-pt`) call `isTextBlock`/`isSpan` at runtime, so the devDep was a latent resolution failure for published consumers under isolated `node_modules`. The parsers' own test suites stay editor-side because they build real containers via the editor-internal `resolveContainers`.

Extracted from the `@portabletext/steps` package PR (#3208), whose interpreter suite is the first consumer outside the editor; landing this first keeps that PR free of changes to existing packages.

The lockfile diff also carries unrelated `pnpm install` cleanup: pruned orphaned `@yuku-parser` 0.8.3 entries and three vitest peer-resolution keys refreshed from a stale `@types/node@20.19.25`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and shared test-package API surface; no production editor runtime behavior changes beyond dependency/import moves.
> 
> **Overview**
> **Moves textspec parsing and serialization into `@portabletext/test`** as a minor release: public `fromTextspec`, `toTextspec`, and `selectionFromTextspec`, plus `TextspecContainers`, `TextspecContainerRegistration`, `TextspecSelection`, and `TextspecSelectionPoint`. Implementation is lifted out of the editor’s internal `test-utils` (no duplicate copy); `@textspec/notation` becomes a runtime dependency of `@portabletext/test` instead of a devDependency on `@portabletext/editor`.
> 
> **Editor and tests only change imports and wiring.** Dozens of editor tests, Gherkin step definitions, and the editor test re-export now import these helpers from `@portabletext/test`. Selection types in the moved code use the new portable types so they stay structurally compatible with `EditorSelection` and container maps without casts.
> 
> **Docs and release notes** add a Textspec section to `packages/test/README.md` and a changeset describing the new API for writing seeds and assertions as notation strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0959f97ac49aba476b8e6255e0ea61966e5c1ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->