### PR TITLE
test: give the html unit project a timeout sized to its fixtures

### DIFF
--- a/packages/html/vitest.config.ts
+++ b/packages/html/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
         test: {
           name: 'unit',
           environment: 'node',
+          // Some fixtures are 300KB Word exports that can need more than
+          // the default 5s on a busy CI runner. The tests are all
+          // synchronous converters, so a high timeout is safe.
+          testTimeout: 30_000,
         },
       },
     ],


### PR DESCRIPTION
The `App SDK Quickstart Guide > Word Online` unit test times out intermittently on CI (twice recently, both on `changeset-release/main` pushes, e.g. https://github.com/portabletext/editor/actions/runs/33495322568/job/99816039934). The test parses a 323KB Word Online HTML export through jsdom: ~400ms alone, but the unit shard shares a 2-core runner with the release build on those pushes and the default 5s ceiling is too tight under that contention. Conversion scales linearly with fixture size (93KB → 235ms, 323KB → 361ms), so there is nothing pathological to fix in the transform, and real paste uses the browser's parser, not jsdom.

This raises `testTimeout` to 30s for `@portabletext/html`'s unit project, which also covers the sibling 300KB-class `word-online.test.ts` fixtures. Every test in the package is a deterministic converter, no waits, so the wider ceiling still catches genuine hangs and masks nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test configuration only; no production or conversion logic changes.
> 
> **Overview**
> **Raises the `@portabletext/html` unit Vitest project `testTimeout` from the default 5s to 30s** so large (~300KB) Word Online HTML export fixtures do not flake on contended CI runners.
> 
> The change is config-only in `vitest.config.ts`, with a short comment noting that converters are synchronous, so a higher ceiling mainly absorbs slow jsdom parsing under load rather than hiding real hangs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2d39b187e6d2ba73cb00411178cfedbebac58b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->