### PR TITLE
fix: support `@sanity/sdk-react@3` with normalized document handles

### DIFF
--- a/.changeset/sdk-react-v3.md
+++ b/.changeset/sdk-react-v3.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-sdk-value': patch
+---
+
+fix: support `@sanity/sdk-react` 3 with normalized document handles
+
+`@portabletext/plugin-sdk-value` now supports `@sanity/sdk-react` 3 in addition to 2.19 and later. The removed `source` document-handle alias is translated to `resource`, so existing integrations do not need code changes.

--- a/packages/plugin-sdk-value/package.json
+++ b/packages/plugin-sdk-value/package.json
@@ -73,7 +73,7 @@
     "@portabletext/test": "workspace:^",
     "@sanity/diff-match-patch": "catalog:",
     "@sanity/pkg-utils": "catalog:tooling",
-    "@sanity/sdk-react": "^2.19.0",
+    "@sanity/sdk-react": "^3.0.0",
     "@sanity/tsconfig": "catalog:tooling",
     "@types/debug": "catalog:",
     "@types/react": "catalog:tooling",
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "@portabletext/editor": "workspace:^",
-    "@sanity/sdk-react": "^2.19.0",
+    "@sanity/sdk-react": "^2.19.0 || ^3",
     "react": "^19.2",
     "react-dom": "^19.2"
   },

--- a/packages/plugin-sdk-value/src/plugin.sdk-presence.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-presence.tsx
@@ -3,11 +3,13 @@ import {
   usePresenceForDocument,
   useReportPresence,
   type DocumentHandle,
+  type DocumentResource,
   type UseReportPresenceOptions,
 } from '@sanity/sdk-react'
 import {useMemo, type PropsWithChildren, type ReactElement} from 'react'
 import {useLocalSelection, useRemoteCursors} from './plugin.presence-sync'
 import {arrayifyPath} from './plugin.sdk-value'
+import {normalizeDocumentHandle} from './sdk-document-handle'
 
 /**
  * `@sanity/sdk-react` exports the presence hooks and their option types but not
@@ -55,6 +57,10 @@ export interface SDKRemoteCursor {
  */
 export interface SDKPresencePluginProps extends DocumentHandle {
   /**
+   * @deprecated Use `resource` instead.
+   */
+  source?: DocumentResource
+  /**
    * The document path of the Portable Text field, for example `content`. The
    * same form `SDKValuePlugin` takes.
    */
@@ -67,6 +73,10 @@ export interface SDKPresencePluginProps extends DocumentHandle {
  * @public
  */
 export interface UseSDKPresenceCursorsOptions extends DocumentHandle {
+  /**
+   * @deprecated Use `resource` instead.
+   */
+  source?: DocumentResource
   path: string
   renderCursor: RenderCursorFunction
 }
@@ -86,7 +96,7 @@ export interface UseSDKPresenceCursorsOptions extends DocumentHandle {
  * @public
  */
 export function SDKPresencePlugin(props: SDKPresencePluginProps) {
-  const {path, ...handle} = props
+  const {path, ...handle} = normalizeDocumentHandle(props)
   const selection = useLocalSelection()
   const fieldPath = useFieldPath(path)
 
@@ -112,7 +122,7 @@ export function SDKPresencePlugin(props: SDKPresencePluginProps) {
 export function useSDKPresenceCursors(
   options: UseSDKPresenceCursorsOptions,
 ): RangeDecoration[] {
-  const {path, renderCursor, ...handle} = options
+  const {path, renderCursor, ...handle} = normalizeDocumentHandle(options)
   const fieldPath = useFieldPath(path)
   // Exact id matching: a caret reported while editing a draft must not be drawn
   // in a release version of the same document, where the text differs.

--- a/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
+++ b/packages/plugin-sdk-value/src/plugin.sdk-value.tsx
@@ -27,12 +27,14 @@ import {
   useEditDocument,
   useSanityInstance,
   type DocumentHandle,
+  type DocumentResource,
   type EditDocumentAction,
 } from '@sanity/sdk-react'
 import {useActorRef} from '@xstate/react'
 import {useCallback} from 'react'
 import {fromCallback, setup, type AnyEventObject} from 'xstate'
 import {debug} from './debug'
+import {normalizeDocumentHandle} from './sdk-document-handle'
 
 type InsertPatch = Required<Pick<SanityPatchOperations, 'insert'>>
 
@@ -1084,6 +1086,7 @@ const valueSyncMachine = setup({
 })
 
 interface SDKValuePluginProps extends DocumentHandle {
+  source?: DocumentResource
   path: string
 }
 
@@ -1122,9 +1125,10 @@ function getPublishedDocumentId(id: string): string {
  * @public
  */
 export function SDKValuePlugin(props: SDKValuePluginProps) {
-  const {documentId, documentType, path} = props
-  const setSdkValue = useEditDocument(props)
-  const instance = useSanityInstance(props)
+  const normalizedProps = normalizeDocumentHandle(props)
+  const {documentId, documentType, path} = normalizedProps
+  const setSdkValue = useEditDocument(normalizedProps)
+  const instance = useSanityInstance()
   const applyActions = useApplyDocumentActions()
 
   const handle = {documentId, documentType, path}

--- a/packages/plugin-sdk-value/src/sdk-document-handle.ts
+++ b/packages/plugin-sdk-value/src/sdk-document-handle.ts
@@ -1,0 +1,17 @@
+import type {DocumentHandle, DocumentResource} from '@sanity/sdk-react'
+
+type DocumentHandleWithLegacySource = DocumentHandle & {
+  source?: DocumentResource
+}
+
+export function normalizeDocumentHandle<T extends DocumentHandle>(
+  handle: T & DocumentHandleWithLegacySource,
+): Omit<T, 'source'> {
+  const {source, ...normalizedHandle} = handle
+
+  if (normalizedHandle.resource !== undefined || source === undefined) {
+    return normalizedHandle
+  }
+
+  return {...normalizedHandle, resource: source}
+}

--- a/packages/plugin-sdk-value/src/sdk-editable.test.ts
+++ b/packages/plugin-sdk-value/src/sdk-editable.test.ts
@@ -48,7 +48,6 @@ describe('splitEditableProps', () => {
       projectId: true,
       resource: true,
       resourceName: true,
-      source: true,
     } satisfies {[Key in keyof DocumentHandle]-?: true}
 
     // Every handle key has to be present in the input, or a field the component
@@ -96,6 +95,28 @@ describe('splitEditableProps', () => {
     expect(handle.projectId).toBe('project-1')
     expect(handle.dataset).toBe('production')
     expect(handle.resourceName).toBe('resource-1')
+  })
+
+  it('maps the removed source alias to resource without forwarding it', () => {
+    const source: SDKPortableTextEditableProps['source'] = {
+      projectId: 'source-project',
+      dataset: 'source-dataset',
+    }
+    const legacyProps = {
+      'documentId': 'doc-1',
+      'documentType': 'post',
+      'path': 'content',
+      'source': source,
+      'data-testid': 'editable',
+    }
+    const {handle, editableProps} = splitEditableProps(legacyProps)
+
+    expect(handle).toEqual({
+      documentId: 'doc-1',
+      documentType: 'post',
+      resource: {projectId: 'source-project', dataset: 'source-dataset'},
+    })
+    expect(editableProps).toEqual({'data-testid': 'editable'})
   })
 
   it('omits handle fields the caller never passed', () => {

--- a/packages/plugin-sdk-value/src/sdk-editable.tsx
+++ b/packages/plugin-sdk-value/src/sdk-editable.tsx
@@ -3,7 +3,7 @@ import {
   type PortableTextEditableProps,
   type RangeDecoration,
 } from '@portabletext/editor'
-import type {DocumentHandle} from '@sanity/sdk-react'
+import type {DocumentHandle, DocumentResource} from '@sanity/sdk-react'
 import {useMemo} from 'react'
 import {
   SDKPresencePlugin,
@@ -12,6 +12,7 @@ import {
 } from './plugin.sdk-presence'
 import {SDKValuePlugin} from './plugin.sdk-value'
 import {renderDefaultCursor} from './presence-caret'
+import {normalizeDocumentHandle} from './sdk-document-handle'
 
 /**
  * Props for {@link SDKPortableTextEditable}.
@@ -24,6 +25,10 @@ export interface SDKPortableTextEditableProps
     // `resource` is both a document handle field and an RDFa HTML attribute, so
     // the handle wins. Dropping the attribute costs nothing in an editor.
     Omit<PortableTextEditableProps, keyof DocumentHandle> {
+  /**
+   * @deprecated Use `resource` instead.
+   */
+  source?: DocumentResource
   /**
    * The document path of the Portable Text field, for example `content`.
    */
@@ -115,6 +120,7 @@ export function SDKPortableTextEditable(props: SDKPortableTextEditableProps) {
 export function splitEditableProps(
   props: SDKPortableTextEditableProps,
 ): SplitEditableProps {
+  const normalizedProps = normalizeDocumentHandle(props)
   const {
     documentId,
     documentType,
@@ -122,14 +128,13 @@ export function splitEditableProps(
     dataset,
     resource,
     resourceName,
-    source,
     liveEdit,
     perspective,
     path,
     renderCursor,
     rangeDecorations,
     ...editableProps
-  } = props
+  } = normalizedProps
 
   return {
     // Only the fields the caller actually passed. The SDK resolves an ambient
@@ -142,9 +147,8 @@ export function splitEditableProps(
       documentType,
       ...('projectId' in props && {projectId}),
       ...('dataset' in props && {dataset}),
-      ...('resource' in props && {resource}),
+      ...('resource' in normalizedProps && {resource}),
       ...('resourceName' in props && {resourceName}),
-      ...('source' in props && {source}),
       ...('liveEdit' in props && {liveEdit}),
       ...('perspective' in props && {perspective}),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,8 +1170,8 @@ importers:
         specifier: catalog:tooling
         version: 12.3.0(@babel/runtime@7.28.4)(@tsdown/css@0.22.14)(@types/node@24.12.2)(@volar/typescript@2.4.28)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(oxc-transform-react@0.145.0)(typescript@7.0.2)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
       '@sanity/sdk-react':
-        specifier: ^2.19.0
-        version: 2.19.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)
+        specifier: ^3.0.0
+        version: 3.0.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
       '@sanity/tsconfig':
         specifier: catalog:tooling
         version: 2.1.0
@@ -2624,6 +2624,18 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@module-federation/error-codes@2.9.0':
+    resolution: {integrity: sha512-IGpd+VRlji3NyGOGGTsk7YEmPRKcDoBK4YHqIuP+OQwyb2YhHCUHO2vW9RXeQxCuKwi+c6xkTweRYG+Umy+0Zw==}
+
+  '@module-federation/runtime-core@2.9.0':
+    resolution: {integrity: sha512-dLykRYfpbEJBTdk2NlbNoVVTB196O3qujawTBguLABJkPCWETJNk60NR1yZO34eI+DTH+eGwHU3m7FddAWnbnw==}
+
+  '@module-federation/runtime@2.9.0':
+    resolution: {integrity: sha512-3cyAav0hWP+dNvB7qrcK9CKxQn+JvkbRvLtZz3zS2g0EyxtDFDjgbHY0Afcf7oHf8IHhKeEdzb/3Kjr1Pjmr7A==}
+
+  '@module-federation/sdk@2.9.0':
+    resolution: {integrity: sha512-IMjObgBGQTXd33jTTCYcxvz8iOQGLsZ2QIPOj90rDxuBtJsN4WJwYyXqligrhY/e5p/BipUPdbIgKmWL7zFhTw==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -4778,8 +4790,16 @@ packages:
     resolution: {integrity: sha512-7GEzTFRY6kWRjHbJYUDEGKPXHVl/XItGpV5LYCLcWMvBlgfujXuAjdp4hJVZqX8F8OtBzIFqdhiSn5Kh5u/V5Q==}
     engines: {node: '>=20'}
 
+  '@sanity/client@7.26.2':
+    resolution: {integrity: sha512-iEkGiHbrxCnT/A30A6pH+vX4otP3lLp935Vwuv0/YrnETxrKCn6PnsZU+TfTm6ZEZ9kZGs8wKP5yBLmZw5S6OQ==}
+    engines: {node: '>=20'}
+
   '@sanity/comlink@4.0.1':
     resolution: {integrity: sha512-vdGOd6sxNjqTo2H3Q3L2/Gepy+cDBiQ1mr9ck7c/A9o4NnmBLoDliifsNHIwgNwBUz37oH4+EIz/lIjNy8hSew==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
+  '@sanity/comlink@4.0.3':
+    resolution: {integrity: sha512-gCnltbeB8BmXVLSr/6XHAA3tQmhJDMKXufOVRXYxAhIEv+5n9CtnxupjY5IzmdI+7v+G67TZV/8zCQhvaFlVww==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@sanity/descriptors@1.3.0':
@@ -4819,6 +4839,10 @@ packages:
     resolution: {integrity: sha512-UfQDuWRzbK4dRTfLURGCZo7ZlR0sK+2lwT2QMAfqsM5kMq5GR31lbX4LMcSw27h7rwUv8ZSf1hBEbluVpgRmlg==}
     engines: {node: '>=20.0.0'}
 
+  '@sanity/message-protocol@0.24.0':
+    resolution: {integrity: sha512-F/MwFVc3fN8uVvCIGuTxHN5EVo148wLhjL7h/u6wbShWJGMKgcGx0n6MwfCPyi6ftpdvRXsPZVDgZ1GMeeBf2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@sanity/mutate@0.18.1':
     resolution: {integrity: sha512-28iICKl33s9yr8XtgpoCHOb+l5kKVbd6CpFYi4Vx0fHNZcFiKDGdY+RzZrC34GWqb6M16wkxwtHSVbEmXbfTpw==}
     peerDependencies:
@@ -4856,14 +4880,14 @@ packages:
   '@sanity/schema@6.9.1':
     resolution: {integrity: sha512-bLMnZaBx/dT+avceIgIaNDQ/WccS27zvtuCpsuhvX9sjjtv5Latp8vCHQlRBQa7t8gyE6C6h+gbOr0dbPg9+nw==}
 
-  '@sanity/sdk-react@2.19.0':
-    resolution: {integrity: sha512-dphdWEAY7vO3i9Y4Eht85LJnezqwAhTH2U/7iewMMqLXBYPrfRHIEium2eTWb5rX7UpigiqRcJpREi9ZkcKjBA==}
+  '@sanity/sdk-react@3.0.0':
+    resolution: {integrity: sha512-YAPk+IdHoaQasgHY/ZHgxsxOutD7uJFAp2aPzSWVJH10cmFEoMtEAy8nDetV+R1kEEd/g0pTlMgbb4HIJBDWKA==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.0
+      react-dom: ^19.2.0
 
-  '@sanity/sdk@2.19.0':
-    resolution: {integrity: sha512-UOrxOmISioW22b0IyGgkRJCk1VnzmevH7jY8WZpANStmwa/4lsujRNlWOYeW3IguhIz0HptgtVfRXXyZwr9UXQ==}
+  '@sanity/sdk@3.0.0':
+    resolution: {integrity: sha512-RI7WOjgl8mFoj3NelcYq3WPUI9UCAyA76LDwZWQDmN+S+iqjhhQVmWFkTfS6Zij7Pr5rbNhIccYDsMKZb66Qfw==}
 
   '@sanity/signed-urls@2.0.4':
     resolution: {integrity: sha512-wH7L9iOxQDVTa7COVEXoknalNgjpqxLJoOcZYQa3D/2JVEQOGUm82RgFVgZkKoclhQ8Y8dBby+KPkFoIDoUc1g==}
@@ -4897,11 +4921,6 @@ packages:
       oxc-transform-react:
         optional: true
 
-  '@sanity/types@6.8.0':
-    resolution: {integrity: sha512-VvhWNrupGjXxytz/tRbjOHeEHctUsZqf7AF+eT1MxP0pgOdhtRlXsroV6e4Uayoux/cbbuYTX5JpCnW6cAuZYw==}
-    peerDependencies:
-      '@types/react': ^19.2.17
-
   '@sanity/types@6.9.1':
     resolution: {integrity: sha512-C9Pe/mVn1ZGqgE4Zpwd1Y2IeTjL33/60imsDocqzdwezJPGN5I3XPOced/M/6Uvxl+afuyt0Sx9+B+TXmrUrBQ==}
     peerDependencies:
@@ -4928,6 +4947,13 @@ packages:
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       tsdown: ^0.22.5
+
+  '@sanity/workbench@0.1.0-alpha.24':
+    resolution: {integrity: sha512-235mR37+z8eg9OQqhUwgkQ4dZnveFHczUTgW2jk81qm1pP6vMlTdEAiKpz1Tq4zU9zRfg2xck51DP1VlkVzdWA==}
+    engines: {node: '>=20.19.1 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/sdk': ^2.9.0
+      xstate: ^5.31.0
 
   '@shikijs/core@3.21.0':
     resolution: {integrity: sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==}
@@ -7419,11 +7445,6 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -8831,6 +8852,10 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@14.0.2:
+    resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
     hasBin: true
 
   uuid@8.3.2:
@@ -10601,6 +10626,21 @@ snapshots:
       resolve: 1.22.11
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@module-federation/error-codes@2.9.0': {}
+
+  '@module-federation/runtime-core@2.9.0':
+    dependencies:
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/sdk': 2.9.0
+
+  '@module-federation/runtime@2.9.0':
+    dependencies:
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/runtime-core': 2.9.0
+      '@module-federation/sdk': 2.9.0
+
+  '@module-federation/sdk@2.9.0': {}
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -12699,10 +12739,23 @@ snapshots:
       nanoid: 3.3.17
       rxjs: 7.8.2
 
+  '@sanity/client@7.26.2':
+    dependencies:
+      '@sanity/eventsource': 5.0.4
+      get-it: 8.8.3
+      nanoid: 3.3.17
+      rxjs: 7.8.2
+
   '@sanity/comlink@4.0.1':
     dependencies:
       rxjs: 7.8.2
       uuid: 13.0.0
+      xstate: 5.32.5
+
+  '@sanity/comlink@4.0.3':
+    dependencies:
+      rxjs: 7.8.2
+      uuid: 14.0.2
       xstate: 5.32.5
 
   '@sanity/descriptors@1.3.0':
@@ -12742,10 +12795,14 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
+  '@sanity/message-protocol@0.24.0':
+    dependencies:
+      '@sanity/comlink': 4.0.1
+
   '@sanity/mutate@0.18.1(xstate@5.32.5)':
     dependencies:
       '@isaacs/ttlcache': 2.1.5
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.2
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
@@ -12878,38 +12935,39 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@sanity/sdk-react@2.19.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)':
+  '@sanity/sdk-react@3.0.0(@types/react@19.2.17)(immer@11.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))':
     dependencies:
-      '@sanity/client': 7.26.0
-      '@sanity/message-protocol': 0.23.0
-      '@sanity/sdk': 2.19.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)
-      '@sanity/types': 6.8.0(@types/react@19.2.17)
+      '@sanity/client': 7.26.2
+      '@sanity/message-protocol': 0.24.0
+      '@sanity/sdk': 3.0.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)
+      '@sanity/types': 6.9.1(@types/react@19.2.17)
+      '@sanity/workbench': 0.1.0-alpha.24(@sanity/sdk@3.0.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(react@19.2.8)(xstate@5.32.5)
       groq: 3.88.1-typegen-experimental.0
       react: 19.2.8
       react-compiler-runtime: 1.0.0(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
       react-error-boundary: 6.1.2(react@19.2.8)
       rxjs: 7.8.2
+      xstate: 5.32.5
     transitivePeerDependencies:
       - '@types/react'
       - immer
       - use-sync-external-store
-      - xstate
 
-  '@sanity/sdk@2.19.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)':
+  '@sanity/sdk@3.0.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
-      '@sanity/client': 7.26.0
-      '@sanity/comlink': 4.0.1
+      '@sanity/client': 7.26.2
+      '@sanity/comlink': 4.0.3
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.1.1
       '@sanity/json-match': 1.0.5
-      '@sanity/message-protocol': 0.23.0
+      '@sanity/message-protocol': 0.24.0
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
-      '@sanity/types': 6.8.0(@types/react@19.2.17)
+      '@sanity/types': 6.9.1(@types/react@19.2.17)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 2.0.0
       reselect: 5.1.1
@@ -12996,7 +13054,7 @@ snapshots:
       - supports-color
       - vite
 
-  '@sanity/types@6.8.0(@types/react@19.2.17)':
+  '@sanity/types@6.9.1(@types/react@19.2.17)':
     dependencies:
       '@sanity/client': 7.26.0
       '@sanity/media-library-types': 1.6.0
@@ -13038,6 +13096,19 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - rolldown
+
+  '@sanity/workbench@0.1.0-alpha.24(@sanity/sdk@3.0.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(react@19.2.8)(xstate@5.32.5)':
+    dependencies:
+      '@module-federation/runtime': 2.9.0
+      '@sanity/message-protocol': 0.23.0
+      '@sanity/sdk': 3.0.0(@types/react@19.2.17)(immer@11.0.1)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      rxjs: 7.8.2
+      semver: 7.8.5
+      xstate: 5.32.5
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
 
   '@shikijs/core@3.21.0':
     dependencies:
@@ -15996,8 +16067,6 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.12: {}
-
   nanoid@3.3.17: {}
 
   nanoid@5.1.11: {}
@@ -16343,7 +16412,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -17642,6 +17711,8 @@ snapshots:
 
   uuid@13.0.0: {}
 
+  uuid@14.0.2: {}
+
   uuid@8.3.2: {}
 
   uuidv7@0.4.4: {}
@@ -17719,7 +17790,7 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.11(@types/node@20.19.25)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@20.19.25)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
+      vitest: 4.1.11(@types/node@24.12.2)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-istanbul@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@27.2.0)(vite@8.2.0(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.12)(yaml@2.8.3))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
`@portabletext/plugin-sdk-value` currently rejects `@sanity/sdk-react` 3 at install time. Compiling against v3 also exposes two removed deprecated APIs: `useSanityInstance` no longer accepts a config argument, and `DocumentHandle` no longer includes the `source` alias.

This widens the peer range, reads the ambient instance without arguments, and retains `source` in the plugin's public props while translating it to `resource` before value and presence hooks receive the handle. An explicit `resource` keeps precedence when both fields are present, matching the v2 normalization behavior. The development dependency moves to v3 so the package is built and tested against the new major.

pnpm reports an upstream peer warning because `@sanity/sdk-react@3.0.0` includes `@sanity/workbench@0.1.0-alpha.24`, whose peer range still names SDK 2. The SDK React release itself publishes that dependency combination - we're working on resolving that.