### PR TITLE
fix: stop clearing the drop position on continuous `drag` events

### DIFF
--- a/.changeset/dnd-drag-clear.md
+++ b/.changeset/dnd-drag-clear.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/plugin-dnd': patch
+---
+
+fix: stop clearing the drop position on continuous `drag` events
+
+Dragging a block no longer forces a layout reflow on every pointer move. The browser fires `drag` on the dragged element continuously during a drag, and the plugin treated each one as an end-of-drag signal: it cleared the drop position and restored the editor's caret color, only for the next `dragover` to set both back. The two style writes per pointer move invalidated layout right before the editor's own drag handling read element rects, so every move paid a full-page reflow that grew with document size, and the drop indicator visibly trailed the pointer in large documents (~12ms per event at 300 blocks with sibling fields mounted, now ~1.5ms, flat across document sizes). The drop position now clears on `dragend`, `dragleave`, `drop`, and `dragstart`, not on `drag`.

--- a/packages/plugin-dnd/src/plugin.dnd.test.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.test.tsx
@@ -143,6 +143,31 @@ describe('DndProvider', () => {
     await expectDropPositions({b0: 'none', b1: 'none', b2: 'start'})
   })
 
+  test('Scenario: A `drag` event on the source does not clear the drop position', async () => {
+    const {editor} = await renderEditorWithProbes()
+    const editorElement = getEditorElement(editor)
+
+    editor.send(
+      dragover({
+        dragOrigin: blockSelection('b0'),
+        over: caretIn('b2'),
+        block: 'end',
+      }),
+    )
+    await expectDropPositions({b2: 'end'})
+    expect(editorElement.style.caretColor).toBe('transparent')
+
+    editor.send({
+      type: 'drag.drag',
+      originEvent: {dataTransfer: new DataTransfer()},
+    })
+
+    // The caret-color write happens synchronously in the store, so a clear
+    // would already have restored it here.
+    expect(editorElement.style.caretColor).toBe('transparent')
+    await expectDropPositions({b0: 'none', b1: 'none', b2: 'end'})
+  })
+
   test('Scenario: Ending the drag clears the drop position', async () => {
     const {editor} = await renderEditorWithProbes()
 

--- a/packages/plugin-dnd/src/plugin.dnd.tsx
+++ b/packages/plugin-dnd/src/plugin.dnd.tsx
@@ -275,7 +275,14 @@ function createDropPositionBehaviors(
     }),
     defineBehavior({
       on: 'drag.*',
-      guard: ({event}) => event.type !== 'drag.dragover',
+      guard: ({event}) =>
+        // `drag.drag` fires continuously on the drag source between
+        // `dragover`s. Clearing on it would toggle the drop position (and
+        // the caret-color write on the editor root) on every pointer move,
+        // and each write invalidates layout for the whole page right before
+        // the next drag event reads element rects: a forced reflow per move,
+        // scaling with page size.
+        event.type !== 'drag.dragover' && event.type !== 'drag.drag',
       actions: [
         ({event}) => [
           effect(() => {


### PR DESCRIPTION
Dragging a block in a large document makes the drop indicator trail the pointer, and devtools log forced-reflow violations on every pointer move. Small documents never show it, which is why the plugin's own test documents stayed green.

The browser fires `drag` on the dragged element between `dragover`s, continuously for the whole drag. The plugin's clearing behavior matches `drag.*` with only `dragover` excluded, so every `drag` cleared the drop position and restored the editor root's inline `caret-color`, and the next `dragover` set both back. Two style writes on the editor root per pointer move invalidate layout right before the editor's drag handling reads element rects (`getEventPosition` reads the first-block, last-block, and target rects on each drag event), so every move pays a synchronous full-page reflow whose cost scales with the page's total DOM size.

The fix excludes `drag.drag` from the clearing guard: it is a carrier event on the drag source, not an end-of-interaction signal. Clearing still happens on `dragstart`, `dragend`, `dragleave`, and `drop`, and `caret-color` is now only written when the drop position genuinely transitions. Pinned by a test sending a `drag` between two `dragover`s and asserting the drop position and the hidden drop caret survive it; red on the old guard.

Numbers, from a Studio-shaped browser probe (chromium, dev-mode React, eight mounted editors, 45 synthetic `drag`+`dragover` pairs swept across the document, three document sizes): per-event p90 was 1.9/6.5/13.2ms at 9/100/300 blocks; with the fix it is 1.5/1.6/1.6ms, and rect-read time inside the handlers drops from 121ms to 2ms at 300 blocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow DnD plugin behavior change with a regression test; improves performance without touching auth, data, or core editor APIs.
> 
> **Overview**
> **Fixes drag-and-drop jank in large documents** by no longer treating the browser’s repeated `drag` events on the drag source as “end drag.”
> 
> The catch-all `drag.*` behavior in `plugin.dnd.tsx` used to clear the drop position (and flip the editor root’s inline `caret-color`) on every `drag` between `dragover`s. That paired with the next `dragover` re-applying both states caused **two style writes per pointer move**, forcing layout before rect reads and making the drop indicator lag in big docs. **`drag.drag` is now excluded** from that clear path, same as `dragover`; clearing still runs on `dragstart`, `dragend`, `dragleave`, and `drop`.
> 
> A new scenario test fires `drag.drag` after a `dragover` and asserts the drop position and hidden caret stay put. A patch changeset documents the `@portabletext/plugin-dnd` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fba87929ffddb4b30376485f608c206a75f9e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->