### PR TITLE
fix: guard `drag` and `dragleave` handlers without resolving an event position

### DIFF
--- a/.changeset/drag-event-guard.md
+++ b/.changeset/drag-event-guard.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: guard `drag` and `dragleave` handlers without resolving an event position
+
+The editor no longer runs a caret hit-test and block rect reads for every `drag` and `dragleave` event during a drag. Both events forward to behaviors without a position, so the resolution was pure per-pointer-move cost; the handlers now only check that the event target belongs to the editor. In rare cases where position resolution would have failed (for example while the editor is tearing down mid-drag), the `drag.drag` and `drag.dragleave` behavior events now still fire.

--- a/packages/editor/src/editor/Editable.tsx
+++ b/packages/editor/src/editor/Editable.tsx
@@ -687,13 +687,14 @@ export const PortableTextEditable = forwardRef<
         return
       }
 
-      const position = getEventPosition({
-        editorActor,
-        editorEngine,
-        event: event.nativeEvent,
-      })
-
-      if (!position) {
+      // The forwarded `drag.drag` event carries no position, so resolving
+      // one (a caret hit-test plus block rect reads) is wasted work on an
+      // event the browser fires continuously on the drag source. A
+      // containment check is all the guard needs.
+      if (
+        editorActor.getSnapshot().matches({setup: 'setting up'}) ||
+        !DOMEditor.hasTarget(editorEngine, event.target)
+      ) {
         return
       }
 
@@ -860,13 +861,13 @@ export const PortableTextEditable = forwardRef<
         return
       }
 
-      const position = getEventPosition({
-        editorActor,
-        editorEngine,
-        event: event.nativeEvent,
-      })
-
-      if (!position) {
+      // The forwarded `drag.dragleave` event carries no position either;
+      // the same cheap guard as `drag.drag` applies. `dragleave` fires on
+      // every element boundary inside the editor during a drag.
+      if (
+        editorActor.getSnapshot().matches({setup: 'setting up'}) ||
+        !DOMEditor.hasTarget(editorEngine, event.target)
+      ) {
         return
       }
 

--- a/packages/editor/tests/event.drag.test.tsx
+++ b/packages/editor/tests/event.drag.test.tsx
@@ -1,0 +1,69 @@
+import {describe, expect, test, vi} from 'vitest'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event.drag', () => {
+  test('Scenario: `drag.drag` and `drag.dragleave` reach behaviors without a caret hit-test', async () => {
+    const onDrag = vi.fn()
+    const onDragLeave = vi.fn()
+
+    const {locator} = await createTestEditor({
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'drag.drag',
+              guard: () => {
+                onDrag()
+                return false
+              },
+              actions: [],
+            }),
+            defineBehavior({
+              on: 'drag.dragleave',
+              guard: () => {
+                onDragLeave()
+                return false
+              },
+              actions: [],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const editorElement = locator.element()
+
+    const documentWithCaret = window.document as Document & {
+      caretPositionFromPoint(x: number, y: number): unknown
+    }
+    const caretHitTest = vi.spyOn(documentWithCaret, 'caretPositionFromPoint')
+
+    editorElement.dispatchEvent(
+      new DragEvent('drag', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    )
+    editorElement.dispatchEvent(
+      new DragEvent('dragleave', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(onDrag).toHaveBeenCalledTimes(1)
+      expect(onDragLeave).toHaveBeenCalledTimes(1)
+    })
+
+    // These events carry no position, so the handlers must not pay for
+    // resolving one at pointer-move frequency.
+    expect(caretHitTest).not.toHaveBeenCalled()
+
+    caretHitTest.mockRestore()
+  })
+})


### PR DESCRIPTION
During a drag, the editor runs a full `getEventPosition` for every `drag` and `dragleave` event: a `caretPositionFromPoint` hit-test plus first-block, last-block, and target rect reads. Both handlers use the result only as a bail-out guard; the forwarded `drag.drag` and `drag.dragleave` behavior events carry no position. The browser fires `drag` continuously on the drag source and `dragleave` on every element boundary crossed, so this is wasted work at pointer-move frequency on the same hot path #3214 fixed, and whenever layout is dirty (indicator commits, style writes), each rect read becomes a forced reflow that scales with page size.

The handlers now guard with the same checks `getEventPosition` front-loads (editor actor not setting up, `DOMEditor.hasTarget` on the event target) and skip the resolution. One narrow delta rides along: where position resolution would have failed beyond those checks (missing block DOM nodes mid-teardown, a failed hit-test), the behavior events now fire instead of being swallowed; they carry no payload a consumer could read stale data from.

Pinned by a browser test asserting both events reach behaviors and that dispatching them runs no caret hit-test; red on the old handlers, which make two `caretPositionFromPoint` calls. Full editor browser suite green (2040 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized drag-handler performance change with a narrow semantic shift (more behavior events in teardown/hit-test failure cases) and no position payload for consumers to misread.
> 
> **Overview**
> **`drag` and `dragleave` no longer call `getEventPosition`** before forwarding `drag.drag` and `drag.dragleave` to behaviors. Those behavior events never included a caret position, but each DOM event was still paying for `caretPositionFromPoint` and block rect reads—expensive while the browser fires `drag` continuously and `dragleave` on every nested boundary.
> 
> The handlers now bail out only when the editor is still in setup or the event target is outside the editor (`DOMEditor.hasTarget`), matching the cheap checks `getEventPosition` already did up front. **Edge case:** if position resolution would have failed later (e.g. missing block DOM during teardown), the behavior events **still fire** instead of being dropped; the payload is unchanged (no position).
> 
> Adds a Vitest browser test that asserts both behaviors run and **`caretPositionFromPoint` is never invoked** for these events. Patch changeset for `@portabletext/editor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f623a2d28401387c8e82112da8dc604cead0a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->