### PR TITLE
chore: explain lockstep releases in generated changelogs

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,27 @@
+/**
+ * Wraps `@changesets/changelog-github` to explain releases that would
+ * otherwise get an empty changelog entry. `updateInternalDependents:
+ * "always"` releases every workspace dependent whenever a package it
+ * depends on releases; when that is the only reason for the release
+ * (no own changesets, no runtime dependency range updates), upstream
+ * writes nothing and the version shows up as a bare heading.
+ */
+const upstream = require('@changesets/changelog-github')
+const base = upstream.default ?? upstream
+
+module.exports = {
+  default: {
+    getReleaseLine: base.getReleaseLine,
+    async getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+      const line = await base.getDependencyReleaseLine(
+        changesets,
+        dependenciesUpdated,
+        options,
+      )
+      if (line.trim() === '' && changesets.length === 0) {
+        return '- Released to stay in lockstep with the other Portable Text packages released on the same day. No changes.'
+      }
+      return line
+    },
+  },
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://unpkg.com/@changesets/config/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
-    {"repo": "portabletext/editor"}
+    "./changelog.cjs",
+    {
+      "repo": "portabletext/editor"
+    }
   ],
   "commit": false,
   "access": "public",


### PR DESCRIPTION
Some plugin changelog entries are bare version headings with no content (`plugin-dnd` 2.0.3 through 2.0.5). The cause sits in the release config: `updateInternalDependents: "always"` releases every workspace dependent whenever a package it depends on releases, which we want, since it keeps every plugin co-released and tested against the editor version of the same day. But when the lockstep bump is the only reason for a release, `@changesets/changelog-github` has nothing to write, and the reader is left with a version that explains nothing.

The fix keeps the release policy and fixes the explanation: `.changeset/changelog.cjs` wraps `@changesets/changelog-github` and, when the dependency release line comes back empty for a release that carries no changesets of its own, writes "Released to stay in lockstep with the other Portable Text packages released on the same day. No changes."

Verified with a `changeset version` dry run against a probe changeset: lockstep-only releases (nine packages) gain the line, the editor's own release entry is byte-identical to upstream output, and releases with real runtime dependency updates keep the regular "Updated dependencies" lines.
