### PR TITLE
chore: explain lockstep releases in generated changelogs

### DIFF
--- a/.changeset/annotate-lockstep-releases.mjs
+++ b/.changeset/annotate-lockstep-releases.mjs
@@ -1,0 +1,134 @@
+/**
+ * Runs right after `changeset version` (see the `changeset:version` script).
+ *
+ * `updateInternalDependents: "always"` releases every workspace dependent
+ * whenever a package it depends on releases. When that is the only reason
+ * for the release, changesets writes a bare version heading with no body:
+ * it derives changelog dependency lines from source-tree range rewrites,
+ * and a `workspace:` range is never rewritten in the source tree. The
+ * published artifact does change (pnpm substitutes `workspace:` ranges
+ * with the co-released versions at publish time), so this script fills
+ * each bare section with the exact ranges the release will publish.
+ *
+ * Lockstep bumps are always patches here (`updateInternalDependencies:
+ * "patch"`, and `workspace:^` ranges are never out of range), so the
+ * inserted heading is hardcoded to `### Patch Changes`. Revisit if the
+ * repo ever adopts changesets pre-release mode.
+ *
+ * The pure logic is exported and pinned by
+ * `annotate-lockstep-releases.test.mjs`; only `main` touches git and the
+ * file system.
+ */
+import {execSync} from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+/**
+ * The range pnpm publishes for a `workspace:` range once the dependency
+ * is released at `releasedVersion`, or `null` when the release does not
+ * move the published range: an explicit range like `workspace:^8.0.2`
+ * publishes as `^8.0.2` verbatim, release after release.
+ */
+export function movedPublishedRange(range, releasedVersion) {
+  const protocolSuffix = range.slice('workspace:'.length)
+  if (protocolSuffix === '^' || protocolSuffix === '~') {
+    return `${protocolSuffix}${releasedVersion}`
+  }
+  if (protocolSuffix === '*') {
+    return releasedVersion
+  }
+  return null
+}
+
+/**
+ * Returns the changelog with the bare `## <version>` section filled in,
+ * or `null` when there is nothing to do (heading missing, or the section
+ * already has content).
+ */
+export function annotateChangelog({
+  changelog,
+  version,
+  manifest,
+  releasedVersions,
+}) {
+  const heading = `## ${version}`
+  const headingStart = changelog.indexOf(`${heading}\n`)
+  if (headingStart === -1) {
+    return null
+  }
+  const bodyStart = headingStart + heading.length
+  const bodyEnd = changelog.indexOf('\n## ', bodyStart)
+  const body = changelog.slice(bodyStart, bodyEnd === -1 ? undefined : bodyEnd)
+  if (body.trim() !== '') {
+    return null
+  }
+
+  const publishedRanges = []
+  for (const dependencyField of [
+    'dependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ]) {
+    for (const [dependencyName, range] of Object.entries(
+      manifest[dependencyField] ?? {},
+    )) {
+      const releasedVersion = releasedVersions.get(dependencyName)
+      if (releasedVersion === undefined || !range.startsWith('workspace:')) {
+        continue
+      }
+      const published = movedPublishedRange(range, releasedVersion)
+      if (published === null) {
+        continue
+      }
+      publishedRanges.push(`\`${dependencyName}@${published}\``)
+    }
+  }
+
+  const explanation =
+    publishedRanges.length > 0
+      ? `- fix(deps): require ${publishedRanges.join(', ')}`
+      : '- chore: lockstep release, no changes'
+
+  return `${changelog.slice(0, bodyStart)}\n\n### Patch Changes\n\n${explanation}${changelog.slice(bodyStart)}`
+}
+
+function main() {
+  const changedManifestPaths = execSync('git diff HEAD --name-only', {
+    encoding: 'utf8',
+  })
+    .split('\n')
+    // Encodes the workspace layout: every publishable package lives
+    // directly under `packages/`. A new workspace directory needs a
+    // matching pattern here or its releases go unannotated.
+    .filter((line) => /^packages\/[^/]+\/package\.json$/.test(line))
+
+  const manifests = changedManifestPaths.map((manifestPath) => ({
+    manifestPath,
+    manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+  }))
+  const releasedVersions = new Map(
+    manifests.map(({manifest}) => [manifest.name, manifest.version]),
+  )
+
+  for (const {manifestPath, manifest} of manifests) {
+    const changelogPath = path.join(path.dirname(manifestPath), 'CHANGELOG.md')
+    if (!fs.existsSync(changelogPath)) {
+      continue
+    }
+    const annotated = annotateChangelog({
+      changelog: fs.readFileSync(changelogPath, 'utf8'),
+      version: manifest.version,
+      manifest,
+      releasedVersions,
+    })
+    if (annotated !== null) {
+      fs.writeFileSync(changelogPath, annotated)
+      console.log(`annotated ${manifest.name}@${manifest.version}`)
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/.changeset/annotate-lockstep-releases.test.mjs
+++ b/.changeset/annotate-lockstep-releases.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+import {
+  annotateChangelog,
+  movedPublishedRange,
+} from './annotate-lockstep-releases.mjs'
+
+const releasedVersions = new Map([
+  ['@portabletext/editor', '8.1.3'],
+  ['@portabletext/schema', '2.3.4'],
+])
+
+test('fills a bare section with the exact published ranges', () => {
+  const annotated = annotateChangelog({
+    changelog: [
+      '# @portabletext/plugin-dnd',
+      '',
+      '## 2.0.8',
+      '',
+      '## 2.0.7',
+      '',
+      '### Patch Changes',
+      '',
+      '- An earlier release line.',
+      '',
+    ].join('\n'),
+    version: '2.0.8',
+    manifest: {
+      name: '@portabletext/plugin-dnd',
+      peerDependencies: {
+        '@portabletext/editor': 'workspace:^',
+        'react': '^19.2',
+      },
+      devDependencies: {'@portabletext/editor': 'workspace:^'},
+    },
+    releasedVersions,
+  })
+
+  assert.equal(
+    annotated,
+    [
+      '# @portabletext/plugin-dnd',
+      '',
+      '## 2.0.8',
+      '',
+      '### Patch Changes',
+      '',
+      '- fix(deps): require `@portabletext/editor@^8.1.3`',
+      '',
+      '## 2.0.7',
+      '',
+      '### Patch Changes',
+      '',
+      '- An earlier release line.',
+      '',
+    ].join('\n'),
+  )
+})
+
+test('lists every released workspace dependency, skipping unreleased and non-workspace ranges', () => {
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.1\n\n## 1.0.0\n\n- Initial release.\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      dependencies: {
+        '@portabletext/editor': 'workspace:^',
+        '@portabletext/schema': 'workspace:~',
+        '@portabletext/unreleased': 'workspace:^',
+        'react': '^19.2',
+      },
+    },
+    releasedVersions,
+  })
+
+  assert.equal(
+    annotated,
+    '# pkg\n\n## 1.0.1\n\n### Patch Changes\n\n- fix(deps): require `@portabletext/editor@^8.1.3`, `@portabletext/schema@~2.3.4`\n\n## 1.0.0\n\n- Initial release.\n',
+  )
+})
+
+test('falls back to a generic line when no released workspace dependency is published', () => {
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.1\n\n## 1.0.0\n\n- Initial release.\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      devDependencies: {'@portabletext/editor': 'workspace:^'},
+    },
+    releasedVersions,
+  })
+
+  assert.equal(
+    annotated,
+    '# pkg\n\n## 1.0.1\n\n### Patch Changes\n\n- chore: lockstep release, no changes\n\n## 1.0.0\n\n- Initial release.\n',
+  )
+})
+
+test('annotates a bare section that is the only section in the file', () => {
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.1\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      peerDependencies: {'@portabletext/editor': 'workspace:^'},
+    },
+    releasedVersions,
+  })
+
+  assert.equal(
+    annotated,
+    '# pkg\n\n## 1.0.1\n\n### Patch Changes\n\n- fix(deps): require `@portabletext/editor@^8.1.3`\n',
+  )
+})
+
+test('leaves a section with content alone', () => {
+  const annotated = annotateChangelog({
+    changelog:
+      '# pkg\n\n## 1.0.1\n\n### Patch Changes\n\n- fix: a real change.\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      peerDependencies: {'@portabletext/editor': 'workspace:^'},
+    },
+    releasedVersions,
+  })
+
+  assert.equal(annotated, null)
+})
+
+test('returns null when the version heading is missing', () => {
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.0\n\n- Initial release.\n',
+    version: '1.0.1',
+    manifest: {name: 'pkg'},
+    releasedVersions,
+  })
+
+  assert.equal(annotated, null)
+})
+
+test('matches the version heading exactly, not as a prefix', () => {
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.10\n\n- A real change.\n',
+    version: '1.0.1',
+    manifest: {name: 'pkg'},
+    releasedVersions,
+  })
+
+  assert.equal(annotated, null)
+})
+
+test('a second run over annotated output changes nothing', () => {
+  const input = {
+    changelog: '# pkg\n\n## 1.0.1\n\n## 1.0.0\n\n- Initial release.\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      peerDependencies: {'@portabletext/editor': 'workspace:^'},
+    },
+    releasedVersions,
+  }
+  const annotated = annotateChangelog(input)
+
+  assert.equal(annotateChangelog({...input, changelog: annotated}), null)
+})
+
+test('movedPublishedRange mirrors the pnpm workspace protocol substitutions', () => {
+  assert.equal(movedPublishedRange('workspace:^', '8.1.3'), '^8.1.3')
+  assert.equal(movedPublishedRange('workspace:~', '8.1.3'), '~8.1.3')
+  assert.equal(movedPublishedRange('workspace:*', '8.1.3'), '8.1.3')
+})
+
+test('an explicit workspace range publishes verbatim, so a release does not move it', () => {
+  assert.equal(movedPublishedRange('workspace:^8.0.2', '8.1.3'), null)
+
+  const annotated = annotateChangelog({
+    changelog: '# pkg\n\n## 1.0.1\n\n## 1.0.0\n\n- Initial release.\n',
+    version: '1.0.1',
+    manifest: {
+      name: 'pkg',
+      peerDependencies: {'@portabletext/editor': 'workspace:^8.0.2'},
+    },
+    releasedVersions,
+  })
+
+  assert.equal(
+    annotated,
+    '# pkg\n\n## 1.0.1\n\n### Patch Changes\n\n- chore: lockstep release, no changes\n\n## 1.0.0\n\n- Initial release.\n',
+  )
+})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     with:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      version: pnpm changeset:version
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:sanity-bridge": "turbo build --filter=@portabletext/sanity-bridge...",
     "build:schema": "turbo build --filter=@portabletext/schema...",
     "build:toolbar": "turbo build --filter=@portabletext/toolbar...",
+    "changeset:version": "changeset version && node .changeset/annotate-lockstep-releases.mjs",
     "check:format": "oxfmt --check . && prettier --check \"**/*.{astro,feature}\"",
     "check:knip": "knip",
     "check:lint": "oxlint",
@@ -42,7 +43,7 @@
     "test:browser:chromium": "turbo test:browser:chromium",
     "test:browser:firefox": "turbo test:browser:firefox",
     "test:browser:webkit": "turbo test:browser:webkit",
-    "test:unit": "turbo test:unit",
+    "test:unit": "turbo test:unit && node --test .changeset/annotate-lockstep-releases.test.mjs",
     "test:unit:watch": "turbo test:unit:watch",
     "test:watch": "turbo test:watch"
   },


### PR DESCRIPTION
**What is broken:** some plugin changelogs show versions with nothing under them. `plugin-dnd` 2.0.3, 2.0.4, and 2.0.5 are just headings. A reader cannot tell why those versions exist.

**Why it happens:** every editor release also re-releases all plugins. That is on purpose: plugin and editor versions stay in lockstep. But since the changesets tooling update (2c415d37f), changesets writes no changelog text for these re-releases. It only reports changes it makes in the source tree, and the plugins' `workspace:` ranges never change there. The real change happens later: pnpm fills in the concrete versions at publish time (`plugin-dnd` 2.0.2 requires `editor ^8.0.2`, 2.0.3 requires `^8.0.3`). Changesets never sees that, so it says nothing.

**The fix:** after `changeset version`, a small script (`.changeset/annotate-lockstep-releases.mjs`) finds every released package whose new changelog section is empty and writes what the release actually does:

> fix(deps): require `@portabletext/editor@^8.1.3`

The line reads like every other changelog entry (commit-style subject). Dependencies pinned to an explicit range (`workspace:^8.0.2`) publish the same range every time, so they are not named; when nothing moves at all, the entry is "chore: lockstep release, no changes".

**How it is verified:** the logic is pure functions with `node:test` unit tests, run by the root `test:unit` script in CI. A `changeset version` dry run confirms the end result: empty sections get the line, all other entries are byte-identical to what changesets writes today.

**Dependency:** needs portabletext/.github#26 (merged), which lets the release workflow run the script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time changelog automation only; no runtime or published package behavior beyond clearer CHANGELOG text.
> 
> **Overview**
> Lockstep plugin releases no longer leave **empty changelog sections** when Changesets only bumps versions for `workspace:` deps.
> 
> A post-`changeset version` script (`.changeset/annotate-lockstep-releases.mjs`) finds bare `## <version>` headings in `packages/*/CHANGELOG.md` and inserts a **Patch Changes** block. It documents the semver ranges pnpm will publish (`fix(deps): require …`) or falls back to `chore: lockstep release, no changes` when no published range moves.
> 
> **Wiring:** root `changeset:version` runs the annotator; CI `test:unit` runs `node:test` coverage; the release workflow passes `version: pnpm changeset:version` into the shared Changesets workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c84d2ebdeb9456a81e7924fb606c0a3c7ef13f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->