### PR TITLE
fix(deps): replace pinned `workspace:^8.0.2` peer ranges with `workspace:^`

### DIFF
--- a/.changeset/unpin-workspace-peer-ranges.md
+++ b/.changeset/unpin-workspace-peer-ranges.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/toolbar': patch
+'@portabletext/plugin-input-rule': patch
+'@portabletext/plugin-emoji-picker': patch
+'@portabletext/plugin-typeahead-picker': patch
+'@portabletext/plugin-typography': patch
+---
+
+fix(deps): replace pinned `workspace:^8.0.2` peer ranges with `workspace:^`
+
+These five packages again require the `@portabletext/editor` version released alongside them. Their published peer range had been frozen at `^8.0.2`: the release tooling used to rewrite the pinned range on every release and stopped doing so in late August, leaving the pin as a fossil. With the bare `workspace:^` range, pnpm substitutes the co-released editor version at publish time, matching the other packages in the monorepo.

--- a/packages/plugin-dnd/CHANGELOG.md
+++ b/packages/plugin-dnd/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## 2.0.7
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 2.0.6
 
 ### Patch Changes
@@ -24,9 +28,21 @@
 
 ## 2.0.5
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
+
 ## 2.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 2.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 2.0.2
 

--- a/packages/plugin-emoji-picker/package.json
+++ b/packages/plugin-emoji-picker/package.json
@@ -76,7 +76,7 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:^8.0.2",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.2"
   },
   "engines": {

--- a/packages/plugin-input-rule/CHANGELOG.md
+++ b/packages/plugin-input-rule/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 7.0.6
 
+### Patch Changes
+
+- chore: lockstep release, no changes
+
 ## 7.0.5
+
+### Patch Changes
+
+- chore: lockstep release, no changes
 
 ## 7.0.4
 
@@ -13,6 +21,10 @@
   Pressing Backspace right after an input rule fires still undoes the rule, including when a collaborator's changes arrive in between. Once any other local edit lands, Backspace acts normally again.
 
 ## 7.0.3
+
+### Patch Changes
+
+- chore: lockstep release, no changes
 
 ## 7.0.2
 

--- a/packages/plugin-input-rule/package.json
+++ b/packages/plugin-input-rule/package.json
@@ -76,7 +76,7 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:^8.0.2",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.2"
   },
   "engines": {

--- a/packages/plugin-list-index/CHANGELOG.md
+++ b/packages/plugin-list-index/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## 2.0.6
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 2.0.5
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
 
 ## 2.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 2.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 2.0.2
 

--- a/packages/plugin-one-line/CHANGELOG.md
+++ b/packages/plugin-one-line/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## 8.0.6
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 8.0.5
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
 
 ## 8.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 8.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 8.0.2
 

--- a/packages/plugin-paste-link/CHANGELOG.md
+++ b/packages/plugin-paste-link/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## 5.0.6
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 5.0.5
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
 
 ## 5.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 5.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 5.0.2
 

--- a/packages/plugin-sdk-value/CHANGELOG.md
+++ b/packages/plugin-sdk-value/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 8.1.1
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 8.1.0
 
 ### Minor Changes
@@ -55,9 +59,21 @@
 
 ## 8.0.5
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
+
 ## 8.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 8.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 8.0.2
 

--- a/packages/plugin-table/CHANGELOG.md
+++ b/packages/plugin-table/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## 2.0.6
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.2`
+
 ## 2.0.5
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.1`
 
 ## 2.0.4
 
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.1.0`
+
 ## 2.0.3
+
+### Patch Changes
+
+- fix(deps): require `@portabletext/editor@^8.0.3`
 
 ## 2.0.2
 

--- a/packages/plugin-typeahead-picker/package.json
+++ b/packages/plugin-typeahead-picker/package.json
@@ -81,7 +81,7 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:^8.0.2",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.2"
   },
   "engines": {

--- a/packages/plugin-typography/package.json
+++ b/packages/plugin-typography/package.json
@@ -73,7 +73,7 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:^8.0.2",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.2"
   },
   "engines": {

--- a/packages/toolbar/CHANGELOG.md
+++ b/packages/toolbar/CHANGELOG.md
@@ -2,11 +2,27 @@
 
 ## 9.0.6
 
+### Patch Changes
+
+- chore: lockstep release, no changes
+
 ## 9.0.5
+
+### Patch Changes
+
+- chore: lockstep release, no changes
 
 ## 9.0.4
 
+### Patch Changes
+
+- chore: lockstep release, no changes
+
 ## 9.0.3
+
+### Patch Changes
+
+- chore: lockstep release, no changes
 
 ## 9.0.2
 

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -73,7 +73,7 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@portabletext/editor": "workspace:^8.0.2",
+    "@portabletext/editor": "workspace:^",
     "react": "^19.2.8"
   },
   "engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# `pnpm add` writes bare `workspace:^` instead of embedding the current
+# version; embedded versions freeze the published range (the release
+# tooling no longer rewrites them).
+saveWorkspaceProtocol: rolling
+
 packages:
   - apps/*
   - packages/*


### PR DESCRIPTION
Two related repairs to the lockstep-release story, following up on #3222.

**Normalize the fossilized peer pins (`fix(deps)` commit).** Five packages (toolbar, plugin-input-rule, plugin-emoji-picker, plugin-typeahead-picker, plugin-typography) declare their `@portabletext/editor` peer as `workspace:^8.0.2`. Nobody chose that pin: the old changesets tooling rewrote the explicit range on every release, and the tooling update (2c415d37f) stopped rewriting `workspace:` ranges, freezing the last written value. npm shows the effect: toolbar's published peer floor moved with every release up to 9.0.2 and has sat at `^8.0.2` since. Normalizing to bare `workspace:^` restores the moving floor via pnpm's publish-time substitution, uniform with the rest of the monorepo. Ships a changeset for all five packages. `saveWorkspaceProtocol: rolling` prevents recurrence: the versioned pins came from `pnpm add` embedding the current version at package-creation time, so any future `pnpm add` of a workspace dependency would have re-introduced one.

**Backfill the empty changelog entries (`docs` commit).** The lockstep releases cut between the tooling update and #3222 left 31 bare version headings across eight changelogs. Each is filled with the same commit-style line the annotation script now writes, derived from npm's published manifests: for every bare version, the internal dependency ranges are diffed against the previous published version, and whatever moved is named ("fix(deps): require `@portabletext/editor@^8.0.3`"). Versions where nothing moved (the frozen-pin packages above) read "chore: lockstep release, no changes".

Changelog text and dependency declarations only; no runtime code changes. Prettier-clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and changelog-only changes; the peer-range fix aligns published metadata with existing monorepo practice and should reduce version-mismatch risk for consumers.
> 
> **Overview**
> Repairs **lockstep release metadata** so published `@portabletext/editor` peer floors move with each release again. No runtime code changes.
> 
> Five packages (`toolbar`, `plugin-input-rule`, `plugin-emoji-picker`, `plugin-typeahead-picker`, `plugin-typography`) change their `@portabletext/editor` **peer** from frozen `workspace:^8.0.2` to bare `workspace:^`, matching packages like `plugin-dnd`. On publish, pnpm substitutes the co-released editor version instead of leaving npm stuck at `^8.0.2`. A changeset covers those five patch releases.
> 
> `pnpm-workspace.yaml` adds **`saveWorkspaceProtocol: rolling`** so future `pnpm add` of workspace deps writes bare `workspace:^` instead of embedding a version that would freeze again.
> 
> Several **changelogs** backfill empty lockstep version headings: dependency-only releases get `fix(deps): require @portabletext/editor@^…` lines; no-op lockstep cuts get `chore: lockstep release, no changes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a549690c19198a30b2f2cc8d85cd480f8bac40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->