### PR TITLE
fix: resolve drop and click positions in viewport coordinates

### DIFF
--- a/.changeset/event-position-client-y.md
+++ b/.changeset/event-position-client-y.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: resolve drop and click positions in viewport coordinates
+
+On a page where the window itself scrolls, dragging a block resolved every drop position to the hovered block's `end` edge once the page was scrolled: the drop indicator stuck to bottom edges and drops landed after the hovered block regardless of pointer position. The position math compared the event's page coordinates against viewport-relative element rects, so the scroll offset inflated every comparison; editors inside an inner scroll container (like Sanity Studio's panes) were unaffected because the two coordinate spaces coincide there. Positions now resolve from viewport coordinates in all cases. Block-boundary rect reads also now only happen when the pointer is over the editor's own surface rather than over a block, removing two layout reads per drag event.

--- a/packages/editor/src/internal-utils/event-position.ts
+++ b/packages/editor/src/internal-utils/event-position.ts
@@ -239,43 +239,45 @@ function getEventPositionBlock({
   editorEngine: PortableTextEditorEngine
   event: DragEvent | MouseEvent
 }): EventPositionBlock | undefined {
-  const firstBlockEntry = getNode(editorEngine.snapshot, [0])
+  if (nodePath.length === 0) {
+    // Over a block, the pointer sits inside that block's band, between the
+    // first block's top and the last block's bottom, so these boundary
+    // checks can only decide anything when the event targets the editor's
+    // own surface.
+    const firstBlockEntry = getNode(editorEngine.snapshot, [0])
 
-  if (!firstBlockEntry) {
-    return undefined
-  }
+    if (!firstBlockEntry) {
+      return undefined
+    }
 
-  const firstBlockElement = getDomNode(editorEngine, firstBlockEntry.path)
+    const firstBlockElement = getDomNode(editorEngine, firstBlockEntry.path)
 
-  if (!firstBlockElement) {
-    return undefined
-  }
+    if (!firstBlockElement) {
+      return undefined
+    }
 
-  const firstBlockRect = firstBlockElement.getBoundingClientRect()
+    if (event.clientY < firstBlockElement.getBoundingClientRect().top) {
+      return 'start'
+    }
 
-  if (event.pageY < firstBlockRect.top) {
-    return 'start'
-  }
+    const lastBlock = editorEngine.snapshot.context.value.at(-1)
+    const lastBlockEntry = lastBlock
+      ? getNode(editorEngine.snapshot, [{_key: lastBlock._key}])
+      : undefined
 
-  const lastBlock = editorEngine.snapshot.context.value.at(-1)
-  const lastBlockEntry = lastBlock
-    ? getNode(editorEngine.snapshot, [{_key: lastBlock._key}])
-    : undefined
+    if (!lastBlockEntry) {
+      return undefined
+    }
 
-  if (!lastBlockEntry) {
-    return undefined
-  }
+    const lastBlockElement = getDomNode(editorEngine, lastBlockEntry.path)
 
-  const lastBlockElement = getDomNode(editorEngine, lastBlockEntry.path)
+    if (!lastBlockElement) {
+      return undefined
+    }
 
-  if (!lastBlockElement) {
-    return undefined
-  }
-
-  const lastBlockRef = lastBlockElement.getBoundingClientRect()
-
-  if (event.pageY > lastBlockRef.bottom) {
-    return 'end'
+    if (event.clientY > lastBlockElement.getBoundingClientRect().bottom) {
+      return 'end'
+    }
   }
 
   const element = getDomNode(editorEngine, nodePath)
@@ -287,7 +289,7 @@ function getEventPositionBlock({
   const elementRect = element.getBoundingClientRect()
   const top = elementRect.top
   const height = elementRect.height
-  const location = Math.abs(top - event.pageY)
+  const location = Math.abs(top - event.clientY)
 
   return location < height / 2 ? 'start' : 'end'
 }

--- a/packages/editor/tests/event-position-scroll.test.tsx
+++ b/packages/editor/tests/event-position-scroll.test.tsx
@@ -1,0 +1,69 @@
+import {describe, expect, test, vi} from 'vitest'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
+import {createTestEditor} from '../src/test/vitest'
+
+describe('event position on a window-scrolled page', () => {
+  test('Scenario: the drop half comes from viewport coordinates, not page coordinates', async () => {
+    const capturedBlocks: Array<'start' | 'end'> = []
+
+    const {locator} = await createTestEditor({
+      initialValue: [
+        {
+          _key: 'b0',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: 'b0s', _type: 'span', text: 'foo', marks: []}],
+        },
+        {
+          _key: 'b1',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_key: 'b1s', _type: 'span', text: 'bar', marks: []}],
+        },
+      ],
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'drag.dragover',
+              guard: ({event}) => {
+                capturedBlocks.push(event.position.block)
+                return false
+              },
+              actions: [],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    const editorElement = locator.element()
+    const blockElement = editorElement.querySelector(
+      '[data-pt-block="text"]',
+    ) as HTMLElement
+    const blockRect = blockElement.getBoundingClientRect()
+
+    // Synthetic events always report `pageY === clientY`, so a real window
+    // scroll cannot exercise this; simulate the trusted-event relationship
+    // on the instance instead.
+    const dragoverEvent = new DragEvent('dragover', {
+      bubbles: true,
+      cancelable: true,
+      clientX: blockRect.left + 4,
+      clientY: blockRect.top + 1,
+      dataTransfer: new DataTransfer(),
+    })
+    Object.defineProperty(dragoverEvent, 'pageY', {
+      value: blockRect.top + 1 + 2000,
+    })
+
+    blockElement.dispatchEvent(dragoverEvent)
+
+    await vi.waitFor(() => {
+      expect(capturedBlocks).toEqual(['start'])
+    })
+  })
+})


### PR DESCRIPTION
Take an editor on a page where the whole window scrolls, like the playground or a plain embed (Studio is unaffected: its panes scroll an inner container). Before scrolling, drag and drop works. Scroll down and drag a block: the drop line now always sits at the bottom edge of whatever block you hover, and dropping always puts the dragged block after it. Dropping before a block becomes impossible.

The cause is a units mix-up. To decide whether the pointer is in the upper or lower half of a block, the code compared the pointer position measured from the top of the page (`pageY`, which includes the scroll distance) with the block position measured from the top of the visible window (`getBoundingClientRect`). Once the page is scrolled, the pointer number is bigger than every block number by the scroll distance, so the pointer always looks like it is below everything and every check answers `end`. The fix measures both from the window: `clientY`.

A small perf rider: the "above the first block / below the last block" checks now run only when the pointer is over the editor's own padding. Over a block they can never be true, and skipping them removes two layout reads per drag event.

The pinning test sets `pageY` on the event by hand, the way a real scrolled page would; synthetic events always have `pageY` equal to `clientY`, so a real scroll cannot trigger the bug from a test. It fails on the old code. Full editor suite green (2041 passed, 3 expected fail).
