### PR TITLE
refactor: make apply-state wrappers exception-safe

### DIFF
--- a/packages/editor/src/engine-plugins/engine-plugin.redoing.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.redoing.ts
@@ -8,7 +8,9 @@ export function pluginRedoing(
 
   editor.isRedoing = true
 
-  fn()
-
-  editor.isRedoing = prev
+  try {
+    fn()
+  } finally {
+    editor.isRedoing = prev
+  }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.remote-changes.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.remote-changes.ts
@@ -6,6 +6,9 @@ export function withRemoteChanges(
 ): void {
   const prev = editor.isProcessingRemoteChanges
   editor.isProcessingRemoteChanges = true
-  fn()
-  editor.isProcessingRemoteChanges = prev
+  try {
+    fn()
+  } finally {
+    editor.isProcessingRemoteChanges = prev
+  }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.undoing.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.undoing.ts
@@ -8,7 +8,9 @@ export function pluginUndoing(
 
   editor.isUndoing = true
 
-  fn()
-
-  editor.isUndoing = prev
+  try {
+    fn()
+  } finally {
+    editor.isUndoing = prev
+  }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.without-history.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.without-history.ts
@@ -8,7 +8,9 @@ export function pluginWithoutHistory(
 
   editor.withHistory = false
 
-  fn()
-
-  editor.withHistory = prev
+  try {
+    fn()
+  } finally {
+    editor.withHistory = prev
+  }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.without-patching.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.without-patching.ts
@@ -6,6 +6,9 @@ export function withoutPatching(
 ): void {
   const prev = editor.isPatching
   editor.isPatching = false
-  fn()
-  editor.isPatching = prev
+  try {
+    fn()
+  } finally {
+    editor.isPatching = prev
+  }
 }

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -6,6 +6,10 @@ import {
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import {describe, expect, test} from 'vitest'
+import {withRemoteChanges} from '../../engine-plugins/engine-plugin.remote-changes'
+import {pluginUndoing} from '../../engine-plugins/engine-plugin.undoing'
+import {pluginWithoutHistory} from '../../engine-plugins/engine-plugin.without-history'
+import {withoutPatching} from '../../engine-plugins/engine-plugin.without-patching'
 import {createEditor} from '../create-editor'
 import type {Editor} from '../interfaces/editor'
 import type {EngineOperation} from '../interfaces/operation'
@@ -345,5 +349,83 @@ describe('operation channel', () => {
       'after:insert.text:normalization',
       'after:set:local',
     ])
+  })
+
+  test('a throw inside `withRemoteChanges` does not stick `isProcessingRemoteChanges`', () => {
+    const editor = createBareEditor(createDefaultValue())
+    editor.isProcessingRemoteChanges = false
+    const origins: Array<OperationEvent['origin']> = []
+
+    subscribeToOperations(editor, (event) => {
+      origins.push(event.origin)
+    })
+
+    expect(() =>
+      withRemoteChanges(editor, () => {
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+
+    expect(editor.isProcessingRemoteChanges).toEqual(false)
+
+    editor.apply(insertTextOperation)
+
+    expect(origins).toEqual(['local'])
+  })
+
+  test('a throw inside `withoutPatching` does not stick `isPatching`', () => {
+    const editor = createBareEditor(createDefaultValue())
+    editor.isPatching = true
+    const isPatchingFlags: Array<boolean> = []
+
+    subscribeToOperations(editor, (event) => {
+      isPatchingFlags.push(event.isPatching)
+    })
+
+    expect(() =>
+      withoutPatching(editor, () => {
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+
+    expect(editor.isPatching).toEqual(true)
+
+    editor.apply(insertTextOperation)
+
+    expect(isPatchingFlags).toEqual([true])
+  })
+
+  test('a throw inside `pluginWithoutHistory` does not stick `withHistory`', () => {
+    const editor = createBareEditor(createDefaultValue())
+    editor.withHistory = true
+    const withHistoryFlags: Array<boolean> = []
+
+    subscribeToOperations(editor, (event) => {
+      withHistoryFlags.push(event.withHistory)
+    })
+
+    expect(() =>
+      pluginWithoutHistory(editor, () => {
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+
+    expect(editor.withHistory).toEqual(true)
+
+    editor.apply(insertTextOperation)
+
+    expect(withHistoryFlags).toEqual([true])
+  })
+  test('a throw inside `pluginUndoing` does not stick `isUndoing`', () => {
+    const editor = createBareEditor(createDefaultValue())
+    editor.isUndoing = false
+
+    expect(() => {
+      pluginUndoing(editor, () => {
+        throw new Error('boom')
+      })
+    }).toThrow('boom')
+
+    expect(editor.isUndoing).toEqual(false)
   })
 })

--- a/packages/editor/src/operations/operation.history.redo.ts
+++ b/packages/editor/src/operations/operation.history.redo.ts
@@ -42,8 +42,6 @@ export const historyRedoOperationImplementation: OperationImplementation<
         editor.remotePatches.splice(0, editor.remotePatches.length)
         applyDeselect(editor)
         editor.history = {undos: [], redos: []}
-        editor.withHistory = true
-        editor.isRedoing = false
         editor.onChange()
         return
       }

--- a/packages/editor/src/operations/operation.history.undo.ts
+++ b/packages/editor/src/operations/operation.history.undo.ts
@@ -47,8 +47,6 @@ export const historyUndoOperationImplementation: OperationImplementation<
         editor.remotePatches.splice(0, editor.remotePatches.length)
         applyDeselect(editor)
         editor.history = {undos: [], redos: []}
-        editor.withHistory = true
-        editor.isUndoing = false
         editor.onChange()
         return
       }


### PR DESCRIPTION
Groundwork for the apply-context refactor (the initiative replacing the change-attribution flag algebra with an explicit frame stack). The stack's push/pop will be exception-safe by default, and the flag wrappers it dual-writes with must match, or the two diverge on the throw path and the follow-up's strictly-behavior-preserving claim carries a hidden delta. Landing the hardening separately keeps that refactor honest.

The five apply-state wrappers (`withRemoteChanges`, `withoutPatching`, `pluginWithoutHistory`, `pluginUndoing`, `pluginRedoing`) restored their flag with no `try/finally`, so an escaping exception left it stuck: everything afterward attributing as remote, patch emission or history suppressed, and the sync machine's `is busy` guard blocked. The restore now runs in a `finally`, and the manual flag resets in the undo/redo `catch` paths are deleted as dead (unwinding runs the wrappers' `finally` blocks before the outer `catch` observes state).

One honest scoping note, which is why this is a `refactor:` with no changeset: a genuine hunt found no way to reach the stuck-flag state through public APIs today. Per-patch errors are caught, `performOperation` blanket-catches operation throws, every reachable `applyNodeProperties` caller passes safe path shapes, and the normalization rules resolve their own violations. The exception windows are real (`normalize` and `onChange` run uncaught inside the remote bracket) but currently defended at every entrance; this makes the invariant structural instead of coincidental, in a codebase that is deliberately adding throw paths to apply internals.

Four unit tests in the operation-channel suite pin the wrapper contract, asserting both the flag and its observable projection after a synthetic throw, each red on the unwrapped code. Two net-neutral catch-path deltas are detailed in the commit body.
